### PR TITLE
fix: always show a thin scrollbar instead of revealing it on hover

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -424,15 +424,14 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: hsl(var(--muted-foreground) / 0.3);
+  background-color: hsl(var(--muted-foreground) / 0.3);
   border-radius: 4px;
   border: 2px solid transparent;
   background-clip: content-box;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.5);
-  background-clip: content-box;
+  background-color: hsl(var(--muted-foreground) / 0.5);
 }
 
 /* Ensure execution log content does not overflow */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -408,49 +408,31 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
   overflow-y: auto;
 }
 
-/* Native scrollbar style optimization */
+/* Native scrollbar: always visible, thin and subtle */
 .overflow-y-auto {
-  scrollbar-width: none;
-  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
 }
 
 .overflow-y-auto::-webkit-scrollbar {
-  width: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 .overflow-y-auto::-webkit-scrollbar-track {
   background: transparent;
-  border-radius: 3px;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 3px;
+  background: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: content-box;
 }
 
-.overflow-y-auto.scrolling,
-.overflow-y-auto:hover,
-.overflow-y-auto:focus-within {
-  scrollbar-width: thin;
-  scrollbar-color: hsl(var(--muted-foreground) / 0.35) hsl(var(--muted) / 0.18);
-}
-
-.overflow-y-auto.scrolling::-webkit-scrollbar-track,
-.overflow-y-auto:hover::-webkit-scrollbar-track,
-.overflow-y-auto:focus-within::-webkit-scrollbar-track {
-  background: hsl(var(--muted) / 0.18);
-}
-
-.overflow-y-auto.scrolling::-webkit-scrollbar-thumb,
-.overflow-y-auto:hover::-webkit-scrollbar-thumb,
-.overflow-y-auto:focus-within::-webkit-scrollbar-thumb {
-  background: hsl(var(--muted-foreground) / 0.35);
-}
-
-.overflow-y-auto.scrolling::-webkit-scrollbar-thumb:hover,
-.overflow-y-auto:hover::-webkit-scrollbar-thumb:hover,
-.overflow-y-auto:focus-within::-webkit-scrollbar-thumb:hover {
+.overflow-y-auto::-webkit-scrollbar-thumb:hover {
   background: hsl(var(--muted-foreground) / 0.5);
+  background-clip: content-box;
 }
 
 /* Ensure execution log content does not overflow */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -416,7 +416,6 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
 
 .overflow-y-auto::-webkit-scrollbar {
   width: 8px;
-  height: 8px;
 }
 
 .overflow-y-auto::-webkit-scrollbar-track {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import type { CSSProperties } from "react";
-import Script from "next/script";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/auth-context";
 import { ThemeProvider } from "@/contexts/theme-context";
@@ -128,34 +127,6 @@ export default function RootLayout({
             </AuthProvider>
           </ThemeProvider>
         </I18nProvider>
-        <Script id="scrollbar-visibility-controller" strategy="afterInteractive">
-          {`
-            (() => {
-              const hideTimers = new WeakMap();
-
-              document.addEventListener("scroll", (event) => {
-                const target = event.target;
-                if (!(target instanceof HTMLElement) || !target.classList.contains("overflow-y-auto")) {
-                  return;
-                }
-
-                target.classList.add("scrolling");
-
-                const existingTimer = hideTimers.get(target);
-                if (existingTimer) {
-                  window.clearTimeout(existingTimer);
-                }
-
-                const nextTimer = window.setTimeout(() => {
-                  target.classList.remove("scrolling");
-                  hideTimers.delete(target);
-                }, 700);
-
-                hideTimers.set(target, nextTimer);
-              }, true);
-            })();
-          `}
-        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Problem
Global `.overflow-y-auto` containers hid the scrollbar by default and only
revealed it on hover/focus. Moving the mouse into any scrollable area (e.g.
the home page) made the scrollbar flash in and out — visually jarring.

## Change
`frontend/src/app/globals.css`: drop the hover-reveal logic; always show a
thin, subtle scrollbar.

## Scope
All `.overflow-y-auto` scroll regions app-wide.