### PR TITLE
fix: filter TTS voice metadata by configured models

### DIFF
--- a/src/xagent/core/tools/core/audio_tool.py
+++ b/src/xagent/core/tools/core/audio_tool.py
@@ -361,6 +361,70 @@ class AudioToolCore:
 
         return providers
 
+    def _get_configured_tts_model_ids(self, provider_name: str) -> set[str]:
+        """Return model IDs configured for the selected TTS provider."""
+        model_ids = {
+            model_id
+            for model_id, model in self._tts_models.items()
+            if self._get_tts_provider_name(model) == provider_name
+        }
+        if (
+            self._default_tts_model is not None
+            and self._get_tts_provider_name(self._default_tts_model) == provider_name
+        ):
+            default_model_id = getattr(self._default_tts_model, "model_name", None)
+            if default_model_id:
+                model_ids.add(str(default_model_id))
+        return model_ids
+
+    @staticmethod
+    def _filter_voice_model_metadata(
+        voices: list[dict[str, Any]],
+        configured_model_ids: set[str],
+    ) -> list[dict[str, Any]]:
+        """Remove provider model metadata for models not configured by the user."""
+        filtered_voices: list[dict[str, Any]] = []
+        for voice in voices:
+            filtered_voice = dict(voice)
+
+            if "high_quality_base_model_ids" in filtered_voice:
+                high_quality_model_ids = filtered_voice["high_quality_base_model_ids"]
+                matching_model_ids = [
+                    model_id
+                    for model_id in (
+                        high_quality_model_ids
+                        if isinstance(high_quality_model_ids, list)
+                        else []
+                    )
+                    if str(model_id) in configured_model_ids
+                ]
+                if matching_model_ids:
+                    filtered_voice["high_quality_base_model_ids"] = matching_model_ids
+                else:
+                    filtered_voice.pop("high_quality_base_model_ids")
+
+            if "verified_languages" in filtered_voice:
+                verified_languages = filtered_voice["verified_languages"]
+                matching_languages = [
+                    language
+                    for language in (
+                        verified_languages
+                        if isinstance(verified_languages, list)
+                        else []
+                    )
+                    if isinstance(language, dict)
+                    and language.get("model_id") is not None
+                    and str(language["model_id"]) in configured_model_ids
+                ]
+                if matching_languages:
+                    filtered_voice["verified_languages"] = matching_languages
+                else:
+                    filtered_voice.pop("verified_languages")
+
+            filtered_voices.append(filtered_voice)
+
+        return filtered_voices
+
     def _validate_tts_provider_kwargs(
         self,
         *,
@@ -964,6 +1028,8 @@ class AudioToolCore:
                 }
 
             voices = await tts_model.list_available_voices()
+            configured_model_ids = self._get_configured_tts_model_ids(provider_name)
+            voices = self._filter_voice_model_metadata(voices, configured_model_ids)
             return {
                 "success": True,
                 "supported": True,

--- a/src/xagent/core/tools/core/audio_tool_descriptions.py
+++ b/src/xagent/core/tools/core/audio_tool_descriptions.py
@@ -210,7 +210,7 @@ Output:
 - supported (bool): Whether the selected provider supports dynamic voice listing
 - provider (str): Selected provider name
 - model_used (str): Selected model ID or "default"
-- voices (list): Voice metadata. Use voice_id from an item as the voice parameter in synthesize_speech or synthesize_speech_json.
+- voices (list): Voice metadata filtered to model IDs configured for the selected provider. Use voice_id from an item as the voice parameter in synthesize_speech or synthesize_speech_json.
 - count (int): Number of voices returned
 - supported_providers (list): Providers that currently support dynamic voice listing
 

--- a/tests/core/tools/test_audio_tool.py
+++ b/tests/core/tools/test_audio_tool.py
@@ -256,6 +256,111 @@ async def test_list_tts_voices_returns_provider_voices() -> None:
     }
 
 
+async def test_list_tts_voices_filters_metadata_to_configured_provider_models() -> None:
+    voice_listing_tts = FakeTTS(
+        provider_name="elevenlabs",
+        abilities=["tts", "voice_listing"],
+        voices=[
+            {
+                "voice_id": "voice-1",
+                "high_quality_base_model_ids": [
+                    "eleven_v3",
+                    "eleven_flash_v2",
+                    "eleven_turbo_v2",
+                ],
+                "verified_languages": [
+                    {"language": "en", "model_id": "eleven_v3"},
+                    {"language": "de", "model_id": "eleven_flash_v2"},
+                    {"language": "fr", "model_id": "eleven_turbo_v2"},
+                    {"language": "es"},
+                    {"language": "it", "model_id": None},
+                    None,
+                    "invalid",
+                ],
+            },
+            {
+                "voice_id": "voice-2",
+                "high_quality_base_model_ids": ["eleven_turbo_v2"],
+                "verified_languages": [
+                    {"language": "fr", "model_id": "eleven_turbo_v2"}
+                ],
+            },
+            {
+                "voice_id": "voice-3",
+                "high_quality_base_model_ids": "eleven_v3",
+                "verified_languages": None,
+            },
+        ],
+    )
+    tool = AudioToolCore(
+        tts_models={
+            "eleven_v3": voice_listing_tts,
+            "eleven_flash_v2": FakeTTS(provider_name="elevenlabs"),
+            "None": FakeTTS(provider_name="elevenlabs"),
+            "chat-tts": FakeTTS(provider_name="xinference"),
+        }
+    )
+
+    result = await tool.list_tts_voices(model_id="eleven_v3")
+
+    assert result["voices"] == [
+        {
+            "voice_id": "voice-1",
+            "high_quality_base_model_ids": ["eleven_v3", "eleven_flash_v2"],
+            "verified_languages": [
+                {"language": "en", "model_id": "eleven_v3"},
+                {"language": "de", "model_id": "eleven_flash_v2"},
+            ],
+        },
+        {"voice_id": "voice-2"},
+        {"voice_id": "voice-3"},
+    ]
+
+
+async def test_list_tts_voices_keeps_default_model_metadata() -> None:
+    default_tts = FakeTTS(
+        provider_name="elevenlabs",
+        abilities=["tts", "voice_listing"],
+        voices=[
+            {
+                "voice_id": "voice-1",
+                "high_quality_base_model_ids": ["default-model", "other-model"],
+                "verified_languages": [
+                    {"language": "en", "model_id": "default-model"},
+                    {"language": "de", "model_id": "other-model"},
+                ],
+            }
+        ],
+    )
+    default_tts.model_name = "default-model"
+    tool = AudioToolCore(default_tts_model=default_tts)
+
+    result = await tool.list_tts_voices()
+
+    assert result["voices"] == [
+        {
+            "voice_id": "voice-1",
+            "high_quality_base_model_ids": ["default-model"],
+            "verified_languages": [{"language": "en", "model_id": "default-model"}],
+        }
+    ]
+
+
+def test_filter_voice_model_metadata_handles_empty_configured_set() -> None:
+    voices = AudioToolCore._filter_voice_model_metadata(
+        [
+            {
+                "voice_id": "voice-1",
+                "high_quality_base_model_ids": ["eleven_v3"],
+                "verified_languages": [{"language": "en", "model_id": "eleven_v3"}],
+            }
+        ],
+        configured_model_ids=set(),
+    )
+
+    assert voices == [{"voice_id": "voice-1"}]
+
+
 async def test_list_tts_voices_reports_dynamic_supported_providers() -> None:
     tool = AudioToolCore(
         tts_models={


### PR DESCRIPTION
## Summary

- filter TTS voice model metadata against the model IDs configured for the selected provider
- remove empty model-specific metadata after filtering
- document the filtered response contract and add regression coverage

## Why

`list_tts_voices` returned provider-wide model IDs in fields such as `high_quality_base_model_ids` and `verified_languages`, including models the user had never added. This exposed unusable model choices to the agent and unnecessarily inflated the tool result.

## Impact

Voice entries remain available, but their model-specific metadata now contains only models configured by the current user for that provider. Configured models are retained even when they are not the model selected for the current voice-listing call.

## Validation

- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent-filter-tts-voice-models/src pytest -q tests/core/tools/test_audio_tool.py tests/core/model/tts/test_elevenlabs.py` (33 passed)
- Ruff lint and format checks
- repository pre-commit hooks, including mypy, isort, codespell, and whitespace checks
