### PR TITLE
feat: serialize task execution control

### DIFF
--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6,6 +6,12 @@ type TestWebSocketMessage = {
   type: string
   timestamp: string
   data?: unknown
+  task_id?: number
+  task?: Record<string, unknown>
+  status?: string
+  run_id?: string | null
+  state_version?: number
+  control_state?: string
 }
 
 const webSocketOptions = vi.hoisted(() => ({
@@ -209,6 +215,72 @@ describe("AppProvider websocket message routing", () => {
     await waitFor(() => {
       expect(screen.getByTestId("task-status").textContent).toBe("failed")
       expect(screen.getByTestId("processing").textContent).toBe("false")
+    })
+  })
+
+  it("ignores out-of-order and semantically stale task state events", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_paused",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        status: "paused",
+        run_id: "run-1",
+        state_version: 4,
+        control_state: "paused",
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("paused")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_resumed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        status: "running",
+        run_id: "run-1",
+        state_version: 5,
+        control_state: "running",
+      })
+      onMessage?.({
+        type: "task_paused",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 1,
+        status: "paused",
+        run_id: "run-1",
+        state_version: 4,
+        control_state: "paused",
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_paused",
+        timestamp: "2026-05-27T05:00:04Z",
+        task_id: 1,
+        status: "running",
+        run_id: "run-1",
+        state_version: 6,
+        control_state: "running",
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
     })
   })
 

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -383,6 +383,15 @@ describe("AppProvider websocket message routing", () => {
 
     act(() => {
       onMessage?.({
+        type: "task_started",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        status: "running",
+        run_id: "run-1",
+        state_version: 4,
+        control_state: "running",
+      })
+      onMessage?.({
         type: "error",
         timestamp: "2026-05-27T05:00:03Z",
         message: "No live execution found to pause",

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -57,7 +57,13 @@ vi.mock("sonner", () => ({
   },
 }))
 
-import { AppProvider, useApp } from "./app-context-chat"
+import {
+  AppProvider,
+  extractTaskControlEnvelope,
+  useApp,
+} from "./app-context-chat"
+
+type TaskControlMessage = Parameters<typeof extractTaskControlEnvelope>[0]
 
 function StateProbe() {
   const { state } = useApp()
@@ -113,6 +119,40 @@ function SeedRunningTask() {
 
   return null
 }
+
+describe("task control envelope parsing", () => {
+  it("does not coerce null, boolean, or empty identifiers to integers", () => {
+    const nullEnvelope = extractTaskControlEnvelope({
+      type: "task_paused",
+      timestamp: "2026-05-27T05:00:00Z",
+      task_id: null,
+      state_version: null,
+    } as unknown as TaskControlMessage)
+    const coercedEnvelope = extractTaskControlEnvelope({
+      type: "task_paused",
+      timestamp: "2026-05-27T05:00:00Z",
+      task_id: true,
+      state_version: "",
+    } as unknown as TaskControlMessage)
+
+    expect(nullEnvelope.taskId).toBeUndefined()
+    expect(nullEnvelope.stateVersion).toBeUndefined()
+    expect(coercedEnvelope.taskId).toBeUndefined()
+    expect(coercedEnvelope.stateVersion).toBeUndefined()
+  })
+
+  it("accepts positive task IDs and non-negative versions", () => {
+    const envelope = extractTaskControlEnvelope({
+      type: "task_paused",
+      timestamp: "2026-05-27T05:00:00Z",
+      task_id: "12",
+      state_version: "0",
+    } as unknown as TaskControlMessage)
+
+    expect(envelope.taskId).toBe(12)
+    expect(envelope.stateVersion).toBe(0)
+  })
+})
 
 describe("AppProvider websocket message routing", () => {
   beforeEach(() => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -18,6 +18,89 @@ interface WebSocketMessage {
   step_id?: string
   event_type?: string
   event_id?: string
+  run_id?: string | null
+  state_version?: number
+  control_state?: TaskControlState
+  status?: unknown
+  task?: Record<string, unknown>
+}
+
+type TaskControlState =
+  | "idle"
+  | "running"
+  | "pause_requested"
+  | "paused"
+  | "resume_requested"
+  | "waiting_for_user"
+  | "completed"
+  | "failed"
+
+type TaskControlEnvelope = {
+  isStateEvent: boolean
+  taskId?: number
+  runId?: string | null
+  stateVersion?: number
+  controlState?: TaskControlState
+  status?: TaskStatus
+}
+
+const VERSIONED_TASK_EVENT_TYPES = new Set([
+  "agent_error",
+  "error",
+  "task_completed",
+  "task_error",
+  "task_pause_requested",
+  "task_paused",
+  "task_resumed",
+  "task_started",
+  "task_waiting_for_user",
+])
+
+const asMessageRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" ? value as Record<string, unknown> : {}
+
+const extractTaskControlEnvelope = (message: WebSocketMessage): TaskControlEnvelope => {
+  const root = message as unknown as Record<string, unknown>
+  const data = asMessageRecord(root.data)
+  const nestedData = asMessageRecord(data.data)
+  const task = asMessageRecord(root.task)
+  const eventType = String(root.event_type || data.event_type || "")
+  const isStateEvent = VERSIONED_TASK_EVENT_TYPES.has(message.type)
+    || (message.type === "trace_event" && eventType === "task_info")
+  if (!isStateEvent) return { isStateEvent: false }
+
+  const rawTaskId = root.task_id ?? task.id ?? task.task_id ?? data.id ?? data.task_id ?? nestedData.id ?? nestedData.task_id
+  const parsedTaskId = Number(rawTaskId)
+  const rawVersion = root.state_version ?? task.state_version ?? data.state_version ?? nestedData.state_version
+  const parsedVersion = Number(rawVersion)
+  const rawRunId = root.run_id ?? task.run_id ?? data.run_id ?? nestedData.run_id
+  const rawControlState = root.control_state ?? task.control_state ?? data.control_state ?? nestedData.control_state
+  const rawStatus = root.status ?? task.status ?? data.status ?? nestedData.status
+
+  return {
+    isStateEvent: true,
+    taskId: Number.isFinite(parsedTaskId) ? parsedTaskId : undefined,
+    runId: typeof rawRunId === "string" || rawRunId === null ? rawRunId : undefined,
+    stateVersion: Number.isInteger(parsedVersion) && parsedVersion >= 0 ? parsedVersion : undefined,
+    controlState: typeof rawControlState === "string" ? rawControlState as TaskControlState : undefined,
+    status: normalizeTaskStatus(rawStatus) || undefined,
+  }
+}
+
+const taskEventMatchesControlState = (
+  message: WebSocketMessage,
+  envelope: TaskControlEnvelope,
+): boolean => {
+  const expected: Partial<Record<string, TaskControlState[]>> = {
+    task_completed: ["completed", "failed"],
+    task_pause_requested: ["pause_requested"],
+    task_paused: ["paused"],
+    task_resumed: ["running"],
+    task_started: ["running"],
+    task_waiting_for_user: ["waiting_for_user"],
+  }
+  const allowed = expected[message.type]
+  return !allowed || !envelope.controlState || allowed.includes(envelope.controlState)
 }
 export interface Interaction {
   type: "select_one" | "select_multiple" | "text_input" | "file_upload" | "confirm" | "number_input" | "action_cards";
@@ -357,6 +440,9 @@ export interface Task {
   agentLogoUrl?: string
   waitingQuestion?: string
   waitingInteractions?: Interaction[]
+  runId?: string | null
+  stateVersion?: number
+  controlState?: TaskControlState
 }
 
 interface StepExecution {
@@ -502,7 +588,7 @@ type AppAction =
   | { type: "ADD_MESSAGE"; payload: Message }
   | { type: "UPSERT_STREAMING_FINAL_ANSWER"; payload: { messageId: string; delta?: string; content?: string; status?: Message["status"]; timestamp: string } }
   | { type: "SET_CURRENT_TASK"; payload: Task | null }
-  | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[] } }
+  | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; runId?: string | null; stateVersion?: number; controlState?: TaskControlState } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
   | { type: "SET_CONTEXT_USAGE"; payload: { tokens: number; threshold: number } | null }
@@ -755,6 +841,9 @@ function appReducer(state: AppState, action: AppAction): AppState {
           waitingInteractions: isWaitingForUser
             ? action.payload.waitingInteractions ?? state.currentTask.waitingInteractions
             : undefined,
+          runId: action.payload.runId ?? state.currentTask.runId,
+          stateVersion: action.payload.stateVersion ?? state.currentTask.stateVersion,
+          controlState: action.payload.controlState ?? state.currentTask.controlState,
         },
       }
     }
@@ -1101,6 +1190,9 @@ export function AppProvider({
   const { t } = useI18n()
   const router = useRouter()
   const lastConnectedTaskId = useRef<number | null>(null)
+  const taskStateVersionsRef = useRef(
+    new Map<number, { version: number; runId?: string | null }>()
+  )
 
   // Ref to track current state for WebSocket message handler
   const stateRef = useRef(state)
@@ -1315,6 +1407,48 @@ export function AppProvider({
       return
     }
 
+    const controlEnvelope = extractTaskControlEnvelope(message)
+    if (controlEnvelope.isStateEvent && controlEnvelope.taskId !== undefined) {
+      const knownState = taskStateVersionsRef.current.get(controlEnvelope.taskId)
+      if (controlEnvelope.stateVersion === undefined) {
+        // Once the server has established the versioned protocol for a task,
+        // legacy/unversioned replay events must not be allowed to roll it back.
+        if (knownState) return
+      } else {
+        const isOlderVersion = knownState
+          && controlEnvelope.stateVersion < knownState.version
+        const isDifferentRunAtSameVersion = knownState
+          && controlEnvelope.stateVersion === knownState.version
+          && knownState.runId !== undefined
+          && controlEnvelope.runId !== undefined
+          && knownState.runId !== controlEnvelope.runId
+        if (isOlderVersion || isDifferentRunAtSameVersion) return
+        taskStateVersionsRef.current.set(controlEnvelope.taskId, {
+          version: controlEnvelope.stateVersion,
+          runId: controlEnvelope.runId,
+        })
+      }
+
+      // A late event may have an old semantic type (for example
+      // ``task_paused``) after a newer run is already RUNNING. The backend
+      // rewrites its state tuple to the canonical row; apply only that tuple
+      // and skip the stale event-specific side effects.
+      if (!taskEventMatchesControlState(message, controlEnvelope)) {
+        if (controlEnvelope.status) {
+          dispatch({
+            type: "UPDATE_TASK_STATUS",
+            payload: {
+              status: controlEnvelope.status,
+              runId: controlEnvelope.runId,
+              stateVersion: controlEnvelope.stateVersion,
+              controlState: controlEnvelope.controlState,
+            },
+          })
+        }
+        return
+      }
+    }
+
     // Normal message processing when not in replay mode
     if (isFinalAnswerStreamEventType(message.type)) {
       const payload = getFinalAnswerStreamActionPayload({
@@ -1326,17 +1460,6 @@ export function AppProvider({
       })
       if (payload) {
         dispatch({ type: "UPSERT_STREAMING_FINAL_ANSWER", payload })
-        if (message.type === "final_answer_start") {
-          dispatch({ type: "SET_PROCESSING", payload: true })
-        } else if (message.type === "final_answer_end") {
-          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
-          dispatch({ type: "TRIGGER_TASK_UPDATE" })
-          dispatch({ type: "SET_PROCESSING", payload: false })
-        } else if (message.type === "final_answer_error") {
-          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
-          dispatch({ type: "TRIGGER_TASK_UPDATE" })
-          dispatch({ type: "SET_PROCESSING", payload: false })
-        }
       }
       return
     }
@@ -1419,6 +1542,9 @@ export function AppProvider({
                 agentLogoUrl: taskData.agent_logo_url,
                 waitingQuestion: taskData.waiting_question,
                 waitingInteractions: normalizeInteractions(taskData.waiting_interactions),
+                runId: taskData.run_id,
+                stateVersion: taskData.state_version,
+                controlState: taskData.control_state,
               }
             })
 
@@ -1574,17 +1700,6 @@ export function AppProvider({
               return
             }
             dispatch({ type: "UPSERT_STREAMING_FINAL_ANSWER", payload })
-            if (eventType === "final_answer_start") {
-              dispatch({ type: "SET_PROCESSING", payload: true })
-            } else if (eventType === "final_answer_end") {
-              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
-              dispatch({ type: "TRIGGER_TASK_UPDATE" })
-              dispatch({ type: "SET_PROCESSING", payload: false })
-            } else if (eventType === "final_answer_error") {
-              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
-              dispatch({ type: "TRIGGER_TASK_UPDATE" })
-              dispatch({ type: "SET_PROCESSING", payload: false })
-            }
           }
 
           // Agent progress messages belong in the execution timeline, not the chat transcript.
@@ -3773,7 +3888,12 @@ export function AppProvider({
         const taskData = normalizeTaskCompletedMessage(message)
         dispatch({
           type: "UPDATE_TASK_STATUS",
-          payload: { status: taskData.status }
+          payload: {
+            status: taskData.status,
+            runId: controlEnvelope.runId,
+            stateVersion: controlEnvelope.stateVersion,
+            controlState: controlEnvelope.controlState,
+          }
         })
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
         dispatch({ type: "SET_PROCESSING", payload: false })  // Stop processing on task completion
@@ -3942,8 +4062,30 @@ export function AppProvider({
 
       case "task_paused":
         console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (task_paused)')
-        dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "paused" } })
+        dispatch({
+          type: "UPDATE_TASK_STATUS",
+          payload: {
+            status: controlEnvelope.status || "paused",
+            runId: controlEnvelope.runId,
+            stateVersion: controlEnvelope.stateVersion,
+            controlState: controlEnvelope.controlState || "paused",
+          },
+        })
         dispatch({ type: "SET_PROCESSING", payload: false })
+        break
+
+      case "task_pause_requested":
+        if (controlEnvelope.status) {
+          dispatch({
+            type: "UPDATE_TASK_STATUS",
+            payload: {
+              status: controlEnvelope.status,
+              runId: controlEnvelope.runId,
+              stateVersion: controlEnvelope.stateVersion,
+              controlState: controlEnvelope.controlState || "pause_requested",
+            },
+          })
+        }
         break
 
       case "task_waiting_for_user":
@@ -3954,9 +4096,12 @@ export function AppProvider({
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {
-            status: "waiting_for_user",
+            status: controlEnvelope.status || "waiting_for_user",
             waitingQuestion: waitingMessage && waitingMessage !== "Task waiting for user response" ? waitingMessage : undefined,
             waitingInteractions: interactions.length > 0 ? interactions : undefined,
+            runId: controlEnvelope.runId,
+            stateVersion: controlEnvelope.stateVersion,
+            controlState: controlEnvelope.controlState || "waiting_for_user",
           }
         })
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -3983,7 +4128,15 @@ export function AppProvider({
 
       case "task_resumed":
         console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (task_resumed)')
-        dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+        dispatch({
+          type: "UPDATE_TASK_STATUS",
+          payload: {
+            status: controlEnvelope.status || "running",
+            runId: controlEnvelope.runId,
+            stateVersion: controlEnvelope.stateVersion,
+            controlState: controlEnvelope.controlState || "running",
+          },
+        })
         break
 
       case "agent_error":
@@ -3994,7 +4147,12 @@ export function AppProvider({
         if (agentErrorTaskStatus) {
           dispatch({
             type: "UPDATE_TASK_STATUS",
-            payload: { status: agentErrorTaskStatus },
+            payload: {
+              status: agentErrorTaskStatus,
+              runId: controlEnvelope.runId,
+              stateVersion: controlEnvelope.stateVersion,
+              controlState: controlEnvelope.controlState,
+            },
           })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
         }
@@ -4239,6 +4397,9 @@ export function AppProvider({
             agentLogoUrl: taskData.agent_logo_url,
             waitingQuestion: taskData.waiting_question,
             waitingInteractions: normalizeInteractions(taskData.waiting_interactions),
+            runId: taskData.run_id,
+            stateVersion: taskData.state_version,
+            controlState: taskData.control_state,
           }
           dispatch({ type: "SET_CURRENT_TASK", payload: newTask })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -59,7 +59,14 @@ const VERSIONED_TASK_EVENT_TYPES = new Set([
 const asMessageRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" ? value as Record<string, unknown> : {}
 
-const extractTaskControlEnvelope = (message: WebSocketMessage): TaskControlEnvelope => {
+const parseInteger = (value: unknown): number | undefined => {
+  if (typeof value === "number") return Number.isInteger(value) ? value : undefined
+  if (typeof value !== "string" || value.trim() === "") return undefined
+  const parsed = Number(value)
+  return Number.isInteger(parsed) ? parsed : undefined
+}
+
+export const extractTaskControlEnvelope = (message: WebSocketMessage): TaskControlEnvelope => {
   const root = message as unknown as Record<string, unknown>
   const data = asMessageRecord(root.data)
   const nestedData = asMessageRecord(data.data)
@@ -70,18 +77,18 @@ const extractTaskControlEnvelope = (message: WebSocketMessage): TaskControlEnvel
   if (!isStateEvent) return { isStateEvent: false }
 
   const rawTaskId = root.task_id ?? task.id ?? task.task_id ?? data.id ?? data.task_id ?? nestedData.id ?? nestedData.task_id
-  const parsedTaskId = Number(rawTaskId)
+  const parsedTaskId = parseInteger(rawTaskId)
   const rawVersion = root.state_version ?? task.state_version ?? data.state_version ?? nestedData.state_version
-  const parsedVersion = Number(rawVersion)
+  const parsedVersion = parseInteger(rawVersion)
   const rawRunId = root.run_id ?? task.run_id ?? data.run_id ?? nestedData.run_id
   const rawControlState = root.control_state ?? task.control_state ?? data.control_state ?? nestedData.control_state
   const rawStatus = root.status ?? task.status ?? data.status ?? nestedData.status
 
   return {
     isStateEvent: true,
-    taskId: Number.isFinite(parsedTaskId) ? parsedTaskId : undefined,
+    taskId: parsedTaskId !== undefined && parsedTaskId > 0 ? parsedTaskId : undefined,
     runId: typeof rawRunId === "string" || rawRunId === null ? rawRunId : undefined,
-    stateVersion: Number.isInteger(parsedVersion) && parsedVersion >= 0 ? parsedVersion : undefined,
+    stateVersion: parsedVersion !== undefined && parsedVersion >= 0 ? parsedVersion : undefined,
     controlState: typeof rawControlState === "string" ? rawControlState as TaskControlState : undefined,
     status: normalizeTaskStatus(rawStatus) || undefined,
   }

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1424,6 +1424,8 @@ export function AppProvider({
       } else {
         const isOlderVersion = knownState
           && controlEnvelope.stateVersion < knownState.version
+        // Backend transitions currently advance the version whenever run_id
+        // changes. Keep this defensive guard for malformed or future emitters.
         const isDifferentRunAtSameVersion = knownState
           && controlEnvelope.stateVersion === knownState.version
           && knownState.runId !== undefined

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -55,6 +55,7 @@ const VERSIONED_TASK_EVENT_TYPES = new Set([
   "task_started",
   "task_waiting_for_user",
 ])
+const MAX_TRACKED_TASK_STATE_VERSIONS = 500
 
 const asMessageRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" ? value as Record<string, unknown> : {}
@@ -69,20 +70,19 @@ const parseInteger = (value: unknown): number | undefined => {
 export const extractTaskControlEnvelope = (message: WebSocketMessage): TaskControlEnvelope => {
   const root = message as unknown as Record<string, unknown>
   const data = asMessageRecord(root.data)
-  const nestedData = asMessageRecord(data.data)
   const task = asMessageRecord(root.task)
   const eventType = String(root.event_type || data.event_type || "")
   const isStateEvent = VERSIONED_TASK_EVENT_TYPES.has(message.type)
     || (message.type === "trace_event" && eventType === "task_info")
   if (!isStateEvent) return { isStateEvent: false }
 
-  const rawTaskId = root.task_id ?? task.id ?? task.task_id ?? data.id ?? data.task_id ?? nestedData.id ?? nestedData.task_id
+  const rawTaskId = root.task_id ?? task.id ?? data.id
   const parsedTaskId = parseInteger(rawTaskId)
-  const rawVersion = root.state_version ?? task.state_version ?? data.state_version ?? nestedData.state_version
+  const rawVersion = root.state_version ?? task.state_version ?? data.state_version
   const parsedVersion = parseInteger(rawVersion)
-  const rawRunId = root.run_id ?? task.run_id ?? data.run_id ?? nestedData.run_id
-  const rawControlState = root.control_state ?? task.control_state ?? data.control_state ?? nestedData.control_state
-  const rawStatus = root.status ?? task.status ?? data.status ?? nestedData.status
+  const rawRunId = root.run_id ?? task.run_id ?? data.run_id
+  const rawControlState = root.control_state ?? task.control_state ?? data.control_state
+  const rawStatus = root.status ?? task.status ?? data.status
 
   return {
     isStateEvent: true,
@@ -1420,7 +1420,10 @@ export function AppProvider({
       if (controlEnvelope.stateVersion === undefined) {
         // Once the server has established the versioned protocol for a task,
         // legacy/unversioned replay events must not be allowed to roll it back.
-        if (knownState) return
+        // Error events carry information rather than a state transition, so a
+        // rare unversioned error must still reach the user.
+        const isErrorEvent = message.type === "error" || message.type === "agent_error"
+        if (knownState && !isErrorEvent) return
       } else {
         const isOlderVersion = knownState
           && controlEnvelope.stateVersion < knownState.version
@@ -1432,10 +1435,17 @@ export function AppProvider({
           && controlEnvelope.runId !== undefined
           && knownState.runId !== controlEnvelope.runId
         if (isOlderVersion || isDifferentRunAtSameVersion) return
+        taskStateVersionsRef.current.delete(controlEnvelope.taskId)
         taskStateVersionsRef.current.set(controlEnvelope.taskId, {
           version: controlEnvelope.stateVersion,
           runId: controlEnvelope.runId,
         })
+        if (taskStateVersionsRef.current.size > MAX_TRACKED_TASK_STATE_VERSIONS) {
+          const oldestTaskId = taskStateVersionsRef.current.keys().next().value
+          if (oldestTaskId !== undefined) {
+            taskStateVersionsRef.current.delete(oldestTaskId)
+          }
+        }
       }
 
       // A late event may have an old semantic type (for example

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -26,6 +26,11 @@ interface WebSocketMessage {
   message_id?: string
   delta?: string
   content?: string
+  run_id?: string | null
+  state_version?: number
+  control_state?: "idle" | "running" | "pause_requested" | "paused" | "resume_requested" | "waiting_for_user" | "completed" | "failed"
+  status?: unknown
+  task?: Record<string, unknown>
 }
 
 interface MessageDeliveryAck {
@@ -368,6 +373,14 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
               step_id: data.step_id,
             }
           }
+
+          // Preserve the canonical task-control envelope even when a message
+          // type normalizes its payload into ``data`` above.
+          message.run_id = data.run_id
+          message.state_version = data.state_version
+          message.control_state = data.control_state
+          message.status = data.status
+          message.task = data.task
 
           setLastMessage(message)
           onMessage?.(message)

--- a/src/xagent/migrations/versions/20260711_add_task_execution_control_state.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_control_state.py
@@ -35,11 +35,12 @@ def _indexes() -> set[str]:
 
 
 def upgrade() -> None:
-    if not _columns():
+    columns = _columns()
+    if not columns:
         return
-    if "run_id" not in _columns():
+    if "run_id" not in columns:
         op.add_column(TABLE, sa.Column("run_id", sa.String(64), nullable=True))
-    if "state_version" not in _columns():
+    if "state_version" not in columns:
         op.add_column(
             TABLE,
             sa.Column(
@@ -49,7 +50,7 @@ def upgrade() -> None:
                 server_default="0",
             ),
         )
-    if "control_state" not in _columns():
+    if "control_state" not in columns:
         op.add_column(
             TABLE,
             sa.Column(
@@ -59,18 +60,20 @@ def upgrade() -> None:
                 server_default="idle",
             ),
         )
-        op.execute(
-            sa.text(
-                "UPDATE tasks SET control_state = CASE "
-                "WHEN LOWER(CAST(status AS VARCHAR)) = 'running' THEN 'running' "
-                "WHEN LOWER(CAST(status AS VARCHAR)) = 'paused' THEN 'paused' "
-                "WHEN LOWER(CAST(status AS VARCHAR)) = 'waiting_for_user' "
-                "THEN 'waiting_for_user' "
-                "WHEN LOWER(CAST(status AS VARCHAR)) = 'completed' THEN 'completed' "
-                "WHEN LOWER(CAST(status AS VARCHAR)) = 'failed' THEN 'failed' "
-                "ELSE 'idle' END"
+        if "status" in columns:
+            op.execute(
+                sa.text(
+                    "UPDATE tasks SET control_state = CASE "
+                    "WHEN LOWER(CAST(status AS VARCHAR)) = 'running' THEN 'running' "
+                    "WHEN LOWER(CAST(status AS VARCHAR)) = 'paused' THEN 'paused' "
+                    "WHEN LOWER(CAST(status AS VARCHAR)) = 'waiting_for_user' "
+                    "THEN 'waiting_for_user' "
+                    "WHEN LOWER(CAST(status AS VARCHAR)) = 'completed' "
+                    "THEN 'completed' "
+                    "WHEN LOWER(CAST(status AS VARCHAR)) = 'failed' THEN 'failed' "
+                    "ELSE 'idle' END"
+                )
             )
-        )
     if RUN_ID_INDEX not in _indexes():
         op.create_index(RUN_ID_INDEX, TABLE, ["run_id"])
 

--- a/src/xagent/migrations/versions/20260711_add_task_execution_control_state.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_control_state.py
@@ -1,0 +1,88 @@
+"""add versioned task execution control state
+
+Revision ID: 20260711_task_control_state
+Revises: 20260710_add_chat_delivery_state
+Create Date: 2026-07-11
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260711_task_control_state"
+down_revision: Union[str, None] = "20260710_add_chat_delivery_state"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "tasks"
+RUN_ID_INDEX = "ix_tasks_run_id"
+
+
+def _columns() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(TABLE)}
+
+
+def _indexes() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(TABLE)}
+
+
+def upgrade() -> None:
+    if not _columns():
+        return
+    if "run_id" not in _columns():
+        op.add_column(TABLE, sa.Column("run_id", sa.String(64), nullable=True))
+    if "state_version" not in _columns():
+        op.add_column(
+            TABLE,
+            sa.Column(
+                "state_version",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+    if "control_state" not in _columns():
+        op.add_column(
+            TABLE,
+            sa.Column(
+                "control_state",
+                sa.String(32),
+                nullable=False,
+                server_default="idle",
+            ),
+        )
+        op.execute(
+            sa.text(
+                "UPDATE tasks SET control_state = CASE "
+                "WHEN LOWER(CAST(status AS VARCHAR)) = 'running' THEN 'running' "
+                "WHEN LOWER(CAST(status AS VARCHAR)) = 'paused' THEN 'paused' "
+                "WHEN LOWER(CAST(status AS VARCHAR)) = 'waiting_for_user' "
+                "THEN 'waiting_for_user' "
+                "WHEN LOWER(CAST(status AS VARCHAR)) = 'completed' THEN 'completed' "
+                "WHEN LOWER(CAST(status AS VARCHAR)) = 'failed' THEN 'failed' "
+                "ELSE 'idle' END"
+            )
+        )
+    if RUN_ID_INDEX not in _indexes():
+        op.create_index(RUN_ID_INDEX, TABLE, ["run_id"])
+
+
+def downgrade() -> None:
+    if not _columns():
+        return
+    if RUN_ID_INDEX in _indexes():
+        op.drop_index(RUN_ID_INDEX, table_name=TABLE)
+    if "control_state" in _columns():
+        op.drop_column(TABLE, "control_state")
+    if "state_version" in _columns():
+        op.drop_column(TABLE, "state_version")
+    if "run_id" in _columns():
+        op.drop_column(TABLE, "run_id")

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -34,7 +34,6 @@ from ..services.a2a_protocol import (
     task_to_a2a,
 )
 from ..services.task_execution_controller import (
-    TaskCommand,
     TaskControlState,
     apply_task_control_transition,
     task_execution_controller,
@@ -343,24 +342,20 @@ async def _start_a2a_turn(
     context_id: str | None,
     task_id: int | None,
 ) -> Task:
+    async def start_unserialized() -> Task:
+        return await _start_a2a_turn_unserialized(
+            db=db,
+            agent=agent,
+            text=text,
+            message_id=message_id,
+            context_id=context_id,
+            task_id=task_id,
+        )
+
     if task_id is not None:
-        async with task_execution_controller.command(task_id, TaskCommand.MESSAGE):
-            return await _start_a2a_turn_unserialized(
-                db=db,
-                agent=agent,
-                text=text,
-                message_id=message_id,
-                context_id=context_id,
-                task_id=task_id,
-            )
-    return await _start_a2a_turn_unserialized(
-        db=db,
-        agent=agent,
-        text=text,
-        message_id=message_id,
-        context_id=context_id,
-        task_id=task_id,
-    )
+        async with task_execution_controller.command(task_id):
+            return await start_unserialized()
+    return await start_unserialized()
 
 
 async def _start_a2a_turn_unserialized(
@@ -850,7 +845,7 @@ async def cancel_task(
 ) -> Any:
     agent, _key = authed
     _require_bound_agent(agent_id, agent)
-    async with task_execution_controller.command(task_id, TaskCommand.CANCEL):
+    async with task_execution_controller.command(task_id):
         return await _cancel_task_unserialized(task_id=task_id, agent=agent, db=db)
 
 

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Tuple
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import String, and_, cast, false, or_
+from sqlalchemy import String, and_, cast, false, func, or_
 from sqlalchemy.orm import Session
 
 from ..models.agent import Agent
@@ -32,6 +32,12 @@ from ..services.a2a_protocol import (
     task_context_id,
     task_state,
     task_to_a2a,
+)
+from ..services.task_execution_controller import (
+    TaskCommand,
+    TaskControlState,
+    apply_task_control_transition,
+    task_execution_controller,
 )
 from ..services.task_orchestrator import (
     TaskTurnError,
@@ -104,6 +110,11 @@ def _resolve_a2a_task(db: Session, task_id: int, agent: Agent) -> Task:
     return task
 
 
+def _task_run_id(task: Task) -> str | None:
+    run_id = getattr(task, "run_id", None)
+    return str(run_id) if run_id is not None else None
+
+
 def _require_bound_agent(path_agent_id: int, agent: Agent) -> None:
     if int(agent.id) != int(path_agent_id) or not is_published_agent(agent):
         raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
@@ -114,19 +125,30 @@ def _schedule_waiting_a2a_resume(
     task_id: int,
     agent_service: Any,
     task_owner_user_id: int,
+    run_id: str | None,
 ) -> None:
     from .websocket import background_task_manager, execute_resume_background
 
+    if not background_task_manager.reserve_resume(task_id):
+        raise RuntimeError(f"Task {task_id} already has a resume in progress")
     previous_task = background_task_manager.running_tasks.get(task_id)
-    bg_task = asyncio.create_task(
-        execute_resume_background(
-            task_id=task_id,
-            agent_service=agent_service,
-            task_owner_user_id=task_owner_user_id,
-            previous_task=previous_task,
+    bg_task: asyncio.Task[None] | None = None
+    try:
+        bg_task = asyncio.create_task(
+            execute_resume_background(
+                task_id=task_id,
+                agent_service=agent_service,
+                task_owner_user_id=task_owner_user_id,
+                expected_run_id=run_id,
+                previous_task=previous_task,
+            )
         )
-    )
-    background_task_manager.register_task(task_id, bg_task)
+        background_task_manager.register_reserved_resume(task_id, bg_task)
+    except BaseException:
+        if bg_task is not None:
+            bg_task.cancel()
+        background_task_manager.release_resume_reservation(task_id)
+        raise
 
 
 def _restore_waiting_resume_claim(db: Session, task_id: int) -> None:
@@ -138,7 +160,14 @@ def _restore_waiting_resume_claim(db: Session, task_id: int) -> None:
             Task.status == TaskStatus.RUNNING,
             Task.runner_id.is_(None),
         )
-        .update({Task.status: TaskStatus.WAITING_FOR_USER}, synchronize_session=False)
+        .update(
+            {
+                Task.status: TaskStatus.WAITING_FOR_USER,
+                Task.control_state: TaskControlState.WAITING_FOR_USER.value,
+                Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+            },
+            synchronize_session=False,
+        )
     )
     db.commit()
     db.expire_all()
@@ -167,6 +196,8 @@ async def _resume_waiting_a2a_task(
                 Task.runner_id: None,
                 Task.lease_expires_at: None,
                 Task.last_heartbeat_at: None,
+                Task.control_state: TaskControlState.RESUME_REQUESTED.value,
+                Task.state_version: func.coalesce(Task.state_version, 0) + 1,
             },
             synchronize_session=False,
         )
@@ -206,7 +237,12 @@ async def _resume_waiting_a2a_task(
         # A WAITING_FOR_USER checkpoint should normally be durable. If it is
         # unavailable, retain the previous restart-safe behavior by starting a
         # new turn from transcript history instead of leaving the task stuck.
-        task.status = TaskStatus.PAUSED
+        apply_task_control_transition(
+            task,
+            TaskControlState.PAUSED,
+            status=TaskStatus.PAUSED,
+            expected_run_id=_task_run_id(task),
+        )
         db.commit()
         db.refresh(task)
         return False
@@ -220,6 +256,7 @@ async def _resume_waiting_a2a_task(
         task_id=task_id,
         agent_service=agent_service,
         task_owner_user_id=int(agent.user_id),
+        run_id=_task_run_id(task),
     )
     return True
 
@@ -298,6 +335,35 @@ def _validate_send_configuration(body: Mapping[str, Any]) -> bool:
 
 
 async def _start_a2a_turn(
+    *,
+    db: Session,
+    agent: Agent,
+    text: str,
+    message_id: str,
+    context_id: str | None,
+    task_id: int | None,
+) -> Task:
+    if task_id is not None:
+        async with task_execution_controller.command(task_id, TaskCommand.MESSAGE):
+            return await _start_a2a_turn_unserialized(
+                db=db,
+                agent=agent,
+                text=text,
+                message_id=message_id,
+                context_id=context_id,
+                task_id=task_id,
+            )
+    return await _start_a2a_turn_unserialized(
+        db=db,
+        agent=agent,
+        text=text,
+        message_id=message_id,
+        context_id=context_id,
+        task_id=task_id,
+    )
+
+
+async def _start_a2a_turn_unserialized(
     *,
     db: Session,
     agent: Agent,
@@ -427,7 +493,12 @@ def _recover_failed_turn_start(
         db.commit()
         return
     if restore_waiting and task.status == TaskStatus.PAUSED:
-        task.status = TaskStatus.WAITING_FOR_USER
+        apply_task_control_transition(
+            task,
+            TaskControlState.WAITING_FOR_USER,
+            status=TaskStatus.WAITING_FOR_USER,
+            expected_run_id=_task_run_id(task),
+        )
         db.commit()
 
 
@@ -779,6 +850,16 @@ async def cancel_task(
 ) -> Any:
     agent, _key = authed
     _require_bound_agent(agent_id, agent)
+    async with task_execution_controller.command(task_id, TaskCommand.CANCEL):
+        return await _cancel_task_unserialized(task_id=task_id, agent=agent, db=db)
+
+
+async def _cancel_task_unserialized(
+    *,
+    task_id: int,
+    agent: Agent,
+    db: Session,
+) -> Any:
     task = _resolve_a2a_task(db, task_id, agent)
     agent_config: dict[str, Any] = (
         dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
@@ -798,7 +879,12 @@ async def cancel_task(
     await background_task_manager.cancel_task(int(task.id))
     agent_config["a2a_state"] = "TASK_STATE_CANCELED"
     setattr(task, "agent_config", agent_config)
-    task.status = TaskStatus.FAILED
+    apply_task_control_transition(
+        task,
+        TaskControlState.FAILED,
+        status=TaskStatus.FAILED,
+        expected_run_id=_task_run_id(task),
+    )
     setattr(task, "output", None)
     setattr(task, "error_message", "Task canceled by A2A client.")
     db.commit()

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2194,13 +2194,10 @@ class AgentServiceManager:
 
         if manage_task_lease and db_session and tracker_task_id:
             from ..services.task_execution_controller import (
-                TaskCommand,
                 task_execution_controller,
             )
 
-            async with task_execution_controller.command(
-                int(tracker_task_id), TaskCommand.START_TURN
-            ):
+            async with task_execution_controller.command(int(tracker_task_id)):
                 lease = acquire_task_lease(db_session, int(tracker_task_id))
             if lease is None:
                 return {

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2193,7 +2193,15 @@ class AgentServiceManager:
                 logger.warning("Quota gate check failed open", exc_info=True)
 
         if manage_task_lease and db_session and tracker_task_id:
-            lease = acquire_task_lease(db_session, int(tracker_task_id))
+            from ..services.task_execution_controller import (
+                TaskCommand,
+                task_execution_controller,
+            )
+
+            async with task_execution_controller.command(
+                int(tracker_task_id), TaskCommand.START_TURN
+            ):
+                lease = acquire_task_lease(db_session, int(tracker_task_id))
             if lease is None:
                 return {
                     "success": False,
@@ -3009,6 +3017,9 @@ async def create_task(
             agent_id=task.agent_id,
             agent_name=task.agent.name if task.agent else None,
             agent_logo_url=task.agent.logo_url if task.agent else None,
+            run_id=task.run_id,
+            state_version=int(task.state_version or 0),
+            control_state=str(task.control_state or "idle"),
         )
 
     except HTTPException:
@@ -3130,6 +3141,9 @@ async def get_tasks(
                         "task_id": task.id,
                         "title": task.title,
                         "status": status_value,
+                        "run_id": task.run_id,
+                        "state_version": int(task.state_version or 0),
+                        "control_state": str(task.control_state or "idle"),
                         "created_at": format_datetime_for_api(task.created_at),
                         "updated_at": format_datetime_for_api(task.updated_at),
                         "model_id": task.model_id,
@@ -3284,6 +3298,9 @@ async def get_task(
                 "title": task.title,
                 "description": task.description,
                 "status": status_value,
+                "run_id": task.run_id,
+                "state_version": int(task.state_version or 0),
+                "control_state": str(task.control_state or "idle"),
                 "created_at": format_datetime_for_api(task.created_at),
                 "updated_at": format_datetime_for_api(task.updated_at),
                 "model_id": model_id,
@@ -3396,6 +3413,9 @@ async def get_task_status(
                 "task_id": task.id,
                 "title": task.title,
                 "status": status_value,
+                "run_id": task.run_id,
+                "state_version": int(task.state_version or 0),
+                "control_state": str(task.control_state or "idle"),
                 "created_at": format_datetime_for_api(task.created_at),
                 "updated_at": format_datetime_for_api(task.updated_at),
                 "model_id": model_id,

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -50,6 +50,10 @@ from ...services.hot_path_cache import (
     task_snapshot_key,
     task_steps_key,
 )
+from ...services.task_execution_controller import (
+    TaskControlState,
+    apply_task_control_transition,
+)
 from ...services.task_orchestrator import (
     TaskTurnError,
     TaskTurnNotFoundError,
@@ -99,7 +103,11 @@ def _mark_task_failed_after_runtime_setup_error(db: Session, task_id: int) -> No
         task = db.query(Task).filter(Task.id == task_id).first()
         if task is not None:
             orm_task = cast(Any, task)
-            orm_task.status = TaskStatus.FAILED
+            apply_task_control_transition(
+                task,
+                TaskControlState.FAILED,
+                status=TaskStatus.FAILED,
+            )
             orm_task.error_message = _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE
             db.commit()
     except Exception:
@@ -297,6 +305,9 @@ async def create_chat_task(
         agent_id=int(agent.id),
         status=started.status.value,
         created_at=task.created_at,
+        run_id=started.run_id,
+        state_version=started.state_version,
+        control_state=started.control_state,
     )
 
 
@@ -475,6 +486,9 @@ async def append_message_to_task(
         agent_id=int(agent.id),
         status=started.status.value,
         accepted_at=started.updated_at,
+        run_id=started.run_id,
+        state_version=started.state_version,
+        control_state=started.control_state,
     )
 
 
@@ -524,6 +538,9 @@ async def get_chat_task(
         task_id=int(task.id),
         agent_id=int(task.agent_id),
         status=task.status.value,
+        run_id=task.run_id,
+        state_version=int(task.state_version or 0),
+        control_state=str(task.control_state or "idle"),
         input=task.input,
         output=task.output,
         error=task.error_message,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2724,6 +2724,7 @@ def _event_task_control_state(message: dict[str, Any]) -> dict[str, Any] | None:
         status = source.get("status")
         if (
             isinstance(version, int)
+            and not isinstance(version, bool)
             and version >= 0
             and isinstance(control_state, str)
             and isinstance(status, str)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -67,7 +67,6 @@ from ..services.managed_file_ref import (
     ensure_uploaded_file_local_path,
 )
 from ..services.task_execution_controller import (
-    TaskCommand,
     TaskControlState,
     apply_task_control_transition,
     task_execution_controller,
@@ -3067,7 +3066,7 @@ async def handle_chat_message(
 ) -> None:
     """Serialize one inbound WebSocket message against task control commands."""
 
-    async with task_execution_controller.command(task_id, TaskCommand.MESSAGE):
+    async with task_execution_controller.command(task_id):
         await _handle_chat_message_unserialized(websocket, task_id, message_data)
 
 
@@ -4958,7 +4957,7 @@ async def handle_pause_task(
 ) -> None:
     """Serialize pause against messages and resume requests for this task."""
 
-    async with task_execution_controller.command(task_id, TaskCommand.PAUSE):
+    async with task_execution_controller.command(task_id):
         await _handle_pause_task_unserialized(websocket, task_id, message_data)
 
 
@@ -5100,7 +5099,7 @@ async def handle_resume_task(
 ) -> None:
     """Serialize resume against messages and pause requests for this task."""
 
-    async with task_execution_controller.command(task_id, TaskCommand.RESUME):
+    async with task_execution_controller.command(task_id):
         await _handle_resume_task_unserialized(websocket, task_id, message_data)
 
 
@@ -5180,7 +5179,7 @@ async def _handle_resume_task_unserialized(
                     websocket,
                 )
                 return
-            await task_execution_controller.transition(
+            resume_snapshot = await task_execution_controller.transition(
                 task_id,
                 TaskControlState.RESUME_REQUESTED,
                 expected_run_id=_task_run_id(task),
@@ -5193,7 +5192,7 @@ async def _handle_resume_task_unserialized(
                         task_id=task_id,
                         agent_service=agent_service,
                         task_owner_user_id=int(task.user_id),
-                        expected_run_id=_task_run_id(task),
+                        expected_run_id=resume_snapshot.run_id,
                         previous_task=previous_task,
                     )
                 )
@@ -5207,10 +5206,10 @@ async def _handle_resume_task_unserialized(
                         task_id,
                         (
                             TaskControlState.WAITING_FOR_USER
-                            if task.status == TaskStatus.WAITING_FOR_USER
+                            if resume_snapshot.status == TaskStatus.WAITING_FOR_USER
                             else TaskControlState.PAUSED
                         ),
-                        expected_run_id=_task_run_id(task),
+                        expected_run_id=resume_snapshot.run_id,
                     )
                 )
                 raise
@@ -5219,7 +5218,7 @@ async def _handle_resume_task_unserialized(
 
         # Check if agent supports resume functionality
         if hasattr(agent_service, "resume_execution"):
-            await task_execution_controller.transition(
+            resume_snapshot = await task_execution_controller.transition(
                 task_id,
                 TaskControlState.RESUME_REQUESTED,
                 expected_run_id=_task_run_id(task),
@@ -5229,7 +5228,7 @@ async def _handle_resume_task_unserialized(
                 task_id,
                 TaskControlState.RUNNING,
                 status=TaskStatus.RUNNING,
-                expected_run_id=_task_run_id(task),
+                expected_run_id=resume_snapshot.run_id,
             )
 
             # Send resume confirmation

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -69,6 +69,7 @@ from ..services.managed_file_ref import (
 from ..services.task_execution_controller import (
     TaskControlState,
     apply_task_control_transition,
+    task_control_snapshot,
     task_execution_controller,
 )
 from ..services.task_lease_service import (
@@ -4780,6 +4781,7 @@ async def send_historical_data_as_stream(
                     "task_id": task_id,
                     "message": message,
                     "timestamp": datetime.now(timezone.utc).timestamp(),
+                    **task_control_snapshot(task).as_dict(),
                 }
                 if question_message:
                     status_event["question"] = question_message
@@ -5158,13 +5160,14 @@ async def _handle_resume_task_unserialized(
             )
             return
 
+        resume_control_state = task_control_snapshot(task).as_dict()
         if getattr(agent_service, "supports_live_control", lambda: False)():
             if task.status not in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
                 await manager.send_personal_message(
                     {
                         "type": "error",
                         "message": "Task is not paused and cannot be resumed.",
-                        "task": {"id": task_id, "status": task.status.value},
+                        "task": {"id": task_id, **resume_control_state},
                     },
                     websocket,
                 )
@@ -5174,7 +5177,7 @@ async def _handle_resume_task_unserialized(
                     {
                         "type": "error",
                         "message": "Task resume is already in progress.",
-                        "task": {"id": task_id, "status": task.status.value},
+                        "task": {"id": task_id, **resume_control_state},
                     },
                     websocket,
                 )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -66,6 +66,12 @@ from ..services.managed_file_ref import (
     DurableStorageOperationError,
     ensure_uploaded_file_local_path,
 )
+from ..services.task_execution_controller import (
+    TaskCommand,
+    TaskControlState,
+    apply_task_control_transition,
+    task_execution_controller,
+)
 from ..services.task_lease_service import (
     acquire_task_lease,
     mark_task_paused_if_stale,
@@ -104,12 +110,17 @@ def _is_task_pause_accepted(task_id: int) -> bool:
 
 
 def _task_status_uses_live_control(
-    status: TaskStatus, *, pause_accepted: bool = False
+    status: TaskStatus,
+    *,
+    control_state: str | None = None,
+    pause_accepted: bool = False,
 ) -> bool:
     """Return True when a user message should be delivered to an active run."""
 
-    if pause_accepted:
+    if pause_accepted or control_state == TaskControlState.PAUSE_REQUESTED.value:
         return False
+    if control_state == TaskControlState.RESUME_REQUESTED.value:
+        return True
     return status in {TaskStatus.WAITING_FOR_USER, TaskStatus.RUNNING}
 
 
@@ -178,12 +189,29 @@ def _terminal_task_error_payload(
     message: str,
     *,
     event_type: str = "agent_error",
+    expected_run_id: str | None = None,
 ) -> dict[str, Any]:
     SessionLocal = get_session_local()
     db = SessionLocal()
     try:
+        current_task = db.query(Task).filter(Task.id == task_id).first()
+        if (
+            current_task is not None
+            and expected_run_id is not None
+            and current_task.run_id != expected_run_id
+        ):
+            logger.info(
+                "Ignoring late terminal error for task %s run %s; current run is %s",
+                task_id,
+                expected_run_id,
+                current_task.run_id,
+            )
+            return _task_error_payload(db, task_id, message, event_type=event_type)
         released = release_current_runner_task_lease_with_workforce_sync(
-            db, task_id, status=TaskStatus.FAILED
+            db,
+            task_id,
+            status=TaskStatus.FAILED,
+            expected_run_id=expected_run_id,
         )
         task = db.query(Task).filter(Task.id == task_id).first()
         if task is not None:
@@ -1363,6 +1391,16 @@ def _task_user_id(task: Any) -> int | None:
     return int(cast(Any, user_id))
 
 
+def _task_run_id(task: Any) -> str | None:
+    run_id = getattr(task, "run_id", None)
+    return str(run_id) if run_id is not None else None
+
+
+def _task_control_state_value(task: Any) -> str | None:
+    control_state = getattr(task, "control_state", None)
+    return str(control_state) if control_state is not None else None
+
+
 async def execute_task_background(
     task_id: int,
     user_message: str,
@@ -1372,6 +1410,7 @@ async def execute_task_background(
     before_message_id: int | None = None,
     llm_user_message: Optional[str] = None,
     task_setup_snapshot: Optional["TaskSetupSnapshot"] = None,
+    expected_run_id: str | None = None,
 ) -> None:
     """Execute task in background without blocking WebSocket message loop.
 
@@ -1525,6 +1564,7 @@ async def execute_task_background(
         # Task execution result is logged by ConsoleTraceHandler, no need for duplicate logs
 
         db_new_gen = get_db()
+        final_control_snapshot = None
         try:
             db_new = next(db_new_gen)
             waiting_for_control = False
@@ -1542,6 +1582,18 @@ async def execute_task_background(
                 final_task_status = TaskStatus.PENDING.value
             task_updated = db_new.query(Task).filter(Task.id == task_id).first()
             if task_updated:
+                if (
+                    expected_run_id is not None
+                    and task_updated.run_id != expected_run_id
+                ):
+                    logger.info(
+                        "Ignoring late task result for task %s run %s; "
+                        "current run is %s",
+                        task_id,
+                        expected_run_id,
+                        task_updated.run_id,
+                    )
+                    return
                 # Caller is responsible for the lease lifecycle (acquire +
                 # release); this function only writes ``status``. The
                 # orchestrator's ``_schedule_bg`` wraps the call in
@@ -1570,7 +1622,18 @@ async def execute_task_background(
                         task_id,
                     )
                 elif result.get("status") == "waiting_for_user":
-                    task_updated.status = TaskStatus.WAITING_FOR_USER
+                    next_control_state = (
+                        TaskControlState.RESUME_REQUESTED
+                        if task_updated.control_state
+                        == TaskControlState.RESUME_REQUESTED.value
+                        else TaskControlState.WAITING_FOR_USER
+                    )
+                    final_control_snapshot = apply_task_control_transition(
+                        task_updated,
+                        next_control_state,
+                        status=TaskStatus.WAITING_FOR_USER,
+                        expected_run_id=expected_run_id,
+                    )
                     sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     db_new.commit()
                     waiting_for_control = True
@@ -1578,7 +1641,18 @@ async def execute_task_background(
                         f"Updated task {task_id} status to WAITING_FOR_USER for v2 control state"
                     )
                 elif result.get("status") == "interrupted":
-                    task_updated.status = TaskStatus.PAUSED
+                    next_control_state = (
+                        TaskControlState.RESUME_REQUESTED
+                        if task_updated.control_state
+                        == TaskControlState.RESUME_REQUESTED.value
+                        else TaskControlState.PAUSED
+                    )
+                    final_control_snapshot = apply_task_control_transition(
+                        task_updated,
+                        next_control_state,
+                        status=TaskStatus.PAUSED,
+                        expected_run_id=expected_run_id,
+                    )
                     sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     db_new.commit()
                     waiting_for_control = True
@@ -1589,10 +1663,22 @@ async def execute_task_background(
                     TaskStatus.PAUSED,
                     TaskStatus.WAITING_FOR_USER,
                 }:
-                    if result.get("success", False):
-                        task_updated.status = TaskStatus.COMPLETED
-                    else:
-                        task_updated.status = TaskStatus.FAILED
+                    final_control_state = (
+                        TaskControlState.COMPLETED
+                        if result.get("success", False)
+                        else TaskControlState.FAILED
+                    )
+                    final_status = (
+                        TaskStatus.COMPLETED
+                        if result.get("success", False)
+                        else TaskStatus.FAILED
+                    )
+                    final_control_snapshot = apply_task_control_transition(
+                        task_updated,
+                        final_control_state,
+                        status=final_status,
+                        expected_run_id=expected_run_id,
+                    )
                     sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     # Do NOT commit the terminal status here. Leave it
                     # pending so the assistant-message persistence below
@@ -1723,6 +1809,12 @@ async def execute_task_background(
 
         # Note: trace_task_completion is handled by the agent execution logic (e.g., dag_plan_execute.py)
 
+        control_event_state = (
+            final_control_snapshot.as_dict()
+            if final_control_snapshot is not None
+            else {}
+        )
+
         if waiting_for_control:
             await manager.broadcast_to_task(
                 create_stream_event(
@@ -1737,6 +1829,7 @@ async def execute_task_background(
                         "agent_id": broadcast_agent_meta["agent_id"],
                         "agent_name": broadcast_agent_meta["agent_name"],
                         "agent_logo_url": broadcast_agent_meta["agent_logo_url"],
+                        **control_event_state,
                     },
                     broadcast_meta["updated_at"] or None,
                 ),
@@ -1759,6 +1852,7 @@ async def execute_task_background(
                 "output": ai_response,
                 "file_outputs": normalized_outputs,
                 "success": result.get("success", False),
+                **control_event_state,
                 "chat_response": chat_response
                 if isinstance(chat_response, dict)
                 else None,
@@ -1783,6 +1877,7 @@ async def execute_task_background(
             current = status_db.query(Task).filter(Task.id == task_id).first()
             still_running = current is not None and (
                 current.status == TaskStatus.RUNNING
+                and (expected_run_id is None or current.run_id == expected_run_id)
             )
         finally:
             status_db.close()
@@ -1811,6 +1906,7 @@ async def execute_task_background(
                             task_id,
                             message,
                             event_type="task_error",
+                            expected_run_id=expected_run_id,
                         ),
                         "task_id": task_id,
                         "error": message,
@@ -1875,6 +1971,7 @@ async def execute_resume_background(
     delivery_already_dispatched: bool = False,
     delivery_websocket: WebSocket | None = None,
     delivery_client_message_id: str | None = None,
+    expected_run_id: str | None = None,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
@@ -1901,6 +1998,7 @@ async def execute_resume_background(
     agent_name: str | None = None
     agent_logo_url: str | None = None
     delivery_was_dispatched = delivery_already_dispatched
+    final_control_snapshot = None
 
     async def notify_deferred_delivery(
         accepted: bool,
@@ -1945,7 +2043,11 @@ async def execute_resume_background(
         db_gen = get_db()
         db_lease = next(db_gen)
         try:
-            lease = acquire_task_lease(db_lease, task_id)
+            lease = acquire_task_lease(
+                db_lease,
+                task_id,
+                expected_run_id=expected_run_id,
+            )
             if lease is not None:
                 task_for_sync = db_lease.query(Task).filter(Task.id == task_id).first()
                 # Same owner guard as ``execute_task_background``: the resume
@@ -1968,6 +2070,8 @@ async def execute_resume_background(
                 if task_for_sync is not None and sync_workforce_run_status(
                     db_lease, task_for_sync, TaskStatus.RUNNING
                 ):
+                    db_lease.commit()
+                elif task_for_sync is not None:
                     db_lease.commit()
         finally:
             db_lease.close()
@@ -2103,6 +2207,18 @@ async def execute_resume_background(
                 else:
                     final_task_status = TaskStatus.FAILED
 
+                final_control_snapshot = apply_task_control_transition(
+                    task_updated,
+                    {
+                        TaskStatus.WAITING_FOR_USER: TaskControlState.WAITING_FOR_USER,
+                        TaskStatus.PAUSED: TaskControlState.PAUSED,
+                        TaskStatus.COMPLETED: TaskControlState.COMPLETED,
+                        TaskStatus.FAILED: TaskControlState.FAILED,
+                    }[final_task_status],
+                    status=final_task_status,
+                    expected_run_id=expected_run_id,
+                )
+
                 if success and output.strip() and task_owner_user_id is not None:
                     from ..services.chat_history_service import (
                         persist_assistant_message_no_commit,
@@ -2124,7 +2240,10 @@ async def execute_resume_background(
                     orm_task_updated.output = None
                     orm_task_updated.error_message = output or "Task execution failed."
                 lease_released = release_current_runner_task_lease_with_workforce_sync(
-                    db_new, task_id, status=final_task_status
+                    db_new,
+                    task_id,
+                    status=final_task_status,
+                    expected_run_id=expected_run_id,
                 )
                 db_new.refresh(task_updated)
                 final_status = task_updated.status.value
@@ -2138,6 +2257,12 @@ async def execute_resume_background(
                 delivery_turn_id,
                 DELIVERY_COMPLETED,
             )
+
+        control_event_state = (
+            final_control_snapshot.as_dict()
+            if final_control_snapshot is not None
+            else {}
+        )
 
         if status in {"interrupted", "waiting_for_user"}:
             await manager.broadcast_to_task(
@@ -2153,6 +2278,7 @@ async def execute_resume_background(
                         "agent_id": task_agent_id,
                         "agent_name": agent_name,
                         "agent_logo_url": agent_logo_url,
+                        **control_event_state,
                     },
                 ),
                 task_id,
@@ -2172,6 +2298,7 @@ async def execute_resume_background(
                 "output": output,
                 "file_outputs": normalized_outputs,
                 "success": success,
+                **control_event_state,
                 "metadata": result.get("metadata", {}),
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
@@ -2207,12 +2334,26 @@ async def execute_resume_background(
                 error_message,
                 retry_with_new_id=True,
             )
+        current_snapshot = (
+            await task_execution_controller.snapshot(task_id)
+            if expected_run_id is not None
+            else None
+        )
+        if current_snapshot is not None and current_snapshot.run_id != expected_run_id:
+            logger.info(
+                "Suppressing late resume error for task %s run %s; current run is %s",
+                task_id,
+                expected_run_id,
+                current_snapshot.run_id,
+            )
+            return
         await manager.broadcast_to_task(
             {
                 **_terminal_task_error_payload(
                     task_id,
                     error_message,
                     event_type="task_error",
+                    expected_run_id=expected_run_id,
                 ),
                 "task_id": task_id,
                 "error": error_message,
@@ -2517,6 +2658,124 @@ async def redirect_legacy_preview(
     )
 
 
+_VERSIONED_TASK_EVENT_TYPES = {
+    "agent_error",
+    "error",
+    "task_completed",
+    "task_error",
+    "task_pause_requested",
+    "task_paused",
+    "task_resumed",
+    "task_started",
+    "task_waiting_for_user",
+}
+
+
+def _is_versioned_task_event(message: dict[str, Any]) -> bool:
+    message_type = str(message.get("type") or "")
+    if message_type in _VERSIONED_TASK_EVENT_TYPES:
+        return True
+    return (
+        message_type == "trace_event"
+        and str(
+            message.get("event_type")
+            or (
+                message.get("data", {}).get("event_type")
+                if isinstance(message.get("data"), dict)
+                else ""
+            )
+        )
+        == "task_info"
+    )
+
+
+def _event_task_id(message: dict[str, Any]) -> int | None:
+    candidates = [message.get("task_id")]
+    task_data = message.get("task")
+    if isinstance(task_data, dict):
+        candidates.append(task_data.get("id"))
+        candidates.append(task_data.get("task_id"))
+    data = message.get("data")
+    if isinstance(data, dict):
+        candidates.append(data.get("id"))
+        candidates.append(data.get("task_id"))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            return int(candidate)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _event_task_control_state(message: dict[str, Any]) -> dict[str, Any] | None:
+    sources = [message]
+    task_data = message.get("task")
+    if isinstance(task_data, dict):
+        sources.append(task_data)
+    data = message.get("data")
+    if isinstance(data, dict):
+        sources.append(data)
+
+    for source in sources:
+        version = source.get("state_version")
+        control_state = source.get("control_state")
+        status = source.get("status")
+        if (
+            isinstance(version, int)
+            and version >= 0
+            and isinstance(control_state, str)
+            and isinstance(status, str)
+            and (isinstance(source.get("run_id"), str) or source.get("run_id") is None)
+        ):
+            return {
+                "run_id": source.get("run_id"),
+                "state_version": version,
+                "control_state": control_state,
+                "status": status,
+            }
+    return None
+
+
+async def _with_current_task_control_state(
+    message: dict[str, Any],
+    *,
+    fallback_task_id: int | None = None,
+) -> dict[str, Any]:
+    """Attach one canonical DB state tuple to a state-bearing event.
+
+    Event producers can finish out of order. Preserve a producer-captured
+    state tuple when present; otherwise attach the current row snapshot.
+    Clients compare the resulting ``run_id`` / ``state_version`` before
+    applying the event.
+    """
+
+    if not _is_versioned_task_event(message):
+        return message
+    task_id = _event_task_id(message) or fallback_task_id
+    if task_id is None:
+        return message
+    state = _event_task_control_state(message)
+    if state is None:
+        snapshot = await task_execution_controller.snapshot(task_id)
+        if snapshot is None:
+            return message
+        state = snapshot.as_dict()
+    enriched = dict(message)
+    enriched.update(state)
+    enriched["task_id"] = task_id
+
+    if enriched.get("type") == "trace_event":
+        data = enriched.get("data")
+        enriched["data"] = {**(data if isinstance(data, dict) else {}), **state}
+
+    task_data = enriched.get("task")
+    if isinstance(task_data, dict):
+        enriched["task"] = {**task_data, **state, "id": task_id}
+    return enriched
+
+
 # Connection manager
 class ConnectionManager:
     def __init__(self) -> None:
@@ -2563,13 +2822,18 @@ class ConnectionManager:
         )
 
     async def send_personal_message(self, message: dict, websocket: WebSocket) -> None:
-        await websocket.send_text(json.dumps(message))
+        versioned_message = await _with_current_task_control_state(message)
+        await websocket.send_text(json.dumps(versioned_message))
 
     async def broadcast_to_task(self, message: dict, task_id: int) -> None:
         if task_id in self.active_connections:
+            versioned_message = await _with_current_task_control_state(
+                message,
+                fallback_task_id=task_id,
+            )
             for connection in self.active_connections[task_id].copy():
                 try:
-                    await connection.send_text(json.dumps(message))
+                    await connection.send_text(json.dumps(versioned_message))
                 except (ConnectionError, WebSocketDisconnect, RuntimeError) as e:
                     # Network connection error, remove disconnected connection
                     logger.warning(f"Connection error for task {task_id}: {e}")
@@ -2798,6 +3062,15 @@ async def get_authenticated_user(
 
 
 async def handle_chat_message(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
+    """Serialize one inbound WebSocket message against task control commands."""
+
+    async with task_execution_controller.command(task_id, TaskCommand.MESSAGE):
+        await _handle_chat_message_unserialized(websocket, task_id, message_data)
+
+
+async def _handle_chat_message_unserialized(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
     """Handle chat message"""
@@ -3197,6 +3470,7 @@ async def handle_chat_message(
                 pause_accepted = _is_task_pause_accepted(task_id)
                 task_uses_live_control = _task_status_uses_live_control(
                     task.status,
+                    control_state=_task_control_state_value(task),
                     pause_accepted=pause_accepted,
                 )
                 agent_service = None
@@ -3414,6 +3688,12 @@ async def handle_chat_message(
                         # before the coordinator can be registered.
                         delivery_dispatched = posted
 
+                        await task_execution_controller.transition(
+                            task_id,
+                            TaskControlState.RESUME_REQUESTED,
+                            expected_run_id=_task_run_id(task),
+                        )
+
                         previous_task = background_task_manager.running_tasks.get(
                             task_id
                         )
@@ -3422,6 +3702,7 @@ async def handle_chat_message(
                                 task_id=task_id,
                                 agent_service=agent_service,
                                 task_owner_user_id=int(task.user_id),
+                                expected_run_id=_task_run_id(task),
                                 previous_task=previous_task,
                                 pending_user_message=(
                                     None
@@ -3971,6 +4252,10 @@ async def handle_execute_task(
                         "description": task.description,
                     },
                     "success": result.get("success", False),
+                    "run_id": _task_run_id(task),
+                    "state_version": int(task.state_version or 0),
+                    "control_state": _task_control_state_value(task) or "idle",
+                    "status": task.status.value,
                     "result": result.get("output", ""),
                     "output": result.get("output", ""),
                     "chat_response": result.get("chat_response"),
@@ -4670,6 +4955,15 @@ async def handle_intervention(
 async def handle_pause_task(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
+    """Serialize pause against messages and resume requests for this task."""
+
+    async with task_execution_controller.command(task_id, TaskCommand.PAUSE):
+        await _handle_pause_task_unserialized(websocket, task_id, message_data)
+
+
+async def _handle_pause_task_unserialized(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle task pause request"""
     db: Session | None = None
     try:
@@ -4732,6 +5026,23 @@ async def handle_pause_task(
                 logger.warning(f"No live execution found to pause for task {task_id}")
                 return
             logger.info("Agent pause_execution completed")
+            db.refresh(task)
+            if task.status != TaskStatus.RUNNING:
+                await manager.send_personal_message(
+                    _task_error_payload(
+                        db,
+                        task_id,
+                        "Task finished before the pause request was applied",
+                    ),
+                    websocket,
+                )
+                return
+            apply_task_control_transition(
+                task,
+                TaskControlState.PAUSE_REQUESTED,
+                expected_run_id=_task_run_id(task),
+            )
+            db.commit()
             _mark_task_pause_accepted(task_id)
 
             # This confirms only that the control request was accepted. The
@@ -4784,6 +5095,15 @@ async def handle_pause_task(
 
 
 async def handle_resume_task(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
+    """Serialize resume against messages and pause requests for this task."""
+
+    async with task_execution_controller.command(task_id, TaskCommand.RESUME):
+        await _handle_resume_task_unserialized(websocket, task_id, message_data)
+
+
+async def _handle_resume_task_unserialized(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
     """Handle task resume request"""
@@ -4859,6 +5179,11 @@ async def handle_resume_task(
                     websocket,
                 )
                 return
+            await task_execution_controller.transition(
+                task_id,
+                TaskControlState.RESUME_REQUESTED,
+                expected_run_id=_task_run_id(task),
+            )
             previous_task = background_task_manager.running_tasks.get(task_id)
             bg_task: asyncio.Task[None] | None = None
             try:
@@ -4867,6 +5192,7 @@ async def handle_resume_task(
                         task_id=task_id,
                         agent_service=agent_service,
                         task_owner_user_id=int(task.user_id),
+                        expected_run_id=_task_run_id(task),
                         previous_task=previous_task,
                     )
                 )
@@ -4875,13 +5201,35 @@ async def handle_resume_task(
                 if bg_task is not None:
                     bg_task.cancel()
                 background_task_manager.release_resume_reservation(task_id)
+                await asyncio.shield(
+                    task_execution_controller.transition(
+                        task_id,
+                        (
+                            TaskControlState.WAITING_FOR_USER
+                            if task.status == TaskStatus.WAITING_FOR_USER
+                            else TaskControlState.PAUSED
+                        ),
+                        expected_run_id=_task_run_id(task),
+                    )
+                )
                 raise
             logger.info(f"Task {task_id} v2 resume scheduled")
             return
 
         # Check if agent supports resume functionality
         if hasattr(agent_service, "resume_execution"):
+            await task_execution_controller.transition(
+                task_id,
+                TaskControlState.RESUME_REQUESTED,
+                expected_run_id=_task_run_id(task),
+            )
             await agent_service.resume_execution()
+            await task_execution_controller.transition(
+                task_id,
+                TaskControlState.RUNNING,
+                status=TaskStatus.RUNNING,
+                expected_run_id=_task_run_id(task),
+            )
 
             # Send resume confirmation
             await manager.broadcast_to_task(

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -20,7 +20,6 @@ from ...models.user import User
 from ...models.user_channel import UserChannel
 from ...services.execution_result_projection import project_execution_result_for_channel
 from ...services.task_execution_controller import (
-    TaskCommand,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
@@ -256,9 +255,7 @@ class FeishuBotInstance:
             else:
                 is_new_task = False
 
-            async with task_execution_controller.command(
-                int(task.id), TaskCommand.CHANNEL_MESSAGE
-            ):
+            async with task_execution_controller.command(int(task.id)):
                 db.refresh(task)
                 if task.status == TaskStatus.RUNNING:
                     await self._send_text(

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -19,6 +19,13 @@ from ...models.task import Task, TaskStatus
 from ...models.user import User
 from ...models.user_channel import UserChannel
 from ...services.execution_result_projection import project_execution_result_for_channel
+from ...services.task_execution_controller import (
+    TaskCommand,
+    TaskControlState,
+    apply_task_control_transition,
+    control_state_for_status,
+    task_execution_controller,
+)
 from .trace_handler import FeishuTraceHandler
 
 logger = logging.getLogger(__name__)
@@ -121,6 +128,8 @@ class FeishuBotInstance:
 
         db_gen = get_db()
         db = next(db_gen)
+        claimed_task_id: int | None = None
+        claimed_run_id: str | None = None
         try:
             user = None
             if self.channel_id:
@@ -246,8 +255,27 @@ class FeishuBotInstance:
                 self._save_active_tasks()
             else:
                 is_new_task = False
-                task.status = TaskStatus.PENDING
+
+            async with task_execution_controller.command(
+                int(task.id), TaskCommand.CHANNEL_MESSAGE
+            ):
+                db.refresh(task)
+                if task.status == TaskStatus.RUNNING:
+                    await self._send_text(
+                        chat_id,
+                        "I'm still working on the previous message. "
+                        "Please wait for it to finish.",
+                    )
+                    return
+                run_snapshot = apply_task_control_transition(
+                    task,
+                    TaskControlState.RUNNING,
+                    status=TaskStatus.RUNNING,
+                    new_run=True,
+                )
                 db.commit()
+                claimed_task_id = int(task.id)
+                claimed_run_id = run_snapshot.run_id
 
             agent_manager = get_agent_manager()
             agent_service = await agent_manager.get_agent_for_task(
@@ -320,8 +348,19 @@ class FeishuBotInstance:
                 )
 
             projection = project_execution_result_for_channel(result)
-            task.status = projection.task_status
-            db.commit()
+            db.refresh(task)
+            projected_control_state = control_state_for_status(projection.task_status)
+            if (
+                task.status != projection.task_status
+                or task.control_state != projected_control_state.value
+            ):
+                apply_task_control_transition(
+                    task,
+                    projected_control_state,
+                    status=projection.task_status,
+                    expected_run_id=run_snapshot.run_id,
+                )
+                db.commit()
 
             output = projection.visible_text
 
@@ -340,6 +379,26 @@ class FeishuBotInstance:
 
         except Exception as e:
             logger.error(f"Error processing Feishu message: {e}", exc_info=True)
+            if claimed_task_id is not None and claimed_run_id is not None:
+                try:
+                    snapshot = await task_execution_controller.snapshot(claimed_task_id)
+                    if (
+                        snapshot is not None
+                        and snapshot.run_id == claimed_run_id
+                        and snapshot.status == TaskStatus.RUNNING
+                    ):
+                        await task_execution_controller.transition(
+                            claimed_task_id,
+                            TaskControlState.FAILED,
+                            status=TaskStatus.FAILED,
+                            expected_run_id=claimed_run_id,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to finalize Feishu task %s after channel error",
+                        claimed_task_id,
+                        exc_info=True,
+                    )
             await self._send_text(
                 chat_id, "Sorry, an error occurred while processing your request."
             )

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -20,6 +20,7 @@ from ...models.user import User
 from ...models.user_channel import UserChannel
 from ...services.execution_result_projection import project_execution_result_for_channel
 from ...services.task_execution_controller import (
+    StaleTaskRunError,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
@@ -351,13 +352,21 @@ class FeishuBotInstance:
                 task.status != projection.task_status
                 or task.control_state != projected_control_state.value
             ):
-                apply_task_control_transition(
-                    task,
-                    projected_control_state,
-                    status=projection.task_status,
-                    expected_run_id=run_snapshot.run_id,
-                )
-                db.commit()
+                try:
+                    apply_task_control_transition(
+                        task,
+                        projected_control_state,
+                        status=projection.task_status,
+                        expected_run_id=run_snapshot.run_id,
+                    )
+                    db.commit()
+                except StaleTaskRunError:
+                    db.rollback()
+                    logger.info(
+                        "Skipping stale Feishu completion for task %s run %s",
+                        task.id,
+                        run_snapshot.run_id,
+                    )
 
             output = projection.visible_text
 

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -25,6 +25,13 @@ from ...models.uploaded_file import UploadedFile
 from ...models.user import User
 from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
+from ...services.task_execution_controller import (
+    TaskCommand,
+    TaskControlState,
+    apply_task_control_transition,
+    control_state_for_status,
+    task_execution_controller,
+)
 from .handler import TelegramTraceHandler
 from .utils import (
     TelegramFileRef,
@@ -463,6 +470,8 @@ class TelegramBotInstance:
 
         self.user_preparing_executions.add(user_id)
         self._clear_user_stop_request(user_id)
+        claimed_task_id: int | None = None
+        claimed_run_id: str | None = None
         try:
             db_gen = get_db()
             db = next(db_gen)
@@ -531,8 +540,27 @@ class TelegramBotInstance:
                     self._save_active_tasks()
                     is_new_task = True
                 else:
-                    task.status = TaskStatus.PENDING
+                    db.refresh(task)
+
+                async with task_execution_controller.command(
+                    int(task.id), TaskCommand.CHANNEL_MESSAGE
+                ):
+                    db.refresh(task)
+                    if task.status == TaskStatus.RUNNING:
+                        await last_message.answer(
+                            "I'm still working on the previous message. "
+                            "Please wait for it to finish."
+                        )
+                        return
+                    run_snapshot = apply_task_control_transition(
+                        task,
+                        TaskControlState.RUNNING,
+                        status=TaskStatus.RUNNING,
+                        new_run=True,
+                    )
                     db.commit()
+                    claimed_task_id = int(task.id)
+                    claimed_run_id = run_snapshot.run_id
 
                 agent_manager = get_agent_manager()
                 agent_service = await agent_manager.get_agent_for_task(
@@ -547,7 +575,12 @@ class TelegramBotInstance:
                 context: dict = {"turn_id": message_turn_id}
 
                 if self._consume_user_stop_request(user_id):
-                    task.status = TaskStatus.PAUSED
+                    apply_task_control_transition(
+                        task,
+                        TaskControlState.PAUSED,
+                        status=TaskStatus.PAUSED,
+                        expected_run_id=run_snapshot.run_id,
+                    )
                     db.commit()
                     return
 
@@ -581,7 +614,12 @@ class TelegramBotInstance:
                         context["state"]["file_info"] = uploaded_info
 
                 if self._consume_user_stop_request(user_id):
-                    task.status = TaskStatus.PAUSED
+                    apply_task_control_transition(
+                        task,
+                        TaskControlState.PAUSED,
+                        status=TaskStatus.PAUSED,
+                        expected_run_id=run_snapshot.run_id,
+                    )
                     db.commit()
                     return
 
@@ -615,7 +653,12 @@ class TelegramBotInstance:
 
                 try:
                     if self._consume_user_stop_request(user_id):
-                        task.status = TaskStatus.PAUSED
+                        apply_task_control_transition(
+                            task,
+                            TaskControlState.PAUSED,
+                            status=TaskStatus.PAUSED,
+                            expected_run_id=run_snapshot.run_id,
+                        )
                         db.commit()
                         return
 
@@ -639,8 +682,21 @@ class TelegramBotInstance:
                         agent_service.tracer.handlers.remove(tg_handler)
 
                 projection = project_execution_result_for_channel(result)
-                task.status = projection.task_status
-                db.commit()
+                db.refresh(task)
+                projected_control_state = control_state_for_status(
+                    projection.task_status
+                )
+                if (
+                    task.status != projection.task_status
+                    or task.control_state != projected_control_state.value
+                ):
+                    apply_task_control_transition(
+                        task,
+                        projected_control_state,
+                        status=projection.task_status,
+                        expected_run_id=run_snapshot.run_id,
+                    )
+                    db.commit()
 
                 persist_telegram_assistant_turn(
                     db=db,
@@ -714,6 +770,26 @@ class TelegramBotInstance:
                     pass
         except Exception as e:
             logger.error(f"Error processing Telegram message: {e}")
+            if claimed_task_id is not None and claimed_run_id is not None:
+                try:
+                    snapshot = await task_execution_controller.snapshot(claimed_task_id)
+                    if (
+                        snapshot is not None
+                        and snapshot.run_id == claimed_run_id
+                        and snapshot.status == TaskStatus.RUNNING
+                    ):
+                        await task_execution_controller.transition(
+                            claimed_task_id,
+                            TaskControlState.FAILED,
+                            status=TaskStatus.FAILED,
+                            expected_run_id=claimed_run_id,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to finalize Telegram task %s after channel error",
+                        claimed_task_id,
+                        exc_info=True,
+                    )
             await last_message.answer(
                 "Sorry, an error occurred while processing your request."
             )

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -26,6 +26,7 @@ from ...models.user import User
 from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
 from ...services.task_execution_controller import (
+    StaleTaskRunError,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
@@ -687,13 +688,21 @@ class TelegramBotInstance:
                     task.status != projection.task_status
                     or task.control_state != projected_control_state.value
                 ):
-                    apply_task_control_transition(
-                        task,
-                        projected_control_state,
-                        status=projection.task_status,
-                        expected_run_id=run_snapshot.run_id,
-                    )
-                    db.commit()
+                    try:
+                        apply_task_control_transition(
+                            task,
+                            projected_control_state,
+                            status=projection.task_status,
+                            expected_run_id=run_snapshot.run_id,
+                        )
+                        db.commit()
+                    except StaleTaskRunError:
+                        db.rollback()
+                        logger.info(
+                            "Skipping stale Telegram completion for task %s run %s",
+                            task.id,
+                            run_snapshot.run_id,
+                        )
 
                 persist_telegram_assistant_turn(
                     db=db,

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -26,7 +26,6 @@ from ...models.user import User
 from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
 from ...services.task_execution_controller import (
-    TaskCommand,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
@@ -542,9 +541,7 @@ class TelegramBotInstance:
                 else:
                     db.refresh(task)
 
-                async with task_execution_controller.command(
-                    int(task.id), TaskCommand.CHANNEL_MESSAGE
-                ):
+                async with task_execution_controller.command(int(task.id)):
                     db.refresh(task)
                     if task.status == TaskStatus.RUNNING:
                         await last_message.answer(

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -86,6 +86,14 @@ class Task(Base):  # type: ignore
     lease_expires_at = Column(DateTime(timezone=True), nullable=True)
     last_heartbeat_at = Column(DateTime(timezone=True), nullable=True)
     last_checkpoint_event_id = Column(String(255), nullable=True)
+    # Monotonic task-control identity. ``run_id`` changes for each new turn,
+    # while pause/resume transitions retain it and advance ``state_version``.
+    # Clients use the version to ignore stale WebSocket status events.
+    run_id = Column(String(64), nullable=True, index=True)
+    state_version = Column(Integer, nullable=False, default=0, server_default="0")
+    control_state = Column(
+        String(32), nullable=False, default="idle", server_default="idle"
+    )
 
     # Model configuration
     model_name = Column(String(255), nullable=True)  # Main model used for the task

--- a/src/xagent/web/schemas/chat.py
+++ b/src/xagent/web/schemas/chat.py
@@ -105,6 +105,9 @@ class TaskCreateResponse(BaseModel):
     agent_id: Optional[int] = None
     agent_name: Optional[str] = None
     agent_logo_url: Optional[str] = None
+    run_id: Optional[str] = None
+    state_version: int = 0
+    control_state: str = "idle"
 
 
 class ExecutionStatus(BaseModel):

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -226,6 +226,13 @@ class CreateTaskResponse(BaseModel):
         ),
     )
     created_at: datetime = Field(..., description="UTC creation timestamp.")
+    run_id: str = Field(..., description="Identity of the accepted execution run.")
+    state_version: int = Field(
+        ..., description="Monotonic version of the task control state."
+    )
+    control_state: str = Field(
+        ..., description="Detailed control state, such as running or pause_requested."
+    )
 
 
 class AppendMessageRequest(BaseModel):
@@ -284,6 +291,11 @@ class AppendMessageResponse(BaseModel):
             "created_at (which may differ slightly due to DB clock)."
         ),
     )
+    run_id: str = Field(..., description="Identity of the accepted execution run.")
+    state_version: int = Field(
+        ..., description="Monotonic version of the task control state."
+    )
+    control_state: str = Field(..., description="Detailed task control state.")
 
 
 class TaskInfoResponse(BaseModel):
@@ -301,6 +313,11 @@ class TaskInfoResponse(BaseModel):
         ...,
         description="One of: pending / running / paused / completed / failed.",
     )
+    run_id: Optional[str] = Field(None, description="Current execution run identity.")
+    state_version: int = Field(
+        0, description="Monotonic version of the task control state."
+    )
+    control_state: str = Field("idle", description="Detailed task control state.")
     input: Optional[str] = Field(
         None,
         description="Latest-turn user input. Null if no message yet recorded.",

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -56,14 +56,17 @@ class TaskControlSnapshot:
 
 
 def control_state_for_status(status: TaskStatus) -> TaskControlState:
-    return {
+    control_state = {
         TaskStatus.PENDING: TaskControlState.IDLE,
         TaskStatus.RUNNING: TaskControlState.RUNNING,
         TaskStatus.PAUSED: TaskControlState.PAUSED,
         TaskStatus.WAITING_FOR_USER: TaskControlState.WAITING_FOR_USER,
         TaskStatus.COMPLETED: TaskControlState.COMPLETED,
         TaskStatus.FAILED: TaskControlState.FAILED,
-    }[status]
+    }.get(status)
+    if control_state is None:
+        raise ValueError(f"Unsupported task status: {status!r}")
+    return control_state
 
 
 def task_control_snapshot(task: Task) -> TaskControlSnapshot:

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -78,8 +78,11 @@ def task_control_snapshot(task: Task) -> TaskControlSnapshot:
         control_state = TaskControlState(raw_state)
     except ValueError:
         control_state = control_state_for_status(task.status)
+    task_id = getattr(task, "id", None)
+    if task_id is None:
+        raise ValueError("Cannot create a task control snapshot for a task with no ID")
     return TaskControlSnapshot(
-        task_id=int(task.id),
+        task_id=int(task_id),
         run_id=getattr(task, "run_id", None),
         state_version=int(getattr(task, "state_version", 0) or 0),
         control_state=control_state,
@@ -121,7 +124,7 @@ def apply_task_control_transition(
     if session is not None and task_id is not None:
         # Preserve caller-owned pending fields (for example A2A cancellation
         # metadata) before the Core UPDATE + refresh below.
-        session.flush()
+        session.flush([task])
         values: dict[Any, Any] = {
             Task.control_state: control_state.value,
             Task.state_version: func.coalesce(Task.state_version, 0) + 1,
@@ -134,14 +137,18 @@ def apply_task_control_transition(
         statement = update(Task).where(Task.id == int(task_id))
         if expected_run_id is not None:
             statement = statement.where(Task.run_id == expected_run_id)
-        result = session.execute(
-            statement.values(values).execution_options(synchronize_session=False)
-        )
-        if int(getattr(result, "rowcount", 0) or 0) != 1:
-            raise StaleTaskRunError(
-                f"task {task_id} no longer belongs to run {expected_run_id}"
+        # Keep unrelated caller-owned pending objects out of this helper's
+        # atomic UPDATE and refresh. ``Session.execute`` and ``refresh`` can
+        # otherwise trigger another session-wide autoflush.
+        with session.no_autoflush:
+            result = session.execute(
+                statement.values(values).execution_options(synchronize_session=False)
             )
-        session.refresh(task)
+            if int(getattr(result, "rowcount", 0) or 0) != 1:
+                raise StaleTaskRunError(
+                    f"task {task_id} no longer belongs to run {expected_run_id}"
+                )
+            session.refresh(task)
         return task_control_snapshot(task)
 
     # Fallback for detached/transient objects. Persistent task rows use the

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -3,6 +3,8 @@
 P1 keeps command serialization process-local. Cross-worker command transport is
 deliberately a later concern; the database state tuple written here is the
 authoritative ordering contract shared by every transport and by the frontend.
+Channel transports share this gate and state tuple but do not yet use the turn
+orchestrator or runner-lease lifecycle.
 """
 
 from __future__ import annotations
@@ -10,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import enum
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, AsyncIterator
 from uuid import uuid4
@@ -18,15 +21,6 @@ from sqlalchemy import func, update
 from sqlalchemy.orm import object_session
 
 from ..models.task import Task, TaskStatus
-
-
-class TaskCommand(str, enum.Enum):
-    START_TURN = "start_turn"
-    MESSAGE = "message"
-    PAUSE = "pause"
-    RESUME = "resume"
-    CANCEL = "cancel"
-    CHANNEL_MESSAGE = "channel_message"
 
 
 class TaskControlState(str, enum.Enum):
@@ -231,6 +225,11 @@ class _ReentrantCommandGate:
             self.lock.release()
 
 
+_command_owners: ContextVar[tuple[tuple[int, int, asyncio.Task[Any]], ...]] = (
+    ContextVar("task_execution_command_owners", default=())
+)
+
+
 class TaskExecutionController:
     """Per-task serial command gate plus versioned state transitions."""
 
@@ -238,17 +237,47 @@ class TaskExecutionController:
         self._gates: dict[int, _ReentrantCommandGate] = {}
 
     @asynccontextmanager
-    async def command(self, task_id: int, command: TaskCommand) -> AsyncIterator[None]:
-        del command  # retained for tracing/debug call sites and future queue metrics
+    async def command(self, task_id: int) -> AsyncIterator[None]:
         normalized_task_id = int(task_id)
         gate = self._gates.setdefault(normalized_task_id, _ReentrantCommandGate())
+        current = asyncio.current_task()
+        if current is None:
+            raise RuntimeError("Task execution command has no current asyncio task")
+
+        # Reentry is safe only in the same asyncio Task. Context is inherited by
+        # child Tasks, so detect the otherwise-self-deadlocking pattern before
+        # the child waits on a gate that its awaiting parent still owns.
+        inherited_owner = next(
+            (
+                owner
+                for controller_id, held_task_id, owner in _command_owners.get()
+                if controller_id == id(self) and held_task_id == normalized_task_id
+            ),
+            None,
+        )
+        if (
+            inherited_owner is not None
+            and inherited_owner is not current
+            and gate.owner is inherited_owner
+        ):
+            raise RuntimeError(
+                f"Task execution command for task {normalized_task_id} cannot be "
+                "reentered from a child asyncio task while its parent holds the gate"
+            )
+
         gate.users += 1
         acquired = False
+        owner_token = None
         try:
             await gate.acquire()
             acquired = True
+            owner_token = _command_owners.set(
+                _command_owners.get() + ((id(self), normalized_task_id, current),)
+            )
             yield
         finally:
+            if owner_token is not None:
+                _command_owners.reset(owner_token)
             if acquired:
                 gate.release()
             gate.users -= 1

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -1,0 +1,273 @@
+"""Serialized task control commands and versioned execution state.
+
+P1 keeps command serialization process-local. Cross-worker command transport is
+deliberately a later concern; the database state tuple written here is the
+authoritative ordering contract shared by every transport and by the frontend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from sqlalchemy import func, update
+from sqlalchemy.orm import object_session
+
+from ..models.task import Task, TaskStatus
+
+
+class TaskCommand(str, enum.Enum):
+    START_TURN = "start_turn"
+    MESSAGE = "message"
+    PAUSE = "pause"
+    RESUME = "resume"
+    CANCEL = "cancel"
+    CHANNEL_MESSAGE = "channel_message"
+
+
+class TaskControlState(str, enum.Enum):
+    IDLE = "idle"
+    RUNNING = "running"
+    PAUSE_REQUESTED = "pause_requested"
+    PAUSED = "paused"
+    RESUME_REQUESTED = "resume_requested"
+    WAITING_FOR_USER = "waiting_for_user"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class StaleTaskRunError(RuntimeError):
+    """Raised when a late transition targets an execution that is no longer current."""
+
+
+@dataclass(frozen=True)
+class TaskControlSnapshot:
+    task_id: int
+    run_id: str | None
+    state_version: int
+    control_state: TaskControlState
+    status: TaskStatus
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "state_version": self.state_version,
+            "control_state": self.control_state.value,
+            "status": self.status.value,
+        }
+
+
+def control_state_for_status(status: TaskStatus) -> TaskControlState:
+    return {
+        TaskStatus.PENDING: TaskControlState.IDLE,
+        TaskStatus.RUNNING: TaskControlState.RUNNING,
+        TaskStatus.PAUSED: TaskControlState.PAUSED,
+        TaskStatus.WAITING_FOR_USER: TaskControlState.WAITING_FOR_USER,
+        TaskStatus.COMPLETED: TaskControlState.COMPLETED,
+        TaskStatus.FAILED: TaskControlState.FAILED,
+    }[status]
+
+
+def task_control_snapshot(task: Task) -> TaskControlSnapshot:
+    raw_state = str(getattr(task, "control_state", None) or "")
+    try:
+        control_state = TaskControlState(raw_state)
+    except ValueError:
+        control_state = control_state_for_status(task.status)
+    return TaskControlSnapshot(
+        task_id=int(task.id),
+        run_id=getattr(task, "run_id", None),
+        state_version=int(getattr(task, "state_version", 0) or 0),
+        control_state=control_state,
+        status=task.status,
+    )
+
+
+def apply_task_control_transition(
+    task: Task,
+    control_state: TaskControlState,
+    *,
+    status: TaskStatus | None = None,
+    new_run: bool = False,
+    expected_run_id: str | None = None,
+) -> TaskControlSnapshot:
+    """Mutate one ORM task with a monotonic control-state transition.
+
+    The caller owns the transaction. This lets terminal task status and its
+    assistant transcript row continue to commit atomically.
+    """
+
+    current_run_id = getattr(task, "run_id", None)
+    if expected_run_id is not None and current_run_id != expected_run_id:
+        raise StaleTaskRunError(
+            f"task {task.id} run changed from {expected_run_id} to {current_run_id}"
+        )
+
+    if new_run:
+        current_run_id = str(uuid4())
+    elif current_run_id is None and control_state not in {
+        TaskControlState.IDLE,
+        TaskControlState.COMPLETED,
+        TaskControlState.FAILED,
+    }:
+        current_run_id = str(uuid4())
+
+    session = object_session(task)
+    task_id = getattr(task, "id", None)
+    if session is not None and task_id is not None:
+        # Preserve caller-owned pending fields (for example A2A cancellation
+        # metadata) before the Core UPDATE + refresh below.
+        session.flush()
+        values: dict[Any, Any] = {
+            Task.control_state: control_state.value,
+            Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+        }
+        if status is not None:
+            values[Task.status] = status
+        if current_run_id != getattr(task, "run_id", None):
+            values[Task.run_id] = current_run_id
+
+        statement = update(Task).where(Task.id == int(task_id))
+        if expected_run_id is not None:
+            statement = statement.where(Task.run_id == expected_run_id)
+        result = session.execute(
+            statement.values(values).execution_options(synchronize_session=False)
+        )
+        if int(getattr(result, "rowcount", 0) or 0) != 1:
+            raise StaleTaskRunError(
+                f"task {task_id} no longer belongs to run {expected_run_id}"
+            )
+        session.refresh(task)
+        return task_control_snapshot(task)
+
+    # Fallback for detached/transient objects. Persistent task rows use the
+    # atomic UPDATE above so concurrent lifecycle writers cannot reuse a
+    # version number.
+    if current_run_id != getattr(task, "run_id", None):
+        setattr(task, "run_id", current_run_id)
+    if status is not None:
+        setattr(task, "status", status)
+    setattr(task, "control_state", control_state.value)
+    setattr(task, "state_version", int(getattr(task, "state_version", 0) or 0) + 1)
+    return task_control_snapshot(task)
+
+
+def transition_task_control_state_sync(
+    task_id: int,
+    control_state: TaskControlState,
+    *,
+    status: TaskStatus | None = None,
+    new_run: bool = False,
+    expected_run_id: str | None = None,
+) -> TaskControlSnapshot:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            raise ValueError(f"Task {task_id} not found")
+        snapshot = apply_task_control_transition(
+            task,
+            control_state,
+            status=status,
+            new_run=new_run,
+            expected_run_id=expected_run_id,
+        )
+        db.commit()
+        return snapshot
+
+
+def load_task_control_snapshot_sync(task_id: int) -> TaskControlSnapshot | None:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        return task_control_snapshot(task) if task is not None else None
+
+
+class _ReentrantCommandGate:
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.owner: asyncio.Task[Any] | None = None
+        self.depth = 0
+        # Includes the owner and tasks waiting to acquire the gate.  A plain
+        # ``lock.locked()`` check is not enough for cleanup: ``release()``
+        # wakes a waiter before that waiter gets CPU time to mark the lock as
+        # held again, which can otherwise let a third command create a second
+        # gate for the same task.
+        self.users = 0
+
+    async def acquire(self) -> None:
+        current = asyncio.current_task()
+        if current is None:
+            raise RuntimeError("Task execution command has no current asyncio task")
+        if self.owner is current:
+            self.depth += 1
+            return
+        await self.lock.acquire()
+        self.owner = current
+        self.depth = 1
+
+    def release(self) -> None:
+        current = asyncio.current_task()
+        if current is None or self.owner is not current:
+            raise RuntimeError("Task execution command gate released by non-owner")
+        self.depth -= 1
+        if self.depth == 0:
+            self.owner = None
+            self.lock.release()
+
+
+class TaskExecutionController:
+    """Per-task serial command gate plus versioned state transitions."""
+
+    def __init__(self) -> None:
+        self._gates: dict[int, _ReentrantCommandGate] = {}
+
+    @asynccontextmanager
+    async def command(self, task_id: int, command: TaskCommand) -> AsyncIterator[None]:
+        del command  # retained for tracing/debug call sites and future queue metrics
+        normalized_task_id = int(task_id)
+        gate = self._gates.setdefault(normalized_task_id, _ReentrantCommandGate())
+        gate.users += 1
+        acquired = False
+        try:
+            await gate.acquire()
+            acquired = True
+            yield
+        finally:
+            if acquired:
+                gate.release()
+            gate.users -= 1
+            if gate.users == 0:
+                self._gates.pop(normalized_task_id, None)
+
+    async def transition(
+        self,
+        task_id: int,
+        control_state: TaskControlState,
+        *,
+        status: TaskStatus | None = None,
+        new_run: bool = False,
+        expected_run_id: str | None = None,
+    ) -> TaskControlSnapshot:
+        return await asyncio.to_thread(
+            transition_task_control_state_sync,
+            int(task_id),
+            control_state,
+            status=status,
+            new_run=new_run,
+            expected_run_id=expected_run_id,
+        )
+
+    async def snapshot(self, task_id: int) -> TaskControlSnapshot | None:
+        return await asyncio.to_thread(load_task_control_snapshot_sync, int(task_id))
+
+
+task_execution_controller = TaskExecutionController()

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -88,6 +88,7 @@ def acquire_task_lease(
     expires_at = _expires_at(now)
     candidate_run_id = expected_run_id or str(uuid.uuid4())
     current_version = func.coalesce(Task.state_version, 0)
+    running_control_state = control_state_for_status(TaskStatus.RUNNING).value
     stmt = (
         update(Task)
         .where(Task.id == task_id)
@@ -109,12 +110,12 @@ def acquire_task_lease(
                 (Task.status != TaskStatus.RUNNING, candidate_run_id),
                 else_=func.coalesce(Task.run_id, candidate_run_id),
             ),
-            control_state="running",
+            control_state=running_control_state,
             state_version=case(
                 (
                     or_(
                         Task.status != TaskStatus.RUNNING,
-                        Task.control_state != "running",
+                        Task.control_state != running_control_state,
                     ),
                     current_version + 1,
                 ),

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
-from sqlalchemy import or_, update
+from sqlalchemy import case, func, or_, update
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -36,6 +36,7 @@ def _rowcount(result: Any) -> int:
 class TaskLease:
     task_id: int
     runner_id: str
+    run_id: str | None = None
 
 
 def get_runner_id() -> str:
@@ -78,11 +79,14 @@ def acquire_task_lease(
     task_id: int,
     *,
     runner_id: str | None = None,
+    expected_run_id: str | None = None,
 ) -> TaskLease | None:
     """Acquire the task execution lease if no live runner owns it."""
     runner = runner_id or get_runner_id()
     now = utc_now()
     expires_at = _expires_at(now)
+    candidate_run_id = expected_run_id or str(uuid.uuid4())
+    current_version = func.coalesce(Task.state_version, 0)
     stmt = (
         update(Task)
         .where(Task.id == task_id)
@@ -100,26 +104,49 @@ def acquire_task_lease(
             runner_id=runner,
             last_heartbeat_at=now,
             lease_expires_at=expires_at,
+            run_id=case(
+                (Task.status != TaskStatus.RUNNING, candidate_run_id),
+                else_=func.coalesce(Task.run_id, candidate_run_id),
+            ),
+            control_state="running",
+            state_version=case(
+                (
+                    or_(
+                        Task.status != TaskStatus.RUNNING,
+                        Task.control_state != "running",
+                    ),
+                    current_version + 1,
+                ),
+                else_=current_version,
+            ),
         )
     )
+    if expected_run_id is not None:
+        stmt = stmt.where(Task.run_id == expected_run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
     db.commit()
     if _rowcount(result) != 1:
         logger.info("Task %s lease acquisition denied for runner %s", task_id, runner)
         return None
+    stored_run_id = db.query(Task.run_id).filter(Task.id == task_id).scalar()
     logger.info(
         "Task %s lease acquired by runner %s until %s",
         task_id,
         runner,
         expires_at.isoformat(),
     )
-    return TaskLease(task_id=task_id, runner_id=runner)
+    return TaskLease(
+        task_id=task_id,
+        runner_id=runner,
+        run_id=str(stored_run_id) if stored_run_id is not None else None,
+    )
 
 
 def acquire_task_lease_isolated(
     task_id: int,
     *,
     runner_id: str | None = None,
+    expected_run_id: str | None = None,
 ) -> TaskLease | None:
     """Same semantics as :func:`acquire_task_lease` but opens, commits,
     and closes its own ``SessionLocal``.
@@ -135,7 +162,12 @@ def acquire_task_lease_isolated(
     SessionLocal = get_session_local()
     db = SessionLocal()
     try:
-        return acquire_task_lease(db, task_id, runner_id=runner_id)
+        return acquire_task_lease(
+            db,
+            task_id,
+            runner_id=runner_id,
+            expected_run_id=expected_run_id,
+        )
     finally:
         db.close()
 
@@ -151,6 +183,8 @@ def refresh_task_lease(db: Session, lease: TaskLease) -> bool:
         .where(Task.status == TaskStatus.RUNNING)
         .values(last_heartbeat_at=now, lease_expires_at=expires_at)
     )
+    if lease.run_id is not None:
+        stmt = stmt.where(Task.run_id == lease.run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
     db.commit()
     return _rowcount(result) == 1
@@ -165,6 +199,8 @@ def release_task_lease(
     """Release a task lease and set its final visible status."""
     if lease is None:
         return False
+    control_state = _control_state_value(status)
+    current_version = func.coalesce(Task.state_version, 0)
     stmt = (
         update(Task)
         .where(Task.id == lease.task_id)
@@ -174,8 +210,18 @@ def release_task_lease(
             runner_id=None,
             lease_expires_at=None,
             last_heartbeat_at=utc_now(),
+            control_state=control_state,
+            state_version=case(
+                (
+                    or_(Task.status != status, Task.control_state != control_state),
+                    current_version + 1,
+                ),
+                else_=current_version,
+            ),
         )
     )
+    if lease.run_id is not None:
+        stmt = stmt.where(Task.run_id == lease.run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
     db.commit()
     return _rowcount(result) == 1
@@ -187,9 +233,12 @@ def release_current_runner_task_lease(
     *,
     status: TaskStatus,
     runner_id: str | None = None,
+    expected_run_id: str | None = None,
 ) -> bool:
     """Release the current runner's lease for a task."""
     runner = runner_id or get_runner_id()
+    control_state = _control_state_value(status)
+    current_version = func.coalesce(Task.state_version, 0)
     stmt = (
         update(Task)
         .where(Task.id == task_id)
@@ -199,11 +248,32 @@ def release_current_runner_task_lease(
             runner_id=None,
             lease_expires_at=None,
             last_heartbeat_at=utc_now(),
+            control_state=control_state,
+            state_version=case(
+                (
+                    or_(Task.status != status, Task.control_state != control_state),
+                    current_version + 1,
+                ),
+                else_=current_version,
+            ),
         )
     )
+    if expected_run_id is not None:
+        stmt = stmt.where(Task.run_id == expected_run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
     db.commit()
     return _rowcount(result) == 1
+
+
+def _control_state_value(status: TaskStatus) -> str:
+    return {
+        TaskStatus.PENDING: "idle",
+        TaskStatus.RUNNING: "running",
+        TaskStatus.PAUSED: "paused",
+        TaskStatus.WAITING_FOR_USER: "waiting_for_user",
+        TaskStatus.COMPLETED: "completed",
+        TaskStatus.FAILED: "failed",
+    }[status]
 
 
 def mark_task_paused_if_stale(db: Session, task: Task) -> bool:
@@ -219,12 +289,24 @@ def mark_task_paused_if_stale(db: Session, task: Task) -> bool:
     if lease_expires_at is not None and lease_expires_at >= now:
         return False
 
-    setattr(
-        task,
-        "status",
+    from .task_execution_controller import (
+        TaskControlState,
+        apply_task_control_transition,
+    )
+
+    next_status = (
         TaskStatus.PAUSED
         if has_agent_checkpoint(db, int(task.id))
-        else TaskStatus.FAILED,
+        else TaskStatus.FAILED
+    )
+    apply_task_control_transition(
+        task,
+        (
+            TaskControlState.PAUSED
+            if next_status == TaskStatus.PAUSED
+            else TaskControlState.FAILED
+        ),
+        status=next_status,
     )
     setattr(task, "runner_id", None)
     setattr(task, "lease_expires_at", None)

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -22,6 +22,7 @@ from ...config import (
 from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
 from ..models.database import get_db
 from ..models.task import Task, TaskStatus, TraceEvent
+from .task_execution_controller import control_state_for_status
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +200,7 @@ def release_task_lease(
     """Release a task lease and set its final visible status."""
     if lease is None:
         return False
-    control_state = _control_state_value(status)
+    control_state = control_state_for_status(status).value
     current_version = func.coalesce(Task.state_version, 0)
     stmt = (
         update(Task)
@@ -237,7 +238,7 @@ def release_current_runner_task_lease(
 ) -> bool:
     """Release the current runner's lease for a task."""
     runner = runner_id or get_runner_id()
-    control_state = _control_state_value(status)
+    control_state = control_state_for_status(status).value
     current_version = func.coalesce(Task.state_version, 0)
     stmt = (
         update(Task)
@@ -263,17 +264,6 @@ def release_current_runner_task_lease(
     result = db.execute(stmt.execution_options(synchronize_session=False))
     db.commit()
     return _rowcount(result) == 1
-
-
-def _control_state_value(status: TaskStatus) -> str:
-    return {
-        TaskStatus.PENDING: "idle",
-        TaskStatus.RUNNING: "running",
-        TaskStatus.PAUSED: "paused",
-        TaskStatus.WAITING_FOR_USER: "waiting_for_user",
-        TaskStatus.COMPLETED: "completed",
-        TaskStatus.FAILED: "failed",
-    }[status]
 
 
 def mark_task_paused_if_stale(db: Session, task: Task) -> bool:

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -243,13 +243,27 @@ class TaskTurnOrchestrator:
                 # may still be running under its own shield. Keep the command
                 # gate until it settles so a replacement message cannot enter
                 # the task while that claim is committing in the background.
-                try:
-                    await operation
-                except Exception:
-                    logger.exception(
-                        "Turn start failed while cancelled caller waited for task %s",
-                        task_id,
-                    )
+                while not operation.done():
+                    try:
+                        await asyncio.shield(operation)
+                    except asyncio.CancelledError:
+                        # Repeated cancellation must not release the command
+                        # gate while the atomic claim is still in flight.
+                        continue
+                    except Exception:
+                        break
+                if not operation.cancelled():
+                    operation_error = operation.exception()
+                    if operation_error is not None:
+                        logger.error(
+                            "Turn start failed while cancelled caller waited for task %s",
+                            task_id,
+                            exc_info=(
+                                type(operation_error),
+                                operation_error,
+                                operation_error.__traceback__,
+                            ),
+                        )
                 raise
 
     @staticmethod

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -58,7 +58,6 @@ from ..models.task import Task, TaskStatus
 from .chat_history_service import mark_user_message_delivery_sync
 from .hot_path_cache import invalidate_task_cache
 from .task_execution_controller import (
-    TaskCommand,
     TaskControlState,
     apply_task_control_transition,
     task_execution_controller,
@@ -224,7 +223,7 @@ class TaskTurnOrchestrator:
     ) -> TurnStarted:
         """Serialize every transport's new-turn command for one task."""
 
-        async with task_execution_controller.command(task_id, TaskCommand.START_TURN):
+        async with task_execution_controller.command(task_id):
             operation = asyncio.create_task(
                 TaskTurnOrchestrator._begin_turn_unserialized(
                     task_id=task_id,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -52,9 +52,17 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from sqlalchemy import func
+
 from ..models.task import Task, TaskStatus
 from .chat_history_service import mark_user_message_delivery_sync
 from .hot_path_cache import invalidate_task_cache
+from .task_execution_controller import (
+    TaskCommand,
+    TaskControlState,
+    apply_task_control_transition,
+    task_execution_controller,
+)
 from .task_lease_service import (
     acquire_task_lease_isolated,
     get_runner_id,
@@ -190,6 +198,9 @@ class TurnStarted:
     before_message_id: Optional[int]
     task_source: Optional[str]
     background_task: "asyncio.Task[None]"
+    run_id: str = ""
+    state_version: int = 0
+    control_state: str = TaskControlState.RUNNING.value
 
 
 class TaskTurnOrchestrator:
@@ -202,6 +213,47 @@ class TaskTurnOrchestrator:
 
     @staticmethod
     async def begin_turn(
+        *,
+        task_id: int,
+        task_owner_user_id: int,
+        payload: TaskTurnPayload,
+        kind: TurnKind,
+        force_fresh: bool = False,
+        context: Optional[Dict[str, Any]] = None,
+        actor_user_id: Optional[int] = None,
+    ) -> TurnStarted:
+        """Serialize every transport's new-turn command for one task."""
+
+        async with task_execution_controller.command(task_id, TaskCommand.START_TURN):
+            operation = asyncio.create_task(
+                TaskTurnOrchestrator._begin_turn_unserialized(
+                    task_id=task_id,
+                    task_owner_user_id=task_owner_user_id,
+                    payload=payload,
+                    kind=kind,
+                    force_fresh=force_fresh,
+                    context=context,
+                    actor_user_id=actor_user_id,
+                )
+            )
+            try:
+                return await asyncio.shield(operation)
+            except asyncio.CancelledError:
+                # The atomic claim/schedule contract is cancellation-safe and
+                # may still be running under its own shield. Keep the command
+                # gate until it settles so a replacement message cannot enter
+                # the task while that claim is committing in the background.
+                try:
+                    await operation
+                except Exception:
+                    logger.exception(
+                        "Turn start failed while cancelled caller waited for task %s",
+                        task_id,
+                    )
+                raise
+
+    @staticmethod
+    async def _begin_turn_unserialized(
         *,
         task_id: int,
         task_owner_user_id: int,
@@ -225,10 +277,10 @@ class TaskTurnOrchestrator:
 
           1. ``_refuse_if_bg_inflight`` — reject if a bg coroutine is still
              running for this task (``TaskTurnError("bg_inflight")``). Pure
-             in-memory dict check. NOTE: it now sits before the
-             ``await asyncio.to_thread`` below, so two concurrent new turns
-             can both pass it; the authoritative serializer is the DB atomic
-             claim (the status-filter rowcount), which lets exactly one win.
+             in-memory dict check. The process-local task controller serializes
+             callers in this worker; callers in different workers can still
+             both pass, so the DB atomic claim remains the authoritative
+             cross-worker guard and lets exactly one win.
           2. ``_begin_turn_atomic_sync`` (off-loop): atomic claim
              (``id == task_id AND user_id == task_owner_user_id AND
              <status_filter>``) + persist + snapshot SELECT + single commit.
@@ -309,6 +361,7 @@ class TaskTurnOrchestrator:
                     task_id=task_id,
                     task_owner_user_id=task_owner_user_id,
                     task_source=res.task_source,
+                    run_id=res.run_id,
                     payload=payload,
                     force_fresh=force_fresh,
                     context=context,
@@ -322,6 +375,7 @@ class TaskTurnOrchestrator:
                     _mark_task_failed_if_running,
                     task_id,
                     "turn scheduling failed after claim commit",
+                    res.run_id,
                 )
                 try:
                     await asyncio.to_thread(
@@ -365,6 +419,9 @@ class TaskTurnOrchestrator:
             updated_at=claimed.updated_at,
             before_message_id=claimed.before_message_id,
             task_source=claimed.task_source,
+            run_id=claimed.run_id,
+            state_version=claimed.state_version,
+            control_state=claimed.control_state,
             background_task=bg_task,
         )
 
@@ -382,6 +439,9 @@ class _ClaimedTurn:
     updated_at: Optional[datetime]
     before_message_id: Optional[int]
     task_source: Optional[str]
+    run_id: str = ""
+    state_version: int = 0
+    control_state: str = TaskControlState.RUNNING.value
 
 
 def _begin_turn_atomic_sync(
@@ -424,6 +484,7 @@ def _begin_turn_atomic_sync(
 
     SessionLocal = get_session_local()
     db = SessionLocal()
+    run_id = str(uuid4())
     try:
         claimed = (
             db.query(Task)
@@ -448,6 +509,9 @@ def _begin_turn_atomic_sync(
                     Task.runner_id: None,
                     Task.lease_expires_at: None,
                     Task.last_heartbeat_at: None,
+                    Task.run_id: run_id,
+                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+                    Task.control_state: TaskControlState.RUNNING.value,
                 },
                 synchronize_session=False,
             )
@@ -482,8 +546,15 @@ def _begin_turn_atomic_sync(
         # in the same transaction). Keeps commit as the last fallible DB op,
         # so there is no post-commit window where the row is RUNNING but this
         # helper still raises.
-        status, updated_at, source = (
-            db.query(Task.status, Task.updated_at, Task.source)
+        status, updated_at, source, stored_run_id, state_version, control_state = (
+            db.query(
+                Task.status,
+                Task.updated_at,
+                Task.source,
+                Task.run_id,
+                Task.state_version,
+                Task.control_state,
+            )
             .filter(Task.id == task_id)
             .one()
         )
@@ -513,6 +584,9 @@ def _begin_turn_atomic_sync(
         updated_at=updated_at,
         before_message_id=before_message_id,
         task_source=source,
+        run_id=str(stored_run_id),
+        state_version=int(state_version),
+        control_state=str(control_state),
     )
 
 
@@ -552,7 +626,11 @@ def _get_agent_manager() -> Any:
     return get_agent_manager()
 
 
-def _mark_task_failed_if_running(task_id: int, error_message: str) -> None:
+def _mark_task_failed_if_running(
+    task_id: int,
+    error_message: str,
+    expected_run_id: str | None = None,
+) -> None:
     """Setup/run-error sentinel for ``_schedule_bg._runner``.
 
     ``acquire_task_lease_isolated`` sets ``task.status = RUNNING`` as
@@ -577,9 +655,17 @@ def _mark_task_failed_if_running(task_id: int, error_message: str) -> None:
     try:
         with SessionLocal() as db:
             task = db.query(Task).filter(Task.id == task_id).first()
-            if task is None or task.status != TaskStatus.RUNNING:
+            if (
+                task is None
+                or task.status != TaskStatus.RUNNING
+                or (expected_run_id is not None and task.run_id != expected_run_id)
+            ):
                 return
-            task.status = TaskStatus.FAILED
+            apply_task_control_transition(
+                task,
+                TaskControlState.FAILED,
+                status=TaskStatus.FAILED,
+            )
             task.error_message = error_message  # type: ignore[assignment]
             db.commit()
     except Exception as e:
@@ -730,7 +816,11 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             )
             return
         # Genuinely stuck: our bg coroutine returned, no live lease elsewhere.
-        fresh.status = TaskStatus.FAILED
+        apply_task_control_transition(
+            fresh,
+            TaskControlState.FAILED,
+            status=TaskStatus.FAILED,
+        )
         fresh.error_message = "Task execution failed without status update; see /steps."
         fresh.output = None  # latest-turn snapshot invariant
         sync_workforce_run_status(bg_db, fresh, TaskStatus.FAILED)
@@ -795,6 +885,7 @@ def _schedule_bg(
     task_id: int,
     task_owner_user_id: int,
     task_source: Optional[str],
+    run_id: str | None = None,
     payload: TaskTurnPayload,
     force_fresh: bool,
     context: Optional[Dict[str, Any]],
@@ -853,7 +944,11 @@ def _schedule_bg(
             # event loop (issue #427). ``acquire_task_lease_isolated``
             # wraps the existing helper with its own SessionLocal so
             # the work runs on a worker thread.
-            lease = await asyncio.to_thread(acquire_task_lease_isolated, task_id)
+            lease = await asyncio.to_thread(
+                acquire_task_lease_isolated,
+                task_id,
+                expected_run_id=run_id,
+            )
             if lease is None:
                 logger.info(
                     "task %s acquired by another worker; skipping "
@@ -902,7 +997,9 @@ def _schedule_bg(
                             task_id,
                         )
                         _mark_task_failed_if_running(
-                            task_id, "task vanished before snapshot load"
+                            task_id,
+                            "task vanished before snapshot load",
+                            run_id,
                         )
                         return
 
@@ -917,6 +1014,7 @@ def _schedule_bg(
                         before_message_id=before_message_id,
                         llm_user_message=payload.execution_message,
                         task_setup_snapshot=snapshot,
+                        expected_run_id=run_id,
                     )
                 except Exception as setup_or_run_err:
                     logger.error(
@@ -929,6 +1027,7 @@ def _schedule_bg(
                         task_id,
                         f"setup/run error: "
                         f"{type(setup_or_run_err).__name__}: {setup_or_run_err}",
+                        run_id,
                     )
                     # Do not re-raise: ``finish_turn`` + release below
                     # must run so the lease is freed and the row is
@@ -990,7 +1089,10 @@ def _schedule_bg(
                     # cleanly here -- decorator-style, no perf regression.
                     try:
                         release_current_runner_task_lease_with_workforce_sync(
-                            release_db, task_id, status=final_status
+                            release_db,
+                            task_id,
+                            status=final_status,
+                            expected_run_id=run_id,
                         )
                     except Exception as e:
                         logger.warning(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -584,7 +584,7 @@ def _begin_turn_atomic_sync(
         updated_at=updated_at,
         before_message_id=before_message_id,
         task_source=source,
-        run_id=str(stored_run_id),
+        run_id=str(stored_run_id) if stored_run_id is not None else "",
         state_version=int(state_version),
         control_state=str(control_state),
     )

--- a/src/xagent/web/services/workforce_runtime.py
+++ b/src/xagent/web/services/workforce_runtime.py
@@ -200,9 +200,19 @@ def mark_workforce_task_status(
     clear_output: bool = False,
 ) -> bool:
     """Update the task lifecycle source of truth and project it to WorkforceRun."""
+    from .task_execution_controller import (
+        apply_task_control_transition,
+        control_state_for_status,
+    )
+
     changed = False
-    if task.status != status:
-        task.status = status
+    expected_control_state = control_state_for_status(status)
+    if task.status != status or task.control_state != expected_control_state.value:
+        apply_task_control_transition(
+            task,
+            expected_control_state,
+            status=status,
+        )
         changed = True
     if error_message is not None and task.error_message != error_message:
         setattr(task, "error_message", error_message)
@@ -257,12 +267,14 @@ def release_current_runner_task_lease_with_workforce_sync(
     *,
     status: TaskStatus,
     runner_id: str | None = None,
+    expected_run_id: str | None = None,
 ) -> bool:
     released = release_current_runner_task_lease(
         db,
         task_id,
         status=status,
         runner_id=runner_id,
+        expected_run_id=expected_run_id,
     )
     if not released:
         return released

--- a/tests/alembic/test_20260711_add_task_execution_control_state.py
+++ b/tests/alembic/test_20260711_add_task_execution_control_state.py
@@ -61,3 +61,28 @@ def test_upgrade_adds_and_backfills_task_control_state() -> None:
         assert "run_id" not in downgraded_columns
         assert "state_version" not in downgraded_columns
         assert "control_state" not in downgraded_columns
+
+
+def test_upgrade_defaults_control_state_when_legacy_tasks_lack_status() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+            {"revision": DOWN_REVISION},
+        )
+        connection.execute(text("CREATE TABLE tasks (id INTEGER PRIMARY KEY)"))
+        connection.execute(text("INSERT INTO tasks (id) VALUES (1)"))
+
+        config.attributes["connection"] = connection
+        command.upgrade(config, REVISION)
+
+        row = connection.execute(
+            text("SELECT run_id, state_version, control_state FROM tasks")
+        ).one()
+
+        assert row == (None, 0, "idle")

--- a/tests/alembic/test_20260711_add_task_execution_control_state.py
+++ b/tests/alembic/test_20260711_add_task_execution_control_state.py
@@ -1,0 +1,63 @@
+from alembic import command
+from sqlalchemy import create_engine, inspect, text
+
+from xagent.db.config import create_alembic_config
+
+REVISION = "20260711_task_control_state"
+DOWN_REVISION = "20260710_add_chat_delivery_state"
+
+
+def test_upgrade_adds_and_backfills_task_control_state() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:down_revision)"),
+            {"down_revision": DOWN_REVISION},
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE tasks ("
+                "id INTEGER PRIMARY KEY, status VARCHAR(32) NOT NULL)"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO tasks (id, status) VALUES "
+                "(1, 'RUNNING'), (2, 'paused'), (3, 'completed'), (4, 'pending')"
+            )
+        )
+
+        config.attributes["connection"] = connection
+        command.upgrade(config, REVISION)
+
+        columns = {
+            column["name"] for column in inspect(connection).get_columns("tasks")
+        }
+        indexes = {index["name"] for index in inspect(connection).get_indexes("tasks")}
+        rows = connection.execute(
+            text(
+                "SELECT id, run_id, state_version, control_state FROM tasks ORDER BY id"
+            )
+        ).all()
+
+        assert {"run_id", "state_version", "control_state"} <= columns
+        assert "ix_tasks_run_id" in indexes
+        assert rows == [
+            (1, None, 0, "running"),
+            (2, None, 0, "paused"),
+            (3, None, 0, "completed"),
+            (4, None, 0, "idle"),
+        ]
+
+        command.downgrade(config, DOWN_REVISION)
+        downgraded_columns = {
+            column["name"] for column in inspect(connection).get_columns("tasks")
+        }
+        assert "run_id" not in downgraded_columns
+        assert "state_version" not in downgraded_columns
+        assert "control_state" not in downgraded_columns

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -530,6 +530,12 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
     agent.supports_live_control = MagicMock(return_value=True)
 
     resume_bg = AsyncMock()
+    transition = AsyncMock(
+        return_value=SimpleNamespace(
+            run_id="run-from-resume-transition",
+            status=TaskStatus.PAUSED,
+        )
+    )
     bg_mgr = MagicMock()
     bg_mgr.running_tasks.get = MagicMock(return_value=None)
 
@@ -537,6 +543,10 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
         patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
         patch("xagent.web.api.websocket.manager", ws_manager),
         patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch(
+            "xagent.web.api.websocket.task_execution_controller.transition",
+            new=transition,
+        ),
         patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
     ):
         await handle_resume_task(MagicMock(), int(task.id), {"user": admin})
@@ -545,6 +555,7 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
     assert captured["task_owner_user_id"] == int(owner.id)
     resume_bg.assert_called_once()
     assert resume_bg.call_args.kwargs["task_owner_user_id"] == int(owner.id)
+    assert resume_bg.call_args.kwargs["expected_run_id"] == "run-from-resume-transition"
     bg_mgr.reserve_resume.assert_called_once_with(int(task.id))
     bg_mgr.register_reserved_resume.assert_called_once()
 

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -519,6 +519,33 @@ async def test_resume_admin_on_other_users_task_runs_as_owner(db_session) -> Non
 
 
 @pytest.mark.asyncio
+async def test_resume_rejection_embeds_known_control_state(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.run_id = "run-current"
+    task.state_version = 7
+    task.control_state = "running"
+    db_session.commit()
+    _captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+    agent.supports_live_control = MagicMock(return_value=True)
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await handle_resume_task(MagicMock(), int(task.id), {"user": owner})
+
+    payload = ws_manager.send_personal_message.await_args.args[0]
+    assert payload["task"] == {
+        "id": int(task.id),
+        "run_id": "run-current",
+        "state_version": 7,
+        "control_state": "running",
+        "status": "running",
+    }
+
+
+@pytest.mark.asyncio
 async def test_resume_live_control_admin_runs_background_as_owner(db_session) -> None:
     """Live-control resume schedules ``execute_resume_background``; when an
     admin resumes another user's task it must run with the OWNER's

--- a/tests/web/api/test_websocket_task_control_state.py
+++ b/tests/web/api/test_websocket_task_control_state.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.api.websocket import _with_current_task_control_state
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+
+
+@pytest.fixture()
+def current_task(tmp_path) -> Task:
+    init_db(db_url=f"sqlite:///{tmp_path / 'task-state-events.db'}")
+    db = next(get_db())
+    try:
+        user = User(username="event-user", password_hash="hash", is_admin=False)
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=user.id,
+            title="Event state",
+            description="Event state",
+            status=TaskStatus.RUNNING,
+            execution_mode="auto",
+            run_id="run-current",
+            state_version=7,
+            control_state="running",
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        db.expunge(task)
+        yield task
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.mark.asyncio
+async def test_late_state_event_is_rewritten_to_current_snapshot(current_task) -> None:
+    event = await _with_current_task_control_state(
+        {
+            "type": "task_paused",
+            "task_id": int(current_task.id),
+            "status": "paused",
+        }
+    )
+
+    assert event["type"] == "task_paused"
+    assert event["run_id"] == "run-current"
+    assert event["state_version"] == 7
+    assert event["control_state"] == "running"
+    assert event["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_task_info_trace_gets_versioned_state_tuple(current_task) -> None:
+    event = await _with_current_task_control_state(
+        {
+            "type": "trace_event",
+            "event_type": "task_info",
+            "task_id": int(current_task.id),
+            "data": {"id": int(current_task.id), "status": "paused"},
+        }
+    )
+
+    assert event["state_version"] == 7
+    assert event["data"] == {
+        "id": int(current_task.id),
+        "status": "running",
+        "run_id": "run-current",
+        "state_version": 7,
+        "control_state": "running",
+    }
+
+
+@pytest.mark.asyncio
+async def test_producer_snapshot_is_not_relabelled_as_a_newer_run(current_task) -> None:
+    event = await _with_current_task_control_state(
+        {
+            "type": "task_completed",
+            "task_id": int(current_task.id),
+            "run_id": "run-old",
+            "state_version": 5,
+            "control_state": "completed",
+            "status": "completed",
+            "result": "old result",
+        }
+    )
+
+    assert event["run_id"] == "run-old"
+    assert event["state_version"] == 5
+    assert event["control_state"] == "completed"
+    assert event["status"] == "completed"

--- a/tests/web/api/test_websocket_task_control_state.py
+++ b/tests/web/api/test_websocket_task_control_state.py
@@ -92,3 +92,24 @@ async def test_producer_snapshot_is_not_relabelled_as_a_newer_run(current_task) 
     assert event["state_version"] == 5
     assert event["control_state"] == "completed"
     assert event["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_boolean_state_version_is_replaced_with_current_snapshot(
+    current_task,
+) -> None:
+    event = await _with_current_task_control_state(
+        {
+            "type": "task_completed",
+            "task_id": int(current_task.id),
+            "run_id": "run-old",
+            "state_version": True,
+            "control_state": "completed",
+            "status": "completed",
+        }
+    )
+
+    assert event["run_id"] == "run-current"
+    assert event["state_version"] == 7
+    assert event["control_state"] == "running"
+    assert event["status"] == "running"

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -21,6 +21,17 @@ def test_active_task_user_messages_stay_live_control() -> None:
     assert _task_status_uses_live_control(TaskStatus.WAITING_FOR_USER)
 
 
+def test_requested_control_states_route_messages_consistently() -> None:
+    assert _task_status_uses_live_control(
+        TaskStatus.PAUSED,
+        control_state="resume_requested",
+    )
+    assert not _task_status_uses_live_control(
+        TaskStatus.RUNNING,
+        control_state="pause_requested",
+    )
+
+
 def test_accepted_pause_routes_active_task_out_of_live_control() -> None:
     assert not _task_status_uses_live_control(
         TaskStatus.RUNNING,

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -229,6 +229,9 @@ def test_create_task_happy_path(mock_start_task):
     # POST atomically claims RUNNING before returning 202, so the
     # response body reports the post-claim state, not 'pending'.
     assert body["status"] == "running"
+    assert body["run_id"]
+    assert body["state_version"] == 1
+    assert body["control_state"] == "running"
     assert "task_id" in body
     assert "created_at" in body
     task_id = body["task_id"]
@@ -261,6 +264,9 @@ def test_create_task_happy_path(mock_start_task):
     sdk_task = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
     assert sdk_task.status_code == 200, sdk_task.text
     assert sdk_task.json()["task_id"] == task_id
+    assert sdk_task.json()["run_id"] == body["run_id"]
+    assert sdk_task.json()["state_version"] == body["state_version"]
+    assert sdk_task.json()["control_state"] == "running"
 
     # Background kickoff was called exactly once for this task. The
     # scheduler receives a ``TaskTurnPayload`` carrying both transcript

--- a/tests/web/services/test_task_execution_controller.py
+++ b/tests/web/services/test_task_execution_controller.py
@@ -13,6 +13,8 @@ from xagent.web.services.task_execution_controller import (
     TaskCommand,
     TaskControlState,
     TaskExecutionController,
+    apply_task_control_transition,
+    task_control_snapshot,
     transition_task_control_state_sync,
 )
 
@@ -43,6 +45,43 @@ def _create_task(db) -> Task:
     db.commit()
     db.refresh(task)
     return task
+
+
+def test_snapshot_requires_a_persisted_task_id() -> None:
+    task = Task(
+        user_id=1,
+        title="Transient task",
+        description="Transient task",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+    )
+
+    with pytest.raises(ValueError, match="task with no ID"):
+        task_control_snapshot(task)
+
+
+def test_transition_does_not_flush_unrelated_pending_objects(db_session) -> None:
+    task = _create_task(db_session)
+    unrelated = Task(
+        user_id=task.user_id,
+        title="Unrelated task",
+        description="Unrelated task",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+    )
+    db_session.add(unrelated)
+    db_session.commit()
+    unrelated.title = "Still pending"
+
+    snapshot = apply_task_control_transition(
+        task,
+        TaskControlState.RUNNING,
+        status=TaskStatus.RUNNING,
+        new_run=True,
+    )
+
+    assert snapshot.control_state == TaskControlState.RUNNING
+    assert unrelated in db_session.dirty
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_execution_controller.py
+++ b/tests/web/services/test_task_execution_controller.py
@@ -10,7 +10,6 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.task_execution_controller import (
     StaleTaskRunError,
-    TaskCommand,
     TaskControlState,
     TaskExecutionController,
     apply_task_control_transition,
@@ -92,7 +91,7 @@ async def test_same_task_commands_are_fifo_serialized() -> None:
     order: list[str] = []
 
     async def first() -> None:
-        async with controller.command(7, TaskCommand.MESSAGE):
+        async with controller.command(7):
             order.append("first-enter")
             first_entered.set()
             await release_first.wait()
@@ -100,7 +99,7 @@ async def test_same_task_commands_are_fifo_serialized() -> None:
 
     async def queued(name: str) -> None:
         await first_entered.wait()
-        async with controller.command(7, TaskCommand.PAUSE):
+        async with controller.command(7):
             order.append(name)
 
     tasks = [
@@ -121,9 +120,25 @@ async def test_same_task_commands_are_fifo_serialized() -> None:
 async def test_gate_is_reentrant_for_nested_transport_and_turn_claim() -> None:
     controller = TaskExecutionController()
 
-    async with controller.command(11, TaskCommand.MESSAGE):
-        async with controller.command(11, TaskCommand.START_TURN):
+    async with controller.command(11):
+        async with controller.command(11):
             assert controller._gates[11].depth == 2
+
+    assert controller._gates == {}
+
+
+@pytest.mark.asyncio
+async def test_child_task_reentry_fails_instead_of_deadlocking() -> None:
+    controller = TaskExecutionController()
+
+    async def reenter_from_child() -> None:
+        async with controller.command(11):
+            raise AssertionError("child task must not acquire its parent's gate")
+
+    async with controller.command(11):
+        child = asyncio.create_task(reenter_from_child())
+        with pytest.raises(RuntimeError, match="reentered from a child asyncio task"):
+            await asyncio.wait_for(child, timeout=1)
 
     assert controller._gates == {}
 
@@ -136,16 +151,16 @@ async def test_cancelled_waiter_does_not_split_or_leak_the_gate() -> None:
     third_entered = asyncio.Event()
 
     async def owner() -> None:
-        async with controller.command(19, TaskCommand.MESSAGE):
+        async with controller.command(19):
             owner_entered.set()
             await release_owner.wait()
 
     async def waiter() -> None:
-        async with controller.command(19, TaskCommand.PAUSE):
+        async with controller.command(19):
             raise AssertionError("cancelled waiter must not enter")
 
     async def third() -> None:
-        async with controller.command(19, TaskCommand.RESUME):
+        async with controller.command(19):
             third_entered.set()
 
     owner_task = asyncio.create_task(owner())
@@ -171,7 +186,7 @@ async def test_different_tasks_can_progress_concurrently() -> None:
     entered: set[int] = set()
 
     async def run(task_id: int) -> None:
-        async with controller.command(task_id, TaskCommand.MESSAGE):
+        async with controller.command(task_id):
             entered.add(task_id)
             if len(entered) == 2:
                 both_entered.set()

--- a/tests/web/services/test_task_execution_controller.py
+++ b/tests/web/services/test_task_execution_controller.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.task_execution_controller import (
+    StaleTaskRunError,
+    TaskCommand,
+    TaskControlState,
+    TaskExecutionController,
+    transition_task_control_state_sync,
+)
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'task-controller.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _create_task(db) -> Task:
+    user = User(username="controller-user", password_hash="hash", is_admin=False)
+    db.add(user)
+    db.commit()
+    task = Task(
+        user_id=user.id,
+        title="Controller test",
+        description="Controller test",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_same_task_commands_are_fifo_serialized() -> None:
+    controller = TaskExecutionController()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    order: list[str] = []
+
+    async def first() -> None:
+        async with controller.command(7, TaskCommand.MESSAGE):
+            order.append("first-enter")
+            first_entered.set()
+            await release_first.wait()
+            order.append("first-exit")
+
+    async def queued(name: str) -> None:
+        await first_entered.wait()
+        async with controller.command(7, TaskCommand.PAUSE):
+            order.append(name)
+
+    tasks = [
+        asyncio.create_task(first()),
+        asyncio.create_task(queued("second")),
+        asyncio.create_task(queued("third")),
+    ]
+    await first_entered.wait()
+    await asyncio.sleep(0)
+    release_first.set()
+    await asyncio.gather(*tasks)
+
+    assert order == ["first-enter", "first-exit", "second", "third"]
+    assert controller._gates == {}
+
+
+@pytest.mark.asyncio
+async def test_gate_is_reentrant_for_nested_transport_and_turn_claim() -> None:
+    controller = TaskExecutionController()
+
+    async with controller.command(11, TaskCommand.MESSAGE):
+        async with controller.command(11, TaskCommand.START_TURN):
+            assert controller._gates[11].depth == 2
+
+    assert controller._gates == {}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_does_not_split_or_leak_the_gate() -> None:
+    controller = TaskExecutionController()
+    owner_entered = asyncio.Event()
+    release_owner = asyncio.Event()
+    third_entered = asyncio.Event()
+
+    async def owner() -> None:
+        async with controller.command(19, TaskCommand.MESSAGE):
+            owner_entered.set()
+            await release_owner.wait()
+
+    async def waiter() -> None:
+        async with controller.command(19, TaskCommand.PAUSE):
+            raise AssertionError("cancelled waiter must not enter")
+
+    async def third() -> None:
+        async with controller.command(19, TaskCommand.RESUME):
+            third_entered.set()
+
+    owner_task = asyncio.create_task(owner())
+    await owner_entered.wait()
+    waiter_task = asyncio.create_task(waiter())
+    await asyncio.sleep(0)
+    waiter_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    third_task = asyncio.create_task(third())
+    await asyncio.sleep(0)
+    assert not third_entered.is_set()
+    release_owner.set()
+    await asyncio.gather(owner_task, third_task)
+    assert controller._gates == {}
+
+
+@pytest.mark.asyncio
+async def test_different_tasks_can_progress_concurrently() -> None:
+    controller = TaskExecutionController()
+    both_entered = asyncio.Event()
+    entered: set[int] = set()
+
+    async def run(task_id: int) -> None:
+        async with controller.command(task_id, TaskCommand.MESSAGE):
+            entered.add(task_id)
+            if len(entered) == 2:
+                both_entered.set()
+            await asyncio.wait_for(both_entered.wait(), timeout=1)
+
+    await asyncio.gather(run(1), run(2))
+    assert entered == {1, 2}
+
+
+def test_transitions_keep_run_identity_and_advance_version(db_session) -> None:
+    task = _create_task(db_session)
+
+    running = transition_task_control_state_sync(
+        int(task.id),
+        TaskControlState.RUNNING,
+        status=TaskStatus.RUNNING,
+        new_run=True,
+    )
+    pause_requested = transition_task_control_state_sync(
+        int(task.id),
+        TaskControlState.PAUSE_REQUESTED,
+        expected_run_id=running.run_id,
+    )
+    paused = transition_task_control_state_sync(
+        int(task.id),
+        TaskControlState.PAUSED,
+        status=TaskStatus.PAUSED,
+        expected_run_id=running.run_id,
+    )
+
+    assert running.run_id
+    assert pause_requested.run_id == running.run_id == paused.run_id
+    assert [
+        running.state_version,
+        pause_requested.state_version,
+        paused.state_version,
+    ] == [
+        1,
+        2,
+        3,
+    ]
+    assert pause_requested.status == TaskStatus.RUNNING
+    assert pause_requested.control_state == TaskControlState.PAUSE_REQUESTED
+
+    with pytest.raises(StaleTaskRunError):
+        transition_task_control_state_sync(
+            int(task.id),
+            TaskControlState.COMPLETED,
+            status=TaskStatus.COMPLETED,
+            expected_run_id="superseded-run",
+        )
+
+
+def test_concurrent_transitions_get_distinct_atomic_versions(db_session) -> None:
+    task = _create_task(db_session)
+    running = transition_task_control_state_sync(
+        int(task.id),
+        TaskControlState.RUNNING,
+        status=TaskStatus.RUNNING,
+        new_run=True,
+    )
+
+    def transition(state: TaskControlState):
+        return transition_task_control_state_sync(
+            int(task.id),
+            state,
+            expected_run_id=running.run_id,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        pause_future = executor.submit(transition, TaskControlState.PAUSE_REQUESTED)
+        resume_future = executor.submit(transition, TaskControlState.RESUME_REQUESTED)
+        snapshots = [pause_future.result(), resume_future.result()]
+
+    assert {snapshot.state_version for snapshot in snapshots} == {2, 3}
+    assert {snapshot.run_id for snapshot in snapshots} == {running.run_id}

--- a/tests/web/services/test_task_execution_controller.py
+++ b/tests/web/services/test_task_execution_controller.py
@@ -13,6 +13,7 @@ from xagent.web.services.task_execution_controller import (
     TaskControlState,
     TaskExecutionController,
     apply_task_control_transition,
+    control_state_for_status,
     task_control_snapshot,
     transition_task_control_state_sync,
 )
@@ -57,6 +58,11 @@ def test_snapshot_requires_a_persisted_task_id() -> None:
 
     with pytest.raises(ValueError, match="task with no ID"):
         task_control_snapshot(task)
+
+
+def test_unknown_task_status_has_a_clear_error() -> None:
+    with pytest.raises(ValueError, match="Unsupported task status"):
+        control_state_for_status("cancelled")  # type: ignore[arg-type]
 
 
 def test_transition_does_not_flush_unrelated_pending_objects(db_session) -> None:

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -36,6 +36,10 @@ from xagent.web.services.connector_runtime import (
     pop_ephemeral_runtime_values,
     store_ephemeral_runtime_values,
 )
+from xagent.web.services.task_execution_controller import (
+    TaskCommand,
+    task_execution_controller,
+)
 from xagent.web.services.task_lease_service import get_runner_id
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
@@ -548,6 +552,71 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
         await asyncio.sleep(0.3)
 
     sched.assert_called_once()  # scheduled despite the cancellation
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_keeps_turn_command_gate_until_claim_settles(
+    db_session,
+) -> None:
+    """A second cancellation cannot release the per-task command gate while
+    the shielded claim is still committing in its worker thread."""
+    import threading
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+    claim_started = threading.Event()
+    release_claim = threading.Event()
+    contender_entered = asyncio.Event()
+
+    def blocked_claim(task_id, task_owner_user_id, *, payload, kind):
+        claim_started.set()
+        assert release_claim.wait(timeout=2)
+        return _ClaimedTurn(
+            status=TaskStatus.RUNNING,
+            updated_at=datetime.now(timezone.utc),
+            before_message_id=1,
+            task_source="sdk",
+        )
+
+    async def contender() -> None:
+        async with task_execution_controller.command(int(task.id), TaskCommand.MESSAGE):
+            contender_entered.set()
+
+    sched = MagicMock(return_value=MagicMock())
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator._begin_turn_atomic_sync",
+            new=blocked_claim,
+        ),
+        patch("xagent.web.services.task_orchestrator._schedule_bg", new=sched),
+    ):
+        turn = asyncio.create_task(
+            TaskTurnOrchestrator.begin_turn(
+                task_id=int(task.id),
+                task_owner_user_id=int(user.id),
+                payload=TaskTurnPayload("x"),
+                kind=TurnKind.CREATE,
+            )
+        )
+        while not claim_started.is_set():
+            await asyncio.sleep(0)
+
+        turn.cancel()
+        await asyncio.sleep(0.01)
+        turn.cancel()
+        contender_task = asyncio.create_task(contender())
+        await asyncio.sleep(0.05)
+
+        assert not turn.done()
+        assert not contender_entered.is_set()
+
+        release_claim.set()
+        with pytest.raises(asyncio.CancelledError):
+            await turn
+        await asyncio.wait_for(contender_task, timeout=1)
+
+    assert contender_entered.is_set()
+    sched.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -171,7 +171,7 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
     payload = TaskTurnPayload("first turn")
 
-    await TaskTurnOrchestrator.begin_turn(
+    started = await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=payload,
         task_owner_user_id=int(user.id),
@@ -186,6 +186,9 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     assert task.error_message is None
     assert task.runner_id is None
     assert task.lease_expires_at is None
+    assert task.run_id == started.run_id
+    assert task.state_version == started.state_version == 1
+    assert task.control_state == started.control_state == "running"
     delivery = (
         db_session.query(TaskChatMessage)
         .filter(TaskChatMessage.turn_id == payload.turn_id)

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -36,10 +36,7 @@ from xagent.web.services.connector_runtime import (
     pop_ephemeral_runtime_values,
     store_ephemeral_runtime_values,
 )
-from xagent.web.services.task_execution_controller import (
-    TaskCommand,
-    task_execution_controller,
-)
+from xagent.web.services.task_execution_controller import task_execution_controller
 from xagent.web.services.task_lease_service import get_runner_id
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
@@ -579,7 +576,7 @@ async def test_repeated_cancellation_keeps_turn_command_gate_until_claim_settles
         )
 
     async def contender() -> None:
-        async with task_execution_controller.command(int(task.id), TaskCommand.MESSAGE):
+        async with task_execution_controller.command(int(task.id)):
             contender_entered.set()
 
     sched = MagicMock(return_value=MagicMock())

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -318,6 +318,55 @@ def _create_trace_handler_test_task(
     return SessionLocal, db, task
 
 
+@pytest.mark.asyncio
+async def test_paused_replay_event_embeds_known_control_state(monkeypatch) -> None:
+    SessionLocal, db, task = _create_trace_handler_test_task("paused-replay")
+    task.status = TaskStatus.PAUSED
+    task.run_id = "run-paused"
+    task.state_version = 9
+    task.control_state = "paused"
+    db.commit()
+    task_id = int(task.id)
+    user_id = int(task.user_id)
+    db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    paused_event = next(
+        event for event in sent_events if event.get("type") == "task_paused"
+    )
+    assert paused_event["run_id"] == "run-paused"
+    assert paused_event["state_version"] == 9
+    assert paused_event["control_state"] == "paused"
+    assert paused_event["status"] == "paused"
+
+
 def test_database_trace_handler_dedupes_user_message_turn_id() -> None:
     _, db, task = _create_trace_handler_test_task("tester")
     try:

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -76,14 +76,58 @@ def test_task_lease_acquire_refresh_and_release(db_session) -> None:
     assert task.status == TaskStatus.RUNNING
     assert task.runner_id == "runner-a"
     assert task.lease_expires_at is not None
+    assert task.run_id == lease.run_id
+    assert task.state_version == 1
+    assert task.control_state == "running"
 
     assert acquire_task_lease(db_session, int(task.id), runner_id="runner-b") is None
     assert refresh_task_lease(db_session, lease) is True
     assert release_task_lease(db_session, lease, status=TaskStatus.COMPLETED) is True
     db_session.refresh(task)
     assert task.status == TaskStatus.COMPLETED
+    assert task.state_version == 2
+    assert task.control_state == "completed"
     assert task.runner_id is None
     assert task.lease_expires_at is None
+
+
+def test_lease_acquire_rejects_a_superseded_run(db_session) -> None:
+    task = _create_task(db_session, status=TaskStatus.RUNNING)
+    task.run_id = "current-run"
+    task.control_state = "running"
+    task.state_version = 3
+    db_session.commit()
+
+    assert (
+        acquire_task_lease(
+            db_session,
+            int(task.id),
+            runner_id="runner-a",
+            expected_run_id="old-run",
+        )
+        is None
+    )
+    db_session.refresh(task)
+    assert task.run_id == "current-run"
+    assert task.state_version == 3
+
+
+def test_old_lease_cannot_refresh_or_release_a_new_run(db_session) -> None:
+    task = _create_task(db_session)
+    old_lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert old_lease is not None
+
+    task.run_id = "new-run"
+    task.status = TaskStatus.RUNNING
+    task.control_state = "running"
+    task.runner_id = "runner-a"
+    db_session.commit()
+
+    assert refresh_task_lease(db_session, old_lease) is False
+    assert release_task_lease(db_session, old_lease, status=TaskStatus.FAILED) is False
+    db_session.refresh(task)
+    assert task.run_id == "new-run"
+    assert task.status == TaskStatus.RUNNING
 
 
 def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -282,7 +282,9 @@ async def test_completion_broadcast_failure_keeps_task_completed(
         async def execute_task(self, **kwargs):
             return {"success": True, "output": "ok", "file_outputs": []}
 
-    def fake_payload(task_id, message, *, event_type="agent_error"):
+    def fake_payload(
+        task_id, message, *, event_type="agent_error", expected_run_id=None
+    ):
         payload_calls.append((task_id, message, event_type))
         return {"type": event_type, "task_id": task_id}
 
@@ -379,7 +381,9 @@ async def test_execution_failure_routes_real_error_to_terminal_payload(
         async def execute_task(self, **kwargs):
             raise RuntimeError("agent boom xyz")
 
-    def fake_payload(task_id, message, *, event_type="agent_error"):
+    def fake_payload(
+        task_id, message, *, event_type="agent_error", expected_run_id=None
+    ):
         payload_calls.append((task_id, message, event_type))
         return {"type": event_type, "task_id": task_id}
 
@@ -428,7 +432,9 @@ async def test_assistant_persist_failure_surfaces_as_task_failure(
     def boom(*args, **kwargs):
         raise RuntimeError("durable persist failed")
 
-    def fake_payload(task_id, message, *, event_type="agent_error"):
+    def fake_payload(
+        task_id, message, *, event_type="agent_error", expected_run_id=None
+    ):
         payload_calls.append((task_id, event_type))
         return {"type": event_type, "task_id": task_id}
 
@@ -477,7 +483,9 @@ async def test_empty_reply_turn_still_completes(db_session, monkeypatch):
         async def execute_task(self, **kwargs):
             return {"success": True, "output": "ok", "file_outputs": []}
 
-    def fake_payload(task_id, message, *, event_type="agent_error"):
+    def fake_payload(
+        task_id, message, *, event_type="agent_error", expected_run_id=None
+    ):
         payload_calls.append((task_id, event_type))
         return {"type": event_type, "task_id": task_id}
 


### PR DESCRIPTION
## Summary

- add a reentrant FIFO `TaskExecutionController` so task messages, pause, resume, cancel, and new-turn commands are serialized per task within a worker
- persist `run_id`, monotonic `state_version`, and detailed `control_state` values, and bind task leases/heartbeats/releases to the expected run
- version WebSocket task-state events and make the frontend ignore stale runs, lower versions, and semantically late events
- route WebSocket, v1 API, A2A, Telegram, and Feishu task starts/control transitions through the same control contract
- add the task-control migration plus concurrency, lease, event-ordering, API, and frontend regression coverage

## Why

Task commands and lifecycle events could complete out of order. A delayed pause/completion event could overwrite a newer running state, and an old execution could still refresh or release a lease after a new run had started. There was no durable execution identity or monotonic state version for clients to use when ordering updates.

This PR gives every run an identity, advances task state atomically, preserves producer-captured event versions, and rejects stale run mutations. Cross-worker durable command transport remains a separate follow-up; this phase keeps the command queue process-local while using the database tuple as the ordering contract.

## Validation

- targeted backend pytest suite covering the controller, orchestrator, leases, WebSocket routing/events, v1 tasks, A2A, Workforce, Telegram, and the migration
- `npm run --prefix frontend test:run -- src/contexts/app-context-chat.test.tsx src/hooks/use-websocket.test.ts`
- `npm run --prefix frontend type-check`
- pre-commit: ruff, mypy, end-of-file, trailing whitespace, isort, codespell, Alembic head check, frontend type-check

`npm lint` still reports the repository's existing lint debt in `app-context-chat.tsx`, so that hook was skipped for the commit; the TypeScript type-check and focused frontend tests pass.
