### PR TITLE
feat(tools): positive tool-allowlist hook and layered-quota error codes

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -671,6 +671,14 @@ class AgentService:
             # Re-read the hook-backed policy before comparing signatures.
             refresh_overrides()
 
+        refresh_allowlist = getattr(
+            self.tool_config, "refresh_user_tool_allowlist", None
+        )
+        if callable(refresh_allowlist):
+            # The CA allowlist is resolved from the active execution scope, so
+            # it can change between turns even when the config is reused.
+            refresh_allowlist()
+
         overrides: Any = _get_conf("get_user_tool_overrides", {})
         if isinstance(overrides, dict):
             override_items = tuple(
@@ -690,6 +698,13 @@ class AgentService:
             None
             if allowed_tools is None
             else tuple(str(name) for name in allowed_tools)
+        )
+
+        tool_allowlist = _get_conf("get_user_tool_allowlist")
+        tool_allowlist_items = (
+            None
+            if tool_allowlist is None
+            else tuple(str(name) for name in tool_allowlist)
         )
 
         allowed_agent_ids = _get_conf("get_allowed_agent_ids")
@@ -732,6 +747,7 @@ class AgentService:
         return (
             override_items,
             allowed_items,
+            tool_allowlist_items,
             allowed_agent_items,
             agent_override_items,
             bool(enable_global_agent_tools),

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -353,6 +353,17 @@ class ToolFactory:
                         tool for tool in tools if tool.name not in disabled_by_hook
                     ]
 
+            # Positive allowlist filter (execution layer). When the hook
+            # returns a concrete list, keep only tools whose name is in it.
+            # Applied to the already-built list — including dynamically loaded
+            # MCP tools — so no tool-universe enumeration is needed. ``None``
+            # means "no allowlist configured" and skips filtering; an empty
+            # list is an explicit "no tools allowed".
+            allowlist = getattr(config, "get_user_tool_allowlist", lambda: None)()
+            if allowlist is not None:
+                allowed_by_hook = set(allowlist)
+                tools = [tool for tool in tools if tool.name in allowed_by_hook]
+
         # Wrap sandbox-enabled tools if sandbox is available
         sandbox = config.get_sandbox()
         if sandbox is not None:

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -70,6 +70,15 @@ class V1ErrorCode(str, Enum):
     # it stays in the enum so SDK clients can encode the mapping now.
     RATE_LIMITED = "rate_limited"
 
+    # Monthly execution quota exhausted. 402 Payment Required. Two distinct
+    # codes so a client application can tell "my own sub-quota is spent" apart
+    # from "the whole team's ceiling is spent" — the team ceiling always wins,
+    # so QUOTA_EXCEEDED means there is no headroom at all, while
+    # CLIENT_QUOTA_EXCEEDED means the team still has room but this application's
+    # slice is used up.
+    QUOTA_EXCEEDED = "quota_exceeded"
+    CLIENT_QUOTA_EXCEEDED = "client_quota_exceeded"
+
     # Server-side bug. Detail is sanitized; the raw exception stays in
     # the server log.
     INTERNAL_ERROR = "internal_error"
@@ -97,6 +106,10 @@ _DEFAULT_MESSAGES: dict[V1ErrorCode, str] = {
     V1ErrorCode.TASK_BUSY: "Task is currently running; retry after it completes.",
     V1ErrorCode.INVALID_INPUT: "Request body failed validation.",
     V1ErrorCode.RATE_LIMITED: "Rate limit exceeded; retry later.",
+    V1ErrorCode.QUOTA_EXCEEDED: "Monthly execution quota exceeded for this team.",
+    V1ErrorCode.CLIENT_QUOTA_EXCEEDED: (
+        "Monthly execution quota exceeded for this client application."
+    ),
     V1ErrorCode.INTERNAL_ERROR: "Internal server error.",
     V1ErrorCode.CONNECTOR_NOT_FOUND: "Connector not found or not accessible.",
     V1ErrorCode.INVALID_RUNTIME_CONTEXT: "Invalid connector runtime context.",

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -35,6 +35,29 @@ def get_user_tool_overrides(db: Session, user: Any) -> dict:
     return {}
 
 
+# Hook signature: (db: Session, user: Any) -> list[str] | None
+# Returns a positive tool allowlist for the current execution: only tools whose
+# name is in the list are kept. ``None`` means "no allowlist configured" (no
+# filtering); an empty list means "no tools allowed". Unlike the disable-set
+# override hook above, this filters positively against the already-built tool
+# list, so dynamically-loaded MCP tools are covered without enumerating a tool
+# universe. Application layers inject it via set_user_tool_allowlist_hook().
+_get_user_tool_allowlist_hook: Callable[[Session, Any], list[str] | None] | None = None
+
+
+def set_user_tool_allowlist_hook(
+    hook: Callable[[Session, Any], list[str] | None] | None,
+) -> None:
+    global _get_user_tool_allowlist_hook
+    _get_user_tool_allowlist_hook = hook
+
+
+def get_user_tool_allowlist(db: Session, user: Any) -> list[str] | None:
+    if _get_user_tool_allowlist_hook is not None:
+        return _get_user_tool_allowlist_hook(db, user)
+    return None
+
+
 TOOL_CREDENTIAL_SPECS: dict[str, dict[str, ToolFieldSpec]] = {
     "exa_web_search": {
         "api_key": {

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -28,6 +28,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
 )
 from ..services.tool_credentials import (
     get_sql_connection_map,
+    get_user_tool_allowlist,
     get_user_tool_overrides,
     resolve_tool_credential,
 )
@@ -275,6 +276,10 @@ class WebToolConfig(BaseToolConfig):
         # Use explicit user param first; fall back to request.user.
         self._user = user if user is not None else getattr(request, "user", None)
         self._cached_tool_overrides: Optional[dict] = None
+        # ``None`` is a meaningful allowlist value ("no allowlist"), so a
+        # separate flag tracks whether the hook has been consulted yet.
+        self._cached_tool_allowlist: Optional[list] = None
+        self._tool_allowlist_cached: bool = False
 
         # Sandbox instance - only store reference, lifecycle managed by upper layer
         self._sandbox: Optional[Any] = sandbox
@@ -689,6 +694,32 @@ class WebToolConfig(BaseToolConfig):
         # The policy can change while an AgentService instance is reused.
         self._cached_tool_overrides = None
         return self.get_user_tool_overrides()
+
+    def get_user_tool_allowlist(self) -> Optional[list]:
+        """Return the positive tool allowlist from the registered hook.
+
+        ``None`` means "no allowlist configured" — no filtering. A concrete
+        list means keep only those tool names (execution layer only). The
+        allowlist is resolved from the active execution scope by the hook, so
+        it can differ per turn even for the same user.
+        """
+        if self._tool_allowlist_cached:
+            return self._cached_tool_allowlist
+        try:
+            self._cached_tool_allowlist = get_user_tool_allowlist(self.db, self._user)
+        except Exception:
+            logger.exception("Failed to get user tool allowlist")
+            self._cached_tool_allowlist = None
+        self._tool_allowlist_cached = True
+        return self._cached_tool_allowlist
+
+    def refresh_user_tool_allowlist(self) -> Optional[list]:
+        """Reload the positive tool allowlist from the registered hook."""
+        # The active execution scope (hence the CA allowlist) can change while
+        # an AgentService instance is reused across turns.
+        self._tool_allowlist_cached = False
+        self._cached_tool_allowlist = None
+        return self.get_user_tool_allowlist()
 
     def get_excluded_agent_id(self) -> Optional[int]:
         """Get agent ID to exclude from agent tools (to prevent self-calls)."""

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -1,0 +1,213 @@
+"""Positive tool-allowlist hook, its WebToolConfig wiring, factory filter, and
+tool-policy-signature inclusion (added for xagent-saas #81 area A).
+
+The allowlist is a positive counterpart to the disable-set override hook: the
+factory keeps only tools whose name is in the list, applied to the already-built
+tool list so dynamically-loaded (e.g. MCP) tools are covered.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import xagent.core.tools.adapters.vibe.factory as factory_module
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+from xagent.web.services.tool_credentials import (
+    get_user_tool_allowlist,
+    set_user_tool_allowlist_hook,
+)
+from xagent.web.tools.config import WebToolConfig
+
+
+@pytest.fixture
+def clear_allowlist_hook():
+    set_user_tool_allowlist_hook(None)
+    yield
+    set_user_tool_allowlist_hook(None)
+
+
+# --------------------------------------------------------------------------- #
+# Hook registration
+# --------------------------------------------------------------------------- #
+def test_no_hook_returns_none(clear_allowlist_hook):
+    assert get_user_tool_allowlist(None, None) is None
+
+
+def test_registered_hook_is_invoked(clear_allowlist_hook):
+    set_user_tool_allowlist_hook(lambda db, user: ["a", "b"])
+    assert get_user_tool_allowlist(None, None) == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# WebToolConfig caching / refresh
+# --------------------------------------------------------------------------- #
+def _config() -> WebToolConfig:
+    return WebToolConfig(db=None, request=SimpleNamespace(), user_id=1)
+
+
+def test_config_reads_and_caches_allowlist(clear_allowlist_hook):
+    holder = {"value": ["only_this"]}
+    set_user_tool_allowlist_hook(lambda db, user: holder["value"])
+    cfg = _config()
+
+    assert cfg.get_user_tool_allowlist() == ["only_this"]
+    # Cached: a later change to the hook result is not observed until refresh.
+    holder["value"] = ["changed"]
+    assert cfg.get_user_tool_allowlist() == ["only_this"]
+    assert cfg.refresh_user_tool_allowlist() == ["changed"]
+
+
+def test_config_caches_none_result(clear_allowlist_hook):
+    calls = {"n": 0}
+
+    def _hook(db, user):
+        calls["n"] += 1
+        return None
+
+    set_user_tool_allowlist_hook(_hook)
+    cfg = _config()
+
+    assert cfg.get_user_tool_allowlist() is None
+    assert cfg.get_user_tool_allowlist() is None
+    # None is a real value, not "uncomputed": the hook is consulted only once.
+    assert calls["n"] == 1
+
+
+def test_config_swallows_hook_errors(clear_allowlist_hook):
+    def _boom(db, user):
+        raise RuntimeError("hook failed")
+
+    set_user_tool_allowlist_hook(_boom)
+    cfg = _config()
+    # A failing hook must not break tool building; treated as "no allowlist".
+    assert cfg.get_user_tool_allowlist() is None
+
+
+# --------------------------------------------------------------------------- #
+# Factory positive filter
+# --------------------------------------------------------------------------- #
+class _FakeTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeConfig:
+    def __init__(self, allowlist) -> None:
+        self._allowlist = allowlist
+
+    def get_tool_selection_spec(self):
+        return None
+
+    def get_allowed_tools(self):
+        return None
+
+    def get_user_tool_overrides(self):
+        return {}
+
+    def get_user_tool_allowlist(self):
+        return self._allowlist
+
+    def get_sandbox(self):
+        return None
+
+    def get_max_output_length(self):
+        return 10_000
+
+    def get_max_field_count(self):
+        return 100
+
+    def get_max_recursion_depth(self):
+        return 10
+
+
+_UNIVERSE = ["web_search", "python_executor", "mcp__server__do_thing"]
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    async def _create_registered_tools(config):
+        return [_FakeTool(name) for name in _UNIVERSE]
+
+    monkeypatch.setattr(
+        factory_module.ToolRegistry,
+        "create_registered_tools",
+        _create_registered_tools,
+    )
+
+
+def _build(config, *, apply_user_override_filter=True):
+    import asyncio
+
+    tools = asyncio.run(
+        ToolFactory.create_all_tools(config, apply_user_override_filter=apply_user_override_filter)
+    )
+    return [t.name for t in tools]
+
+
+def test_factory_keeps_only_allowlisted_including_mcp(fake_registry):
+    assert _build(_FakeConfig(["web_search", "mcp__server__do_thing"])) == [
+        "web_search",
+        "mcp__server__do_thing",
+    ]
+
+
+def test_factory_none_allowlist_keeps_all(fake_registry):
+    assert _build(_FakeConfig(None)) == _UNIVERSE
+
+
+def test_factory_empty_allowlist_drops_all(fake_registry):
+    assert _build(_FakeConfig([])) == []
+
+
+def test_factory_display_layer_ignores_allowlist(fake_registry):
+    assert _build(_FakeConfig(["web_search"]), apply_user_override_filter=False) == _UNIVERSE
+
+
+# --------------------------------------------------------------------------- #
+# Tool-policy signature includes the allowlist (cache isolation across turns)
+# --------------------------------------------------------------------------- #
+class _SigConfig:
+    def __init__(self, allowlist) -> None:
+        self._allowlist = allowlist
+
+    def get_user_tool_allowlist(self):
+        return self._allowlist
+
+    def refresh_user_tool_allowlist(self):
+        return self._allowlist
+
+
+def _signature(config):
+    from xagent.core.agent.service import AgentService
+
+    svc = AgentService.__new__(AgentService)
+    svc.tool_config = config
+    return svc._current_tool_policy_signature()
+
+
+def test_signature_differs_by_allowlist():
+    sig_a = _signature(_SigConfig(["a"]))
+    sig_b = _signature(_SigConfig(["a", "b"]))
+    sig_none = _signature(_SigConfig(None))
+    # Different allowlists must not collide, or a reused AgentService could
+    # serve one client application's cached tool set to another.
+    assert sig_a != sig_b
+    assert sig_a != sig_none
+    assert sig_b != sig_none
+
+
+def test_signature_stable_for_same_allowlist():
+    assert _signature(_SigConfig(["a", "b"])) == _signature(_SigConfig(["a", "b"]))
+
+
+def test_signature_backward_compatible_without_allowlist_methods():
+    # A legacy config lacking the allowlist methods must still produce a
+    # signature (the allowlist slot is simply None).
+    legacy = SimpleNamespace()
+    from xagent.core.agent.service import AgentService
+
+    svc = AgentService.__new__(AgentService)
+    svc.tool_config = legacy
+    # truthy config required; SimpleNamespace() is truthy.
+    assert isinstance(svc._current_tool_policy_signature(), tuple)


### PR DESCRIPTION
Enablers in xagent for **xorbitsai/xagent-saas#81** (external client-application policy, layered quota, usage breakdown). Two small, backward-compatible additions consumed by the SaaS layer; **no behavior change for existing callers**.

## What this adds

**1. Positive tool-allowlist hook** (`set_user_tool_allowlist_hook` / `get_user_tool_allowlist` in `web/services/tool_credentials.py`)

A positive counterpart to the existing disable-set override hook. The tool factory applies it as a filter on the **already-built** tool list, so it also covers dynamically-loaded MCP tools without enumerating a tool universe. `None` means "no allowlist" (no filtering); an empty list means "no tools allowed". It runs only under the execution-layer flag, so the display/config path still shows every tool.

- `WebToolConfig` caches/refreshes the allowlist alongside the overrides.
- `AgentService._current_tool_policy_signature` now includes the allowlist, so a reused `AgentService` cannot serve one caller's cached tool set to another.

**2. Layered-quota error codes** (`web/api/v1/errors.py`)

`QUOTA_EXCEEDED` (team ceiling) and `CLIENT_QUOTA_EXCEEDED` (per-client-application sub-quota), both intended for HTTP 402. Distinct codes let an SDK client tell "the whole team is out of quota" from "this application's slice is spent while the team still has room". `RATE_LIMITED` (429) stays reserved for request-rate throttling.

## Relationship to in-flight tool-policy work

- **#470** (separate structural allow-lists from runtime availability): the new hook is a *runtime-availability* filter, aligned with that separation. It also addresses the reused-`AgentService` staleness #470 calls out, by including the allowlist in the tool-policy signature.
- **#766** tool-approval epic (#768): orthogonal concern — "which tools are available" (this hook) vs "which calls need runtime confirmation" (approval gate). Both live in `factory.py` / `service.py` but do not overlap functionally.

## Tests

`tests/web/tools/test_user_tool_allowlist.py`: hook default/registration, `WebToolConfig` caching/refresh (incl. `None` cached as a real value, hook errors swallowed), factory positive filter (incl. MCP-style names, `None`, empty, display layer), and tool-policy-signature inclusion / cache isolation.
