### PR TITLE
enh: dedupe checkpoint trace storage and prune history (20 GB -> 2.2 GB on a real DB)

### DIFF
--- a/example.env
+++ b/example.env
@@ -243,6 +243,17 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # Fallback threshold in tokens when a model has no context window configured.
 # XAGENT_COMPACT_THRESHOLD_DEFAULT="32000"
 
+# Checkpoint storage encoding v2: dedup nested DAG/auto contexts, per-record
+# tool ledgers, and large system prompts into content-addressed blob tables.
+# Decode support is unconditional; this only gates NEW writes. For a mixed
+# fleet, roll out in two phases: deploy every instance with "false" first
+# (decode-only), then remove the override to start writing v2. Default on.
+# XAGENT_CHECKPOINT_ENCODING_V2="true"
+# How many checkpoint trace-event rows to keep per task execution. Older rows
+# are pruned when a new checkpoint is written (resume only reads the latest
+# readable one; a few extras are kept as fallback). "0" disables pruning.
+# XAGENT_CHECKPOINT_HISTORY_LIMIT="8"
+
 # Zhipu Web Search (recommended for Chinese users, get key at https://open.bigmodel.cn/)
 ZHIPU_API_KEY=""
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -71,6 +71,8 @@ WEB_SEARCH_PROVIDER = "XAGENT_WEB_SEARCH_PROVIDER"
 WEB_CRAWL_TLS_IMPERSONATE = "XAGENT_WEB_CRAWL_TLS_IMPERSONATE"
 TOOL_PARALLEL_ENABLED = "XAGENT_TOOL_PARALLEL_ENABLED"
 TOOL_MAX_CONCURRENCY = "XAGENT_TOOL_MAX_CONCURRENCY"
+CHECKPOINT_ENCODING_V2 = "XAGENT_CHECKPOINT_ENCODING_V2"
+CHECKPOINT_HISTORY_LIMIT = "XAGENT_CHECKPOINT_HISTORY_LIMIT"
 COMPACT_THRESHOLD_RATIO = "XAGENT_COMPACT_THRESHOLD_RATIO"
 COMPACT_THRESHOLD_DEFAULT = "XAGENT_COMPACT_THRESHOLD_DEFAULT"
 REDIS_URL = "XAGENT_REDIS_URL"
@@ -423,6 +425,46 @@ def get_tool_max_concurrency() -> int:
         The per-batch concurrency cap (>= 1).
     """
     return _get_positive_int_env(TOOL_MAX_CONCURRENCY, 3)
+
+
+def get_checkpoint_encoding_v2_enabled() -> bool:
+    """Whether checkpoint trace events use the v2 storage encoding.
+
+    v2 extends the v1 refs/blob encoding to nested DAG/auto contexts,
+    per-record tool-ledger dedup, and system-prompt blobs. Decode support
+    for v2 is unconditional; this flag only gates NEW writes so a fleet can
+    be rolled out in two phases (deploy with ``0`` first so every instance
+    can read v2, then remove the override to start writing it).
+
+    Priority:
+        1. XAGENT_CHECKPOINT_ENCODING_V2 environment variable
+        2. Default ``True``
+
+    Returns:
+        True if new checkpoints are written with the v2 encoding.
+    """
+    return _get_bool_env(CHECKPOINT_ENCODING_V2, True)
+
+
+def get_checkpoint_history_limit() -> int:
+    """How many checkpoint trace events to retain per task execution.
+
+    Older checkpoint rows beyond this limit are deleted when a new
+    checkpoint is persisted (resume only ever reads the most recent
+    readable checkpoint; a few older rows are kept as a fallback for
+    unreadable-latest recovery and debugging).
+
+    Priority:
+        1. XAGENT_CHECKPOINT_HISTORY_LIMIT environment variable
+        2. Default ``8``
+
+    ``0`` disables pruning entirely. Invalid values fall back to the
+    default.
+
+    Returns:
+        The number of checkpoint rows to keep per execution (>= 0).
+    """
+    return _get_positive_int_env(CHECKPOINT_HISTORY_LIMIT, 8, minimum=0)
 
 
 def get_compact_threshold_ratio() -> float:

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -20,6 +20,21 @@ CHECKPOINT_EVENT_TYPE = TraceEventType(
 )
 
 
+def checkpoint_execution_id(data: dict[str, Any]) -> str:
+    """Canonical execution id of a checkpoint event payload.
+
+    ``_event_payload`` writes ``root_execution_id`` and ``execution_id``
+    identically today; this helper is the single place that defines the
+    precedence (root first, then the flat field, then the snapshot's own id)
+    so readers, pruning, and the storage encoder cannot drift apart.
+    """
+    snapshot = data.get("snapshot")
+    nested = snapshot.get("execution_id") if isinstance(snapshot, dict) else None
+    return str(
+        data.get("root_execution_id") or data.get("execution_id") or nested or ""
+    )
+
+
 class CheckpointPersistenceError(RuntimeError):
     """Raised when a checkpoint cannot be durably persisted."""
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2084,7 +2084,7 @@ class ReActPattern(AgentPattern):
     def _args_hash(self, args: dict[str, Any]) -> str:
         try:
             canonical = json.dumps(args, sort_keys=True, default=str)
-        except TypeError:
+        except (TypeError, ValueError):
             canonical = str(args)
         # Digest instead of the raw JSON: the hash is persisted in every
         # ledger record, so large args would otherwise be stored twice.

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import hashlib
 import inspect
 import json
 from dataclasses import dataclass, replace
@@ -2082,9 +2083,12 @@ class ReActPattern(AgentPattern):
 
     def _args_hash(self, args: dict[str, Any]) -> str:
         try:
-            return json.dumps(args, sort_keys=True, default=str)
+            canonical = json.dumps(args, sort_keys=True, default=str)
         except TypeError:
-            return str(args)
+            canonical = str(args)
+        # Digest instead of the raw JSON: the hash is persisted in every
+        # ledger record, so large args would otherwise be stored twice.
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _tool_call_args_dict(
         self, tool_call: dict[str, Any], *, require_mapping: bool = False

--- a/src/xagent/migrations/versions/20260711_add_trace_events_task_type_index.py
+++ b/src/xagent/migrations/versions/20260711_add_trace_events_task_type_index.py
@@ -5,7 +5,7 @@ by task_id + event_type on every checkpoint write/resume; without an index
 each lookup scans the table, which keeps growing.
 
 Revision ID: 20260711_add_trace_events_task_idx
-Revises: 20260710_add_chat_delivery_state
+Revises: 20260711_task_control_state
 Create Date: 2026-07-11 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260711_add_trace_events_task_idx"
-down_revision: Union[str, None] = "20260710_add_chat_delivery_state"
+down_revision: Union[str, None] = "20260711_task_control_state"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260711_add_trace_events_task_type_index.py
+++ b/src/xagent/migrations/versions/20260711_add_trace_events_task_type_index.py
@@ -1,0 +1,44 @@
+"""add composite index on trace_events (task_id, event_type)
+
+Checkpoint pruning and latest-checkpoint loading both filter trace_events
+by task_id + event_type on every checkpoint write/resume; without an index
+each lookup scans the table, which keeps growing.
+
+Revision ID: 20260711_add_trace_events_task_idx
+Revises: 20260710_add_chat_delivery_state
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260711_add_trace_events_task_idx"
+down_revision: Union[str, None] = "20260710_add_chat_delivery_state"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "trace_events"
+INDEX = "ix_trace_events_task_id_event_type"
+
+
+def _indexes() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(TABLE)}
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if INDEX not in _indexes():
+        op.create_index(INDEX, TABLE, ["task_id", "event_type"])
+
+
+def downgrade() -> None:
+    if INDEX in _indexes():
+        op.drop_index(INDEX, table_name=TABLE)

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -27,6 +27,10 @@ from ...web.services.trace_message_storage import (
 
 logger = logging.getLogger(__name__)
 
+# Keep IN-clause deletes under SQLite's bind-parameter limit (commonly 999);
+# matches SQL_IN_CLAUSE_CHUNK_SIZE in trace_message_storage.
+PRUNE_DELETE_CHUNK_SIZE = 900
+
 
 def _convert_float_to_datetime(timestamp: Any) -> datetime:
     """Convert float timestamp to datetime for database storage."""
@@ -342,9 +346,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
             if not stale_rows:
                 return
             stale_ids = [row_id for (row_id,) in stale_rows]
-            db.query(DatabaseTraceEvent).filter(
-                DatabaseTraceEvent.id.in_(stale_ids)
-            ).delete(synchronize_session=False)
+            # Chunk the IN clause: a backlog from previously-disabled pruning
+            # can exceed SQLite's bind-parameter limit in one statement.
+            for start in range(0, len(stale_ids), PRUNE_DELETE_CHUNK_SIZE):
+                chunk = stale_ids[start : start + PRUNE_DELETE_CHUNK_SIZE]
+                db.query(DatabaseTraceEvent).filter(
+                    DatabaseTraceEvent.id.in_(chunk)
+                ).delete(synchronize_session=False)
             db.commit()
             logger.debug(
                 "Pruned %d checkpoint rows for task %s execution %s",

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -9,7 +9,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...config import get_checkpoint_history_limit
-from ...core.agent.checkpoint import CHECKPOINT_TYPE, READABLE_CHECKPOINT_TYPES
+from ...core.agent.checkpoint import (
+    CHECKPOINT_TYPE,
+    READABLE_CHECKPOINT_TYPES,
+    checkpoint_execution_id,
+)
 from ...core.agent.trace import BaseTraceHandler
 from ...core.agent.trace import TraceEvent as CoreTraceEvent
 from ...core.tools.adapters.vibe.connector_runtime import (
@@ -20,16 +24,14 @@ from ...web.models.task import Task
 from ...web.models.task import TraceEvent as DatabaseTraceEvent
 from ...web.models.tool_config import ToolUsage
 from ...web.services.trace_message_storage import (
+    SQL_IN_CLAUSE_CHUNK_SIZE,
     CheckpointMessageDecodeError,
+    chunks,
     decode_trace_event_data,
     encode_checkpoint_data_for_storage,
 )
 
 logger = logging.getLogger(__name__)
-
-# Keep IN-clause deletes under SQLite's bind-parameter limit (commonly 999);
-# matches SQL_IN_CLAUSE_CHUNK_SIZE in trace_message_storage.
-PRUNE_DELETE_CHUNK_SIZE = 900
 
 
 def _convert_float_to_datetime(timestamp: Any) -> datetime:
@@ -135,9 +137,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
                 if data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES:
                     continue
-                if str(
-                    data.get("root_execution_id") or data.get("execution_id")
-                ) != str(execution_id):
+                if checkpoint_execution_id(data) != str(execution_id):
                     continue
                 try:
                     data = decode_trace_event_data(
@@ -307,16 +307,16 @@ class DatabaseTraceHandler(BaseTraceHandler):
         Resume only reads the most recent readable checkpoint; a few older
         rows are kept so an unreadable latest can fall back. Runs in its own
         transaction after the checkpoint commit so a prune failure can never
-        take the checkpoint write down with it. Blobs are left in place:
-        they are content-deduplicated, so the surviving checkpoints keep
-        referencing them.
+        take the checkpoint write down with it. Blobs are not touched: most
+        stay referenced by the surviving checkpoints thanks to content
+        dedup, but a blob referenced only by pruned rows (e.g. a message
+        later dropped by context compaction) is orphaned until whole-task
+        deletion cleans it up.
         """
         limit = get_checkpoint_history_limit()
         if limit <= 0:
             return
-        execution_id = str(
-            data.get("execution_id") or data.get("root_execution_id") or ""
-        )
+        execution_id = checkpoint_execution_id(data)
         if not execution_id:
             return
         try:
@@ -348,8 +348,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
             stale_ids = [row_id for (row_id,) in stale_rows]
             # Chunk the IN clause: a backlog from previously-disabled pruning
             # can exceed SQLite's bind-parameter limit in one statement.
-            for start in range(0, len(stale_ids), PRUNE_DELETE_CHUNK_SIZE):
-                chunk = stale_ids[start : start + PRUNE_DELETE_CHUNK_SIZE]
+            for chunk in chunks(stale_ids, SQL_IN_CLAUSE_CHUNK_SIZE):
                 db.query(DatabaseTraceEvent).filter(
                     DatabaseTraceEvent.id.in_(chunk)
                 ).delete(synchronize_session=False)

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from ...config import get_checkpoint_history_limit
 from ...core.agent.checkpoint import CHECKPOINT_TYPE, READABLE_CHECKPOINT_TYPES
 from ...core.agent.trace import BaseTraceHandler
 from ...core.agent.trace import TraceEvent as CoreTraceEvent
@@ -260,6 +261,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
 
             db.commit()
 
+            if (
+                event_type_str == "system_update_general"
+                and isinstance(data, dict)
+                and data.get("checkpoint_type") == CHECKPOINT_TYPE
+            ):
+                self._prune_checkpoint_history(db, data)
+
             logger.debug(
                 f"Saved trace event {event.id} of type {event_type_str} to database"
             )
@@ -288,6 +296,69 @@ class DatabaseTraceHandler(BaseTraceHandler):
             logger.error(f"Failed to save trace event to database: {e}")
             db.rollback()
             raise
+
+    def _prune_checkpoint_history(self, db: Session, data: Dict[str, Any]) -> None:
+        """Drop checkpoint rows beyond the retention limit for one execution.
+
+        Resume only reads the most recent readable checkpoint; a few older
+        rows are kept so an unreadable latest can fall back. Runs in its own
+        transaction after the checkpoint commit so a prune failure can never
+        take the checkpoint write down with it. Blobs are left in place:
+        they are content-deduplicated, so the surviving checkpoints keep
+        referencing them.
+        """
+        limit = get_checkpoint_history_limit()
+        if limit <= 0:
+            return
+        execution_id = str(
+            data.get("execution_id") or data.get("root_execution_id") or ""
+        )
+        if not execution_id:
+            return
+        try:
+            build_filter = (
+                DatabaseTraceEvent.build_id == self.build_id
+                if self.build_id is not None
+                else DatabaseTraceEvent.build_id.is_(None)
+            )
+            stale_rows = (
+                db.query(DatabaseTraceEvent.id)
+                .filter(
+                    DatabaseTraceEvent.task_id == self.task_id,
+                    build_filter,
+                    DatabaseTraceEvent.event_type == "system_update_general",
+                    DatabaseTraceEvent.data["checkpoint_type"]
+                    .as_string()
+                    .in_(sorted(READABLE_CHECKPOINT_TYPES)),
+                    DatabaseTraceEvent.data["execution_id"].as_string() == execution_id,
+                )
+                .order_by(
+                    DatabaseTraceEvent.timestamp.desc(),
+                    DatabaseTraceEvent.id.desc(),
+                )
+                .offset(limit)
+                .all()
+            )
+            if not stale_rows:
+                return
+            stale_ids = [row_id for (row_id,) in stale_rows]
+            db.query(DatabaseTraceEvent).filter(
+                DatabaseTraceEvent.id.in_(stale_ids)
+            ).delete(synchronize_session=False)
+            db.commit()
+            logger.debug(
+                "Pruned %d checkpoint rows for task %s execution %s",
+                len(stale_ids),
+                self.task_id,
+                execution_id,
+            )
+        except Exception:
+            db.rollback()
+            logger.warning(
+                "Failed to prune checkpoint history for task %s",
+                self.task_id,
+                exc_info=True,
+            )
 
     def _is_duplicate_user_message_turn(
         self,

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -24,6 +24,11 @@ from ...web.models.database import get_db
 from ...web.models.task import Task
 from ...web.models.task import TraceEvent as DatabaseTraceEvent
 from ...web.models.tool_config import ToolUsage
+from ...web.services.ops_signals import (
+    CHECKPOINT_DECODE_FALLBACK,
+    clear_degradation,
+    register_degradation,
+)
 from ...web.services.trace_message_storage import (
     SQL_IN_CLAUSE_CHUNK_SIZE,
     CheckpointMessageDecodeError,
@@ -158,7 +163,15 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 except Exception:
                     # E.g. a transient DB error from the blob prefetch. Fall
                     # back to an older readable checkpoint instead of letting
-                    # the error abort loading for the whole task.
+                    # the error abort loading for the whole task. Surface the
+                    # degradation on /health so a systemic decode failure is
+                    # observable instead of only a per-row warning log; the
+                    # signal self-clears on the next successful decode.
+                    register_degradation(
+                        CHECKPOINT_DECODE_FALLBACK,
+                        f"task {self.task_id}: checkpoint decode failed, "
+                        f"fell back past event {row.event_id}",
+                    )
                     logger.warning(
                         "Skipping checkpoint trace event %s for task %s after "
                         "decode failure",
@@ -167,6 +180,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         exc_info=True,
                     )
                     continue
+                clear_degradation(CHECKPOINT_DECODE_FALLBACK)
                 snapshot = data.get("snapshot")
                 return dict(snapshot) if isinstance(snapshot, dict) else None
             return None

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -152,6 +153,18 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         row.event_id,
                         self.task_id,
                         exc,
+                    )
+                    continue
+                except Exception:
+                    # E.g. a transient DB error from the blob prefetch. Fall
+                    # back to an older readable checkpoint instead of letting
+                    # the error abort loading for the whole task.
+                    logger.warning(
+                        "Skipping checkpoint trace event %s for task %s after "
+                        "decode failure",
+                        row.event_id,
+                        self.task_id,
+                        exc_info=True,
                     )
                     continue
                 snapshot = data.get("snapshot")
@@ -334,7 +347,21 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     DatabaseTraceEvent.data["checkpoint_type"]
                     .as_string()
                     .in_(sorted(READABLE_CHECKPOINT_TYPES)),
-                    DatabaseTraceEvent.data["execution_id"].as_string() == execution_id,
+                    # SQL mirror of checkpoint_execution_id(): root wins,
+                    # then the flat field, then the snapshot's own id, so
+                    # legacy rows that only set one of them are not skipped.
+                    func.coalesce(
+                        func.nullif(
+                            DatabaseTraceEvent.data["root_execution_id"].as_string(),
+                            "",
+                        ),
+                        func.nullif(
+                            DatabaseTraceEvent.data["execution_id"].as_string(),
+                            "",
+                        ),
+                        DatabaseTraceEvent.data["snapshot"]["execution_id"].as_string(),
+                    )
+                    == execution_id,
                 )
                 .order_by(
                     DatabaseTraceEvent.timestamp.desc(),

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -315,6 +315,11 @@ class TraceEvent(Base):  # type: ignore
     """Unified trace event model for consistent storage and WebSocket transmission"""
 
     __tablename__ = "trace_events"
+    # Checkpoint pruning and latest-checkpoint loading both filter by
+    # task_id + event_type on every checkpoint write/resume.
+    __table_args__ = (
+        Index("ix_trace_events_task_id_event_type", "task_id", "event_type"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import threading
 
 GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED = "gmail_oidc_service_account_unverified"
+CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -211,7 +211,7 @@ def _encode_checkpoint_data_v2(
     fresh copy of the whole history.
     """
 
-    if not _find_v2_encodable_payloads(data):
+    if not _has_v2_encodable_payloads(data):
         return data
 
     encoded = copy.deepcopy(data)
@@ -346,29 +346,32 @@ def _encode_ledger_payload(
     }
 
 
-def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
-    """Locate every inline payload the v2 encoder should replace with refs.
+def _iter_v2_encodable_payloads(data: Any) -> Iterator[EncodablePayload]:
+    """Yield every inline payload the v2 encoder should replace with refs.
 
     The walk never descends into payloads it reports (or into existing ref
     markers): their contents get persisted as blobs, and encoding something
     nested inside a blob-bound object would corrupt the stored payload.
+    Lazily evaluated so presence checks can stop at the first hit.
     """
 
-    results: list[EncodablePayload] = []
     if not _is_readable_checkpoint_data(data):
-        return results
+        return
     snapshot = data.get("snapshot")
     if not isinstance(snapshot, dict):
-        return results
+        return
 
     root_context = snapshot.get("context")
     visited: set[int] = set()
 
-    def visit_context(node: dict[str, Any]) -> set[str]:
+    def visit_context(
+        node: dict[str, Any],
+    ) -> tuple[set[str], list[EncodablePayload]]:
         consumed: set[str] = set()
+        found: list[EncodablePayload] = []
         messages = node.get("messages")
         if isinstance(messages, list):
-            results.append(EncodablePayload(node, "messages", "messages", messages))
+            found.append(EncodablePayload(node, "messages", "messages", messages))
             consumed.add("messages")
         elif _is_message_refs_payload(messages):
             consumed.add("messages")
@@ -377,7 +380,7 @@ def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
             isinstance(system_prompt, str)
             and len(system_prompt) >= SYSTEM_PROMPT_BLOB_MIN_CHARS
         ):
-            results.append(
+            found.append(
                 EncodablePayload(node, "system_prompt", "system_prompt", system_prompt)
             )
             consumed.add("system_prompt")
@@ -385,18 +388,18 @@ def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
             consumed.add("system_prompt")
         metadata = node.get("metadata")
         if _should_store_checkpoint_blob_payload(metadata):
-            results.append(EncodablePayload(node, "metadata", "metadata", metadata))
+            found.append(EncodablePayload(node, "metadata", "metadata", metadata))
             consumed.add("metadata")
         elif _is_checkpoint_blob_ref_payload(metadata):
             consumed.add("metadata")
-        return consumed
+        return consumed, found
 
-    def walk(node: Any, depth: int) -> None:
+    def walk(node: Any, depth: int) -> Iterator[EncodablePayload]:
         if depth > MAX_SNAPSHOT_WALK_DEPTH:
             return
         if isinstance(node, list):
             for item in node:
-                walk(item, depth + 1)
+                yield from walk(item, depth + 1)
             return
         if not isinstance(node, dict) or "__encoding" in node:
             return
@@ -406,10 +409,11 @@ def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
 
         consumed: set[str] = set()
         if node is root_context or _is_context_payload_shape(node):
-            consumed |= visit_context(node)
+            consumed, found = visit_context(node)
+            yield from found
         ledger = node.get("tool_ledger")
         if _is_ledger_payload_shape(ledger):
-            results.append(EncodablePayload(node, "tool_ledger", "tool_ledger", ledger))
+            yield EncodablePayload(node, "tool_ledger", "tool_ledger", ledger)
             consumed.add("tool_ledger")
         elif _is_ledger_refs_payload(ledger) or _is_checkpoint_blob_ref_payload(ledger):
             consumed.add("tool_ledger")
@@ -417,40 +421,51 @@ def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
         for key, value in node.items():
             if key in consumed:
                 continue
-            walk(value, depth + 1)
+            yield from walk(value, depth + 1)
 
-    walk(snapshot, 0)
-    return results
+    yield from walk(snapshot, 0)
 
 
-def _find_storage_markers(data: Any) -> list[dict[str, Any]]:
-    """Collect every storage-encoding marker dict inside a checkpoint payload."""
+def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
+    return list(_iter_v2_encodable_payloads(data))
 
-    markers: list[dict[str, Any]] = []
+
+def _has_v2_encodable_payloads(data: Any) -> bool:
+    return next(_iter_v2_encodable_payloads(data), None) is not None
+
+
+def _iter_storage_markers(data: Any) -> Iterator[dict[str, Any]]:
+    """Yield every storage-encoding marker dict inside a checkpoint payload.
+
+    Lazily evaluated so presence checks stop at the first marker instead of
+    walking the whole snapshot tree.
+    """
+
     if not _is_readable_checkpoint_data(data):
-        return markers
+        return
 
-    def walk(node: Any, depth: int) -> None:
+    stack: list[tuple[Any, int]] = [(data.get("snapshot"), 0)]
+    while stack:
+        node, depth = stack.pop()
         if depth > MAX_SNAPSHOT_WALK_DEPTH:
-            return
+            continue
         if isinstance(node, list):
-            for item in node:
-                walk(item, depth + 1)
-            return
+            stack.extend((item, depth + 1) for item in node)
+            continue
         if not isinstance(node, dict):
-            return
+            continue
         if node.get("__encoding") in (
             MESSAGE_REFS_ENCODING,
             CHECKPOINT_BLOB_REF_ENCODING,
             LEDGER_REFS_ENCODING,
         ):
-            markers.append(node)
-            return
-        for value in node.values():
-            walk(value, depth + 1)
+            yield node
+            continue
+        stack.extend((value, depth + 1) for value in node.values())
 
-    walk(data.get("snapshot"), 0)
-    return markers
+
+def _find_storage_markers(data: Any) -> list[dict[str, Any]]:
+    return list(_iter_storage_markers(data))
 
 
 def encode_checkpoint_messages_for_storage(
@@ -613,6 +628,9 @@ def decode_trace_event_data(
     With ``strict=False``, decode failures preserve the stored refs and attach a
     decode error marker for debug/raw API callers.
     """
+
+    if not _is_readable_checkpoint_data(data) or not _has_storage_markers(data):
+        return data
 
     # Prefetch referenced blobs in bulk; per-record ledger refs would
     # otherwise issue one query per tool call during checkpoint restore.
@@ -862,7 +880,7 @@ def _decode_marker_payload(
 
 
 def _has_storage_markers(data: Any) -> bool:
-    return bool(_find_storage_markers(data))
+    return next(_iter_storage_markers(data), None) is not None
 
 
 def _is_readable_checkpoint_data(data: Any) -> bool:

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
+from ...config import get_checkpoint_encoding_v2_enabled
 from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
 from ..models.task import TraceCheckpointBlob, TraceMessageBlob
 
@@ -23,9 +24,18 @@ logger = logging.getLogger(__name__)
 
 MESSAGE_REFS_ENCODING = "xagent.message_refs_v1"
 CHECKPOINT_BLOB_REF_ENCODING = "xagent.checkpoint_blob_ref_v1"
+LEDGER_REFS_ENCODING = "xagent.ledger_refs_v1"
 MESSAGE_HASH_PREFIX = "sha256:"
 MESSAGE_REFS_DECODE_ERROR_KEY = "_decode_error"
 SQL_IN_CLAUSE_CHUNK_SIZE = 900
+CONTEXT_SYSTEM_PROMPT_KIND = "context.system_prompt"
+CONTEXT_METADATA_KIND = "context.metadata"
+TOOL_LEDGER_RECORD_KIND = "pattern_state.tool_ledger.record"
+# Prompts below this size are cheaper inline than as a blob row + ref dict.
+SYSTEM_PROMPT_BLOB_MIN_CHARS = 256
+# Snapshot trees nest as auto -> dag -> react frames; real depth stays in
+# single digits, the cap only guards against pathological payloads.
+MAX_SNAPSHOT_WALK_DEPTH = 24
 CheckpointMessageStorageState = Literal["inline", "refs", "none"]
 CheckpointStorageState = Literal["inline", "refs", "mixed", "none"]
 
@@ -54,6 +64,16 @@ CHECKPOINT_BLOB_FIELDS: tuple[CheckpointBlobField, ...] = (
     ),
     CheckpointBlobField("context.metadata", ("snapshot", "context", "metadata")),
 )
+
+
+@dataclass(frozen=True)
+class EncodablePayload:
+    """One inline snapshot value the v2 encoder would replace with a ref."""
+
+    parent: dict[str, Any]
+    key: str
+    kind: Literal["messages", "system_prompt", "metadata", "tool_ledger"]
+    value: Any
 
 
 class CheckpointMessageDecodeError(ValueError):
@@ -92,10 +112,14 @@ def get_checkpoint_messages_storage_state(
     return "none"
 
 
-def get_checkpoint_storage_state(data: Any) -> CheckpointStorageState:
+def get_checkpoint_storage_state(
+    data: Any,
+    *,
+    use_v2: bool | None = None,
+) -> CheckpointStorageState:
     """Return whether all checkpoint-optimized fields are inline or refs."""
 
-    field_states = _checkpoint_storage_field_states(data)
+    field_states = _checkpoint_storage_field_states(data, use_v2=use_v2)
     has_inline = "inline" in field_states
     has_refs = "refs" in field_states
     if has_inline and has_refs:
@@ -107,11 +131,25 @@ def get_checkpoint_storage_state(data: Any) -> CheckpointStorageState:
     return "none"
 
 
-def checkpoint_storage_payload_bytes(data: Any) -> int:
+def checkpoint_storage_payload_bytes(
+    data: Any,
+    *,
+    use_v2: bool | None = None,
+) -> int:
     """Measure optimized checkpoint payload bytes inside one trace event."""
 
     if not _is_readable_checkpoint_data(data):
         return 0
+
+    if _resolve_use_v2(use_v2):
+        total = sum(
+            len(canonical_json_bytes(payload.value))
+            for payload in _find_v2_encodable_payloads(data)
+        )
+        total += sum(
+            len(canonical_json_bytes(marker)) for marker in _find_storage_markers(data)
+        )
+        return total
 
     total = 0
     messages = _get_checkpoint_messages_payload(data)
@@ -127,13 +165,23 @@ def checkpoint_storage_payload_bytes(data: Any) -> int:
     return total
 
 
+def _resolve_use_v2(use_v2: bool | None) -> bool:
+    if use_v2 is None:
+        return get_checkpoint_encoding_v2_enabled()
+    return use_v2
+
+
 def encode_checkpoint_data_for_storage(
     db: Session,
     *,
     task_id: int,
     data: Any,
+    use_v2: bool | None = None,
 ) -> Any:
     """Encode all storage-optimized checkpoint fields."""
+
+    if _resolve_use_v2(use_v2):
+        return _encode_checkpoint_data_v2(db, task_id=task_id, data=data)
 
     should_encode_messages = get_checkpoint_messages_storage_state(data) == "inline"
     fields_to_encode = _checkpoint_blob_fields_to_encode(data)
@@ -151,6 +199,263 @@ def encode_checkpoint_data_for_storage(
             fields_to_encode=fields_to_encode,
         )
     return encoded
+
+
+def _encode_checkpoint_data_v2(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+) -> Any:
+    """Encode every ref-able payload anywhere in the snapshot tree.
+
+    Beyond the v1 root-context fields, this covers nested DAG/auto contexts
+    (``active_step_context(s)`` and ``execution_snapshot`` frames) and encodes
+    tool ledgers per record instead of as one cumulative blob, so a ledger
+    that only grows produces one new small blob per tool call rather than a
+    fresh copy of the whole history.
+    """
+
+    if not _find_v2_encodable_payloads(data):
+        return data
+
+    encoded = copy.deepcopy(data)
+    message_blobs: dict[str, BlobCandidate] = {}
+    blob_candidates: dict[tuple[str, str], BlobCandidate] = {}
+    for payload in _find_v2_encodable_payloads(encoded):
+        if payload.kind == "messages":
+            payload.parent[payload.key] = _encode_messages_payload(
+                payload.value,
+                task_id=task_id,
+                message_blobs=message_blobs,
+            )
+        elif payload.kind == "system_prompt":
+            payload.parent[payload.key] = _encode_blob_ref_payload(
+                payload.value,
+                kind=CONTEXT_SYSTEM_PROMPT_KIND,
+                task_id=task_id,
+                blob_candidates=blob_candidates,
+            )
+        elif payload.kind == "metadata":
+            payload.parent[payload.key] = _encode_blob_ref_payload(
+                payload.value,
+                kind=CONTEXT_METADATA_KIND,
+                task_id=task_id,
+                blob_candidates=blob_candidates,
+            )
+        else:
+            payload.parent[payload.key] = _encode_ledger_payload(
+                payload.value,
+                task_id=task_id,
+                blob_candidates=blob_candidates,
+            )
+
+    execution_id = _checkpoint_execution_id(encoded)
+    _upsert_message_blobs(
+        db,
+        task_id=task_id,
+        execution_id=execution_id,
+        blobs_by_hash=message_blobs,
+    )
+    _upsert_checkpoint_blobs(
+        db,
+        task_id=task_id,
+        execution_id=execution_id,
+        blobs_by_ref=blob_candidates,
+    )
+    return encoded
+
+
+def _encode_messages_payload(
+    messages: list[Any],
+    *,
+    task_id: int,
+    message_blobs: dict[str, BlobCandidate],
+) -> dict[str, Any]:
+    refs: list[str] = []
+    for message in messages:
+        message_payload = canonical_json_bytes(message)
+        message_hash = canonical_json_hash_from_bytes(message_payload)
+        _remember_blob_candidate(
+            message_blobs,
+            blob_hash=message_hash,
+            # Parse the canonical bytes back so the candidate owns an
+            # independent copy: the snapshot tree may alias these objects
+            # and must never mutate what gets persisted.
+            data=json.loads(message_payload),
+            payload_bytes=len(message_payload),
+            collision_message=(
+                f"trace message blob hash collision for task {task_id}: {message_hash}"
+            ),
+        )
+        refs.append(message_hash)
+    return {
+        "__encoding": MESSAGE_REFS_ENCODING,
+        "count": len(refs),
+        "hash": canonical_json_hash(refs),
+        "refs": refs,
+    }
+
+
+def _encode_blob_ref_payload(
+    value: Any,
+    *,
+    kind: str,
+    task_id: int,
+    blob_candidates: dict[tuple[str, str], BlobCandidate],
+) -> dict[str, Any]:
+    blob_payload = canonical_json_bytes(value)
+    blob_hash = canonical_json_hash_from_bytes(blob_payload)
+    _remember_blob_candidate(
+        blob_candidates,
+        blob_hash=(kind, blob_hash),
+        data=json.loads(blob_payload),
+        payload_bytes=len(blob_payload),
+        collision_message=(
+            f"trace checkpoint blob hash collision for task {task_id}: "
+            f"{kind} {blob_hash}"
+        ),
+    )
+    return {
+        "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+        "kind": kind,
+        "hash": blob_hash,
+    }
+
+
+def _encode_ledger_payload(
+    ledger: dict[str, Any],
+    *,
+    task_id: int,
+    blob_candidates: dict[tuple[str, str], BlobCandidate],
+) -> dict[str, Any]:
+    records: list[list[str]] = []
+    for key, record in ledger.items():
+        record_payload = canonical_json_bytes(record)
+        record_hash = canonical_json_hash_from_bytes(record_payload)
+        _remember_blob_candidate(
+            blob_candidates,
+            blob_hash=(TOOL_LEDGER_RECORD_KIND, record_hash),
+            data=json.loads(record_payload),
+            payload_bytes=len(record_payload),
+            collision_message=(
+                f"trace checkpoint blob hash collision for task {task_id}: "
+                f"{TOOL_LEDGER_RECORD_KIND} {record_hash}"
+            ),
+        )
+        records.append([str(key), record_hash])
+    return {
+        "__encoding": LEDGER_REFS_ENCODING,
+        "count": len(records),
+        "records": records,
+    }
+
+
+def _find_v2_encodable_payloads(data: Any) -> list[EncodablePayload]:
+    """Locate every inline payload the v2 encoder should replace with refs.
+
+    The walk never descends into payloads it reports (or into existing ref
+    markers): their contents get persisted as blobs, and encoding something
+    nested inside a blob-bound object would corrupt the stored payload.
+    """
+
+    results: list[EncodablePayload] = []
+    if not _is_readable_checkpoint_data(data):
+        return results
+    snapshot = data.get("snapshot")
+    if not isinstance(snapshot, dict):
+        return results
+
+    root_context = snapshot.get("context")
+    visited: set[int] = set()
+
+    def visit_context(node: dict[str, Any]) -> set[str]:
+        consumed: set[str] = set()
+        messages = node.get("messages")
+        if isinstance(messages, list):
+            results.append(EncodablePayload(node, "messages", "messages", messages))
+            consumed.add("messages")
+        elif _is_message_refs_payload(messages):
+            consumed.add("messages")
+        system_prompt = node.get("system_prompt")
+        if (
+            isinstance(system_prompt, str)
+            and len(system_prompt) >= SYSTEM_PROMPT_BLOB_MIN_CHARS
+        ):
+            results.append(
+                EncodablePayload(node, "system_prompt", "system_prompt", system_prompt)
+            )
+            consumed.add("system_prompt")
+        elif _is_checkpoint_blob_ref_payload(system_prompt):
+            consumed.add("system_prompt")
+        metadata = node.get("metadata")
+        if _should_store_checkpoint_blob_payload(metadata):
+            results.append(EncodablePayload(node, "metadata", "metadata", metadata))
+            consumed.add("metadata")
+        elif _is_checkpoint_blob_ref_payload(metadata):
+            consumed.add("metadata")
+        return consumed
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > MAX_SNAPSHOT_WALK_DEPTH:
+            return
+        if isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+            return
+        if not isinstance(node, dict) or "__encoding" in node:
+            return
+        if id(node) in visited:
+            return
+        visited.add(id(node))
+
+        consumed: set[str] = set()
+        if node is root_context or _is_context_payload_shape(node):
+            consumed |= visit_context(node)
+        ledger = node.get("tool_ledger")
+        if _is_ledger_payload_shape(ledger):
+            results.append(EncodablePayload(node, "tool_ledger", "tool_ledger", ledger))
+            consumed.add("tool_ledger")
+        elif _is_ledger_refs_payload(ledger) or _is_checkpoint_blob_ref_payload(ledger):
+            consumed.add("tool_ledger")
+
+        for key, value in node.items():
+            if key in consumed:
+                continue
+            walk(value, depth + 1)
+
+    walk(snapshot, 0)
+    return results
+
+
+def _find_storage_markers(data: Any) -> list[dict[str, Any]]:
+    """Collect every storage-encoding marker dict inside a checkpoint payload."""
+
+    markers: list[dict[str, Any]] = []
+    if not _is_readable_checkpoint_data(data):
+        return markers
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > MAX_SNAPSHOT_WALK_DEPTH:
+            return
+        if isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("__encoding") in (
+            MESSAGE_REFS_ENCODING,
+            CHECKPOINT_BLOB_REF_ENCODING,
+            LEDGER_REFS_ENCODING,
+        ):
+            markers.append(node)
+            return
+        for value in node.values():
+            walk(value, depth + 1)
+
+    walk(data.get("snapshot"), 0)
+    return markers
 
 
 def encode_checkpoint_messages_for_storage(
@@ -323,12 +628,28 @@ def decode_trace_event_data(
     decode error marker for debug/raw API callers.
     """
 
+    # Prefetch referenced blobs in bulk; per-record ledger refs would
+    # otherwise issue one query per tool call during checkpoint restore.
+    try:
+        lookup: TraceBlobLookup | None = _load_trace_blob_lookup(
+            db, task_id=task_id, data_items=[data]
+        )
+    except Exception:
+        if strict:
+            raise
+        logger.warning(
+            "Trace-blob lookup failed for task %s; decoding without prefetch",
+            task_id,
+            exc_info=True,
+        )
+        lookup = None
+
     try:
         return _decode_trace_event_data(
             db,
             task_id=task_id,
             data=data,
-            lookup=None,
+            lookup=lookup,
             verify_blob_hashes=verify_blob_hashes,
         )
     except CheckpointMessageDecodeError as exc:
@@ -400,72 +721,162 @@ def _decode_trace_event_data(
     lookup: TraceBlobLookup | None,
     verify_blob_hashes: bool,
 ) -> Any:
-    decoded = data
+    if not _is_readable_checkpoint_data(data):
+        return data
+    if not _has_storage_markers(data):
+        return data
 
-    messages_payload = _get_checkpoint_messages_payload(data)
-    if isinstance(messages_payload, list):
-        pass
-    elif (
-        isinstance(messages_payload, dict)
-        and messages_payload.get("__encoding") == MESSAGE_REFS_ENCODING
-        and not _is_message_refs_payload(messages_payload)
-    ):
-        raise CheckpointMessageDecodeError(
-            "checkpoint message refs payload is malformed"
+    decoded = copy.deepcopy(data)
+    _decode_tree_in_place(
+        db,
+        decoded["snapshot"],
+        task_id=task_id,
+        lookup=lookup,
+        verify_blob_hashes=verify_blob_hashes,
+        depth=0,
+    )
+    return decoded
+
+
+def _decode_tree_in_place(
+    db: Session,
+    node: Any,
+    *,
+    task_id: int,
+    lookup: TraceBlobLookup | None,
+    verify_blob_hashes: bool,
+    depth: int,
+) -> None:
+    if depth > MAX_SNAPSHOT_WALK_DEPTH:
+        return
+    if isinstance(node, list):
+        for index, value in enumerate(node):
+            replacement = _decode_marker_payload(
+                db,
+                value,
+                task_id=task_id,
+                lookup=lookup,
+                verify_blob_hashes=verify_blob_hashes,
+            )
+            if replacement is not None:
+                node[index] = replacement.value
+            else:
+                _decode_tree_in_place(
+                    db,
+                    value,
+                    task_id=task_id,
+                    lookup=lookup,
+                    verify_blob_hashes=verify_blob_hashes,
+                    depth=depth + 1,
+                )
+        return
+    if not isinstance(node, dict):
+        return
+    for key, value in list(node.items()):
+        replacement = _decode_marker_payload(
+            db,
+            value,
+            task_id=task_id,
+            lookup=lookup,
+            verify_blob_hashes=verify_blob_hashes,
         )
-    elif _is_message_refs_payload(messages_payload):
-        refs = messages_payload["refs"]
-        expected_count = messages_payload["count"]
+        if replacement is not None:
+            node[key] = replacement.value
+        else:
+            _decode_tree_in_place(
+                db,
+                value,
+                task_id=task_id,
+                lookup=lookup,
+                verify_blob_hashes=verify_blob_hashes,
+                depth=depth + 1,
+            )
+
+
+@dataclass(frozen=True)
+class _DecodedValue:
+    """Wrapper so ``None``-valued blobs are distinguishable from 'no marker'."""
+
+    value: Any
+
+
+def _decode_marker_payload(
+    db: Session,
+    payload: Any,
+    *,
+    task_id: int,
+    lookup: TraceBlobLookup | None,
+    verify_blob_hashes: bool,
+) -> _DecodedValue | None:
+    if not isinstance(payload, dict):
+        return None
+    encoding = payload.get("__encoding")
+    if encoding == MESSAGE_REFS_ENCODING:
+        if not _is_message_refs_payload(payload):
+            raise CheckpointMessageDecodeError(
+                "checkpoint message refs payload is malformed"
+            )
+        refs = payload["refs"]
+        expected_count = payload["count"]
         if expected_count != len(refs):
             raise CheckpointMessageDecodeError(
                 f"checkpoint message refs count mismatch: expected {expected_count}, got {len(refs)}"
             )
-
-        expected_sequence_hash = messages_payload["hash"]
-        actual_sequence_hash = canonical_json_hash(refs)
-        if expected_sequence_hash != actual_sequence_hash:
+        if payload["hash"] != canonical_json_hash(refs):
             raise CheckpointMessageDecodeError(
                 "checkpoint message refs sequence hash mismatch"
             )
-
-        messages = _load_messages_by_refs(
-            db,
-            task_id=task_id,
-            refs=refs,
-            lookup=lookup,
-            verify_blob_hashes=verify_blob_hashes,
-        )
-        decoded = _ensure_decoded_copy(data, decoded)
-        decoded["snapshot"]["context"]["messages"] = messages
-
-    for field in CHECKPOINT_BLOB_FIELDS:
-        payload = _get_nested(decoded, field.path)
-        if (
-            isinstance(payload, dict)
-            and payload.get("__encoding") == CHECKPOINT_BLOB_REF_ENCODING
-            and not _is_checkpoint_blob_ref_payload(payload)
-        ):
-            raise CheckpointMessageDecodeError(
-                f"checkpoint blob refs payload is malformed for {field.kind}"
+        return _DecodedValue(
+            _load_messages_by_refs(
+                db,
+                task_id=task_id,
+                refs=refs,
+                lookup=lookup,
+                verify_blob_hashes=verify_blob_hashes,
             )
+        )
+    if encoding == CHECKPOINT_BLOB_REF_ENCODING:
         if not _is_checkpoint_blob_ref_payload(payload):
-            continue
-        if payload["kind"] != field.kind:
             raise CheckpointMessageDecodeError(
-                f"checkpoint blob refs kind mismatch: expected {field.kind}, got {payload['kind']}"
+                "checkpoint blob refs payload is malformed"
             )
-
-        blob_data = _load_checkpoint_blob_by_ref(
-            db,
-            task_id=task_id,
-            blob_kind=field.kind,
-            blob_hash=payload["hash"],
-            lookup=lookup,
-            verify_blob_hashes=verify_blob_hashes,
+        return _DecodedValue(
+            _load_checkpoint_blob_by_ref(
+                db,
+                task_id=task_id,
+                blob_kind=payload["kind"],
+                blob_hash=payload["hash"],
+                lookup=lookup,
+                verify_blob_hashes=verify_blob_hashes,
+            )
         )
-        decoded = _ensure_decoded_copy(data, decoded)
-        _set_nested(decoded, field.path, blob_data)
-    return decoded
+    if encoding == LEDGER_REFS_ENCODING:
+        if not _is_ledger_refs_payload(payload):
+            raise CheckpointMessageDecodeError(
+                "checkpoint ledger refs payload is malformed"
+            )
+        records = payload["records"]
+        expected_count = payload["count"]
+        if expected_count != len(records):
+            raise CheckpointMessageDecodeError(
+                f"checkpoint ledger refs count mismatch: expected {expected_count}, got {len(records)}"
+            )
+        ledger: dict[str, Any] = {}
+        for record_key, record_hash in records:
+            ledger[record_key] = _load_checkpoint_blob_by_ref(
+                db,
+                task_id=task_id,
+                blob_kind=TOOL_LEDGER_RECORD_KIND,
+                blob_hash=record_hash,
+                lookup=lookup,
+                verify_blob_hashes=verify_blob_hashes,
+            )
+        return _DecodedValue(ledger)
+    return None
+
+
+def _has_storage_markers(data: Any) -> bool:
+    return bool(_find_storage_markers(data))
 
 
 def _is_readable_checkpoint_data(data: Any) -> bool:
@@ -475,8 +886,20 @@ def _is_readable_checkpoint_data(data: Any) -> bool:
     )
 
 
-def _checkpoint_storage_field_states(data: Any) -> list[Literal["inline", "refs"]]:
-    states: list[Literal["inline", "refs"]] = []
+def _checkpoint_storage_field_states(
+    data: Any,
+    *,
+    use_v2: bool | None = None,
+) -> list[Literal["inline", "refs"]]:
+    if _resolve_use_v2(use_v2):
+        states: list[Literal["inline", "refs"]] = []
+        if _find_v2_encodable_payloads(data):
+            states.append("inline")
+        if _find_storage_markers(data):
+            states.append("refs")
+        return states
+
+    states = []
     messages_state = get_checkpoint_messages_storage_state(data)
     if messages_state == "inline":
         states.append("inline")
@@ -548,16 +971,44 @@ def _is_checkpoint_blob_ref_payload(value: Any) -> bool:
     return isinstance(value.get("kind"), str) and isinstance(value.get("hash"), str)
 
 
+def _is_ledger_refs_payload(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("__encoding") != LEDGER_REFS_ENCODING:
+        return False
+    records = value.get("records")
+    if not isinstance(records, list) or not isinstance(value.get("count"), int):
+        return False
+    return all(
+        isinstance(record, list)
+        and len(record) == 2
+        and isinstance(record[0], str)
+        and isinstance(record[1], str)
+        for record in records
+    )
+
+
+def _is_context_payload_shape(value: Any) -> bool:
+    """Match serialized ``ExecutionContext`` dicts nested inside snapshots."""
+
+    if not isinstance(value, dict) or "execution_id" not in value:
+        return False
+    messages = value.get("messages")
+    return isinstance(messages, list) or _is_message_refs_payload(messages)
+
+
+def _is_ledger_payload_shape(value: Any) -> bool:
+    """Match inline tool-ledger dicts (tool_call_id -> record dict)."""
+
+    if not isinstance(value, dict) or not value or "__encoding" in value:
+        return False
+    return all(isinstance(record, dict) for record in value.values())
+
+
 def _should_store_checkpoint_blob_payload(value: Any) -> bool:
     if _is_checkpoint_blob_ref_payload(value):
         return False
     return isinstance(value, dict) and bool(value)
-
-
-def _ensure_decoded_copy(original: Any, current: Any) -> Any:
-    if current is original:
-        return copy.deepcopy(original)
-    return current
 
 
 def _chunks(values: list[Any], size: int) -> Iterator[list[Any]]:
@@ -654,21 +1105,16 @@ def _collect_trace_blob_refs(data: Any) -> tuple[set[str], set[tuple[str, str]]]
     message_refs: set[str] = set()
     checkpoint_refs: set[tuple[str, str]] = set()
 
-    messages_payload = _get_checkpoint_messages_payload(data)
-    if _is_message_refs_payload(messages_payload):
-        message_refs.update(
-            ref for ref in messages_payload["refs"] if isinstance(ref, str)
-        )
-
-    for field in CHECKPOINT_BLOB_FIELDS:
-        payload = _get_nested(data, field.path)
-        if not _is_checkpoint_blob_ref_payload(payload):
-            continue
-        if payload["kind"] != field.kind:
-            continue
-        blob_hash = payload["hash"]
-        if isinstance(blob_hash, str):
-            checkpoint_refs.add((field.kind, blob_hash))
+    for marker in _find_storage_markers(data):
+        if _is_message_refs_payload(marker):
+            message_refs.update(ref for ref in marker["refs"] if isinstance(ref, str))
+        elif _is_checkpoint_blob_ref_payload(marker):
+            checkpoint_refs.add((marker["kind"], marker["hash"]))
+        elif _is_ledger_refs_payload(marker):
+            checkpoint_refs.update(
+                (TOOL_LEDGER_RECORD_KIND, record_hash)
+                for _record_key, record_hash in marker["records"]
+            )
 
     return message_refs, checkpoint_refs
 

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -71,10 +71,12 @@ CHECKPOINT_BLOB_FIELDS: tuple[CheckpointBlobField, ...] = (
 
 @dataclass(frozen=True)
 class EncodablePayload:
-    """One inline snapshot value the v2 encoder would replace with a ref."""
+    """One inline snapshot value the v2 encoder would replace with a ref.
+
+    ``kind`` doubles as the payload's key in ``parent``.
+    """
 
     parent: dict[str, Any]
-    key: str
     kind: Literal["messages", "system_prompt", "metadata", "tool_ledger"]
     value: Any
 
@@ -219,27 +221,27 @@ def _encode_checkpoint_data_v2(
     blob_candidates: dict[tuple[str, str], BlobCandidate] = {}
     for payload in _find_v2_encodable_payloads(encoded):
         if payload.kind == "messages":
-            payload.parent[payload.key] = _encode_messages_payload(
+            payload.parent[payload.kind] = _encode_messages_payload(
                 payload.value,
                 task_id=task_id,
                 message_blobs=message_blobs,
             )
         elif payload.kind == "system_prompt":
-            payload.parent[payload.key] = _encode_blob_ref_payload(
+            payload.parent[payload.kind] = _encode_blob_ref_payload(
                 payload.value,
                 kind=CONTEXT_SYSTEM_PROMPT_KIND,
                 task_id=task_id,
                 blob_candidates=blob_candidates,
             )
         elif payload.kind == "metadata":
-            payload.parent[payload.key] = _encode_blob_ref_payload(
+            payload.parent[payload.kind] = _encode_blob_ref_payload(
                 payload.value,
                 kind=CONTEXT_METADATA_KIND,
                 task_id=task_id,
                 blob_candidates=blob_candidates,
             )
         else:
-            payload.parent[payload.key] = _encode_ledger_payload(
+            payload.parent[payload.kind] = _encode_ledger_payload(
                 payload.value,
                 task_id=task_id,
                 blob_candidates=blob_candidates,
@@ -371,7 +373,7 @@ def _iter_v2_encodable_payloads(data: Any) -> Iterator[EncodablePayload]:
         found: list[EncodablePayload] = []
         messages = node.get("messages")
         if isinstance(messages, list):
-            found.append(EncodablePayload(node, "messages", "messages", messages))
+            found.append(EncodablePayload(node, "messages", messages))
             consumed.add("messages")
         elif _is_message_refs_payload(messages):
             consumed.add("messages")
@@ -380,15 +382,13 @@ def _iter_v2_encodable_payloads(data: Any) -> Iterator[EncodablePayload]:
             isinstance(system_prompt, str)
             and len(system_prompt) >= SYSTEM_PROMPT_BLOB_MIN_CHARS
         ):
-            found.append(
-                EncodablePayload(node, "system_prompt", "system_prompt", system_prompt)
-            )
+            found.append(EncodablePayload(node, "system_prompt", system_prompt))
             consumed.add("system_prompt")
         elif _is_checkpoint_blob_ref_payload(system_prompt):
             consumed.add("system_prompt")
         metadata = node.get("metadata")
         if _should_store_checkpoint_blob_payload(metadata):
-            found.append(EncodablePayload(node, "metadata", "metadata", metadata))
+            found.append(EncodablePayload(node, "metadata", metadata))
             consumed.add("metadata")
         elif _is_checkpoint_blob_ref_payload(metadata):
             consumed.add("metadata")
@@ -413,7 +413,7 @@ def _iter_v2_encodable_payloads(data: Any) -> Iterator[EncodablePayload]:
             yield from found
         ledger = node.get("tool_ledger")
         if _is_ledger_payload_shape(ledger):
-            yield EncodablePayload(node, "tool_ledger", "tool_ledger", ledger)
+            yield EncodablePayload(node, "tool_ledger", ledger)
             consumed.add("tool_ledger")
         elif _is_ledger_refs_payload(ledger) or _is_checkpoint_blob_ref_payload(ledger):
             consumed.add("tool_ledger")

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -17,7 +17,10 @@ from typing import Any, Literal
 from sqlalchemy.orm import Session
 
 from ...config import get_checkpoint_encoding_v2_enabled
-from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
+from ...core.agent.checkpoint import (
+    READABLE_CHECKPOINT_TYPES,
+    checkpoint_execution_id,
+)
 from ..models.task import TraceCheckpointBlob, TraceMessageBlob
 
 logger = logging.getLogger(__name__)
@@ -112,14 +115,10 @@ def get_checkpoint_messages_storage_state(
     return "none"
 
 
-def get_checkpoint_storage_state(
-    data: Any,
-    *,
-    use_v2: bool | None = None,
-) -> CheckpointStorageState:
+def get_checkpoint_storage_state(data: Any) -> CheckpointStorageState:
     """Return whether all checkpoint-optimized fields are inline or refs."""
 
-    field_states = _checkpoint_storage_field_states(data, use_v2=use_v2)
+    field_states = _checkpoint_storage_field_states(data)
     has_inline = "inline" in field_states
     has_refs = "refs" in field_states
     if has_inline and has_refs:
@@ -131,17 +130,13 @@ def get_checkpoint_storage_state(
     return "none"
 
 
-def checkpoint_storage_payload_bytes(
-    data: Any,
-    *,
-    use_v2: bool | None = None,
-) -> int:
+def checkpoint_storage_payload_bytes(data: Any) -> int:
     """Measure optimized checkpoint payload bytes inside one trace event."""
 
     if not _is_readable_checkpoint_data(data):
         return 0
 
-    if _resolve_use_v2(use_v2):
+    if _resolve_use_v2(None):
         total = sum(
             len(canonical_json_bytes(payload.value))
             for payload in _find_v2_encodable_payloads(data)
@@ -250,7 +245,7 @@ def _encode_checkpoint_data_v2(
                 blob_candidates=blob_candidates,
             )
 
-    execution_id = _checkpoint_execution_id(encoded)
+    execution_id = checkpoint_execution_id(encoded)
     _upsert_message_blobs(
         db,
         task_id=task_id,
@@ -489,7 +484,7 @@ def _encode_checkpoint_messages_in_place(
         return
 
     encoded_context = data["snapshot"]["context"]
-    execution_id = _checkpoint_execution_id(data)
+    execution_id = checkpoint_execution_id(data)
     refs: list[str] = []
     blobs_by_hash: dict[str, BlobCandidate] = {}
     for message in messages:
@@ -558,15 +553,6 @@ def _checkpoint_blob_fields_to_encode(
     return fields_to_encode
 
 
-def _checkpoint_execution_id(data: dict[str, Any]) -> str:
-    return str(
-        data.get("root_execution_id")
-        or data.get("execution_id")
-        or _get_nested(data, ("snapshot", "execution_id"))
-        or ""
-    )
-
-
 def _encode_checkpoint_blob_fields_in_place(
     db: Session,
     *,
@@ -574,7 +560,7 @@ def _encode_checkpoint_blob_fields_in_place(
     data: dict[str, Any],
     fields_to_encode: list[tuple[CheckpointBlobField, Any]],
 ) -> None:
-    execution_id = _checkpoint_execution_id(data)
+    execution_id = checkpoint_execution_id(data)
 
     blobs_by_ref: dict[tuple[str, str], BlobCandidate] = {}
     refs_by_field: dict[CheckpointBlobField, str] = {}
@@ -886,12 +872,8 @@ def _is_readable_checkpoint_data(data: Any) -> bool:
     )
 
 
-def _checkpoint_storage_field_states(
-    data: Any,
-    *,
-    use_v2: bool | None = None,
-) -> list[Literal["inline", "refs"]]:
-    if _resolve_use_v2(use_v2):
+def _checkpoint_storage_field_states(data: Any) -> list[Literal["inline", "refs"]]:
+    if _resolve_use_v2(None):
         states: list[Literal["inline", "refs"]] = []
         if _find_v2_encodable_payloads(data):
             states.append("inline")
@@ -1011,7 +993,7 @@ def _should_store_checkpoint_blob_payload(value: Any) -> bool:
     return isinstance(value, dict) and bool(value)
 
 
-def _chunks(values: list[Any], size: int) -> Iterator[list[Any]]:
+def chunks(values: list[Any], size: int) -> Iterator[list[Any]]:
     for index in range(0, len(values), size):
         yield values[index : index + size]
 
@@ -1058,7 +1040,7 @@ def _load_trace_blob_lookup(
     message_data_by_hash: dict[str, Any] = {}
     if message_refs:
         chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
-        for refs_chunk in _chunks(sorted(message_refs), chunk_size):
+        for refs_chunk in chunks(sorted(message_refs), chunk_size):
             rows = (
                 db.query(TraceMessageBlob)
                 .filter(
@@ -1079,7 +1061,7 @@ def _load_trace_blob_lookup(
 
         for kind, blob_hashes in refs_by_kind.items():
             chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=2)
-            for hash_chunk in _chunks(sorted(blob_hashes), chunk_size):
+            for hash_chunk in chunks(sorted(blob_hashes), chunk_size):
                 rows = (
                     db.query(TraceCheckpointBlob)
                     .filter(
@@ -1138,7 +1120,7 @@ def _load_messages_by_refs(
     if lookup is None:
         by_hash: dict[str, Any] = {}
         chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
-        for refs_chunk in _chunks(unique_refs, chunk_size):
+        for refs_chunk in chunks(unique_refs, chunk_size):
             rows = (
                 db.query(TraceMessageBlob)
                 .filter(
@@ -1259,7 +1241,7 @@ def _upsert_message_blobs(
     hashes_to_query = sorted(set(blobs_by_hash) - pending_hashes)
     existing_hashes: set[str] = set()
     chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
-    for hashes_chunk in _chunks(hashes_to_query, chunk_size):
+    for hashes_chunk in chunks(hashes_to_query, chunk_size):
         rows = (
             db.query(TraceMessageBlob.message_hash, TraceMessageBlob.message_bytes)
             .filter(
@@ -1344,7 +1326,7 @@ def _upsert_checkpoint_blobs(
 
         for kind, blob_hashes in refs_by_kind.items():
             chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=2)
-            for hash_chunk in _chunks(sorted(blob_hashes), chunk_size):
+            for hash_chunk in chunks(sorted(blob_hashes), chunk_size):
                 rows = (
                     db.query(
                         TraceCheckpointBlob.blob_kind,

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -3274,6 +3274,29 @@ def test_tool_call_record_from_dict_handles_null_args() -> None:
     assert record.status == "pending"
 
 
+def test_args_hash_is_stable_sha256_digest() -> None:
+    pattern = ReActPattern()
+
+    digest = pattern._args_hash({"b": 2, "a": 1})
+
+    assert len(digest) == 64
+    assert all(char in "0123456789abcdef" for char in digest)
+    # Key order must not affect the digest.
+    assert digest == pattern._args_hash({"a": 1, "b": 2})
+    assert digest != pattern._args_hash({"a": 1, "b": 3})
+
+
+def test_args_hash_survives_circular_reference_args() -> None:
+    pattern = ReActPattern()
+    circular: dict = {"query": "x"}
+    circular["self"] = circular
+
+    digest = pattern._args_hash(circular)
+
+    assert len(digest) == 64
+    assert all(char in "0123456789abcdef" for char in digest)
+
+
 @pytest.mark.asyncio
 async def test_react_pattern_reasoning_action_mode_is_explicit_placeholder() -> None:
     pattern = ReActPattern(reasoning_mode=ReActReasoningMode.REASONING_ACTION)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1324,6 +1324,46 @@ class TestToolConcurrencyConfig:
         assert get_tool_max_concurrency() == 3
 
 
+class TestCheckpointStorageConfig:
+    """Config for checkpoint trace-event storage encoding and retention."""
+
+    def test_encoding_v2_default_is_true(self, monkeypatch):
+        from xagent.config import get_checkpoint_encoding_v2_enabled
+
+        monkeypatch.delenv("XAGENT_CHECKPOINT_ENCODING_V2", raising=False)
+        assert get_checkpoint_encoding_v2_enabled() is True
+
+    def test_encoding_v2_env_override(self, monkeypatch):
+        from xagent.config import get_checkpoint_encoding_v2_enabled
+
+        monkeypatch.setenv("XAGENT_CHECKPOINT_ENCODING_V2", "false")
+        assert get_checkpoint_encoding_v2_enabled() is False
+        monkeypatch.setenv("XAGENT_CHECKPOINT_ENCODING_V2", "1")
+        assert get_checkpoint_encoding_v2_enabled() is True
+
+    def test_history_limit_default_is_eight(self, monkeypatch):
+        from xagent.config import get_checkpoint_history_limit
+
+        monkeypatch.delenv("XAGENT_CHECKPOINT_HISTORY_LIMIT", raising=False)
+        assert get_checkpoint_history_limit() == 8
+
+    def test_history_limit_env_override_and_zero_disables(self, monkeypatch):
+        from xagent.config import get_checkpoint_history_limit
+
+        monkeypatch.setenv("XAGENT_CHECKPOINT_HISTORY_LIMIT", "20")
+        assert get_checkpoint_history_limit() == 20
+        monkeypatch.setenv("XAGENT_CHECKPOINT_HISTORY_LIMIT", "0")
+        assert get_checkpoint_history_limit() == 0
+
+    def test_history_limit_invalid_falls_back_to_default(self, monkeypatch):
+        from xagent.config import get_checkpoint_history_limit
+
+        monkeypatch.setenv("XAGENT_CHECKPOINT_HISTORY_LIMIT", "not-a-number")
+        assert get_checkpoint_history_limit() == 8
+        monkeypatch.setenv("XAGENT_CHECKPOINT_HISTORY_LIMIT", "-1")
+        assert get_checkpoint_history_limit() == 8
+
+
 class TestSandboxConcurrencyConfig:
     """Config for sandbox worker concurrency."""
 

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1201,6 +1201,147 @@ def test_database_trace_handler_prunes_checkpoint_history(
         db.close()
 
 
+def test_loader_falls_back_to_older_row_when_prefetch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient blob-prefetch failure must not abort checkpoint loading."""
+    from unittest.mock import patch
+
+    import xagent.web.services.trace_message_storage as tms
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        old_messages = [{"role": "user", "content": "older inline"}]
+        now = datetime.now(timezone.utc)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="older-inline",
+                event_type="system_update_general",
+                timestamp=now,
+                data=_checkpoint_data("exec-prefetch", old_messages),
+            )
+        )
+        encoded = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data(
+                "exec-prefetch", [{"role": "user", "content": "newest refs"}]
+            ),
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="newest-refs",
+                event_type="system_update_general",
+                timestamp=now + timedelta(seconds=1),
+                data=encoded,
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        # The newest row needs the prefetch (it has refs) and fails; the
+        # older inline row has no markers, never touches the prefetch, and
+        # must be returned as the fallback.
+        with patch.object(
+            tms,
+            "_load_trace_blob_lookup",
+            side_effect=RuntimeError("transient db error"),
+        ):
+            loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-prefetch"
+            )
+
+        assert loaded is not None
+        assert loaded["context"]["messages"] == old_messages
+    finally:
+        db.close()
+
+
+def test_prune_matches_legacy_execution_id_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rows keyed only by root/nested execution ids must still be pruned."""
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        handler = DatabaseTraceHandler(task_id)
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+            lambda: 2,
+        )
+        now = datetime.now(timezone.utc)
+
+        # Legacy row: only root_execution_id set (no flat execution_id).
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="legacy-root-only",
+                event_type="system_update_general",
+                timestamp=now - timedelta(seconds=2),
+                data={
+                    "checkpoint_type": "agent_v2_execution_checkpoint",
+                    "root_execution_id": "exec-legacy",
+                    "snapshot": {"context": {"messages": []}},
+                },
+            )
+        )
+        # Legacy row: only the nested snapshot execution_id set.
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="legacy-nested-only",
+                event_type="system_update_general",
+                timestamp=now - timedelta(seconds=1),
+                data={
+                    "checkpoint_type": "agent_v2_execution_checkpoint",
+                    "snapshot": {
+                        "execution_id": "exec-legacy",
+                        "context": {"messages": []},
+                    },
+                },
+            )
+        )
+        db.commit()
+
+        for index in range(2):
+            handler._save_trace_event(
+                db,
+                TraceEvent(
+                    CHECKPOINT_EVENT_TYPE,
+                    task_id=str(task_id),
+                    data=_checkpoint_data(
+                        "exec-legacy",
+                        [{"role": "user", "content": f"turn-{index}"}],
+                    ),
+                ),
+            )
+
+        remaining = [
+            row.event_id
+            for row in db.query(DatabaseTraceEvent)
+            .filter(DatabaseTraceEvent.task_id == task_id)
+            .order_by(DatabaseTraceEvent.id)
+            .all()
+        ]
+        # Both legacy-shaped rows are older than the 2 new checkpoints and
+        # must have been pruned by the coalesce predicate.
+        assert "legacy-root-only" not in remaining
+        assert "legacy-nested-only" not in remaining
+        assert len(remaining) == 2
+    finally:
+        db.close()
+
+
 def test_database_trace_handler_prune_disabled_keeps_all_checkpoints(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -442,6 +442,53 @@ def test_decode_trace_events_data_degrades_when_bulk_lookup_fails() -> None:
         db.close()
 
 
+def test_ledger_records_decode_without_bulk_lookup() -> None:
+    """The no-prefetch fallback resolves per-record ledger refs correctly."""
+    from unittest.mock import patch
+
+    import xagent.web.services.trace_message_storage as tms
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        tool_ledger = {
+            f"call-{index}": {
+                "tool_call_id": f"call-{index}",
+                "result": f"output-{index}",
+            }
+            for index in range(5)
+        }
+        item = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields(
+                "exec-ledger-fallback",
+                [{"role": "user", "content": "hello"}],
+                tool_ledger=tool_ledger,
+            ),
+        )
+        db.flush()
+        assert (
+            item["snapshot"]["pattern_state"]["tool_ledger"]["__encoding"]
+            == LEDGER_REFS_ENCODING
+        )
+
+        boom = RuntimeError("bulk lookup boom")
+        with patch.object(tms, "_load_trace_blob_lookup", side_effect=boom):
+            decoded = decode_trace_events_data(
+                db, task_id=task_id, data_items=[item], strict=False
+            )
+
+        assert decoded[0]["snapshot"]["pattern_state"]["tool_ledger"] == tool_ledger
+        assert list(decoded[0]["snapshot"]["pattern_state"]["tool_ledger"]) == list(
+            tool_ledger
+        )
+    finally:
+        db.close()
+
+
 def test_blob_lookups_respect_sqlite_bind_parameter_limit() -> None:
     SessionLocal = _session_factory()
     db = SessionLocal()
@@ -1091,7 +1138,7 @@ def test_database_trace_handler_prunes_checkpoint_history(
         )
         # Force the batched-delete loop to run multiple chunks.
         monkeypatch.setattr(
-            "xagent.web.api.trace_handlers.PRUNE_DELETE_CHUNK_SIZE",
+            "xagent.web.api.trace_handlers.SQL_IN_CLAUSE_CHUNK_SIZE",
             1,
         )
 

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1089,6 +1089,11 @@ def test_database_trace_handler_prunes_checkpoint_history(
             "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
             lambda: 3,
         )
+        # Force the batched-delete loop to run multiple chunks.
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.PRUNE_DELETE_CHUNK_SIZE",
+            1,
+        )
 
         # A non-checkpoint system event and another execution's checkpoint
         # must both survive pruning.

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import sqlite3
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
@@ -34,8 +35,10 @@ from xagent.web.models.task import (
 from xagent.web.models.user import User
 from xagent.web.services.trace_message_storage import (
     CHECKPOINT_BLOB_REF_ENCODING,
+    LEDGER_REFS_ENCODING,
     MESSAGE_REFS_DECODE_ERROR_KEY,
     MESSAGE_REFS_ENCODING,
+    TOOL_LEDGER_RECORD_KIND,
     CheckpointMessageDecodeError,
     canonical_json_hash,
     decode_trace_event_data,
@@ -296,9 +299,9 @@ def test_checkpoint_blob_refs_round_trip_and_dedupe() -> None:
         stored_metadata = encoded["snapshot"]["context"]["metadata"]
         assert stored_messages["__encoding"] == MESSAGE_REFS_ENCODING
         assert stored_tool_ledger == {
-            "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
-            "kind": "pattern_state.tool_ledger",
-            "hash": canonical_json_hash(tool_ledger),
+            "__encoding": LEDGER_REFS_ENCODING,
+            "count": 1,
+            "records": [["call-1", canonical_json_hash(tool_ledger["call-1"])]],
         }
         assert stored_metadata == {
             "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
@@ -625,7 +628,7 @@ def test_database_trace_handler_stores_checkpoint_messages_as_refs(
         stored_messages = row.data["snapshot"]["context"]["messages"]
         stored_tool_ledger = row.data["snapshot"]["pattern_state"]["tool_ledger"]
         assert stored_messages["__encoding"] == MESSAGE_REFS_ENCODING
-        assert stored_tool_ledger["__encoding"] == CHECKPOINT_BLOB_REF_ENCODING
+        assert stored_tool_ledger["__encoding"] == LEDGER_REFS_ENCODING
         assert db.query(TraceMessageBlob).count() == 2
         assert db.query(TraceCheckpointBlob).count() == 2
 
@@ -821,6 +824,368 @@ def test_database_trace_handler_falls_back_when_latest_refs_are_unreadable(
         db.close()
 
 
+def _context_payload(
+    execution_id: str,
+    messages: list[dict[str, Any]],
+    system_prompt: str,
+) -> dict[str, Any]:
+    return {
+        "execution_id": execution_id,
+        "messages": messages,
+        "system_prompt": system_prompt,
+        "metadata": {},
+    }
+
+
+def _dag_checkpoint_data(
+    execution_id: str,
+    messages: list[dict[str, Any]],
+    system_prompt: str,
+    tool_ledger: dict[str, Any],
+) -> dict[str, Any]:
+    root_context = _context_payload(execution_id, messages, system_prompt)
+    child_context = _context_payload(f"{execution_id}_child", messages, system_prompt)
+    return {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "root_execution_id": execution_id,
+        "execution_id": execution_id,
+        "label": "dag_step_completed",
+        "snapshot": {
+            "type": "checkpoint",
+            "label": "dag_step_completed",
+            "execution_id": execution_id,
+            "context": root_context,
+            "pattern": "DAGPlanExecutePattern",
+            "pattern_state": {
+                "status": "running",
+                "active_step_contexts": {"step-1": dict(child_context)},
+                "active_step_pattern_states": {"step-1": {"tool_ledger": tool_ledger}},
+                "step_results": {},
+            },
+            "execution_snapshot": {
+                "root_execution_id": execution_id,
+                "frames": {
+                    "root:dag": {
+                        "frame_id": "root:dag",
+                        "pattern_type": "dag",
+                        "context": dict(root_context),
+                        "pattern_state": {},
+                    },
+                    "child:react": {
+                        "frame_id": "child:react",
+                        "pattern_type": "react",
+                        "context": dict(child_context),
+                        "pattern_state": {"tool_ledger": tool_ledger},
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_v2_ledger_records_dedupe_across_growing_checkpoints() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        record_one = {
+            "tool_call_id": "call-1",
+            "tool_name": "web_search",
+            "args": {"query": "growth"},
+            "status": "completed",
+            "result": "large tool output " * 10,
+        }
+        record_two = {
+            "tool_call_id": "call-2",
+            "tool_name": "calculator",
+            "args": {"expression": "1+1"},
+            "status": "completed",
+            "result": "2",
+        }
+        first = _checkpoint_data_with_large_fields(
+            "exec-ledger",
+            [{"role": "user", "content": "task"}],
+            tool_ledger={"call-1": record_one},
+        )
+        second = _checkpoint_data_with_large_fields(
+            "exec-ledger",
+            [{"role": "user", "content": "task"}],
+            tool_ledger={"call-1": record_one, "call-2": record_two},
+        )
+
+        encoded_first = encode_checkpoint_data_for_storage(
+            db, task_id=task_id, data=first
+        )
+        encoded_second = encode_checkpoint_data_for_storage(
+            db, task_id=task_id, data=second
+        )
+        db.flush()
+
+        # The unchanged record is shared: two checkpoints with a growing
+        # ledger store 2 record blobs, not 3.
+        record_blobs = (
+            db.query(TraceCheckpointBlob)
+            .filter(TraceCheckpointBlob.blob_kind == TOOL_LEDGER_RECORD_KIND)
+            .all()
+        )
+        assert len(record_blobs) == 2
+
+        decoded_second = decode_trace_event_data(
+            db, task_id=task_id, data=encoded_second, strict=True
+        )
+        assert decoded_second["snapshot"]["pattern_state"]["tool_ledger"] == {
+            "call-1": record_one,
+            "call-2": record_two,
+        }
+        assert list(decoded_second["snapshot"]["pattern_state"]["tool_ledger"]) == [
+            "call-1",
+            "call-2",
+        ]
+
+        decoded_first = decode_trace_event_data(
+            db, task_id=task_id, data=encoded_first, strict=True
+        )
+        assert decoded_first["snapshot"]["pattern_state"]["tool_ledger"] == {
+            "call-1": record_one
+        }
+    finally:
+        db.close()
+
+
+def test_v2_encodes_nested_contexts_system_prompt_and_frame_ledgers() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        messages = [
+            {"role": "user", "content": "build a report"},
+            {"role": "assistant", "content": "planning"},
+        ]
+        system_prompt = "You are a meticulous data analyst. " * 20
+        tool_ledger = {"call-1": {"tool_call_id": "call-1", "result": "step output"}}
+        data = _dag_checkpoint_data("exec-dag", messages, system_prompt, tool_ledger)
+        original = copy.deepcopy(data)
+
+        encoded = encode_checkpoint_data_for_storage(db, task_id=task_id, data=data)
+        db.flush()
+
+        snapshot = encoded["snapshot"]
+        # Root context, both frames, and the active step context all encode
+        # their messages as refs against the same shared blobs.
+        assert snapshot["context"]["messages"]["__encoding"] == MESSAGE_REFS_ENCODING
+        for frame in snapshot["execution_snapshot"]["frames"].values():
+            assert frame["context"]["messages"]["__encoding"] == MESSAGE_REFS_ENCODING
+        step_context = snapshot["pattern_state"]["active_step_contexts"]["step-1"]
+        assert step_context["messages"]["__encoding"] == MESSAGE_REFS_ENCODING
+        assert db.query(TraceMessageBlob).count() == len(messages)
+
+        # The large system prompt is stored once and referenced everywhere.
+        assert (
+            snapshot["context"]["system_prompt"]["__encoding"]
+            == CHECKPOINT_BLOB_REF_ENCODING
+        )
+        prompt_blobs = (
+            db.query(TraceCheckpointBlob)
+            .filter(TraceCheckpointBlob.blob_kind == "context.system_prompt")
+            .all()
+        )
+        assert len(prompt_blobs) == 1
+        assert prompt_blobs[0].blob_data == system_prompt
+
+        # Nested ledgers (active step pattern state + react frame) encode
+        # per record and share the same record blob.
+        assert (
+            snapshot["pattern_state"]["active_step_pattern_states"]["step-1"][
+                "tool_ledger"
+            ]["__encoding"]
+            == LEDGER_REFS_ENCODING
+        )
+        assert (
+            snapshot["execution_snapshot"]["frames"]["child:react"]["pattern_state"][
+                "tool_ledger"
+            ]["__encoding"]
+            == LEDGER_REFS_ENCODING
+        )
+        record_blobs = (
+            db.query(TraceCheckpointBlob)
+            .filter(TraceCheckpointBlob.blob_kind == TOOL_LEDGER_RECORD_KIND)
+            .all()
+        )
+        assert len(record_blobs) == 1
+
+        decoded = decode_trace_event_data(
+            db, task_id=task_id, data=encoded, strict=True
+        )
+        assert decoded == original
+    finally:
+        db.close()
+
+
+def test_v2_small_system_prompt_and_empty_metadata_stay_inline() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        data = _checkpoint_data("exec-small", [{"role": "user", "content": "hi"}])
+        data["snapshot"]["context"]["execution_id"] = "exec-small"
+        data["snapshot"]["context"]["system_prompt"] = "short prompt"
+        data["snapshot"]["context"]["metadata"] = {}
+
+        encoded = encode_checkpoint_data_for_storage(db, task_id=task_id, data=data)
+        db.flush()
+
+        assert encoded["snapshot"]["context"]["system_prompt"] == "short prompt"
+        assert encoded["snapshot"]["context"]["metadata"] == {}
+        assert db.query(TraceCheckpointBlob).count() == 0
+    finally:
+        db.close()
+
+
+def test_v1_flag_still_writes_whole_ledger_blob_and_v2_decodes_it() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        tool_ledger = {"call-1": {"result": "legacy output"}}
+        data = _checkpoint_data_with_large_fields(
+            "exec-v1",
+            [{"role": "user", "content": "hello"}],
+            tool_ledger=tool_ledger,
+        )
+
+        encoded = encode_checkpoint_data_for_storage(
+            db, task_id=task_id, data=data, use_v2=False
+        )
+        db.flush()
+
+        assert encoded["snapshot"]["pattern_state"]["tool_ledger"] == {
+            "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+            "kind": "pattern_state.tool_ledger",
+            "hash": canonical_json_hash(tool_ledger),
+        }
+
+        decoded = decode_trace_event_data(
+            db, task_id=task_id, data=encoded, strict=True
+        )
+        assert decoded["snapshot"]["pattern_state"]["tool_ledger"] == tool_ledger
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_prunes_checkpoint_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        handler = DatabaseTraceHandler(task_id)
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+            lambda: 3,
+        )
+
+        # A non-checkpoint system event and another execution's checkpoint
+        # must both survive pruning.
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="other-system",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data={"note": "not a checkpoint"},
+            )
+        )
+        db.commit()
+        handler._save_trace_event(
+            db,
+            TraceEvent(
+                CHECKPOINT_EVENT_TYPE,
+                task_id=str(task_id),
+                data=_checkpoint_data(
+                    "exec-other", [{"role": "user", "content": "other"}]
+                ),
+            ),
+        )
+
+        for index in range(5):
+            handler._save_trace_event(
+                db,
+                TraceEvent(
+                    CHECKPOINT_EVENT_TYPE,
+                    task_id=str(task_id),
+                    data=_checkpoint_data(
+                        "exec-prune",
+                        [{"role": "user", "content": f"turn-{index}"}],
+                    ),
+                ),
+            )
+
+        rows = (
+            db.query(DatabaseTraceEvent)
+            .filter(DatabaseTraceEvent.task_id == task_id)
+            .order_by(DatabaseTraceEvent.id)
+            .all()
+        )
+        prune_rows = [
+            row for row in rows if row.data.get("execution_id") == "exec-prune"
+        ]
+        assert len(prune_rows) == 3
+        # The most recent checkpoints are the ones kept.
+        latest = decode_trace_event_data(
+            db, task_id=task_id, data=prune_rows[-1].data, strict=True
+        )
+        assert latest["snapshot"]["context"]["messages"] == [
+            {"role": "user", "content": "turn-4"}
+        ]
+        assert any(row.event_id == "other-system" for row in rows)
+        assert any(row.data.get("execution_id") == "exec-other" for row in rows)
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_prune_disabled_keeps_all_checkpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        handler = DatabaseTraceHandler(task_id)
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+            lambda: 0,
+        )
+
+        for index in range(4):
+            handler._save_trace_event(
+                db,
+                TraceEvent(
+                    CHECKPOINT_EVENT_TYPE,
+                    task_id=str(task_id),
+                    data=_checkpoint_data(
+                        "exec-keep",
+                        [{"role": "user", "content": f"turn-{index}"}],
+                    ),
+                ),
+            )
+
+        assert (
+            db.query(DatabaseTraceEvent)
+            .filter(DatabaseTraceEvent.task_id == task_id)
+            .count()
+            == 4
+        )
+    finally:
+        db.close()
+
+
 def test_convert_trace_checkpoint_messages_script_dry_run_and_execute() -> None:
     SessionLocal = _session_factory()
     db = SessionLocal()
@@ -899,7 +1264,7 @@ def test_convert_trace_checkpoint_messages_script_dry_run_and_execute() -> None:
         mixed_row = db.query(DatabaseTraceEvent).filter_by(event_id="mixed").one()
         assert (
             mixed_row.data["snapshot"]["pattern_state"]["tool_ledger"]["__encoding"]
-            == CHECKPOINT_BLOB_REF_ENCODING
+            == LEDGER_REFS_ENCODING
         )
         assert db.query(TraceMessageBlob).count() == 1
         assert db.query(TraceCheckpointBlob).count() == 2


### PR DESCRIPTION
## Why

Production databases were growing rapidly, and profiling a real 20 GB local database showed checkpoint trace events were the dominant cause: `system_update_general` rows held 6.1 GB of payload across just 20,555 rows. Three compounding problems:

1. **O(N²) tool-ledger storage.** The whole `tool_ledger` dict was stored as a single content-addressed blob. Every completed tool call changed the dict, producing a new hash, so the entire cumulative ledger (including all previous tool results) was re-stored on every checkpoint. A task with N tool calls stored the first call's result ~N times. `args_hash` also held the full args JSON, persisting args twice per record.
2. **Nested context copies were never deduplicated.** Ref/blob encoding only covered `snapshot.context.messages`, `snapshot.context.metadata`, and the whole-ledger blob. DAG/auto checkpoints carry 2–3 more full context copies (`execution_snapshot.frames.*.context`, `pattern_state.active_step_contexts`) plus the full `system_prompt` inline in **every** checkpoint row.
3. **Checkpoint rows are never pruned.** Resume only reads the newest readable checkpoint, but every historical row was retained forever. 88% of checkpoint rows in the profiled database were beyond any retention need.

## What

- **Per-record ledger encoding** (`xagent.ledger_refs_v1`): records are immutable once completed, so a growing ledger adds one small blob per call instead of a fresh copy of the whole history. Kills the O(N²) growth.
- **Snapshot-tree walking encoder**: nested DAG/auto contexts (frames, active step contexts, nested pattern-state ledgers) now share the same message/metadata blobs as the root context instead of being stored inline per checkpoint.
- **System-prompt blobs** (`context.system_prompt`): prompts ≥ 256 chars are stored once per task instead of once per checkpoint row.
- **`args_hash` is now a sha256 digest** instead of the raw canonical args JSON.
- **Write-time checkpoint pruning**: keep the last `XAGENT_CHECKPOINT_HISTORY_LIMIT` (default 8, `0` disables) checkpoint rows per execution, deleted in a separate transaction so prune failures can never take the checkpoint write down.

## Compatibility / rollout

- Decode support for **every** format (legacy inline, v1 refs, v2 refs) is unconditional; old rows keep working without migration.
- `XAGENT_CHECKPOINT_ENCODING_V2` (default **on**) only gates new writes. Mixed fleets can roll out decode-first: deploy all instances with `XAGENT_CHECKPOINT_ENCODING_V2=0`, then remove the override.
- No schema migration needed — new blob kinds are strings in the existing `trace_checkpoint_blobs` table.
- The existing `scripts/convert_trace_checkpoint_messages.py` converts historical rows to the new encoding (its storage-state helpers are now v2-aware).

## Measured results (real 20 GB SQLite database, 328 tasks)

| Metric | Before | After |
|---|---|---|
| Database file (after VACUUM) | 20 GB | **2.2 GB** (−89%) |
| Checkpoint rows | 20,553 | 2,538 |
| Checkpoint row payload | 6,145 MB | **47 MB** |
| Blob tables (deduplicated content) | 1,184 MB | 159 MB |

Breakdown: pruning to last-8-per-execution removed 18,015 rows (5.5 GB); converting the remaining 1,025 inline rows shrank their payload 455 MB → 4.9 MB (−99%); a **one-time offline blob-GC pass** (not shipped in this PR — live pruning intentionally leaves blobs in place, and the reusable maintenance script is a tracked follow-up) reclaimed another 1,036 MB of blobs orphaned by the prune. All 2,538 surviving checkpoints strict-decode (including blob hash verification) with 0 failures, and an end-to-end smoke test (real `ExecutionContext` + `ReActPattern`, 12 checkpoints with a growing ledger → prune → restore → `load_state`) round-trips intact.

## Tests

- `tests/web/test_trace_message_storage.py`: 25 tests (new: growing-ledger record dedup, DAG nested-context blob sharing, single-copy system prompt, v1 flag fallback + v2-decodes-v1, prune keeps newest / prune disabled).
- `tests/core/test_config.py`: new getters covered (defaults, overrides, invalid fallbacks).
- Full `tests/core/agent` + `tests/web` suites pass (the only failures are pre-existing trigger rate-limit tests that also fail on a clean checkout).
