### PR TITLE
fix: scope execution plan to DAG process

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -73,6 +73,7 @@ export interface ChatMessageProps {
   interactions?: any[];
   interactionsActive?: boolean;
   showEmptyStatus?: boolean;
+  onOpenExecutionPlan?: () => void;
   onSendInteraction?: (message: string, files?: File[], metadata?: any) => Promise<void> | void;
 }
 
@@ -280,6 +281,7 @@ export function ChatMessage({
   interactions,
   interactionsActive = true,
   showEmptyStatus = true,
+  onOpenExecutionPlan,
   onSendInteraction,
 }: ChatMessageProps) {
   const { t, tDynamic } = useI18n();
@@ -365,7 +367,11 @@ export function ChatMessage({
     <div className="w-full space-y-2 animate-fade-in group">
       {shouldShowProcess && !isUser && (
         <div className={cn("pl-7")}>
-          <TraceEventRenderer events={traceEvents} taskStatus={resolvedProcessStatus} />
+          <TraceEventRenderer
+            events={traceEvents}
+            taskStatus={resolvedProcessStatus}
+            onOpenExecutionPlan={onOpenExecutionPlan}
+          />
         </div>
       )}
 

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -497,6 +497,46 @@ describe("TraceEventRenderer", () => {
     expect(screen.getByText(/traceEventRenderer.executeTool:web_search/)).toBeInTheDocument()
   })
 
+  it("shows the execution plan action only in a process with DAG execution events", () => {
+    const onOpenExecutionPlan = vi.fn()
+    const { rerender } = render(
+      <TraceEventRenderer
+        onOpenExecutionPlan={onOpenExecutionPlan}
+        events={[
+          {
+            event_id: "react-start",
+            event_type: "react_task_start",
+            step_id: "step-1",
+            timestamp: 1000,
+            data: {},
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByTitle("chatPage.executionPlan.tooltip")).not.toBeInTheDocument()
+
+    rerender(
+      <TraceEventRenderer
+        onOpenExecutionPlan={onOpenExecutionPlan}
+        events={[
+          {
+            event_id: "dag-execution",
+            event_type: "dag_execution",
+            timestamp: 1000,
+            data: {
+              phase: "executing",
+              steps: [{ id: "1", task: "Create audio", dependencies: [] }],
+            },
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("chatPage.executionPlan.dagSection"))
+    expect(onOpenExecutionPlan).toHaveBeenCalledOnce()
+  })
+
   it("stops running process spinners when the parent task has failed", () => {
     const { container } = render(
       <TraceEventRenderer

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/contexts/i18n-context", () => ({
     t: (key: string, vars?: Record<string, string | number>) => {
       if (vars?.tool) return `${key}:${vars.tool}`
       if (vars?.worker) return `${key}:${vars.worker}`
+      if (vars && "count" in vars) return `${key}:${vars.count}`
       return key
     },
   }),
@@ -533,8 +534,30 @@ describe("TraceEventRenderer", () => {
       />,
     )
 
-    fireEvent.click(screen.getByText("chatPage.executionPlan.dagSection"))
+    fireEvent.click(screen.getByText("chatPage.executionPlan.dagSectionOne:1"))
     expect(onOpenExecutionPlan).toHaveBeenCalledOnce()
+
+    rerender(
+      <TraceEventRenderer
+        onOpenExecutionPlan={onOpenExecutionPlan}
+        events={[
+          {
+            event_id: "dag-execution",
+            event_type: "dag_execution",
+            timestamp: 1000,
+            data: {
+              phase: "executing",
+              steps: [
+                { id: "1", task: "Create audio", dependencies: [] },
+                { id: "2", task: "Edit audio", dependencies: ["1"] },
+              ],
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("chatPage.executionPlan.dagSectionOther:2")).toBeInTheDocument()
   })
 
   it("stops running process spinners when the parent task has failed", () => {

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   Search,
   FileText,
+  GitMerge,
   Check,
   Shield,
   MessageSquare,
@@ -145,6 +146,7 @@ interface ProcessedStep {
 interface TraceEventRendererProps {
   events: TraceEvent[];
   taskStatus?: string;
+  onOpenExecutionPlan?: () => void;
 }
 
 function getTraceData(event: TraceEvent): NonNullable<TraceEvent['data']> {
@@ -1348,7 +1350,7 @@ function StepItem({ step, index, onOpenTerminal, onViewDetail, onFileClick, onAg
 }
 
 // Main TraceEventRenderer Component
-export function TraceEventRenderer({ events, taskStatus }: TraceEventRendererProps) {
+export function TraceEventRenderer({ events, taskStatus, onOpenExecutionPlan }: TraceEventRendererProps) {
   const { t } = useI18n();
   const processStatus = resolveTraceProcessStatus({
     taskStatus,
@@ -1375,6 +1377,19 @@ export function TraceEventRenderer({ events, taskStatus }: TraceEventRendererPro
     }
     return null;
   }, [events]);
+
+  const hasExecutionPlan = useMemo(
+    () => events.some((event) => {
+      const eventType = event.event_type || '';
+      return eventType === 'dag_execution'
+        || eventType === 'dag_execute_start'
+        || eventType === 'dag_execute_end'
+        || eventType === 'dag_plan_start'
+        || eventType === 'dag_plan_end'
+        || eventType.startsWith('dag_step_');
+    }),
+    [events],
+  );
 
   const getFileNameFromPath = (path?: string) => {
     if (!path) return '';
@@ -1434,6 +1449,25 @@ export function TraceEventRenderer({ events, taskStatus }: TraceEventRendererPro
 
   return (
     <div className="space-y-4">
+      {hasExecutionPlan && onOpenExecutionPlan && (
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/50 bg-muted/20 px-3 py-2 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onOpenExecutionPlan}
+          title={t('chatPage.executionPlan.tooltip')}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <GitMerge className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate text-sm font-medium text-foreground">
+              {t('chatPage.executionPlan.dagSection', { count: steps.length })}
+            </span>
+          </div>
+          <span className="flex shrink-0 items-center text-xs font-medium text-muted-foreground">
+            {t('chatPage.executionPlan.view')}
+            <ChevronRight className="ml-1 h-3.5 w-3.5" />
+          </span>
+        </button>
+      )}
       {skillSelection && (
         <div className="bg-muted/30 border border-border/50 rounded-lg p-3 flex items-center gap-2">
           <Cpu className="w-4 h-4 text-primary" />

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -1391,6 +1391,34 @@ export function TraceEventRenderer({ events, taskStatus, onOpenExecutionPlan }: 
     [events],
   );
 
+  const executionPlanStepCount = useMemo(() => {
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      const data = events[index].data;
+      if (!data || typeof data !== 'object') continue;
+
+      const record = data as Record<string, unknown>;
+      const planCandidates = [record, record.plan_data, record.current_plan, record.plan];
+      for (const candidate of planCandidates) {
+        if (!candidate || typeof candidate !== 'object') continue;
+        const planSteps = (candidate as Record<string, unknown>).steps;
+        if (Array.isArray(planSteps) && planSteps.length > 0) {
+          return planSteps.length;
+        }
+      }
+    }
+
+    return steps.length > 0 ? steps.length : null;
+  }, [events, steps.length]);
+
+  const executionPlanLabel = executionPlanStepCount === null
+    ? t('chatPage.executionPlan.dagSection')
+    : t(
+      executionPlanStepCount === 1
+        ? 'chatPage.executionPlan.dagSectionOne'
+        : 'chatPage.executionPlan.dagSectionOther',
+      { count: executionPlanStepCount },
+    );
+
   const getFileNameFromPath = (path?: string) => {
     if (!path) return '';
     const parts = path.split('/');
@@ -1459,7 +1487,7 @@ export function TraceEventRenderer({ events, taskStatus, onOpenExecutionPlan }: 
           <div className="flex min-w-0 items-center gap-2">
             <GitMerge className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate text-sm font-medium text-foreground">
-              {t('chatPage.executionPlan.dagSection', { count: steps.length })}
+              {executionPlanLabel}
             </span>
           </div>
           <span className="flex shrink-0 items-center text-xs font-medium text-muted-foreground">

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -149,6 +149,16 @@ interface TraceEventRendererProps {
   onOpenExecutionPlan?: () => void;
 }
 
+function isDagExecutionEvent(event: TraceEvent): boolean {
+  const eventType = event.event_type || '';
+  return eventType === 'dag_execution'
+    || eventType === 'dag_execute_start'
+    || eventType === 'dag_execute_end'
+    || eventType === 'dag_plan_start'
+    || eventType === 'dag_plan_end'
+    || eventType.startsWith('dag_step_');
+}
+
 function getTraceData(event: TraceEvent): NonNullable<TraceEvent['data']> {
   if (event.data && typeof event.data === 'object') {
     return event.data;
@@ -1378,21 +1388,11 @@ export function TraceEventRenderer({ events, taskStatus, onOpenExecutionPlan }: 
     return null;
   }, [events]);
 
-  const hasExecutionPlan = useMemo(
-    () => events.some((event) => {
-      const eventType = event.event_type || '';
-      return eventType === 'dag_execution'
-        || eventType === 'dag_execute_start'
-        || eventType === 'dag_execute_end'
-        || eventType === 'dag_plan_start'
-        || eventType === 'dag_plan_end'
-        || eventType.startsWith('dag_step_');
-    }),
-    [events],
-  );
+  const hasExecutionPlan = useMemo(() => events.some(isDagExecutionEvent), [events]);
 
   const executionPlanStepCount = useMemo(() => {
     for (let index = events.length - 1; index >= 0; index -= 1) {
+      if (!isDagExecutionEvent(events[index])) continue;
       const data = events[index].data;
       if (!data || typeof data !== 'object') continue;
 

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -621,7 +621,6 @@ describe("TaskConversationPanel", () => {
     render(<TaskConversationPanel mode="page" />)
 
     expect(screen.getAllByTitle("chatPage.executionPlan.tooltip")).toHaveLength(1)
-    expect(screen.queryByTitle("chatPage.executionPlan.title")).not.toBeInTheDocument()
   })
 
   it("ignores malformed DAG layout failures without throwing", async () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -68,6 +68,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     taskStatus,
     processStatus,
     showEmptyStatus,
+    onOpenExecutionPlan,
   }: {
     content?: string | null
     interactionsActive?: boolean
@@ -75,6 +76,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     taskStatus?: string
     processStatus?: string
     showEmptyStatus?: boolean
+    onOpenExecutionPlan?: () => void
   }) => (
     <div
       data-testid="chat-message"
@@ -85,6 +87,21 @@ vi.mock("@/components/chat/ChatMessage", () => ({
       data-show-empty-status={showEmptyStatus ? "true" : "false"}
     >
       {content}
+      {onOpenExecutionPlan && traceEvents?.some((event) => {
+        if (!event || typeof event !== "object" || !("event_type" in event)) return false
+        return typeof event.event_type === "string" && (
+          event.event_type === "dag_execution" ||
+          event.event_type === "dag_execute_start" ||
+          event.event_type === "dag_execute_end" ||
+          event.event_type === "dag_plan_start" ||
+          event.event_type === "dag_plan_end" ||
+          event.event_type.startsWith("dag_step_")
+        )
+      }) && (
+        <button type="button" title="chatPage.executionPlan.tooltip" onClick={onOpenExecutionPlan}>
+          chatPage.executionPlan.view
+        </button>
+      )}
     </div>
   ),
 }))
@@ -551,9 +568,32 @@ describe("TaskConversationPanel", () => {
     expect(screen.getByText("Context compacted (56860→449 tokens)")).toBeInTheDocument()
   })
 
+  it("does not show a task-level execution plan action without DAG planning events", () => {
+    appState.currentTask = {
+      id: "42",
+      title: "Task",
+      description: "Task",
+      status: "completed",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      isDag: true,
+    } as any
+
+    render(<TaskConversationPanel mode="page" />)
+
+    expect(screen.queryByTitle("chatPage.executionPlan.title")).not.toBeInTheDocument()
+  })
+
   it("ignores malformed DAG layout failures without throwing", async () => {
     appState.messages = []
-    appState.traceEvents = []
+    appState.traceEvents = [
+      {
+        event_id: "dag-execution",
+        event_type: "dag_execution",
+        timestamp: 1000,
+        data: { phase: "executing", steps: [] },
+      },
+    ] as any
     appState.currentTask = {
       id: "42",
       title: "Task",
@@ -586,7 +626,7 @@ describe("TaskConversationPanel", () => {
     appState.filePreview = { isOpen: false } as any
 
     expect(() => render(<TaskConversationPanel mode="page" />)).not.toThrow()
-    fireEvent.click(screen.getByTitle("chatPage.executionPlan.title"))
+    fireEvent.click(screen.getByTitle("chatPage.executionPlan.tooltip"))
 
     expect(await screen.findByTestId("center-panel")).toHaveAttribute("data-node-count", "3")
     expect(screen.getByTestId("center-panel")).toHaveAttribute("data-edge-count", "0")

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -568,7 +568,46 @@ describe("TaskConversationPanel", () => {
     expect(screen.getByText("Context compacted (56860→449 tokens)")).toBeInTheDocument()
   })
 
-  it("does not show a task-level execution plan action without DAG planning events", () => {
+  it("scopes the execution plan action to the DAG turn instead of task actions", () => {
+    appState.messages = [
+      {
+        id: "user-react",
+        role: "user",
+        content: "Use tools",
+        timestamp: 1000,
+      },
+      {
+        id: "result-react",
+        role: "assistant",
+        content: "Done",
+        timestamp: 1500,
+        isResult: true,
+      },
+      {
+        id: "user-dag",
+        role: "user",
+        content: "Create a plan",
+        timestamp: 2000,
+      },
+    ] as any
+    appState.traceEvents = [
+      {
+        event_id: "react-start",
+        event_type: "react_task_start",
+        step_id: "react-step",
+        timestamp: 1100,
+        data: {},
+      },
+      {
+        event_id: "dag-execution",
+        event_type: "dag_execution",
+        timestamp: 2100,
+        data: {
+          phase: "executing",
+          steps: [{ id: "dag-step", task: "Create output", dependencies: [] }],
+        },
+      },
+    ] as any
     appState.currentTask = {
       id: "42",
       title: "Task",
@@ -581,6 +620,7 @@ describe("TaskConversationPanel", () => {
 
     render(<TaskConversationPanel mode="page" />)
 
+    expect(screen.getAllByTitle("chatPage.executionPlan.tooltip")).toHaveLength(1)
     expect(screen.queryByTitle("chatPage.executionPlan.title")).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { FolderOpen, GitMerge, Loader2 } from "lucide-react"
+import { FolderOpen, Loader2 } from "lucide-react"
 import dagre from "dagre"
 import { ChatInput } from "@/components/chat/ChatInput"
 import { ChatMessage } from "@/components/chat/ChatMessage"
@@ -159,6 +159,11 @@ export function TaskConversationPanel({
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const anyPreviewOpen = mode === "page" && (state.filePreview.isOpen || dagPreviewOpen)
+
+  const openDagPreview = useCallback(() => {
+    closeFilePreview()
+    setDagPreviewOpen(true)
+  }, [closeFilePreview])
 
   const handleSend = async (message: string, config?: any, filesToSend?: File[]) => {
     await (onSend ?? sendMessage)(message, config, filesToSend || files)
@@ -638,6 +643,7 @@ export function TaskConversationPanel({
                         interactions={item.interactions}
                         interactionsActive={item.id === activeWaitingMessageId}
                         showEmptyStatus={item.showEmptyStatus}
+                        onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                       />
                     )
                   })}
@@ -653,6 +659,7 @@ export function TaskConversationPanel({
                       taskStatus={state.currentTask?.status}
                       interactions={state.currentTask?.status === "waiting_for_user" ? waitingInteractions : undefined}
                       interactionsActive={state.currentTask?.status === "waiting_for_user"}
+                      onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                     />
                   )}
                 </>
@@ -667,22 +674,6 @@ export function TaskConversationPanel({
             {showTaskActions && (
               <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                 <div className="flex flex-wrap items-center gap-2">
-                  {showDagPreview && state.currentTask?.isDag !== false && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="h-auto rounded-xl bg-card/80 px-3 py-2 text-sm"
-                      onClick={() => {
-                        closeFilePreview()
-                        setDagPreviewOpen(true)
-                      }}
-                      title={t("chatPage.executionPlan.title")}
-                    >
-                      <GitMerge className="w-3.5 h-3.5 mr-1" />
-                      {t("chatPage.executionPlan.title")}
-                    </Button>
-                  )}
-
                   {showTaskFiles && (
                     <TaskFileManager taskId={state.taskId} onPreview={(fileId, fileName) => openFilePreview(fileId, fileName)}>
                       <Button type="button" variant="outline" className="h-auto rounded-xl bg-card/80 px-3 py-2 text-sm" title={t("files.header.title")}>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -262,6 +262,8 @@ const en = {
     executionPlan: {
       title: "Execution Plan",
       tooltip: "Click to view execution plan",
+      dagSection: "DAG execution · {count} steps",
+      view: "View plan",
     },
     aiOutput: {
       title: "AI Output",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -262,7 +262,9 @@ const en = {
     executionPlan: {
       title: "Execution Plan",
       tooltip: "Click to view execution plan",
-      dagSection: "DAG execution · {count} steps",
+      dagSection: "DAG execution",
+      dagSectionOne: "DAG execution · {count} step",
+      dagSectionOther: "DAG execution · {count} steps",
       view: "View plan",
     },
     aiOutput: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -262,7 +262,9 @@ const zh = {
     executionPlan: {
       title: "执行计划",
       tooltip: "点击查看执行计划",
-      dagSection: "DAG 执行 · {count} 个步骤",
+      dagSection: "DAG 执行",
+      dagSectionOne: "DAG 执行 · {count} 个步骤",
+      dagSectionOther: "DAG 执行 · {count} 个步骤",
       view: "查看计划",
     },
     aiOutput: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -262,6 +262,8 @@ const zh = {
     executionPlan: {
       title: "执行计划",
       tooltip: "点击查看执行计划",
+      dagSection: "DAG 执行 · {count} 个步骤",
+      view: "查看计划",
     },
     aiOutput: {
       title: "AI 输出",


### PR DESCRIPTION
## Summary

- move the execution-plan entry from the persistent task actions into the relevant DAG process group
- render a full-width clickable DAG header with the step count and plan affordance
- recognize both current and legacy DAG trace events and cover the behavior with focused tests

## Why

Auto tasks can mix execution patterns across turns, while the task-level `isDag` value may be unset. The previous persistent action could therefore appear for non-DAG turns and made the plan look like a task-wide artifact instead of a DAG-turn artifact.

## Validation

- `npm test -- --run src/components/task/task-conversation-panel.test.tsx src/components/chat/TraceEventRenderer.test.tsx` (26 tests)
- `pre-commit run --files` for the seven changed frontend files

## Screenshots

<img width="2280" height="1734" alt="image" src="https://github.com/user-attachments/assets/e5088341-d639-4745-b17c-28e01cafe1a8" />

