### PR TITLE
feat: support file attachments on v1 SDK task turns

### DIFF
--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -440,10 +440,12 @@ async def create_chat_task(
         pop_ephemeral_runtime_values(payload.turn_id)
         raise
 
-    # Bind files only after the turn is committed to running. This is a
-    # synchronous commit with no await before the response returns, so it
-    # lands before the background execution coroutine (scheduled inside
-    # begin_turn) gets to read the files.
+    # Bind files only after the turn is committed to running. This bind can
+    # race the background runner (begin_turn schedules it via create_task and
+    # may await further steps before returning here), but that's harmless: the
+    # runner's file query tolerates a NULL task_id (task_id == this OR IS NULL,
+    # owned by the user), so the just-uploaded files are readable whether or
+    # not this bind has landed. The bind is for durable task<->file association.
     bind_turn_files(
         file_ids=[info["file_id"] for info in file_infos],
         task_id=int(task.id),
@@ -645,7 +647,9 @@ async def append_message_to_task(
         raise
 
     # Bind files only after the turn is claimed -- a 409 above leaves them
-    # unbound and reusable. Synchronous commit, no await before returning.
+    # unbound and reusable. The bind can race the background runner, but the
+    # runner's file query tolerates a NULL task_id (see create_chat_task), so
+    # visibility doesn't depend on this commit landing first.
     bind_turn_files(
         file_ids=[info["file_id"] for info in file_infos],
         task_id=int(task.id),

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -17,11 +17,12 @@ by the WebSocket UI path so both transports share one state machine.
 import logging
 from typing import Any, NoReturn, Optional, Tuple, cast
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ....core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from ...config import is_allowed_file
 from ...models.agent import Agent
 from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_db
@@ -45,6 +46,13 @@ from ...services.connector_runtime import (
     prepare_create_connector_runtime,
     store_ephemeral_runtime_values,
 )
+from ...services.file_turn import (
+    append_uploaded_files_context,
+    bind_turn_files,
+    build_uploaded_files_context,
+    normalize_attachments_for_persistence,
+    resolve_turn_file_infos,
+)
 from ...services.hot_path_cache import (
     cache_get,
     cache_set,
@@ -53,6 +61,7 @@ from ...services.hot_path_cache import (
     task_snapshot_key,
     task_steps_key,
 )
+from ...services.managed_file_ref import DurableStorageOperationError
 from ...services.task_execution_controller import (
     TaskControlState,
     apply_task_control_transition,
@@ -95,15 +104,45 @@ async def upload_task_files(
     if owner is None:
         raise V1ApiError(V1ErrorCode.INTERNAL_ERROR, 500)
 
-    result = await store_uploaded_files(
-        upload_items=list(files),
-        task_type="general",
-        task_id=None,
-        folder=None,
-        user=owner,
-        db=db,
-        single_file_mode=False,
-    )
+    # Reject unsupported types up front with a clean v1 400. ``store_uploaded_files``
+    # would otherwise raise a bare HTTPException (a 500 for unsupported type) that
+    # bypasses the v1 error envelope and leaks the internal ``task_type`` wording.
+    for uploaded in files:
+        if not is_allowed_file(uploaded.filename or "", "general"):
+            raise V1ApiError(
+                V1ErrorCode.INVALID_INPUT,
+                400,
+                message=f"Unsupported file type: {uploaded.filename}",
+            )
+
+    try:
+        result = await store_uploaded_files(
+            upload_items=list(files),
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user=owner,
+            db=db,
+            single_file_mode=False,
+        )
+    except HTTPException as exc:
+        # ``store_uploaded_files`` is shared with the JWT upload route and raises
+        # bare HTTPExceptions; translate to the v1 envelope so SDK clients keep a
+        # stable {"error": {"code": ...}} shape. 503 (durable storage) stays 503 so
+        # callers can retry; 413 (too large) stays 413; other client errors -> 400.
+        if exc.status_code == 503:
+            raise V1ApiError(
+                V1ErrorCode.INTERNAL_ERROR,
+                503,
+                message="File storage is temporarily unavailable.",
+            ) from exc
+        if 400 <= exc.status_code < 500:
+            raise V1ApiError(
+                V1ErrorCode.INVALID_INPUT,
+                413 if exc.status_code == 413 else 400,
+                message="File upload rejected.",
+            ) from exc
+        raise V1ApiError(V1ErrorCode.INTERNAL_ERROR, 500) from exc
     return UploadFilesResponse(
         files=[
             UploadedFileInfo(
@@ -117,45 +156,60 @@ async def upload_task_files(
     )
 
 
-async def _build_file_turn_extras(
-    *, task_id: int, file_ids: list[str], owner_user_id: int, content: str, db: Session
-) -> Tuple[Optional[str], Optional[list[dict[str, Any]]]]:
-    """Bind ``file_ids`` to the task and build (execution_message, attachments).
+def _resolve_turn_files_or_400(
+    *,
+    file_ids: list[str],
+    owner_user_id: int,
+    db: Session,
+    task_id: Optional[int] = None,
+) -> list[dict[str, Any]]:
+    """Resolve every ``file_id`` up front (all-or-nothing) WITHOUT binding.
 
-    Mirrors the WebSocket file path so the agent sees the same
-    ``## UPLOADED FILES`` context and the transcript row carries the same
-    clickable chips. Returns ``(None, None)`` when no files were supplied.
-    Raises 400 ``invalid_input`` if file_ids were given but none resolved
-    to a file owned by this user (bad id, wrong owner, or bound elsewhere).
+    Called before the task is committed (create) or the turn is claimed
+    (append), so a bad/unowned/already-bound id fails with 400 before any
+    task row is created or mutated -- no orphan task, no binding stuck to a
+    turn that later 409s. Actual binding happens via :func:`bind_turn_files`
+    only after the turn is committed to running.
     """
     if not file_ids:
-        return None, None
-
-    from ..websocket import (
-        _append_uploaded_files_context_to_message,
-        _build_uploaded_files_context,
-        _normalize_attachments_for_persistence,
-        handle_file_upload_for_task,
-    )
-
-    upload_result = await handle_file_upload_for_task(
-        task_id,
-        [{"file_id": fid} for fid in file_ids],
-        db,
-        task_owner_id=owner_user_id,
-    )
-    file_info_list = upload_result.get("file_info_list", [])
-    if not file_info_list:
+        return []
+    try:
+        file_infos, missing = resolve_turn_file_infos(
+            file_ids=file_ids,
+            owner_user_id=owner_user_id,
+            db=db,
+            task_id=task_id,
+        )
+    except DurableStorageOperationError as exc:
+        # Transient storage fault, not a client error -- 503 so SDK can retry.
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            503,
+            message="File storage is temporarily unavailable.",
+        ) from exc
+    if missing:
         raise V1ApiError(
             V1ErrorCode.INVALID_INPUT,
             400,
-            message="None of the supplied file ids are accessible.",
+            message="These file ids are not accessible: " + ", ".join(missing),
         )
+    return file_infos
 
-    context = _build_uploaded_files_context(file_info_list)
-    execution_message = _append_uploaded_files_context_to_message(content, context)
-    attachments = _normalize_attachments_for_persistence(file_info_list) or None
-    return execution_message, attachments
+
+def _turn_payload(content: str, file_infos: list[dict[str, Any]]) -> TaskTurnPayload:
+    """Build a :class:`TaskTurnPayload`, file-enriching the execution channel.
+
+    Consolidates the payload construction shared by create and append so the
+    transcript-vs-execution split can't drift between the two entry points.
+    """
+    if not file_infos:
+        return TaskTurnPayload(transcript_message=content)
+    context = build_uploaded_files_context(file_infos)
+    return TaskTurnPayload(
+        transcript_message=content,
+        execution_message=append_uploaded_files_context(content, context),
+        attachments=normalize_attachments_for_persistence(file_infos) or None,
+    )
 
 
 def _raise_v1_connector_runtime_error(exc: ConnectorRuntimeError) -> NoReturn:
@@ -299,6 +353,16 @@ async def create_chat_task(
     if request.agent_id != agent.id:
         raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
 
+    # Validate any attached file ids BEFORE creating the task, so a bad id
+    # fails with 400 without leaving an orphan PENDING task behind. Binding
+    # happens after the turn is claimed (below).
+    file_infos = _resolve_turn_files_or_400(
+        file_ids=request.message.files or [],
+        owner_user_id=int(agent.user_id),
+        db=db,
+        task_id=None,
+    )
+
     try:
         runtime_plan = prepare_create_connector_runtime(
             db=db,
@@ -348,18 +412,7 @@ async def create_chat_task(
     # commit, and bg coroutine scheduling under a lease lifecycle.
     # A brand-new task shouldn't ever hit busy -- but we map it
     # anyway for defense.
-    execution_message, attachments = await _build_file_turn_extras(
-        task_id=int(task.id),
-        file_ids=request.message.files or [],
-        owner_user_id=int(agent.user_id),
-        content=request.message.content,
-        db=db,
-    )
-    payload = TaskTurnPayload(
-        transcript_message=request.message.content,
-        execution_message=execution_message,
-        attachments=attachments,
-    )
+    payload = _turn_payload(request.message.content, file_infos)
     _store_connector_runtime_values_or_fail(
         db=db,
         task_id=int(task.id),
@@ -386,6 +439,17 @@ async def create_chat_task(
     except Exception:
         pop_ephemeral_runtime_values(payload.turn_id)
         raise
+
+    # Bind files only after the turn is committed to running. This is a
+    # synchronous commit with no await before the response returns, so it
+    # lands before the background execution coroutine (scheduled inside
+    # begin_turn) gets to read the files.
+    bind_turn_files(
+        file_ids=[info["file_id"] for info in file_infos],
+        task_id=int(task.id),
+        owner_user_id=int(agent.user_id),
+        db=db,
+    )
 
     # Record usage here (not in the shared auth dependency) so read-only
     # status/steps polling below doesn't count as a "call". Runtime validation
@@ -537,22 +601,22 @@ async def append_message_to_task(
     except ConnectorRuntimeError as exc:
         _raise_v1_connector_runtime_error(exc)
 
+    # Validate attached file ids before claiming the turn: an unresolvable id
+    # is a 400 that must not mutate anything, and files must not be bound to a
+    # turn that then 409s (task busy). ``task_id`` is passed so files already
+    # bound to this task re-resolve idempotently. Binding runs after the claim.
+    file_infos = _resolve_turn_files_or_400(
+        file_ids=request.message.files or [],
+        owner_user_id=int(agent.user_id),
+        db=db,
+        task_id=int(task.id),
+    )
+
     # Orchestrator does the atomic claim (status must be terminal --
     # COMPLETED or FAILED -- to be appendable, so PENDING/RUNNING both
     # 409), persists the new user message, and schedules the bg turn
     # with a single-flight guard against concurrent kickoffs.
-    execution_message, attachments = await _build_file_turn_extras(
-        task_id=int(task.id),
-        file_ids=request.message.files or [],
-        owner_user_id=int(agent.user_id),
-        content=request.message.content,
-        db=db,
-    )
-    payload = TaskTurnPayload(
-        transcript_message=request.message.content,
-        execution_message=execution_message,
-        attachments=attachments,
-    )
+    payload = _turn_payload(request.message.content, file_infos)
     _store_connector_runtime_values_or_fail(
         db=db,
         task_id=int(task.id),
@@ -579,6 +643,15 @@ async def append_message_to_task(
     except Exception:
         pop_ephemeral_runtime_values(payload.turn_id)
         raise
+
+    # Bind files only after the turn is claimed -- a 409 above leaves them
+    # unbound and reusable. Synchronous commit, no await before returning.
+    bind_turn_files(
+        file_ids=[info["file_id"] for info in file_infos],
+        task_id=int(task.id),
+        owner_user_id=int(agent.user_id),
+        db=db,
+    )
 
     # See the matching comment in create_chat_task: recorded here, not in
     # the shared auth dependency, so status polling elsewhere never counts.

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -15,9 +15,9 @@ by the WebSocket UI path so both transports share one state machine.
 """
 
 import logging
-from typing import Any, NoReturn, Tuple, cast
+from typing import Any, NoReturn, Optional, Tuple, cast
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, UploadFile
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -26,6 +26,7 @@ from ...models.agent import Agent
 from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_db
 from ...models.task import Task, TaskStatus, TraceEvent
+from ...models.user import User
 from ...schemas.v1 import (
     AppendMessageRequest,
     AppendMessageResponse,
@@ -34,6 +35,8 @@ from ...schemas.v1 import (
     PublicStep,
     StepsResponse,
     TaskInfoResponse,
+    UploadedFileInfo,
+    UploadFilesResponse,
 )
 from ...services.connector_runtime import (
     persist_create_connector_runtime_context,
@@ -69,6 +72,90 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE = "Connector runtime setup failed."
+
+
+@router.post("/chat/files", response_model=UploadFilesResponse)
+async def upload_task_files(
+    files: list[UploadFile] = File(...),
+    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> UploadFilesResponse:
+    """Store files for later attachment to a task turn.
+
+    API-key-gated counterpart to the JWT-only ``POST /api/files/upload``.
+    Files are stored unbound (``task_id`` NULL) and owned by the agent's
+    user; the returned ``file_id`` values are passed back in
+    ``message.files`` on ``POST /v1/chat/tasks`` (or ``.../messages``),
+    where they get bound to the task and exposed to the agent.
+    """
+    from ..files import store_uploaded_files
+
+    agent, _key = authed
+    owner = db.query(User).filter(User.id == agent.user_id).first()
+    if owner is None:
+        raise V1ApiError(V1ErrorCode.INTERNAL_ERROR, 500)
+
+    result = await store_uploaded_files(
+        upload_items=list(files),
+        task_type="general",
+        task_id=None,
+        folder=None,
+        user=owner,
+        db=db,
+        single_file_mode=False,
+    )
+    return UploadFilesResponse(
+        files=[
+            UploadedFileInfo(
+                file_id=f["file_id"],
+                filename=f["filename"],
+                file_size=f["file_size"],
+                mime_type=f.get("mime_type"),
+            )
+            for f in result.get("files", [])
+        ]
+    )
+
+
+async def _build_file_turn_extras(
+    *, task_id: int, file_ids: list[str], owner_user_id: int, content: str, db: Session
+) -> Tuple[Optional[str], Optional[list[dict[str, Any]]]]:
+    """Bind ``file_ids`` to the task and build (execution_message, attachments).
+
+    Mirrors the WebSocket file path so the agent sees the same
+    ``## UPLOADED FILES`` context and the transcript row carries the same
+    clickable chips. Returns ``(None, None)`` when no files were supplied.
+    Raises 400 ``invalid_input`` if file_ids were given but none resolved
+    to a file owned by this user (bad id, wrong owner, or bound elsewhere).
+    """
+    if not file_ids:
+        return None, None
+
+    from ..websocket import (
+        _append_uploaded_files_context_to_message,
+        _build_uploaded_files_context,
+        _normalize_attachments_for_persistence,
+        handle_file_upload_for_task,
+    )
+
+    upload_result = await handle_file_upload_for_task(
+        task_id,
+        [{"file_id": fid} for fid in file_ids],
+        db,
+        task_owner_id=owner_user_id,
+    )
+    file_info_list = upload_result.get("file_info_list", [])
+    if not file_info_list:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            message="None of the supplied file ids are accessible.",
+        )
+
+    context = _build_uploaded_files_context(file_info_list)
+    execution_message = _append_uploaded_files_context_to_message(content, context)
+    attachments = _normalize_attachments_for_persistence(file_info_list) or None
+    return execution_message, attachments
 
 
 def _raise_v1_connector_runtime_error(exc: ConnectorRuntimeError) -> NoReturn:
@@ -261,7 +348,18 @@ async def create_chat_task(
     # commit, and bg coroutine scheduling under a lease lifecycle.
     # A brand-new task shouldn't ever hit busy -- but we map it
     # anyway for defense.
-    payload = TaskTurnPayload(transcript_message=request.message.content)
+    execution_message, attachments = await _build_file_turn_extras(
+        task_id=int(task.id),
+        file_ids=request.message.files or [],
+        owner_user_id=int(agent.user_id),
+        content=request.message.content,
+        db=db,
+    )
+    payload = TaskTurnPayload(
+        transcript_message=request.message.content,
+        execution_message=execution_message,
+        attachments=attachments,
+    )
     _store_connector_runtime_values_or_fail(
         db=db,
         task_id=int(task.id),
@@ -443,7 +541,18 @@ async def append_message_to_task(
     # COMPLETED or FAILED -- to be appendable, so PENDING/RUNNING both
     # 409), persists the new user message, and schedules the bg turn
     # with a single-flight guard against concurrent kickoffs.
-    payload = TaskTurnPayload(transcript_message=request.message.content)
+    execution_message, attachments = await _build_file_turn_extras(
+        task_id=int(task.id),
+        file_ids=request.message.files or [],
+        owner_user_id=int(agent.user_id),
+        content=request.message.content,
+        db=db,
+    )
+    payload = TaskTurnPayload(
+        transcript_message=request.message.content,
+        execution_message=execution_message,
+        attachments=attachments,
+    )
     _store_connector_runtime_values_or_fail(
         db=db,
         task_id=int(task.id),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5,7 +5,6 @@ import json
 import logging
 import re
 import shutil
-import unicodedata
 import uuid
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -55,6 +54,22 @@ from ..services.chat_history_service import (
     mark_user_message_delivery,
     mark_user_message_delivery_sync,
 )
+from ..services.file_turn import (
+    append_uploaded_files_context as _append_uploaded_files_context_to_message,
+)
+from ..services.file_turn import (
+    bind_turn_files,
+)
+from ..services.file_turn import (
+    build_uploaded_files_context as _build_uploaded_files_context,
+)
+from ..services.file_turn import (
+    normalize_attachments_for_persistence as _normalize_attachments_for_persistence,
+)
+from ..services.file_turn import (
+    normalize_filename,
+    resolve_turn_file_infos,
+)
 from ..services.hot_path_cache import (
     cache_get,
     cache_set,
@@ -64,7 +79,6 @@ from ..services.hot_path_cache import (
 )
 from ..services.managed_file_ref import (
     DurableStorageOperationError,
-    ensure_uploaded_file_local_path,
 )
 from ..services.task_execution_controller import (
     TaskControlState,
@@ -297,51 +311,6 @@ def _resolve_task_llm_ids(
     )
 
 
-def normalize_filename(filename: str) -> str:
-    """
-    Normalize filename by removing special characters and spaces.
-
-    Args:
-        filename: Original filename
-
-    Returns:
-        Normalized filename safe for file operations
-    """
-    from pathlib import Path
-
-    # Keep file extension
-    name_part = Path(filename).stem
-    extension = Path(filename).suffix
-
-    # Unicode normalize (NFD to NFC, remove diacritics)
-    name_part = unicodedata.normalize("NFC", name_part)
-
-    # Replace spaces with underscores
-    name_part = re.sub(r"\s+", "_", name_part)
-
-    # Remove special characters, keep only letters, numbers, underscores, Chinese characters
-    name_part = re.sub(r"[^\w\u4e00-\u9fff\-_.]", "", name_part)
-
-    # Remove consecutive underscores
-    name_part = re.sub(r"_+", "_", name_part)
-
-    # Remove leading and trailing underscores
-    name_part = name_part.strip("_")
-
-    # Use default name if filename is empty
-    if not name_part:
-        name_part = "file"
-
-    # Reassemble filename
-    normalized_name = name_part + extension
-
-    # Ensure filename doesn't start with a dot (hidden file)
-    if normalized_name.startswith("."):
-        normalized_name = "_" + normalized_name
-
-    return normalized_name
-
-
 def build_unique_target_path(target_dir: Any, filename: str) -> Any:
     from pathlib import Path
 
@@ -357,58 +326,6 @@ def build_unique_target_path(target_dir: Any, filename: str) -> Any:
         if not candidate.exists():
             return candidate
         counter += 1
-
-
-def _build_uploaded_files_context(
-    file_info_list: List[Dict[str, Any]], *, is_agent_builder: bool = False
-) -> str:
-    """Build stable LLM context for files already uploaded for this turn."""
-    if not file_info_list:
-        return ""
-
-    file_summaries = []
-    file_ids = []
-    for file_info in file_info_list:
-        file_id = str(file_info.get("file_id") or "").strip()
-        if not file_id:
-            continue
-        name = str(
-            file_info.get("original_name") or file_info.get("name") or "uploaded file"
-        )
-        file_ids.append(file_id)
-        file_summaries.append(f"- {name}: file_id={file_id}")
-
-    if not file_ids:
-        return ""
-
-    lines = [
-        "## UPLOADED FILES",
-        "The user has uploaded file(s) for this turn. Use these exact file_id values:",
-        *file_summaries,
-        "",
-        FILE_REF_MODEL_INSTRUCTIONS,
-    ]
-    if is_agent_builder:
-        joined_file_ids = ", ".join(f'"{file_id}"' for file_id in file_ids)
-        lines.extend(
-            [
-                "",
-                "For knowledge-base creation, call `create_knowledge_base_from_file` with:",
-                f"  file_ids = [{joined_file_ids}]",
-                "Do NOT ask the user to upload again unless these file_ids fail.",
-            ]
-        )
-    return "\n".join(lines)
-
-
-def _append_uploaded_files_context_to_message(
-    message: str, uploaded_files_context: str
-) -> str:
-    if not uploaded_files_context:
-        return message
-    if uploaded_files_context in message:
-        return message
-    return f"{message.rstrip()}\n\n{uploaded_files_context}"
 
 
 def _display_message_for_user(user_message: str, has_files: bool) -> str:
@@ -513,22 +430,6 @@ def _selected_file_refs_from_task(task: Any, db: Session) -> list[dict[str, Any]
             continue
         refs.append(_uploaded_file_ref(record))
     return refs
-
-
-def _normalize_attachments_for_persistence(
-    file_info_list: Optional[List[Dict[str, Any]]],
-) -> List[Dict[str, Any]]:
-    """Project file_info_list to the minimal shape we persist on chat rows.
-
-    Thin wrapper around the shared
-    ``core.agent.attachments.project_file_info_to_chip`` so the trace
-    callback and the persistence path can't drift on what fields the
-    browser sees (paths must never leak — the attachments column and the
-    user_message trace events both reach the UI).
-    """
-    from ...core.agent.attachments import project_file_info_to_chip
-
-    return project_file_info_to_chip(file_info_list)
 
 
 def _attachment_fingerprint(attachments: Any) -> str:
@@ -2912,13 +2813,14 @@ async def handle_file_upload_for_task(
     user: Optional[User] = None,
     task_owner_id: Optional[int] = None,
 ) -> dict:
-    """Handle file upload for task"""
+    """Handle file upload for task.
+
+    Thin transport wrapper over the shared ``services.file_turn`` pipeline:
+    resolve the requested file ids to file-info dicts, then bind the ones
+    that resolved to this task. WS keeps its lenient behavior — files that
+    don't resolve are logged and skipped, not raised.
+    """
     try:
-        from ..models.uploaded_file import UploadedFile
-
-        uploaded_files = []
-        file_info_list = []
-
         logger.info(f"📁 Starting file upload for task {task_id}, files: {len(files)}")
 
         authorized_owner_id = task_owner_id
@@ -2931,84 +2833,27 @@ async def handle_file_upload_for_task(
             )
             return {"uploaded_files": [], "file_info_list": []}
 
-        for file_info in files:
-            file_id = file_info.get("file_id")
-            if not file_id:
-                logger.warning(f"No file_id provided in file info: {file_info}")
-                continue
-
-            file_record = (
-                db.query(UploadedFile)
-                .filter(
-                    UploadedFile.file_id == file_id,
-                    UploadedFile.user_id == int(authorized_owner_id),
-                    or_(
-                        UploadedFile.task_id == int(task_id),
-                        UploadedFile.task_id.is_(None),
-                    ),
-                )
-                .first()
+        file_ids = [str(f.get("file_id")) for f in files if f.get("file_id")]
+        file_info_list, missing = resolve_turn_file_infos(
+            file_ids=file_ids,
+            owner_user_id=int(authorized_owner_id),
+            db=db,
+            task_id=int(task_id),
+        )
+        for missing_id in missing:
+            logger.warning(
+                "File record not accessible for task %s: %s", task_id, missing_id
             )
-            if not file_record:
-                logger.warning(
-                    "File record not accessible for task %s: %s",
-                    task_id,
-                    file_id,
-                )
-                continue
 
-            file_name = file_record.filename
-            file_size = file_record.file_size
-            file_type = file_record.mime_type
-            source_path = ensure_uploaded_file_local_path(file_record)
+        bind_turn_files(
+            file_ids=[info["file_id"] for info in file_info_list],
+            task_id=int(task_id),
+            owner_user_id=int(authorized_owner_id),
+            db=db,
+        )
 
-            if not source_path.exists():
-                logger.warning(f"Physical file not found: {source_path}")
-                continue
-
-            try:
-                # Use normalized filename instead of original
-                original_file_name = Path(file_name).name
-                normalized_file_name = normalize_filename(original_file_name)
-
-                # Keep the real file in the user-level uploads dir, but expose
-                # a symlink inside the task workspace's input/ directory so
-                # the agent's `list_files` tool can see it without needing
-                # additional tool calls. Without this link, `list_files`
-                # returns an empty workspace and the agent often gives up
-                # before falling back to `list_all_user_files`.
-                target_path = source_path
-                uploaded_files.append(str(target_path))
-
-                if file_record.task_id is None:
-                    file_record.task_id = task_id
-
-                db.flush()
-
-                # Build file info using normalized filename
-                file_info_list.append(
-                    {
-                        "file_id": file_record.file_id,
-                        "name": normalized_file_name,
-                        "original_name": original_file_name,
-                        "size": file_size,
-                        "type": file_type,
-                        "path": str(target_path),
-                        "workspace_path": None,
-                    }
-                )
-
-                logger.info(
-                    f"File staged: storage={target_path} "
-                    f"(original={original_file_name} normalized={normalized_file_name})"
-                )
-
-            except Exception as e:
-                logger.error(f"Error handling file {file_info.get('name')}: {e}")
-                raise
-
+        uploaded_files = [info["path"] for info in file_info_list]
         logger.info(f"🎉 File upload completed, uploaded {len(uploaded_files)} files")
-        db.commit()
         return {"uploaded_files": uploaded_files, "file_info_list": file_info_list}
 
     except Exception as e:

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -52,6 +52,14 @@ class MessageBody(BaseModel):
         min_length=1,
         description="The user's message text. Must be non-empty.",
     )
+    files: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "file_id values previously returned by ``POST /v1/chat/files``. "
+            "The referenced files are attached to this turn and exposed to "
+            "the agent via file references."
+        ),
+    )
 
 
 class ConnectorRuntimeRefBody(BaseModel):
@@ -104,6 +112,26 @@ class CreateTaskRequest(BaseModel):
             "validated and applied below the LLM/tool-argument layer."
         ),
     )
+
+
+class UploadedFileInfo(BaseModel):
+    """One stored file returned by ``POST /v1/chat/files``."""
+
+    file_id: str
+    filename: str
+    file_size: int
+    mime_type: Optional[str] = None
+
+
+class UploadFilesResponse(BaseModel):
+    """``POST /v1/chat/files`` -> stored file handles.
+
+    Pass the returned ``file_id`` values in a subsequent
+    ``POST /v1/chat/tasks`` (or ``.../messages``) under ``message.files``
+    to attach them to a turn.
+    """
+
+    files: List[UploadedFileInfo]
 
 
 class RuntimeKeyResponse(BaseModel):

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -118,11 +118,17 @@ def resolve_turn_file_infos(
 
     file_infos: List[Dict[str, Any]] = []
     missing: List[str] = []
+    seen: set[str] = set()
     for raw_file_id in file_ids:
         file_id = str(raw_file_id or "").strip()
         if not file_id:
             missing.append(str(raw_file_id))
             continue
+        # Dedup at the source so a repeated file_id doesn't produce duplicate
+        # UPLOADED FILES lines / attachment chips downstream.
+        if file_id in seen:
+            continue
+        seen.add(file_id)
 
         record = (
             db.query(UploadedFile)

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -1,0 +1,248 @@
+"""Shared file-attachment pipeline for a single task turn.
+
+One owner for the resolve -> bind -> LLM-context steps so both transports
+stay identical and cannot drift:
+
+  - ``api/websocket.py`` (WebSocket UI path)
+  - ``api/v1/tasks.py``  (SDK ``/v1`` path)
+
+The resolve and bind steps are deliberately split:
+
+  - :func:`resolve_turn_file_infos` is read-only. The SDK path calls it to
+    validate file ids *before* it commits a task or claims a turn, so a bad
+    id fails with 400 without leaving an orphan PENDING task behind, and no
+    file gets bound to a turn that then 409s.
+  - :func:`bind_turn_files` performs the mutation (stamping ``task_id``) and
+    is called only once the turn is committed to running.
+
+The WebSocket path keeps its resolve-then-bind-in-one behavior via
+``handle_file_upload_for_task``, which now delegates to both.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from ...core.agent.attachments import project_file_info_to_chip
+from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS
+from ..models.uploaded_file import UploadedFile
+from .managed_file_ref import ensure_uploaded_file_local_path
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_filename(filename: str) -> str:
+    """
+    Normalize filename by removing special characters and spaces.
+
+    Args:
+        filename: Original filename
+
+    Returns:
+        Normalized filename safe for file operations
+    """
+    # Keep file extension
+    name_part = Path(filename).stem
+    extension = Path(filename).suffix
+
+    # Unicode normalize (NFD to NFC, remove diacritics)
+    name_part = unicodedata.normalize("NFC", name_part)
+
+    # Replace spaces with underscores
+    name_part = re.sub(r"\s+", "_", name_part)
+
+    # Remove special characters, keep only letters, numbers, underscores, Chinese characters
+    name_part = re.sub(r"[^\w一-鿿\-_.]", "", name_part)
+
+    # Remove consecutive underscores
+    name_part = re.sub(r"_+", "_", name_part)
+
+    # Remove leading and trailing underscores
+    name_part = name_part.strip("_")
+
+    # Use default name if filename is empty
+    if not name_part:
+        name_part = "file"
+
+    # Reassemble filename
+    normalized_name = name_part + extension
+
+    # Ensure filename doesn't start with a dot (hidden file)
+    if normalized_name.startswith("."):
+        normalized_name = "_" + normalized_name
+
+    return normalized_name
+
+
+def resolve_turn_file_infos(
+    *,
+    file_ids: List[str],
+    owner_user_id: int,
+    db: Session,
+    task_id: Optional[int] = None,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Resolve file ids to bindable file-info dicts WITHOUT mutating them.
+
+    A file id resolves when a row exists that is owned by ``owner_user_id``,
+    is either unbound (``task_id IS NULL``) or already bound to ``task_id``,
+    and whose bytes are present on disk.
+
+    Args:
+        file_ids: Requested file ids, in caller order.
+        owner_user_id: The only user whose files are reachable.
+        db: Session for the read.
+        task_id: When set, files already bound to this task also resolve
+            (so re-attaching within the same task is idempotent). When
+            ``None`` (task not created yet), only unbound files resolve.
+
+    Returns:
+        ``(file_info_list, missing_ids)``. ``file_info_list`` preserves input
+        order and carries the same shape the WebSocket path produces
+        (file_id, name, original_name, size, type, path). ``missing_ids``
+        lists ids that did not resolve (bad id, wrong owner, bound to another
+        task, or missing bytes) so callers can decide strict-vs-lenient.
+    """
+    if task_id is not None:
+        bind_filter: Any = or_(
+            UploadedFile.task_id == task_id, UploadedFile.task_id.is_(None)
+        )
+    else:
+        bind_filter = UploadedFile.task_id.is_(None)
+
+    file_infos: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    for raw_file_id in file_ids:
+        file_id = str(raw_file_id or "").strip()
+        if not file_id:
+            missing.append(str(raw_file_id))
+            continue
+
+        record = (
+            db.query(UploadedFile)
+            .filter(
+                UploadedFile.file_id == file_id,
+                UploadedFile.user_id == owner_user_id,
+                bind_filter,
+            )
+            .first()
+        )
+        if record is None:
+            missing.append(file_id)
+            continue
+
+        source_path = ensure_uploaded_file_local_path(record)
+        if not source_path.exists():
+            logger.warning("Physical file not found for %s: %s", file_id, source_path)
+            missing.append(file_id)
+            continue
+
+        original_name = Path(record.filename).name
+        file_infos.append(
+            {
+                "file_id": record.file_id,
+                "name": normalize_filename(original_name),
+                "original_name": original_name,
+                "size": record.file_size,
+                "type": record.mime_type,
+                "path": str(source_path),
+                "workspace_path": None,
+            }
+        )
+
+    return file_infos, missing
+
+
+def bind_turn_files(
+    *,
+    file_ids: List[str],
+    task_id: int,
+    owner_user_id: int,
+    db: Session,
+) -> None:
+    """Stamp ``task_id`` onto the given still-unbound files and commit.
+
+    Only rows owned by ``owner_user_id`` and currently ``task_id IS NULL``
+    are moved; rows already bound (to this or another task) are left as-is.
+    Committing here makes the binding visible to the background execution
+    session that reads the files.
+    """
+    ids = [str(f).strip() for f in file_ids if str(f).strip()]
+    if not ids:
+        return
+    db.query(UploadedFile).filter(
+        UploadedFile.file_id.in_(ids),
+        UploadedFile.user_id == owner_user_id,
+        UploadedFile.task_id.is_(None),
+    ).update({UploadedFile.task_id: task_id}, synchronize_session=False)
+    db.commit()
+
+
+def build_uploaded_files_context(
+    file_info_list: List[Dict[str, Any]], *, is_agent_builder: bool = False
+) -> str:
+    """Build stable LLM context for files already uploaded for this turn."""
+    if not file_info_list:
+        return ""
+
+    file_summaries = []
+    file_ids = []
+    for file_info in file_info_list:
+        file_id = str(file_info.get("file_id") or "").strip()
+        if not file_id:
+            continue
+        name = str(
+            file_info.get("original_name") or file_info.get("name") or "uploaded file"
+        )
+        file_ids.append(file_id)
+        file_summaries.append(f"- {name}: file_id={file_id}")
+
+    if not file_ids:
+        return ""
+
+    lines = [
+        "## UPLOADED FILES",
+        "The user has uploaded file(s) for this turn. Use these exact file_id values:",
+        *file_summaries,
+        "",
+        FILE_REF_MODEL_INSTRUCTIONS,
+    ]
+    if is_agent_builder:
+        joined_file_ids = ", ".join(f'"{file_id}"' for file_id in file_ids)
+        lines.extend(
+            [
+                "",
+                "For knowledge-base creation, call `create_knowledge_base_from_file` with:",
+                f"  file_ids = [{joined_file_ids}]",
+                "Do NOT ask the user to upload again unless these file_ids fail.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def append_uploaded_files_context(message: str, uploaded_files_context: str) -> str:
+    if not uploaded_files_context:
+        return message
+    if uploaded_files_context in message:
+        return message
+    return f"{message.rstrip()}\n\n{uploaded_files_context}"
+
+
+def normalize_attachments_for_persistence(
+    file_info_list: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Project ``file_info_list`` to the minimal chip shape persisted on rows.
+
+    Thin wrapper around the shared
+    ``core.agent.attachments.project_file_info_to_chip`` so the trace
+    callback and the persistence path can't drift on what fields the
+    browser sees (paths must never leak — the attachments column and the
+    user_message trace events both reach the UI).
+    """
+    return project_file_info_to_chip(file_info_list)

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -355,6 +355,73 @@ def test_create_task_records_key_usage_but_polling_does_not(mock_start_task):
         db.close()
 
 
+# ===== POST /v1/chat/files + message.files =====
+
+
+def test_upload_and_attach_files_to_task(mock_start_task):
+    """Upload via /v1/chat/files, then attach the file_id to a task turn.
+
+    Asserts the returned file_id round-trips into the turn payload: the
+    execution_message carries the file reference context (so the agent
+    sees it) while the transcript stays the raw user text.
+    """
+    agent_id, full_key = _create_agent_with_key()
+
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("lesson_plan.txt", b"lesson content", "text/plain"))],
+    )
+    assert up.status_code == 200, up.text
+    files = up.json()["files"]
+    assert len(files) == 1
+    file_id = files[0]["file_id"]
+    assert files[0]["filename"] == "lesson_plan.txt"
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "check this lesson plan",
+                "files": [file_id],
+            },
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    payload = mock_start_task.call_args.kwargs["payload"]
+    # Transcript is the raw text; execution channel is file-enriched.
+    assert payload.transcript_message == "check this lesson plan"
+    assert payload.execution_message is not None
+    assert file_id in payload.execution_message
+    assert "UPLOADED FILES" in payload.execution_message
+    assert payload.attachments
+    assert any(a.get("file_id") == file_id for a in payload.attachments)
+
+
+def test_attach_unknown_file_id_is_rejected(mock_start_task):
+    """A file_id that doesn't resolve to an owned file -> 400 invalid_input."""
+    agent_id, full_key = _create_agent_with_key()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "check this",
+                "files": ["does-not-exist"],
+            },
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
 def test_create_task_persists_connector_runtime_snapshot_and_context(
     mock_start_task,
 ):

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -504,6 +504,98 @@ def test_partial_file_set_is_all_or_nothing(mock_start_task):
     assert mock_start_task.call_count == 0
 
 
+def test_repeated_file_id_is_deduped(mock_start_task):
+    """The same file_id twice in one request attaches once, not twice."""
+    agent_id, full_key = _create_agent_with_key()
+
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("dup.txt", b"content", "text/plain"))],
+    )
+    file_id = up.json()["files"][0]["file_id"]
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "check it",
+                "files": [file_id, file_id],
+            },
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    payload = mock_start_task.call_args.kwargs["payload"]
+    # One context line and one chip, despite the duplicate id.
+    assert payload.execution_message.count(f"file_id={file_id}") == 1
+    assert [a.get("file_id") for a in payload.attachments] == [file_id]
+
+
+def test_append_message_with_files(mock_start_task):
+    """The append route also accepts and attaches files."""
+    agent_id, full_key = _create_agent_with_key()
+
+    created = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "turn one"},
+        },
+    )
+    task_id = created.json()["task_id"]
+
+    # Append is only allowed once the task leaves RUNNING.
+    db = _direct_db_session()
+    try:
+        db.query(Task).filter(Task.id == task_id).update(
+            {"status": TaskStatus.COMPLETED}
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("turn2.txt", b"more", "text/plain"))],
+    )
+    file_id = up.json()["files"][0]["file_id"]
+
+    appended = client.post(
+        f"/v1/chat/tasks/{task_id}/messages",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "look at this too",
+                "files": [file_id],
+            },
+        },
+    )
+    assert appended.status_code == 202, appended.text
+
+    payload = mock_start_task.call_args.kwargs["payload"]
+    assert payload.transcript_message == "look at this too"
+    assert file_id in payload.execution_message
+    assert any(a.get("file_id") == file_id for a in payload.attachments)
+
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        rec = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+        assert rec is not None
+        assert rec.task_id == task_id
+    finally:
+        db.close()
+
+
 def test_create_task_persists_connector_runtime_snapshot_and_context(
     mock_start_task,
 ):

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -391,6 +391,7 @@ def test_upload_and_attach_files_to_task(mock_start_task):
         },
     )
     assert resp.status_code == 202, resp.text
+    task_id = resp.json()["task_id"]
 
     payload = mock_start_task.call_args.kwargs["payload"]
     # Transcript is the raw text; execution channel is file-enriched.
@@ -401,9 +402,40 @@ def test_upload_and_attach_files_to_task(mock_start_task):
     assert payload.attachments
     assert any(a.get("file_id") == file_id for a in payload.attachments)
 
+    # File is bound to the task after the turn is claimed (not before).
+    from xagent.web.models.uploaded_file import UploadedFile
 
-def test_attach_unknown_file_id_is_rejected(mock_start_task):
-    """A file_id that doesn't resolve to an owned file -> 400 invalid_input."""
+    db = _direct_db_session()
+    try:
+        rec = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+        assert rec is not None
+        assert rec.task_id == task_id
+    finally:
+        db.close()
+
+
+def test_upload_rejects_unsupported_type_with_v1_envelope(mock_start_task):
+    """Unsupported extension -> 400 invalid_input in the v1 envelope.
+
+    Guards against the shared ``store_uploaded_files`` leaking its bare
+    HTTPException (a 500 {"detail": ...}) past the v1 error handler.
+    """
+    _agent_id, full_key = _create_agent_with_key()
+
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("payload.xyz", b"junk", "application/octet-stream"))],
+    )
+    assert up.status_code == 400, up.text
+    body = up.json()
+    assert body["error"]["code"] == "invalid_input"
+    # Must be the stable v1 envelope, not FastAPI's default {"detail": ...}.
+    assert "detail" not in body
+
+
+def test_attach_unknown_file_id_is_rejected_without_orphan(mock_start_task):
+    """A bad file_id -> 400 and NO task row is created (no orphan)."""
     agent_id, full_key = _create_agent_with_key()
 
     resp = client.post(
@@ -420,6 +452,56 @@ def test_attach_unknown_file_id_is_rejected(mock_start_task):
     )
     assert resp.status_code == 400, resp.text
     assert resp.json()["error"]["code"] == "invalid_input"
+
+    # #2 regression: validation happens before task creation, so nothing is
+    # left behind. The background kickoff must never have fired either.
+    db = _direct_db_session()
+    try:
+        assert db.query(Task).filter(Task.agent_id == agent_id).count() == 0, (
+            "a bad file id must not leave an orphan task"
+        )
+    finally:
+        db.close()
+    assert mock_start_task.call_count == 0
+
+
+def test_partial_file_set_is_all_or_nothing(mock_start_task):
+    """[good, bad] -> 400; the good file is left unbound (not half-attached)."""
+    agent_id, full_key = _create_agent_with_key()
+
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("good.txt", b"content", "text/plain"))],
+    )
+    good_id = up.json()["files"][0]["file_id"]
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "check these",
+                "files": [good_id, "typo-id"],
+            },
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        assert db.query(Task).filter(Task.agent_id == agent_id).count() == 0
+        rec = db.query(UploadedFile).filter(UploadedFile.file_id == good_id).first()
+        assert rec is not None
+        assert rec.task_id is None, "good file must stay unbound on all-or-nothing"
+    finally:
+        db.close()
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_persists_connector_runtime_snapshot_and_context(

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -16,9 +16,10 @@ drive the mapping.
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
@@ -54,7 +55,32 @@ from xagent.web.tools.config import (
     set_oauth_token_resolver_hook,
 )
 
-from ..conftest import _admin_headers, _direct_db_session, client
+from ..conftest import (
+    _admin_headers,
+    _direct_db_session,
+    _register_second_user,
+    client,
+)
+
+
+def _create_agent_with_key_for(headers: dict[str, str]) -> tuple[int, str]:
+    """Create an agent + api key under the user owning ``headers``."""
+    agent_resp = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "v1 tasks test agent",
+            "description": "test",
+            "instructions": "you are a test agent",
+            "execution_mode": "balanced",
+        },
+    )
+    assert agent_resp.status_code == 200, agent_resp.text
+    agent_id = agent_resp.json()["id"]
+    key_resp = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+    assert key_resp.status_code == 200, key_resp.text
+    return agent_id, key_resp.json()["full_key"]
+
 
 # Opt this file into the shared conftest ``_test_db`` fixture; see the
 # note in test_agent_api_keys.py for why we use ``usefixtures`` with a
@@ -592,6 +618,97 @@ def test_append_message_with_files(mock_start_task):
         rec = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
         assert rec is not None
         assert rec.task_id == task_id
+    finally:
+        db.close()
+
+
+def test_upload_files_requires_api_key(mock_start_task):
+    """POST /v1/chat/files without a key -> 401 invalid_api_key envelope."""
+    resp = client.post(
+        "/v1/chat/files",
+        files=[("files", ("x.txt", b"data", "text/plain"))],
+    )
+    assert resp.status_code == 401, resp.text
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+def test_upload_oversized_maps_to_413(mock_start_task):
+    """A 413 from the shared uploader surfaces as a v1-enveloped 413."""
+    _agent_id, full_key = _create_agent_with_key()
+
+    with patch(
+        "xagent.web.api.files.store_uploaded_files",
+        new=AsyncMock(side_effect=HTTPException(status_code=413, detail="too big")),
+    ):
+        resp = client.post(
+            "/v1/chat/files",
+            headers=_bearer(full_key),
+            files=[("files", ("big.txt", b"data", "text/plain"))],
+        )
+    assert resp.status_code == 413, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
+    assert "detail" not in body  # not FastAPI's default envelope
+
+
+def test_upload_storage_unavailable_maps_to_503(mock_start_task):
+    """A 503 from the shared uploader surfaces as a retryable v1 503."""
+    _agent_id, full_key = _create_agent_with_key()
+
+    with patch(
+        "xagent.web.api.files.store_uploaded_files",
+        new=AsyncMock(side_effect=HTTPException(status_code=503, detail="down")),
+    ):
+        resp = client.post(
+            "/v1/chat/files",
+            headers=_bearer(full_key),
+            files=[("files", ("f.txt", b"data", "text/plain"))],
+        )
+    assert resp.status_code == 503, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "internal_error"
+    assert "detail" not in body
+
+
+def test_cross_user_file_not_attachable(mock_start_task):
+    """User B's agent key cannot attach a file uploaded by user A."""
+    # User A (admin) uploads a file under their own agent key.
+    _agent_a, key_a = _create_agent_with_key()
+    up = client.post(
+        "/v1/chat/files",
+        headers=_bearer(key_a),
+        files=[("files", ("secret.txt", b"private", "text/plain"))],
+    )
+    file_id_a = up.json()["files"][0]["file_id"]
+
+    # User B has a separate account, agent, and key.
+    bob_headers = _register_second_user()
+    agent_b, key_b = _create_agent_with_key_for(bob_headers)
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(key_b),
+        json={
+            "agent_id": agent_b,
+            "message": {
+                "role": "user",
+                "content": "read A's file",
+                "files": [file_id_a],
+            },
+        },
+    )
+    # user_id filter makes A's file invisible to B -> unresolvable -> 400.
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+    # A's file must remain unbound (B's failed attempt cannot touch it).
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        rec = db.query(UploadedFile).filter(UploadedFile.file_id == file_id_a).first()
+        assert rec is not None
+        assert rec.task_id is None
     finally:
         db.close()
 


### PR DESCRIPTION
## Background

The public `/v1/*` SDK surface currently accepts text only (`message.content`)
and has no way to attach files. File-oriented tasks are a common need. The
existing upload endpoint `POST /api/files/upload` is JWT-session gated and lives
outside the `/v1` namespace, so an API key cannot use it — leaving
server-to-server SDK callers unable to complete the "upload a file → run a task
with it" flow.

## Changes

Add API-key-gated file support to `/v1`, reusing the mature file pipeline the
WebSocket UI path already uses so both transports share one context-building path:

- **`POST /v1/chat/files`**: API-key-gated upload endpoint. Files are stored
  unbound (`task_id` NULL), owned by the key-bound agent's user, and their
  `file_id` handles are returned. Internally reuses `store_uploaded_files`.
- **`MessageBody.files`**: `POST /v1/chat/tasks` and `.../messages` gain an
  optional `files` field. Pass the `file_id` values returned by the upload
  endpoint to attach them to the turn.
- **Binding & context**: bind the `file_id`s to the task and build the same
  `## UPLOADED FILES` execution context (fed to the agent) and transcript
  attachment chips (shown in the UI) as the WebSocket path. Unknown, unowned, or
  already-bound `file_id`s return `400 invalid_input`.

## Usage

```bash
# 1. Upload a file
curl -X POST $BASE/v1/chat/files \
  -H "Authorization: Bearer $KEY" \
  -F "files=@document.pdf"
# -> {"files":[{"file_id":"...","filename":"document.pdf",...}]}

# 2. Create a task with the file attached
curl -X POST $BASE/v1/chat/tasks \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"agent_id":1,"message":{"role":"user","content":"Check this document","files":["..."]}}'

# 3. Poll GET /v1/chat/tasks/{id} for the result
```

## Tests

- `test_upload_and_attach_files_to_task`: upload → attach → assert the turn
  payload's `execution_message` carries the file-reference context, the
  `transcript_message` stays the raw user text, and `attachments` land correctly.
- `test_attach_unknown_file_id_is_rejected`: an unresolvable `file_id` → 400.
- Full `tests/web/api/v1/test_tasks.py` suite (56) passes; ruff / mypy / isort clean.

## Compatibility

Purely additive; no change to the existing `/v1` contract. `message.files` is
optional — omitting it behaves exactly as before.
