### PR TITLE
feat: add OAuth resolver runtime refresh support

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -45,7 +45,7 @@ from ...context.enrichment import (
     latest_user_text,
 )
 from ...language import final_answer_language_rule
-from ...result import unwrap_final_answer_content
+from ...result import tool_result_succeeded, unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult, truncate_prompt_preview
 from ..final_answer_stream import (
@@ -1867,12 +1867,7 @@ class ReActPattern(AgentPattern):
         }
 
     def _tool_result_success(self, result: Any) -> bool:
-        if not isinstance(result, dict):
-            return True
-        if result.get("success") is False:
-            return False
-        status = result.get("status")
-        return not (isinstance(status, str) and status.lower() == "error")
+        return tool_result_succeeded(result)
 
     def _latest_tool_result_success(self, context: Any) -> bool:
         for message in reversed(getattr(context, "messages", [])):

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -3,6 +3,25 @@ from __future__ import annotations
 import json
 from typing import Any
 
+TOOL_FAILURE_CODES = frozenset({"oauth_token_required"})
+
+
+def normalize_tool_failure_code(value: Any) -> str | None:
+    """Return an exact public tool failure code when it is allowlisted."""
+
+    return value if isinstance(value, str) and value in TOOL_FAILURE_CODES else None
+
+
+def tool_result_succeeded(result: Any) -> bool:
+    """Classify the supported structured tool-result failure shapes."""
+
+    if not isinstance(result, dict):
+        return True
+    if result.get("success") is False or result.get("is_error") is True:
+        return False
+    status = result.get("status")
+    return not (isinstance(status, str) and status.lower() == "error")
+
 
 def extract_assistant_message(result: dict[str, Any]) -> str | None:
     """Return the assistant-facing output from a normalized pattern result."""

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any
 
 TOOL_FAILURE_CODES = frozenset({"oauth_token_required"})
@@ -10,6 +11,17 @@ def normalize_tool_failure_code(value: Any) -> str | None:
     """Return an exact public tool failure code when it is allowlisted."""
 
     return value if type(value) is str and value in TOOL_FAILURE_CODES else None
+
+
+@dataclass(frozen=True)
+class ClassifiedToolFailure:
+    """Safe classified failure outcome shared across core runtime boundaries."""
+
+    failure_code: str
+
+    def __post_init__(self) -> None:
+        if normalize_tool_failure_code(self.failure_code) is None:
+            raise ValueError("invalid tool failure code")
 
 
 def tool_result_succeeded(result: Any) -> bool:

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -9,7 +9,7 @@ TOOL_FAILURE_CODES = frozenset({"oauth_token_required"})
 def normalize_tool_failure_code(value: Any) -> str | None:
     """Return an exact public tool failure code when it is allowlisted."""
 
-    return value if isinstance(value, str) and value in TOOL_FAILURE_CODES else None
+    return value if type(value) is str and value in TOOL_FAILURE_CODES else None
 
 
 def tool_result_succeeded(result: Any) -> bool:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -16,6 +16,7 @@ from ..agent.trace import (
 )
 from ..model.chat.basic.base import BaseLLM
 from ..model.chat.types import ChunkType
+from .result import normalize_tool_failure_code, tool_result_succeeded
 from .streaming import merge_streamed_tool_call_arguments
 
 logger = logging.getLogger(__name__)
@@ -632,7 +633,9 @@ class PatternRuntime:
         success = self._tool_result_success(result)
         if not success:
             await self.on_tool_error(
-                tool_call=tool_call, error=self._tool_result_error(result)
+                tool_call=tool_call,
+                error=self._tool_result_error(result),
+                result=result,
             )
             return
 
@@ -676,6 +679,11 @@ class PatternRuntime:
         }
         if result is not None:
             data["result"] = result
+        failure_code = normalize_tool_failure_code(
+            result.get("failure_code") if isinstance(result, dict) else None
+        )
+        if failure_code is not None:
+            data["failure_code"] = failure_code
 
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.TOOL),
@@ -696,13 +704,7 @@ class PatternRuntime:
             await self._maybe_await(finish_span(**payload))
 
     def _tool_result_success(self, result: Any) -> bool:
-        if isinstance(result, dict):
-            if result.get("success") is False:
-                return False
-            status = result.get("status")
-            if isinstance(status, str) and status.lower() == "error":
-                return False
-        return True
+        return tool_result_succeeded(result)
 
     def _tool_result_error(self, result: Any) -> Exception:
         if isinstance(result, dict):

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -520,6 +520,7 @@ class ToolFactory:
     ) -> List[Tool]:
         """Create MCP tools from configurations."""
         try:
+            from ....agent.result import normalize_tool_failure_code
             from .mcp_adapter import UnavailableMCPTool, load_mcp_tools_as_agent_tools
 
             unavailable_tools: List[Tool] = []
@@ -540,6 +541,9 @@ class ToolFactory:
                                 allow_users=allow_users
                                 if isinstance(allow_users, list)
                                 else None,
+                                failure_code=normalize_tool_failure_code(
+                                    inner_config.get("failure_code")
+                                ),
                             )
                         )
                     except Exception as e:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -53,22 +53,23 @@ _HTTP_401_TEXT_RE = re.compile(
 
 
 def _bounded_exception_nodes(
-    exc: BaseException, *, excluded_ids: set[int] | None = None
+    exc: BaseException, *, excluded_subtree_ids: frozenset[int] = frozenset()
 ) -> Iterator[BaseException]:
-    excluded = set(excluded_ids or ())
     pending = [(exc, True)]
     visited: set[int] = set()
     visited_count = 0
     while pending and visited_count < _RESOLVER_HTTP_401_NODE_LIMIT:
         current, is_root = pending.pop()
         current_id = id(current)
-        if current_id in visited or (current_id in excluded and not is_root):
+        if current_id in visited or (
+            current_id in excluded_subtree_ids and not is_root
+        ):
             continue
         visited.add(current_id)
         visited_count += 1
         yield current
 
-        if current_id in excluded:
+        if current_id in excluded_subtree_ids:
             continue
         linked: list[BaseException] = []
         if isinstance(current, BaseExceptionGroup):
@@ -81,27 +82,46 @@ def _bounded_exception_nodes(
 
 
 def _strict_http_401_responses(
-    exc: BaseException, *, excluded_ids: set[int] | None = None
+    exc: BaseException,
+    *,
+    excluded_response_ids: frozenset[int] = frozenset(),
+    excluded_subtree_ids: frozenset[int] = frozenset(),
 ) -> Iterator[httpx.Response]:
-    for current in _bounded_exception_nodes(exc, excluded_ids=excluded_ids):
+    for current in _bounded_exception_nodes(
+        exc, excluded_subtree_ids=excluded_subtree_ids
+    ):
         if not isinstance(current, httpx.HTTPStatusError):
             continue
         response = current.response
-        if isinstance(response, httpx.Response) and response.status_code == 401:
+        if (
+            isinstance(response, httpx.Response)
+            and response.status_code == 401
+            and id(response) not in excluded_response_ids
+        ):
             yield response
 
 
-def _resolver_invalid_token_challenge(exc: BaseException) -> Any | None:
+def _resolver_401_evidence(exc: BaseException) -> tuple[Any | None, frozenset[int]]:
     # Lazy import keeps the core adapter independent from the web layer at import time.
     from .....web.services.mcp_oauth import parse_www_authenticate_bearer
 
+    challenge = None
+    response_ids: set[int] = set()
     for response in _strict_http_401_responses(exc):
-        challenge = parse_www_authenticate_bearer(
+        response_ids.add(id(response))
+        if challenge is not None:
+            continue
+        candidate = parse_www_authenticate_bearer(
             response.headers.get_list("WWW-Authenticate")
         )
-        if challenge is not None and challenge.params.get("error") == "invalid_token":
-            return challenge
-    return None
+        if candidate is not None and candidate.params.get("error") == "invalid_token":
+            challenge = candidate
+    return challenge, frozenset(response_ids)
+
+
+def _resolver_invalid_token_challenge(exc: BaseException) -> Any | None:
+    challenge, _ = _resolver_401_evidence(exc)
+    return challenge
 
 
 def _is_executable_remote_connection(value: Any) -> bool:
@@ -732,11 +752,10 @@ class MCPToolAdapter(AbstractBaseTool):
         tool_args: Mapping[str, Any],
         tool_meta: Mapping[str, Any],
     ) -> dict[str, Any] | None:
-        strict_401 = next(_strict_http_401_responses(exc), None)
-        if strict_401 is None:
+        challenge, initial_response_ids = _resolver_401_evidence(exc)
+        if not initial_response_ids:
             return None
 
-        challenge = _resolver_invalid_token_challenge(exc)
         refresh = self.connection.get(_OAUTH_TOKEN_RESOLVER_REFRESH_KEY)
         if challenge is None or not callable(refresh):
             return _delegated_authorization_failed_result()
@@ -772,13 +791,15 @@ class MCPToolAdapter(AbstractBaseTool):
                 cast(Connection, refreshed), tool_args, tool_meta
             )
         except (BaseExceptionGroup, Exception) as retry_exc:
-            original_exception_ids = {
-                id(node) for node in _bounded_exception_nodes(exc)
-            }
+            excluded_response_ids = (
+                frozenset() if retry_exc is exc else initial_response_ids
+            )
             if (
                 next(
                     _strict_http_401_responses(
-                        retry_exc, excluded_ids=original_exception_ids
+                        retry_exc,
+                        excluded_response_ids=excluded_response_ids,
+                        excluded_subtree_ids=frozenset({id(exc)}),
                     ),
                     None,
                 )

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -55,18 +55,21 @@ _HTTP_401_TEXT_RE = re.compile(
 def _bounded_exception_nodes(
     exc: BaseException, *, excluded_ids: set[int] | None = None
 ) -> Iterator[BaseException]:
-    pending = [exc]
-    visited: set[int] = set(excluded_ids or ())
+    excluded = set(excluded_ids or ())
+    pending = [(exc, True)]
+    visited: set[int] = set()
     visited_count = 0
     while pending and visited_count < _RESOLVER_HTTP_401_NODE_LIMIT:
-        current = pending.pop()
+        current, is_root = pending.pop()
         current_id = id(current)
-        if current_id in visited:
+        if current_id in visited or (current_id in excluded and not is_root):
             continue
         visited.add(current_id)
         visited_count += 1
         yield current
 
+        if current_id in excluded:
+            continue
         linked: list[BaseException] = []
         if isinstance(current, BaseExceptionGroup):
             linked.extend(current.exceptions)
@@ -74,7 +77,7 @@ def _bounded_exception_nodes(
             linked.append(current.__cause__)
         if isinstance(current.__context__, BaseException):
             linked.append(current.__context__)
-        pending.extend(reversed(linked))
+        pending.extend((node, False) for node in reversed(linked))
 
 
 def _strict_http_401_responses(
@@ -99,6 +102,17 @@ def _resolver_invalid_token_challenge(exc: BaseException) -> Any | None:
         if challenge is not None and challenge.params.get("error") == "invalid_token":
             return challenge
     return None
+
+
+def _is_executable_connection(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    transport = value.get("transport")
+    required_key = "command" if transport == "stdio" else "url"
+    if transport not in {"stdio", "sse", "streamable_http", "websocket"}:
+        return False
+    required_value = value.get(required_key)
+    return isinstance(required_value, str) and bool(required_value)
 
 
 def _exception_indicates_http_401(exc: BaseException) -> bool:
@@ -689,7 +703,7 @@ class MCPToolAdapter(AbstractBaseTool):
         refreshed = refresh()
         if inspect.isawaitable(refreshed):
             refreshed = await refreshed
-        if not isinstance(refreshed, dict):
+        if not _is_executable_connection(refreshed):
             return _delegated_authorization_failed_result()
         try:
             return await self._execute_mcp_call(
@@ -736,7 +750,7 @@ class MCPToolAdapter(AbstractBaseTool):
             )
             return _delegated_authorization_failed_result()
 
-        if not isinstance(refreshed, dict):
+        if not _is_executable_connection(refreshed):
             return _delegated_authorization_failed_result()
 
         try:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -131,8 +131,12 @@ def _exception_indicates_http_401(exc: BaseException) -> bool:
     return bool(_HTTP_401_TEXT_RE.search(text))
 
 
-def _delegated_authorization_failed_result() -> dict[str, Any]:
-    return {
+def _delegated_authorization_failed_result(
+    *, failure_code: object = None
+) -> dict[str, Any]:
+    from ....agent.result import normalize_tool_failure_code
+
+    result: dict[str, Any] = {
         "content": [
             {
                 "text": (
@@ -143,6 +147,10 @@ def _delegated_authorization_failed_result() -> dict[str, Any]:
         ],
         "is_error": True,
     }
+    normalized_failure_code = normalize_tool_failure_code(failure_code)
+    if normalized_failure_code is not None:
+        result["failure_code"] = normalized_failure_code
+    return result
 
 
 def _delegated_retry_failed_result() -> dict[str, Any]:
@@ -749,6 +757,13 @@ class MCPToolAdapter(AbstractBaseTool):
                 type(refresh_exc).__name__,
             )
             return _delegated_authorization_failed_result()
+
+        from ....agent.result import ClassifiedToolFailure
+
+        if isinstance(refreshed, ClassifiedToolFailure):
+            return _delegated_authorization_failed_result(
+                failure_code=refreshed.failure_code
+            )
 
         if not _is_executable_connection(refreshed):
             return _delegated_authorization_failed_result()

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -886,7 +886,9 @@ class MCPToolAdapter(AbstractBaseTool):
 class _UnavailableMCPToolResult(BaseModel):
     success: bool = Field(default=False, description="Whether execution succeeded")
     status: str = Field(default="error", description="Tool execution status")
-    error: str = Field(description="Public-safe tool failure message")
+    error: str | None = Field(
+        default=None, description="Public-safe tool failure message when available"
+    )
     failure_code: str | None = Field(
         default=None, description="Allowlisted public tool failure classification"
     )

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -703,7 +703,7 @@ class MCPToolAdapter(AbstractBaseTool):
         refreshed = refresh()
         if inspect.isawaitable(refreshed):
             refreshed = await refreshed
-        if not _is_executable_connection(refreshed):
+        if not isinstance(refreshed, dict):
             return _delegated_authorization_failed_result()
         try:
             return await self._execute_mcp_call(

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -870,6 +870,12 @@ class MCPToolAdapter(AbstractBaseTool):
 
 
 class _UnavailableMCPToolResult(BaseModel):
+    success: bool = Field(default=False, description="Whether execution succeeded")
+    status: str = Field(default="error", description="Tool execution status")
+    error: str = Field(description="Public-safe tool failure message")
+    failure_code: str | None = Field(
+        default=None, description="Allowlisted public tool failure classification"
+    )
     content: List[Dict[str, Any]] = Field(
         default_factory=list, description="Tool execution result content"
     )
@@ -891,13 +897,16 @@ class UnavailableMCPTool(AbstractBaseTool):
         server_name: str,
         server_id: Any | None,
         allow_users: Optional[List[str]] = None,
+        failure_code: str | None = None,
     ) -> None:
+        from ....agent.result import normalize_tool_failure_code
         from .base import ToolCategory
         from .selection_spec import normalize_mcp_server_name
 
         self._server_name = server_name
         self._server_id = server_id
         self._allow_users = allow_users
+        self._failure_code = normalize_tool_failure_code(failure_code)
         self._name = _format_unavailable_mcp_tool_name(server_name, server_id)
         self.source_server = normalize_mcp_server_name(server_name)
         self.category = ToolCategory.MCP
@@ -927,7 +936,10 @@ class UnavailableMCPTool(AbstractBaseTool):
         current_user_id = _get_current_mcp_user_id()
         if not _is_mcp_user_allowed(current_user_id, self._allow_users):
             return _mcp_access_denied_result(current_user_id, self.name)
-        return {
+        result: Dict[str, Any] = {
+            "success": False,
+            "status": "error",
+            "error": "MCP server credentials are unavailable.",
             "content": [
                 {
                     "text": (
@@ -938,6 +950,9 @@ class UnavailableMCPTool(AbstractBaseTool):
             ],
             "is_error": True,
         }
+        if self._failure_code is not None:
+            result["failure_code"] = self._failure_code
+        return result
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         return self._run_unavailable()

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -9,8 +9,10 @@ import inspect
 import logging
 import os
 import re
+from collections.abc import Iterator
 from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
 
+import httpx
 from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, Field, create_model
 
@@ -41,11 +43,62 @@ class EmptyArgsModel(BaseModel):
 
 logger = logging.getLogger(__name__)
 _RUNTIME_CONNECTION_REFRESH_KEY = "_connector_runtime_refresh"
+_OAUTH_TOKEN_RESOLVER_REFRESH_KEY = "_oauth_token_resolver_refresh"
+_RESOLVER_HTTP_401_NODE_LIMIT = 64
 _HTTP_401_TEXT_RE = re.compile(
     r"\b(?:http(?:\s+status)?|status(?:\s+code)?|response|code)\s*[:=]?\s*401\b|"
     r"\b401\s+unauthorized\b",
     re.IGNORECASE,
 )
+
+
+def _bounded_exception_nodes(
+    exc: BaseException, *, excluded_ids: set[int] | None = None
+) -> Iterator[BaseException]:
+    pending = [exc]
+    visited: set[int] = set(excluded_ids or ())
+    visited_count = 0
+    while pending and visited_count < _RESOLVER_HTTP_401_NODE_LIMIT:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+        visited_count += 1
+        yield current
+
+        linked: list[BaseException] = []
+        if isinstance(current, BaseExceptionGroup):
+            linked.extend(current.exceptions)
+        if isinstance(current.__cause__, BaseException):
+            linked.append(current.__cause__)
+        if isinstance(current.__context__, BaseException):
+            linked.append(current.__context__)
+        pending.extend(reversed(linked))
+
+
+def _strict_http_401_responses(
+    exc: BaseException, *, excluded_ids: set[int] | None = None
+) -> Iterator[httpx.Response]:
+    for current in _bounded_exception_nodes(exc, excluded_ids=excluded_ids):
+        if not isinstance(current, httpx.HTTPStatusError):
+            continue
+        response = current.response
+        if isinstance(response, httpx.Response) and response.status_code == 401:
+            yield response
+
+
+def _resolver_invalid_token_challenge(exc: BaseException) -> Any | None:
+    # Lazy import keeps the core adapter independent from the web layer at import time.
+    from .....web.services.mcp_oauth import parse_www_authenticate_bearer
+
+    for response in _strict_http_401_responses(exc):
+        challenge = parse_www_authenticate_bearer(
+            response.headers.get_list("WWW-Authenticate")
+        )
+        if challenge is not None and challenge.params.get("error") == "invalid_token":
+            return challenge
+    return None
 
 
 def _exception_indicates_http_401(exc: BaseException) -> bool:
@@ -616,6 +669,11 @@ class MCPToolAdapter(AbstractBaseTool):
         tool_args: Mapping[str, Any],
         tool_meta: Mapping[str, Any],
     ) -> dict[str, Any] | None:
+        if isinstance(self.connection, Mapping) and (
+            _OAUTH_TOKEN_RESOLVER_REFRESH_KEY in self.connection
+        ):
+            return await self._retry_resolver_401(exc, tool_args, tool_meta)
+
         if not _exception_indicates_http_401(exc):
             return None
         if not isinstance(self.connection, Mapping):
@@ -642,6 +700,65 @@ class MCPToolAdapter(AbstractBaseTool):
                 return _delegated_authorization_failed_result()
             logger.error(
                 "MCP tool %s delegated authorization retry failed with %s",
+                self.mcp_tool.name,
+                type(retry_exc).__name__,
+            )
+            return _delegated_retry_failed_result()
+
+    async def _retry_resolver_401(
+        self,
+        exc: BaseException,
+        tool_args: Mapping[str, Any],
+        tool_meta: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        strict_401 = next(_strict_http_401_responses(exc), None)
+        if strict_401 is None:
+            return None
+
+        challenge = _resolver_invalid_token_challenge(exc)
+        refresh = self.connection.get(_OAUTH_TOKEN_RESOLVER_REFRESH_KEY)
+        if challenge is None or not callable(refresh):
+            return _delegated_authorization_failed_result()
+
+        logger.info(
+            "Retrying MCP tool %s after resolver authorization failure",
+            self.mcp_tool.name,
+        )
+        try:
+            refreshed = refresh(challenge)
+            if inspect.isawaitable(refreshed):
+                refreshed = await refreshed
+        except (BaseExceptionGroup, Exception) as refresh_exc:
+            logger.error(
+                "MCP tool %s resolver authorization refresh failed with %s",
+                self.mcp_tool.name,
+                type(refresh_exc).__name__,
+            )
+            return _delegated_authorization_failed_result()
+
+        if not isinstance(refreshed, dict):
+            return _delegated_authorization_failed_result()
+
+        try:
+            return await self._execute_mcp_call(
+                cast(Connection, refreshed), tool_args, tool_meta
+            )
+        except (BaseExceptionGroup, Exception) as retry_exc:
+            original_exception_ids = {
+                id(node) for node in _bounded_exception_nodes(exc)
+            }
+            if (
+                next(
+                    _strict_http_401_responses(
+                        retry_exc, excluded_ids=original_exception_ids
+                    ),
+                    None,
+                )
+                is not None
+            ):
+                return _delegated_authorization_failed_result()
+            logger.error(
+                "MCP tool %s resolver authorization retry failed with %s",
                 self.mcp_tool.name,
                 type(retry_exc).__name__,
             )

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -104,15 +104,14 @@ def _resolver_invalid_token_challenge(exc: BaseException) -> Any | None:
     return None
 
 
-def _is_executable_connection(value: Any) -> bool:
+def _is_executable_remote_connection(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     transport = value.get("transport")
-    required_key = "command" if transport == "stdio" else "url"
-    if transport not in {"stdio", "sse", "streamable_http", "websocket"}:
+    if transport not in {"sse", "streamable_http", "websocket"}:
         return False
-    required_value = value.get(required_key)
-    return isinstance(required_value, str) and bool(required_value)
+    url = value.get("url")
+    return isinstance(url, str) and bool(url)
 
 
 def _exception_indicates_http_401(exc: BaseException) -> bool:
@@ -629,7 +628,7 @@ class MCPToolAdapter(AbstractBaseTool):
                         self.connection, tool_args, tool_meta
                     )
                 except (BaseExceptionGroup, Exception) as exc:
-                    retry_result = await self._retry_delegated_401(
+                    retry_result = await self._retry_after_authorization_failure(
                         exc, tool_args, tool_meta
                     )
                     if retry_result is not None:
@@ -685,7 +684,7 @@ class MCPToolAdapter(AbstractBaseTool):
                 "is_error": result.isError if hasattr(result, "isError") else False,
             }
 
-    async def _retry_delegated_401(
+    async def _retry_after_authorization_failure(
         self,
         exc: BaseException,
         tool_args: Mapping[str, Any],
@@ -765,7 +764,7 @@ class MCPToolAdapter(AbstractBaseTool):
                 failure_code=refreshed.failure_code
             )
 
-        if not _is_executable_connection(refreshed):
+        if not _is_executable_remote_connection(refreshed):
             return _delegated_authorization_failed_result()
 
         try:

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -220,13 +220,9 @@ async def build_mcp_runtime_connection(
             ),
         )
 
-    headers = headers_without_authorization(
-        connection.get("headers")
-        if isinstance(connection.get("headers"), dict)
-        else None
+    connection = connection_with_bearer_authorization(
+        connection, runtime_auth.access_token
     )
-    headers["Authorization"] = f"Bearer {runtime_auth.access_token}"
-    connection["headers"] = headers
     connection.pop("auth", None)
     return MCPRuntimeConnectionBuild(connection=connection)
 
@@ -246,6 +242,51 @@ def mcp_oauth_selection(
     """Return the runtime grant selection for one server."""
     selection = (mcp_auth_context or {}).get(str(server_id))
     return selection if isinstance(selection, dict) else {}
+
+
+def effective_mcp_oauth_resource(
+    server: Any, *, mcp_auth_context: dict[str, Any] | None
+) -> str | None:
+    """Select the first configured OAuth resource without normalizing it."""
+    server_id = getattr(server, "id", None)
+    selection = (
+        mcp_oauth_selection(mcp_auth_context, server_id)
+        if isinstance(server_id, int)
+        else {}
+    )
+    auth_config = server._decrypt_auth_config(getattr(server, "auth", None))
+    configured_resource = (
+        auth_config.get("resource") if isinstance(auth_config, dict) else None
+    )
+    for resource in (
+        selection.get("resource"),
+        configured_resource,
+        getattr(server, "url", None),
+    ):
+        if isinstance(resource, str) and resource:
+            return resource
+    return None
+
+
+def connection_without_authorization(
+    connection: dict[str, Any],
+) -> dict[str, Any]:
+    """Copy a connection and its headers while removing Authorization values."""
+    copied_connection = dict(connection)
+    raw_headers = connection.get("headers")
+    copied_connection["headers"] = headers_without_authorization(
+        raw_headers if isinstance(raw_headers, dict) else None
+    )
+    return copied_connection
+
+
+def connection_with_bearer_authorization(
+    connection: dict[str, Any], access_token: str
+) -> dict[str, Any]:
+    """Copy a connection and replace static authorization with a Bearer token."""
+    copied_connection = connection_without_authorization(connection)
+    copied_connection["headers"]["Authorization"] = f"Bearer {access_token}"
+    return copied_connection
 
 
 def headers_without_authorization(headers: dict[str, Any] | None) -> dict[str, Any]:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -815,8 +815,6 @@ class WebToolConfig(BaseToolConfig):
         runtime_bindings: Any,
         allow_delegated_authorization: bool,
     ) -> dict[str, Any] | None:
-        from ...web.services.mcp_runtime import headers_without_authorization
-
         delegated_headers = self._runtime_transport_headers(
             runtime_values=runtime_values,
             runtime_bindings=runtime_bindings,
@@ -824,14 +822,31 @@ class WebToolConfig(BaseToolConfig):
         )
         if not delegated_headers:
             return None
-        connection = dict(server.to_connection_dict())
-        headers = headers_without_authorization(
-            connection.get("headers")
-            if isinstance(connection.get("headers"), dict)
-            else None
+        connection = self._non_auth_mcp_connection(
+            server=server,
+            runtime_values=runtime_values,
+            runtime_bindings=runtime_bindings,
         )
-        headers.update(delegated_headers)
-        connection["headers"] = headers
+        connection["headers"].update(delegated_headers)
+        return connection
+
+    def _non_auth_mcp_connection(
+        self,
+        *,
+        server: Any,
+        runtime_values: Optional[Dict[str, Any]],
+        runtime_bindings: Any,
+    ) -> dict[str, Any]:
+        from ...web.services.mcp_runtime import connection_without_authorization
+
+        connection = connection_without_authorization(server.to_connection_dict())
+        connection["headers"].update(
+            self._runtime_transport_headers(
+                runtime_values=runtime_values,
+                runtime_bindings=runtime_bindings,
+                allow_delegated_authorization=False,
+            )
+        )
         connection.pop("auth", None)
         return connection
 
@@ -1301,8 +1316,10 @@ class WebToolConfig(BaseToolConfig):
         *,
         providers: list[str],
         resource: str | None,
+        resolver: TokenResolver | None = None,
     ) -> _ResolvedHookToken | None:
-        resolver, _ = _get_oauth_token_resolver_hook()
+        if resolver is None:
+            resolver, _ = _get_oauth_token_resolver_hook()
         if resolver is None or not providers or self._user_id is None:
             return None
 
@@ -1337,6 +1354,113 @@ class WebToolConfig(BaseToolConfig):
             )
 
         return None
+
+    async def _refresh_resolver_owned_mcp_connection(
+        self,
+        *,
+        challenge: object,
+        resolver: TokenResolver,
+        registration_generation: int,
+        provider: str,
+        providers: list[str],
+        user_id: int,
+        scope: Any,
+        resource: str | None,
+        failed_generation: str | None,
+        non_auth_connection: dict[str, Any],
+        refresh_callback: Callable[[object], Awaitable[dict[str, Any] | None]],
+    ) -> dict[str, Any] | None:
+        from ...web.services.mcp_oauth import MCPAuthorizationChallenge
+        from ...web.services.mcp_runtime import connection_with_bearer_authorization
+
+        if not isinstance(challenge, MCPAuthorizationChallenge):
+            return None
+        current_resolver, current_generation = _get_oauth_token_resolver_hook()
+        if (
+            current_resolver is not resolver
+            or current_generation != registration_generation
+        ):
+            return None
+
+        request = TokenRequest(
+            provider=provider,
+            user_id=user_id,
+            scope=scope,
+            resource=resource,
+            refresh=OAuthRefreshContext(
+                reason="invalid_token",
+                resource_metadata_url=challenge.resource_metadata_url,
+                challenge_scope=challenge.scope,
+                failed_generation=failed_generation,
+            ),
+        )
+        try:
+            resolved = await _maybe_await_oauth_token_resolver_result(resolver(request))
+        except Exception:
+            return None
+
+        current_resolver, current_generation = _get_oauth_token_resolver_hook()
+        if (
+            current_resolver is not resolver
+            or current_generation != registration_generation
+            or resolved is None
+        ):
+            return None
+        try:
+            normalized = self._normalize_resolved_oauth_token_from_hook(
+                provider=provider,
+                providers=providers,
+                resource=resource,
+                resolved=resolved,
+            )
+        except _OAuthTokenResolverFailed:
+            return None
+        if normalized.generation is None or normalized.generation == failed_generation:
+            return None
+
+        connection = connection_with_bearer_authorization(
+            non_auth_connection, normalized.access_token
+        )
+        connection["_oauth_token_resolver_refresh"] = refresh_callback
+        connection.pop("_connector_runtime_refresh", None)
+        return connection
+
+    def _resolver_owned_mcp_connection(
+        self,
+        *,
+        resolver: TokenResolver,
+        registration_generation: int,
+        resolved: _ResolvedHookToken,
+        providers: list[str],
+        resource: str | None,
+        non_auth_connection: dict[str, Any],
+    ) -> dict[str, Any]:
+        from ...web.services.mcp_runtime import connection_with_bearer_authorization
+
+        user_id = int(self._user_id)
+        scope = self.get_execution_scope()
+
+        async def refresh(challenge: object) -> dict[str, Any] | None:
+            return await self._refresh_resolver_owned_mcp_connection(
+                challenge=challenge,
+                resolver=resolver,
+                registration_generation=registration_generation,
+                provider=resolved.provider,
+                providers=providers,
+                user_id=user_id,
+                scope=scope,
+                resource=resource,
+                failed_generation=resolved.generation,
+                non_auth_connection=non_auth_connection,
+                refresh_callback=refresh,
+            )
+
+        connection = connection_with_bearer_authorization(
+            non_auth_connection, resolved.access_token
+        )
+        connection["_oauth_token_resolver_refresh"] = refresh
+        connection.pop("_connector_runtime_refresh", None)
+        return connection
 
     def _normalize_resolved_oauth_token_from_hook(
         self,
@@ -1430,6 +1554,28 @@ class WebToolConfig(BaseToolConfig):
         if error.actor_id:
             diagnostic["actor_id"] = error.actor_id
         return diagnostic
+
+    def _resolver_failure_config(
+        self,
+        *,
+        server: Any,
+        error: _OAuthTokenResolverFailed,
+    ) -> Dict[str, Any]:
+        self._mcp_hook_resolution_failed = True
+        diagnostic = self._build_oauth_token_resolver_diagnostic(
+            server=server,
+            error=error,
+        )
+        self._mcp_oauth_diagnostics.append(diagnostic)
+        logger.warning(
+            "OAuth token resolver failed for MCP server '%s' with %s",
+            getattr(server, "name", "<unknown>"),
+            error.exception_type,
+        )
+        return self._build_unavailable_oauth_mcp_config(
+            server=server,
+            diagnostic=diagnostic,
+        )
 
     def _build_unavailable_oauth_mcp_config(
         self,
@@ -1597,23 +1743,10 @@ class WebToolConfig(BaseToolConfig):
                                 resource=configured_resource,
                             )
                         except _OAuthTokenResolverFailed as error:
-                            self._mcp_hook_resolution_failed = True
-                            diagnostic = self._build_oauth_token_resolver_diagnostic(
-                                server=server,
-                                error=error,
-                            )
-                            self._mcp_oauth_diagnostics.append(diagnostic)
-                            # Do not log the resolver exception message or
-                            # traceback here; they can contain token material.
-                            logger.warning(
-                                "OAuth token resolver failed for MCP server '%s' with %s",
-                                getattr(server, "name", "<unknown>"),
-                                error.exception_type,
-                            )
                             configs.append(
-                                self._build_unavailable_oauth_mcp_config(
+                                self._resolver_failure_config(
                                     server=server,
-                                    diagnostic=diagnostic,
+                                    error=error,
                                 )
                             )
                             continue
@@ -1737,51 +1870,100 @@ class WebToolConfig(BaseToolConfig):
                         transport_config["cwd"] = server.cwd
 
                 elif server.transport in ["sse", "websocket", "streamable_http"]:
+                    from ...web.mcp_apps import get_app_by_name
                     from ...web.services.mcp_runtime import (
                         build_mcp_runtime_connection,
                         connection_to_transport_config,
+                        effective_mcp_oauth_resource,
                     )
 
-                    delegated_connection = self._delegated_mcp_connection(
-                        server=server,
+                    auth_context = self._mcp_auth_context_for_server(
+                        server_id=int(server.id),
                         runtime_values=runtime_values,
-                        runtime_bindings=runtime_bindings,
-                        allow_delegated_authorization=allow_delegated_authorization,
                     )
-                    if delegated_connection:
-                        delegated_connection["_connector_runtime_refresh"] = (
-                            lambda _server=server,
-                            _runtime_bindings=runtime_bindings,
-                            _allow_delegated_authorization=allow_delegated_authorization: (
-                                self._refresh_delegated_mcp_connection(
-                                    server=_server,
-                                    runtime_bindings=_runtime_bindings,
-                                    allow_delegated_authorization=_allow_delegated_authorization,
+                    app_info = get_app_by_name(self.db, str(server.name))
+                    providers_to_resolve = (
+                        _oauth_token_provider_candidates(app_info) if app_info else []
+                    )
+                    configured_resource = effective_mcp_oauth_resource(
+                        server,
+                        mcp_auth_context=auth_context,
+                    )
+                    resolver, registration_generation = _get_oauth_token_resolver_hook()
+                    remote_hook_token: _ResolvedHookToken | None = None
+                    if resolver is not None and providers_to_resolve:
+                        try:
+                            remote_hook_token = (
+                                await self._resolve_oauth_token_from_hook(
+                                    providers=providers_to_resolve,
+                                    resource=configured_resource,
+                                    resolver=resolver,
                                 )
                             )
-                        )
-                        transport_config.update(
-                            connection_to_transport_config(delegated_connection)
-                        )
-                    else:
-                        runtime_build = await build_mcp_runtime_connection(
-                            self.db,
-                            server,
-                            user_id=self._user_id,
-                            mcp_auth_context=self._mcp_auth_context_for_server(
-                                server_id=int(server.id),
+                        except _OAuthTokenResolverFailed as error:
+                            configs.append(
+                                self._resolver_failure_config(
+                                    server=server,
+                                    error=error,
+                                )
+                            )
+                            continue
+
+                    if remote_hook_token is not None and resolver is not None:
+                        self._mark_hook_token_cache_metadata(remote_hook_token)
+                        resolver_connection = self._resolver_owned_mcp_connection(
+                            resolver=resolver,
+                            registration_generation=registration_generation,
+                            resolved=remote_hook_token,
+                            providers=providers_to_resolve,
+                            resource=configured_resource,
+                            non_auth_connection=self._non_auth_mcp_connection(
+                                server=server,
                                 runtime_values=runtime_values,
+                                runtime_bindings=runtime_bindings,
                             ),
                         )
-                        if runtime_build.connection is None:
-                            if runtime_build.diagnostic is not None:
-                                self._mcp_oauth_diagnostics.append(
-                                    runtime_build.diagnostic
-                                )
-                            continue
                         transport_config.update(
-                            connection_to_transport_config(runtime_build.connection)
+                            connection_to_transport_config(resolver_connection)
                         )
+                    else:
+                        delegated_connection = self._delegated_mcp_connection(
+                            server=server,
+                            runtime_values=runtime_values,
+                            runtime_bindings=runtime_bindings,
+                            allow_delegated_authorization=allow_delegated_authorization,
+                        )
+                        if delegated_connection:
+                            delegated_connection["_connector_runtime_refresh"] = (
+                                lambda _server=server,
+                                _runtime_bindings=runtime_bindings,
+                                _allow_delegated_authorization=allow_delegated_authorization: (
+                                    self._refresh_delegated_mcp_connection(
+                                        server=_server,
+                                        runtime_bindings=_runtime_bindings,
+                                        allow_delegated_authorization=_allow_delegated_authorization,
+                                    )
+                                )
+                            )
+                            transport_config.update(
+                                connection_to_transport_config(delegated_connection)
+                            )
+                        else:
+                            runtime_build = await build_mcp_runtime_connection(
+                                self.db,
+                                server,
+                                user_id=self._user_id,
+                                mcp_auth_context=auth_context,
+                            )
+                            if runtime_build.connection is None:
+                                if runtime_build.diagnostic is not None:
+                                    self._mcp_oauth_diagnostics.append(
+                                        runtime_build.diagnostic
+                                    )
+                                continue
+                            transport_config.update(
+                                connection_to_transport_config(runtime_build.connection)
+                            )
 
                 transport_config["concurrency_safe"] = bool(
                     getattr(server, "concurrency_safe", False)

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -62,11 +62,12 @@ class OAuthRefreshContext:
 class TokenRequest:
     """Request passed to the OAuth token resolver hook.
 
-    Providers are requested in the same candidate order used by the built-in
-    UserOAuth lookup: provider name first, then app id, de-duplicated. The
-    first resolver hit wins. ``resource`` is the configured MCP OAuth resource
-    URI for the current app/server when present, passed verbatim without
-    canonicalization. ``scope`` is the current execution scope from
+    Registered MCP apps use provider name followed by app id, de-duplicated.
+    Remote MCP servers without a matching app use the server name as a neutral
+    compatibility candidate; embedders must not treat that name as an identity
+    boundary. The first resolver hit wins. ``resource`` is the configured MCP
+    OAuth resource URI for the current app/server when present, passed verbatim
+    without canonicalization. ``scope`` is the current execution scope from
     ``WebToolConfig.get_execution_scope()`` when present; it is typed as
     Optional[Any] to avoid importing the core scope type into this config layer.
     """
@@ -1378,7 +1379,10 @@ class WebToolConfig(BaseToolConfig):
     ) -> dict[str, Any] | None:
         from ...web.services.mcp_oauth import MCPAuthorizationChallenge
 
-        if not isinstance(challenge, MCPAuthorizationChallenge):
+        if (
+            not isinstance(challenge, MCPAuthorizationChallenge)
+            or failed_generation is None
+        ):
             return None
         current_resolver, current_generation = _get_oauth_token_resolver_hook()
         if (
@@ -1914,7 +1918,9 @@ class WebToolConfig(BaseToolConfig):
                     )
                     app_info = get_app_by_name(self.db, str(server.name))
                     providers_to_resolve = (
-                        _oauth_token_provider_candidates(app_info) if app_info else []
+                        _oauth_token_provider_candidates(app_info)
+                        if app_info
+                        else [str(server.name)]
                     )
                     configured_resource = effective_mcp_oauth_resource(
                         server,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -18,6 +18,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Literal, Mapping, Optio
 import httpx
 
 from ...config import get_uploads_dir
+from ...core.agent.result import normalize_tool_failure_code
 from ...core.tools.adapters.vibe.config import (
     BaseToolConfig,
     normalize_tool_allowlist,
@@ -145,12 +146,14 @@ class _OAuthTokenResolverFailed(Exception):
         exception_type: str,
         resource: str | None = None,
         actor_id: str | None = None,
+        failure_code: str | None = None,
     ) -> None:
         super().__init__(OAUTH_TOKEN_RESOLVER_FAILURE_CODE)
         self.providers = providers
         self.exception_type = exception_type
         self.resource = resource
         self.actor_id = actor_id
+        self.failure_code = normalize_tool_failure_code(failure_code)
 
 
 class _OAuthLaunchConfigInvalid(Exception):
@@ -174,6 +177,14 @@ def _extract_oauth_token_resolver_diagnostic_actor_id(exc: Exception) -> str | N
         return _bounded_oauth_metadata(raw_actor_id)
     except Exception:
         return None
+
+
+def _extract_oauth_token_resolver_failure_code(exc: Exception) -> str | None:
+    try:
+        raw_failure_code = getattr(exc, "oauth_token_resolver_failure_code", None)
+    except Exception:
+        return None
+    return normalize_tool_failure_code(raw_failure_code)
 
 
 def _normalize_oauth_expires_at(expires_at: datetime | None) -> datetime | None:
@@ -1350,6 +1361,7 @@ class WebToolConfig(BaseToolConfig):
                     exception_type=_bounded_oauth_metadata(type(exc).__name__),
                     resource=resource,
                     actor_id=_extract_oauth_token_resolver_diagnostic_actor_id(exc),
+                    failure_code=_extract_oauth_token_resolver_failure_code(exc),
                 ) from exc
 
             if resolved is None:
@@ -1610,6 +1622,7 @@ class WebToolConfig(BaseToolConfig):
         return self._build_unavailable_oauth_mcp_config(
             server=server,
             diagnostic=diagnostic,
+            failure_code=error.failure_code,
         )
 
     def _build_unavailable_oauth_mcp_config(
@@ -1617,18 +1630,22 @@ class WebToolConfig(BaseToolConfig):
         *,
         server: Any,
         diagnostic: Dict[str, Any],
+        failure_code: str | None,
     ) -> Dict[str, Any]:
+        inner_config: Dict[str, Any] = {
+            "unavailable": True,
+            "reason": OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
+            "message": UNAVAILABLE_MCP_CREDENTIAL_MESSAGE,
+            "server_id": getattr(server, "id", None),
+            "diagnostic": diagnostic,
+        }
+        if failure_code is not None:
+            inner_config["failure_code"] = failure_code
         return {
             "name": server.name,
             "transport": "unavailable",
             "description": server.description,
-            "config": {
-                "unavailable": True,
-                "reason": OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
-                "message": UNAVAILABLE_MCP_CREDENTIAL_MESSAGE,
-                "server_id": getattr(server, "id", None),
-                "diagnostic": diagnostic,
-            },
+            "config": inner_config,
             "user_id": str(self._user_id),
             "allow_users": [str(self._user_id)],
         }

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -9,10 +9,10 @@ import inspect
 import logging
 import os
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Mapping, Optional
 
 import httpx
 
@@ -43,9 +43,18 @@ logger = logging.getLogger(__name__)
 
 
 OAUTH_TOKEN_EXPIRY_SKEW = timedelta(minutes=5)
+OAUTH_TOKEN_GENERATION_MAX_LENGTH = 1024
 OAUTH_TOKEN_RESOLVER_FAILURE_CODE = "oauth_token_resolver_failed"
 OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE = "OAuth token resolver failed"
 UNAVAILABLE_MCP_CREDENTIAL_MESSAGE = "MCP server credentials are unavailable."
+
+
+@dataclass(frozen=True)
+class OAuthRefreshContext:
+    reason: Literal["invalid_token"]
+    resource_metadata_url: str | None
+    challenge_scope: str | None
+    failed_generation: str | None = field(repr=False)
 
 
 @dataclass(frozen=True)
@@ -65,6 +74,7 @@ class TokenRequest:
     user_id: int
     scope: Optional[Any] = None
     resource: str | None = None
+    refresh: OAuthRefreshContext | None = None
 
 
 @dataclass(frozen=True)
@@ -78,8 +88,9 @@ class ResolvedToken:
     and this ``WebToolConfig`` instance will reload MCP configs on later calls.
     """
 
-    access_token: str
+    access_token: str = field(repr=False)
     expires_at: datetime | None = None
+    generation: str | None = field(default=None, repr=False)
 
 
 TokenResolverResult = ResolvedToken | Awaitable[ResolvedToken | None] | None
@@ -119,8 +130,9 @@ async def _maybe_await_oauth_token_resolver_result(result: object) -> object:
 @dataclass(frozen=True)
 class _ResolvedHookToken:
     provider: str
-    access_token: str
+    access_token: str = field(repr=False)
     expires_at: datetime | None
+    generation: str | None = field(repr=False)
 
 
 class _OAuthTokenResolverFailed(Exception):
@@ -1354,6 +1366,16 @@ class WebToolConfig(BaseToolConfig):
                 exception_type="InvalidExpiresAt",
                 resource=resource,
             )
+        if resolved.generation is not None and (
+            type(resolved.generation) is not str
+            or not resolved.generation
+            or len(resolved.generation) > OAUTH_TOKEN_GENERATION_MAX_LENGTH
+        ):
+            raise _OAuthTokenResolverFailed(
+                providers=providers,
+                exception_type="InvalidGeneration",
+                resource=resource,
+            )
 
         expires_at = _normalize_oauth_expires_at(resolved.expires_at)
         if expires_at is not None and _oauth_token_is_expired(expires_at):
@@ -1367,6 +1389,7 @@ class WebToolConfig(BaseToolConfig):
             provider=provider,
             access_token=resolved.access_token,
             expires_at=expires_at,
+            generation=resolved.generation,
         )
 
     def _mark_hook_token_cache_metadata(self, resolved: _ResolvedHookToken) -> None:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1464,30 +1464,6 @@ class WebToolConfig(BaseToolConfig):
             non_auth_connection=non_auth_connection,
         )
 
-    def _resolver_owned_mcp_connection(
-        self,
-        *,
-        resolver: TokenResolver,
-        registration_generation: int,
-        resolved: _ResolvedHookToken,
-        providers: list[str],
-        resource: str | None,
-        non_auth_connection: dict[str, Any],
-    ) -> dict[str, Any]:
-        user_id = int(self._user_id)
-        scope = self.get_execution_scope()
-
-        return self._build_resolver_owned_mcp_connection(
-            resolver=resolver,
-            registration_generation=registration_generation,
-            resolved=resolved,
-            providers=providers,
-            user_id=user_id,
-            scope=scope,
-            resource=resource,
-            non_auth_connection=non_auth_connection,
-        )
-
     def _build_resolver_owned_mcp_connection(
         self,
         *,
@@ -1981,11 +1957,13 @@ class WebToolConfig(BaseToolConfig):
 
                     if remote_hook_token is not None and resolver is not None:
                         self._mark_hook_token_cache_metadata(remote_hook_token)
-                        resolver_connection = self._resolver_owned_mcp_connection(
+                        resolver_connection = self._build_resolver_owned_mcp_connection(
                             resolver=resolver,
                             registration_generation=registration_generation,
                             resolved=remote_hook_token,
                             providers=providers_to_resolve,
+                            user_id=int(self._user_id),
+                            scope=self.get_execution_scope(),
                             resource=configured_resource,
                             non_auth_connection=self._non_auth_mcp_connection(
                                 server=server,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -11,6 +11,7 @@ import os
 import shlex
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Literal, Mapping, Optional
 
@@ -1965,14 +1966,11 @@ class WebToolConfig(BaseToolConfig):
                         )
                         if delegated_connection:
                             delegated_connection["_connector_runtime_refresh"] = (
-                                lambda _server=server,
-                                _runtime_bindings=runtime_bindings,
-                                _allow_delegated_authorization=allow_delegated_authorization: (
-                                    self._refresh_delegated_mcp_connection(
-                                        server=_server,
-                                        runtime_bindings=_runtime_bindings,
-                                        allow_delegated_authorization=_allow_delegated_authorization,
-                                    )
+                                partial(
+                                    self._refresh_delegated_mcp_connection,
+                                    server=server,
+                                    runtime_bindings=runtime_bindings,
+                                    allow_delegated_authorization=allow_delegated_authorization,
                                 )
                             )
                             transport_config.update(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -775,6 +775,7 @@ class WebToolConfig(BaseToolConfig):
         runtime_values: Optional[Dict[str, Any]],
         runtime_bindings: Any,
         allow_delegated_authorization: bool,
+        warn_on_rejected_authorization: bool = True,
     ) -> Dict[str, str]:
         if not isinstance(runtime_values, dict):
             return {}
@@ -792,10 +793,11 @@ class WebToolConfig(BaseToolConfig):
                 header_name.lower() == "authorization"
                 and not allow_delegated_authorization
             ):
-                logger.warning(
-                    "Ignoring runtime MCP Authorization header binding because "
-                    "delegated authorization is disabled"
-                )
+                if warn_on_rejected_authorization:
+                    logger.warning(
+                        "Ignoring runtime MCP Authorization header binding because "
+                        "delegated authorization is disabled"
+                    )
                 continue
             value = binding_source_value(
                 binding,
@@ -822,12 +824,19 @@ class WebToolConfig(BaseToolConfig):
         )
         if not delegated_headers:
             return None
-        connection = self._non_auth_mcp_connection(
-            server=server,
-            runtime_values=runtime_values,
-            runtime_bindings=runtime_bindings,
+        return self._mcp_connection_with_runtime_headers(
+            server=server, runtime_headers=delegated_headers
         )
-        connection["headers"].update(delegated_headers)
+
+    @staticmethod
+    def _mcp_connection_with_runtime_headers(
+        *, server: Any, runtime_headers: Mapping[str, str]
+    ) -> dict[str, Any]:
+        from ...web.services.mcp_runtime import connection_without_authorization
+
+        connection = connection_without_authorization(server.to_connection_dict())
+        connection["headers"].update(runtime_headers)
+        connection.pop("auth", None)
         return connection
 
     def _non_auth_mcp_connection(
@@ -837,18 +846,15 @@ class WebToolConfig(BaseToolConfig):
         runtime_values: Optional[Dict[str, Any]],
         runtime_bindings: Any,
     ) -> dict[str, Any]:
-        from ...web.services.mcp_runtime import connection_without_authorization
-
-        connection = connection_without_authorization(server.to_connection_dict())
-        connection["headers"].update(
-            self._runtime_transport_headers(
-                runtime_values=runtime_values,
-                runtime_bindings=runtime_bindings,
-                allow_delegated_authorization=False,
-            )
+        runtime_headers = self._runtime_transport_headers(
+            runtime_values=runtime_values,
+            runtime_bindings=runtime_bindings,
+            allow_delegated_authorization=False,
+            warn_on_rejected_authorization=False,
         )
-        connection.pop("auth", None)
-        return connection
+        return self._mcp_connection_with_runtime_headers(
+            server=server, runtime_headers=runtime_headers
+        )
 
     def _refresh_delegated_mcp_connection(
         self,
@@ -1368,10 +1374,8 @@ class WebToolConfig(BaseToolConfig):
         resource: str | None,
         failed_generation: str | None,
         non_auth_connection: dict[str, Any],
-        refresh_callback: Callable[[object], Awaitable[dict[str, Any] | None]],
     ) -> dict[str, Any] | None:
         from ...web.services.mcp_oauth import MCPAuthorizationChallenge
-        from ...web.services.mcp_runtime import connection_with_bearer_authorization
 
         if not isinstance(challenge, MCPAuthorizationChallenge):
             return None
@@ -1418,12 +1422,16 @@ class WebToolConfig(BaseToolConfig):
         if normalized.generation is None or normalized.generation == failed_generation:
             return None
 
-        connection = connection_with_bearer_authorization(
-            non_auth_connection, normalized.access_token
+        return self._build_resolver_owned_mcp_connection(
+            resolver=resolver,
+            registration_generation=registration_generation,
+            resolved=normalized,
+            providers=providers,
+            user_id=user_id,
+            scope=scope,
+            resource=resource,
+            non_auth_connection=non_auth_connection,
         )
-        connection["_oauth_token_resolver_refresh"] = refresh_callback
-        connection.pop("_connector_runtime_refresh", None)
-        return connection
 
     def _resolver_owned_mcp_connection(
         self,
@@ -1435,10 +1443,33 @@ class WebToolConfig(BaseToolConfig):
         resource: str | None,
         non_auth_connection: dict[str, Any],
     ) -> dict[str, Any]:
-        from ...web.services.mcp_runtime import connection_with_bearer_authorization
-
         user_id = int(self._user_id)
         scope = self.get_execution_scope()
+
+        return self._build_resolver_owned_mcp_connection(
+            resolver=resolver,
+            registration_generation=registration_generation,
+            resolved=resolved,
+            providers=providers,
+            user_id=user_id,
+            scope=scope,
+            resource=resource,
+            non_auth_connection=non_auth_connection,
+        )
+
+    def _build_resolver_owned_mcp_connection(
+        self,
+        *,
+        resolver: TokenResolver,
+        registration_generation: int,
+        resolved: _ResolvedHookToken,
+        providers: list[str],
+        user_id: int,
+        scope: Any,
+        resource: str | None,
+        non_auth_connection: dict[str, Any],
+    ) -> dict[str, Any]:
+        from ...web.services.mcp_runtime import connection_with_bearer_authorization
 
         async def refresh(challenge: object) -> dict[str, Any] | None:
             return await self._refresh_resolver_owned_mcp_connection(
@@ -1452,7 +1483,6 @@ class WebToolConfig(BaseToolConfig):
                 resource=resource,
                 failed_generation=resolved.generation,
                 non_auth_connection=non_auth_connection,
-                refresh_callback=refresh,
             )
 
         connection = connection_with_bearer_authorization(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1925,35 +1925,38 @@ class WebToolConfig(BaseToolConfig):
                         server_id=int(server.id),
                         runtime_values=runtime_values,
                     )
-                    app_info = get_app_by_name(self.db, str(server.name))
-                    providers_to_resolve = (
-                        _oauth_token_provider_candidates(app_info)
-                        if app_info
-                        else [str(server.name)]
-                    )
-                    configured_resource = effective_mcp_oauth_resource(
-                        server,
-                        mcp_auth_context=auth_context,
-                    )
                     resolver, registration_generation = _get_oauth_token_resolver_hook()
+                    remote_providers_to_resolve: list[str] = []
+                    remote_configured_resource: str | None = None
                     remote_hook_token: _ResolvedHookToken | None = None
-                    if resolver is not None and providers_to_resolve:
-                        try:
-                            remote_hook_token = (
-                                await self._resolve_oauth_token_from_hook(
-                                    providers=providers_to_resolve,
-                                    resource=configured_resource,
-                                    resolver=resolver,
+                    if resolver is not None:
+                        app_info = get_app_by_name(self.db, str(server.name))
+                        remote_providers_to_resolve = (
+                            _oauth_token_provider_candidates(app_info)
+                            if app_info
+                            else [str(server.name)]
+                        )
+                        remote_configured_resource = effective_mcp_oauth_resource(
+                            server,
+                            mcp_auth_context=auth_context,
+                        )
+                        if remote_providers_to_resolve:
+                            try:
+                                remote_hook_token = (
+                                    await self._resolve_oauth_token_from_hook(
+                                        providers=remote_providers_to_resolve,
+                                        resource=remote_configured_resource,
+                                        resolver=resolver,
+                                    )
                                 )
-                            )
-                        except _OAuthTokenResolverFailed as error:
-                            configs.append(
-                                self._resolver_failure_config(
-                                    server=server,
-                                    error=error,
+                            except _OAuthTokenResolverFailed as error:
+                                configs.append(
+                                    self._resolver_failure_config(
+                                        server=server,
+                                        error=error,
+                                    )
                                 )
-                            )
-                            continue
+                                continue
 
                     if remote_hook_token is not None and resolver is not None:
                         self._mark_hook_token_cache_metadata(remote_hook_token)
@@ -1961,10 +1964,10 @@ class WebToolConfig(BaseToolConfig):
                             resolver=resolver,
                             registration_generation=registration_generation,
                             resolved=remote_hook_token,
-                            providers=providers_to_resolve,
+                            providers=remote_providers_to_resolve,
                             user_id=int(self._user_id),
                             scope=self.get_execution_scope(),
-                            resource=configured_resource,
+                            resource=remote_configured_resource,
                             non_auth_connection=self._non_auth_mcp_connection(
                                 server=server,
                                 runtime_values=runtime_values,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -18,7 +18,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Literal, Mapping, Optio
 import httpx
 
 from ...config import get_uploads_dir
-from ...core.agent.result import normalize_tool_failure_code
+from ...core.agent.result import ClassifiedToolFailure, normalize_tool_failure_code
 from ...core.tools.adapters.vibe.config import (
     BaseToolConfig,
     normalize_tool_allowlist,
@@ -122,6 +122,15 @@ def set_oauth_token_resolver_hook(resolver: TokenResolver | None) -> None:
 
 def _get_oauth_token_resolver_hook() -> tuple[TokenResolver | None, int]:
     return _oauth_token_resolver_hook, _oauth_token_resolver_generation
+
+
+def _oauth_token_resolver_registration_matches(
+    resolver: TokenResolver, registration_generation: int
+) -> bool:
+    current_resolver, current_generation = _get_oauth_token_resolver_hook()
+    return (
+        current_resolver is resolver and current_generation == registration_generation
+    )
 
 
 async def _maybe_await_oauth_token_resolver_result(result: object) -> object:
@@ -1388,7 +1397,7 @@ class WebToolConfig(BaseToolConfig):
         resource: str | None,
         failed_generation: str | None,
         non_auth_connection: dict[str, Any],
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, Any] | ClassifiedToolFailure | None:
         from ...web.services.mcp_oauth import MCPAuthorizationChallenge
 
         if (
@@ -1396,10 +1405,8 @@ class WebToolConfig(BaseToolConfig):
             or failed_generation is None
         ):
             return None
-        current_resolver, current_generation = _get_oauth_token_resolver_hook()
-        if (
-            current_resolver is not resolver
-            or current_generation != registration_generation
+        if not _oauth_token_resolver_registration_matches(
+            resolver, registration_generation
         ):
             return None
 
@@ -1417,13 +1424,20 @@ class WebToolConfig(BaseToolConfig):
         )
         try:
             resolved = await _maybe_await_oauth_token_resolver_result(resolver(request))
-        except Exception:
+        except Exception as exc:
+            if not _oauth_token_resolver_registration_matches(
+                resolver, registration_generation
+            ):
+                return None
+            failure_code = _extract_oauth_token_resolver_failure_code(exc)
+            if failure_code is not None:
+                return ClassifiedToolFailure(failure_code=failure_code)
             return None
 
-        current_resolver, current_generation = _get_oauth_token_resolver_hook()
         if (
-            current_resolver is not resolver
-            or current_generation != registration_generation
+            not _oauth_token_resolver_registration_matches(
+                resolver, registration_generation
+            )
             or resolved is None
         ):
             return None
@@ -1488,7 +1502,9 @@ class WebToolConfig(BaseToolConfig):
     ) -> dict[str, Any]:
         from ...web.services.mcp_runtime import connection_with_bearer_authorization
 
-        async def refresh(challenge: object) -> dict[str, Any] | None:
+        async def refresh(
+            challenge: object,
+        ) -> dict[str, Any] | ClassifiedToolFailure | None:
             return await self._refresh_resolver_owned_mcp_connection(
                 challenge=challenge,
                 resolver=resolver,

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -219,6 +219,21 @@ class StatusErrorResultTool:
         return {"status": "error", "message": f"failed with {args}"}
 
 
+class IsErrorResultTool:
+    def __init__(self) -> None:
+        class Metadata:
+            name = "is_error_result"
+            description = "Returns an MCP-style is_error result."
+
+        self.metadata = Metadata()
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        return {
+            "is_error": True,
+            "content": [{"text": f"failed with {args}"}],
+        }
+
+
 class FakeAskUserTool:
     def __init__(self) -> None:
         class Metadata:
@@ -2869,6 +2884,51 @@ async def test_react_pattern_status_error_tool_result_is_failed() -> None:
     assert pattern.tool_ledger["call_status_error_result"].status == "failed"
     event_types = {event["event_type"] for event in tracer.events}
     assert "action_error_tool" in event_types
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_mcp_is_error_result_is_failed_without_failure_code() -> (
+    None
+):
+    tracer = TraceEventRecorder()
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Use failing MCP tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_is_error_result",
+                        "function": {
+                            "name": "is_error_result",
+                            "arguments": '{"value":3}',
+                        },
+                    }
+                ],
+            },
+            {"content": "Recovered after MCP tool failure."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(execution_id="is-error-result")
+    context.add_user_message("Recover")
+    runtime = PatternRuntime(tracer=tracer)
+
+    result = await pattern.run(
+        context=context,
+        tools=[IsErrorResultTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    tool_message = context.get_messages_by_role("tool")[0]
+    assert tool_message.metadata["raw_result"]["is_error"] is True
+    assert pattern.tool_ledger["call_is_error_result"].status == "failed"
+    failure_events = [
+        event for event in tracer.events if event["event_type"] == "action_error_tool"
+    ]
+    assert len(failure_events) == 1
+    assert "failure_code" not in failure_events[0]["data"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -2908,7 +2908,7 @@ async def test_react_pattern_mcp_is_error_result_is_failed_without_failure_code(
             {"content": "Recovered after MCP tool failure."},
         ]
     )
-    pattern = ReActPattern(max_iterations=3)
+    pattern = ReActPattern(max_iterations=3, finalize_after_tool_result=True)
     context = ExecutionContext(execution_id="is-error-result")
     context.add_user_message("Recover")
     runtime = PatternRuntime(tracer=tracer)
@@ -2924,6 +2924,7 @@ async def test_react_pattern_mcp_is_error_result_is_failed_without_failure_code(
     tool_message = context.get_messages_by_role("tool")[0]
     assert tool_message.metadata["raw_result"]["is_error"] is True
     assert pattern.tool_ledger["call_is_error_result"].status == "failed"
+    assert llm.calls[1]["tools"] is not None
     failure_events = [
         event for event in tracer.events if event["event_type"] == "action_error_tool"
     ]

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -284,6 +284,22 @@ async def test_concurrent_batch_updates_consecutive_group_count() -> None:
     assert pattern._consecutive_successful_tool_group_count(group) == 3
 
 
+async def test_mcp_error_result_stops_consecutive_successful_group_count() -> None:
+    group = "search"
+    tool = FakeTool("s1", concurrency_safe=True, decision_group=group)
+    pattern = make_react(parallel=True)
+    pattern._tool_decision_groups_by_name = pattern._tool_decision_groups_for_tools(
+        [tool]
+    )
+    pattern._record_tool_call(
+        make_tool_call("s1"),
+        status="completed",
+        result={"content": [{"text": "failed"}], "is_error": True},
+    )
+
+    assert pattern._consecutive_successful_tool_group_count(group) == 0
+
+
 async def test_concurrent_batch_with_failure_counts_work_calls() -> None:
     tools = [
         FakeTool("s1", concurrency_safe=True),

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -172,6 +172,23 @@ async def test_concurrent_batch_then_unsafe_serial_preserves_order() -> None:
     assert "before_tool" in statuses  # u1 serial
 
 
+async def test_concurrent_mcp_error_results_do_not_force_final_answer() -> None:
+    mcp_error = {"content": [{"text": "failed"}], "is_error": True}
+    tools = [
+        FakeTool("s1", read_only=True, result=mcp_error),
+        FakeTool("s2", read_only=True, result=mcp_error),
+    ]
+    pattern = _make_pattern(finalize_after_tool_result=True)
+    pattern.pending_tool_calls = [make_tool_call("s1"), make_tool_call("s2")]
+
+    result = await pattern._execute_pending_tool_calls(
+        context=RecordingContext(), tools=tools, llm=None, runtime=FakeRuntime()
+    )
+
+    assert result is None
+    assert pattern.force_final_answer_next is False
+
+
 async def test_flag_off_runs_everything_serially() -> None:
     # With the flag off, two safe tools each run as their own serial segment.
     tools = [FakeTool("s1", read_only=True), FakeTool("s2", read_only=True)]

--- a/tests/core/agent/test_result.py
+++ b/tests/core/agent/test_result.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.agent.result import (
+    normalize_tool_failure_code,
+    tool_result_succeeded,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("oauth_token_required", "oauth_token_required"),
+        ("other_valid_code", None),
+        (" oauth_token_required", None),
+        ("OAUTH_TOKEN_REQUIRED", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_normalize_tool_failure_code_uses_exact_allowlist(value, expected):
+    assert normalize_tool_failure_code(value) == expected
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"success": False},
+        {"status": "error"},
+        {"status": "ERROR"},
+        {"is_error": True},
+    ],
+)
+def test_tool_result_succeeded_recognizes_supported_failure_shapes(result):
+    assert tool_result_succeeded(result) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        "ok",
+        {},
+        {"success": True},
+        {"status": "success"},
+        {"is_error": False},
+        {"is_error": 1},
+    ],
+)
+def test_tool_result_succeeded_preserves_non_failure_results(result):
+    assert tool_result_succeeded(result) is True

--- a/tests/core/agent/test_result.py
+++ b/tests/core/agent/test_result.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from xagent.core.agent.result import (
+    ClassifiedToolFailure,
     normalize_tool_failure_code,
     tool_result_succeeded,
 )
@@ -26,6 +27,15 @@ class _FailureCodeStringSubclass(str):
 )
 def test_normalize_tool_failure_code_uses_exact_allowlist(value, expected):
     assert normalize_tool_failure_code(value) == expected
+
+
+def test_classified_tool_failure_accepts_only_allowlisted_plain_string():
+    outcome = ClassifiedToolFailure(failure_code="oauth_token_required")
+
+    assert outcome.failure_code == "oauth_token_required"
+
+    with pytest.raises(ValueError, match="invalid tool failure code"):
+        ClassifiedToolFailure(failure_code="other_valid_code")
 
 
 @pytest.mark.parametrize(

--- a/tests/core/agent/test_result.py
+++ b/tests/core/agent/test_result.py
@@ -8,6 +8,10 @@ from xagent.core.agent.result import (
 )
 
 
+class _FailureCodeStringSubclass(str):
+    pass
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -17,6 +21,7 @@ from xagent.core.agent.result import (
         ("OAUTH_TOKEN_REQUIRED", None),
         (None, None),
         (123, None),
+        (_FailureCodeStringSubclass("oauth_token_required"), None),
     ],
 )
 def test_normalize_tool_failure_code_uses_exact_allowlist(value, expected):

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -669,6 +669,54 @@ async def test_tool_invocation_counts_one_action_each() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_failure_code", "expected_failure_code"),
+    [
+        ("oauth_token_required", "oauth_token_required"),
+        ("other_valid_code", None),
+        (" oauth_token_required", None),
+        ({"failure_code": "oauth_token_required"}, None),
+    ],
+)
+async def test_on_tool_end_emits_only_allowlisted_top_level_failure_code(
+    raw_failure_code,
+    expected_failure_code,
+) -> None:
+    class CapturingTracer:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+
+        async def trace_event(self, event_type: Any, **kwargs: Any) -> None:
+            self.events.append(
+                {
+                    "type": getattr(event_type, "value", str(event_type)),
+                    "data": kwargs.get("data") or {},
+                }
+            )
+
+    tracer = CapturingTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="task-failure-code")
+    result = {
+        "is_error": True,
+        "error": "MCP server credentials are unavailable.",
+        "failure_code": raw_failure_code,
+    }
+
+    await runtime.on_tool_end(
+        tool_call={"name": "mcp_unavailable", "id": "call-1"},
+        result=result,
+    )
+
+    assert [event["type"] for event in tracer.events] == ["action_error_tool"]
+    event_data = tracer.events[0]["data"]
+    assert event_data["result"] == result
+    if expected_failure_code is None:
+        assert "failure_code" not in event_data
+    else:
+        assert event_data["failure_code"] == expected_failure_code
+
+
+@pytest.mark.asyncio
 async def test_concurrent_tool_calls_all_count() -> None:
     """A concurrent batch (asyncio.gather) increments the shared counter once per tool.
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -521,6 +522,200 @@ async def test_resolver_401_has_priority_and_retries_rebuilt_connection_once(
     assert resolver_calls[0].params["error"] == "invalid_token"
     assert connector_calls == 0
     assert attempted_connections == [connection, fresh_connection]
+
+
+@pytest.mark.asyncio
+async def test_real_mcp_session_retries_nested_resolver_401_once(monkeypatch, caplog):
+    initial_token = "real-initial-access-token-secret"
+    refreshed_token = "real-refreshed-access-token-secret"
+    generation = "real-resolver-generation-secret"
+    raw_exception_secret = "real-http-status-error-secret"
+    tool_args = {"query": "active", "account_id": "6185"}
+    tool_meta = {"account_id": "6185"}
+    initial_requests = []
+    refreshed_requests = []
+    initial_client_builds = 0
+    refreshed_client_builds = 0
+    refresh_calls = []
+
+    async def _initial_handler(request):
+        payload = json.loads(request.content) if request.content else {}
+        initial_requests.append((request, payload))
+        assert payload["method"] == "initialize"
+        return httpx.Response(
+            401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer error="invalid_token", scope="records.read"'
+                )
+            },
+            extensions={"reason_phrase": raw_exception_secret.encode()},
+            request=request,
+        )
+
+    async def _refreshed_handler(request):
+        payload = json.loads(request.content) if request.content else {}
+        refreshed_requests.append((request, payload))
+        method = payload.get("method")
+        if method == "initialize":
+            result = {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "mock-mcp", "version": "1"},
+            }
+        elif method == "tools/call":
+            result = {
+                "content": [{"type": "text", "text": "clients-ok"}],
+                "isError": False,
+            }
+        elif method == "tools/list":
+            result = {
+                "tools": [
+                    {
+                        "name": "list_clients",
+                        "description": "List clients",
+                        "inputSchema": {"type": "object"},
+                    }
+                ]
+            }
+        else:
+            return httpx.Response(405 if request.method == "GET" else 202)
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "mcp-session-id": "refreshed-session",
+            },
+            json={"jsonrpc": "2.0", "id": payload["id"], "result": result},
+            request=request,
+        )
+
+    def _initial_client_factory(headers=None, timeout=None, auth=None):
+        nonlocal initial_client_builds
+        initial_client_builds += 1
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(_initial_handler),
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
+        )
+
+    def _refreshed_client_factory(headers=None, timeout=None, auth=None):
+        nonlocal refreshed_client_builds
+        refreshed_client_builds += 1
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(_refreshed_handler),
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
+        )
+
+    async def _resolver_refresh(challenge):
+        refresh_calls.append((challenge, generation))
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "headers": {"Authorization": f"Bearer {refreshed_token}"},
+            "httpx_client_factory": _refreshed_client_factory,
+            "terminate_on_close": False,
+        }
+
+    connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test",
+        "headers": {"Authorization": f"Bearer {initial_token}"},
+        "httpx_client_factory": _initial_client_factory,
+        "terminate_on_close": False,
+        "runtime_bindings": [
+            {
+                "source": {"input_type": "context", "key": "account_id"},
+                "target": {"target_type": "tool_arguments", "key": "account_id"},
+            },
+            {
+                "source": {"input_type": "context", "key": "account_id"},
+                "target": {"target_type": "mcp_meta", "key": "account_id"},
+            },
+        ],
+        "connector_runtime": {
+            "context": {"account_id": "6185"},
+            "secrets": {},
+            "auth_selector": {},
+        },
+        "_oauth_token_resolver_refresh": _resolver_refresh,
+    }
+    adapter = MCPToolAdapter(
+        mcp_tool=SimpleNamespace(
+            name="list_clients",
+            description="List clients",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "account_id": {"type": "string"},
+                },
+                "required": ["query", "account_id"],
+            },
+        ),
+        connection=connection,
+    )
+    nested_failures = []
+    retry = adapter._retry_delegated_401
+
+    async def _observe_nested_failure(exc, attempted_args, attempted_meta):
+        nested_failures.append(exc)
+        responses = list(mcp_adapter_module._strict_http_401_responses(exc))
+        assert len(responses) == 1
+        assert responses[0].headers.get_list("WWW-Authenticate") == [
+            'Bearer error="invalid_token", scope="records.read"'
+        ]
+        return await retry(exc, attempted_args, attempted_meta)
+
+    monkeypatch.setattr(adapter, "_retry_delegated_401", _observe_nested_failure)
+    caplog.set_level("DEBUG")
+
+    result = await adapter.run_json_async(
+        {"query": "active", "account_id": "llm-supplied"}
+    )
+
+    assert result == {
+        "content": [
+            {
+                "type": "text",
+                "text": "clients-ok",
+                "annotations": None,
+                "meta": None,
+            }
+        ],
+        "is_error": False,
+    }
+    assert initial_client_builds == 1
+    assert refreshed_client_builds == 1
+    assert len(refresh_calls) == 1
+    assert refresh_calls[0][0].params["error"] == "invalid_token"
+    assert refresh_calls[0][0].scope == "records.read"
+    assert len(nested_failures) == 1
+    assert raw_exception_secret in repr(nested_failures[0])
+    assert len(initial_requests) == 1
+    assert initial_requests[0][0].headers["Authorization"] == (
+        f"Bearer {initial_token}"
+    )
+    tool_calls = [
+        (request, payload)
+        for request, payload in refreshed_requests
+        if payload.get("method") == "tools/call"
+    ]
+    assert len(tool_calls) == 1
+    assert tool_calls[0][0].headers["Authorization"] == f"Bearer {refreshed_token}"
+    assert tool_calls[0][1]["params"] == {
+        "_meta": tool_meta,
+        "name": "list_clients",
+        "arguments": tool_args,
+    }
+    public_output = repr(result) + caplog.text
+    assert initial_token not in public_output
+    assert refreshed_token not in public_output
+    assert generation not in public_output
+    assert raw_exception_secret not in public_output
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -649,6 +649,56 @@ async def test_resolver_refresh_failure_is_fixed_and_sanitized(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "refreshed_connection",
+    [
+        {},
+        {"transport": "unsupported", "url": "https://mcp.example.test"},
+        {"transport": "stdio"},
+        {"transport": "stdio", "command": ""},
+        {"transport": "stdio", "command": ["python"]},
+        {"transport": "sse"},
+        {"transport": "streamable_http"},
+        {"transport": "streamable_http", "url": ""},
+        {"transport": "streamable_http", "url": 42},
+        {"transport": "websocket"},
+    ],
+)
+async def test_resolver_refresh_rejects_non_executable_connection_before_retry(
+    monkeypatch, refreshed_connection
+):
+    refresh_calls = 0
+
+    async def _resolver_refresh(challenge):
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return refreshed_connection
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    execution_calls = 0
+
+    async def _execute(connection, tool_args, tool_meta):
+        nonlocal execution_calls
+        execution_calls += 1
+        raise _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert refresh_calls == 1
+    assert execution_calls == 1
+    assert result["is_error"] is True
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
 async def test_resolver_retry_second_401_does_not_refresh_twice(monkeypatch):
     refresh_calls = 0
 
@@ -674,6 +724,46 @@ async def test_resolver_retry_second_401_does_not_refresh_twice(monkeypatch):
         nonlocal execution_calls
         execution_calls += 1
         raise _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert execution_calls == 2
+    assert refresh_calls == 1
+    assert result["is_error"] is True
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_retry_classifies_same_401_instance_without_second_refresh(
+    monkeypatch,
+):
+    refresh_calls = 0
+
+    async def _resolver_refresh(challenge):
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    execution_calls = 0
+    repeated_error = _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    async def _execute(connection, tool_args, tool_meta):
+        nonlocal execution_calls
+        execution_calls += 1
+        raise repeated_error
 
     monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -819,6 +819,37 @@ async def test_resolver_retry_non_401_failure_does_not_leak_secrets(
 
 
 @pytest.mark.asyncio
+async def test_connector_refresh_empty_dict_preserves_legacy_retry_failure(
+    monkeypatch,
+):
+    connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test",
+        "_connector_runtime_refresh": lambda: {},
+    }
+    adapter = _resolver_retry_adapter(connection)
+    attempted_connections = []
+
+    async def _execute(attempted, tool_args, tool_meta):
+        attempted_connections.append(attempted)
+        if attempted is connection:
+            raise RuntimeError("HTTP 401 Unauthorized")
+        raise RuntimeError("malformed connector retry connection")
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert attempted_connections == [connection, {}]
+    assert result == {
+        "content": [
+            {"text": "Error executing MCP tool after delegated authorization retry."}
+        ],
+        "is_error": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_delegated_authorization_401_refreshes_connection_once(monkeypatch):
     mcp_tool = SimpleNamespace(
         name="list_clients",

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -476,6 +476,45 @@ def _resolver_retry_adapter(connection):
 
 
 @pytest.mark.asyncio
+async def test_resolver_retry_analyzes_initial_401_chain_once(monkeypatch):
+    from xagent.core.agent.result import ClassifiedToolFailure
+
+    strict_401_calls = 0
+    strict_401_responses = mcp_adapter_module._strict_http_401_responses
+
+    def counting_strict_401_responses(exc, **kwargs):
+        nonlocal strict_401_calls
+        strict_401_calls += 1
+        yield from strict_401_responses(exc, **kwargs)
+
+    async def _resolver_refresh(challenge):
+        return ClassifiedToolFailure(failure_code="oauth_token_required")
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    monkeypatch.setattr(
+        mcp_adapter_module,
+        "_strict_http_401_responses",
+        counting_strict_401_responses,
+    )
+
+    result = await adapter._retry_resolver_401(
+        _http_status_error(authenticate=['Bearer error="invalid_token"']),
+        {},
+        {},
+    )
+
+    assert strict_401_calls == 1
+    assert result is not None
+    assert result["failure_code"] == "oauth_token_required"
+
+
+@pytest.mark.asyncio
 async def test_resolver_401_has_priority_and_retries_rebuilt_connection_once(
     monkeypatch,
 ):
@@ -971,6 +1010,104 @@ async def test_resolver_retry_classifies_same_401_instance_without_second_refres
     assert refresh_calls == 1
     assert result["is_error"] is True
     assert "delegated_authorization_failed" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_retry_ignores_rewrapped_initial_401_response(monkeypatch):
+    async def _resolver_refresh(challenge):
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    initial_error = _http_status_error(authenticate=['Bearer error="invalid_token"'])
+    rewrapped_initial_response = httpx.HTTPStatusError(
+        "rewrapped initial response",
+        request=initial_error.request,
+        response=initial_error.response,
+    )
+    execution_calls = 0
+
+    async def _execute(connection, tool_args, tool_meta):
+        nonlocal execution_calls
+        execution_calls += 1
+        if execution_calls == 1:
+            raise initial_error
+        raise rewrapped_initial_response
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert execution_calls == 2
+    assert result == {
+        "content": [
+            {"text": "Error executing MCP tool after delegated authorization retry."}
+        ],
+        "is_error": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolver_retry_prunes_over_budget_initial_exception_subtree(
+    monkeypatch,
+):
+    async def _resolver_refresh(challenge):
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    deep_original: BaseException = _http_status_error(
+        authenticate=['Bearer error="invalid_token"']
+    )
+    for index in range(mcp_adapter_module._RESOLVER_HTTP_401_NODE_LIMIT + 1):
+        wrapper = RuntimeError(f"initial-wrapper-{index}")
+        wrapper.__cause__ = deep_original
+        deep_original = wrapper
+    initial_error = ExceptionGroup(
+        "initial",
+        [
+            _http_status_error(authenticate=['Bearer error="invalid_token"']),
+            deep_original,
+        ],
+    )
+    execution_calls = 0
+
+    async def _execute(connection, tool_args, tool_meta):
+        nonlocal execution_calls
+        execution_calls += 1
+        if execution_calls == 1:
+            raise initial_error
+        raise RuntimeError("retry transport failed")
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert execution_calls == 2
+    assert result == {
+        "content": [
+            {"text": "Error executing MCP tool after delegated authorization retry."}
+        ],
+        "is_error": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,14 +1,29 @@
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
+from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPToolAdapter,
     _build_mcp_tool_adapter,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
 )
+
+
+def _http_status_error(
+    *, status_code: int = 401, authenticate: list[str] | None = None
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://mcp.example.test/tools")
+    headers = [(b"www-authenticate", value.encode()) for value in (authenticate or [])]
+    response = httpx.Response(status_code, headers=headers, request=request)
+    return httpx.HTTPStatusError(
+        "planted-secret-must-not-be-evidence",
+        request=request,
+        response=response,
+    )
 
 
 def test_build_mcp_tool_adapter_stamps_normalized_source_server():
@@ -92,6 +107,82 @@ def test_exception_indicates_http_401_uses_bounded_status_signals():
         RuntimeError("connection reset on port 401")
     )
     assert not _exception_indicates_http_401(RuntimeError("tool returned id 40123"))
+
+
+def test_resolver_challenge_extracts_from_nested_group_cause_and_context():
+    cause = RuntimeError("outer")
+    cause.__cause__ = _http_status_error(
+        authenticate=['Bearer error="invalid_token", scope="records.read"']
+    )
+    context = RuntimeError("context")
+    context.__context__ = cause
+    nested = ExceptionGroup("nested", [RuntimeError("noise"), context])
+
+    challenge = mcp_adapter_module._resolver_invalid_token_challenge(
+        ExceptionGroup("root", [nested])
+    )
+
+    assert challenge is not None
+    assert challenge.params["error"] == "invalid_token"
+    assert challenge.scope == "records.read"
+
+
+def test_resolver_challenge_traversal_handles_cycles():
+    outer = RuntimeError("outer")
+    inner = RuntimeError("inner")
+    outer.__cause__ = inner
+    inner.__context__ = outer
+
+    assert mcp_adapter_module._resolver_invalid_token_challenge(outer) is None
+
+
+def test_resolver_challenge_traversal_stops_at_named_node_budget():
+    current: BaseException = _http_status_error(
+        authenticate=['Bearer error="invalid_token"']
+    )
+    for index in range(mcp_adapter_module._RESOLVER_HTTP_401_NODE_LIMIT):
+        wrapper = RuntimeError(f"wrapper-{index}")
+        wrapper.__cause__ = current
+        current = wrapper
+
+    assert mcp_adapter_module._resolver_invalid_token_challenge(current) is None
+
+
+def test_resolver_challenge_uses_all_www_authenticate_header_values():
+    exc = _http_status_error(
+        authenticate=[
+            'Basic realm="legacy"',
+            (
+                'Bearer error="invalid_token", '
+                'resource_metadata="https://mcp.example.test/.well-known/resource"'
+            ),
+        ]
+    )
+
+    challenge = mcp_adapter_module._resolver_invalid_token_challenge(exc)
+
+    assert challenge is not None
+    assert challenge.resource_metadata_url == (
+        "https://mcp.example.test/.well-known/resource"
+    )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _http_status_error(authenticate=[]),
+        _http_status_error(authenticate=['Bearer error="invalid_token']),
+        _http_status_error(authenticate=['Basic error="invalid_token"']),
+        _http_status_error(authenticate=['Bearer error="insufficient_scope"']),
+        _http_status_error(authenticate=['Bearer scope="records.read"']),
+        _http_status_error(
+            status_code=403, authenticate=['Bearer error="invalid_token"']
+        ),
+        RuntimeError("HTTP 401 Unauthorized; Bearer error=invalid_token"),
+    ],
+)
+def test_resolver_challenge_rejects_non_refreshable_evidence(exc):
+    assert mcp_adapter_module._resolver_invalid_token_challenge(exc) is None
 
 
 def test_mcp_return_value_as_string_keeps_malformed_scalar_content_together():
@@ -370,6 +461,271 @@ def test_mcp_runtime_tool_argument_missing_source_warns(caplog):
     )
     assert "account_id" in caplog.text
     assert "list_clients" in caplog.text
+
+
+def _resolver_retry_adapter(connection):
+    return MCPToolAdapter(
+        mcp_tool=SimpleNamespace(
+            name="list_clients",
+            description="List clients",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        connection=connection,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolver_401_has_priority_and_retries_rebuilt_connection_once(
+    monkeypatch,
+):
+    resolver_calls = []
+    connector_calls = 0
+    fresh_connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test",
+        "headers": {"Authorization": "Bearer fresh-token"},
+    }
+
+    async def _resolver_refresh(challenge):
+        resolver_calls.append(challenge)
+        return fresh_connection
+
+    def _connector_refresh():
+        nonlocal connector_calls
+        connector_calls += 1
+        return fresh_connection
+
+    connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test",
+        "_oauth_token_resolver_refresh": _resolver_refresh,
+        "_connector_runtime_refresh": _connector_refresh,
+    }
+    adapter = _resolver_retry_adapter(connection)
+    attempted_connections = []
+
+    async def _execute(attempted, tool_args, tool_meta):
+        attempted_connections.append(attempted)
+        if attempted is connection:
+            raise _http_status_error(
+                authenticate=['Bearer error="invalid_token", scope="records.read"']
+            )
+        return {"content": [{"text": "ok"}], "is_error": False}
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert result == {"content": [{"text": "ok"}], "is_error": False}
+    assert len(resolver_calls) == 1
+    assert resolver_calls[0].params["error"] == "invalid_token"
+    assert connector_calls == 0
+    assert attempted_connections == [connection, fresh_connection]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authenticate",
+    [
+        [],
+        ['Bearer error="invalid_token'],
+        ['Basic error="invalid_token"'],
+        ['Bearer error="insufficient_scope"'],
+        ['Bearer scope="records.read"'],
+    ],
+)
+async def test_resolver_owned_invalid_401_challenge_fails_without_connector_fallback(
+    monkeypatch, authenticate
+):
+    resolver_calls = 0
+    connector_calls = 0
+
+    def _resolver_refresh(challenge):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return {}
+
+    def _connector_refresh():
+        nonlocal connector_calls
+        connector_calls += 1
+        return {}
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+            "_connector_runtime_refresh": _connector_refresh,
+        }
+    )
+
+    async def _execute(connection, tool_args, tool_meta):
+        raise _http_status_error(authenticate=authenticate)
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert result["is_error"] is True
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+    assert resolver_calls == 0
+    assert connector_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_resolver_owned_text_only_401_does_not_use_either_refresh_callback(
+    monkeypatch,
+):
+    resolver_calls = 0
+    connector_calls = 0
+
+    def _resolver_refresh(challenge):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return {}
+
+    def _connector_refresh():
+        nonlocal connector_calls
+        connector_calls += 1
+        return {}
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+            "_connector_runtime_refresh": _connector_refresh,
+        }
+    )
+
+    async def _execute(connection, tool_args, tool_meta):
+        raise RuntimeError("HTTP 401 Unauthorized; Bearer error=invalid_token")
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert resolver_calls == 0
+    assert connector_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("refresh_behavior", ["none", "raise", "malformed"])
+async def test_resolver_refresh_failure_is_fixed_and_sanitized(
+    monkeypatch, caplog, refresh_behavior
+):
+    secret = f"resolver-{refresh_behavior}-secret"
+
+    async def _resolver_refresh(challenge):
+        if refresh_behavior == "raise":
+            raise RuntimeError(secret)
+        if refresh_behavior == "malformed":
+            return SimpleNamespace(secret=secret)
+        return None
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+
+    async def _execute(connection, tool_args, tool_meta):
+        raise _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result["is_error"] is True
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+    assert secret not in repr(result) + caplog.text
+
+
+@pytest.mark.asyncio
+async def test_resolver_retry_second_401_does_not_refresh_twice(monkeypatch):
+    refresh_calls = 0
+
+    async def _resolver_refresh(challenge):
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+
+    adapter = _resolver_retry_adapter(
+        {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "_oauth_token_resolver_refresh": _resolver_refresh,
+        }
+    )
+    execution_calls = 0
+
+    async def _execute(connection, tool_args, tool_meta):
+        nonlocal execution_calls
+        execution_calls += 1
+        raise _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+
+    result = await adapter.run_json_async({})
+
+    assert execution_calls == 2
+    assert refresh_calls == 1
+    assert result["is_error"] is True
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_retry_non_401_failure_does_not_leak_secrets(
+    monkeypatch, caplog
+):
+    initial_secret = "initial-resolver-secret"
+    refreshed_secret = "refreshed-resolver-secret"
+
+    async def _resolver_refresh(challenge):
+        return {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "headers": {"Authorization": f"Bearer {refreshed_secret}"},
+        }
+
+    initial_connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test",
+        "headers": {"Authorization": f"Bearer {initial_secret}"},
+        "_oauth_token_resolver_refresh": _resolver_refresh,
+    }
+    adapter = _resolver_retry_adapter(initial_connection)
+
+    async def _execute(connection, tool_args, tool_meta):
+        if connection is initial_connection:
+            raise _http_status_error(authenticate=['Bearer error="invalid_token"'])
+        raise RuntimeError(f"transport failed with {refreshed_secret}")
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", _execute)
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [
+            {"text": "Error executing MCP tool after delegated authorization retry."}
+        ],
+        "is_error": True,
+    }
+    public_output = repr(result) + caplog.text
+    assert initial_secret not in public_output
+    assert refreshed_secret not in public_output
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -659,7 +659,7 @@ async def test_real_mcp_session_retries_nested_resolver_401_once(monkeypatch, ca
         connection=connection,
     )
     nested_failures = []
-    retry = adapter._retry_delegated_401
+    retry = adapter._retry_after_authorization_failure
 
     async def _observe_nested_failure(exc, attempted_args, attempted_meta):
         nested_failures.append(exc)
@@ -670,7 +670,9 @@ async def test_real_mcp_session_retries_nested_resolver_401_once(monkeypatch, ca
         ]
         return await retry(exc, attempted_args, attempted_meta)
 
-    monkeypatch.setattr(adapter, "_retry_delegated_401", _observe_nested_failure)
+    monkeypatch.setattr(
+        adapter, "_retry_after_authorization_failure", _observe_nested_failure
+    )
     caplog.set_level("DEBUG")
 
     result = await adapter.run_json_async(
@@ -852,6 +854,7 @@ async def test_resolver_refresh_failure_is_fixed_and_sanitized(
         {"transport": "stdio"},
         {"transport": "stdio", "command": ""},
         {"transport": "stdio", "command": ["python"]},
+        {"transport": "stdio", "command": "python"},
         {"transport": "sse"},
         {"transport": "streamable_http"},
         {"transport": "streamable_http", "url": ""},

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -161,6 +161,17 @@ async def test_unavailable_tool_async_unauthorized_uses_mcp_access_denied(
     }
 
 
+def test_unavailable_tool_return_schema_accepts_access_denied_result(monkeypatch):
+    monkeypatch.setenv("XAGENT_USER_ID", "8")
+    tool = _unavailable_tool(allow_users=["7"])
+
+    result = tool.run_json_sync({})
+    parsed = tool.return_type().model_validate(result)
+
+    assert parsed.error is None
+    assert parsed.is_error is True
+
+
 def test_unavailable_tool_sync_unauthorized_uses_mcp_access_denied(monkeypatch):
     monkeypatch.setenv("XAGENT_USER_ID", "8")
     tool = _unavailable_tool(allow_users=["7"])

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
 import pytest
 from mcp.types import Tool as MCPTool
 
+from xagent.core.agent.runtime import PatternRuntime
 from xagent.core.tools.adapters.vibe.base import ToolCategory
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
@@ -21,11 +23,13 @@ def _unavailable_tool(
     server_name: str = "Google Drive",
     server_id: int | None = 42,
     allow_users: list[str] | None = None,
+    failure_code: str | None = None,
 ) -> UnavailableMCPTool:
     return UnavailableMCPTool(
         server_name=server_name,
         server_id=server_id,
         allow_users=allow_users,
+        failure_code=failure_code,
     )
 
 
@@ -34,8 +38,9 @@ def _unavailable_config(
     name: str | None = "Google Drive",
     server_id: int | None = 42,
     allow_users: list[str] | None = None,
+    failure_code: object | None = None,
 ) -> dict:
-    return {
+    config = {
         "name": name,
         "transport": "unavailable",
         "description": f"{name} server",
@@ -47,6 +52,9 @@ def _unavailable_config(
         },
         "allow_users": allow_users,
     }
+    if failure_code is not None:
+        config["config"]["failure_code"] = failure_code
+    return config
 
 
 def test_unavailable_tool_name_is_llm_safe_and_uses_server_id():
@@ -95,6 +103,30 @@ async def test_unavailable_tool_async_authorized_returns_clean_error(monkeypatch
     assert "resolver" not in text
     assert "provider" not in text
     assert "RuntimeError" not in text
+
+
+@pytest.mark.asyncio
+async def test_unavailable_tool_authorized_returns_classified_failure(monkeypatch):
+    monkeypatch.setenv("XAGENT_USER_ID", "7")
+    tool = _unavailable_tool(allow_users=["7"], failure_code="oauth_token_required")
+
+    result = await tool.run_json_async({})
+
+    assert result == {
+        "success": False,
+        "status": "error",
+        "is_error": True,
+        "error": "MCP server credentials are unavailable.",
+        "failure_code": "oauth_token_required",
+        "content": [
+            {
+                "text": (
+                    "MCP server credentials are unavailable. Please reconnect "
+                    "the MCP server credentials and retry."
+                )
+            }
+        ],
+    }
 
 
 def test_unavailable_tool_sync_authorized_returns_clean_error(monkeypatch):
@@ -214,6 +246,78 @@ async def test_factory_builds_unavailable_tools_without_normal_loader(monkeypatc
     tools = await ToolFactory._create_mcp_tools_from_configs([_unavailable_config()])
 
     assert [tool.name for tool in tools] == ["mcp_google_drive_42_unavailable"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_failure_code", "expected_failure_code"),
+    [
+        ("oauth_token_required", "oauth_token_required"),
+        ("other_valid_code", None),
+        (" oauth_token_required", None),
+        (123, None),
+    ],
+)
+async def test_factory_revalidates_unavailable_failure_code(
+    monkeypatch,
+    raw_failure_code,
+    expected_failure_code,
+):
+    monkeypatch.setenv("XAGENT_USER_ID", "7")
+    config = _unavailable_config(allow_users=["7"], failure_code=raw_failure_code)
+    config["config"]["diagnostic"] = {
+        "actor": "internal-actor",
+        "resource": "internal-resource",
+        "provider": "internal-provider",
+        "access_token": "internal-token",
+    }
+
+    tools = await ToolFactory._create_mcp_tools_from_configs([config])
+    result = await tools[0].run_json_async({})
+
+    assert result.get("failure_code") == expected_failure_code
+    assert "internal-" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_unavailable_config_failure_code_reaches_tool_failure_trace(monkeypatch):
+    class CapturingTracer:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+
+        async def trace_event(self, event_type: Any, **kwargs: Any) -> None:
+            self.events.append(
+                {
+                    "type": getattr(event_type, "value", str(event_type)),
+                    "data": kwargs.get("data") or {},
+                }
+            )
+
+    monkeypatch.setenv("XAGENT_USER_ID", "7")
+    config = _unavailable_config(allow_users=["7"], failure_code="oauth_token_required")
+    config["config"]["diagnostic"] = {
+        "actor": "internal-actor",
+        "resource": "internal-resource",
+        "provider": "internal-provider",
+        "access_token": "internal-token",
+        "refresh_payload": "internal-refresh-payload",
+        "webhook_url": "https://internal.example/webhook",
+    }
+    tools = await ToolFactory._create_mcp_tools_from_configs([config])
+    result = await tools[0].run_json_async({})
+    tracer = CapturingTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="task-oauth-required")
+
+    await runtime.on_tool_end(
+        tool_call={"name": tools[0].name, "id": "call-1"},
+        result=result,
+    )
+
+    assert tracer.events[0]["type"] == "action_error_tool"
+    assert tracer.events[0]["data"]["failure_code"] == "oauth_token_required"
+    public_payload = repr(result) + repr(tracer.events)
+    assert "internal-" not in public_payload
+    assert "webhook" not in public_payload
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -24,6 +24,7 @@ from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.models.agent import Agent
 from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.task import (
     Task,
     TaskConnectorRuntimeContext,
@@ -45,7 +46,13 @@ from xagent.web.services.hot_path_cache import (
     set_cache_backend_for_testing,
     task_steps_key,
 )
-from xagent.web.tools.config import WebToolConfig
+from xagent.web.services.mcp_oauth import MCPAuthorizationChallenge
+from xagent.web.tools.config import (
+    ResolvedToken,
+    TokenRequest,
+    WebToolConfig,
+    set_oauth_token_resolver_hook,
+)
 
 from ..conftest import _admin_headers, _direct_db_session, client
 
@@ -998,6 +1005,97 @@ async def test_web_tool_config_applies_runtime_mcp_authorization_header(
     assert configs[0]["config"]["headers"]["Authorization"] == "Bearer tenant-token"
     assert refreshed_connection["headers"]["Authorization"] == "Bearer refreshed-token"
     assert configs[0]["connector_runtime"]["secrets"] == {}
+
+
+@pytest.mark.asyncio
+async def test_web_tool_config_resolver_owned_remote_keeps_adapter_runtime_data(
+    mock_start_task,
+):
+    agent_id, full_key = _create_agent_with_key()
+    server_id = _install_runtime_mcp_connector(agent_id, required=False)
+
+    db = _direct_db_session()
+    try:
+        db.add(
+            PublicMCPApp(
+                app_id="shiftcare-runtime",
+                name="ShiftCare",
+                description="ShiftCare runtime app",
+                transport="streamable_http",
+                provider_name="shiftcare",
+                launch_config={},
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "first user message"},
+            "connector_runtime_context": [
+                {
+                    "connector_ref": {
+                        "connector_type": "mcp",
+                        "connector_id": server_id,
+                    },
+                    "context": {"account_id": "tenant-account"},
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    task_id = resp.json()["task_id"]
+    turn_id = mock_start_task.call_args.kwargs["payload"].turn_id
+    requests: list[TokenRequest] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        requests.append(request)
+        generation = "generation-1" if request.refresh is None else "generation-2"
+        return ResolvedToken(access_token=generation, generation=generation)
+
+    set_oauth_token_resolver_hook(resolver)
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        tool_config = WebToolConfig(
+            db=db,
+            request=None,
+            user=SimpleNamespace(id=int(task.user_id), is_admin=False),
+            user_id=int(task.user_id),
+            is_admin=False,
+            task_id=f"web_task_{task_id}",
+            include_mcp_tools=True,
+            tool_selection_spec=ToolSelectionSpec.from_raw(
+                tool_categories=["mcp:ShiftCare"]
+            ),
+            connector_runtime_turn_id=turn_id,
+        )
+        configs = await tool_config.get_mcp_server_configs()
+        refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+        refreshed = await refresh(
+            MCPAuthorizationChallenge(
+                resource_metadata_url=None,
+                scope="shiftcare.read",
+                params={},
+            )
+        )
+    finally:
+        set_oauth_token_resolver_hook(None)
+        db.close()
+
+    assert requests[0].provider == "shiftcare"
+    assert configs[0]["connector_runtime"] == {
+        "context": {"account_id": "tenant-account"},
+        "secrets": {},
+        "auth_selector": {},
+    }
+    assert configs[0]["runtime_bindings"][0]["target"]["target_type"] == "mcp_meta"
+    assert refreshed["headers"]["Authorization"] == "Bearer generation-2"
 
 
 def test_connector_runtime_secrets_do_not_enter_task_transcript(mock_start_task):

--- a/tests/web/tools/test_mcp_oauth_runtime.py
+++ b/tests/web/tools/test_mcp_oauth_runtime.py
@@ -14,6 +14,11 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import MCPOAuthClient, MCPOAuthGrant
 from xagent.web.models.user import User
 from xagent.web.services import mcp_oauth as mcp_oauth_service
+from xagent.web.services.mcp_runtime import (
+    connection_with_bearer_authorization,
+    connection_without_authorization,
+    effective_mcp_oauth_resource,
+)
 from xagent.web.tools.config import WebToolConfig
 
 
@@ -148,6 +153,112 @@ async def _load_configs(db, user: User, **kwargs):
     return await cfg.get_mcp_server_configs(), cfg
 
 
+def test_effective_mcp_oauth_resource_prefers_selector_verbatim(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+
+    assert (
+        effective_mcp_oauth_resource(
+            server,
+            mcp_auth_context={
+                str(server.id): {"resource": " https://selector.example/mcp "}
+            },
+        )
+        == " https://selector.example/mcp "
+    )
+
+
+def test_effective_mcp_oauth_resource_falls_back_to_auth_verbatim(db_session):
+    db, user, _ = db_session
+    configured_server = _add_mcp_oauth_server(
+        db,
+        user,
+        resource=" https://configured.example/mcp ",
+    )
+
+    assert (
+        effective_mcp_oauth_resource(
+            configured_server,
+            mcp_auth_context={
+                str(configured_server.id): {"resource": ""},
+            },
+        )
+        == " https://configured.example/mcp "
+    )
+
+
+def test_effective_mcp_oauth_resource_falls_back_to_server_url(db_session):
+    db, user, _ = db_session
+    transport_server = _add_mcp_oauth_server(db, user, resource="")
+
+    assert (
+        effective_mcp_oauth_resource(
+            transport_server,
+            mcp_auth_context={
+                str(transport_server.id): {"resource": object()},
+            },
+        )
+        == "https://mcp.example.com/mcp"
+    )
+
+
+def test_connection_without_authorization_copies_and_filters_headers():
+    connection = {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.com/mcp",
+        "headers": {
+            "Authorization": "Bearer uppercase",
+            "authorization": "Bearer lowercase",
+            "AUTHORIZATION": "Bearer shouting",
+            "X-Request-Source": "xagent",
+        },
+        "auth": {"type": "mcp_oauth"},
+    }
+
+    result = connection_without_authorization(connection)
+
+    assert result == {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.com/mcp",
+        "headers": {"X-Request-Source": "xagent"},
+        "auth": {"type": "mcp_oauth"},
+    }
+    assert result is not connection
+    assert result["headers"] is not connection["headers"]
+    assert connection["headers"] == {
+        "Authorization": "Bearer uppercase",
+        "authorization": "Bearer lowercase",
+        "AUTHORIZATION": "Bearer shouting",
+        "X-Request-Source": "xagent",
+    }
+
+
+def test_connection_with_bearer_authorization_replaces_static_auth_without_mutation():
+    connection = {
+        "url": "https://mcp.example.com/mcp",
+        "headers": {
+            "authorization": "Basic static-credential",
+            "X-Request-Source": "xagent",
+        },
+    }
+
+    result = connection_with_bearer_authorization(connection, "runtime-token")
+
+    assert result == {
+        "url": "https://mcp.example.com/mcp",
+        "headers": {
+            "X-Request-Source": "xagent",
+            "Authorization": "Bearer runtime-token",
+        },
+    }
+    assert result is not connection
+    assert result["headers"] is not connection["headers"]
+    assert connection["headers"] == {
+        "authorization": "Basic static-credential",
+        "X-Request-Source": "xagent",
+    }
+
+
 @pytest.mark.asyncio
 async def test_mcp_oauth_missing_grant_does_not_fall_back_to_static_headers(
     db_session,
@@ -201,8 +312,11 @@ async def test_mcp_oauth_runtime_selects_resource_owner_grant(db_session):
     assert cfg.get_mcp_oauth_diagnostics() == []
     assert len(configs) == 1
     headers = configs[0]["config"]["headers"]
-    assert headers["X-Request-Source"] == "xagent"
-    assert headers["Authorization"] == "Bearer access-token-b"
+    assert headers == {
+        "X-Request-Source": "xagent",
+        "Authorization": "Bearer access-token-b",
+    }
+    assert "auth" not in configs[0]["config"]
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
 
+import httpx
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.agent.runtime import PatternRuntime
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
@@ -1734,6 +1739,63 @@ async def test_remote_hook_refresh_rejects_registration_change_during_await(
 
 
 @pytest.mark.asyncio
+async def test_remote_hook_refresh_classification_rejects_registration_change_during_await(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    class RefreshFailure(RuntimeError):
+        oauth_token_resolver_failure_code = "oauth_token_required"
+
+    async def resolver(request: TokenRequest):
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        refresh_started.set()
+        await release_refresh.wait()
+        raise RefreshFailure("refresh-private-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    pending = asyncio.create_task(refresh(_challenge()))
+    await refresh_started.wait()
+    set_oauth_token_resolver_hook(resolver)
+    release_refresh.set()
+
+    assert await pending is None
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_unknown_failure_code_remains_unclassified(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+
+    class RefreshFailure(RuntimeError):
+        oauth_token_resolver_failure_code = "other_valid_code"
+
+    async def resolver(request: TokenRequest):
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        raise RefreshFailure("refresh-private-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    assert await refresh(_challenge()) is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "refresh_result",
     [
@@ -1828,3 +1890,89 @@ async def test_remote_hook_refresh_resolver_raise_has_no_authorization_fallback(
     refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
 
     assert await refresh(_challenge()) is None
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_classification_reaches_tool_failure_trace(
+    db_session,
+    monkeypatch,
+    caplog,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    private_exception_text = "refresh-private-exception-secret"
+
+    class RefreshFailure(RuntimeError):
+        oauth_token_resolver_failure_code = "oauth_token_required"
+
+    async def resolver(request: TokenRequest):
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        raise RefreshFailure(private_exception_text)
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    connection = {
+        "transport": configs[0]["transport"],
+        **configs[0]["config"],
+    }
+    adapter = MCPToolAdapter(
+        mcp_tool=SimpleNamespace(
+            name="list_records",
+            description="List records",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        connection=connection,
+        allow_users=configs[0]["allow_users"],
+    )
+    request = httpx.Request("POST", "https://mcp.example/api")
+    response = httpx.Response(
+        401,
+        headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+        request=request,
+    )
+    execution_error = httpx.HTTPStatusError(
+        "http-private-exception-secret",
+        request=request,
+        response=response,
+    )
+
+    async def execute(connection, tool_args, tool_meta):
+        raise execution_error
+
+    monkeypatch.setattr(adapter, "_execute_mcp_call", execute)
+    monkeypatch.setenv("XAGENT_USER_ID", str(user.id))
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result["is_error"] is True
+    assert result["failure_code"] == "oauth_token_required"
+    assert "delegated_authorization_failed" in result["content"][0]["text"]
+
+    class CapturingTracer:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+
+        async def trace_event(self, event_type: Any, **kwargs: Any) -> None:
+            self.events.append(
+                {
+                    "type": getattr(event_type, "value", str(event_type)),
+                    "data": kwargs.get("data") or {},
+                }
+            )
+
+    tracer = CapturingTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="task-refresh-required")
+    await runtime.on_tool_end(
+        tool_call={"name": adapter.name, "id": "call-1"},
+        result=result,
+    )
+
+    assert tracer.events[0]["type"] == "action_error_tool"
+    assert tracer.events[0]["data"]["failure_code"] == "oauth_token_required"
+    public_output = repr(result) + repr(tracer.events) + caplog.text
+    assert private_exception_text not in public_output
+    assert "http-private-exception-secret" not in public_output

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1227,6 +1227,7 @@ def _challenge() -> MCPAuthorizationChallenge:
 @pytest.mark.asyncio
 async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
     db_session,
+    caplog,
 ):
     db, user = db_session
     scope = object()
@@ -1268,7 +1269,8 @@ async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
         }
     }
 
-    configs = await cfg.get_mcp_server_configs()
+    with caplog.at_level("WARNING"):
+        configs = await cfg.get_mcp_server_configs()
 
     assert [
         (request.provider, request.resource, request.scope) for request in requests
@@ -1286,6 +1288,7 @@ async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
         "auth_selector": {},
     }
     assert configs[0]["runtime_bindings"] == _remote_runtime_bindings()
+    assert "delegated authorization is disabled" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1440,7 +1443,7 @@ async def test_remote_hook_initial_raise_fails_closed(db_session):
 
 
 @pytest.mark.asyncio
-async def test_remote_hook_refresh_uses_challenge_and_changed_generation(db_session):
+async def test_remote_hook_consecutive_refreshes_advance_failed_generation(db_session):
     db, user = db_session
     server = _add_remote_server(
         db,
@@ -1478,8 +1481,68 @@ async def test_remote_hook_refresh_uses_challenge_and_changed_generation(db_sess
         "Authorization": "Bearer refreshed-token",
     }
     assert "auth" not in refreshed
-    assert refreshed["_oauth_token_resolver_refresh"] is refresh
+    next_refresh = refreshed["_oauth_token_resolver_refresh"]
+    assert next_refresh is not refresh
     assert "_connector_runtime_refresh" not in refreshed
+
+    assert await next_refresh(_challenge()) is None
+    assert requests[2].refresh == web_tools_config.OAuthRefreshContext(
+        reason="invalid_token",
+        resource_metadata_url=(
+            "https://mcp.example/.well-known/oauth-protected-resource"
+        ),
+        challenge_scope="records.read",
+        failed_generation="generation-2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_delegated_remote_evaluates_bindings_once_without_false_warning(
+    db_session,
+    monkeypatch,
+    caplog,
+):
+    db, user = db_session
+    server = _add_remote_server(
+        db,
+        user,
+        runtime_bindings=_remote_runtime_bindings(),
+        allow_delegated_authorization=True,
+    )
+    evaluations = 0
+    original = web_tools_config.runtime_bindings_from_config
+
+    def counted_runtime_bindings_from_config(config):
+        nonlocal evaluations
+        evaluations += 1
+        return original(config)
+
+    monkeypatch.setattr(
+        web_tools_config,
+        "runtime_bindings_from_config",
+        counted_runtime_bindings_from_config,
+    )
+    cfg = _tool_config(db, user)
+    cfg._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {},
+            "secrets": {
+                "runtime_header": "runtime",
+                "authorization": "Bearer delegated-token",
+            },
+            "auth_selector": {},
+        }
+    }
+
+    with caplog.at_level("WARNING"):
+        configs = await cfg.get_mcp_server_configs()
+
+    assert evaluations == 1
+    assert configs[0]["config"]["headers"] == {
+        "X-Runtime": "runtime",
+        "Authorization": "Bearer delegated-token",
+    }
+    assert "delegated authorization is disabled" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -659,6 +659,26 @@ async def test_hook_is_not_asked_without_app_info(db_session):
 
 
 @pytest.mark.asyncio
+async def test_remote_hook_without_app_info_can_claim_authorization(db_session):
+    db, user = db_session
+    server = _add_remote_server(db, user, name="Unregistered Remote")
+    db.query(PublicMCPApp).filter(PublicMCPApp.name == server.name).delete()
+    db.commit()
+    seen: list[TokenRequest] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        seen.append(request)
+        return ResolvedToken(access_token="resolver-token", generation="generation-1")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [request.provider for request in seen] == ["Unregistered Remote"]
+    assert configs[0]["config"]["headers"]["Authorization"] == ("Bearer resolver-token")
+
+
+@pytest.mark.asyncio
 async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
     db_session,
     caplog,
@@ -1697,6 +1717,29 @@ async def test_remote_hook_refresh_invalid_results_fail_closed(
     refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
 
     assert await refresh(_challenge()) is None
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_missing_initial_generation_does_not_call_refresh_resolver(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    refresh_calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        nonlocal refresh_calls
+        if request.refresh is None:
+            return ResolvedToken(access_token="initial-token")
+        refresh_calls += 1
+        return ResolvedToken(access_token="refreshed-token", generation="generation-2")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    assert await refresh(_challenge()) is None
+    assert refresh_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1316,6 +1316,36 @@ async def test_remote_hook_future_expiry_is_cached_until_registration_changes(
 
 
 @pytest.mark.asyncio
+async def test_remote_hook_near_expiry_token_is_used_but_not_cached(db_session):
+    db, user = db_session
+    _add_remote_server(db, user)
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(
+            access_token=f"remote-hook-token-{calls}",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            generation=f"remote-generation-{calls}",
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    second = await cfg.get_mcp_server_configs()
+
+    assert calls == 2
+    assert first[0]["config"]["headers"]["Authorization"] == (
+        "Bearer remote-hook-token-1"
+    )
+    assert second[0]["config"]["headers"]["Authorization"] == (
+        "Bearer remote-hook-token-2"
+    )
+
+
+@pytest.mark.asyncio
 async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
     db_session,
     caplog,

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -13,6 +14,7 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services.mcp_oauth import MCPAuthorizationChallenge
 from xagent.web.tools import config as web_tools_config
 from xagent.web.tools.config import (
     ResolvedToken,
@@ -151,6 +153,54 @@ def _add_stdio_server(db, user: User, *, name: str) -> MCPServer:
             mcpserver_id=server.id,
             is_owner=True,
             is_active=True,
+        )
+    )
+    db.commit()
+    return server
+
+
+def _add_remote_server(
+    db,
+    user: User,
+    *,
+    name: str = "Remote Records",
+    app_id: str = "remote-records",
+    provider: str = "records",
+    auth: object | None = None,
+    headers: dict | None = None,
+    runtime_bindings: list[dict] | None = None,
+    allow_delegated_authorization: bool = False,
+) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} server",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example/api",
+        auth=auth,
+        headers=headers,
+        runtime_bindings=runtime_bindings,
+        allow_delegated_authorization=allow_delegated_authorization,
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.add(
+        PublicMCPApp(
+            app_id=app_id,
+            name=name,
+            description=f"{name} app",
+            transport="streamable_http",
+            provider_name=provider,
+            launch_config={},
         )
     )
     db.commit()
@@ -1143,3 +1193,469 @@ async def test_hook_request_receives_execution_scope(db_session):
 
     assert seen_scope == [scope]
     assert _access_token_env(configs[0]) == "hook-token"
+
+
+def _remote_runtime_bindings() -> list[dict]:
+    return [
+        {
+            "source": {"input_type": "secrets", "key": "runtime_header"},
+            "target": {
+                "target_type": "transport_headers",
+                "key": "X-Runtime",
+            },
+        },
+        {
+            "source": {"input_type": "secrets", "key": "authorization"},
+            "target": {
+                "target_type": "transport_headers",
+                "key": "Authorization",
+            },
+        },
+    ]
+
+
+def _challenge() -> MCPAuthorizationChallenge:
+    return MCPAuthorizationChallenge(
+        resource_metadata_url=(
+            "https://mcp.example/.well-known/oauth-protected-resource"
+        ),
+        scope="records.read",
+        params={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
+    db_session,
+):
+    db, user = db_session
+    scope = object()
+    server = _add_remote_server(
+        db,
+        user,
+        auth={"type": "mcp_oauth", "resource": "https://auth.example/resource"},
+        headers={"X-Static": "static", "authorization": "Bearer static-token"},
+        runtime_bindings=_remote_runtime_bindings(),
+        allow_delegated_authorization=True,
+    )
+    requests: list[TokenRequest] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        requests.append(request)
+        return ResolvedToken(
+            access_token="resolver-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            generation="generation-1",
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(
+        db,
+        user,
+        execution_scope=scope,
+        mcp_auth_context={
+            str(server.id): {"resource": " https://selector.example/resource "}
+        },
+    )
+    cfg._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {"account_id": "account-1"},
+            "secrets": {
+                "runtime_header": "runtime",
+                "authorization": "Bearer delegated-token",
+            },
+            "auth_selector": {},
+        }
+    }
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert [
+        (request.provider, request.resource, request.scope) for request in requests
+    ] == [("records", " https://selector.example/resource ", scope)]
+    assert configs[0]["config"]["headers"] == {
+        "X-Static": "static",
+        "X-Runtime": "runtime",
+        "Authorization": "Bearer resolver-token",
+    }
+    assert callable(configs[0]["config"]["_oauth_token_resolver_refresh"])
+    assert "_connector_runtime_refresh" not in configs[0]["config"]
+    assert configs[0]["connector_runtime"] == {
+        "context": {"account_id": "account-1"},
+        "secrets": {},
+        "auth_selector": {},
+    }
+    assert configs[0]["runtime_bindings"] == _remote_runtime_bindings()
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_checks_all_candidates_before_existing_plain_path(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        headers={"X-Static": "static", "Authorization": "Bearer static-token"},
+    )
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> None:
+        seen.append(request.provider)
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert seen == ["records", "remote-records"]
+    assert configs[0]["config"]["headers"] == {
+        "X-Static": "static",
+        "Authorization": "Bearer static-token",
+    }
+    assert "_oauth_token_resolver_refresh" not in configs[0]["config"]
+    assert "_connector_runtime_refresh" not in configs[0]["config"]
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_decline_preserves_delegated_runtime_path(db_session):
+    db, user = db_session
+    server = _add_remote_server(
+        db,
+        user,
+        headers={"X-Static": "static"},
+        runtime_bindings=_remote_runtime_bindings(),
+        allow_delegated_authorization=True,
+    )
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> None:
+        seen.append(request.provider)
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+    cfg._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {},
+            "secrets": {
+                "runtime_header": "runtime",
+                "authorization": "Bearer delegated-token",
+            },
+            "auth_selector": {},
+        }
+    }
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert seen == ["records", "remote-records"]
+    assert configs[0]["config"]["headers"]["Authorization"] == (
+        "Bearer delegated-token"
+    )
+    assert callable(configs[0]["config"]["_connector_runtime_refresh"])
+    assert "_oauth_token_resolver_refresh" not in configs[0]["config"]
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_decline_preserves_standard_oauth_path(db_session):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        auth={"type": "mcp_oauth", "resource": "https://auth.example/resource"},
+    )
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> None:
+        seen.append(request.provider)
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert seen == ["records", "remote-records"]
+    assert configs == []
+    assert cfg.get_mcp_oauth_diagnostics()[0]["code"] == "authorization_required"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("resolved", "exception_type"),
+    [
+        (object(), "object"),
+        (
+            ResolvedToken(access_token="", generation="generation-1"),
+            "InvalidAccessToken",
+        ),
+    ],
+)
+async def test_remote_hook_malformed_initial_result_fails_closed(
+    db_session,
+    resolved,
+    exception_type,
+):
+    db, user = db_session
+    server = _add_remote_server(
+        db,
+        user,
+        headers={"Authorization": "Bearer static-token"},
+        auth={"type": "bearer", "bearer_token": "fallback-token"},
+    )
+
+    async def resolver(request: TokenRequest):
+        return resolved
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["server_id"] == server.id
+    assert cfg.get_mcp_oauth_diagnostics()[0]["exception_type"] == exception_type
+    assert "fallback-token" not in repr(configs)
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_initial_raise_fails_closed(db_session):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        headers={"Authorization": "Bearer static-token"},
+    )
+
+    async def resolver(request: TokenRequest):
+        raise RuntimeError("resolver-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "resolver-secret" not in repr(configs)
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_uses_challenge_and_changed_generation(db_session):
+    db, user = db_session
+    server = _add_remote_server(
+        db,
+        user,
+        headers={"X-Static": "static", "Authorization": "Bearer static-token"},
+    )
+    requests: list[TokenRequest] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        requests.append(request)
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        return ResolvedToken(access_token="refreshed-token", generation="generation-2")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    refreshed = await refresh(_challenge())
+
+    assert requests[1].provider == requests[0].provider == "records"
+    assert requests[1].resource == requests[0].resource == server.url
+    assert requests[1].refresh == web_tools_config.OAuthRefreshContext(
+        reason="invalid_token",
+        resource_metadata_url=(
+            "https://mcp.example/.well-known/oauth-protected-resource"
+        ),
+        challenge_scope="records.read",
+        failed_generation="generation-1",
+    )
+    assert refreshed["headers"] == {
+        "X-Static": "static",
+        "Authorization": "Bearer refreshed-token",
+    }
+    assert "auth" not in refreshed
+    assert refreshed["_oauth_token_resolver_refresh"] is refresh
+    assert "_connector_runtime_refresh" not in refreshed
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_reuses_captured_non_auth_runtime_snapshot(
+    db_session,
+):
+    db, user = db_session
+    server = _add_remote_server(
+        db,
+        user,
+        headers={"X-Static": "static"},
+        runtime_bindings=_remote_runtime_bindings(),
+    )
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        return ResolvedToken(access_token="refreshed-token", generation="generation-2")
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+    cfg._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {},
+            "secrets": {"runtime_header": "captured-runtime"},
+            "auth_selector": {},
+        }
+    }
+    configs = await cfg.get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+    cfg._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {},
+            "secrets": {"runtime_header": "later-runtime"},
+            "auth_selector": {},
+        }
+    }
+
+    refreshed = await refresh(_challenge())
+
+    assert refreshed["headers"]["X-Runtime"] == "captured-runtime"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("registration_action", ["same", "replace", "clear"])
+async def test_remote_hook_refresh_rejects_changed_registration(
+    db_session,
+    registration_action,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(
+            access_token=f"token-{calls}", generation=f"generation-{calls}"
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    if registration_action == "same":
+        set_oauth_token_resolver_hook(resolver)
+    elif registration_action == "replace":
+        set_oauth_token_resolver_hook(lambda request: None)
+    else:
+        set_oauth_token_resolver_hook(None)
+
+    assert await refresh(_challenge()) is None
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_rejects_registration_change_during_await(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def resolver(request: TokenRequest) -> ResolvedToken:
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        refresh_started.set()
+        await release_refresh.wait()
+        return ResolvedToken(access_token="refreshed-token", generation="generation-2")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    pending = asyncio.create_task(refresh(_challenge()))
+    await refresh_started.wait()
+    set_oauth_token_resolver_hook(resolver)
+    release_refresh.set()
+
+    assert await pending is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "refresh_result",
+    [
+        None,
+        object(),
+        ResolvedToken(access_token="refreshed", generation=None),
+        ResolvedToken(access_token="refreshed", generation="generation-1"),
+        ResolvedToken(access_token="refreshed", generation=""),
+        ResolvedToken(
+            access_token="refreshed",
+            generation="generation-2",
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        ),
+    ],
+    ids=[
+        "none",
+        "invalid",
+        "missing-generation",
+        "unchanged",
+        "invalid-generation",
+        "expired",
+    ],
+)
+async def test_remote_hook_refresh_invalid_results_fail_closed(
+    db_session,
+    refresh_result,
+):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        headers={"Authorization": "Bearer static-token"},
+    )
+
+    async def resolver(request: TokenRequest):
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        return refresh_result
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    assert await refresh(_challenge()) is None
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_refresh_resolver_raise_has_no_authorization_fallback(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        headers={"Authorization": "Bearer static-token"},
+    )
+
+    async def resolver(request: TokenRequest):
+        if request.refresh is None:
+            return ResolvedToken(
+                access_token="initial-token", generation="generation-1"
+            )
+        raise RuntimeError("refresh-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+    refresh = configs[0]["config"]["_oauth_token_resolver_refresh"]
+
+    assert await refresh(_challenge()) is None

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -13,12 +13,42 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as web_tools_config
 from xagent.web.tools.config import (
     ResolvedToken,
     TokenRequest,
     WebToolConfig,
     set_oauth_token_resolver_hook,
 )
+
+
+def test_token_request_refresh_defaults_to_none():
+    request = TokenRequest(provider="google", user_id=1)
+
+    assert request.refresh is None
+
+
+def test_resolver_contract_repr_hides_token_and_generation():
+    refresh = web_tools_config.OAuthRefreshContext(
+        reason="invalid_token",
+        resource_metadata_url=None,
+        challenge_scope=None,
+        failed_generation="failed-generation-secret",
+    )
+    token = ResolvedToken(
+        access_token="access-token-secret",
+        generation="current-generation-secret",
+    )
+
+    rendered = repr((refresh, token))
+
+    assert "access-token-secret" not in rendered
+    assert "failed-generation-secret" not in rendered
+    assert "current-generation-secret" not in rendered
+
+
+def test_oauth_token_generation_max_length_is_1024():
+    assert web_tools_config.OAUTH_TOKEN_GENERATION_MAX_LENGTH == 1024
 
 
 @pytest.fixture(autouse=True)
@@ -844,6 +874,85 @@ async def test_hook_malformed_token_creates_unavailable_config(
     assert configs[0]["transport"] == "unavailable"
     assert configs[0]["config"]["server_id"] == server.id
     assert cfg.get_mcp_oauth_diagnostics()[0]["exception_type"] == exception_type
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("generation", [None, " generation-v1 "])
+async def test_hook_preserves_valid_generation_during_normalization(
+    db_session,
+    generation,
+):
+    db, user = db_session
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="access-token-secret",
+            expires_at=None,
+            generation=generation,
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    resolved = await _tool_config(db, user)._resolve_oauth_token_from_hook(
+        providers=["google"],
+        resource=None,
+    )
+
+    assert resolved is not None
+    assert resolved.provider == "google"
+    assert resolved.access_token == "access-token-secret"
+    assert resolved.generation == generation
+    assert "access-token-secret" not in repr(resolved)
+    if generation is not None:
+        assert generation not in repr(resolved)
+
+
+class _SecretStringGeneration(str):
+    pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generation", "secret_marker"),
+    [
+        ("", None),
+        (
+            _SecretStringGeneration("wrong-type-generation-secret"),
+            "wrong-type-generation-secret",
+        ),
+        ("oversized-generation-secret" + "x" * 1024, "oversized-generation-secret"),
+    ],
+    ids=["empty", "wrong-type", "oversized"],
+)
+async def test_hook_invalid_generation_creates_sanitized_unavailable_config(
+    db_session,
+    caplog,
+    generation,
+    secret_marker,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    server = _add_oauth_server(db, user, launch_config=_launch_config())
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=None,
+            generation=generation,
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["server_id"] == server.id
+    assert cfg.get_mcp_oauth_diagnostics()[0]["exception_type"] == ("InvalidGeneration")
+    if secret_marker is not None:
+        assert secret_marker not in repr(configs)
+        assert secret_marker not in repr(cfg.get_mcp_oauth_diagnostics())
+        assert secret_marker not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1250,6 +1250,72 @@ def _challenge() -> MCPAuthorizationChallenge:
 
 
 @pytest.mark.asyncio
+async def test_remote_without_hook_skips_resolver_candidate_work(
+    db_session,
+    monkeypatch,
+):
+    db, user = db_session
+    _add_remote_server(
+        db,
+        user,
+        headers={"X-Static": "static", "Authorization": "Bearer static-token"},
+    )
+
+    def unexpected_resolver_work(*args, **kwargs):
+        pytest.fail("resolver-specific work ran without a registered hook")
+
+    monkeypatch.setattr("xagent.web.mcp_apps.get_app_by_name", unexpected_resolver_work)
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.effective_mcp_oauth_resource",
+        unexpected_resolver_work,
+    )
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"] == {
+        "X-Static": "static",
+        "Authorization": "Bearer static-token",
+    }
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_future_expiry_is_cached_until_registration_changes(
+    db_session,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(
+            access_token=f"remote-hook-token-{calls}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            generation=f"remote-generation-{calls}",
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    second = await cfg.get_mcp_server_configs()
+    set_oauth_token_resolver_hook(resolver)
+    third = await cfg.get_mcp_server_configs()
+
+    assert calls == 2
+    assert first[0]["config"]["headers"]["Authorization"] == (
+        "Bearer remote-hook-token-1"
+    )
+    assert second[0]["config"]["headers"]["Authorization"] == (
+        "Bearer remote-hook-token-1"
+    )
+    assert third[0]["config"]["headers"]["Authorization"] == (
+        "Bearer remote-hook-token-2"
+    )
+
+
+@pytest.mark.asyncio
 async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
     db_session,
     caplog,

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1463,6 +1463,69 @@ async def test_remote_hook_initial_raise_fails_closed(db_session):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_failure_code", "expected_failure_code"),
+    [
+        ("oauth_token_required", "oauth_token_required"),
+        ("other_valid_code", None),
+        (" oauth_token_required", None),
+        (123, None),
+    ],
+)
+async def test_remote_hook_preserves_only_allowlisted_resolver_failure_code(
+    db_session,
+    raw_failure_code,
+    expected_failure_code,
+):
+    db, user = db_session
+    _add_remote_server(db, user)
+
+    class ResolverFailure(RuntimeError):
+        oauth_token_resolver_failure_code = raw_failure_code
+
+    async def resolver(request: TokenRequest):
+        raise ResolverFailure("resolver-internal-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    configs = await cfg.get_mcp_server_configs()
+
+    unavailable_config = configs[0]["config"]
+    if expected_failure_code is None:
+        assert "failure_code" not in unavailable_config
+    else:
+        assert unavailable_config["failure_code"] == expected_failure_code
+    assert "failure_code" not in cfg.get_mcp_oauth_diagnostics()[0]
+    assert "resolver-internal-secret" not in repr(configs)
+
+
+@pytest.mark.asyncio
+async def test_remote_hook_failure_code_property_error_is_sanitized(db_session):
+    db, user = db_session
+    _add_remote_server(db, user)
+
+    class ResolverFailure(RuntimeError):
+        @property
+        def oauth_token_resolver_failure_code(self):
+            raise RuntimeError("failure-code-property-secret")
+
+    async def resolver(request: TokenRequest):
+        raise ResolverFailure("resolver-internal-secret")
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "failure_code" not in configs[0]["config"]
+    public_output = repr(configs) + repr(cfg.get_mcp_oauth_diagnostics())
+    assert "failure-code-property-secret" not in public_output
+    assert "resolver-internal-secret" not in public_output
+
+
+@pytest.mark.asyncio
 async def test_remote_hook_consecutive_refreshes_advance_failed_generation(db_session):
     db, user = db_session
     server = _add_remote_server(


### PR DESCRIPTION
## Summary

- extend the OAuth token resolver contract with opaque token generations and invalid-token refresh context
- let resolver-owned remote HTTP MCP connections rebuild their connection and session after a strict Bearer invalid_token response, then retry the original tool call once
- propagate the allowlisted oauth_token_required failure classification through unavailable tools, runtime failure handling, and tool_execution_failed traces
- treat the MCP protocol CallToolResult.isError=true signal as a failed tool execution across the shared ReAct/runtime result classifier

## Behavior and safety

Resolver ownership is established only after the initial resolver returns a valid token. Once claimed, Authorization cannot fall back to connector runtime, standard MCP OAuth, or static credentials. Non-authentication connector headers, runtime context, metadata, and tool arguments remain intact.

For remote HTTP transports, a registered resolver is consulted before connector-runtime authorization and standard MCP OAuth. If every provider candidate declines, the existing connector-runtime, standard OAuth, and static credential paths retain their previous order and behavior. Deployments without a registered resolver skip resolver-only registry lookup and resource computation.

Refresh requires a valid failed generation, an unchanged resolver registration, a real HTTP 401 response, and a Bearer invalid_token challenge. Resolver decline, malformed results, unchanged or missing generations, registration changes, refresh failures, and a second 401 all fail closed with the existing sanitized delegated authorization error.

The shared is_error classification is intentional and is not limited to OAuth. CallToolResult.isError is the MCP protocol tool-execution failure signal; treating it as success would write ordinary MCP failures into completed ledgers and success traces. UnavailableMCPTool uses the full failure envelope, while MCP adapter results preserve the protocol-level is_error signal. Regression coverage pins finalization gating, concurrent-batch aggregation, repeated-success counting, ledger state, and trace state.

Access tokens, opaque generations, resolver exception details, diagnostics, and refresh payloads are excluded from representations, tool results, traces, and user-facing errors. Existing connector runtime refresh and MCPOAuthGrant flows remain unchanged.

## Validation

- OAuth resolver injection, generation, ownership, registration, and fail-closed tests
- no-hook remote fast-path and remote resolver cache invalidation tests
- real httpx and MCP exception-chain refresh/retry coverage
- connector runtime refresh contract regressions
- standard MCP OAuth runtime and discovery regressions
- unavailable tool, ReAct finalization, concurrent aggregation, repeated-success counting, PatternRuntime, trace, checkpoint, and task API regressions
- Ruff lint and format checks
- mypy on all changed production modules
- git diff whitespace validation