### PR TITLE
fix: preserve OAuth resolver actor diagnostics

### DIFF
--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1300,7 +1300,7 @@ class WebToolConfig(BaseToolConfig):
             _bounded_oauth_metadata(provider) for provider in error.providers[:2]
         ]
         diagnostic["exception_type"] = _bounded_oauth_metadata(error.exception_type)
-        if error.actor_id is not None:
+        if error.actor_id:
             diagnostic["actor_id"] = error.actor_id
         return diagnostic
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -149,7 +149,10 @@ def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
 
 
 def _extract_oauth_token_resolver_diagnostic_actor_id(exc: Exception) -> str | None:
-    raw_actor_id = getattr(exc, "oauth_token_resolver_diagnostic_actor_id", None)
+    try:
+        raw_actor_id = getattr(exc, "oauth_token_resolver_diagnostic_actor_id", None)
+    except Exception:
+        return None
     if not isinstance(raw_actor_id, str):
         return None
     return _bounded_oauth_metadata(raw_actor_id)

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -151,11 +151,11 @@ def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
 def _extract_oauth_token_resolver_diagnostic_actor_id(exc: Exception) -> str | None:
     try:
         raw_actor_id = getattr(exc, "oauth_token_resolver_diagnostic_actor_id", None)
+        if type(raw_actor_id) is not str:
+            return None
+        return _bounded_oauth_metadata(raw_actor_id)
     except Exception:
         return None
-    if not isinstance(raw_actor_id, str):
-        return None
-    return _bounded_oauth_metadata(raw_actor_id)
 
 
 def _normalize_oauth_expires_at(expires_at: datetime | None) -> datetime | None:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -126,11 +126,13 @@ class _OAuthTokenResolverFailed(Exception):
         providers: list[str],
         exception_type: str,
         resource: str | None = None,
+        actor_id: str | None = None,
     ) -> None:
         super().__init__(OAUTH_TOKEN_RESOLVER_FAILURE_CODE)
         self.providers = providers
         self.exception_type = exception_type
         self.resource = resource
+        self.actor_id = actor_id
 
 
 class _OAuthLaunchConfigInvalid(Exception):
@@ -144,6 +146,13 @@ def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
     if len(text) <= max_length:
         return text
     return f"{text[: max_length - 3]}..."
+
+
+def _extract_oauth_token_resolver_diagnostic_actor_id(exc: Exception) -> str | None:
+    raw_actor_id = getattr(exc, "oauth_token_resolver_diagnostic_actor_id", None)
+    if not isinstance(raw_actor_id, str):
+        return None
+    return _bounded_oauth_metadata(raw_actor_id)
 
 
 def _normalize_oauth_expires_at(expires_at: datetime | None) -> datetime | None:
@@ -1196,6 +1205,7 @@ class WebToolConfig(BaseToolConfig):
                     providers=providers,
                     exception_type=_bounded_oauth_metadata(type(exc).__name__),
                     resource=resource,
+                    actor_id=_extract_oauth_token_resolver_diagnostic_actor_id(exc),
                 ) from exc
 
             if resolved is None:
@@ -1287,6 +1297,8 @@ class WebToolConfig(BaseToolConfig):
             _bounded_oauth_metadata(provider) for provider in error.providers[:2]
         ]
         diagnostic["exception_type"] = _bounded_oauth_metadata(error.exception_type)
+        if error.actor_id is not None:
+            diagnostic["actor_id"] = error.actor_id
         return diagnostic
 
     def _build_unavailable_oauth_mcp_config(

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -787,6 +787,32 @@ async def test_hook_failure_with_raising_actor_string_subclass_stays_sanitized(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("raw_actor_id", [123, 1.5, True, ""])
+async def test_hook_failure_drops_non_string_or_empty_actor_id(
+    db_session,
+    raw_actor_id,
+):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+
+    class ResolverFailure(RuntimeError):
+        oauth_token_resolver_diagnostic_actor_id = raw_actor_id
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise ResolverFailure("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
+    assert configs[0]["transport"] == "unavailable"
+    assert diagnostic["exception_type"] == "ResolverFailure"
+    assert "actor_id" not in diagnostic
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("resolved", "exception_type"),
     [

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -746,6 +746,47 @@ async def test_hook_failure_with_raising_actor_attribute_stays_sanitized(
 
 
 @pytest.mark.asyncio
+async def test_hook_failure_with_raising_actor_string_subclass_stays_sanitized(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    oauth_server = _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_stdio_server(db, user, name="after")
+
+    class RaisingStr(str):
+        def __str__(self) -> str:
+            raise RuntimeError("secret-from-string-conversion")
+
+    class ResolverFailure(RuntimeError):
+        oauth_token_resolver_diagnostic_actor_id = RaisingStr("actor-1")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise ResolverFailure("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == [
+        "before",
+        "Google Drive",
+        "after",
+    ]
+    unavailable = configs[1]
+    diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
+    assert unavailable["transport"] == "unavailable"
+    assert unavailable["config"]["server_id"] == oauth_server.id
+    assert diagnostic["exception_type"] == "ResolverFailure"
+    assert "actor_id" not in diagnostic
+    assert "secret-from-string-conversion" not in str(unavailable)
+    assert "secret-from-string-conversion" not in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("resolved", "exception_type"),
     [

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -707,6 +707,45 @@ async def test_hook_failure_diagnostic_includes_bounded_actor_id_without_secrets
 
 
 @pytest.mark.asyncio
+async def test_hook_failure_with_raising_actor_attribute_stays_sanitized(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    oauth_server = _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_stdio_server(db, user, name="after")
+
+    class AttributeReadFailure(RuntimeError):
+        @property
+        def oauth_token_resolver_diagnostic_actor_id(self) -> str:
+            raise RuntimeError("secret-token-from-diagnostic-property")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise AttributeReadFailure("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == [
+        "before",
+        "Google Drive",
+        "after",
+    ]
+    unavailable = configs[1]
+    diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
+    assert unavailable["transport"] == "unavailable"
+    assert unavailable["config"]["server_id"] == oauth_server.id
+    assert diagnostic["exception_type"] == "AttributeReadFailure"
+    assert "actor_id" not in diagnostic
+    assert "secret-token-from-diagnostic-property" not in str(unavailable)
+    assert "secret-token-from-diagnostic-property" not in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("resolved", "exception_type"),
     [

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -613,7 +613,9 @@ async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
     assert "runtime_bindings" not in unavailable
     assert "allow_delegated_authorization" not in unavailable
     assert "connector_runtime" not in unavailable
-    assert cfg.get_mcp_oauth_diagnostics() == [
+    diagnostics = cfg.get_mcp_oauth_diagnostics()
+    assert "actor_id" not in diagnostics[0]
+    assert diagnostics == [
         {
             "code": "oauth_token_resolver_failed",
             "message": "OAuth token resolver failed",
@@ -669,6 +671,39 @@ async def test_hook_failure_diagnostic_includes_bounded_resource(db_session):
     diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
     assert diagnostic["resource"] == f"{resource[:125]}..."
     assert len(diagnostic["resource"]) == 128
+
+
+@pytest.mark.asyncio
+async def test_hook_failure_diagnostic_includes_bounded_actor_id_without_secrets(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    resource = "https://mcp.example.com/oauth/resource"
+    _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
+    actor_id = "actor-" + "x" * 200
+
+    class DelegatedRefreshFailure(RuntimeError):
+        oauth_token_resolver_diagnostic_actor_id = actor_id
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise DelegatedRefreshFailure("secret-token-in-exception")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    unavailable = configs[0]
+    diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
+    assert unavailable["transport"] == "unavailable"
+    assert diagnostic["resource"] == resource
+    assert diagnostic["actor_id"] == f"{actor_id[:125]}..."
+    assert len(diagnostic["actor_id"]) == 128
+    assert "secret-token-in-exception" not in str(unavailable)
+    assert "secret-token-in-exception" not in diagnostic["message"]
+    assert "secret-token-in-exception" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Preserve a bounded actor ID supplied as structured metadata by OAuth token resolver hook failures.
- Keep actor metadata optional and neutral: Xagent does not import SaaS code, classify SaaS exceptions, or parse exception text.
- Contain failures while reading the optional exception property so unavailable-tool diagnostics and secret-safe logging remain intact.

## Root cause

The resolver-failure wrapper preserved provider, resource, and exception type but dropped hook-supplied actor metadata. Additionally, an exception property accessor could raise and bypass the wrapper, causing the outer MCP config loader to log unsafe error text and stop loading later servers.

## Validation

- `uv run pytest tests/web/tools/test_oauth_token_resolver_hook.py tests/web/tools/test_mcp_oauth_runtime.py -q`
- `uv run ruff check src/xagent/web/tools/config.py tests/web/tools/test_oauth_token_resolver_hook.py`
