### PR TITLE
fix: deduplicate replayed user messages

### DIFF
--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 type TestWebSocketMessage = {
@@ -17,6 +17,7 @@ type TestWebSocketMessage = {
 const webSocketOptions = vi.hoisted(() => ({
   current: null as null | { onMessage?: (message: TestWebSocketMessage) => void },
 }))
+const sendChatMessageMock = vi.hoisted(() => vi.fn())
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
@@ -38,7 +39,7 @@ vi.mock("@/hooks/use-websocket", () => ({
     return {
       isConnected: true,
       connectionError: null,
-      sendChatMessage: vi.fn(),
+      sendChatMessage: sendChatMessageMock,
       executeTask: vi.fn(),
       pauseTask: vi.fn(),
       resumeTask: vi.fn(),
@@ -76,9 +77,11 @@ function StateProbe() {
       <div data-testid="messages">
         {JSON.stringify(
           state.messages.map((message) => ({
+            id: message.id,
             role: message.role,
             content:
               typeof message.content === "string" ? message.content : "react-node",
+            isOptimistic: message.isOptimistic,
           }))
         )}
       </div>
@@ -120,6 +123,44 @@ function SeedRunningTask() {
   return null
 }
 
+function SeedExistingTask() {
+  const { dispatch } = useApp()
+
+  React.useEffect(() => {
+    dispatch({ type: "SET_TASK_ID", payload: 1 })
+    dispatch({
+      type: "SET_CURRENT_TASK",
+      payload: {
+        id: "1",
+        title: "Test task",
+        status: "running",
+        description: "Test task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:00:00Z",
+      },
+    })
+  }, [dispatch])
+
+  return null
+}
+
+function SendMessageProbe() {
+  const { sendMessage } = useApp()
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void sendMessage("Optimistic round trip", {
+          clientMessageId: "turn-optimistic",
+        })
+      }}
+    >
+      Send message
+    </button>
+  )
+}
+
 describe("task control envelope parsing", () => {
   it("does not coerce null, boolean, or empty identifiers to integers", () => {
     const nullEnvelope = extractTaskControlEnvelope({
@@ -157,6 +198,13 @@ describe("task control envelope parsing", () => {
 describe("AppProvider websocket message routing", () => {
   beforeEach(() => {
     webSocketOptions.current = null
+    sendChatMessageMock.mockReset()
+    sendChatMessageMock.mockResolvedValue({
+      client_message_id: "turn-optimistic",
+      turn_id: "turn-optimistic",
+    })
+    ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+      .clearDuplicateMessageCache?.()
   })
 
   afterEach(() => {
@@ -221,6 +269,172 @@ describe("AppProvider websocket message routing", () => {
       )
     })
     expect(screen.getByTestId("messages").textContent).not.toContain("Searching")
+  })
+
+  it("deduplicates the same user turn when history is replayed after reconnect", async () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+    const userTurn = {
+      type: "trace_event",
+      timestamp: "2026-05-27T05:00:00Z",
+      data: {
+        event_id: "user-event-1",
+        event_type: "user_message",
+        data: {
+          message: "Repeated after reconnect",
+          turn_id: "turn-1",
+        },
+      },
+    }
+
+    act(() => {
+      onMessage?.(userTurn)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Repeated after reconnect"
+      )
+    })
+
+    // A hot reload can reset the old content cache before the socket replays
+    // the same persisted turn.
+    act(() => {
+      ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+        .clearDuplicateMessageCache?.()
+      onMessage?.(userTurn)
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string }>
+      expect(messages.filter(message => message.content === "Repeated after reconnect"))
+        .toHaveLength(1)
+    })
+  })
+
+  it("keeps identical text from distinct user turns", async () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        data: {
+          event_id: "user-event-1",
+          event_type: "user_message",
+          data: { message: "Send it again", turn_id: "turn-1" },
+        },
+      })
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        data: {
+          event_id: "user-event-2",
+          event_type: "user_message",
+          data: { message: "Send it again", turn_id: "turn-2" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string }>
+      expect(messages.filter(message => message.content === "Send it again"))
+        .toHaveLength(2)
+    })
+  })
+
+  it("reconciles an optimistic send with its persisted user turn", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }))
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          content: "Optimistic round trip",
+          isOptimistic: true,
+        }),
+      ])
+    })
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        data: {
+          event_id: "user-event-optimistic",
+          event_type: "user_message",
+          data: {
+            message: "Optimistic round trip",
+            turn_id: "turn-optimistic",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          content: "Optimistic round trip",
+          isOptimistic: false,
+        }),
+      ])
+    })
+  })
+
+  it("does not crash on a trace event without data", () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    expect(() => {
+      act(() => {
+        onMessage?.({
+          type: "trace_event",
+          event_type: "unknown_event",
+          timestamp: "2026-05-27T05:00:02Z",
+        } as TestWebSocketMessage)
+      })
+    }).not.toThrow()
   })
 
   it("handles top-level failed task completion payloads", async () => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -208,7 +208,28 @@ const dispatchAutoOpenPreview = (
 }
 
 const OPTIMISTIC_USER_MESSAGE_PREFIX = "msg-user-optimistic"
+const USER_TURN_MESSAGE_PREFIX = "msg-user-turn"
+const USER_EVENT_MESSAGE_PREFIX = "msg-user-event"
 const USER_MESSAGE_REPLACE_WINDOW_MS = 30000
+
+const userTurnMessageId = (turnId: string): string =>
+  `${USER_TURN_MESSAGE_PREFIX}-${turnId}`
+
+const stableUserMessageId = (
+  eventData: { turn_id?: unknown } & Record<string, unknown>,
+  eventId?: unknown,
+): string | null => {
+  const turnId = eventData.turn_id
+  if (typeof turnId === "string" && turnId.trim()) {
+    return userTurnMessageId(turnId.trim())
+  }
+
+  if (typeof eventId === "string" && eventId.trim()) {
+    return `${USER_EVENT_MESSAGE_PREFIX}-${eventId.trim()}`
+  }
+
+  return null
+}
 
 const extractTextFromReactNode = (node: React.ReactNode): string => {
   if (typeof node === 'string') return node
@@ -253,7 +274,10 @@ const findOptimisticUserMessageIndex = (
     if (
       existingMessage.role !== "user" ||
       typeof existingMessage.id !== "string" ||
-      !existingMessage.id.startsWith(OPTIMISTIC_USER_MESSAGE_PREFIX)
+      (
+        !existingMessage.isOptimistic &&
+        !existingMessage.id.startsWith(OPTIMISTIC_USER_MESSAGE_PREFIX)
+      )
     ) {
       continue
     }
@@ -422,6 +446,7 @@ interface Message {
   traceEvents?: TraceEvent[]
   interactions?: Interaction[]
   isSystemNotice?: boolean
+  isOptimistic?: boolean
 }
 
 export interface Task {
@@ -741,13 +766,41 @@ function appReducer(state: AppState, action: AppAction): AppState {
         state.messages,
         messageToAdd,
       )
+
+      if (messageToAdd.role === "user") {
+        const existingUserMessageIndex = state.messages.findIndex(
+          message => message.role === "user" && message.id === messageToAdd.id,
+        )
+        if (existingUserMessageIndex >= 0) {
+          const existingMessage = state.messages[existingUserMessageIndex]
+          if (messageToAdd.isOptimistic && !existingMessage.isOptimistic) {
+            return state
+          }
+
+          const updatedMessages = state.messages.map((message, index) =>
+            index === existingUserMessageIndex
+              ? {
+                ...message,
+                ...messageToAdd,
+                isOptimistic: messageToAdd.isOptimistic ?? false,
+              }
+              : message
+          )
+          updatedMessages.sort((a, b) => {
+            return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
+          })
+          return { ...state, messages: updatedMessages, traceEvents: newTraceEvents }
+        }
+      }
+
       if (optimisticUserMessageIndex >= 0) {
         const updatedMessages = state.messages.map((message, index) =>
           index === optimisticUserMessageIndex
             ? {
               ...message,
               ...messageToAdd,
-              id: message.id,
+              id: messageToAdd.id,
+              isOptimistic: messageToAdd.isOptimistic ?? false,
             }
             : message
         )
@@ -1502,7 +1555,7 @@ export function AppProvider({
         break
 
       case "trace_event":
-        const traceEventData = message.data as any
+        const traceEventData = (message.data ?? {}) as any
 
         // Check if this has the expected structure with event_type
         // event_type can be in message.event_type (new format) or traceEventData.event_type (old format)
@@ -1609,6 +1662,10 @@ export function AppProvider({
           else if (eventType === "user_message") {
             dispatch({ type: "SET_HISTORY_LOADING", payload: false })
             const messageContent = eventData.message || eventData.content || ""
+            const userMessageId = stableUserMessageId(
+              eventData,
+              message.event_id || traceEventData.event_id,
+            )
 
             // Debug log
             console.log('🔍 User message debug:', {
@@ -1622,11 +1679,14 @@ export function AppProvider({
               timestamp: message.timestamp
             })
 
-            // Check if this is a duplicate message.
-            // Use caching so the entry expires after 30s, preventing the
-            // immediate chat/user_message duplicate pair without permanently
-            // blocking subsequent identical messages later in the session.
-            const isDuplicate = isDuplicateMessage(messageContent, 'user-message', false, true)
+            // Modern user-message events carry a stable turn_id (or at least
+            // an event_id). The reducer reconciles those identities across
+            // live delivery, optimistic rendering, and history replay. Only
+            // legacy events without either identity fall back to short-lived
+            // content-based deduplication.
+            const isDuplicate = userMessageId === null
+              ? isDuplicateMessage(messageContent, 'user-message', false, true)
+              : false
             console.log('🔍 Duplicate check:', {
               messageContent,
               isDuplicate,
@@ -1691,10 +1751,11 @@ export function AppProvider({
             })
 
             const messagePayload = {
-              id: generateMessageId("msg-user"),
+              id: userMessageId || generateMessageId("msg-user"),
               role: "user" as const,
               content: content,
               timestamp: message.timestamp,
+              isOptimistic: false,
             }
 
             console.log('📤 Message payload:', messagePayload)
@@ -4479,33 +4540,33 @@ export function AppProvider({
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
       }
 
-      // The user_message trace usually arrives before the acknowledgement. If
-      // it has not, add a local copy now; the normal dedupe path reconciles the
-      // later trace without displaying a duplicate.
-      if (!isDuplicateMessage(message, 'user-message', config?.force)) {
-        let content: React.ReactNode = message
-        if (files && files.length > 0) {
-          content = (
-            <div className="space-y-2">
-              <div className="whitespace-pre-wrap max-h-60 overflow-y-auto">{message}</div>
-              <FileAttachment
-                files={files.map(f => ({ name: f.name, type: f.type, size: f.size, path: '' }))} // Basic info for optimistic render
-                variant="user-message"
-              />
-            </div>
-          )
-        }
-
-        dispatch({
-          type: "ADD_MESSAGE",
-          payload: {
-            id: generateMessageId("msg-user-optimistic"),
-            role: "user",
-            content: content,
-            timestamp: Date.now().toString(),
-          }
-        })
+      // The user_message trace usually arrives before the acknowledgement. Add
+      // a stable optimistic copy either way; the reducer keeps the persisted
+      // event when it already arrived and replaces this copy when it arrives
+      // later.
+      let content: React.ReactNode = message
+      if (files && files.length > 0) {
+        content = (
+          <div className="space-y-2">
+            <div className="whitespace-pre-wrap max-h-60 overflow-y-auto">{message}</div>
+            <FileAttachment
+              files={files.map(f => ({ name: f.name, type: f.type, size: f.size, path: '' }))} // Basic info for optimistic render
+              variant="user-message"
+            />
+          </div>
+        )
       }
+
+      dispatch({
+        type: "ADD_MESSAGE",
+        payload: {
+          id: userTurnMessageId(clientMessageId),
+          role: "user",
+          content: content,
+          timestamp: Date.now().toString(),
+          isOptimistic: true,
+        }
+      })
     }
   }, [state.taskId, sendChatMessage, wsExecuteTask, state.currentTask?.status, queuePendingMessage])
 


### PR DESCRIPTION
## Summary

- deduplicate user messages by stable `turn_id` or `event_id` across live delivery, optimistic rendering, and history replay
- keep identical message text when it belongs to distinct user turns
- add regression coverage for reconnect replay and repeated text

## Root cause

WebSocket reconnects replay the persisted transcript while the frontend preserves existing user messages. The previous guard only cached message text for 30 seconds, so a hot reload or later reconnect could append the same persisted turn again. It could also incorrectly hide two intentional turns with identical text.

## Validation

- `npm run test:run -- src/contexts/app-context-chat.test.tsx`
- `npm run type-check`
- pre-commit hooks (`npm lint`, `npm type-check`, `codespell`)
- `git diff --check`

The full frontend test run reached 323 passing tests; 8 unrelated existing tests failed in workforce and knowledge-base test files not changed by this PR.
