### PR TITLE
feat: per-step interrupt seam for mid-run quota enforcement

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -33,6 +33,9 @@ class AgentExecutionConfig:
     tool_parallel_enabled: bool = field(default_factory=get_tool_parallel_enabled)
     tool_max_concurrency: int = field(default_factory=get_tool_max_concurrency)
     outbound_message_handler: Any | None = None
+    # Polled per step by the pattern loop; returns a reason to interrupt the run
+    # (e.g. a mid-run quota gate). None => never interrupt from a checker.
+    interrupt_checker: Any | None = None
     conversation_history: list[dict[str, Any]] = field(default_factory=list)
     execution_context_messages: list[dict[str, Any]] = field(default_factory=list)
     recovered_skill_context: str | None = None
@@ -90,6 +93,7 @@ class AgentExecutionAdapter:
             workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
+            interrupt_checker=self.config.interrupt_checker,
         )
         if handle.task is None:
             raise RuntimeError("Execution registry did not create a task.")
@@ -128,6 +132,7 @@ class AgentExecutionAdapter:
             workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
+            interrupt_checker=self.config.interrupt_checker,
         )
         return handle.to_dict()
 

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -141,6 +141,9 @@ class AgentExecutionAdapter:
 
     async def resume(self, execution_id: str, **kwargs: Any) -> dict[str, Any] | None:
         kwargs.setdefault("workspace_id", self._workspace_id(execution_id))
+        # Carry the mid-run quota checker into the resumed run too, so a
+        # paused-and-resumed continuation is gated like a fresh run.
+        kwargs.setdefault("interrupt_checker", self.config.interrupt_checker)
         handle = self.registry.get(execution_id)
         if handle is None:
             runner, execution_type = self._build_runner()

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -277,6 +277,7 @@ class AgentRunner:
         streaming_handler: Any | None = None,
         extra_tools: list[Any] | None = None,
         metadata: dict[str, Any] | None = None,
+        interrupt_checker: Any | None = None,
     ) -> dict[str, Any]:
         checkpoint = await self._load_latest_checkpoint(execution_id)
         resolved_task = self._resolve_task(
@@ -297,6 +298,7 @@ class AgentRunner:
             streaming_handler=streaming_handler,
             extra_tools=extra_tools,
             metadata=metadata,
+            interrupt_checker=interrupt_checker,
         )
 
     async def inject_user_message(

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -73,6 +73,11 @@ class PatternRuntime:
         result = self.interrupt_checker()
         if inspect.isawaitable(result):
             result = await result
+        # A checker may return a string to both signal interruption AND supply
+        # the reason (e.g. a quota gate surfacing why the run was stopped); a
+        # bare truthy value keeps the previous reason-less behaviour.
+        if isinstance(result, str):
+            self.interrupt_reason = result
         if result:
             self._interrupt_requested = True
             self.request_interrupt(self.interrupt_reason)

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -73,12 +73,14 @@ class PatternRuntime:
         result = self.interrupt_checker()
         if inspect.isawaitable(result):
             result = await result
-        # A checker may return a string to both signal interruption AND supply
-        # the reason (e.g. a quota gate surfacing why the run was stopped); a
-        # bare truthy value keeps the previous reason-less behaviour.
-        if isinstance(result, str):
-            self.interrupt_reason = result
         if result:
+            # A checker may return a string to both signal interruption AND
+            # supply the reason (e.g. a quota gate surfacing why the run was
+            # stopped); a bare truthy value keeps the previous reason-less
+            # behaviour. Only a truthy result sets the reason, so a falsey ""
+            # neither interrupts nor clobbers an existing reason.
+            if isinstance(result, str):
+                self.interrupt_reason = result
             self._interrupt_requested = True
             self.request_interrupt(self.interrupt_reason)
         return bool(result)

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -104,6 +104,7 @@ class AgentService:
         self._current_runner = None
         self._execution_adapter: Any | None = None
         self._outbound_message_handler: Callable[[dict[str, Any]], Any] | None = None
+        self._interrupt_checker: Callable[[], Any] | None = None
         self._conversation_history: list[dict[str, Any]] = []
         self._execution_context_messages: list[dict[str, str]] = []
         self._recovered_skill_context: str | None = None
@@ -248,6 +249,14 @@ class AgentService:
         self._outbound_message_handler = handler
         if self._execution_adapter is not None:
             self._execution_adapter.config.outbound_message_handler = handler
+
+    def set_interrupt_checker(self, checker: Callable[[], Any] | None) -> None:
+        """Register a per-step interrupt-checker (polled by the pattern loop at
+        each LLM reply / tool call). Returning truthy — or a reason string —
+        interrupts the run. Used to enforce mid-run quota; None disables it."""
+        self._interrupt_checker = checker
+        if self._execution_adapter is not None:
+            self._execution_adapter.config.interrupt_checker = checker
 
     def set_allowed_skills(self, allowed_skills: list[str] | None) -> None:
         self.allowed_skills = allowed_skills
@@ -416,6 +425,7 @@ class AgentService:
             self._execution_adapter.config.outbound_message_handler = (
                 self._outbound_message_handler
             )
+            self._execution_adapter.config.interrupt_checker = self._interrupt_checker
             self._execution_adapter.config.conversation_history = (
                 self._conversation_history
             )
@@ -473,6 +483,7 @@ class AgentService:
                 current_task_id=self._current_task_id,
                 service_id=self.id,
                 outbound_message_handler=self._outbound_message_handler,
+                interrupt_checker=self._interrupt_checker,
                 conversation_history=self._conversation_history,
                 execution_context_messages=self._execution_context_messages,
                 recovered_skill_context=self._recovered_skill_context,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2233,6 +2233,12 @@ class AgentServiceManager:
                     db_session=db_session,
                 )
                 await tracker.start_tracking()
+                # Enforce quota mid-run: the pattern loop polls this every step
+                # (each LLM reply / tool call) and stops the run once its live
+                # cost would push the team over quota, instead of only metering at
+                # completion. Cleared in the finally so a reused agent_service
+                # never keeps a finished run's tracker as its checker.
+                agent_service.set_interrupt_checker(tracker.interrupt_reason_for_quota)
                 logger.info(f"Started token tracking for task {tracker_task_id}")
             except Exception as e:
                 logger.warning(
@@ -2284,6 +2290,9 @@ class AgentServiceManager:
                 )
             # Complete tracking if it was started
             if tracker:
+                # Drop the mid-run quota checker before metering so a reused
+                # agent_service can't keep calling this finished run's tracker.
+                agent_service.set_interrupt_checker(None)
                 try:
                     await tracker.complete_tracking()
                     logger.info(f"Completed token tracking for task {tracker_task_id}")

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2261,6 +2261,21 @@ class AgentServiceManager:
                 task=task, context=context, task_id=task_id
             )
 
+            # If a mid-run quota gate stopped the run, surface the reason the way
+            # the start gate does — a terminal quota_exceeded result carrying the
+            # reason as output — instead of the pattern-interrupt path's silent
+            # flip to PAUSED (which persists no message).
+            if tracker is not None and isinstance(result, dict):
+                quota_reason = getattr(tracker, "quota_interrupt_reason", None)
+                if quota_reason:
+                    result = {
+                        **result,
+                        "success": False,
+                        "status": "quota_exceeded",
+                        "output": quota_reason,
+                        "error": quota_reason,
+                    }
+
             logger.info("=== Task executed successfully, updating title if needed ===")
 
             # Update task title with generated task_name (clean architecture: Core provides API, Web handles DB)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1890,6 +1890,11 @@ async def execute_resume_background(
     lease = None
     lease_released = False
     result: Dict[str, Any] | None = None
+    # Token tracking + mid-run quota gate for the resumed segment (resume had
+    # neither before, so a resumed run escaped mid-run enforcement entirely).
+    resume_tracker = None
+    resume_tracker_db = None
+    resume_tracker_db_gen = None
     normalized_outputs: list[Dict[str, str]] = []
     output = ""
     success = False
@@ -2045,6 +2050,27 @@ async def execute_resume_background(
             task_id,
         )
 
+        # Track tokens and enforce the mid-run quota gate on the resumed segment
+        # too. Best-effort: a tracking hiccup must never block the resume.
+        try:
+            from ..tracking.task_tracker import TaskTracker
+
+            resume_tracker_db_gen = get_db()
+            resume_tracker_db = next(resume_tracker_db_gen)
+            resume_tracker = TaskTracker(
+                task_id=int(task_id), db_session=resume_tracker_db
+            )
+            await resume_tracker.start_tracking()
+            agent_service.set_interrupt_checker(
+                resume_tracker.interrupt_reason_for_quota
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"execute_resume_background: token tracking unavailable "
+                f"for task {task_id}: {e}"
+            )
+            resume_tracker = None
+
         with UserContext(task_owner_user_id), turn_execution_scope(task_id):
             result = await agent_service.resume_execution_by_id(str(task_id))
 
@@ -2052,6 +2078,19 @@ async def execute_resume_background(
             raise RuntimeError(
                 f"No resumable execution checkpoint was found for task {task_id}."
             )
+
+        # If the mid-run quota gate stopped the resumed run, surface the reason
+        # the way the start gate does instead of a silent flip to PAUSED.
+        if resume_tracker is not None and isinstance(result, dict):
+            _quota_reason = getattr(resume_tracker, "quota_interrupt_reason", None)
+            if _quota_reason:
+                result = {
+                    **result,
+                    "success": False,
+                    "status": "quota_exceeded",
+                    "output": _quota_reason,
+                    "error": _quota_reason,
+                }
 
         status = str(result.get("status") or "")
         success = bool(result.get("success", False))
@@ -2221,6 +2260,19 @@ async def execute_resume_background(
             task_id,
         )
     finally:
+        # Finalize the resumed segment's tracking: drop the checker, meter the
+        # partial usage, and close the tracker's dedicated session. Best-effort.
+        if resume_tracker is not None:
+            agent_service.set_interrupt_checker(None)
+            try:
+                await resume_tracker.complete_tracking()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"execute_resume_background: token tracking completion "
+                    f"failed for task {task_id}: {e}"
+                )
+        if resume_tracker_db is not None:
+            resume_tracker_db.close()
         await stop_task_lease_heartbeat(lease_heartbeat_task, lease_stop_event)
         if lease is not None and not lease_released:
             db_gen = get_db()

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -32,8 +32,14 @@ _usage_record_hook: Callable[[Any, Any, list, int], None] | None = None
 # in-flight run's live-so-far usage would push the team over a run-gated quota,
 # else None. Polled per step (each LLM reply / tool call) during a run so a
 # single long/expensive run is stopped mid-flight instead of only being metered
-# at completion. Read-only: it must not write or commit `db` (same contract
-# spirit as the metering hook), and should stay cheap since it runs every step.
+# at completion.
+#
+# CONTRACT: invoked SYNCHRONOUSLY on the event loop once per step. It MUST NOT
+# block (no synchronous network/DB round-trips per call) — blocking work stalls
+# the loop every step. Resolve/cache anything expensive out of band (the stock
+# app layer caches the user->team lookup and checks quota off in-memory
+# counters). Read-only: it must not write or commit `db` (same contract spirit
+# as the metering hook).
 _run_progress_gate_hook: Callable[[Any, Any, list, int], str | None] | None = None
 # (db, user_id) -> reason str if the team is out of storage quota, else None
 _storage_gate_hook: Callable[[Any, Any], str | None] | None = None

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -28,6 +28,13 @@ _run_gate_hook: Callable[[Any, Any], str | None] | None = None
 # caller to commit them (they may be rolled back), and must NOT commit `db`
 # itself (that would prematurely persist the caller's unrelated pending state).
 _usage_record_hook: Callable[[Any, Any, list, int], None] | None = None
+# (db, user_id, delta_details, delta_actions) -> reason str if counting this
+# in-flight run's live-so-far usage would push the team over a run-gated quota,
+# else None. Polled per step (each LLM reply / tool call) during a run so a
+# single long/expensive run is stopped mid-flight instead of only being metered
+# at completion. Read-only: it must not write or commit `db` (same contract
+# spirit as the metering hook), and should stay cheap since it runs every step.
+_run_progress_gate_hook: Callable[[Any, Any, list, int], str | None] | None = None
 # (db, user_id) -> reason str if the team is out of storage quota, else None
 _storage_gate_hook: Callable[[Any, Any], str | None] | None = None
 # (user_id) -> None; +1 billable action when a run is fired by a trigger
@@ -43,6 +50,13 @@ def set_run_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
 def set_usage_record_hook(hook: Callable[[Any, Any, list, int], None] | None) -> None:
     global _usage_record_hook
     _usage_record_hook = hook
+
+
+def set_run_progress_gate_hook(
+    hook: Callable[[Any, Any, list, int], str | None] | None,
+) -> None:
+    global _run_progress_gate_hook
+    _run_progress_gate_hook = hook
 
 
 def set_storage_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
@@ -67,6 +81,14 @@ def record_usage(
     if _usage_record_hook is None or user_id is None:
         return
     _usage_record_hook(db, user_id, delta_details, delta_actions)
+
+
+def check_run_progress_gate(
+    db: Any, user_id: Any, delta_details: list, delta_actions: int
+) -> str | None:
+    if _run_progress_gate_hook is None or user_id is None:
+        return None
+    return _run_progress_gate_hook(db, user_id, delta_details, delta_actions)
 
 
 def check_storage_gate(db: Any, user_id: Any) -> str | None:

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -348,7 +348,7 @@ class TaskTracker:
             delta_details, delta_actions = self._turn_delta(usage)
             record_usage(
                 self.db_session,
-                getattr(self.task, "user_id", None),
+                self._user_id,
                 delta_details,
                 delta_actions,
             )

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -257,6 +257,46 @@ class TaskTracker:
         self._is_tracking = False
         logger.info(f"Stopped periodic token updates for task {self.task_id}")
 
+    def _turn_delta(self, usage: TokenUsage | None = None) -> tuple[list, int]:
+        """This turn's (detail entries, tool-call count) over the baseline seeded
+        in start_tracking. Single source for the completion meter and the mid-run
+        gate so they can't disagree on what 'this run's usage' means."""
+        if usage is None:
+            usage = get_token_usage()
+        return (
+            usage.details[self._initial_details_len :],
+            max(0, usage.tool_calls - self._initial_tool_calls),
+        )
+
+    def interrupt_reason_for_quota(self) -> str | None:
+        """Per-step interrupt-checker: return a reason when this run's live-so-far
+        usage would push the team over a run-gated quota, so a single long or
+        expensive run is stopped mid-flight instead of only being metered at
+        completion (``complete_tracking`` still meters the partial usage on exit).
+
+        Wired as the run's ``interrupt_checker`` and polled at every safe point
+        (each LLM reply / tool call). Synchronous and best-effort: it reuses the
+        exact turn-delta the metering path computes, and swallows errors so a
+        quota-infra hiccup fails open rather than wedging a run.
+        """
+        if not self._is_tracking:
+            return None
+        try:
+            from ..services.quota_hooks import check_run_progress_gate
+
+            delta_details, delta_actions = self._turn_delta()
+            return check_run_progress_gate(
+                self.db_session,
+                getattr(self.task, "user_id", None),
+                delta_details,
+                delta_actions,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"Quota progress gate failed open for task {self.task_id}: {e}"
+            )
+            return None
+
     async def complete_tracking(self) -> TokenUsage:
         """Complete tracking and return final statistics.
 
@@ -284,8 +324,7 @@ class TaskTracker:
         try:
             from ..services.quota_hooks import record_usage
 
-            delta_details = usage.details[self._initial_details_len :]
-            delta_actions = max(0, usage.tool_calls - self._initial_tool_calls)
+            delta_details, delta_actions = self._turn_delta(usage)
             record_usage(
                 self.db_session,
                 getattr(self.task, "user_id", None),

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -73,6 +73,17 @@ class TaskTracker:
         if not self.task:
             raise ValueError(f"Task {task_id} not found")
 
+        # Cache user_id at construction: the per-step quota checker reads it every
+        # step, and `self.task` is expired after periodic_update commits
+        # (expire_on_commit), so a fresh `self.task.user_id` would trigger an
+        # implicit blocking SELECT. user_id never changes for a task.
+        self._user_id = getattr(self.task, "user_id", None)
+        # Fail-open logging in the per-step gate must not flood: log once per run.
+        self._quota_gate_warned = False
+        # Set to the gate reason if the mid-run quota gate trips, so the run's
+        # caller can surface why the run stopped instead of a silent PAUSE.
+        self.quota_interrupt_reason: str | None = None
+
     async def start_tracking(self) -> None:
         """Start tracking token usage for this task."""
         if self._is_tracking:
@@ -278,6 +289,10 @@ class TaskTracker:
         (each LLM reply / tool call). Synchronous and best-effort: it reuses the
         exact turn-delta the metering path computes, and swallows errors so a
         quota-infra hiccup fails open rather than wedging a run.
+
+        When it trips it records the reason in ``quota_interrupt_reason`` so the
+        run's caller can surface *why* the run stopped (the pattern interrupt
+        path itself would otherwise flip silently to PAUSED).
         """
         if not self._is_tracking:
             return None
@@ -285,16 +300,22 @@ class TaskTracker:
             from ..services.quota_hooks import check_run_progress_gate
 
             delta_details, delta_actions = self._turn_delta()
-            return check_run_progress_gate(
+            reason = check_run_progress_gate(
                 self.db_session,
-                getattr(self.task, "user_id", None),
+                self._user_id,
                 delta_details,
                 delta_actions,
             )
+            if reason is not None:
+                self.quota_interrupt_reason = reason
+            return reason
         except Exception as e:  # noqa: BLE001
-            logger.warning(
-                f"Quota progress gate failed open for task {self.task_id}: {e}"
-            )
+            # Runs per step; log once per run so a persistent failure can't flood.
+            if not self._quota_gate_warned:
+                self._quota_gate_warned = True
+                logger.warning(
+                    f"Quota progress gate failed open for task {self.task_id}: {e}"
+                )
             return None
 
     async def complete_tracking(self) -> TokenUsage:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -1067,3 +1067,28 @@ async def test_execution_adapter_posts_user_message_after_restart() -> None:
         and message.content == "New message after process restart."
         for message in context_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_set_interrupt_checker_propagates_to_prebuilt_adapter() -> None:
+    # The mid-run quota checker is normally installed before a run, but
+    # set_interrupt_checker must also push onto an already-built adapter — the
+    # only path that updates enforcement on an already-executing task.
+    service = AgentService(
+        name="interrupt-service",
+        id="interrupt-service",
+        pattern="react",
+        llm=cast(Any, FakeLLM([])),
+        tools=cast(Any, []),
+        tool_config=None,
+    )
+    service.allowed_skills = []
+    service._execution_adapter = service._build_execution_adapter()
+
+    def checker() -> None:
+        return None
+
+    service.set_interrupt_checker(checker)
+    assert service._execution_adapter.config.interrupt_checker is checker
+    service.set_interrupt_checker(None)
+    assert service._execution_adapter.config.interrupt_checker is None

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -265,6 +265,22 @@ async def test_runtime_interrupt_converts_active_llm_cancel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_should_interrupt_string_result_becomes_reason() -> None:
+    # A checker returning a string interrupts AND supplies the reason (used by
+    # the mid-run quota gate so the run surfaces *why* it was stopped).
+    runtime = PatternRuntime(interrupt_checker=lambda: "Monthly quota reached")
+    assert await runtime.should_interrupt() is True
+    assert runtime.interrupt_reason == "Monthly quota reached"
+
+
+@pytest.mark.asyncio
+async def test_should_interrupt_falsey_checker_does_not_interrupt() -> None:
+    runtime = PatternRuntime(interrupt_checker=lambda: None)
+    assert await runtime.should_interrupt() is False
+    assert runtime.interrupt_reason is None
+
+
+@pytest.mark.asyncio
 async def test_runtime_preserves_non_interrupt_cancelled_error() -> None:
     runtime = PatternRuntime()
 

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -281,6 +281,15 @@ async def test_should_interrupt_falsey_checker_does_not_interrupt() -> None:
 
 
 @pytest.mark.asyncio
+async def test_should_interrupt_empty_string_neither_interrupts_nor_sets_reason() -> None:
+    # "" is falsey: it must not interrupt, and must not clobber interrupt_reason.
+    runtime = PatternRuntime(interrupt_checker=lambda: "")
+    runtime.interrupt_reason = "prior"
+    assert await runtime.should_interrupt() is False
+    assert runtime.interrupt_reason == "prior"
+
+
+@pytest.mark.asyncio
 async def test_runtime_preserves_non_interrupt_cancelled_error() -> None:
     runtime = PatternRuntime()
 

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -281,7 +281,9 @@ async def test_should_interrupt_falsey_checker_does_not_interrupt() -> None:
 
 
 @pytest.mark.asyncio
-async def test_should_interrupt_empty_string_neither_interrupts_nor_sets_reason() -> None:
+async def test_should_interrupt_empty_string_neither_interrupts_nor_sets_reason() -> (
+    None
+):
     # "" is falsey: it must not interrupt, and must not clobber interrupt_reason.
     runtime = PatternRuntime(interrupt_checker=lambda: "")
     runtime.interrupt_reason = "prior"

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -185,6 +185,7 @@ async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
     tracker.complete_tracking = AsyncMock()
     agent_service = _FakeAgentService()
     agent_service.execute_task = AsyncMock()  # type: ignore[method-assign]
+    agent_service.set_interrupt_checker = MagicMock()  # type: ignore[method-assign]
 
     with (
         patch(
@@ -232,6 +233,9 @@ async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
     assert mock_release.call_args.kwargs["status"] == TaskStatus.FAILED
     tracker.complete_tracking.assert_awaited_once()
     mock_sbx.assert_awaited_once_with(None)
+    # The mid-run quota checker must be cleared in the finally so a reused
+    # agent_service can't keep calling this finished run's tracker.
+    agent_service.set_interrupt_checker.assert_any_call(None)
 
 
 def test_sync_workforce_run_status_running_is_idempotent(db_session) -> None:

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -159,6 +159,64 @@ async def test_execute_task_skips_lease_but_syncs_running_when_manage_false(
 
 
 @pytest.mark.asyncio
+async def test_execute_task_surfaces_mid_run_quota_reason(db_session) -> None:
+    """When the mid-run quota gate trips, the run result is reshaped to a
+    terminal quota_exceeded carrying the reason as output (mirroring the start
+    gate) instead of the pattern-interrupt path's silent flip to PAUSED."""
+    user = User(username="quota-user", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    task = Task(
+        user_id=user.id,
+        title="quota test",
+        description="test",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+    )
+    db_session.add(task)
+    db_session.commit()
+
+    manager = AgentServiceManager()
+    reason = "Monthly ai_credits_per_month quota reached. Upgrade your plan."
+    tracker = MagicMock()
+    tracker.start_tracking = AsyncMock()
+    tracker.complete_tracking = AsyncMock()
+    tracker.quota_interrupt_reason = reason  # the mid-run gate tripped
+
+    agent_service = _FakeAgentService()
+    # The pattern-interrupt path returns a silent "interrupted" result.
+    agent_service.execute_task = AsyncMock(  # type: ignore[method-assign]
+        return_value={"success": False, "status": "interrupted", "error": "interrupted"}
+    )
+
+    with (
+        patch("xagent.web.api.chat.run_task_lease_heartbeat", new=AsyncMock()),
+        patch("xagent.web.api.chat.stop_task_lease_heartbeat", new=AsyncMock()),
+        patch.object(
+            manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
+        ),
+        patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
+        patch("xagent.web.api.chat.sync_workforce_run_status", return_value=False),
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            return_value=tracker,
+        ),
+    ):
+        result = await manager.execute_task(
+            agent_service=agent_service,
+            task="hello",
+            tracking_task_id=str(task.id),
+            db_session=db_session,
+            manage_task_lease=False,
+        )
+
+    assert result["status"] == "quota_exceeded"
+    assert result["success"] is False
+    assert result["output"] == reason
+    assert result["error"] == reason
+
+
+@pytest.mark.asyncio
 async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
     db_session,
 ) -> None:

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -31,6 +31,11 @@ class _FakeAgentService:
     async def execute_task(self, **_kwargs):
         return {"success": True}
 
+    def set_interrupt_checker(self, _checker):
+        # execute_task_background sets the mid-run quota checker after tracking
+        # starts and clears it on completion; the double must accept both.
+        pass
+
 
 @pytest.mark.asyncio
 async def test_execute_task_acquires_and_releases_lease_when_manage_true(

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -528,3 +528,27 @@ class TestTaskTrackerIntegration:
         types = [d.get("type") for d in final_usage.details]
         assert "input" in types
         assert "output" in types
+
+
+def test_check_run_progress_gate_guards():
+    """The quota-gate seam is a no-op when no hook is registered or user_id is
+    None, and otherwise forwards to the hook and returns its reason."""
+    from xagent.web.services import quota_hooks
+
+    # No hook registered → None regardless of args.
+    quota_hooks.set_run_progress_gate_hook(None)
+    assert quota_hooks.check_run_progress_gate("db", 1, [], 0) is None
+
+    seen = []
+    quota_hooks.set_run_progress_gate_hook(
+        lambda db, uid, dd, da: (seen.append(uid), "OVER")[1]
+    )
+    try:
+        # user_id None short-circuits before the hook is called.
+        assert quota_hooks.check_run_progress_gate("db", None, [], 0) is None
+        assert seen == []
+        # Otherwise the hook runs and its reason is returned verbatim.
+        assert quota_hooks.check_run_progress_gate("db", 7, [], 3) == "OVER"
+        assert seen == [7]
+    finally:
+        quota_hooks.set_run_progress_gate_hook(None)

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -92,6 +92,51 @@ class TestTaskTracker:
         assert sorted(d["tokens"] for d in captured["details"]) == [5, 10]
 
     @pytest.mark.asyncio
+    async def test_interrupt_reason_for_quota_passes_turn_delta(self, db_session):
+        """The per-step quota gate must see the same this-turn delta the metering
+        path computes, and surface the gate's reason (or None when open)."""
+        from xagent.core.model.chat.token_context import add_tool_call_usage
+        from xagent.web.services import quota_hooks
+
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        task.user_id = 42
+        task.input_tokens = 100
+        task.output_tokens = 50
+        task.llm_calls = 1
+        task.token_usage_details = [
+            {"type": "input", "tokens": 100, "model": "m", "call_type": "chat"},
+        ]
+
+        captured = {}
+
+        def _gate(db, user_id, delta_details, delta_actions):
+            captured.update(
+                user_id=user_id, details=delta_details, actions=delta_actions
+            )
+            return "over credits" if delta_actions >= 2 else None
+
+        quota_hooks.set_run_progress_gate_hook(_gate)
+        try:
+            tracker = TaskTracker(task_id=123, db_session=db_session)
+            # Before tracking starts, the checker is a no-op (fails open).
+            assert tracker.interrupt_reason_for_quota() is None
+            await tracker.start_tracking()
+            add_token_usage(
+                input_tokens=10, output_tokens=5, model="m", call_type="chat"
+            )
+            add_tool_call_usage(2)
+            reason = tracker.interrupt_reason_for_quota()
+        finally:
+            quota_hooks.set_run_progress_gate_hook(None)
+
+        assert reason == "over credits"
+        assert captured["user_id"] == 42
+        assert captured["actions"] == 2  # only this turn's tool calls
+        # Only this turn's input+output entries, not the seeded baseline one.
+        assert len(captured["details"]) == 2
+        assert sorted(d["tokens"] for d in captured["details"]) == [5, 10]
+
+    @pytest.mark.asyncio
     async def test_init_task_tracker_with_custom_interval(self, db_session):
         """Test TaskTracker with custom update interval."""
         tracker = TaskTracker(

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -169,6 +169,30 @@ class TestTaskTracker:
         assert tracker.quota_interrupt_reason is None  # never tripped → no reason
 
     @pytest.mark.asyncio
+    async def test_runtime_should_interrupt_drives_tracker_gate(self, db_session):
+        """End-to-end seam: the runtime's should_interrupt — the exact call the
+        pattern loop makes at each safe point — wired to the tracker's real gate
+        method fires and records the reason when a registered hook trips."""
+        from xagent.core.agent.runtime import PatternRuntime
+        from xagent.web.services import quota_hooks
+
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        task.user_id = 5
+
+        quota_hooks.set_run_progress_gate_hook(lambda db, uid, dd, da: "Out of credits")
+        try:
+            tracker = TaskTracker(task_id=123, db_session=db_session)
+            await tracker.start_tracking()
+            runtime = PatternRuntime(
+                interrupt_checker=tracker.interrupt_reason_for_quota
+            )
+            assert await runtime.should_interrupt() is True
+            assert runtime.interrupt_reason == "Out of credits"
+            assert tracker.quota_interrupt_reason == "Out of credits"
+        finally:
+            quota_hooks.set_run_progress_gate_hook(None)
+
+    @pytest.mark.asyncio
     async def test_init_task_tracker_with_custom_interval(self, db_session):
         """Test TaskTracker with custom update interval."""
         tracker = TaskTracker(

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -130,11 +130,43 @@ class TestTaskTracker:
             quota_hooks.set_run_progress_gate_hook(None)
 
         assert reason == "over credits"
+        # The reason is recorded so the run's caller can surface why it stopped.
+        assert tracker.quota_interrupt_reason == "over credits"
         assert captured["user_id"] == 42
         assert captured["actions"] == 2  # only this turn's tool calls
         # Only this turn's input+output entries, not the seeded baseline one.
         assert len(captured["details"]) == 2
         assert sorted(d["tokens"] for d in captured["details"]) == [5, 10]
+
+    @pytest.mark.asyncio
+    async def test_quota_gate_caches_user_id_and_logs_once(self, db_session, caplog):
+        """F1: user_id is cached at construction (not re-read per step). F3: the
+        fail-open warning is logged once per run, not once per step."""
+        import logging
+
+        from xagent.web.services import quota_hooks
+
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        task.user_id = 7
+
+        def _boom(db, user_id, dd, da):
+            raise RuntimeError("gate infra down")
+
+        quota_hooks.set_run_progress_gate_hook(_boom)
+        try:
+            tracker = TaskTracker(task_id=123, db_session=db_session)
+            assert tracker._user_id == 7  # F1: cached at construction
+            await tracker.start_tracking()
+            with caplog.at_level(logging.WARNING):
+                assert tracker.interrupt_reason_for_quota() is None
+                assert tracker.interrupt_reason_for_quota() is None
+                assert tracker.interrupt_reason_for_quota() is None
+        finally:
+            quota_hooks.set_run_progress_gate_hook(None)
+
+        warnings = [r for r in caplog.records if "failed open" in r.getMessage()]
+        assert len(warnings) == 1  # F3: one log despite three failing calls
+        assert tracker.quota_interrupt_reason is None  # never tripped → no reason
 
     @pytest.mark.asyncio
     async def test_init_task_tracker_with_custom_interval(self, db_session):


### PR DESCRIPTION
## Problem

Runs are gated once at start and metered once at completion. Between those
two points there is no enforcement, so a single long or expensive run can
burn unbounded cost before it is billed — a run that passes the start gate
can then run arbitrarily long.

## What this adds

A **per-step enforcement seam** that reuses the pattern loop's existing
interrupt polling, keeping core quota-agnostic (the enforcement policy lives
in the application layer, same as the other `quota_hooks`).

- **`quota_hooks`**: new `set_run_progress_gate_hook` / `check_run_progress_gate`
  seam. When no hook is registered it is a no-op, so stock xagent is
  unaffected.
- **`runtime.should_interrupt`**: a checker may now return a **string** to
  both interrupt AND supply the reason (so a gated run surfaces *why* it
  stopped). A bare truthy/`bool` return keeps the previous behaviour —
  backward compatible.
- **`TaskTracker.interrupt_reason_for_quota`**: a synchronous, best-effort
  per-step checker that computes this run's live-so-far delta and asks the
  gate. `_turn_delta()` is shared with the completion meter so the two can't
  disagree on what "this run's usage" means. Errors fail open (never wedge a
  run).
- **Wiring**: `interrupt_checker` is threaded through
  `AgentService` / `AgentExecutionConfig` exactly the way
  `outbound_message_handler` already is; `execute_task_background` sets it
  after `start_tracking` and clears it on completion.

## Behaviour on interrupt

When the gate trips, the pattern stops at the next safe point (checked before
each LLM call and each tool call). Mid-call preemption is streaming-path only:
`run_streaming_llm_call` polls `should_interrupt` per chunk and cancels the
in-flight task, but non-streaming `run_llm_call`, context compaction, DAG
plan-generation, and already-running tool calls are not cancelled mid-call — a
single expensive call started before the gate trips still runs to completion.
Either way `complete_tracking` runs in the `finally`, so a stopped run is
metered for exactly what it burned — no free usage, no double billing.

## Compatibility

- No hook registered → every gate is open and the checker is `None`; stock
  behaviour is unchanged.
- `should_interrupt`'s string-reason handling is additive; existing bool
  checkers are unaffected.

## Tests

- `test_runtime.py`: string-result interrupt sets the reason; falsey checker
  does not interrupt.
- `test_task_tracker.py`: the per-step gate receives the same turn-delta the
  meter computes and surfaces the gate's reason.
