### PR TITLE
fix: avoid DashScope embedding model list GET

### DIFF
--- a/src/xagent/web/services/model_list_service.py
+++ b/src/xagent/web/services/model_list_service.py
@@ -250,9 +250,9 @@ async def fetch_dashscope_embedding_models(
 
     DashScope's OpenAI-compatible API does not implement ``GET /models``.
     Reusing ``fetch_openai_models`` therefore returns an empty list after a
-    400 response. Keep the text models supported by ``DashScopeEmbedding``
-    explicit so the UI can populate its embedding model selector without a
-    provider-side discovery request.
+    400 response. Return the curated DashScope text-embedding models exposed
+    to the UI. ``DashScopeEmbedding`` imposes no model enumeration, so the
+    list is maintained here.
     """
     _ = api_key, base_url
 

--- a/src/xagent/web/services/model_list_service.py
+++ b/src/xagent/web/services/model_list_service.py
@@ -243,6 +243,29 @@ async def fetch_elevenlabs_music_models(
     )
 
 
+async def fetch_dashscope_embedding_models(
+    api_key: str, base_url: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Return curated DashScope text embedding models.
+
+    DashScope's OpenAI-compatible API does not implement ``GET /models``.
+    Reusing ``fetch_openai_models`` therefore returns an empty list after a
+    400 response. Keep the text models supported by ``DashScopeEmbedding``
+    explicit so the UI can populate its embedding model selector without a
+    provider-side discovery request.
+    """
+    _ = api_key, base_url
+
+    return [
+        {
+            "id": model_id,
+            "object": "model",
+            "owned_by": "dashscope",
+        }
+        for model_id in ("text-embedding-v4", "text-embedding-v3")
+    ]
+
+
 async def fetch_dashscope_rerank_models(
     api_key: str, base_url: Optional[str] = None
 ) -> List[Dict[str, Any]]:
@@ -399,6 +422,7 @@ PROVIDER_FETCHERS: Dict[str, Any] = {
     "elevenlabs": fetch_elevenlabs_models,
     "elevenlabs-sound_effect": fetch_elevenlabs_sound_effect_models,
     "elevenlabs-music": fetch_elevenlabs_music_models,
+    "dashscope-embedding": fetch_dashscope_embedding_models,
     "dashscope-rerank": fetch_dashscope_rerank_models,
     "zai-coding-plan": fetch_openai_models,
     "zhipuai-coding-plan": fetch_openai_models,

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -1218,6 +1218,24 @@ class TestModelAPI:
             "thinking_mode",
         ]
 
+    def test_fetch_dashscope_embedding_models_uses_curated_list(
+        self, test_db, regular_user, regular_headers
+    ):
+        response = client.post(
+            "/api/models/providers/dashscope/models",
+            json={"api_key": "test-api-key", "category": "embedding"},
+            headers=regular_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 2
+        assert [model["id"] for model in data["models"]] == [
+            "text-embedding-v4",
+            "text-embedding-v3",
+        ]
+        assert all(model["owned_by"] == "dashscope" for model in data["models"])
+
     def test_fetch_ark_provider_models_returns_platform_scoped_seedance(
         self, test_db, regular_user, regular_headers, monkeypatch
     ):

--- a/tests/web/test_model_list_service.py
+++ b/tests/web/test_model_list_service.py
@@ -9,10 +9,31 @@ from xagent.core.model.music.elevenlabs import ElevenLabsMusicModel
 from xagent.core.model.sound_effect.elevenlabs import ElevenLabsSoundEffectModel
 from xagent.core.model.tts.elevenlabs import ElevenLabsTTS
 from xagent.web.services.model_list_service import (
+    fetch_dashscope_embedding_models,
     fetch_elevenlabs_models,
     fetch_elevenlabs_music_models,
     fetch_elevenlabs_sound_effect_models,
 )
+
+
+async def test_fetch_dashscope_embedding_models_returns_curated_text_models() -> None:
+    models = await fetch_dashscope_embedding_models(
+        api_key="test-key",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+
+    assert models == [
+        {
+            "id": "text-embedding-v4",
+            "object": "model",
+            "owned_by": "dashscope",
+        },
+        {
+            "id": "text-embedding-v3",
+            "object": "model",
+            "owned_by": "dashscope",
+        },
+    ]
 
 
 async def test_fetch_elevenlabs_models_combines_tts_and_stt(


### PR DESCRIPTION
## What changed

- Add a category-specific `dashscope-embedding` model fetcher.
- Return a curated list of the DashScope text embedding models supported by the existing adapter.
- Add service- and API-level regression tests for embedding model discovery.

## Why

The model management UI sends `category=embedding` when it requests DashScope models. Because the provider registry did not contain `dashscope-embedding`, the API fell back to the generic `dashscope` fetcher, which uses the OpenAI SDK's `GET /models` request.

DashScope's OpenAI-compatible endpoint does not implement that request and returns HTTP 400 with `Request method 'GET' is not supported`. The generic OpenAI fetcher then catches the error and returns an empty list, so Xagent responds with HTTP 200 while logging an error and showing no embedding models.

The category-specific fetcher avoids the unsupported network request and follows the existing curated-list approach used for `dashscope-rerank`.

## User impact

Selecting DashScope for an embedding model now lists `text-embedding-v4` and `text-embedding-v3` without emitting an unsupported `GET /models` error.

## Validation

- `pytest -vv tests/web/test_model_list_service.py::test_fetch_dashscope_embedding_models_returns_curated_text_models tests/web/test_model_api.py::TestModelAPI::test_fetch_dashscope_embedding_models_uses_curated_list` — 2 passed
- `ruff check` on all modified Python files
- `ruff format --check` on all modified Python files
- `git diff --check`
