### PR TITLE
feat: localize and badge the built-in model indicator

### DIFF
--- a/frontend/src/components/config-dialog.tsx
+++ b/frontend/src/components/config-dialog.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Settings, X, Loader2, ArrowRight } from "lucide-react"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
+import { isBuiltinModel } from "@/lib/models"
 import { useAuth } from "@/contexts/auth-context"
 import { Select } from "@/components/ui/select"
 import { Slider } from "@/components/ui/slider"
@@ -61,6 +62,13 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
     memorySimilarityThreshold: currentConfig?.memorySimilarityThreshold ?? 1.5
   })
   const { t } = useI18n()
+
+  // Platform (built-in) models show a locale-aware badge next to the name
+  // (isBuiltinModel); their seeded "Built-in" placeholder is then kept out of
+  // the option detail line, while a real description (if one is ever added)
+  // still shows since the badge already conveys built-in.
+  const modelDesc = (m: Model): string | undefined =>
+    isBuiltinModel(m) && m.description?.toLowerCase() === "built-in" ? undefined : m.description
 
   // Fetch models when dialog opens
   useEffect(() => {
@@ -216,7 +224,8 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                     options={models.map(m => ({
                       value: m.model_id,
                       label: m.model_name,
-                      description: `${m.model_name}${m.description ? ' - ' + m.description : ''} (${m.model_provider}) [${m.model_id}]`,
+                      description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider}) [${m.model_id}]`,
+                      isBuiltin: isBuiltinModel(m),
                       isDefault: m.is_default,
                       isSmallFast: m.is_small_fast,
                       isVisual: m.is_visual
@@ -241,7 +250,8 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${m.description ? ' - ' + m.description : ''} (${m.model_provider}) [${m.model_id}]${m.is_small_fast ? t('agent.configDialog.modelSelect.smallFast.options.tagFast') : ''}`,
+                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider}) [${m.model_id}]${m.is_small_fast ? t('agent.configDialog.modelSelect.smallFast.options.tagFast') : ''}`,
+                        isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
                         isVisual: m.is_visual
@@ -267,7 +277,8 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${m.description ? ' - ' + m.description : ''} (${m.model_provider})[${m.model_id}]${m.is_visual ? t('agent.configDialog.modelSelect.visual.options.tagVisual') : ''}`,
+                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider})[${m.model_id}]${m.is_visual ? t('agent.configDialog.modelSelect.visual.options.tagVisual') : ''}`,
+                        isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
                         isVisual: m.is_visual
@@ -293,7 +304,8 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${m.description ? ' - ' + m.description : ''} (${m.model_provider})[${m.model_id}]${m.is_compact ? t('agent.configDialog.modelSelect.compact.options.tagCompact') : ''}`,
+                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider})[${m.model_id}]${m.is_compact ? t('agent.configDialog.modelSelect.compact.options.tagCompact') : ''}`,
+                        isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
                         isVisual: m.is_visual,

--- a/frontend/src/components/pages/model-management-dialog.tsx
+++ b/frontend/src/components/pages/model-management-dialog.tsx
@@ -15,6 +15,7 @@ import { apiRequest } from "@/lib/api-wrapper"
 import {
   DefaultModelType,
   getProviderModels,
+  isBuiltinModel,
   ProviderModel,
   removeUserDefaultModel,
   setUserDefaultModel
@@ -765,7 +766,7 @@ export function ModelManagementDialog({
                                 {tDynamic(`models.defaults.${type}`, type.replace(/_/g, " "))}
                               </Badge>
                             ))}
-                            {!model.is_owner && (
+                            {!model.is_owner && !isBuiltinModel(model) && (
                               <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal text-orange-500">
                                 {t('models.defaults.shared_from_others')}
                               </Badge>
@@ -782,7 +783,11 @@ export function ModelManagementDialog({
                                 </Badge>
                               )
                               })}
-                            {model.is_shared && model.is_owner && (
+                            {isBuiltinModel(model) ? (
+                              <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal bg-amber-500/10 text-amber-600">
+                                {t('models.defaults.builtin')}
+                              </Badge>
+                            ) : model.is_shared && model.is_owner && (
                               <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal text-orange-500">
                                 {t('models.defaults.shared')}
                               </Badge>
@@ -1341,12 +1346,16 @@ export function ModelManagementDialog({
                   <div className="border rounded-md p-4 bg-muted/20">
                     <div className="font-medium flex items-center gap-2 flex-wrap">
                       <span>{defaultTargetModel.model_name}</span>
-                      {!defaultTargetModel.is_owner && (
+                      {!defaultTargetModel.is_owner && !isBuiltinModel(defaultTargetModel) && (
                         <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal text-orange-500">
                           {t('models.defaults.shared_from_others')}
                         </Badge>
                       )}
-                      {defaultTargetModel.is_shared && defaultTargetModel.is_owner && (
+                      {isBuiltinModel(defaultTargetModel) ? (
+                        <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal bg-amber-500/10 text-amber-600">
+                          {t('models.defaults.builtin')}
+                        </Badge>
+                      ) : defaultTargetModel.is_shared && defaultTargetModel.is_owner && (
                         <Badge variant="secondary" className="text-xs px-2 py-0.5 h-auto whitespace-normal text-orange-500">
                           {t('models.defaults.shared')}
                         </Badge>

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -13,6 +13,7 @@ export interface SelectOption {
   isSmallFast?: boolean
   isVisual?: boolean
   isCompact?: boolean
+  isBuiltin?: boolean
   actionIcon?: React.ReactNode
   onAction?: (e: React.MouseEvent) => void
 }
@@ -111,8 +112,11 @@ export function Select({
           {selectedOption ? (
             <div className="flex items-center gap-2 min-w-0 flex-1">
               <span className="font-medium truncate">{selectedOption.label}</span>
-              {(selectedOption.isDefault || selectedOption.isSmallFast || selectedOption.isVisual || selectedOption.isCompact) && (
+              {(selectedOption.isBuiltin || selectedOption.isDefault || selectedOption.isSmallFast || selectedOption.isVisual || selectedOption.isCompact) && (
                 <div className="flex gap-1 flex-shrink-0">
+                  {selectedOption.isBuiltin && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600">{t('models.defaults.builtin')}</span>
+                  )}
                   {selectedOption.isDefault && (
                     <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">Default</span>
                   )}
@@ -158,8 +162,11 @@ export function Select({
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2 min-w-0 flex-1">
                       <span className="font-medium truncate">{option.label}</span>
-                      {(option.isDefault || option.isSmallFast || option.isVisual || option.isCompact) && (
+                      {(option.isBuiltin || option.isDefault || option.isSmallFast || option.isVisual || option.isCompact) && (
                         <div className="flex gap-1 flex-shrink-0">
+                          {option.isBuiltin && (
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600">{t('models.defaults.builtin')}</span>
+                          )}
                           {option.isDefault && (
                             <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">Default</span>
                           )}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1612,6 +1612,7 @@ Build when you need.`,
       rerank: "Rerank Model",
       shared: "Shared",
       shared_from_others: "Public Model",
+      builtin: "Built-in",
     },
     card: {
       owner: "Owner",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1612,6 +1612,7 @@ Build when you need.`,
       rerank: "重排序模型",
       shared: "已分享",
       shared_from_others: "公共模型",
+      builtin: "内置模型",
     },
     card: {
       owner: "我的模型",

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -41,6 +41,12 @@ export interface Model {
   updated_at: string;
 }
 
+// Platform (built-in) models are seeded by xagent cloud with a `platform/`
+// model-id prefix. Central home for that convention so it can't drift across
+// call sites. Inert for OSS, where no model carries the prefix.
+export const isBuiltinModel = (model: { model_id?: string | null }): boolean =>
+  Boolean(model.model_id?.startsWith("platform/"));
+
 export interface UserDefaultModel {
   id: number;
   user_id: number;


### PR DESCRIPTION
## What

Platform-provided models are seeded with a hardcoded "Built-in" description
that the model UI printed verbatim, so a Chinese UI showed English and vice
versa. Replace it with a locale-aware badge.

- **Model picker** (`config-dialog` + `Select`): a new optional `isBuiltin`
  flag on `SelectOption` renders a locale-aware badge next to the model name,
  and the stored "Built-in" text is dropped from the option detail line.
- **Model management**: the same localized badge is shown on platform models,
  and the generic shared / public-model badge is suppressed for them.
- i18n key `models.defaults.builtin` (Built-in / 内置模型).

Keyed on the `platform/*` model-id convention, which only xagent cloud seeds.
This is inert for OSS: no model carries that prefix, so no badge appears and the
picker keeps showing each model's own description unchanged.

## Test

- `npm run type-check`
