### PR TITLE
feat(tools): positive tool-allowlist hook and layered-quota error codes

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -671,6 +671,14 @@ class AgentService:
             # Re-read the hook-backed policy before comparing signatures.
             refresh_overrides()
 
+        refresh_allowlist = getattr(
+            self.tool_config, "refresh_user_tool_allowlist", None
+        )
+        if callable(refresh_allowlist):
+            # The CA allowlist is resolved from the active execution scope, so
+            # it can change between turns even when the config is reused.
+            refresh_allowlist()
+
         overrides: Any = _get_conf("get_user_tool_overrides", {})
         if isinstance(overrides, dict):
             override_items = tuple(
@@ -690,6 +698,13 @@ class AgentService:
             None
             if allowed_tools is None
             else tuple(str(name) for name in allowed_tools)
+        )
+
+        tool_allowlist = _get_conf("get_user_tool_allowlist")
+        tool_allowlist_items = (
+            None
+            if tool_allowlist is None
+            else tuple(str(name) for name in tool_allowlist)
         )
 
         allowed_agent_ids = _get_conf("get_allowed_agent_ids")
@@ -732,6 +747,7 @@ class AgentService:
         return (
             override_items,
             allowed_items,
+            tool_allowlist_items,
             allowed_agent_items,
             agent_override_items,
             bool(enable_global_agent_tools),

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -12,6 +12,7 @@ from ..memory import MemoryStore
 from ..memory.in_memory import InMemoryMemoryStore
 from ..model.chat.basic.base import BaseLLM
 from ..tools.adapters.vibe import Tool
+from ..tools.adapters.vibe.config import normalize_tool_allowlist
 from ..tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from ..workspace import TaskWorkspace, create_workspace
 from .trace import Tracer
@@ -700,12 +701,8 @@ class AgentService:
             else tuple(str(name) for name in allowed_tools)
         )
 
-        tool_allowlist = _get_conf("get_user_tool_allowlist")
-        tool_allowlist_items = (
-            None
-            if tool_allowlist is None
-            else tuple(str(name) for name in tool_allowlist)
-        )
+        tool_allowlist = normalize_tool_allowlist(_get_conf("get_user_tool_allowlist"))
+        tool_allowlist_items = None if tool_allowlist is None else tuple(tool_allowlist)
 
         allowed_agent_ids = _get_conf("get_allowed_agent_ids")
         allowed_agent_items = (

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -7,9 +7,31 @@ to the ToolFactory in a unified way.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import Any, Dict, List, Optional
 
 from ..... import config as _root_config
+
+
+def normalize_tool_allowlist(value: Any) -> Optional[List[str]]:
+    """Coerce a tool-allowlist hook result into a list of tool-name strings.
+
+    The positive tool-allowlist hook is documented as ``Optional[list]``, but
+    it is user-registered and consumed against a duck-typed config, so callers
+    cannot assume the contract holds. Normalizing here keeps a single, uniform
+    policy at every consumption point:
+
+    - ``None`` passes through unchanged ("no allowlist configured").
+    - A bare scalar — ``str``/``bytes`` or any non-iterable such as
+      ``int``/``float``/``bool`` — is treated as a single tool name rather than
+      being iterated character-by-character or raising on a non-iterable.
+    - Any other iterable yields one stringified name per item.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        return [str(value)]
+    return [str(item) for item in value]
 
 
 class BaseToolConfig(ABC):

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from .....config import get_uploads_dir
 from .....core.workspace import TaskWorkspace
 from .base import AbstractBaseTool, Tool
-from .config import BaseToolConfig
+from .config import BaseToolConfig, normalize_tool_allowlist
 from .connector_runtime import ConnectorRuntimeError
 from .output_filter_wrapper import OutputFilteredToolWrapper
 from .selection_spec import ToolSelectionSpec
@@ -359,7 +359,9 @@ class ToolFactory:
             # MCP tools — so no tool-universe enumeration is needed. ``None``
             # means "no allowlist configured" and skips filtering; an empty
             # list is an explicit "no tools allowed".
-            allowlist = getattr(config, "get_user_tool_allowlist", lambda: None)()
+            allowlist = normalize_tool_allowlist(
+                getattr(config, "get_user_tool_allowlist", lambda: None)()
+            )
             if allowlist is not None:
                 allowed_by_hook = set(allowlist)
                 tools = [tool for tool in tools if tool.name in allowed_by_hook]

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -353,6 +353,17 @@ class ToolFactory:
                         tool for tool in tools if tool.name not in disabled_by_hook
                     ]
 
+            # Positive allowlist filter (execution layer). When the hook
+            # returns a concrete list, keep only tools whose name is in it.
+            # Applied to the already-built list — including dynamically loaded
+            # MCP tools — so no tool-universe enumeration is needed. ``None``
+            # means "no allowlist configured" and skips filtering; an empty
+            # list is an explicit "no tools allowed".
+            allowlist = getattr(config, "get_user_tool_allowlist", lambda: None)()
+            if allowlist is not None:
+                allowed_by_hook = set(allowlist)
+                tools = [tool for tool in tools if tool.name in allowed_by_hook]
+
         # Wrap sandbox-enabled tools if sandbox is available
         sandbox = config.get_sandbox()
         if sandbox is not None:

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -70,6 +70,15 @@ class V1ErrorCode(str, Enum):
     # it stays in the enum so SDK clients can encode the mapping now.
     RATE_LIMITED = "rate_limited"
 
+    # Monthly execution quota exhausted. 402 Payment Required. Two distinct
+    # codes so a client application can tell "my own sub-quota is spent" apart
+    # from "the whole team's ceiling is spent" — the team ceiling always wins,
+    # so QUOTA_EXCEEDED means there is no headroom at all, while
+    # CLIENT_QUOTA_EXCEEDED means the team still has room but this application's
+    # slice is used up.
+    QUOTA_EXCEEDED = "quota_exceeded"
+    CLIENT_QUOTA_EXCEEDED = "client_quota_exceeded"
+
     # Server-side bug. Detail is sanitized; the raw exception stays in
     # the server log.
     INTERNAL_ERROR = "internal_error"
@@ -97,6 +106,10 @@ _DEFAULT_MESSAGES: dict[V1ErrorCode, str] = {
     V1ErrorCode.TASK_BUSY: "Task is currently running; retry after it completes.",
     V1ErrorCode.INVALID_INPUT: "Request body failed validation.",
     V1ErrorCode.RATE_LIMITED: "Rate limit exceeded; retry later.",
+    V1ErrorCode.QUOTA_EXCEEDED: "Monthly execution quota exceeded for this team.",
+    V1ErrorCode.CLIENT_QUOTA_EXCEEDED: (
+        "Monthly execution quota exceeded for this client application."
+    ),
     V1ErrorCode.INTERNAL_ERROR: "Internal server error.",
     V1ErrorCode.CONNECTOR_NOT_FOUND: "Connector not found or not accessible.",
     V1ErrorCode.INVALID_RUNTIME_CONTEXT: "Invalid connector runtime context.",

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -35,6 +35,29 @@ def get_user_tool_overrides(db: Session, user: Any) -> dict:
     return {}
 
 
+# Hook signature: (db: Session, user: Any) -> list[str] | None
+# Returns a positive tool allowlist for the current execution: only tools whose
+# name is in the list are kept. ``None`` means "no allowlist configured" (no
+# filtering); an empty list means "no tools allowed". Unlike the disable-set
+# override hook above, this filters positively against the already-built tool
+# list, so dynamically-loaded MCP tools are covered without enumerating a tool
+# universe. Application layers inject it via set_user_tool_allowlist_hook().
+_get_user_tool_allowlist_hook: Callable[[Session, Any], list[str] | None] | None = None
+
+
+def set_user_tool_allowlist_hook(
+    hook: Callable[[Session, Any], list[str] | None] | None,
+) -> None:
+    global _get_user_tool_allowlist_hook
+    _get_user_tool_allowlist_hook = hook
+
+
+def get_user_tool_allowlist(db: Session, user: Any) -> list[str] | None:
+    if _get_user_tool_allowlist_hook is not None:
+        return _get_user_tool_allowlist_hook(db, user)
+    return None
+
+
 TOOL_CREDENTIAL_SPECS: dict[str, dict[str, ToolFieldSpec]] = {
     "exa_web_search": {
         "api_key": {

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1179,7 +1179,9 @@ class WebToolConfig(BaseToolConfig):
                     )
                     if delegated_connection:
                         delegated_connection["_connector_runtime_refresh"] = (
-                            lambda _server=server, _runtime_bindings=runtime_bindings, _allow_delegated_authorization=allow_delegated_authorization: (
+                            lambda _server=server,
+                            _runtime_bindings=runtime_bindings,
+                            _allow_delegated_authorization=allow_delegated_authorization: (
                                 self._refresh_delegated_mcp_connection(
                                     server=_server,
                                     runtime_bindings=_runtime_bindings,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -7,6 +7,7 @@ and other web-specific sources.
 
 import logging
 import os
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -34,6 +35,21 @@ from ..services.tool_credentials import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_allowlist(value: Any) -> Optional[List[str]]:
+    """Coerce a tool-allowlist hook result into a list of tool-name strings.
+
+    ``None`` passes through unchanged ("no allowlist configured"). A bare
+    scalar (str/bytes or any non-iterable such as int/float/bool) is treated
+    as a single tool name rather than being iterated character-by-character or
+    raising. Any other iterable yields one stringified name per item.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        return [str(value)]
+    return [str(item) for item in value]
 
 
 async def refresh_oauth_token_if_needed(
@@ -706,7 +722,9 @@ class WebToolConfig(BaseToolConfig):
         if self._tool_allowlist_cached:
             return self._cached_tool_allowlist
         try:
-            self._cached_tool_allowlist = get_user_tool_allowlist(self.db, self._user)
+            self._cached_tool_allowlist = _normalize_allowlist(
+                get_user_tool_allowlist(self.db, self._user)
+            )
         except Exception:
             logger.exception("Failed to get user tool allowlist")
             self._cached_tool_allowlist = None

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -28,6 +28,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
 )
 from ..services.tool_credentials import (
     get_sql_connection_map,
+    get_user_tool_allowlist,
     get_user_tool_overrides,
     resolve_tool_credential,
 )
@@ -275,6 +276,10 @@ class WebToolConfig(BaseToolConfig):
         # Use explicit user param first; fall back to request.user.
         self._user = user if user is not None else getattr(request, "user", None)
         self._cached_tool_overrides: Optional[dict] = None
+        # ``None`` is a meaningful allowlist value ("no allowlist"), so a
+        # separate flag tracks whether the hook has been consulted yet.
+        self._cached_tool_allowlist: Optional[list] = None
+        self._tool_allowlist_cached: bool = False
 
         # Sandbox instance - only store reference, lifecycle managed by upper layer
         self._sandbox: Optional[Any] = sandbox
@@ -689,6 +694,32 @@ class WebToolConfig(BaseToolConfig):
         # The policy can change while an AgentService instance is reused.
         self._cached_tool_overrides = None
         return self.get_user_tool_overrides()
+
+    def get_user_tool_allowlist(self) -> Optional[list]:
+        """Return the positive tool allowlist from the registered hook.
+
+        ``None`` means "no allowlist configured" — no filtering. A concrete
+        list means keep only those tool names (execution layer only). The
+        allowlist is resolved from the active execution scope by the hook, so
+        it can differ per turn even for the same user.
+        """
+        if self._tool_allowlist_cached:
+            return self._cached_tool_allowlist
+        try:
+            self._cached_tool_allowlist = get_user_tool_allowlist(self.db, self._user)
+        except Exception:
+            logger.exception("Failed to get user tool allowlist")
+            self._cached_tool_allowlist = None
+        self._tool_allowlist_cached = True
+        return self._cached_tool_allowlist
+
+    def refresh_user_tool_allowlist(self) -> Optional[list]:
+        """Reload the positive tool allowlist from the registered hook."""
+        # The active execution scope (hence the CA allowlist) can change while
+        # an AgentService instance is reused across turns.
+        self._tool_allowlist_cached = False
+        self._cached_tool_allowlist = None
+        return self.get_user_tool_allowlist()
 
     def get_excluded_agent_id(self) -> Optional[int]:
         """Get agent ID to exclude from agent tools (to prevent self-calls)."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -7,7 +7,6 @@ and other web-specific sources.
 
 import logging
 import os
-from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -15,7 +14,10 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...config import get_uploads_dir
-from ...core.tools.adapters.vibe.config import BaseToolConfig
+from ...core.tools.adapters.vibe.config import (
+    BaseToolConfig,
+    normalize_tool_allowlist,
+)
 from ...core.tools.adapters.vibe.connector_runtime import (
     ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
     MISSING_RUNTIME_VALUE,
@@ -35,21 +37,6 @@ from ..services.tool_credentials import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_allowlist(value: Any) -> Optional[List[str]]:
-    """Coerce a tool-allowlist hook result into a list of tool-name strings.
-
-    ``None`` passes through unchanged ("no allowlist configured"). A bare
-    scalar (str/bytes or any non-iterable such as int/float/bool) is treated
-    as a single tool name rather than being iterated character-by-character or
-    raising. Any other iterable yields one stringified name per item.
-    """
-    if value is None:
-        return None
-    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
-        return [str(value)]
-    return [str(item) for item in value]
 
 
 async def refresh_oauth_token_if_needed(
@@ -722,7 +709,7 @@ class WebToolConfig(BaseToolConfig):
         if self._tool_allowlist_cached:
             return self._cached_tool_allowlist
         try:
-            self._cached_tool_allowlist = _normalize_allowlist(
+            self._cached_tool_allowlist = normalize_tool_allowlist(
                 get_user_tool_allowlist(self.db, self._user)
             )
         except Exception:
@@ -1192,9 +1179,7 @@ class WebToolConfig(BaseToolConfig):
                     )
                     if delegated_connection:
                         delegated_connection["_connector_runtime_refresh"] = (
-                            lambda _server=server,
-                            _runtime_bindings=runtime_bindings,
-                            _allow_delegated_authorization=allow_delegated_authorization: (
+                            lambda _server=server, _runtime_bindings=runtime_bindings, _allow_delegated_authorization=allow_delegated_authorization: (
                                 self._refresh_delegated_mcp_connection(
                                     server=_server,
                                     runtime_bindings=_runtime_bindings,

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1401,6 +1401,11 @@ async def test_factory_all_mode_keeps_all_tools(isolated_registry):
     cfg.get_sandbox.return_value = None
     cfg.get_workspace_config.return_value = None
     cfg.get_user_tool_overrides.return_value = {}
+    # MagicMock auto-creates every attribute, so an unstubbed
+    # get_user_tool_allowlist() would return a truthy mock that the factory's
+    # positive-allowlist filter reads as "an allowlist containing no tools",
+    # dropping every tool. None = "no allowlist configured" (no filtering).
+    cfg.get_user_tool_allowlist.return_value = None
     cfg.get_max_output_length.return_value = None
     cfg.get_max_field_count.return_value = None
     cfg.get_max_recursion_depth.return_value = None
@@ -1424,6 +1429,11 @@ async def test_factory_none_mode_filters_to_empty(isolated_registry):
     cfg.get_sandbox.return_value = None
     cfg.get_workspace_config.return_value = None
     cfg.get_user_tool_overrides.return_value = {}
+    # MagicMock auto-creates every attribute, so an unstubbed
+    # get_user_tool_allowlist() would return a truthy mock that the factory's
+    # positive-allowlist filter reads as "an allowlist containing no tools",
+    # dropping every tool. None = "no allowlist configured" (no filtering).
+    cfg.get_user_tool_allowlist.return_value = None
     cfg.get_max_output_length.return_value = None
     cfg.get_max_field_count.return_value = None
     cfg.get_max_recursion_depth.return_value = None
@@ -1459,6 +1469,11 @@ async def test_factory_by_categories_filters_by_compute_allowed_names(
     cfg.get_sandbox.return_value = None
     cfg.get_workspace_config.return_value = None
     cfg.get_user_tool_overrides.return_value = {}
+    # MagicMock auto-creates every attribute, so an unstubbed
+    # get_user_tool_allowlist() would return a truthy mock that the factory's
+    # positive-allowlist filter reads as "an allowlist containing no tools",
+    # dropping every tool. None = "no allowlist configured" (no filtering).
+    cfg.get_user_tool_allowlist.return_value = None
     cfg.get_max_output_length.return_value = None
     cfg.get_max_field_count.return_value = None
     cfg.get_max_recursion_depth.return_value = None
@@ -1615,6 +1630,11 @@ def test_factory_falls_back_to_get_allowed_tools_when_spec_none():
     cfg.get_sandbox.return_value = None
     cfg.get_workspace_config.return_value = None
     cfg.get_user_tool_overrides.return_value = {}
+    # MagicMock auto-creates every attribute, so an unstubbed
+    # get_user_tool_allowlist() would return a truthy mock that the factory's
+    # positive-allowlist filter reads as "an allowlist containing no tools",
+    # dropping every tool. None = "no allowlist configured" (no filtering).
+    cfg.get_user_tool_allowlist.return_value = None
     cfg.get_max_output_length.return_value = None
     cfg.get_max_field_count.return_value = None
     cfg.get_max_recursion_depth.return_value = None
@@ -1661,6 +1681,11 @@ def test_factory_prefers_spec_and_warns_when_allowed_tools_also_set(caplog):
     cfg.get_sandbox.return_value = None
     cfg.get_workspace_config.return_value = None
     cfg.get_user_tool_overrides.return_value = {}
+    # MagicMock auto-creates every attribute, so an unstubbed
+    # get_user_tool_allowlist() would return a truthy mock that the factory's
+    # positive-allowlist filter reads as "an allowlist containing no tools",
+    # dropping every tool. None = "no allowlist configured" (no filtering).
+    cfg.get_user_tool_allowlist.return_value = None
     cfg.get_max_output_length.return_value = None
     cfg.get_max_field_count.return_value = None
     cfg.get_max_recursion_depth.return_value = None

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -84,6 +84,23 @@ def test_config_swallows_hook_errors(clear_allowlist_hook):
     assert cfg.get_user_tool_allowlist() is None
 
 
+@pytest.mark.parametrize(
+    ("hook_result", "expected"),
+    [
+        ("only_this", ["only_this"]),  # bare string is one tool name, not chars
+        (5, ["5"]),  # non-iterable scalar coerced to a single name
+        (True, ["True"]),
+        (("a", 2), ["a", "2"]),  # any iterable stringified per item
+    ],
+)
+def test_config_normalizes_scalar_allowlist(clear_allowlist_hook, hook_result, expected):
+    # A hook that violates the ``Optional[list]`` contract must not iterate a
+    # string character-by-character or crash on a non-iterable scalar; it is
+    # coerced to a list of tool-name strings at the WebToolConfig boundary.
+    set_user_tool_allowlist_hook(lambda db, user: hook_result)
+    assert _config().get_user_tool_allowlist() == expected
+
+
 # --------------------------------------------------------------------------- #
 # Factory positive filter
 # --------------------------------------------------------------------------- #

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -181,6 +181,13 @@ def test_factory_display_layer_ignores_allowlist(fake_registry):
     assert _build(_FakeConfig(["web_search"]), apply_user_override_filter=False) == _UNIVERSE
 
 
+def test_factory_normalizes_scalar_allowlist(fake_registry):
+    # A non-WebToolConfig config may hand back a bare string; the factory must
+    # treat it as a single tool name, not split it into characters (which would
+    # match nothing and silently drop every tool).
+    assert _build(_FakeConfig("web_search")) == ["web_search"]
+
+
 # --------------------------------------------------------------------------- #
 # Tool-policy signature includes the allowlist (cache isolation across turns)
 # --------------------------------------------------------------------------- #
@@ -216,6 +223,12 @@ def test_signature_differs_by_allowlist():
 
 def test_signature_stable_for_same_allowlist():
     assert _signature(_SigConfig(["a", "b"])) == _signature(_SigConfig(["a", "b"]))
+
+
+def test_signature_normalizes_scalar_allowlist():
+    # A scalar allowlist and its single-element list form must hash identically,
+    # so the signature does not depend on which the config happens to return.
+    assert _signature(_SigConfig("a")) == _signature(_SigConfig(["a"]))
 
 
 def test_signature_backward_compatible_without_allowlist_methods():

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -1,0 +1,213 @@
+"""Positive tool-allowlist hook, its WebToolConfig wiring, factory filter, and
+tool-policy-signature inclusion (added for xagent-saas #81 area A).
+
+The allowlist is a positive counterpart to the disable-set override hook: the
+factory keeps only tools whose name is in the list, applied to the already-built
+tool list so dynamically-loaded (e.g. MCP) tools are covered.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import xagent.core.tools.adapters.vibe.factory as factory_module
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+from xagent.web.services.tool_credentials import (
+    get_user_tool_allowlist,
+    set_user_tool_allowlist_hook,
+)
+from xagent.web.tools.config import WebToolConfig
+
+
+@pytest.fixture
+def clear_allowlist_hook():
+    set_user_tool_allowlist_hook(None)
+    yield
+    set_user_tool_allowlist_hook(None)
+
+
+# --------------------------------------------------------------------------- #
+# Hook registration
+# --------------------------------------------------------------------------- #
+def test_no_hook_returns_none(clear_allowlist_hook):
+    assert get_user_tool_allowlist(None, None) is None
+
+
+def test_registered_hook_is_invoked(clear_allowlist_hook):
+    set_user_tool_allowlist_hook(lambda db, user: ["a", "b"])
+    assert get_user_tool_allowlist(None, None) == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# WebToolConfig caching / refresh
+# --------------------------------------------------------------------------- #
+def _config() -> WebToolConfig:
+    return WebToolConfig(db=None, request=SimpleNamespace(), user_id=1)
+
+
+def test_config_reads_and_caches_allowlist(clear_allowlist_hook):
+    holder = {"value": ["only_this"]}
+    set_user_tool_allowlist_hook(lambda db, user: holder["value"])
+    cfg = _config()
+
+    assert cfg.get_user_tool_allowlist() == ["only_this"]
+    # Cached: a later change to the hook result is not observed until refresh.
+    holder["value"] = ["changed"]
+    assert cfg.get_user_tool_allowlist() == ["only_this"]
+    assert cfg.refresh_user_tool_allowlist() == ["changed"]
+
+
+def test_config_caches_none_result(clear_allowlist_hook):
+    calls = {"n": 0}
+
+    def _hook(db, user):
+        calls["n"] += 1
+        return None
+
+    set_user_tool_allowlist_hook(_hook)
+    cfg = _config()
+
+    assert cfg.get_user_tool_allowlist() is None
+    assert cfg.get_user_tool_allowlist() is None
+    # None is a real value, not "uncomputed": the hook is consulted only once.
+    assert calls["n"] == 1
+
+
+def test_config_swallows_hook_errors(clear_allowlist_hook):
+    def _boom(db, user):
+        raise RuntimeError("hook failed")
+
+    set_user_tool_allowlist_hook(_boom)
+    cfg = _config()
+    # A failing hook must not break tool building; treated as "no allowlist".
+    assert cfg.get_user_tool_allowlist() is None
+
+
+# --------------------------------------------------------------------------- #
+# Factory positive filter
+# --------------------------------------------------------------------------- #
+class _FakeTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeConfig:
+    def __init__(self, allowlist) -> None:
+        self._allowlist = allowlist
+
+    def get_tool_selection_spec(self):
+        return None
+
+    def get_allowed_tools(self):
+        return None
+
+    def get_user_tool_overrides(self):
+        return {}
+
+    def get_user_tool_allowlist(self):
+        return self._allowlist
+
+    def get_sandbox(self):
+        return None
+
+    def get_max_output_length(self):
+        return 10_000
+
+    def get_max_field_count(self):
+        return 100
+
+    def get_max_recursion_depth(self):
+        return 10
+
+
+_UNIVERSE = ["web_search", "python_executor", "mcp__server__do_thing"]
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    async def _create_registered_tools(config):
+        return [_FakeTool(name) for name in _UNIVERSE]
+
+    monkeypatch.setattr(
+        factory_module.ToolRegistry,
+        "create_registered_tools",
+        _create_registered_tools,
+    )
+
+
+def _build(config, *, apply_user_override_filter=True):
+    import asyncio
+
+    tools = asyncio.run(
+        ToolFactory.create_all_tools(config, apply_user_override_filter=apply_user_override_filter)
+    )
+    return [t.name for t in tools]
+
+
+def test_factory_keeps_only_allowlisted_including_mcp(fake_registry):
+    assert _build(_FakeConfig(["web_search", "mcp__server__do_thing"])) == [
+        "web_search",
+        "mcp__server__do_thing",
+    ]
+
+
+def test_factory_none_allowlist_keeps_all(fake_registry):
+    assert _build(_FakeConfig(None)) == _UNIVERSE
+
+
+def test_factory_empty_allowlist_drops_all(fake_registry):
+    assert _build(_FakeConfig([])) == []
+
+
+def test_factory_display_layer_ignores_allowlist(fake_registry):
+    assert _build(_FakeConfig(["web_search"]), apply_user_override_filter=False) == _UNIVERSE
+
+
+# --------------------------------------------------------------------------- #
+# Tool-policy signature includes the allowlist (cache isolation across turns)
+# --------------------------------------------------------------------------- #
+class _SigConfig:
+    def __init__(self, allowlist) -> None:
+        self._allowlist = allowlist
+
+    def get_user_tool_allowlist(self):
+        return self._allowlist
+
+    def refresh_user_tool_allowlist(self):
+        return self._allowlist
+
+
+def _signature(config):
+    from xagent.core.agent.service import AgentService
+
+    svc = AgentService.__new__(AgentService)
+    svc.tool_config = config
+    return svc._current_tool_policy_signature()
+
+
+def test_signature_differs_by_allowlist():
+    sig_a = _signature(_SigConfig(["a"]))
+    sig_b = _signature(_SigConfig(["a", "b"]))
+    sig_none = _signature(_SigConfig(None))
+    # Different allowlists must not collide, or a reused AgentService could
+    # serve one client application's cached tool set to another.
+    assert sig_a != sig_b
+    assert sig_a != sig_none
+    assert sig_b != sig_none
+
+
+def test_signature_stable_for_same_allowlist():
+    assert _signature(_SigConfig(["a", "b"])) == _signature(_SigConfig(["a", "b"]))
+
+
+def test_signature_backward_compatible_without_allowlist_methods():
+    # A legacy config lacking the allowlist methods must still produce a
+    # signature (the allowlist slot is simply None).
+    legacy = SimpleNamespace()
+    from xagent.core.agent.service import AgentService
+
+    svc = AgentService.__new__(AgentService)
+    svc.tool_config = legacy
+    # truthy config required; SimpleNamespace() is truthy.
+    assert isinstance(svc._current_tool_policy_signature(), tuple)

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+
 import xagent.core.tools.adapters.vibe.factory as factory_module
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.services.tool_credentials import (
@@ -93,7 +94,9 @@ def test_config_swallows_hook_errors(clear_allowlist_hook):
         (("a", 2), ["a", "2"]),  # any iterable stringified per item
     ],
 )
-def test_config_normalizes_scalar_allowlist(clear_allowlist_hook, hook_result, expected):
+def test_config_normalizes_scalar_allowlist(
+    clear_allowlist_hook, hook_result, expected
+):
     # A hook that violates the ``Optional[list]`` contract must not iterate a
     # string character-by-character or crash on a non-iterable scalar; it is
     # coerced to a list of tool-name strings at the WebToolConfig boundary.
@@ -157,7 +160,9 @@ def _build(config, *, apply_user_override_filter=True):
     import asyncio
 
     tools = asyncio.run(
-        ToolFactory.create_all_tools(config, apply_user_override_filter=apply_user_override_filter)
+        ToolFactory.create_all_tools(
+            config, apply_user_override_filter=apply_user_override_filter
+        )
     )
     return [t.name for t in tools]
 
@@ -178,7 +183,10 @@ def test_factory_empty_allowlist_drops_all(fake_registry):
 
 
 def test_factory_display_layer_ignores_allowlist(fake_registry):
-    assert _build(_FakeConfig(["web_search"]), apply_user_override_filter=False) == _UNIVERSE
+    assert (
+        _build(_FakeConfig(["web_search"]), apply_user_override_filter=False)
+        == _UNIVERSE
+    )
 
 
 def test_factory_normalizes_scalar_allowlist(fake_registry):


### PR DESCRIPTION
Enablers in xagent for **xorbitsai/xagent-saas#81** (external client-application policy, layered quota, usage breakdown). Two small, backward-compatible additions consumed by the SaaS layer; **no behavior change for existing callers**.

> Supersedes #852 (re-homed to a fork branch). Same commits, plus a follow-up robustness fix from the review below.

## What this adds

**1. Positive tool-allowlist hook** (`set_user_tool_allowlist_hook` / `get_user_tool_allowlist` in `web/services/tool_credentials.py`)

A positive counterpart to the existing disable-set override hook. The tool factory applies it as a filter on the **already-built** tool list, so it also covers dynamically-loaded MCP tools without enumerating a tool universe. `None` means "no allowlist" (no filtering); an empty list means "no tools allowed". It runs only under the execution-layer flag, so the display/config path still shows every tool.

- `WebToolConfig` caches/refreshes the allowlist alongside the overrides.
- `AgentService._current_tool_policy_signature` now includes the allowlist, so a reused `AgentService` cannot serve one caller's cached tool set to another.

**2. Layered-quota error codes** (`web/api/v1/errors.py`)

`QUOTA_EXCEEDED` (team ceiling) and `CLIENT_QUOTA_EXCEEDED` (per-client-application sub-quota), both intended for HTTP 402. Distinct codes let an SDK client tell "the whole team is out of quota" from "this application's slice is spent while the team still has room". `RATE_LIMITED` (429) stays reserved for request-rate throttling.

## Review follow-up: scalar-allowlist normalization

The allowlist hook is user-registered and documented as `Optional[list]`. If a hook violates that contract and returns a bare scalar, the downstream filters would misbehave — `set("toolname")` splits a string into characters, and `tuple(str(x) for x in 5)` crashes on a non-iterable. `WebToolConfig.get_user_tool_allowlist` now normalizes the hook result at that single boundary: `None` passes through, a bare string/bytes or any non-iterable scalar becomes a single-element list, and any other iterable is stringified per item. The `factory.py` / `service.py` filters are unchanged.

## Relationship to in-flight tool-policy work

- **#470** (separate structural allow-lists from runtime availability): the new hook is a *runtime-availability* filter, aligned with that separation. It also addresses the reused-`AgentService` staleness #470 calls out, by including the allowlist in the tool-policy signature.
- **#766** tool-approval epic (#768): orthogonal concern — "which tools are available" (this hook) vs "which calls need runtime confirmation" (approval gate). Both live in `factory.py` / `service.py` but do not overlap functionally.

## Tests

`tests/web/tools/test_user_tool_allowlist.py`: hook default/registration, `WebToolConfig` caching/refresh (incl. `None` cached as a real value, hook errors swallowed, scalar results normalized), factory positive filter (incl. MCP-style names, `None`, empty, display layer), and tool-policy-signature inclusion / cache isolation.
