### PR TITLE
feat: add durable task command transport

### DIFF
--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -102,6 +102,28 @@ describe("useWebSocket message delivery", () => {
     })
   })
 
+  it("assigns idempotency keys to pause and resume commands", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    act(() => {
+      result.current.pauseTask()
+      result.current.resumeTask()
+    })
+
+    const pause = JSON.parse(socket.send.mock.calls[0][0])
+    const resume = JSON.parse(socket.send.mock.calls[1][0])
+    expect(pause.command_id).toBeTruthy()
+    expect(resume.command_id).toBeTruthy()
+    expect(resume.command_id).not.toBe(pause.command_id)
+  })
+
   it("allows an unacknowledged draft to retry with the same id", async () => {
     const { result } = renderHook(() => useWebSocket({
       url: "ws://localhost",

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -579,6 +579,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       const message = {
         type: "pause_task",
         task_id: taskIdRef.current,
+        command_id: generateClientMessageId(),
       }
       socketRef.current.send(JSON.stringify(message))
     }
@@ -589,6 +590,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       socketRef.current.send(JSON.stringify({
         type: "resume_task",
         task_id: taskIdRef.current,
+        command_id: generateClientMessageId(),
       }))
     }
   }, [taskId])

--- a/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
@@ -21,7 +21,14 @@ TABLE = "task_execution_commands"
 
 def upgrade() -> None:
     inspector = sa.inspect(op.get_bind())
-    if TABLE in inspector.get_table_names():
+    tables = set(inspector.get_table_names())
+    if TABLE in tables:
+        return
+    # Base application tables are created by SQLAlchemy in production. The
+    # migration integration CLI also exercises an Alembic-only empty schema;
+    # follow the existing task-related migrations and skip until those base
+    # tables exist instead of creating invalid foreign keys.
+    if not {"tasks", "users"}.issubset(tables):
         return
     op.create_table(
         TABLE,

--- a/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
@@ -54,6 +54,7 @@ def upgrade() -> None:
         sa.Column("claimed_by", sa.String(255), nullable=True),
         sa.Column("claim_expires_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failure_count", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("result", sa.JSON(), nullable=True),
         sa.Column("error", sa.Text(), nullable=True),
         sa.Column(
@@ -71,7 +72,6 @@ def upgrade() -> None:
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.UniqueConstraint("task_id", "command_id", name="uq_task_command_identity"),
     )
-    op.create_index("ix_task_execution_commands_task_id", TABLE, ["task_id"])
     op.create_index(
         "ix_task_execution_commands_actor_user_id", TABLE, ["actor_user_id"]
     )

--- a/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
@@ -1,0 +1,78 @@
+"""add durable task execution command inbox
+
+Revision ID: 20260711_task_commands
+Revises: 20260711_add_trace_events_task_idx
+Create Date: 2026-07-11
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260711_task_commands"
+down_revision: Union[str, None] = "20260711_add_trace_events_task_idx"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "task_execution_commands"
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE in inspector.get_table_names():
+        return
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "task_id",
+            sa.Integer(),
+            sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "actor_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("command_id", sa.String(64), nullable=False),
+        sa.Column("kind", sa.String(32), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("target_run_id", sa.String(64), nullable=True),
+        sa.Column("target_runner_id", sa.String(255), nullable=True),
+        sa.Column("status", sa.String(32), nullable=False, server_default="pending"),
+        sa.Column("claimed_by", sa.String(255), nullable=True),
+        sa.Column("claim_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("result", sa.JSON(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("task_id", "command_id", name="uq_task_command_identity"),
+    )
+    op.create_index("ix_task_execution_commands_task_id", TABLE, ["task_id"])
+    op.create_index(
+        "ix_task_execution_commands_actor_user_id", TABLE, ["actor_user_id"]
+    )
+    op.create_index("ix_task_commands_status_created", TABLE, ["status", "created_at"])
+    op.create_index("ix_task_commands_task_order", TABLE, ["task_id", "id"])
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE in inspector.get_table_names():
+        op.drop_table(TABLE)

--- a/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
+++ b/src/xagent/migrations/versions/20260711_add_task_execution_commands.py
@@ -55,6 +55,7 @@ def upgrade() -> None:
         sa.Column("claim_expires_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("failure_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("defer_count", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("result", sa.JSON(), nullable=True),
         sa.Column("error", sa.Text(), nullable=True),
         sa.Column(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -33,6 +33,14 @@ from ..services.a2a_protocol import (
     task_state,
     task_to_a2a,
 )
+from ..services.task_command_transport import (
+    COMMAND_COMPLETED,
+    COMMAND_FAILED,
+    TaskCommandKind,
+    dispatch_one_task_command,
+    enqueue_task_command,
+    load_task_command,
+)
 from ..services.task_execution_controller import (
     TaskControlState,
     apply_task_control_transition,
@@ -845,8 +853,52 @@ async def cancel_task(
 ) -> Any:
     agent, _key = authed
     _require_bound_agent(agent_id, agent)
-    async with task_execution_controller.command(task_id):
-        return await _cancel_task_unserialized(task_id=task_id, agent=agent, db=db)
+    task = _resolve_a2a_task(db, task_id, agent)
+    command_identity = f"cancel:{task_id}:{task.run_id or task.state_version}"
+    enqueued = enqueue_task_command(
+        db,
+        task_id=task_id,
+        actor_user_id=int(agent.user_id),
+        command_id=command_identity,
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": int(agent.id)},
+    )
+    if not enqueued.payload_matches:
+        raise a2a_error(
+            "invalid_request",
+            "Cancel command identity conflicts with a different request.",
+            status_code=409,
+        )
+
+    from .websocket import execute_durable_task_command
+
+    # Apply immediately when this process owns the target run. If another
+    # worker owns it, that worker's dispatcher observes the durable row and
+    # completes it; polling here preserves the synchronous A2A cancel contract.
+    await dispatch_one_task_command(
+        execute_durable_task_command,
+        command_db_id=enqueued.command_id,
+    )
+    deadline = monotonic() + 10.0
+    while True:
+        stored = await asyncio.to_thread(load_task_command, enqueued.command_id)
+        if stored is not None and stored.status == COMMAND_COMPLETED:
+            db.expire_all()
+            return a2a_json_response(task_to_a2a(_resolve_a2a_task(db, task_id, agent)))
+        if stored is not None and stored.status == COMMAND_FAILED:
+            raise a2a_error(
+                "internal_error",
+                str(stored.error or "Task cancellation failed."),
+                status_code=500,
+            )
+        if monotonic() >= deadline:
+            raise a2a_error(
+                "temporarily_unavailable",
+                "Task cancellation was accepted but is still being applied.",
+                status_code=503,
+                details={"taskId": task_id, "commandId": command_identity},
+            )
+        await asyncio.sleep(0.05)
 
 
 async def _cancel_task_unserialized(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -898,6 +898,18 @@ async def cancel_task(
             db.expire_all()
             return a2a_json_response(task_to_a2a(_resolve_a2a_task(db, task_id, agent)))
         if stored is not None and stored.status == COMMAND_FAILED:
+            rejection_reason = (
+                stored.result.get("rejection_reason")
+                if isinstance(stored.result, dict)
+                else None
+            )
+            if rejection_reason == "stale_run":
+                raise a2a_error(
+                    "invalid_request",
+                    "Task run changed before cancellation was applied; retry the request.",
+                    status_code=409,
+                    details={"taskId": task_id, "commandId": command_identity},
+                )
             raise a2a_error(
                 "internal_error",
                 str(stored.error or "Task cancellation failed."),
@@ -952,6 +964,7 @@ async def _cancel_task_unserialized(
         TaskControlState.FAILED,
         status=TaskStatus.FAILED,
         expected_run_id=_task_run_id(task),
+        expected_state_version=int(task.state_version or 0),
     )
     setattr(task, "output", None)
     setattr(task, "error_message", "Task canceled by A2A client.")

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -40,6 +40,7 @@ from ..services.task_command_transport import (
     dispatch_one_task_command,
     enqueue_task_command,
     load_task_command,
+    retry_failed_task_command,
 )
 from ..services.task_execution_controller import (
     TaskControlState,
@@ -869,6 +870,17 @@ async def cancel_task(
             "Cancel command identity conflicts with a different request.",
             status_code=409,
         )
+    if enqueued.status == COMMAND_FAILED:
+        retry_failed_task_command(
+            db,
+            enqueued.command_id,
+            target_run_id=_task_run_id(task),
+            target_runner_id=(
+                str(task.runner_id)
+                if task.status == TaskStatus.RUNNING and task.runner_id is not None
+                else None
+            ),
+        )
 
     from .websocket import execute_durable_task_command
 
@@ -924,6 +936,15 @@ async def _cancel_task_unserialized(
     from .websocket import background_task_manager
 
     await background_task_manager.cancel_task(int(task.id))
+    db.expire(task)
+    db.refresh(task)
+    agent_config = (
+        dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+    )
+    if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+        return a2a_json_response(task_to_a2a(task))
+    if task.status in _TERMINAL_STATUSES:
+        return a2a_json_response(task_to_a2a(task))
     agent_config["a2a_state"] = "TASK_STATE_CANCELED"
     setattr(task, "agent_config", agent_config)
     apply_task_control_transition(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5543,7 +5543,15 @@ async def execute_durable_task_command(
         from ..models.agent import Agent
         from .a2a import _cancel_task_unserialized
 
-        agent_id = int(message_data["agent_id"])
+        agent_id_value = message_data.get("agent_id")
+        if agent_id_value is None:
+            raise ValueError("Agent ID is missing or null in cancel command payload")
+        try:
+            agent_id = int(agent_id_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Agent ID {agent_id_value!r} is invalid in cancel command payload"
+            ) from exc
         SessionLocal = get_session_local()
         with SessionLocal() as db:
             agent = db.query(Agent).filter(Agent.id == agent_id).first()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5578,7 +5578,10 @@ def _load_command_message_delivery_status(
             )
             .first()
         )
-        return str(message.delivery_status) if message is not None else None
+        if message is None:
+            return None
+        delivery_status = getattr(message, "delivery_status", None)
+        return delivery_status if isinstance(delivery_status, str) else None
 
 
 def _load_command_task_run_id(task_id: int) -> str | None:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -97,6 +97,7 @@ from ..services.task_command_transport import (
     task_has_live_foreign_runner,
 )
 from ..services.task_execution_controller import (
+    StaleTaskRunError,
     TaskControlState,
     apply_task_control_transition,
     task_control_snapshot,
@@ -5391,14 +5392,15 @@ async def _handle_resume_task_unserialized(
                     websocket,
                 )
                 return
-            resume_snapshot = await task_execution_controller.transition(
-                task_id,
-                TaskControlState.RESUME_REQUESTED,
-                expected_run_id=_task_run_id(task),
-            )
-            previous_task = background_task_manager.running_tasks.get(task_id)
+            resume_snapshot: Any | None = None
             bg_task: asyncio.Task[None] | None = None
             try:
+                resume_snapshot = await task_execution_controller.transition(
+                    task_id,
+                    TaskControlState.RESUME_REQUESTED,
+                    expected_run_id=_task_run_id(task),
+                )
+                previous_task = background_task_manager.running_tasks.get(task_id)
                 bg_task = asyncio.create_task(
                     execute_resume_background(
                         task_id=task_id,
@@ -5413,17 +5415,18 @@ async def _handle_resume_task_unserialized(
                 if bg_task is not None:
                     bg_task.cancel()
                 background_task_manager.release_resume_reservation(task_id)
-                await asyncio.shield(
-                    task_execution_controller.transition(
-                        task_id,
-                        (
-                            TaskControlState.WAITING_FOR_USER
-                            if resume_snapshot.status == TaskStatus.WAITING_FOR_USER
-                            else TaskControlState.PAUSED
-                        ),
-                        expected_run_id=resume_snapshot.run_id,
+                if resume_snapshot is not None:
+                    await asyncio.shield(
+                        task_execution_controller.transition(
+                            task_id,
+                            (
+                                TaskControlState.WAITING_FOR_USER
+                                if resume_snapshot.status == TaskStatus.WAITING_FOR_USER
+                                else TaskControlState.PAUSED
+                            ),
+                            expected_run_id=resume_snapshot.run_id,
+                        )
                     )
-                )
                 raise
             logger.info(f"Task {task_id} v2 resume scheduled")
             return
@@ -5543,6 +5546,18 @@ async def _execute_durable_task_command(
                 f"{command.command_id} was applied",
                 reason="stale_run",
             )
+    if command.kind in {
+        TaskCommandKind.PAUSE,
+        TaskCommandKind.RESUME,
+        TaskCommandKind.CANCEL,
+    } and await asyncio.to_thread(
+        task_has_live_foreign_runner,
+        command.task_id,
+    ):
+        raise TaskCommandDeferred(
+            f"{command.kind.value.title()} command {command.command_id} is waiting "
+            "for the active task lease owner"
+        )
 
     if command.kind == TaskCommandKind.MESSAGE:
         await _handle_chat_message_unserialized(
@@ -5569,14 +5584,6 @@ async def _execute_durable_task_command(
         from ..models.agent import Agent
         from .a2a import _cancel_task_unserialized
 
-        if await asyncio.to_thread(
-            task_has_live_foreign_runner,
-            command.task_id,
-        ):
-            raise TaskCommandDeferred(
-                f"Cancel command {command.command_id} is waiting for the active "
-                "task lease owner"
-            )
         agent_id_value = message_data.get("agent_id")
         if agent_id_value is None:
             raise ValueError("Agent ID is missing or null in cancel command payload")
@@ -5591,11 +5598,14 @@ async def _execute_durable_task_command(
             agent = db.query(Agent).filter(Agent.id == agent_id).first()
             if agent is None:
                 raise ValueError(f"Agent {agent_id} not found for cancel command")
-            await _cancel_task_unserialized(
-                task_id=command.task_id,
-                agent=agent,
-                db=db,
-            )
+            try:
+                await _cancel_task_unserialized(
+                    task_id=command.task_id,
+                    agent=agent,
+                    db=db,
+                )
+            except StaleTaskRunError as exc:
+                raise TaskCommandRejected(str(exc), reason="stale_run") from exc
     else:  # pragma: no cover - enum construction rejects this earlier
         raise ValueError(f"Unsupported task command kind: {command.kind}")
     durable_error = message_data.get("_durable_command_error")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -83,6 +83,7 @@ from ..services.managed_file_ref import (
     DurableStorageOperationError,
 )
 from ..services.task_command_transport import (
+    COMMAND_ID_PATTERN,
     ClaimedTaskCommand,
     EnqueuedTaskCommand,
     TaskCommandDeferred,
@@ -90,6 +91,7 @@ from ..services.task_command_transport import (
     TaskCommandRejected,
     dispatch_task_command_promptly,
     enqueue_task_command,
+    task_has_live_foreign_runner,
 )
 from ..services.task_execution_controller import (
     TaskControlState,
@@ -180,7 +182,7 @@ def _client_message_id(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     normalized = value.strip()
-    if not re.fullmatch(r"[A-Za-z0-9._:-]{1,64}", normalized):
+    if COMMAND_ID_PATTERN.fullmatch(normalized) is None:
         return None
     return normalized
 
@@ -3097,8 +3099,6 @@ def _enqueue_websocket_task_command_sync(
             kind=kind,
             payload=payload,
         )
-        if not result.payload_matches:
-            return result
         return result
 
 
@@ -5543,6 +5543,14 @@ async def execute_durable_task_command(
         from ..models.agent import Agent
         from .a2a import _cancel_task_unserialized
 
+        if await asyncio.to_thread(
+            task_has_live_foreign_runner,
+            command.task_id,
+        ):
+            raise TaskCommandDeferred(
+                f"Cancel command {command.command_id} is waiting for the active "
+                "task lease owner"
+            )
         agent_id_value = message_data.get("agent_id")
         if agent_id_value is None:
             raise ValueError("Agent ID is missing or null in cancel command payload")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -34,6 +34,7 @@ from ...core.agent.trace import TraceEvent, TraceHandler, trace_user_message
 from ...core.execution_scope import resolve_execution_scope, turn_execution_scope
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
+from ..models.chat_message import TaskChatMessage
 from ..models.database import get_db, get_session_local
 from ..models.task import Task, TaskStatus
 from ..models.uploaded_file import UploadedFile
@@ -47,6 +48,7 @@ from ..services.chat_history_service import (
     DELIVERY_COMPLETED,
     DELIVERY_DISPATCHED,
     DELIVERY_FAILED,
+    DELIVERY_PENDING,
     UserMessageDeliveryClaim,
     claim_user_message_delivery,
     get_latest_waiting_question,
@@ -79,6 +81,15 @@ from ..services.hot_path_cache import (
 )
 from ..services.managed_file_ref import (
     DurableStorageOperationError,
+)
+from ..services.task_command_transport import (
+    ClaimedTaskCommand,
+    EnqueuedTaskCommand,
+    TaskCommandDeferred,
+    TaskCommandKind,
+    TaskCommandRejected,
+    dispatch_task_command_promptly,
+    enqueue_task_command,
 )
 from ..services.task_execution_controller import (
     TaskControlState,
@@ -2962,10 +2973,164 @@ async def get_authenticated_user(
 async def handle_chat_message(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
-    """Serialize one inbound WebSocket message against task control commands."""
+    """Durably accept a chat command before acknowledging the client."""
 
-    async with task_execution_controller.command(task_id):
-        await _handle_chat_message_unserialized(websocket, task_id, message_data)
+    try:
+        enqueued = await _enqueue_websocket_task_command(
+            task_id=task_id,
+            message_data=message_data,
+            kind=TaskCommandKind.MESSAGE,
+            command_id=_client_message_id(message_data.get("client_message_id")),
+            allow_missing_task=True,
+        )
+    except (PermissionError, ValueError) as exc:
+        client_message_id = _client_message_id(message_data.get("client_message_id"))
+        await _send_message_delivery(
+            websocket,
+            client_message_id=client_message_id,
+            turn_id=client_message_id or str(uuid.uuid4()),
+            accepted=False,
+            message=str(exc),
+        )
+        await manager.send_personal_message(
+            {"type": "error", "message": str(exc)}, websocket
+        )
+        return
+    if enqueued is None:
+        # Legacy recovery path for a client still connected to a task that was
+        # deleted. The existing handler creates the replacement task first;
+        # subsequent commands use the durable transport normally.
+        async with task_execution_controller.command(task_id):
+            await _handle_chat_message_unserialized(websocket, task_id, message_data)
+        return
+    if not enqueued.payload_matches:
+        await _send_message_delivery(
+            websocket,
+            client_message_id=_client_message_id(message_data.get("client_message_id")),
+            turn_id=enqueued.client_command_id,
+            accepted=False,
+            message="Message id was already used for different content or files.",
+            retry_with_new_id=True,
+        )
+        return
+    if enqueued.status == DELIVERY_FAILED:
+        await _send_message_delivery(
+            websocket,
+            client_message_id=_client_message_id(message_data.get("client_message_id")),
+            turn_id=enqueued.client_command_id,
+            accepted=False,
+            message="The previous delivery attempt failed. Please retry the draft.",
+            retry_with_new_id=True,
+        )
+        return
+    await _send_message_delivery(
+        websocket,
+        client_message_id=_client_message_id(message_data.get("client_message_id")),
+        turn_id=enqueued.client_command_id,
+        accepted=True,
+    )
+    if enqueued.command_id:
+        await dispatch_task_command_promptly(
+            execute_durable_task_command,
+            command_db_id=enqueued.command_id,
+        )
+
+
+def _enqueue_websocket_task_command_sync(
+    *,
+    task_id: int,
+    actor_user_id: int,
+    actor_is_admin: bool,
+    command_id: str,
+    kind: TaskCommandKind,
+    payload: dict[str, Any],
+    allow_missing_task: bool,
+) -> EnqueuedTaskCommand | None:
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            if allow_missing_task:
+                return None
+            raise ValueError(f"Task {task_id} not found")
+        if not actor_is_admin and int(task.user_id) != actor_user_id:
+            raise PermissionError(
+                f"Access denied: Task {task_id} does not belong to you"
+            )
+        if kind == TaskCommandKind.MESSAGE:
+            from ..services.chat_history_service import (
+                inspect_user_message_delivery,
+            )
+
+            existing_delivery = inspect_user_message_delivery(
+                db,
+                task_id,
+                str(payload.get("message") or ""),
+                attachments=(
+                    payload.get("files")
+                    if isinstance(payload.get("files"), list)
+                    else None
+                ),
+                turn_id=command_id,
+            )
+            if (
+                existing_delivery is not None
+                and not existing_delivery.pending
+                and not payload.get("files")
+            ):
+                return EnqueuedTaskCommand(
+                    command_id=0,
+                    client_command_id=command_id,
+                    created=False,
+                    payload_matches=existing_delivery.payload_matches,
+                    status=(
+                        DELIVERY_FAILED
+                        if existing_delivery.failed
+                        else DELIVERY_COMPLETED
+                    ),
+                )
+        result = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=actor_user_id,
+            command_id=command_id,
+            kind=kind,
+            payload=payload,
+        )
+        if not result.payload_matches:
+            return result
+        return result
+
+
+async def _enqueue_websocket_task_command(
+    *,
+    task_id: int,
+    message_data: dict[str, Any],
+    kind: TaskCommandKind,
+    command_id: str | None = None,
+    allow_missing_task: bool = False,
+) -> EnqueuedTaskCommand | None:
+    user = message_data.get("user")
+    if user is None:
+        raise ValueError("User authentication required for task command")
+    resolved_command_id = command_id or f"{kind.value}:{uuid.uuid4()}"
+    # User ORM instances and server-only authentication fields are never put
+    # into the JSON inbox. The consumer re-resolves the actor by id.
+    payload = {
+        key: value
+        for key, value in message_data.items()
+        if key not in {"user", "user_id"} and not key.startswith("_durable_")
+    }
+    return await asyncio.to_thread(
+        _enqueue_websocket_task_command_sync,
+        task_id=int(task_id),
+        actor_user_id=int(user.id),
+        actor_is_admin=bool(user.is_admin),
+        command_id=resolved_command_id,
+        kind=kind,
+        payload=payload,
+        allow_missing_task=allow_missing_task,
+    )
 
 
 async def _handle_chat_message_unserialized(
@@ -2974,9 +3139,11 @@ async def _handle_chat_message_unserialized(
     """Handle chat message"""
     client_message_id = _client_message_id(message_data.get("client_message_id"))
     turn_id = client_message_id or str(uuid.uuid4())
+    suppress_delivery_ack = bool(message_data.get("_durable_ack_sent"))
     delivery_finished = False
     delivery_dispatched = False
     delivery_claimed = False
+    recovered_delivery: UserMessageDeliveryClaim | None = None
 
     async def finish_delivery(
         accepted: bool,
@@ -2988,6 +3155,10 @@ async def _handle_chat_message_unserialized(
         if delivery_finished:
             return
         delivery_finished = True
+        if not accepted:
+            message_data["_durable_command_error"] = message or "Message was rejected"
+        if suppress_delivery_ack:
+            return
         await _send_message_delivery(
             websocket,
             client_message_id=client_message_id,
@@ -3352,8 +3523,42 @@ async def _handle_chat_message_unserialized(
                         turn_id=turn_id,
                     )
                     if existing_delivery is not None:
-                        await finish_existing_delivery(existing_delivery)
-                        return
+                        durable_replay = (
+                            int(message_data.get("_durable_attempt_count") or 0) > 1
+                        )
+                        if (
+                            durable_replay
+                            and existing_delivery.pending
+                            and existing_delivery.payload_matches
+                        ):
+                            # The command claim is the exclusive replay lease,
+                            # so it may safely adopt a PENDING transcript row
+                            # left by a worker that died mid-application.
+                            recovered_delivery = UserMessageDeliveryClaim(
+                                message=existing_delivery.message,
+                                claimed=True,
+                                payload_matches=True,
+                            )
+                            delivery_claimed = True
+                            if (
+                                task.status == TaskStatus.RUNNING
+                                and str(task.input or "").strip()
+                                == display_user_message.strip()
+                            ):
+                                # New-turn claim committed before the old
+                                # worker died. Do not start or inject it again.
+                                mark_user_message_delivery(
+                                    db,
+                                    task_id=task_id,
+                                    turn_id=turn_id,
+                                    status=DELIVERY_DISPATCHED,
+                                )
+                                delivery_dispatched = True
+                                await finish_delivery(True)
+                                return
+                        else:
+                            await finish_existing_delivery(existing_delivery)
+                            return
 
                 # DAG plan-execute will automatically send user_message trace event
 
@@ -3371,6 +3576,14 @@ async def _handle_chat_message_unserialized(
                     control_state=_task_control_state_value(task),
                     pause_accepted=pause_accepted,
                 )
+                if (
+                    recovered_delivery is not None
+                    and message_data.get("_durable_target_run_id") == task.run_id
+                ):
+                    # A crashed owner may have already interrupted the run and
+                    # persisted PAUSED before its command claim was completed.
+                    # This is the same durable guidance command, not a new turn.
+                    task_uses_live_control = True
                 agent_service = None
                 dag_pattern = None
                 supports_live_control = False
@@ -3407,7 +3620,7 @@ async def _handle_chat_message_unserialized(
                     logger.info(f"Using continuation for running task {task_id}")
                     assert dag_pattern is not None  # for mypy type checking
 
-                    delivery_claim = claim_user_message_delivery(
+                    delivery_claim = recovered_delivery or claim_user_message_delivery(
                         db,
                         task_id=task_id,
                         user_id=int(task.user_id),
@@ -3415,6 +3628,7 @@ async def _handle_chat_message_unserialized(
                         attachments=persisted_attachments or None,
                         turn_id=turn_id,
                     )
+                    recovered_delivery = None
                     if not delivery_claim.claimed:
                         await finish_existing_delivery(delivery_claim)
                         return
@@ -3544,14 +3758,18 @@ async def _handle_chat_message_unserialized(
                     # keeps its own immediate trace.
                     bg_task: asyncio.Task[None] | None = None
                     try:
-                        delivery_claim = claim_user_message_delivery(
-                            db,
-                            task_id=task_id,
-                            user_id=int(task.user_id),
-                            content=display_user_message,
-                            attachments=persisted_attachments or None,
-                            turn_id=turn_id,
+                        delivery_claim = (
+                            recovered_delivery
+                            or claim_user_message_delivery(
+                                db,
+                                task_id=task_id,
+                                user_id=int(task.user_id),
+                                content=display_user_message,
+                                attachments=persisted_attachments or None,
+                                turn_id=turn_id,
+                            )
                         )
+                        recovered_delivery = None
                         if not delivery_claim.claimed:
                             background_task_manager.release_resume_reservation(task_id)
                             await finish_existing_delivery(delivery_claim)
@@ -3614,9 +3832,15 @@ async def _handle_chat_message_unserialized(
                                 ),
                                 delivery_turn_id=turn_id,
                                 delivery_already_dispatched=posted,
-                                delivery_websocket=None if posted else websocket,
+                                delivery_websocket=(
+                                    None
+                                    if posted or suppress_delivery_ack
+                                    else websocket
+                                ),
                                 delivery_client_message_id=(
-                                    None if posted else client_message_id
+                                    None
+                                    if posted or suppress_delivery_ack
+                                    else client_message_id
                                 ),
                             )
                         )
@@ -4224,7 +4448,6 @@ async def send_historical_data_as_stream(
     try:
         # Load historical data directly from database
         from ..models.agent import Agent
-        from ..models.chat_message import TaskChatMessage
         from ..models.database import get_db
         from ..models.task import Task, TaskStatus, TraceEvent
 
@@ -4854,10 +5077,43 @@ async def handle_intervention(
 async def handle_pause_task(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
-    """Serialize pause against messages and resume requests for this task."""
+    """Persist a pause request; the lease owner applies it in command order."""
 
-    async with task_execution_controller.command(task_id):
-        await _handle_pause_task_unserialized(websocket, task_id, message_data)
+    try:
+        enqueued = await _enqueue_websocket_task_command(
+            task_id=task_id,
+            message_data=message_data,
+            kind=TaskCommandKind.PAUSE,
+            command_id=_client_message_id(message_data.get("command_id")),
+        )
+    except (PermissionError, ValueError) as exc:
+        await manager.send_personal_message(
+            {"type": "error", "message": str(exc)}, websocket
+        )
+        return
+    assert enqueued is not None
+    if not enqueued.payload_matches:
+        await manager.send_personal_message(
+            {
+                "type": "error",
+                "message": "Command id was already used for a different request.",
+            },
+            websocket,
+        )
+        return
+    await manager.send_personal_message(
+        {
+            "type": "task_command_accepted",
+            "task_id": task_id,
+            "command_id": enqueued.client_command_id,
+            "command": TaskCommandKind.PAUSE.value,
+        },
+        websocket,
+    )
+    await dispatch_task_command_promptly(
+        execute_durable_task_command,
+        command_db_id=enqueued.command_id,
+    )
 
 
 async def _handle_pause_task_unserialized(
@@ -4996,10 +5252,43 @@ async def _handle_pause_task_unserialized(
 async def handle_resume_task(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
-    """Serialize resume against messages and pause requests for this task."""
+    """Persist a resume request; a worker applies it in command order."""
 
-    async with task_execution_controller.command(task_id):
-        await _handle_resume_task_unserialized(websocket, task_id, message_data)
+    try:
+        enqueued = await _enqueue_websocket_task_command(
+            task_id=task_id,
+            message_data=message_data,
+            kind=TaskCommandKind.RESUME,
+            command_id=_client_message_id(message_data.get("command_id")),
+        )
+    except (PermissionError, ValueError) as exc:
+        await manager.send_personal_message(
+            {"type": "error", "message": str(exc)}, websocket
+        )
+        return
+    assert enqueued is not None
+    if not enqueued.payload_matches:
+        await manager.send_personal_message(
+            {
+                "type": "error",
+                "message": "Command id was already used for a different request.",
+            },
+            websocket,
+        )
+        return
+    await manager.send_personal_message(
+        {
+            "type": "task_command_accepted",
+            "task_id": task_id,
+            "command_id": enqueued.client_command_id,
+            "command": TaskCommandKind.RESUME.value,
+        },
+        websocket,
+    )
+    await dispatch_task_command_promptly(
+        execute_durable_task_command,
+        command_db_id=enqueued.command_id,
+    )
 
 
 async def _handle_resume_task_unserialized(
@@ -5171,6 +5460,134 @@ async def _handle_resume_task_unserialized(
         # Other errors, re-raise
         logger.error(f"Unexpected error resuming task {task_id}: {e}")
         raise
+
+
+class _DiscardingCommandWebSocket:
+    """Minimal sink used when a recovered command has no originating socket."""
+
+    async def send_text(self, _message: str) -> None:
+        return None
+
+
+def _load_command_actor(actor_user_id: int | None) -> User:
+    if actor_user_id is None:
+        raise ValueError("Task command has no actor")
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        user = db.query(User).filter(User.id == actor_user_id).first()
+        if user is None:
+            raise ValueError(f"Task command actor {actor_user_id} no longer exists")
+        db.expunge(user)
+        return user
+
+
+async def execute_durable_task_command(
+    command: ClaimedTaskCommand,
+) -> dict[str, Any] | None:
+    """Apply one DB-claimed command using the existing transport adapters.
+
+    The handler is independent of the originating connection. If the socket is
+    still connected, personal validation errors go there; after a crash or on a
+    different worker they are discarded while task-level state/error events are
+    still broadcast normally.
+    """
+
+    user = await asyncio.to_thread(_load_command_actor, command.actor_user_id)
+    connections = manager.active_connections.get(command.task_id, [])
+    websocket: Any = connections[0] if connections else _DiscardingCommandWebSocket()
+    message_data = dict(command.payload)
+    message_data.update(
+        {
+            "user": user,
+            "user_id": int(user.id),
+            "_durable_ack_sent": True,
+            "_durable_attempt_count": command.attempt_count,
+            "_durable_target_run_id": command.target_run_id,
+        }
+    )
+    if command.kind != TaskCommandKind.MESSAGE and command.target_run_id is not None:
+        current_run_id = await asyncio.to_thread(
+            _load_command_task_run_id, command.task_id
+        )
+        if current_run_id != command.target_run_id:
+            raise TaskCommandRejected(
+                f"Task run changed before {command.kind.value} command "
+                f"{command.command_id} was applied"
+            )
+
+    if command.kind == TaskCommandKind.MESSAGE:
+        await _handle_chat_message_unserialized(
+            websocket, command.task_id, message_data
+        )
+        delivery_status = await asyncio.to_thread(
+            _load_command_message_delivery_status,
+            command.task_id,
+            command.command_id,
+        )
+        if delivery_status == DELIVERY_PENDING:
+            raise TaskCommandDeferred(
+                f"Message {command.command_id} is waiting for runtime injection"
+            )
+        if delivery_status == DELIVERY_FAILED:
+            raise TaskCommandRejected(
+                f"Message {command.command_id} could not be applied"
+            )
+        durable_error = message_data.get("_durable_command_error")
+        if isinstance(durable_error, str) and durable_error:
+            raise TaskCommandRejected(durable_error)
+    elif command.kind == TaskCommandKind.PAUSE:
+        await _handle_pause_task_unserialized(websocket, command.task_id, message_data)
+    elif command.kind == TaskCommandKind.RESUME:
+        await _handle_resume_task_unserialized(websocket, command.task_id, message_data)
+    elif command.kind == TaskCommandKind.CANCEL:
+        from ..models.agent import Agent
+        from .a2a import _cancel_task_unserialized
+
+        agent_id = int(message_data["agent_id"])
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            agent = db.query(Agent).filter(Agent.id == agent_id).first()
+            if agent is None:
+                raise ValueError(f"Agent {agent_id} not found for cancel command")
+            await _cancel_task_unserialized(
+                task_id=command.task_id,
+                agent=agent,
+                db=db,
+            )
+    else:  # pragma: no cover - enum construction rejects this earlier
+        raise ValueError(f"Unsupported task command kind: {command.kind}")
+    return {
+        "task_id": command.task_id,
+        "command_id": command.command_id,
+        "kind": command.kind.value,
+    }
+
+
+def _load_command_message_delivery_status(
+    task_id: int,
+    turn_id: str,
+) -> str | None:
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        message = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.role == "user",
+                TaskChatMessage.turn_id == turn_id,
+            )
+            .first()
+        )
+        return str(message.delivery_status) if message is not None else None
+
+
+def _load_command_task_run_id(task_id: int) -> str | None:
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            raise ValueError(f"Task {task_id} no longer exists")
+        return str(task.run_id) if task.run_id is not None else None
 
 
 @ws_router.websocket("/ws/build/chat")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -83,6 +83,7 @@ from ..services.managed_file_ref import (
     DurableStorageOperationError,
 )
 from ..services.task_command_transport import (
+    COMMAND_FAILED,
     COMMAND_ID_PATTERN,
     MAX_COMMAND_DEFERS,
     MAX_COMMAND_FAILURES,
@@ -3017,7 +3018,7 @@ async def handle_chat_message(
             retry_with_new_id=True,
         )
         return
-    if enqueued.status == DELIVERY_FAILED:
+    if enqueued.status == COMMAND_FAILED:
         await _send_message_delivery(
             websocket,
             client_message_id=_client_message_id(message_data.get("client_message_id")),
@@ -3123,6 +3124,11 @@ async def _enqueue_websocket_task_command(
         for key, value in message_data.items()
         if key not in {"user", "user_id"} and not key.startswith("_durable_")
     }
+    if kind == TaskCommandKind.MESSAGE:
+        # The durable command identity is also the delivery/turn identity.
+        # This remains stable across retries even when an API client omitted
+        # or supplied an invalid client_message_id.
+        payload["client_message_id"] = resolved_command_id
     return await asyncio.to_thread(
         _enqueue_websocket_task_command_sync,
         task_id=int(task_id),
@@ -5172,6 +5178,9 @@ async def _handle_pause_task_unserialized(
             logger.info("Agent supports pause_execution, calling it...")
             pause_result = await agent_service.pause_execution()
             if pause_result is False:
+                message_data["_durable_command_error"] = (
+                    "No live execution found to pause"
+                )
                 await manager.send_personal_message(
                     _task_error_payload(
                         db,
@@ -5185,6 +5194,9 @@ async def _handle_pause_task_unserialized(
             logger.info("Agent pause_execution completed")
             db.refresh(task)
             if task.status != TaskStatus.RUNNING:
+                message_data["_durable_command_error"] = (
+                    "Task finished before the pause request was applied"
+                )
                 await manager.send_personal_message(
                     _task_error_payload(
                         db,
@@ -5218,6 +5230,9 @@ async def _handle_pause_task_unserialized(
             logger.info(f"Task {task_id} pause requested successfully")
         else:
             # If pause not supported, send error message
+            message_data["_durable_command_error"] = (
+                "Current agent does not support pause functionality"
+            )
             await manager.send_personal_message(
                 _task_error_payload(
                     db,
@@ -5232,6 +5247,7 @@ async def _handle_pause_task_unserialized(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
+        message_data["_durable_command_error"] = str(e)
         logger.error(f"Data validation error pausing task {task_id}: {e}")
         await manager.send_personal_message(
             {"type": "error", "message": f"Data validation error: {str(e)}"}, websocket
@@ -5242,6 +5258,7 @@ async def _handle_pause_task_unserialized(
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
+        raise
     except Exception as e:
         # Other errors, re-raise
         logger.error(f"Unexpected error pausing task {task_id}: {e}")
@@ -5342,6 +5359,7 @@ async def _handle_resume_task_unserialized(
             db.close()
 
         if task is None:
+            message_data["_durable_command_error"] = "Task not found or access denied"
             await manager.send_personal_message(
                 {"type": "error", "message": "Task not found or access denied"},
                 websocket,
@@ -5351,6 +5369,9 @@ async def _handle_resume_task_unserialized(
         resume_control_state = task_control_snapshot(task).as_dict()
         if getattr(agent_service, "supports_live_control", lambda: False)():
             if task.status not in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
+                message_data["_durable_command_error"] = (
+                    "Task is not paused and cannot be resumed."
+                )
                 await manager.send_personal_message(
                     {
                         "type": "error",
@@ -5435,6 +5456,9 @@ async def _handle_resume_task_unserialized(
             logger.info(f"Task {task_id} resumed successfully")
         else:
             # If resume not supported, send error message
+            message_data["_durable_command_error"] = (
+                "Current agent does not support resume functionality"
+            )
             await manager.send_personal_message(
                 {
                     "type": "error",
@@ -5448,6 +5472,7 @@ async def _handle_resume_task_unserialized(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
+        message_data["_durable_command_error"] = str(e)
         logger.error(f"Data validation error resuming task {task_id}: {e}")
         await manager.send_personal_message(
             {"type": "error", "message": f"Data validation error: {str(e)}"}, websocket
@@ -5458,6 +5483,7 @@ async def _handle_resume_task_unserialized(
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
+        raise
     except Exception as e:
         # Other errors, re-raise
         logger.error(f"Unexpected error resuming task {task_id}: {e}")
@@ -5514,7 +5540,8 @@ async def _execute_durable_task_command(
         if current_run_id != command.target_run_id:
             raise TaskCommandRejected(
                 f"Task run changed before {command.kind.value} command "
-                f"{command.command_id} was applied"
+                f"{command.command_id} was applied",
+                reason="stale_run",
             )
 
     if command.kind == TaskCommandKind.MESSAGE:
@@ -5534,9 +5561,6 @@ async def _execute_durable_task_command(
             raise TaskCommandRejected(
                 f"Message {command.command_id} could not be applied"
             )
-        durable_error = message_data.get("_durable_command_error")
-        if isinstance(durable_error, str) and durable_error:
-            raise TaskCommandRejected(durable_error)
     elif command.kind == TaskCommandKind.PAUSE:
         await _handle_pause_task_unserialized(websocket, command.task_id, message_data)
     elif command.kind == TaskCommandKind.RESUME:
@@ -5574,6 +5598,9 @@ async def _execute_durable_task_command(
             )
     else:  # pragma: no cover - enum construction rejects this earlier
         raise ValueError(f"Unsupported task command kind: {command.kind}")
+    durable_error = message_data.get("_durable_command_error")
+    if isinstance(durable_error, str) and durable_error:
+        raise TaskCommandRejected(durable_error)
     return {
         "task_id": command.task_id,
         "command_id": command.command_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -84,6 +84,8 @@ from ..services.managed_file_ref import (
 )
 from ..services.task_command_transport import (
     COMMAND_ID_PATTERN,
+    MAX_COMMAND_DEFERS,
+    MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
     EnqueuedTaskCommand,
     TaskCommandDeferred,
@@ -5481,7 +5483,7 @@ def _load_command_actor(actor_user_id: int | None) -> User:
         return user
 
 
-async def execute_durable_task_command(
+async def _execute_durable_task_command(
     command: ClaimedTaskCommand,
 ) -> dict[str, Any] | None:
     """Apply one DB-claimed command using the existing transport adapters.
@@ -5492,19 +5494,19 @@ async def execute_durable_task_command(
     still broadcast normally.
     """
 
-    user = await asyncio.to_thread(_load_command_actor, command.actor_user_id)
     connections = manager.active_connections.get(command.task_id, [])
     websocket: Any = connections[0] if connections else _DiscardingCommandWebSocket()
     message_data = dict(command.payload)
     message_data.update(
         {
-            "user": user,
-            "user_id": int(user.id),
             "_durable_ack_sent": True,
             "_durable_attempt_count": command.attempt_count,
             "_durable_target_run_id": command.target_run_id,
         }
     )
+    if command.kind != TaskCommandKind.CANCEL:
+        user = await asyncio.to_thread(_load_command_actor, command.actor_user_id)
+        message_data.update({"user": user, "user_id": int(user.id)})
     if command.kind != TaskCommandKind.MESSAGE and command.target_run_id is not None:
         current_run_id = await asyncio.to_thread(
             _load_command_task_run_id, command.task_id
@@ -5577,6 +5579,43 @@ async def execute_durable_task_command(
         "command_id": command.command_id,
         "kind": command.kind.value,
     }
+
+
+async def _broadcast_terminal_command_error(
+    command: ClaimedTaskCommand,
+    error: BaseException,
+) -> None:
+    await manager.broadcast_to_task(
+        {
+            "type": "agent_error",
+            "message": (f"Task command {command.kind.value} failed: {error}"),
+            "task_id": command.task_id,
+            "command_id": command.command_id,
+            "timestamp": datetime.now(timezone.utc).timestamp(),
+        },
+        command.task_id,
+    )
+
+
+async def execute_durable_task_command(
+    command: ClaimedTaskCommand,
+) -> dict[str, Any] | None:
+    """Apply one command and expose only terminal transport failures to clients."""
+
+    try:
+        return await _execute_durable_task_command(command)
+    except TaskCommandDeferred as exc:
+        if command.defer_count + 1 >= MAX_COMMAND_DEFERS:
+            await _broadcast_terminal_command_error(command, exc)
+        raise
+    except TaskCommandRejected:
+        # Rejections come from handlers that already expose their durable
+        # domain-level outcome. The dispatcher makes them terminal immediately.
+        raise
+    except Exception as exc:
+        if command.failure_count + 1 >= MAX_COMMAND_FAILURES:
+            await _broadcast_terminal_command_error(command, exc)
+        raise
 
 
 def _load_command_message_delivery_status(

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -85,6 +85,7 @@ app = FastAPI(
 _migration_task: asyncio.Task[None] | None = None
 _file_storage_startup_sync_task: asyncio.Task[Any] | None = None
 _trigger_dispatcher_task: asyncio.Task[Any] | None = None
+_task_command_dispatcher_task: asyncio.Task[Any] | None = None
 _sandbox_idle_sweep_task: asyncio.Task[None] | None = None
 
 FILE_STORAGE_STARTUP_SYNC_EXEMPT_PATHS = frozenset({"/health", "/ready"})
@@ -1092,6 +1093,18 @@ async def startup_event() -> None:
     else:
         logger.info("Sandbox manager not available (disabled or init failed)")
 
+    # Recover accepted-but-unfinished task commands only after the runtime,
+    # skill/template managers, tracing, and sandbox services are ready.
+    from .api.websocket import execute_durable_task_command
+    from .services.task_command_transport import start_task_command_dispatcher
+
+    global _task_command_dispatcher_task
+    _task_command_dispatcher_task = start_task_command_dispatcher(
+        execute_durable_task_command
+    )
+    app.state.task_command_dispatcher_task = _task_command_dispatcher_task
+    logger.info("Started durable task command dispatcher")
+
     # Start Telegram and FeiShu channels if enabled
     try:
         from .channels.feishu.bot import get_feishu_channel
@@ -1117,10 +1130,17 @@ async def shutdown_event() -> None:
     global \
         _file_storage_startup_sync_task, \
         _migration_task, \
+        _task_command_dispatcher_task, \
         _trigger_dispatcher_task, \
         _sandbox_idle_sweep_task
 
     flush_langfuse()
+
+    if _task_command_dispatcher_task is not None:
+        from .services.task_command_transport import stop_task_command_dispatcher
+
+        await stop_task_command_dispatcher()
+    _task_command_dispatcher_task = None
 
     if _sandbox_idle_sweep_task and not _sandbox_idle_sweep_task.done():
         logger.info("Cancelling sandbox idle sweep task...")

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -19,11 +19,16 @@ from ...models.task import Task, TaskStatus
 from ...models.user import User
 from ...models.user_channel import UserChannel
 from ...services.execution_result_projection import project_execution_result_for_channel
+from ...services.managed_task_lease import (
+    ManagedTaskLease,
+    claim_managed_task_lease,
+)
 from ...services.task_execution_controller import (
     StaleTaskRunError,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
+    task_control_snapshot,
     task_execution_controller,
 )
 from .trace_handler import FeishuTraceHandler
@@ -130,6 +135,7 @@ class FeishuBotInstance:
         db = next(db_gen)
         claimed_task_id: int | None = None
         claimed_run_id: str | None = None
+        managed_lease: ManagedTaskLease | None = None
         try:
             user = None
             if self.channel_id:
@@ -258,20 +264,16 @@ class FeishuBotInstance:
 
             async with task_execution_controller.command(int(task.id)):
                 db.refresh(task)
-                if task.status == TaskStatus.RUNNING:
+                managed_lease = claim_managed_task_lease(db, int(task.id))
+                if managed_lease is None:
                     await self._send_text(
                         chat_id,
                         "I'm still working on the previous message. "
                         "Please wait for it to finish.",
                     )
                     return
-                run_snapshot = apply_task_control_transition(
-                    task,
-                    TaskControlState.RUNNING,
-                    status=TaskStatus.RUNNING,
-                    new_run=True,
-                )
-                db.commit()
+                db.refresh(task)
+                run_snapshot = task_control_snapshot(task)
                 claimed_task_id = int(task.id)
                 claimed_run_id = run_snapshot.run_id
 
@@ -343,6 +345,7 @@ class FeishuBotInstance:
                     task_id=actual_task_id,
                     tracking_task_id=str(task.id),
                     db_session=db,
+                    manage_task_lease=False,
                 )
 
             projection = project_execution_result_for_channel(result)
@@ -410,9 +413,13 @@ class FeishuBotInstance:
             )
         finally:
             try:
-                next(db_gen)
-            except StopIteration:
-                pass
+                try:
+                    next(db_gen)
+                except StopIteration:
+                    pass
+            finally:
+                if managed_lease is not None:
+                    await managed_lease.close()
 
     async def _download_and_register_files(
         self,

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -25,11 +25,16 @@ from ...models.uploaded_file import UploadedFile
 from ...models.user import User
 from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
+from ...services.managed_task_lease import (
+    ManagedTaskLease,
+    claim_managed_task_lease,
+)
 from ...services.task_execution_controller import (
     StaleTaskRunError,
     TaskControlState,
     apply_task_control_transition,
     control_state_for_status,
+    task_control_snapshot,
     task_execution_controller,
 )
 from .handler import TelegramTraceHandler
@@ -472,6 +477,7 @@ class TelegramBotInstance:
         self._clear_user_stop_request(user_id)
         claimed_task_id: int | None = None
         claimed_run_id: str | None = None
+        managed_lease: ManagedTaskLease | None = None
         try:
             db_gen = get_db()
             db = next(db_gen)
@@ -544,19 +550,15 @@ class TelegramBotInstance:
 
                 async with task_execution_controller.command(int(task.id)):
                     db.refresh(task)
-                    if task.status == TaskStatus.RUNNING:
+                    managed_lease = claim_managed_task_lease(db, int(task.id))
+                    if managed_lease is None:
                         await last_message.answer(
                             "I'm still working on the previous message. "
                             "Please wait for it to finish."
                         )
                         return
-                    run_snapshot = apply_task_control_transition(
-                        task,
-                        TaskControlState.RUNNING,
-                        status=TaskStatus.RUNNING,
-                        new_run=True,
-                    )
-                    db.commit()
+                    db.refresh(task)
+                    run_snapshot = task_control_snapshot(task)
                     claimed_task_id = int(task.id)
                     claimed_run_id = run_snapshot.run_id
 
@@ -670,6 +672,7 @@ class TelegramBotInstance:
                                 task_id=actual_task_id,
                                 tracking_task_id=str(task.id),
                                 db_session=db,
+                                manage_task_lease=False,
                             ),
                             reason="Telegram stop requested",
                         )
@@ -800,6 +803,8 @@ class TelegramBotInstance:
                 "Sorry, an error occurred while processing your request."
             )
         finally:
+            if managed_lease is not None:
+                await managed_lease.close()
             self.user_preparing_executions.discard(user_id)
             self._clear_user_stop_request(user_id)
 

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -16,6 +16,7 @@ from .sandbox import SandboxInfo, SandboxSnapshot
 from .skill import UserSkill, UserSkillFile
 from .system_setting import SystemSetting
 from .task import DAGExecution, Task, TaskConnectorRuntimeContext
+from .task_command import TaskExecutionCommand
 from .template_stats import TemplateStats, UserTemplateRelation
 from .tool_config import ToolConfig, ToolUsage
 from .trigger import (
@@ -56,6 +57,7 @@ __all__ = [
     "CustomApi",
     "UserCustomApi",
     "Task",
+    "TaskExecutionCommand",
     "TaskConnectorRuntimeContext",
     "DAGExecution",
     "TemplateStats",

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -57,6 +57,7 @@ def init_db(db_url: str | None = None) -> None:
         Task,
         TaskChatMessage,
         TaskConnectorRuntimeContext,
+        TaskExecutionCommand,
         TemplateStats,
         ToolConfig,
         ToolUsage,

--- a/src/xagent/web/models/task_command.py
+++ b/src/xagent/web/models/task_command.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from .database import Base
@@ -32,7 +31,6 @@ class TaskExecutionCommand(Base):  # type: ignore
         Integer,
         ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     actor_user_id = Column(
         Integer,
@@ -56,6 +54,7 @@ class TaskExecutionCommand(Base):  # type: ignore
     claimed_by = Column(String(255), nullable=True)
     claim_expires_at = Column(DateTime(timezone=True), nullable=True)
     attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
+    failure_count = Column(Integer, nullable=False, default=0, server_default="0")
     result = Column(JSON, nullable=True)
     error = Column(Text, nullable=True)
     created_at = Column(
@@ -68,6 +67,3 @@ class TaskExecutionCommand(Base):  # type: ignore
         onupdate=func.now(),
     )
     completed_at = Column(DateTime(timezone=True), nullable=True)
-
-    task = relationship("Task")
-    actor = relationship("User")

--- a/src/xagent/web/models/task_command.py
+++ b/src/xagent/web/models/task_command.py
@@ -55,6 +55,7 @@ class TaskExecutionCommand(Base):  # type: ignore
     claim_expires_at = Column(DateTime(timezone=True), nullable=True)
     attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
     failure_count = Column(Integer, nullable=False, default=0, server_default="0")
+    defer_count = Column(Integer, nullable=False, default=0, server_default="0")
     result = Column(JSON, nullable=True)
     error = Column(Text, nullable=True)
     created_at = Column(

--- a/src/xagent/web/models/task_command.py
+++ b/src/xagent/web/models/task_command.py
@@ -1,0 +1,73 @@
+"""Durable control-plane commands for task execution."""
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class TaskExecutionCommand(Base):  # type: ignore
+    """One idempotent task command, claimed by at most one worker at a time."""
+
+    __tablename__ = "task_execution_commands"
+    __table_args__ = (
+        UniqueConstraint("task_id", "command_id", name="uq_task_command_identity"),
+        Index("ix_task_commands_status_created", "status", "created_at"),
+        Index("ix_task_commands_task_order", "task_id", "id"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(
+        Integer,
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    actor_user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    command_id = Column(String(64), nullable=False)
+    kind = Column(String(32), nullable=False)
+    payload = Column(JSON, nullable=False)
+
+    # The run/worker observed when the command was accepted. Commands aimed at
+    # a live run stay with its lease owner; once that lease expires another
+    # worker may recover them from the durable inbox.
+    target_run_id = Column(String(64), nullable=True)
+    target_runner_id = Column(String(255), nullable=True)
+
+    status = Column(
+        String(32), nullable=False, default="pending", server_default="pending"
+    )
+    claimed_by = Column(String(255), nullable=True)
+    claim_expires_at = Column(DateTime(timezone=True), nullable=True)
+    attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
+    result = Column(JSON, nullable=True)
+    error = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    task = relationship("Task")
+    actor = relationship("User")

--- a/src/xagent/web/services/managed_task_lease.py
+++ b/src/xagent/web/services/managed_task_lease.py
@@ -1,0 +1,86 @@
+"""Managed lease lifecycle for inline task transports."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from ..models.task import Task, TaskStatus
+from .task_lease_service import (
+    TaskLease,
+    acquire_task_lease,
+    run_task_lease_heartbeat,
+    stop_task_lease_heartbeat,
+)
+from .workforce_runtime import release_task_lease_with_workforce_sync
+
+logger = logging.getLogger(__name__)
+
+
+def _release_managed_task_lease_sync(lease: TaskLease) -> bool:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == lease.task_id).first()
+        if task is None or task.run_id != lease.run_id:
+            return False
+        final_status = (
+            TaskStatus.FAILED if task.status == TaskStatus.RUNNING else task.status
+        )
+        return release_task_lease_with_workforce_sync(
+            db,
+            lease,
+            status=final_status,
+        )
+
+
+@dataclass
+class ManagedTaskLease:
+    """Keep a pre-acquired lease alive and release it exactly once."""
+
+    lease: TaskLease
+    stop_event: asyncio.Event
+    heartbeat_task: asyncio.Task[None]
+    _closed: bool = field(default=False, init=False)
+
+    async def close(self) -> bool:
+        if self._closed:
+            return False
+        self._closed = True
+        await stop_task_lease_heartbeat(self.heartbeat_task, self.stop_event)
+        try:
+            return await asyncio.to_thread(_release_managed_task_lease_sync, self.lease)
+        except Exception:
+            logger.error(
+                "Failed to release managed task lease for task %s run %s",
+                self.lease.task_id,
+                self.lease.run_id,
+                exc_info=True,
+            )
+            return False
+
+
+def start_managed_task_lease(lease: TaskLease) -> ManagedTaskLease:
+    """Start heartbeating a lease that the caller already claimed."""
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(run_task_lease_heartbeat(lease, stop_event))
+    return ManagedTaskLease(
+        lease=lease,
+        stop_event=stop_event,
+        heartbeat_task=heartbeat_task,
+    )
+
+
+def claim_managed_task_lease(
+    db: Session,
+    task_id: int,
+) -> ManagedTaskLease | None:
+    """Atomically claim a new run and start its lease heartbeat."""
+
+    lease = acquire_task_lease(db, task_id, new_run=True)
+    return start_managed_task_lease(lease) if lease is not None else None

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -1,0 +1,625 @@
+"""Durable, cross-worker transport for task execution commands.
+
+Ingress commits a command before acknowledging it. Every web worker runs the
+same dispatcher; a database claim chooses one consumer while per-task ordering
+prevents a later command from overtaking an earlier unfinished command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import and_, exists, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Query, Session, aliased
+
+from ...config import (
+    get_task_lease_heartbeat_seconds,
+    get_task_lease_ttl_seconds,
+)
+from ..models.task import Task, TaskStatus
+from ..models.task_command import TaskExecutionCommand
+from .task_lease_service import get_runner_id
+
+logger = logging.getLogger(__name__)
+
+COMMAND_PENDING = "pending"
+COMMAND_PROCESSING = "processing"
+COMMAND_COMPLETED = "completed"
+COMMAND_FAILED = "failed"
+COMMAND_TERMINAL = (COMMAND_COMPLETED, COMMAND_FAILED)
+
+COMMAND_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,64}")
+MAX_COMMAND_ATTEMPTS = 5
+DISPATCHER_IDLE_SECONDS = 0.5
+
+
+class TaskCommandKind(str, enum.Enum):
+    MESSAGE = "message"
+    PAUSE = "pause"
+    RESUME = "resume"
+    CANCEL = "cancel"
+
+
+class TaskCommandDeferred(RuntimeError):
+    """The command is durable but its downstream handoff is still pending."""
+
+
+class TaskCommandRejected(RuntimeError):
+    """The downstream handoff reached a durable failed state."""
+
+
+@dataclass(frozen=True)
+class EnqueuedTaskCommand:
+    command_id: int
+    client_command_id: str
+    created: bool
+    payload_matches: bool
+    status: str
+
+
+@dataclass(frozen=True)
+class ClaimedTaskCommand:
+    id: int
+    task_id: int
+    actor_user_id: int | None
+    command_id: str
+    kind: TaskCommandKind
+    payload: dict[str, Any]
+    target_run_id: str | None
+    attempt_count: int
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _canonical_payload(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _matches_existing(
+    command: TaskExecutionCommand,
+    *,
+    actor_user_id: int | None,
+    kind: TaskCommandKind,
+    payload: dict[str, Any],
+) -> bool:
+    stored_payload: dict[str, Any] = (
+        command.payload if isinstance(command.payload, dict) else {}
+    )
+    stored_actor_user_id = getattr(command, "actor_user_id", None)
+    return (
+        stored_actor_user_id == actor_user_id
+        and str(command.kind) == kind.value
+        and _canonical_payload(stored_payload) == _canonical_payload(payload)
+    )
+
+
+def enqueue_task_command(
+    db: Session,
+    *,
+    task_id: int,
+    actor_user_id: int | None,
+    command_id: str,
+    kind: TaskCommandKind,
+    payload: dict[str, Any],
+) -> EnqueuedTaskCommand:
+    """Commit an idempotent command and return only after it is durable."""
+
+    normalized_id = command_id.strip()
+    if COMMAND_ID_PATTERN.fullmatch(normalized_id) is None:
+        raise ValueError("command_id must be 1-64 URL-safe characters")
+    task = db.query(Task).filter(Task.id == int(task_id)).first()
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    existing = (
+        db.query(TaskExecutionCommand)
+        .filter(
+            TaskExecutionCommand.task_id == int(task_id),
+            TaskExecutionCommand.command_id == normalized_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        matches = _matches_existing(
+            existing,
+            actor_user_id=actor_user_id,
+            kind=kind,
+            payload=payload,
+        )
+        return EnqueuedTaskCommand(
+            command_id=int(existing.id),
+            client_command_id=normalized_id,
+            created=False,
+            payload_matches=matches,
+            status=str(existing.status),
+        )
+
+    active_runner_id = (
+        task.runner_id
+        if task.status == TaskStatus.RUNNING and task.runner_id is not None
+        else None
+    )
+    command = TaskExecutionCommand(
+        task_id=int(task_id),
+        actor_user_id=actor_user_id,
+        command_id=normalized_id,
+        kind=kind.value,
+        payload=payload,
+        target_run_id=task.run_id,
+        target_runner_id=active_runner_id,
+        status=COMMAND_PENDING,
+    )
+    db.add(command)
+    try:
+        db.commit()
+        db.refresh(command)
+    except IntegrityError:
+        db.rollback()
+        raced = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.task_id == int(task_id),
+                TaskExecutionCommand.command_id == normalized_id,
+            )
+            .one()
+        )
+        matches = _matches_existing(
+            raced,
+            actor_user_id=actor_user_id,
+            kind=kind,
+            payload=payload,
+        )
+        return EnqueuedTaskCommand(
+            command_id=int(raced.id),
+            client_command_id=normalized_id,
+            created=False,
+            payload_matches=matches,
+            status=str(raced.status),
+        )
+
+    notify_task_command_dispatcher()
+    return EnqueuedTaskCommand(
+        command_id=int(command.id),
+        client_command_id=normalized_id,
+        created=True,
+        payload_matches=True,
+        status=COMMAND_PENDING,
+    )
+
+
+def _claimable_query(
+    db: Session, *, runner_id: str, command_db_id: int | None
+) -> Query[Any]:
+    now = _utc_now()
+    earlier = aliased(TaskExecutionCommand)
+    unfinished_earlier = exists(
+        select(1).where(
+            earlier.task_id == TaskExecutionCommand.task_id,
+            earlier.id < TaskExecutionCommand.id,
+            earlier.status.notin_(COMMAND_TERMINAL),
+        )
+    )
+    query = (
+        db.query(TaskExecutionCommand)
+        .join(Task, Task.id == TaskExecutionCommand.task_id)
+        .filter(
+            or_(
+                and_(
+                    TaskExecutionCommand.status == COMMAND_PENDING,
+                    or_(
+                        TaskExecutionCommand.claim_expires_at.is_(None),
+                        TaskExecutionCommand.claim_expires_at < now,
+                    ),
+                ),
+                and_(
+                    TaskExecutionCommand.status == COMMAND_PROCESSING,
+                    TaskExecutionCommand.claim_expires_at < now,
+                ),
+            ),
+            ~unfinished_earlier,
+            or_(
+                TaskExecutionCommand.target_runner_id.is_(None),
+                TaskExecutionCommand.target_runner_id == runner_id,
+                Task.runner_id.is_(None),
+                Task.runner_id != TaskExecutionCommand.target_runner_id,
+                Task.lease_expires_at.is_(None),
+                Task.lease_expires_at < now,
+            ),
+        )
+    )
+    if command_db_id is not None:
+        query = query.filter(TaskExecutionCommand.id == command_db_id)
+    return query.order_by(TaskExecutionCommand.id.asc())
+
+
+def claim_task_command(
+    db: Session,
+    *,
+    runner_id: str | None = None,
+    command_db_id: int | None = None,
+) -> ClaimedTaskCommand | None:
+    """Atomically claim the oldest eligible command for this worker."""
+
+    resolved_runner_id = runner_id or get_runner_id()
+    candidate = _claimable_query(
+        db,
+        runner_id=resolved_runner_id,
+        command_db_id=command_db_id,
+    ).first()
+    if candidate is None:
+        return None
+
+    now = _utc_now()
+    expires = now + timedelta(seconds=get_task_lease_ttl_seconds())
+    claimed = (
+        db.query(TaskExecutionCommand)
+        .filter(
+            TaskExecutionCommand.id == int(candidate.id),
+            or_(
+                TaskExecutionCommand.status == COMMAND_PENDING,
+                and_(
+                    TaskExecutionCommand.status == COMMAND_PROCESSING,
+                    TaskExecutionCommand.claim_expires_at < now,
+                ),
+            ),
+        )
+        .update(
+            {
+                TaskExecutionCommand.status: COMMAND_PROCESSING,
+                TaskExecutionCommand.claimed_by: resolved_runner_id,
+                TaskExecutionCommand.claim_expires_at: expires,
+                TaskExecutionCommand.attempt_count: (
+                    TaskExecutionCommand.attempt_count + 1
+                ),
+                TaskExecutionCommand.error: None,
+                TaskExecutionCommand.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+    )
+    if claimed != 1:
+        db.rollback()
+        return None
+    db.commit()
+    fresh = (
+        db.query(TaskExecutionCommand)
+        .filter(TaskExecutionCommand.id == int(candidate.id))
+        .one()
+    )
+    payload: dict[str, Any] = fresh.payload if isinstance(fresh.payload, dict) else {}
+    return ClaimedTaskCommand(
+        id=int(fresh.id),
+        task_id=int(fresh.task_id),
+        actor_user_id=(
+            int(fresh.actor_user_id) if fresh.actor_user_id is not None else None
+        ),
+        command_id=str(fresh.command_id),
+        kind=TaskCommandKind(str(fresh.kind)),
+        payload=payload,
+        target_run_id=(str(fresh.target_run_id) if fresh.target_run_id else None),
+        attempt_count=int(fresh.attempt_count or 0),
+    )
+
+
+def renew_task_command_claim(command_db_id: int, runner_id: str) -> bool:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    now = _utc_now()
+    with SessionLocal() as db:
+        updated = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.id == command_db_id,
+                TaskExecutionCommand.status == COMMAND_PROCESSING,
+                TaskExecutionCommand.claimed_by == runner_id,
+            )
+            .update(
+                {
+                    TaskExecutionCommand.claim_expires_at: now
+                    + timedelta(seconds=get_task_lease_ttl_seconds()),
+                    TaskExecutionCommand.updated_at: now,
+                },
+                synchronize_session=False,
+            )
+        )
+        db.commit()
+        return updated == 1
+
+
+async def _claim_heartbeat(
+    command_db_id: int,
+    runner_id: str,
+    stop_event: asyncio.Event,
+) -> None:
+    interval = get_task_lease_heartbeat_seconds()
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            return
+        except asyncio.TimeoutError:
+            pass
+        if not await asyncio.to_thread(
+            renew_task_command_claim, command_db_id, runner_id
+        ):
+            return
+
+
+def finish_task_command(
+    command_db_id: int,
+    runner_id: str,
+    *,
+    result: dict[str, Any] | None = None,
+) -> bool:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    now = _utc_now()
+    with SessionLocal() as db:
+        updated = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.id == command_db_id,
+                TaskExecutionCommand.status == COMMAND_PROCESSING,
+                TaskExecutionCommand.claimed_by == runner_id,
+            )
+            .update(
+                {
+                    TaskExecutionCommand.status: COMMAND_COMPLETED,
+                    TaskExecutionCommand.result: result,
+                    TaskExecutionCommand.error: None,
+                    TaskExecutionCommand.claimed_by: None,
+                    TaskExecutionCommand.claim_expires_at: None,
+                    TaskExecutionCommand.completed_at: now,
+                    TaskExecutionCommand.updated_at: now,
+                },
+                synchronize_session=False,
+            )
+        )
+        db.commit()
+        return updated == 1
+
+
+def fail_task_command(
+    command_db_id: int,
+    runner_id: str,
+    error: str,
+    *,
+    force_terminal: bool = False,
+) -> bool:
+    """Retry a failed claim, or make it terminal after bounded attempts."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    now = _utc_now()
+    with SessionLocal() as db:
+        command = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.id == command_db_id,
+                TaskExecutionCommand.status == COMMAND_PROCESSING,
+                TaskExecutionCommand.claimed_by == runner_id,
+            )
+            .first()
+        )
+        if command is None:
+            return False
+        terminal = force_terminal or (
+            int(command.attempt_count or 0) >= MAX_COMMAND_ATTEMPTS
+        )
+        setattr(command, "status", COMMAND_FAILED if terminal else COMMAND_PENDING)
+        setattr(command, "error", error[:4000])
+        setattr(command, "claimed_by", None)
+        setattr(
+            command,
+            "claim_expires_at",
+            None
+            if terminal
+            else now + timedelta(seconds=min(2 ** int(command.attempt_count or 1), 30)),
+        )
+        setattr(command, "updated_at", now)
+        setattr(command, "completed_at", now if terminal else None)
+        db.commit()
+    if not terminal:
+        notify_task_command_dispatcher()
+    return True
+
+
+def defer_task_command(
+    command_db_id: int,
+    runner_id: str,
+    reason: str,
+) -> bool:
+    """Release a claim for retry without consuming the failure budget."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    now = _utc_now()
+    with SessionLocal() as db:
+        command = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.id == command_db_id,
+                TaskExecutionCommand.status == COMMAND_PROCESSING,
+                TaskExecutionCommand.claimed_by == runner_id,
+            )
+            .first()
+        )
+        if command is None:
+            return False
+        setattr(command, "status", COMMAND_PENDING)
+        setattr(command, "error", reason[:4000])
+        setattr(command, "claimed_by", None)
+        setattr(command, "claim_expires_at", now + timedelta(seconds=1))
+        setattr(command, "updated_at", now)
+        db.commit()
+    notify_task_command_dispatcher()
+    return True
+
+
+CommandExecutor = Callable[[ClaimedTaskCommand], Awaitable[dict[str, Any] | None]]
+_dispatcher_wakeup: asyncio.Event | None = None
+_dispatcher_task: asyncio.Task[Any] | None = None
+_dispatcher_loop: asyncio.AbstractEventLoop | None = None
+
+
+def notify_task_command_dispatcher() -> None:
+    wakeup = _dispatcher_wakeup
+    loop = _dispatcher_loop
+    if wakeup is not None and loop is not None and not loop.is_closed():
+        loop.call_soon_threadsafe(wakeup.set)
+
+
+async def dispatch_one_task_command(
+    executor: CommandExecutor,
+    *,
+    command_db_id: int | None = None,
+) -> bool:
+    from ..models.database import get_session_local
+
+    runner_id = get_runner_id()
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        command = claim_task_command(
+            db,
+            runner_id=runner_id,
+            command_db_id=command_db_id,
+        )
+    if command is None:
+        return False
+
+    stop_event = asyncio.Event()
+    heartbeat = asyncio.get_running_loop().create_task(
+        _claim_heartbeat(command.id, runner_id, stop_event)
+    )
+    try:
+        result = await executor(command)
+    except asyncio.CancelledError:
+        # Leave the processing claim intact. Another worker may reclaim it only
+        # after the claim expires, which avoids concurrent replay on shutdown.
+        raise
+    except TaskCommandDeferred as exc:
+        await asyncio.to_thread(
+            defer_task_command,
+            command.id,
+            runner_id,
+            str(exc),
+        )
+    except TaskCommandRejected as exc:
+        await asyncio.to_thread(
+            fail_task_command,
+            command.id,
+            runner_id,
+            str(exc),
+            force_terminal=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Task command %s (%s) failed on attempt %s",
+            command.command_id,
+            command.kind.value,
+            command.attempt_count,
+        )
+        await asyncio.to_thread(fail_task_command, command.id, runner_id, str(exc))
+    else:
+        if not await asyncio.to_thread(
+            finish_task_command,
+            command.id,
+            runner_id,
+            result=result,
+        ):
+            logger.warning("Lost claim while completing task command %s", command.id)
+    finally:
+        stop_event.set()
+        heartbeat.cancel()
+        try:
+            await heartbeat
+        except asyncio.CancelledError:
+            pass
+    return True
+
+
+async def dispatch_task_command_promptly(
+    executor: CommandExecutor,
+    *,
+    command_db_id: int,
+    handoff_seconds: float = 0.05,
+) -> None:
+    """Kick local consumption without tying WS receive to command execution.
+
+    Fast commands usually finish during the short handoff window. Slow file or
+    checkpoint work continues in its own task, allowing the socket receive loop
+    to accept the next pause/message command instead of blocking behind it.
+    """
+
+    task = asyncio.get_running_loop().create_task(
+        dispatch_one_task_command(executor, command_db_id=command_db_id)
+    )
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=handoff_seconds)
+    except asyncio.TimeoutError:
+        return
+
+
+async def run_task_command_dispatcher(executor: CommandExecutor) -> None:
+    global _dispatcher_loop, _dispatcher_wakeup
+    _dispatcher_loop = asyncio.get_running_loop()
+    _dispatcher_wakeup = asyncio.Event()
+    while True:
+        processed = await dispatch_one_task_command(executor)
+        if processed:
+            continue
+        _dispatcher_wakeup.clear()
+        try:
+            await asyncio.wait_for(
+                _dispatcher_wakeup.wait(), timeout=DISPATCHER_IDLE_SECONDS
+            )
+        except asyncio.TimeoutError:
+            pass
+
+
+def start_task_command_dispatcher(executor: CommandExecutor) -> asyncio.Task[Any]:
+    global _dispatcher_task
+    if _dispatcher_task is not None and not _dispatcher_task.done():
+        return _dispatcher_task
+    _dispatcher_task = asyncio.create_task(run_task_command_dispatcher(executor))
+    return _dispatcher_task
+
+
+async def stop_task_command_dispatcher() -> None:
+    global _dispatcher_loop, _dispatcher_task, _dispatcher_wakeup
+    task = _dispatcher_task
+    _dispatcher_task = None
+    _dispatcher_wakeup = None
+    _dispatcher_loop = None
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def load_task_command(command_db_id: int) -> TaskExecutionCommand | None:
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        return (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.id == command_db_id)
+            .first()
+        )

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -40,6 +40,7 @@ COMMAND_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,64}")
 MAX_COMMAND_FAILURES = 5
 MAX_COMMAND_DEFERS = 60
 DISPATCHER_IDLE_SECONDS = 0.5
+DISPATCHER_CONCURRENCY = 4
 
 
 class TaskCommandKind(str, enum.Enum):
@@ -55,6 +56,10 @@ class TaskCommandDeferred(RuntimeError):
 
 class TaskCommandRejected(RuntimeError):
     """The downstream handoff reached a durable failed state."""
+
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 @dataclass(frozen=True)
@@ -437,6 +442,7 @@ def fail_task_command(
     *,
     force_terminal: bool = False,
     expected_attempt_count: int | None = None,
+    result: dict[str, Any] | None = None,
 ) -> bool:
     """Retry a failed claim, or make it terminal after bounded attempts."""
 
@@ -480,6 +486,7 @@ def fail_task_command(
                     ),
                     TaskExecutionCommand.failure_count: failure_count,
                     TaskExecutionCommand.error: error[:4000],
+                    TaskExecutionCommand.result: result,
                     TaskExecutionCommand.claimed_by: None,
                     TaskExecutionCommand.claim_expires_at: (
                         None
@@ -698,6 +705,9 @@ async def dispatch_one_task_command(
             str(exc),
             force_terminal=True,
             expected_attempt_count=command.attempt_count,
+            result=(
+                {"rejection_reason": exc.reason} if exc.reason is not None else None
+            ),
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception(
@@ -771,24 +781,40 @@ def _consume_prompt_dispatch_result(task: asyncio.Task[bool]) -> None:
         )
 
 
-async def run_task_command_dispatcher(executor: CommandExecutor) -> None:
-    global _dispatcher_loop, _dispatcher_wakeup
-    _dispatcher_loop = asyncio.get_running_loop()
-    _dispatcher_wakeup = asyncio.Event()
+async def _run_task_command_dispatcher_worker(executor: CommandExecutor) -> None:
     while True:
+        wakeup = _dispatcher_wakeup
+        if wakeup is None:
+            return
         # Clear before checking for work. A notify that arrives during the DB
         # claim remains set, so an empty claim cannot erase that wakeup and
         # sleep while work is waiting.
-        _dispatcher_wakeup.clear()
+        wakeup.clear()
         processed = await dispatch_one_task_command(executor)
         if processed:
             continue
         try:
-            await asyncio.wait_for(
-                _dispatcher_wakeup.wait(), timeout=DISPATCHER_IDLE_SECONDS
-            )
+            await asyncio.wait_for(wakeup.wait(), timeout=DISPATCHER_IDLE_SECONDS)
         except asyncio.TimeoutError:
             pass
+
+
+async def run_task_command_dispatcher(executor: CommandExecutor) -> None:
+    """Recover queued commands without serializing unrelated tasks."""
+
+    global _dispatcher_loop, _dispatcher_wakeup
+    _dispatcher_loop = asyncio.get_running_loop()
+    _dispatcher_wakeup = asyncio.Event()
+    workers = [
+        asyncio.create_task(_run_task_command_dispatcher_worker(executor))
+        for _ in range(DISPATCHER_CONCURRENCY)
+    ]
+    try:
+        await asyncio.gather(*workers)
+    finally:
+        for worker in workers:
+            worker.cancel()
+        await asyncio.gather(*workers, return_exceptions=True)
 
 
 def start_task_command_dispatcher(executor: CommandExecutor) -> asyncio.Task[Any]:

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -76,6 +76,8 @@ class ClaimedTaskCommand:
     payload: dict[str, Any]
     target_run_id: str | None
     attempt_count: int
+    failure_count: int = 0
+    defer_count: int = 0
 
 
 def _utc_now() -> datetime:
@@ -198,44 +200,55 @@ def enqueue_task_command(
     )
 
 
-def _claimable_query(
-    db: Session, *, runner_id: str, command_db_id: int | None
-) -> Query[Any]:
-    now = _utc_now()
+def _claim_availability_predicate(now: datetime) -> Any:
+    return or_(
+        and_(
+            TaskExecutionCommand.status == COMMAND_PENDING,
+            or_(
+                TaskExecutionCommand.claim_expires_at.is_(None),
+                TaskExecutionCommand.claim_expires_at < now,
+            ),
+        ),
+        and_(
+            TaskExecutionCommand.status == COMMAND_PROCESSING,
+            TaskExecutionCommand.claim_expires_at < now,
+        ),
+    )
+
+
+def _command_routing_predicate(runner_id: str, now: datetime) -> Any:
+    return or_(
+        TaskExecutionCommand.target_runner_id.is_(None),
+        TaskExecutionCommand.target_runner_id == runner_id,
+        Task.runner_id == runner_id,
+        Task.runner_id.is_(None),
+        Task.lease_expires_at.is_(None),
+        Task.lease_expires_at < now,
+    )
+
+
+def _unfinished_earlier_command() -> Any:
     earlier = aliased(TaskExecutionCommand)
-    unfinished_earlier = exists(
+    return exists(
         select(1).where(
             earlier.task_id == TaskExecutionCommand.task_id,
             earlier.id < TaskExecutionCommand.id,
             earlier.status.notin_(COMMAND_TERMINAL),
         )
     )
+
+
+def _claimable_query(
+    db: Session, *, runner_id: str, command_db_id: int | None
+) -> Query[Any]:
+    now = _utc_now()
     query = (
         db.query(TaskExecutionCommand)
         .join(Task, Task.id == TaskExecutionCommand.task_id)
         .filter(
-            or_(
-                and_(
-                    TaskExecutionCommand.status == COMMAND_PENDING,
-                    or_(
-                        TaskExecutionCommand.claim_expires_at.is_(None),
-                        TaskExecutionCommand.claim_expires_at < now,
-                    ),
-                ),
-                and_(
-                    TaskExecutionCommand.status == COMMAND_PROCESSING,
-                    TaskExecutionCommand.claim_expires_at < now,
-                ),
-            ),
-            ~unfinished_earlier,
-            or_(
-                TaskExecutionCommand.target_runner_id.is_(None),
-                TaskExecutionCommand.target_runner_id == runner_id,
-                Task.runner_id == runner_id,
-                Task.runner_id.is_(None),
-                Task.lease_expires_at.is_(None),
-                Task.lease_expires_at < now,
-            ),
+            _claim_availability_predicate(now),
+            ~_unfinished_earlier_command(),
+            _command_routing_predicate(runner_id, now),
         )
     )
     if command_db_id is not None:
@@ -262,17 +275,19 @@ def claim_task_command(
 
     now = _utc_now()
     expires = now + timedelta(seconds=get_task_lease_ttl_seconds())
+    routable_task = exists(
+        select(1).where(
+            Task.id == TaskExecutionCommand.task_id,
+            _command_routing_predicate(resolved_runner_id, now),
+        )
+    )
     claimed = (
         db.query(TaskExecutionCommand)
         .filter(
             TaskExecutionCommand.id == int(candidate.id),
-            or_(
-                TaskExecutionCommand.status == COMMAND_PENDING,
-                and_(
-                    TaskExecutionCommand.status == COMMAND_PROCESSING,
-                    TaskExecutionCommand.claim_expires_at < now,
-                ),
-            ),
+            _claim_availability_predicate(now),
+            ~_unfinished_earlier_command(),
+            routable_task,
         )
         .update(
             {
@@ -309,30 +324,38 @@ def claim_task_command(
         payload=payload,
         target_run_id=(str(fresh.target_run_id) if fresh.target_run_id else None),
         attempt_count=int(fresh.attempt_count or 0),
+        failure_count=int(fresh.failure_count or 0),
+        defer_count=int(fresh.defer_count or 0),
     )
 
 
-def renew_task_command_claim(command_db_id: int, runner_id: str) -> bool:
+def renew_task_command_claim(
+    command_db_id: int,
+    runner_id: str,
+    *,
+    expected_attempt_count: int | None = None,
+) -> bool:
     from ..models.database import get_session_local
 
     SessionLocal = get_session_local()
     now = _utc_now()
     with SessionLocal() as db:
-        updated = (
-            db.query(TaskExecutionCommand)
-            .filter(
-                TaskExecutionCommand.id == command_db_id,
-                TaskExecutionCommand.status == COMMAND_PROCESSING,
-                TaskExecutionCommand.claimed_by == runner_id,
+        query = db.query(TaskExecutionCommand).filter(
+            TaskExecutionCommand.id == command_db_id,
+            TaskExecutionCommand.status == COMMAND_PROCESSING,
+            TaskExecutionCommand.claimed_by == runner_id,
+        )
+        if expected_attempt_count is not None:
+            query = query.filter(
+                TaskExecutionCommand.attempt_count == expected_attempt_count
             )
-            .update(
-                {
-                    TaskExecutionCommand.claim_expires_at: now
-                    + timedelta(seconds=get_task_lease_ttl_seconds()),
-                    TaskExecutionCommand.updated_at: now,
-                },
-                synchronize_session=False,
-            )
+        updated = query.update(
+            {
+                TaskExecutionCommand.claim_expires_at: now
+                + timedelta(seconds=get_task_lease_ttl_seconds()),
+                TaskExecutionCommand.updated_at: now,
+            },
+            synchronize_session=False,
         )
         db.commit()
         return updated == 1
@@ -341,6 +364,7 @@ def renew_task_command_claim(command_db_id: int, runner_id: str) -> bool:
 async def _claim_heartbeat(
     command_db_id: int,
     runner_id: str,
+    attempt_count: int,
     stop_event: asyncio.Event,
 ) -> None:
     interval = get_task_lease_heartbeat_seconds()
@@ -352,7 +376,10 @@ async def _claim_heartbeat(
             pass
         try:
             renewed = await asyncio.to_thread(
-                renew_task_command_claim, command_db_id, runner_id
+                renew_task_command_claim,
+                command_db_id,
+                runner_id,
+                expected_attempt_count=attempt_count,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -371,31 +398,33 @@ def finish_task_command(
     runner_id: str,
     *,
     result: dict[str, Any] | None = None,
+    expected_attempt_count: int | None = None,
 ) -> bool:
     from ..models.database import get_session_local
 
     SessionLocal = get_session_local()
     now = _utc_now()
     with SessionLocal() as db:
-        updated = (
-            db.query(TaskExecutionCommand)
-            .filter(
-                TaskExecutionCommand.id == command_db_id,
-                TaskExecutionCommand.status == COMMAND_PROCESSING,
-                TaskExecutionCommand.claimed_by == runner_id,
+        query = db.query(TaskExecutionCommand).filter(
+            TaskExecutionCommand.id == command_db_id,
+            TaskExecutionCommand.status == COMMAND_PROCESSING,
+            TaskExecutionCommand.claimed_by == runner_id,
+        )
+        if expected_attempt_count is not None:
+            query = query.filter(
+                TaskExecutionCommand.attempt_count == expected_attempt_count
             )
-            .update(
-                {
-                    TaskExecutionCommand.status: COMMAND_COMPLETED,
-                    TaskExecutionCommand.result: result,
-                    TaskExecutionCommand.error: None,
-                    TaskExecutionCommand.claimed_by: None,
-                    TaskExecutionCommand.claim_expires_at: None,
-                    TaskExecutionCommand.completed_at: now,
-                    TaskExecutionCommand.updated_at: now,
-                },
-                synchronize_session=False,
-            )
+        updated = query.update(
+            {
+                TaskExecutionCommand.status: COMMAND_COMPLETED,
+                TaskExecutionCommand.result: result,
+                TaskExecutionCommand.error: None,
+                TaskExecutionCommand.claimed_by: None,
+                TaskExecutionCommand.claim_expires_at: None,
+                TaskExecutionCommand.completed_at: now,
+                TaskExecutionCommand.updated_at: now,
+            },
+            synchronize_session=False,
         )
         db.commit()
         return updated == 1
@@ -407,6 +436,7 @@ def fail_task_command(
     error: str,
     *,
     force_terminal: bool = False,
+    expected_attempt_count: int | None = None,
 ) -> bool:
     """Retry a failed claim, or make it terminal after bounded attempts."""
 
@@ -415,31 +445,56 @@ def fail_task_command(
     SessionLocal = get_session_local()
     now = _utc_now()
     with SessionLocal() as db:
-        command = (
+        snapshot_query = db.query(
+            TaskExecutionCommand.failure_count,
+            TaskExecutionCommand.attempt_count,
+        ).filter(
+            TaskExecutionCommand.id == command_db_id,
+            TaskExecutionCommand.status == COMMAND_PROCESSING,
+            TaskExecutionCommand.claimed_by == runner_id,
+        )
+        if expected_attempt_count is not None:
+            snapshot_query = snapshot_query.filter(
+                TaskExecutionCommand.attempt_count == expected_attempt_count
+            )
+        snapshot = snapshot_query.first()
+        if snapshot is None:
+            return False
+        observed_failure_count = int(snapshot.failure_count or 0)
+        observed_attempt_count = int(snapshot.attempt_count or 0)
+        failure_count = observed_failure_count + 1
+        terminal = force_terminal or failure_count >= MAX_COMMAND_FAILURES
+        updated = (
             db.query(TaskExecutionCommand)
             .filter(
                 TaskExecutionCommand.id == command_db_id,
                 TaskExecutionCommand.status == COMMAND_PROCESSING,
                 TaskExecutionCommand.claimed_by == runner_id,
+                TaskExecutionCommand.failure_count == observed_failure_count,
+                TaskExecutionCommand.attempt_count == observed_attempt_count,
             )
-            .first()
+            .update(
+                {
+                    TaskExecutionCommand.status: (
+                        COMMAND_FAILED if terminal else COMMAND_PENDING
+                    ),
+                    TaskExecutionCommand.failure_count: failure_count,
+                    TaskExecutionCommand.error: error[:4000],
+                    TaskExecutionCommand.claimed_by: None,
+                    TaskExecutionCommand.claim_expires_at: (
+                        None
+                        if terminal
+                        else now + timedelta(seconds=min(2**failure_count, 30))
+                    ),
+                    TaskExecutionCommand.updated_at: now,
+                    TaskExecutionCommand.completed_at: now if terminal else None,
+                },
+                synchronize_session=False,
+            )
         )
-        if command is None:
-            return False
-        failure_count = int(command.failure_count or 0) + 1
-        terminal = force_terminal or failure_count >= MAX_COMMAND_FAILURES
-        setattr(command, "status", COMMAND_FAILED if terminal else COMMAND_PENDING)
-        setattr(command, "failure_count", failure_count)
-        setattr(command, "error", error[:4000])
-        setattr(command, "claimed_by", None)
-        setattr(
-            command,
-            "claim_expires_at",
-            None if terminal else now + timedelta(seconds=min(2**failure_count, 30)),
-        )
-        setattr(command, "updated_at", now)
-        setattr(command, "completed_at", now if terminal else None)
         db.commit()
+        if updated != 1:
+            return False
     if not terminal:
         notify_task_command_dispatcher()
     return True
@@ -449,6 +504,8 @@ def defer_task_command(
     command_db_id: int,
     runner_id: str,
     reason: str,
+    *,
+    expected_attempt_count: int | None = None,
 ) -> bool:
     """Release a claim for retry without consuming the failure budget."""
 
@@ -457,40 +514,103 @@ def defer_task_command(
     SessionLocal = get_session_local()
     now = _utc_now()
     with SessionLocal() as db:
-        command = (
+        snapshot_query = db.query(
+            TaskExecutionCommand.defer_count,
+            TaskExecutionCommand.attempt_count,
+        ).filter(
+            TaskExecutionCommand.id == command_db_id,
+            TaskExecutionCommand.status == COMMAND_PROCESSING,
+            TaskExecutionCommand.claimed_by == runner_id,
+        )
+        if expected_attempt_count is not None:
+            snapshot_query = snapshot_query.filter(
+                TaskExecutionCommand.attempt_count == expected_attempt_count
+            )
+        snapshot = snapshot_query.first()
+        if snapshot is None:
+            return False
+        observed_defer_count = int(snapshot.defer_count or 0)
+        observed_attempt_count = int(snapshot.attempt_count or 0)
+        defer_count = observed_defer_count + 1
+        terminal = defer_count >= MAX_COMMAND_DEFERS
+        updated = (
             db.query(TaskExecutionCommand)
             .filter(
                 TaskExecutionCommand.id == command_db_id,
                 TaskExecutionCommand.status == COMMAND_PROCESSING,
                 TaskExecutionCommand.claimed_by == runner_id,
+                TaskExecutionCommand.defer_count == observed_defer_count,
+                TaskExecutionCommand.attempt_count == observed_attempt_count,
             )
-            .first()
+            .update(
+                {
+                    TaskExecutionCommand.status: (
+                        COMMAND_FAILED if terminal else COMMAND_PENDING
+                    ),
+                    TaskExecutionCommand.defer_count: defer_count,
+                    TaskExecutionCommand.error: (
+                        (
+                            f"Deferred command exceeded retry budget: {reason}"
+                            if terminal
+                            else reason
+                        )[:4000]
+                    ),
+                    TaskExecutionCommand.claimed_by: None,
+                    TaskExecutionCommand.claim_expires_at: (
+                        None if terminal else now + timedelta(seconds=1)
+                    ),
+                    TaskExecutionCommand.updated_at: now,
+                    TaskExecutionCommand.completed_at: now if terminal else None,
+                },
+                synchronize_session=False,
+            )
         )
-        if command is None:
-            return False
-        terminal = int(command.attempt_count or 0) >= MAX_COMMAND_DEFERS
-        setattr(command, "status", COMMAND_FAILED if terminal else COMMAND_PENDING)
-        setattr(
-            command,
-            "error",
-            (
-                f"Deferred command exceeded retry budget: {reason}"
-                if terminal
-                else reason
-            )[:4000],
-        )
-        setattr(command, "claimed_by", None)
-        setattr(
-            command,
-            "claim_expires_at",
-            None if terminal else now + timedelta(seconds=1),
-        )
-        setattr(command, "updated_at", now)
-        setattr(command, "completed_at", now if terminal else None)
         db.commit()
+        if updated != 1:
+            return False
     if not terminal:
         notify_task_command_dispatcher()
     return True
+
+
+def retry_failed_task_command(
+    db: Session,
+    command_db_id: int,
+    *,
+    target_run_id: str | None,
+    target_runner_id: str | None,
+) -> bool:
+    """Atomically reset a terminal command for an explicit client retry."""
+
+    now = _utc_now()
+    updated = (
+        db.query(TaskExecutionCommand)
+        .filter(
+            TaskExecutionCommand.id == command_db_id,
+            TaskExecutionCommand.status == COMMAND_FAILED,
+        )
+        .update(
+            {
+                TaskExecutionCommand.status: COMMAND_PENDING,
+                TaskExecutionCommand.failure_count: 0,
+                TaskExecutionCommand.defer_count: 0,
+                TaskExecutionCommand.error: None,
+                TaskExecutionCommand.result: None,
+                TaskExecutionCommand.claimed_by: None,
+                TaskExecutionCommand.claim_expires_at: None,
+                TaskExecutionCommand.target_run_id: target_run_id,
+                TaskExecutionCommand.target_runner_id: target_runner_id,
+                TaskExecutionCommand.completed_at: None,
+                TaskExecutionCommand.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+    if updated == 1:
+        notify_task_command_dispatcher()
+        return True
+    return False
 
 
 def task_has_live_foreign_runner(
@@ -554,7 +674,7 @@ async def dispatch_one_task_command(
 
     stop_event = asyncio.Event()
     heartbeat = asyncio.get_running_loop().create_task(
-        _claim_heartbeat(command.id, runner_id, stop_event)
+        _claim_heartbeat(command.id, runner_id, command.attempt_count, stop_event)
     )
     try:
         result = await executor(command)
@@ -568,6 +688,7 @@ async def dispatch_one_task_command(
             command.id,
             runner_id,
             str(exc),
+            expected_attempt_count=command.attempt_count,
         )
     except TaskCommandRejected as exc:
         await asyncio.to_thread(
@@ -576,6 +697,7 @@ async def dispatch_one_task_command(
             runner_id,
             str(exc),
             force_terminal=True,
+            expected_attempt_count=command.attempt_count,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception(
@@ -584,13 +706,20 @@ async def dispatch_one_task_command(
             command.kind.value,
             command.attempt_count,
         )
-        await asyncio.to_thread(fail_task_command, command.id, runner_id, str(exc))
+        await asyncio.to_thread(
+            fail_task_command,
+            command.id,
+            runner_id,
+            str(exc),
+            expected_attempt_count=command.attempt_count,
+        )
     else:
         if not await asyncio.to_thread(
             finish_task_command,
             command.id,
             runner_id,
             result=result,
+            expected_attempt_count=command.attempt_count,
         ):
             logger.warning("Lost claim while completing task command %s", command.id)
     finally:

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -349,9 +349,19 @@ async def _claim_heartbeat(
             return
         except asyncio.TimeoutError:
             pass
-        if not await asyncio.to_thread(
-            renew_task_command_claim, command_db_id, runner_id
-        ):
+        try:
+            renewed = await asyncio.to_thread(
+                renew_task_command_claim, command_db_id, runner_id
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to renew task command claim %s: %s",
+                command_db_id,
+                exc,
+                exc_info=True,
+            )
+            continue
+        if not renewed:
             return
 
 
@@ -578,10 +588,13 @@ async def run_task_command_dispatcher(executor: CommandExecutor) -> None:
     _dispatcher_loop = asyncio.get_running_loop()
     _dispatcher_wakeup = asyncio.Event()
     while True:
+        # Clear before checking for work. A notify that arrives during the DB
+        # claim remains set, so an empty claim cannot erase that wakeup and
+        # sleep while work is waiting.
+        _dispatcher_wakeup.clear()
         processed = await dispatch_one_task_command(executor)
         if processed:
             continue
-        _dispatcher_wakeup.clear()
         try:
             await asyncio.wait_for(
                 _dispatcher_wakeup.wait(), timeout=DISPATCHER_IDLE_SECONDS
@@ -618,8 +631,13 @@ def load_task_command(command_db_id: int) -> TaskExecutionCommand | None:
 
     SessionLocal = get_session_local()
     with SessionLocal() as db:
-        return (
+        command = (
             db.query(TaskExecutionCommand)
             .filter(TaskExecutionCommand.id == command_db_id)
             .first()
         )
+        if command is not None:
+            # Make the session boundary explicit. Callers only read scalar
+            # command state and must never depend on a live/lazy session.
+            db.expunge(command)
+        return command

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -37,7 +37,8 @@ COMMAND_FAILED = "failed"
 COMMAND_TERMINAL = (COMMAND_COMPLETED, COMMAND_FAILED)
 
 COMMAND_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,64}")
-MAX_COMMAND_ATTEMPTS = 5
+MAX_COMMAND_FAILURES = 5
+MAX_COMMAND_DEFERS = 60
 DISPATCHER_IDLE_SECONDS = 0.5
 
 
@@ -230,8 +231,8 @@ def _claimable_query(
             or_(
                 TaskExecutionCommand.target_runner_id.is_(None),
                 TaskExecutionCommand.target_runner_id == runner_id,
+                Task.runner_id == runner_id,
                 Task.runner_id.is_(None),
-                Task.runner_id != TaskExecutionCommand.target_runner_id,
                 Task.lease_expires_at.is_(None),
                 Task.lease_expires_at < now,
             ),
@@ -425,18 +426,16 @@ def fail_task_command(
         )
         if command is None:
             return False
-        terminal = force_terminal or (
-            int(command.attempt_count or 0) >= MAX_COMMAND_ATTEMPTS
-        )
+        failure_count = int(command.failure_count or 0) + 1
+        terminal = force_terminal or failure_count >= MAX_COMMAND_FAILURES
         setattr(command, "status", COMMAND_FAILED if terminal else COMMAND_PENDING)
+        setattr(command, "failure_count", failure_count)
         setattr(command, "error", error[:4000])
         setattr(command, "claimed_by", None)
         setattr(
             command,
             "claim_expires_at",
-            None
-            if terminal
-            else now + timedelta(seconds=min(2 ** int(command.attempt_count or 1), 30)),
+            None if terminal else now + timedelta(seconds=min(2**failure_count, 30)),
         )
         setattr(command, "updated_at", now)
         setattr(command, "completed_at", now if terminal else None)
@@ -469,20 +468,63 @@ def defer_task_command(
         )
         if command is None:
             return False
-        setattr(command, "status", COMMAND_PENDING)
-        setattr(command, "error", reason[:4000])
+        terminal = int(command.attempt_count or 0) >= MAX_COMMAND_DEFERS
+        setattr(command, "status", COMMAND_FAILED if terminal else COMMAND_PENDING)
+        setattr(
+            command,
+            "error",
+            (
+                f"Deferred command exceeded retry budget: {reason}"
+                if terminal
+                else reason
+            )[:4000],
+        )
         setattr(command, "claimed_by", None)
-        setattr(command, "claim_expires_at", now + timedelta(seconds=1))
+        setattr(
+            command,
+            "claim_expires_at",
+            None if terminal else now + timedelta(seconds=1),
+        )
         setattr(command, "updated_at", now)
+        setattr(command, "completed_at", now if terminal else None)
         db.commit()
-    notify_task_command_dispatcher()
+    if not terminal:
+        notify_task_command_dispatcher()
     return True
+
+
+def task_has_live_foreign_runner(
+    task_id: int,
+    *,
+    runner_id: str | None = None,
+) -> bool:
+    """Return whether another process currently owns the task lease."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    resolved_runner_id = runner_id or get_runner_id()
+    now = _utc_now()
+    with SessionLocal() as db:
+        return (
+            db.query(Task.id)
+            .filter(
+                Task.id == task_id,
+                Task.runner_id.is_not(None),
+                Task.runner_id != resolved_runner_id,
+                Task.lease_expires_at.is_not(None),
+                Task.lease_expires_at >= now,
+            )
+            .first()
+            is not None
+        )
 
 
 CommandExecutor = Callable[[ClaimedTaskCommand], Awaitable[dict[str, Any] | None]]
 _dispatcher_wakeup: asyncio.Event | None = None
 _dispatcher_task: asyncio.Task[Any] | None = None
 _dispatcher_loop: asyncio.AbstractEventLoop | None = None
+_prompt_dispatch_tasks: set[asyncio.Task[bool]] = set()
 
 
 def notify_task_command_dispatcher() -> None:
@@ -565,7 +607,6 @@ async def dispatch_task_command_promptly(
     executor: CommandExecutor,
     *,
     command_db_id: int,
-    handoff_seconds: float = 0.05,
 ) -> None:
     """Kick local consumption without tying WS receive to command execution.
 
@@ -578,9 +619,27 @@ async def dispatch_task_command_promptly(
         dispatch_one_task_command(executor, command_db_id=command_db_id)
     )
     try:
-        await asyncio.wait_for(asyncio.shield(task), timeout=handoff_seconds)
+        await asyncio.wait_for(asyncio.shield(task), timeout=0.05)
     except asyncio.TimeoutError:
+        _prompt_dispatch_tasks.add(task)
+        task.add_done_callback(_consume_prompt_dispatch_result)
         return
+
+
+def _consume_prompt_dispatch_result(task: asyncio.Task[bool]) -> None:
+    """Retain and observe timed-out prompt dispatches until they finish."""
+
+    _prompt_dispatch_tasks.discard(task)
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "Detached prompt task command dispatch failed: %s",
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 async def run_task_command_dispatcher(executor: CommandExecutor) -> None:
@@ -613,17 +672,23 @@ def start_task_command_dispatcher(executor: CommandExecutor) -> asyncio.Task[Any
 
 async def stop_task_command_dispatcher() -> None:
     global _dispatcher_loop, _dispatcher_task, _dispatcher_wakeup
+    prompt_tasks = list(_prompt_dispatch_tasks)
+    for prompt_task in prompt_tasks:
+        prompt_task.cancel()
+    if prompt_tasks:
+        await asyncio.gather(*prompt_tasks, return_exceptions=True)
+    _prompt_dispatch_tasks.clear()
+
     task = _dispatcher_task
     _dispatcher_task = None
     _dispatcher_wakeup = None
     _dispatcher_loop = None
-    if task is None or task.done():
-        return
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 def load_task_command(command_db_id: int) -> TaskExecutionCommand | None:

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -1,10 +1,9 @@
-"""Serialized task control commands and versioned execution state.
+"""Process-local task gate and versioned execution state.
 
-P1 keeps command serialization process-local. Cross-worker command transport is
-deliberately a later concern; the database state tuple written here is the
-authoritative ordering contract shared by every transport and by the frontend.
-Channel transports share this gate and state tuple but do not yet use the turn
-orchestrator or runner-lease lifecycle.
+The durable P2 inbox lives in :mod:`task_command_transport`; after one worker
+claims a command, this controller remains the local reentrant guard around the
+state transition. The database state tuple written here is the ordering
+contract shared by every transport and by the frontend.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/task_execution_controller.py
+++ b/src/xagent/web/services/task_execution_controller.py
@@ -93,6 +93,7 @@ def apply_task_control_transition(
     status: TaskStatus | None = None,
     new_run: bool = False,
     expected_run_id: str | None = None,
+    expected_state_version: int | None = None,
 ) -> TaskControlSnapshot:
     """Mutate one ORM task with a monotonic control-state transition.
 
@@ -101,9 +102,18 @@ def apply_task_control_transition(
     """
 
     current_run_id = getattr(task, "run_id", None)
+    current_state_version = int(getattr(task, "state_version", 0) or 0)
     if expected_run_id is not None and current_run_id != expected_run_id:
         raise StaleTaskRunError(
             f"task {task.id} run changed from {expected_run_id} to {current_run_id}"
+        )
+    if (
+        expected_state_version is not None
+        and current_state_version != expected_state_version
+    ):
+        raise StaleTaskRunError(
+            f"task {task.id} state changed from version "
+            f"{expected_state_version} to {current_state_version}"
         )
 
     if new_run:
@@ -133,6 +143,10 @@ def apply_task_control_transition(
         statement = update(Task).where(Task.id == int(task_id))
         if expected_run_id is not None:
             statement = statement.where(Task.run_id == expected_run_id)
+        if expected_state_version is not None:
+            statement = statement.where(
+                func.coalesce(Task.state_version, 0) == expected_state_version
+            )
         # Keep unrelated caller-owned pending objects out of this helper's
         # atomic UPDATE and refresh. ``Session.execute`` and ``refresh`` can
         # otherwise trigger another session-wide autoflush.
@@ -166,6 +180,7 @@ def transition_task_control_state_sync(
     status: TaskStatus | None = None,
     new_run: bool = False,
     expected_run_id: str | None = None,
+    expected_state_version: int | None = None,
 ) -> TaskControlSnapshot:
     from ..models.database import get_session_local
 
@@ -180,6 +195,7 @@ def transition_task_control_state_sync(
             status=status,
             new_run=new_run,
             expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
         )
         db.commit()
         return snapshot

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -81,8 +81,15 @@ def acquire_task_lease(
     *,
     runner_id: str | None = None,
     expected_run_id: str | None = None,
+    new_run: bool = False,
 ) -> TaskLease | None:
-    """Acquire the task execution lease if no live runner owns it."""
+    """Acquire the task execution lease if no live runner owns it.
+
+    ``new_run=True`` atomically requires a non-running task and assigns a new
+    run id in the same UPDATE. This is the durable claim used by channel
+    transports so another worker cannot rotate the run between a status check
+    and lease acquisition.
+    """
     runner = runner_id or get_runner_id()
     now = utc_now()
     expires_at = _expires_at(now)
@@ -106,9 +113,13 @@ def acquire_task_lease(
             runner_id=runner,
             last_heartbeat_at=now,
             lease_expires_at=expires_at,
-            run_id=case(
-                (Task.status != TaskStatus.RUNNING, candidate_run_id),
-                else_=func.coalesce(Task.run_id, candidate_run_id),
+            run_id=(
+                candidate_run_id
+                if new_run
+                else case(
+                    (Task.status != TaskStatus.RUNNING, candidate_run_id),
+                    else_=func.coalesce(Task.run_id, candidate_run_id),
+                )
             ),
             control_state=running_control_state,
             state_version=case(
@@ -123,6 +134,8 @@ def acquire_task_lease(
             ),
         )
     )
+    if new_run:
+        stmt = stmt.where(Task.status != TaskStatus.RUNNING)
     if expected_run_id is not None:
         stmt = stmt.where(Task.run_id == expected_run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
@@ -149,6 +162,7 @@ def acquire_task_lease_isolated(
     *,
     runner_id: str | None = None,
     expected_run_id: str | None = None,
+    new_run: bool = False,
 ) -> TaskLease | None:
     """Same semantics as :func:`acquire_task_lease` but opens, commits,
     and closes its own ``SessionLocal``.
@@ -169,6 +183,7 @@ def acquire_task_lease_isolated(
             task_id,
             runner_id=runner_id,
             expected_run_id=expected_run_id,
+            new_run=new_run,
         )
     finally:
         db.close()

--- a/tests/alembic/test_20260711_add_task_execution_commands.py
+++ b/tests/alembic/test_20260711_add_task_execution_commands.py
@@ -44,6 +44,7 @@ def test_upgrade_adds_durable_task_command_inbox() -> None:
             "claim_expires_at",
             "attempt_count",
             "failure_count",
+            "defer_count",
             "result",
             "error",
             "completed_at",

--- a/tests/alembic/test_20260711_add_task_execution_commands.py
+++ b/tests/alembic/test_20260711_add_task_execution_commands.py
@@ -1,0 +1,54 @@
+from alembic import command
+from sqlalchemy import create_engine, inspect, text
+
+from xagent.db.config import create_alembic_config
+
+REVISION = "20260711_task_commands"
+DOWN_REVISION = "20260711_add_trace_events_task_idx"
+
+
+def test_upgrade_adds_durable_task_command_inbox() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+            {"revision": DOWN_REVISION},
+        )
+        connection.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY)"))
+        connection.execute(text("CREATE TABLE tasks (id INTEGER PRIMARY KEY)"))
+        config.attributes["connection"] = connection
+
+        command.upgrade(config, REVISION)
+
+        columns = {
+            column["name"]
+            for column in inspect(connection).get_columns("task_execution_commands")
+        }
+        indexes = {
+            index["name"]
+            for index in inspect(connection).get_indexes("task_execution_commands")
+        }
+        assert {
+            "command_id",
+            "kind",
+            "payload",
+            "target_run_id",
+            "target_runner_id",
+            "status",
+            "claimed_by",
+            "claim_expires_at",
+            "attempt_count",
+            "result",
+            "error",
+            "completed_at",
+        } <= columns
+        assert "ix_task_commands_status_created" in indexes
+        assert "ix_task_commands_task_order" in indexes
+
+        command.downgrade(config, DOWN_REVISION)
+        assert "task_execution_commands" not in inspect(connection).get_table_names()

--- a/tests/alembic/test_20260711_add_task_execution_commands.py
+++ b/tests/alembic/test_20260711_add_task_execution_commands.py
@@ -43,12 +43,14 @@ def test_upgrade_adds_durable_task_command_inbox() -> None:
             "claimed_by",
             "claim_expires_at",
             "attempt_count",
+            "failure_count",
             "result",
             "error",
             "completed_at",
         } <= columns
         assert "ix_task_commands_status_created" in indexes
         assert "ix_task_commands_task_order" in indexes
+        assert "ix_task_execution_commands_task_id" not in indexes
 
         command.downgrade(config, DOWN_REVISION)
         assert "task_execution_commands" not in inspect(connection).get_table_names()

--- a/tests/alembic/test_20260711_add_task_execution_commands.py
+++ b/tests/alembic/test_20260711_add_task_execution_commands.py
@@ -52,3 +52,22 @@ def test_upgrade_adds_durable_task_command_inbox() -> None:
 
         command.downgrade(config, DOWN_REVISION)
         assert "task_execution_commands" not in inspect(connection).get_table_names()
+
+
+def test_upgrade_skips_when_sqlalchemy_base_tables_do_not_exist() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+            {"revision": DOWN_REVISION},
+        )
+        config.attributes["connection"] = connection
+
+        command.upgrade(config, REVISION)
+
+        assert "task_execution_commands" not in inspect(connection).get_table_names()

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -72,6 +72,16 @@ def _patch_channel_modules_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "xagent.web.channels.feishu.bot", fake_feishu_bot)
 
 
+def _patch_task_command_dispatcher_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep LanceDB startup tests isolated from the durable DB dispatcher."""
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.start_task_command_dispatcher",
+        lambda _executor: None,
+    )
+
+
 @pytest.fixture
 def temp_lancedb_dir():
     """Create a temporary directory for LanceDB."""
@@ -698,6 +708,7 @@ async def test_startup_event_skips_when_auto_migrate_disabled(
     import importlib
 
     _patch_channel_modules_disabled(monkeypatch)
+    _patch_task_command_dispatcher_disabled(monkeypatch)
     web_app_module = importlib.import_module("xagent.web.app")
 
     class _FakeManager:
@@ -806,6 +817,7 @@ async def test_startup_event_triggers_background_auto_migration(
     import importlib
 
     _patch_channel_modules_disabled(monkeypatch)
+    _patch_task_command_dispatcher_disabled(monkeypatch)
     web_app_module = importlib.import_module("xagent.web.app")
 
     class _FakeManager:
@@ -915,6 +927,7 @@ async def test_startup_event_no_task_when_no_table_needs_migration(
     import importlib
 
     _patch_channel_modules_disabled(monkeypatch)
+    _patch_task_command_dispatcher_disabled(monkeypatch)
     web_app_module = importlib.import_module("xagent.web.app")
 
     class _FakeManager:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -963,6 +963,55 @@ def test_cancel_retries_a_previous_terminal_transport_failure() -> None:
         db.close()
 
 
+def test_cancel_maps_stale_run_rejection_to_conflict() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        created = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-stale-cancel",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "rotate before cancel"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+    assert created.status_code == 200, created.text
+    task_id = int(created.json()["task"]["id"])
+    real_dispatch = a2a_api.dispatch_one_task_command
+
+    async def rotate_then_dispatch(executor, *, command_db_id=None):
+        db = _direct_db_session()
+        try:
+            task = db.query(Task).filter(Task.id == task_id).one()
+            task.run_id = "rotated-before-cancel"
+            task.runner_id = None
+            task.lease_expires_at = None
+            db.commit()
+        finally:
+            db.close()
+        return await real_dispatch(executor, command_db_id=command_db_id)
+
+    with patch.object(
+        a2a_api,
+        "dispatch_one_task_command",
+        new=rotate_then_dispatch,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/tasks/{task_id}:cancel",
+            headers=_bearer(full_key),
+        )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["error"]["details"][0]["reason"] == "INVALID_REQUEST"
+    assert "run changed" in response.json()["error"]["message"].lower()
+
+
 @pytest.mark.asyncio
 async def test_cancel_does_not_overwrite_a_concurrent_completion() -> None:
     agent_id, _full_key = _create_published_agent_with_key()

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -9,7 +9,13 @@ from xagent.web.api import a2a as a2a_api
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.services.a2a_protocol import A2A_MAX_MESSAGE_TEXT_LENGTH
+from xagent.web.services.task_command_transport import (
+    COMMAND_FAILED,
+    MAX_COMMAND_DEFERS,
+    MAX_COMMAND_FAILURES,
+)
 from xagent.web.services.task_orchestrator import TaskTurnError
 
 from .conftest import _admin_headers, _direct_db_session, client
@@ -888,6 +894,124 @@ def test_cancel_is_idempotent_and_subscribe_rejects_terminal_task() -> None:
     assert second.json()["status"]["state"] == "TASK_STATE_CANCELED"
     assert subscribed.status_code == 400
     assert subscribed.json()["error"]["details"][0]["reason"] == "UNSUPPORTED_OPERATION"
+
+
+def test_cancel_retries_a_previous_terminal_transport_failure() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        created = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-retry-cancel",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "cancel me after a retry"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+    assert created.status_code == 200, created.text
+    task_id = int(created.json()["task"]["id"])
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        task = db.query(Task).filter(Task.id == task_id).one()
+        db.add(
+            TaskExecutionCommand(
+                task_id=task_id,
+                actor_user_id=int(agent.user_id),
+                command_id=f"cancel:{task_id}:{task.run_id or task.state_version}",
+                kind="cancel",
+                payload={"agent_id": agent_id},
+                target_run_id=str(task.run_id) if task.run_id is not None else None,
+                target_runner_id=None,
+                status=COMMAND_FAILED,
+                attempt_count=1,
+                failure_count=MAX_COMMAND_FAILURES,
+                defer_count=MAX_COMMAND_DEFERS,
+                error="temporary transport failure",
+                completed_at=datetime.now(UTC),
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:cancel",
+        headers=_bearer(full_key),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"]["state"] == "TASK_STATE_CANCELED"
+    db = _direct_db_session()
+    try:
+        command = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .one()
+        )
+        assert command.status == "completed"
+        assert command.failure_count == 0
+        assert command.defer_count == 0
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel_does_not_overwrite_a_concurrent_completion() -> None:
+    agent_id, _full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        task = Task(
+            user_id=int(agent.user_id),
+            title="cancel completion race",
+            status=TaskStatus.RUNNING,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-cancel-race"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+
+        async def complete_during_cancel(_task_id: int) -> None:
+            concurrent_db = _direct_db_session()
+            try:
+                concurrent_task = (
+                    concurrent_db.query(Task).filter(Task.id == task_id).one()
+                )
+                concurrent_task.status = TaskStatus.COMPLETED
+                concurrent_task.output = "completed concurrently"
+                concurrent_db.commit()
+            finally:
+                concurrent_db.close()
+
+        with patch(
+            "xagent.web.api.websocket.background_task_manager.cancel_task",
+            new=AsyncMock(side_effect=complete_during_cancel),
+        ):
+            await a2a_api._cancel_task_unserialized(
+                task_id=task_id,
+                agent=agent,
+                db=db,
+            )
+
+        db.expire_all()
+        completed = db.query(Task).filter(Task.id == task_id).one()
+        assert completed.status == TaskStatus.COMPLETED
+        assert completed.output == "completed concurrently"
+        assert completed.error_message is None
+    finally:
+        db.close()
 
 
 def test_subscribe_stream_starts_with_wrapped_task_snapshot() -> None:

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -226,6 +226,12 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
                 "files": [],
             },
         )
+        for _ in range(100):
+            if bg_mgr.register_reserved_resume.call_count:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("durable live message was not dispatched in time")
 
     stored = (
         db_session.query(TaskChatMessage)

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -25,6 +25,7 @@ from xagent.web.api.websocket import (
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.user import User
 from xagent.web.services.chat_history_service import (
     DELIVERY_DISPATCHED,
@@ -203,7 +204,7 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
 
 
 @pytest.mark.asyncio
-async def test_deferred_chat_message_waits_for_real_injection_before_ack(
+async def test_deferred_chat_message_is_acked_after_durable_command_commit(
     db_session,
 ) -> None:
     owner = _user(db_session, "owner")
@@ -240,14 +241,27 @@ async def test_deferred_chat_message_waits_for_real_injection_before_ack(
             },
         )
 
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0]["client_message_id"] == "deferred-turn-1"
+    stored_command = (
+        db_session.query(TaskExecutionCommand)
+        .filter_by(task_id=int(task.id), command_id="deferred-turn-1")
+        .one()
+    )
+    assert stored_command.status == "pending"
     assert not any(
-        call.args[0].get("type") == "message_accepted"
+        call.args[0].get("type") == "message_rejected"
         for call in ws_manager.send_personal_message.call_args_list
     )
     kwargs = resume_bg.call_args.kwargs
     assert kwargs["delivery_already_dispatched"] is False
-    assert kwargs["delivery_websocket"] is websocket
-    assert kwargs["delivery_client_message_id"] == "deferred-turn-1"
+    assert kwargs["delivery_websocket"] is None
+    assert kwargs["delivery_client_message_id"] is None
 
 
 @pytest.mark.asyncio
@@ -610,6 +624,12 @@ async def test_resume_registration_failure_cancels_coordinator(db_session) -> No
         patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
     ):
         await handle_resume_task(MagicMock(), int(task.id), {"user": owner})
+        for _ in range(100):
+            if bg_handle.cancel.called:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("resume command did not finish in time")
 
     bg_handle.cancel.assert_called_once()
 

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xagent.web.api.websocket import (
+    _handle_pause_task_unserialized,
+    _handle_resume_task_unserialized,
     background_task_manager,
     execute_resume_background,
     handle_chat_message,
@@ -32,6 +34,7 @@ from xagent.web.services.chat_history_service import (
     DELIVERY_FAILED,
     DELIVERY_PENDING,
 )
+from xagent.web.services.task_execution_controller import StaleTaskRunError
 
 
 @pytest.fixture()
@@ -145,6 +148,48 @@ async def test_chat_admin_append_to_other_users_task_claims_as_owner(
     assert len(accepted) == 1
     assert accepted[0]["client_message_id"] == "client-turn-1"
     assert accepted[0]["turn_id"] == "client-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_chat_without_client_id_uses_durable_command_id_as_turn_id(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    begin_turn = AsyncMock()
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {"message": "server generated identity", "user": owner, "files": []},
+        )
+        for _ in range(100):
+            if begin_turn.await_count:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("durable message was not dispatched in time")
+
+    db_session.expire_all()
+    command = (
+        db_session.query(TaskExecutionCommand)
+        .filter(TaskExecutionCommand.task_id == int(task.id))
+        .one()
+    )
+    assert command.command_id.startswith("message:")
+    assert command.payload["client_message_id"] == command.command_id
+    assert begin_turn.await_args.kwargs["payload"].turn_id == command.command_id
 
 
 @pytest.mark.asyncio
@@ -508,6 +553,54 @@ async def test_pause_admin_on_other_users_task_runs_as_owner(db_session) -> None
     # Built and paused as the OWNER, not the admin actor.
     assert captured["task_owner_user_id"] == int(owner.id)
     agent.pause_execution.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_durable_pause_propagates_stale_run_error(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id)
+    _captured, _agent, mgr, ws_manager = _patched_manager_and_agent()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.api.websocket.apply_task_control_transition",
+            side_effect=StaleTaskRunError("run rotated"),
+        ),
+        pytest.raises(StaleTaskRunError, match="run rotated"),
+    ):
+        await _handle_pause_task_unserialized(
+            MagicMock(),
+            int(task.id),
+            {"user": owner, "_durable_ack_sent": True},
+        )
+
+
+@pytest.mark.asyncio
+async def test_durable_resume_propagates_stale_run_error(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    _captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+    agent.supports_live_control.return_value = True
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch(
+            "xagent.web.api.websocket.task_execution_controller.transition",
+            new=AsyncMock(side_effect=StaleTaskRunError("run rotated")),
+        ),
+        pytest.raises(StaleTaskRunError, match="run rotated"),
+    ):
+        await _handle_resume_task_unserialized(
+            MagicMock(),
+            int(task.id),
+            {"user": owner, "_durable_ack_sent": True},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -607,6 +607,7 @@ async def test_durable_resume_propagates_stale_run_error(db_session) -> None:
             int(task.id),
             {"user": owner, "_durable_ack_sent": True},
         )
+    bg_mgr.release_resume_reservation.assert_called_once_with(int(task.id))
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -312,6 +312,12 @@ async def test_resume_registration_failure_preserves_dispatched_delivery(
                 "files": [],
             },
         )
+        for _ in range(100):
+            if bg_handle.cancel.called:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("resume registration failure was not handled in time")
 
     bg_handle.cancel.assert_called_once()
     db_session.expire_all()

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -136,6 +136,12 @@ async def test_chat_admin_append_to_other_users_task_claims_as_owner(
                 "files": [],
             },
         )
+        for _ in range(100):
+            if begin_turn.await_count:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("durable admin message was not dispatched in time")
 
     begin_turn.assert_awaited_once()
     assert begin_turn.await_args.kwargs["task_owner_user_id"] == int(owner.id)

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -240,6 +240,18 @@ async def test_deferred_chat_message_is_acked_after_durable_command_commit(
                 "files": [],
             },
         )
+        for _ in range(100):
+            db_session.expire_all()
+            stored_command = (
+                db_session.query(TaskExecutionCommand)
+                .filter_by(task_id=int(task.id), command_id="deferred-turn-1")
+                .one()
+            )
+            if stored_command.status == "pending":
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("deferred command claim was not released in time")
 
     accepted = [
         call.args[0]
@@ -248,11 +260,6 @@ async def test_deferred_chat_message_is_acked_after_durable_command_commit(
     ]
     assert len(accepted) == 1
     assert accepted[0]["client_message_id"] == "deferred-turn-1"
-    stored_command = (
-        db_session.query(TaskExecutionCommand)
-        .filter_by(task_id=int(task.id), command_id="deferred-turn-1")
-        .one()
-    )
     assert stored_command.status == "pending"
     assert not any(
         call.args[0].get("type") == "message_rejected"

--- a/tests/web/services/test_acquire_task_lease_isolated.py
+++ b/tests/web/services/test_acquire_task_lease_isolated.py
@@ -21,6 +21,8 @@ What this test pins:
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,6 +105,31 @@ def test_isolated_acquire_returns_none_when_lease_taken(db_session) -> None:
 
     lease = acquire_task_lease_isolated(int(task.id))
     assert lease is None
+
+
+def test_new_run_claim_is_atomic_across_sessions(db_session) -> None:
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id))
+    task_id = int(task.id)
+    barrier = Barrier(2)
+
+    def claim(runner_id: str) -> TaskLease | None:
+        barrier.wait()
+        return acquire_task_lease_isolated(
+            task_id,
+            runner_id=runner_id,
+            new_run=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(claim, ["runner-a", "runner-b"]))
+
+    winners = [lease for lease in results if lease is not None]
+    assert len(winners) == 1
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task_id).one()
+    assert stored.run_id == winners[0].run_id
+    assert stored.runner_id == winners[0].runner_id
 
 
 def test_isolated_acquire_closes_session_on_success() -> None:

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.managed_task_lease import (
+    claim_managed_task_lease,
+    start_managed_task_lease,
+)
+from xagent.web.services.task_lease_service import acquire_task_lease
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'managed-lease.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _create_task(db) -> Task:
+    user = User(username="managed-lease-user", password_hash="hash", is_admin=False)
+    db.add(user)
+    db.commit()
+    task = Task(
+        user_id=user.id,
+        title="Managed lease",
+        description="Managed lease",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_managed_lease_releases_terminal_task(db_session) -> None:
+    task = _create_task(db_session)
+    managed = claim_managed_task_lease(db_session, int(task.id))
+    assert managed is not None
+    assert claim_managed_task_lease(db_session, int(task.id)) is None
+    task.status = TaskStatus.COMPLETED
+    task.control_state = "completed"
+    db_session.commit()
+
+    assert await managed.close() is True
+    assert await managed.close() is False
+    db_session.refresh(task)
+    assert task.status == TaskStatus.COMPLETED
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_managed_lease_fails_an_unfinished_task(db_session) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), new_run=True)
+    assert lease is not None
+    managed = start_managed_task_lease(lease)
+
+    assert await managed.close() is True
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
+    assert task.control_state == "failed"
+    assert task.runner_id is None

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -452,6 +452,33 @@ async def test_command_is_rejected_after_run_rotation(db_session) -> None:
         await execute_durable_task_command(command)
 
 
+@pytest.mark.asyncio
+async def test_stale_run_rejection_reason_is_persisted(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="stale-pause-result",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    task.run_id = "run-2"
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+
+    assert await dispatch_one_task_command(
+        execute_durable_task_command,
+        command_db_id=enqueued.command_id,
+    )
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == COMMAND_FAILED
+    assert stored.result == {"rejection_reason": "stale_run"}
+
+
 def test_later_command_cannot_overtake_unfinished_command(db_session) -> None:
     user, task = _create_running_task(db_session)
     first = enqueue_task_command(
@@ -778,6 +805,58 @@ async def test_dispatcher_recovers_command_that_predates_worker_start(
     stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
     assert stored is not None
     assert stored.status == COMMAND_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_recovers_unrelated_tasks_concurrently(db_session) -> None:
+    user, first_task = _create_running_task(db_session)
+    first_task.runner_id = None
+    first_task.lease_expires_at = None
+    second_task = Task(
+        user_id=user.id,
+        title="Second durable command",
+        description="Second durable command",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+        run_id="run-2",
+        runner_id=None,
+        lease_expires_at=None,
+    )
+    db_session.add(second_task)
+    db_session.commit()
+    first = enqueue_task_command(
+        db_session,
+        task_id=int(first_task.id),
+        actor_user_id=int(user.id),
+        command_id="slow-recovery",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    second = enqueue_task_command(
+        db_session,
+        task_id=int(second_task.id),
+        actor_user_id=int(user.id),
+        command_id="independent-recovery",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def execute(command):
+        if command.id == first.command_id:
+            await release_first.wait()
+        elif command.id == second.command_id:
+            second_started.set()
+        return None
+
+    start_task_command_dispatcher(execute)
+    try:
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+        release_first.set()
+    finally:
+        release_first.set()
+        await stop_task_command_dispatcher()
 
 
 def test_load_task_command_returns_an_explicit_detached_snapshot(db_session) -> None:

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+
+import pytest
+
+from xagent.web.api.websocket import execute_durable_task_command
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.user import User
+from xagent.web.services.task_command_transport import (
+    COMMAND_COMPLETED,
+    TaskCommandDeferred,
+    TaskCommandKind,
+    claim_task_command,
+    dispatch_one_task_command,
+    enqueue_task_command,
+    finish_task_command,
+    start_task_command_dispatcher,
+    stop_task_command_dispatcher,
+)
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'task-commands.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _create_running_task(db) -> tuple[User, Task]:
+    user = User(username="command-user", password_hash="hash", is_admin=False)
+    db.add(user)
+    db.commit()
+    task = Task(
+        user_id=user.id,
+        title="Durable commands",
+        description="Durable commands",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+        run_id="run-1",
+        runner_id="runner-a",
+        lease_expires_at=datetime.utcnow() + timedelta(minutes=1),
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return user, task
+
+
+def test_enqueue_is_committed_and_idempotent(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    payload = {"type": "pause_task"}
+
+    first = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="pause-1",
+        kind=TaskCommandKind.PAUSE,
+        payload=payload,
+    )
+    duplicate = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="pause-1",
+        kind=TaskCommandKind.PAUSE,
+        payload=payload,
+    )
+    conflict = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="pause-1",
+        kind=TaskCommandKind.RESUME,
+        payload={"type": "resume_task"},
+    )
+
+    assert first.created is True
+    assert duplicate.command_id == first.command_id
+    assert duplicate.created is False
+    assert duplicate.payload_matches is True
+    assert conflict.payload_matches is False
+    assert db_session.query(TaskExecutionCommand).count() == 1
+
+
+def test_live_run_command_stays_with_owner_until_task_lease_expires(
+    db_session,
+) -> None:
+    user, task = _create_running_task(db_session)
+    command = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="message-1",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"type": "chat", "message": "new guidance"},
+    )
+
+    assert claim_task_command(db_session, runner_id="runner-b") is None
+    owner_claim = claim_task_command(db_session, runner_id="runner-a")
+    assert owner_claim is not None
+    assert owner_claim.id == command.command_id
+
+    # Simulate the owner crashing after claim. Once both the command claim and
+    # task lease expire, another worker can replay the same durable command.
+    row = db_session.query(TaskExecutionCommand).filter_by(id=command.command_id).one()
+    row.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    task.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    db_session.commit()
+
+    recovered = claim_task_command(db_session, runner_id="runner-b")
+    assert recovered is not None
+    assert recovered.id == command.command_id
+    assert recovered.attempt_count == 2
+
+
+def test_later_command_cannot_overtake_unfinished_command(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    first = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="pause-ordered",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    second = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="resume-ordered",
+        kind=TaskCommandKind.RESUME,
+        payload={"type": "resume_task"},
+    )
+
+    claimed_first = claim_task_command(db_session, runner_id="runner-a")
+    assert claimed_first is not None
+    assert claimed_first.id == first.command_id
+    assert (
+        claim_task_command(
+            db_session,
+            runner_id="runner-a",
+            command_db_id=second.command_id,
+        )
+        is None
+    )
+
+    assert finish_task_command(first.command_id, "runner-a") is True
+    claimed_second = claim_task_command(db_session, runner_id="runner-a")
+    assert claimed_second is not None
+    assert claimed_second.id == second.command_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_claims_and_completes_once(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    # Untargeted commands may be consumed by the current test process.
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="cancel-once",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    seen: list[int] = []
+
+    async def execute(command):
+        seen.append(command.id)
+        return {"ok": True}
+
+    assert await dispatch_one_task_command(execute, command_db_id=enqueued.command_id)
+    assert not await dispatch_one_task_command(
+        execute, command_db_id=enqueued.command_id
+    )
+    db_session.expire_all()
+    stored = (
+        db_session.query(TaskExecutionCommand).filter_by(id=enqueued.command_id).one()
+    )
+    assert seen == [enqueued.command_id]
+    assert stored.status == COMMAND_COMPLETED
+    assert stored.result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_deferred_handoff_retries_without_consuming_failure_budget(
+    db_session,
+) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="deferred-message",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"type": "chat", "message": "wait"},
+    )
+
+    async def defer(_command):
+        raise TaskCommandDeferred("checkpoint is not ready")
+
+    assert await dispatch_one_task_command(defer, command_db_id=enqueued.command_id)
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == "pending"
+    assert stored.attempt_count == 1
+    assert stored.claim_expires_at is not None
+
+    stored.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    db_session.commit()
+
+    async def finish(_command):
+        return {"applied": True}
+
+    assert await dispatch_one_task_command(finish, command_db_id=enqueued.command_id)
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == COMMAND_COMPLETED
+    assert stored.attempt_count == 2
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_restart_a_committed_new_turn(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.input = "already committed"
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="committed-turn",
+        kind=TaskCommandKind.MESSAGE,
+        payload={
+            "type": "chat",
+            "message": "already committed",
+            "client_message_id": "committed-turn",
+            "files": [],
+        },
+    )
+    first_claim = claim_task_command(db_session, runner_id="runner-a")
+    assert first_claim is not None
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            role="user",
+            content="already committed",
+            message_type="user_message",
+            turn_id="committed-turn",
+            delivery_status="pending",
+        )
+    )
+    row = db_session.query(TaskExecutionCommand).filter_by(id=enqueued.command_id).one()
+    row.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    task.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    db_session.commit()
+
+    assert await dispatch_one_task_command(
+        execute_durable_task_command,
+        command_db_id=enqueued.command_id,
+    )
+    db_session.expire_all()
+    messages = (
+        db_session.query(TaskChatMessage)
+        .filter_by(task_id=int(task.id), turn_id="committed-turn")
+        .all()
+    )
+    assert len(messages) == 1
+    assert messages[0].delivery_status == "dispatched"
+    command = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert command is not None
+    assert command.status == COMMAND_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_recovers_command_that_predates_worker_start(
+    db_session,
+) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="startup-recovery",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    applied = asyncio.Event()
+
+    async def execute(command):
+        assert command.id == enqueued.command_id
+        applied.set()
+        return None
+
+    start_task_command_dispatcher(execute)
+    try:
+        await asyncio.wait_for(applied.wait(), timeout=2)
+        for _ in range(100):
+            db_session.expire_all()
+            stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+            if stored is not None and stored.status == COMMAND_COMPLETED:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("dispatcher did not complete recovered command")
+    finally:
+        await stop_task_command_dispatcher()
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == COMMAND_COMPLETED

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -5,10 +5,12 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from threading import Barrier
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import inspect as sa_inspect
 
+from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
     _load_command_message_delivery_status,
     execute_durable_task_command,
@@ -35,6 +37,7 @@ from xagent.web.services.task_command_transport import (
     TaskCommandRejected,
     _claim_heartbeat,
     claim_task_command,
+    defer_task_command,
     dispatch_one_task_command,
     dispatch_task_command_promptly,
     enqueue_task_command,
@@ -42,6 +45,8 @@ from xagent.web.services.task_command_transport import (
     finish_task_command,
     load_task_command,
     notify_task_command_dispatcher,
+    renew_task_command_claim,
+    retry_failed_task_command,
     start_task_command_dispatcher,
     stop_task_command_dispatcher,
     task_has_live_foreign_runner,
@@ -202,6 +207,69 @@ def test_same_command_row_has_a_single_concurrent_claim_winner(db_session) -> No
     assert winners == [command.command_id]
 
 
+def test_stale_attempt_cannot_mutate_reclaimed_command(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="reclaimed-generation",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    first = claim_task_command(
+        db_session,
+        runner_id="runner-a",
+        command_db_id=enqueued.command_id,
+    )
+    assert first is not None
+    row = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert row is not None
+    row.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    db_session.commit()
+
+    second = claim_task_command(
+        db_session,
+        runner_id="runner-a",
+        command_db_id=enqueued.command_id,
+    )
+    assert second is not None
+    assert second.attempt_count == first.attempt_count + 1
+
+    assert not renew_task_command_claim(
+        enqueued.command_id,
+        "runner-a",
+        expected_attempt_count=first.attempt_count,
+    )
+    assert not fail_task_command(
+        enqueued.command_id,
+        "runner-a",
+        "stale failure",
+        expected_attempt_count=first.attempt_count,
+    )
+    assert not defer_task_command(
+        enqueued.command_id,
+        "runner-a",
+        "stale deferral",
+        expected_attempt_count=first.attempt_count,
+    )
+    assert not finish_task_command(
+        enqueued.command_id,
+        "runner-a",
+        expected_attempt_count=first.attempt_count,
+    )
+
+    db_session.expire_all()
+    row = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert row is not None
+    assert row.status == "processing"
+    assert row.claimed_by == "runner-a"
+    assert row.attempt_count == second.attempt_count
+
+
 def test_live_foreign_runner_is_rechecked_before_cancel(db_session) -> None:
     _user, task = _create_running_task(db_session)
 
@@ -263,6 +331,103 @@ async def test_cancel_command_defers_on_a_live_foreign_owner(db_session) -> None
 
     with pytest.raises(TaskCommandDeferred, match="active task lease owner"):
         await execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_does_not_require_persisted_actor(db_session) -> None:
+    _user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=None,
+        command_id="cancel-with-deleted-actor",
+        kind=TaskCommandKind.CANCEL,
+        payload={},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with (
+        patch.object(websocket_api, "_load_command_actor") as load_actor,
+        pytest.raises(ValueError, match="Agent ID is missing"),
+    ):
+        await execute_durable_task_command(command)
+    load_actor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_only_terminal_command_failure_is_broadcast(db_session) -> None:
+    _user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    transient = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=None,
+        command_id="transient-cancel-failure",
+        kind=TaskCommandKind.CANCEL,
+        payload={},
+        target_run_id=None,
+        attempt_count=1,
+        failure_count=0,
+    )
+    terminal = ClaimedTaskCommand(
+        id=2,
+        task_id=int(task.id),
+        actor_user_id=None,
+        command_id="terminal-cancel-failure",
+        kind=TaskCommandKind.CANCEL,
+        payload={},
+        target_run_id=None,
+        attempt_count=1,
+        failure_count=MAX_COMMAND_FAILURES - 1,
+    )
+
+    with patch.object(
+        websocket_api.manager,
+        "broadcast_to_task",
+        new=AsyncMock(),
+    ) as broadcast:
+        with pytest.raises(ValueError, match="Agent ID is missing"):
+            await execute_durable_task_command(transient)
+        broadcast.assert_not_awaited()
+
+        with pytest.raises(ValueError, match="Agent ID is missing"):
+            await execute_durable_task_command(terminal)
+        broadcast.assert_awaited_once()
+        event, event_task_id = broadcast.await_args.args
+        assert event_task_id == int(task.id)
+        assert event["type"] == "agent_error"
+        assert event["command_id"] == "terminal-cancel-failure"
+
+
+@pytest.mark.asyncio
+async def test_final_command_deferral_is_broadcast(db_session) -> None:
+    _user, task = _create_running_task(db_session)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=None,
+        command_id="terminal-cancel-defer",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+        target_run_id=None,
+        attempt_count=1,
+        defer_count=MAX_COMMAND_DEFERS - 1,
+    )
+
+    with patch.object(
+        websocket_api.manager,
+        "broadcast_to_task",
+        new=AsyncMock(),
+    ) as broadcast:
+        with pytest.raises(TaskCommandDeferred, match="active task lease owner"):
+            await execute_durable_task_command(command)
+        broadcast.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -385,6 +550,7 @@ async def test_deferred_handoff_retries_without_consuming_failure_budget(
     assert stored.status == "pending"
     assert stored.attempt_count == 1
     assert stored.failure_count == 0
+    assert stored.defer_count == 1
     assert stored.claim_expires_at is not None
 
     stored.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
@@ -400,6 +566,7 @@ async def test_deferred_handoff_retries_without_consuming_failure_budget(
     assert stored.status == COMMAND_COMPLETED
     assert stored.attempt_count == 2
     assert stored.failure_count == 0
+    assert stored.defer_count == 1
 
 
 @pytest.mark.asyncio
@@ -428,7 +595,7 @@ async def test_deferred_message_eventually_fails_and_unblocks_cancel(
     )
     row = db_session.get(TaskExecutionCommand, message.command_id)
     assert row is not None
-    row.attempt_count = MAX_COMMAND_DEFERS - 1
+    row.defer_count = MAX_COMMAND_DEFERS - 1
     db_session.commit()
 
     async def defer(_command):
@@ -440,6 +607,7 @@ async def test_deferred_message_eventually_fails_and_unblocks_cancel(
     assert row is not None
     assert row.status == COMMAND_FAILED
     assert row.failure_count == 0
+    assert row.defer_count == MAX_COMMAND_DEFERS
 
     cancel_claim = claim_task_command(db_session)
     assert cancel_claim is not None
@@ -475,8 +643,47 @@ async def test_real_failures_use_a_separate_bounded_budget(db_session) -> None:
     assert row.failure_count == MAX_COMMAND_FAILURES
 
 
+def test_failed_command_can_be_reset_for_explicit_retry(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="retry-terminal-command",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    row = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert row is not None
+    row.status = COMMAND_FAILED
+    row.failure_count = MAX_COMMAND_FAILURES
+    row.defer_count = MAX_COMMAND_DEFERS
+    row.error = "temporary cancellation failure"
+    row.completed_at = datetime.utcnow()
+    db_session.commit()
+
+    assert retry_failed_task_command(
+        db_session,
+        enqueued.command_id,
+        target_run_id="run-2",
+        target_runner_id="runner-b",
+    )
+    db_session.expire_all()
+    row = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert row is not None
+    assert row.status == "pending"
+    assert row.failure_count == 0
+    assert row.defer_count == 0
+    assert row.error is None
+    assert row.completed_at is None
+    assert row.target_run_id == "run-2"
+    assert row.target_runner_id == "runner-b"
+
+
 @pytest.mark.asyncio
-async def test_recovery_does_not_restart_a_committed_new_turn(db_session) -> None:
+async def test_recovery_dispatches_committed_message_across_run_rotation(
+    db_session,
+) -> None:
     user, task = _create_running_task(db_session)
     task.input = "already committed"
     enqueued = enqueue_task_command(
@@ -507,6 +714,9 @@ async def test_recovery_does_not_restart_a_committed_new_turn(db_session) -> Non
     )
     row = db_session.query(TaskExecutionCommand).filter_by(id=enqueued.command_id).one()
     row.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    # MESSAGE commands represent user intent for the task rather than a control
+    # mutation on one run, so recovery deliberately applies them after rotation.
+    task.run_id = "run-2"
     task.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
     db_session.commit()
 
@@ -525,6 +735,7 @@ async def test_recovery_does_not_restart_a_committed_new_turn(db_session) -> Non
     command = db_session.get(TaskExecutionCommand, enqueued.command_id)
     assert command is not None
     assert command.status == COMMAND_COMPLETED
+    assert task.run_id == "run-2"
 
 
 @pytest.mark.asyncio
@@ -618,8 +829,14 @@ async def test_claim_heartbeat_survives_transient_database_error(
     stop_event = asyncio.Event()
     attempts = 0
 
-    def renew(_command_db_id: int, _runner_id: str) -> bool:
+    def renew(
+        _command_db_id: int,
+        _runner_id: str,
+        *,
+        expected_attempt_count: int | None = None,
+    ) -> bool:
         nonlocal attempts
+        assert expected_attempt_count == 3
         attempts += 1
         if attempts == 1:
             raise RuntimeError("temporary database outage")
@@ -635,7 +852,7 @@ async def test_claim_heartbeat_survives_transient_database_error(
         renew,
     )
 
-    await asyncio.wait_for(_claim_heartbeat(7, "runner-a", stop_event), timeout=0.2)
+    await asyncio.wait_for(_claim_heartbeat(7, "runner-a", 3, stop_event), timeout=0.2)
 
     assert attempts == 2
 

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -334,6 +334,28 @@ async def test_cancel_command_defers_on_a_live_foreign_owner(db_session) -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("kind", [TaskCommandKind.PAUSE, TaskCommandKind.RESUME])
+async def test_control_command_defers_on_a_live_foreign_owner(
+    db_session,
+    kind: TaskCommandKind,
+) -> None:
+    user, task = _create_running_task(db_session)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id=f"misrouted-{kind.value}",
+        kind=kind,
+        payload={"type": f"{kind.value}_task"},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with pytest.raises(TaskCommandDeferred, match="active task lease owner"):
+        await execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
 async def test_cancel_command_does_not_require_persisted_actor(db_session) -> None:
     _user, task = _create_running_task(db_session)
     task.runner_id = None

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
+from threading import Barrier
 
 import pytest
 from sqlalchemy import inspect as sa_inspect
@@ -11,24 +14,37 @@ from xagent.web.api.websocket import (
     execute_durable_task_command,
 )
 from xagent.web.models.chat_message import TaskChatMessage
-from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.database import (
+    Base,
+    get_db,
+    get_engine,
+    get_session_local,
+    init_db,
+)
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.user import User
 from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
+    COMMAND_FAILED,
+    MAX_COMMAND_DEFERS,
+    MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
     TaskCommandDeferred,
     TaskCommandKind,
+    TaskCommandRejected,
     _claim_heartbeat,
     claim_task_command,
     dispatch_one_task_command,
+    dispatch_task_command_promptly,
     enqueue_task_command,
+    fail_task_command,
     finish_task_command,
     load_task_command,
     notify_task_command_dispatcher,
     start_task_command_dispatcher,
     stop_task_command_dispatcher,
+    task_has_live_foreign_runner,
 )
 
 
@@ -131,6 +147,73 @@ def test_live_run_command_stays_with_owner_until_task_lease_expires(
     assert recovered.attempt_count == 2
 
 
+def test_reassigned_command_routes_only_to_the_current_live_owner(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    command = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="owner-takeover",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    task.runner_id = "runner-b"
+    task.lease_expires_at = datetime.utcnow() + timedelta(minutes=1)
+    db_session.commit()
+
+    assert claim_task_command(db_session, runner_id="runner-c") is None
+    current_owner_claim = claim_task_command(db_session, runner_id="runner-b")
+
+    assert current_owner_claim is not None
+    assert current_owner_claim.id == command.command_id
+
+
+def test_same_command_row_has_a_single_concurrent_claim_winner(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    command = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="concurrent-claim",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    barrier = Barrier(2)
+
+    def claim(runner_id: str) -> int | None:
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            barrier.wait()
+            claimed = claim_task_command(
+                db,
+                runner_id=runner_id,
+                command_db_id=command.command_id,
+            )
+            return claimed.id if claimed is not None else None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(claim, "runner-a")
+        second = executor.submit(claim, "runner-b")
+        winners = [value for value in (first.result(), second.result()) if value]
+
+    assert winners == [command.command_id]
+
+
+def test_live_foreign_runner_is_rechecked_before_cancel(db_session) -> None:
+    _user, task = _create_running_task(db_session)
+
+    assert task_has_live_foreign_runner(int(task.id), runner_id="runner-b") is True
+    assert task_has_live_foreign_runner(int(task.id), runner_id="runner-a") is False
+
+    task.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
+    db_session.commit()
+
+    assert task_has_live_foreign_runner(int(task.id), runner_id="runner-b") is False
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("payload", "error"),
@@ -146,6 +229,9 @@ async def test_cancel_command_rejects_invalid_agent_id_payload(
     error: str,
 ) -> None:
     user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
     command = ClaimedTaskCommand(
         id=1,
         task_id=int(task.id),
@@ -158,6 +244,46 @@ async def test_cancel_command_rejects_invalid_agent_id_payload(
     )
 
     with pytest.raises(ValueError, match=error):
+        await execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_defers_on_a_live_foreign_owner(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="misrouted-cancel",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with pytest.raises(TaskCommandDeferred, match="active task lease owner"):
+        await execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_command_is_rejected_after_run_rotation(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.run_id = "run-2"
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="stale-pause",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+        target_run_id="run-1",
+        attempt_count=1,
+    )
+
+    with pytest.raises(TaskCommandRejected, match="Task run changed"):
         await execute_durable_task_command(command)
 
 
@@ -258,6 +384,7 @@ async def test_deferred_handoff_retries_without_consuming_failure_budget(
     assert stored is not None
     assert stored.status == "pending"
     assert stored.attempt_count == 1
+    assert stored.failure_count == 0
     assert stored.claim_expires_at is not None
 
     stored.claim_expires_at = datetime.utcnow() - timedelta(seconds=1)
@@ -272,6 +399,80 @@ async def test_deferred_handoff_retries_without_consuming_failure_budget(
     assert stored is not None
     assert stored.status == COMMAND_COMPLETED
     assert stored.attempt_count == 2
+    assert stored.failure_count == 0
+
+
+@pytest.mark.asyncio
+async def test_deferred_message_eventually_fails_and_unblocks_cancel(
+    db_session,
+) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    message = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="stuck-message",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"type": "chat", "message": "wait forever"},
+    )
+    cancel = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="cancel-after-stuck-message",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    row = db_session.get(TaskExecutionCommand, message.command_id)
+    assert row is not None
+    row.attempt_count = MAX_COMMAND_DEFERS - 1
+    db_session.commit()
+
+    async def defer(_command):
+        raise TaskCommandDeferred("checkpoint never became ready")
+
+    assert await dispatch_one_task_command(defer, command_db_id=message.command_id)
+    db_session.expire_all()
+    row = db_session.get(TaskExecutionCommand, message.command_id)
+    assert row is not None
+    assert row.status == COMMAND_FAILED
+    assert row.failure_count == 0
+
+    cancel_claim = claim_task_command(db_session)
+    assert cancel_claim is not None
+    assert cancel_claim.id == cancel.command_id
+
+
+@pytest.mark.asyncio
+async def test_real_failures_use_a_separate_bounded_budget(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    command = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="last-failure",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    claimed = claim_task_command(db_session, runner_id="runner-a")
+    assert claimed is not None
+    row = db_session.get(TaskExecutionCommand, command.command_id)
+    assert row is not None
+    row.failure_count = MAX_COMMAND_FAILURES - 1
+    db_session.commit()
+
+    assert fail_task_command(command.command_id, "runner-a", "still broken") is True
+    db_session.expire_all()
+    row = db_session.get(TaskExecutionCommand, command.command_id)
+    assert row is not None
+    assert row.status == COMMAND_FAILED
+    assert row.failure_count == MAX_COMMAND_FAILURES
 
 
 @pytest.mark.asyncio
@@ -466,3 +667,30 @@ async def test_dispatcher_does_not_erase_wakeup_during_empty_claim(monkeypatch) 
         await stop_task_command_dispatcher()
 
     assert calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_prompt_dispatch_observes_late_task_failure(monkeypatch, caplog) -> None:
+    async def fail_after_handoff(_executor, *, command_db_id=None) -> bool:
+        del command_db_id
+        await asyncio.sleep(0.06)
+        raise RuntimeError("late dispatch failure")
+
+    async def execute(_command):
+        return None
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.dispatch_one_task_command",
+        fail_after_handoff,
+    )
+    caplog.set_level(logging.ERROR)
+
+    await dispatch_task_command_promptly(execute, command_db_id=1)
+    for _ in range(100):
+        if "Detached prompt task command dispatch failed" in caplog.text:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("late prompt dispatch failure was not observed")
+
+    assert "late dispatch failure" in caplog.text

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -17,6 +17,7 @@ from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.user import User
 from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
+    ClaimedTaskCommand,
     TaskCommandDeferred,
     TaskCommandKind,
     _claim_heartbeat,
@@ -128,6 +129,36 @@ def test_live_run_command_stays_with_owner_until_task_lease_expires(
     assert recovered is not None
     assert recovered.id == command.command_id
     assert recovered.attempt_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({}, "Agent ID is missing or null in cancel command payload"),
+        ({"agent_id": None}, "Agent ID is missing or null in cancel command payload"),
+        ({"agent_id": "invalid"}, "Agent ID 'invalid' is invalid"),
+    ],
+)
+async def test_cancel_command_rejects_invalid_agent_id_payload(
+    db_session,
+    payload,
+    error: str,
+) -> None:
+    user, task = _create_running_task(db_session)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="invalid-cancel",
+        kind=TaskCommandKind.CANCEL,
+        payload=payload,
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with pytest.raises(ValueError, match=error):
+        await execute_durable_task_command(command)
 
 
 def test_later_command_cannot_overtake_unfinished_command(db_session) -> None:

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -4,8 +4,12 @@ import asyncio
 from datetime import datetime, timedelta
 
 import pytest
+from sqlalchemy import inspect as sa_inspect
 
-from xagent.web.api.websocket import execute_durable_task_command
+from xagent.web.api.websocket import (
+    _load_command_message_delivery_status,
+    execute_durable_task_command,
+)
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
@@ -15,10 +19,13 @@ from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
     TaskCommandDeferred,
     TaskCommandKind,
+    _claim_heartbeat,
     claim_task_command,
     dispatch_one_task_command,
     enqueue_task_command,
     finish_task_command,
+    load_task_command,
+    notify_task_command_dispatcher,
     start_task_command_dispatcher,
     stop_task_command_dispatcher,
 )
@@ -328,3 +335,103 @@ async def test_dispatcher_recovers_command_that_predates_worker_start(
     stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
     assert stored is not None
     assert stored.status == COMMAND_COMPLETED
+
+
+def test_load_task_command_returns_an_explicit_detached_snapshot(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="detached-status",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+
+    stored = load_task_command(enqueued.command_id)
+
+    assert stored is not None
+    assert sa_inspect(stored).detached
+    assert stored.status == "pending"
+    assert stored.error is None
+
+
+def test_legacy_delivery_status_preserves_none(db_session) -> None:
+    user, task = _create_running_task(db_session)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            role="user",
+            content="legacy",
+            message_type="user_message",
+            turn_id="legacy-delivery",
+            delivery_status=None,
+        )
+    )
+    db_session.commit()
+
+    assert (
+        _load_command_message_delivery_status(int(task.id), "legacy-delivery") is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_heartbeat_survives_transient_database_error(
+    monkeypatch,
+) -> None:
+    stop_event = asyncio.Event()
+    attempts = 0
+
+    def renew(_command_db_id: int, _runner_id: str) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary database outage")
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.renew_task_command_claim",
+        renew,
+    )
+
+    await asyncio.wait_for(_claim_heartbeat(7, "runner-a", stop_event), timeout=0.2)
+
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_does_not_erase_wakeup_during_empty_claim(monkeypatch) -> None:
+    second_claim = asyncio.Event()
+    calls = 0
+
+    async def fake_dispatch(_executor, *, command_db_id=None) -> bool:
+        nonlocal calls
+        del command_db_id
+        calls += 1
+        if calls == 1:
+            notify_task_command_dispatcher()
+            return False
+        second_claim.set()
+        return False
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.dispatch_one_task_command",
+        fake_dispatch,
+    )
+
+    start_task_command_dispatcher(lambda _command: asyncio.sleep(0))
+    try:
+        await asyncio.wait_for(second_claim.wait(), timeout=0.25)
+    finally:
+        await stop_task_command_dispatcher()
+
+    assert calls >= 2

--- a/tests/web/services/test_task_execution_controller.py
+++ b/tests/web/services/test_task_execution_controller.py
@@ -246,6 +246,31 @@ def test_transitions_keep_run_identity_and_advance_version(db_session) -> None:
         )
 
 
+def test_transition_rejects_a_stale_state_version(db_session) -> None:
+    task = _create_task(db_session)
+    running = transition_task_control_state_sync(
+        int(task.id),
+        TaskControlState.RUNNING,
+        status=TaskStatus.RUNNING,
+        new_run=True,
+    )
+
+    with pytest.raises(StaleTaskRunError, match="state changed"):
+        transition_task_control_state_sync(
+            int(task.id),
+            TaskControlState.FAILED,
+            status=TaskStatus.FAILED,
+            expected_run_id=running.run_id,
+            expected_state_version=running.state_version - 1,
+        )
+
+    db_session.expire_all()
+    stored = db_session.get(Task, int(task.id))
+    assert stored is not None
+    assert stored.status == TaskStatus.RUNNING
+    assert stored.state_version == running.state_version
+
+
 def test_concurrent_transitions_get_distinct_atomic_versions(db_session) -> None:
     task = _create_task(db_session)
     running = transition_task_control_state_sync(

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from threading import Barrier
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -37,13 +39,17 @@ from xagent.web.services.connector_runtime import (
     store_ephemeral_runtime_values,
 )
 from xagent.web.services.task_execution_controller import task_execution_controller
-from xagent.web.services.task_lease_service import get_runner_id
+from xagent.web.services.task_lease_service import (
+    acquire_task_lease_isolated,
+    get_runner_id,
+)
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
     TaskTurnNotFoundError,
     TaskTurnOrchestrator,
     TaskTurnPayload,
     TurnKind,
+    _begin_turn_atomic_sync,
     _ClaimedTurn,
     _schedule_bg,
     finish_turn,
@@ -108,6 +114,50 @@ def _store_runtime_secret_for_turn(turn_id: str) -> None:
             }
         },
     )
+
+
+def test_channel_and_web_claims_are_cross_process_exclusive(db_session) -> None:
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id))
+    task_id = int(task.id)
+    barrier = Barrier(2)
+
+    def claim_channel() -> str | None:
+        barrier.wait()
+        lease = acquire_task_lease_isolated(
+            task_id,
+            runner_id="channel-runner",
+            new_run=True,
+        )
+        return lease.run_id if lease is not None else None
+
+    def claim_web() -> str | None:
+        barrier.wait()
+        try:
+            claimed = _begin_turn_atomic_sync(
+                task_id,
+                int(user.id),
+                payload=TaskTurnPayload("web turn"),
+                kind=TurnKind.CREATE,
+            )
+        except TaskTurnError:
+            return None
+        return claimed.run_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        channel_result = executor.submit(claim_channel)
+        web_result = executor.submit(claim_web)
+        winners = [
+            run_id
+            for run_id in (channel_result.result(), web_result.result())
+            if run_id is not None
+        ]
+
+    assert len(winners) == 1
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task_id).one()
+    assert stored.status == TaskStatus.RUNNING
+    assert stored.run_id == winners[0]
 
 
 @pytest.fixture()

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -91,6 +91,29 @@ def test_task_lease_acquire_refresh_and_release(db_session) -> None:
     assert task.lease_expires_at is None
 
 
+def test_new_run_lease_claim_rejects_a_second_claim(db_session) -> None:
+    task = _create_task(db_session)
+
+    first = acquire_task_lease(
+        db_session,
+        int(task.id),
+        runner_id="runner-a",
+        new_run=True,
+    )
+    second = acquire_task_lease(
+        db_session,
+        int(task.id),
+        runner_id="runner-a",
+        new_run=True,
+    )
+
+    assert first is not None
+    assert first.run_id
+    assert second is None
+    db_session.refresh(task)
+    assert task.run_id == first.run_id
+
+
 def test_lease_acquire_rejects_a_superseded_run(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.run_id = "current-run"


### PR DESCRIPTION
## Summary

- add a durable database-backed inbox for message, pause, resume, and cancel commands
- commit commands before acknowledging clients, with stable idempotency keys and strict per-task FIFO ordering
- route commands to the active task-lease owner, then allow another worker to reclaim them after owner/claim expiry
- keep deferred message handoffs pending until the runtime injection is durably dispatched or failed
- recover unfinished commands on worker startup and reject stale control commands after a run-id change
- atomically claim and manage Telegram/Feishu task leases, closing the cross-process race tracked in #856
- add the task-command migration, frontend control-command IDs, and cross-session/crash-recovery regression coverage

## Why

P1 established `run_id`, `state_version`, and process-local command serialization, but an accepted command could still be lost if its receiving worker exited, and commands received by different workers were not durably ordered. This phase makes command acceptance and ownership database-backed so reconnects, retries, and worker failover preserve the user's intent without duplicate execution or stale-run mutations.

## Validation

- 187 focused backend tests covering P1/P2 control state, leases, WebSocket/A2A entry points, migration, ordering, idempotency, and crash recovery
- 8 focused frontend WebSocket tests
- frontend TypeScript type-check
- commit hooks: Ruff, mypy, codespell, Alembic single-head check, frontend lint, and frontend type-check

Closes #856
