### PR TITLE
fix: install browser and router runtimes

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -51,3 +51,6 @@ jobs:
           export PATH="$UV_TOOL_BIN_DIR:$PATH"
           command -v xagent
           xagent --help
+          tool_python="$(uv tool dir)/xagent-ai/bin/python"
+          "$tool_python" -c 'import playwright'
+          "$tool_python" -c 'from pathlib import Path; from playwright.sync_api import sync_playwright; manager = sync_playwright().start(); executable = Path(manager.chromium.executable_path); manager.stop(); assert executable.is_file(), executable'

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -53,4 +53,5 @@ jobs:
           xagent --help
           tool_python="$(uv tool dir)/xagent-ai/bin/python"
           "$tool_python" -c 'import playwright'
+          "$tool_python" -c 'import xrouter_llm'
           "$tool_python" -c 'from pathlib import Path; from playwright.sync_api import sync_playwright; manager = sync_playwright().start(); executable = Path(manager.chromium.executable_path); manager.stop(); assert executable.is_file(), executable'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,12 +62,12 @@ if [ "${XAGENT_SKIP_ROUTER_INSTALL:-}" = "1" ]; then
   warn "Skipping OpenRouter auto-routing runtime (XAGENT_SKIP_ROUTER_INSTALL=1)."
 fi
 
-spec="$APP[$extras]"
+spec="${APP}[$extras]"
 if [ -n "${XAGENT_VERSION:-}" ]; then
   # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
   version="${XAGENT_VERSION#v}"
   [ -n "$version" ] || err "XAGENT_VERSION='$XAGENT_VERSION' is not a valid version."
-  spec="$APP[$extras]==$version"
+  spec="${APP}[$extras]==$version"
 fi
 
 info "Installing $spec ..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,9 +9,14 @@
 #
 # Options (environment variables):
 #   XAGENT_VERSION   pin a specific version, e.g. XAGENT_VERSION=0.6.0
+#   XAGENT_SKIP_BROWSER_INSTALL=1
+#                    skip Playwright and Chromium installation
 #
 # Prefer not to pipe curl into sh? The equivalent manual install is:
-#   uv tool install xagent-ai        # or, in a venv: pip install xagent-ai
+#   uv tool install 'xagent-ai[browser]'
+#   "$(uv tool dir)/xagent-ai/bin/python" -m playwright install chromium
+#   # Or, in a virtualenv: pip install 'xagent-ai[browser]'
+#   # followed by: python -m playwright install chromium
 set -eu
 
 # The user's PATH before this script mutates it (below, when bootstrapping uv).
@@ -49,16 +54,25 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a new shell and re-run."
 
-spec="$APP"
+spec="$APP[browser]"
 if [ -n "${XAGENT_VERSION:-}" ]; then
   # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
   version="${XAGENT_VERSION#v}"
   [ -n "$version" ] || err "XAGENT_VERSION='$XAGENT_VERSION' is not a valid version."
-  spec="$APP==$version"
+  spec="$APP[browser]==$version"
 fi
 
 info "Installing $spec ..."
 uv tool install --upgrade "$spec"
+
+if [ "${XAGENT_SKIP_BROWSER_INSTALL:-}" != "1" ]; then
+  tool_python="$(uv tool dir)/$APP/bin/python"
+  [ -x "$tool_python" ] || err "Xagent tool Python not found at '$tool_python'."
+  info "Installing Playwright Chromium browser..."
+  "$tool_python" -m playwright install chromium
+else
+  warn "Skipping Playwright Chromium installation (XAGENT_SKIP_BROWSER_INSTALL=1)."
+fi
 
 printf '\n'
 info "Installed. Next steps:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,7 @@ if [ -n "${XAGENT_VERSION:-}" ]; then
   # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
   version="${XAGENT_VERSION#v}"
   [ -n "$version" ] || err "XAGENT_VERSION='$XAGENT_VERSION' is not a valid version."
-  spec="${APP}[$extras]==$version"
+  spec="${spec}==$version"
 fi
 
 info "Installing $spec ..."
@@ -85,7 +85,15 @@ else
   tool_python="$(uv tool dir)/$APP/bin/python"
   [ -x "$tool_python" ] || err "Xagent tool Python not found at '$tool_python'."
   info "Installing Playwright Chromium browser..."
-  "$tool_python" -m playwright install chromium
+  # xagent is already installed and usable at this point; the browser binary is
+  # an optional enhancement for browser-enabled tasks. Don't let a transient
+  # download failure abort the whole install (and swallow the "Next steps"
+  # message) — warn and continue so the user can retry manually.
+  if ! "$tool_python" -m playwright install chromium; then
+    warn "Playwright Chromium download failed. Xagent is installed, but browser-enabled tasks need it."
+    warn "Retry with: \"$tool_python\" -m playwright install chromium"
+    warn "Or skip it on re-run with XAGENT_SKIP_BROWSER_INSTALL=1."
+  fi
 fi
 
 printf '\n'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,12 +10,14 @@
 # Options (environment variables):
 #   XAGENT_VERSION   pin a specific version, e.g. XAGENT_VERSION=0.6.0
 #   XAGENT_SKIP_BROWSER_INSTALL=1
-#                    skip Playwright and Chromium installation
+#                    skip the Playwright Chromium browser download
+#   XAGENT_SKIP_ROUTER_INSTALL=1
+#                    skip the OpenRouter "auto" model routing runtime
 #
 # Prefer not to pipe curl into sh? The equivalent manual install is:
-#   uv tool install 'xagent-ai[browser]'
+#   uv tool install 'xagent-ai[browser,router]'
 #   "$(uv tool dir)/xagent-ai/bin/python" -m playwright install chromium
-#   # Or, in a virtualenv: pip install 'xagent-ai[browser]'
+#   # Or, in a virtualenv: pip install 'xagent-ai[browser,router]'
 #   # followed by: python -m playwright install chromium
 set -eu
 
@@ -54,12 +56,18 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a new shell and re-run."
 
-spec="$APP[browser]"
+extras="browser,router"
+if [ "${XAGENT_SKIP_ROUTER_INSTALL:-}" = "1" ]; then
+  extras="browser"
+  warn "Skipping OpenRouter auto-routing runtime (XAGENT_SKIP_ROUTER_INSTALL=1)."
+fi
+
+spec="$APP[$extras]"
 if [ -n "${XAGENT_VERSION:-}" ]; then
   # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
   version="${XAGENT_VERSION#v}"
   [ -n "$version" ] || err "XAGENT_VERSION='$XAGENT_VERSION' is not a valid version."
-  spec="$APP[browser]==$version"
+  spec="$APP[$extras]==$version"
 fi
 
 info "Installing $spec ..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,6 +35,12 @@ err() {
   printf '\033[1;31merror:\033[0m %s\n' "$1" >&2
   exit 1
 }
+is_truthy() {
+  case "${1:-}" in
+    1 | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss] | [Oo][Nn]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # uv supports Linux and macOS. Windows users should use pip in a venv.
 os="$(uname -s)"
@@ -57,9 +63,9 @@ fi
 command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a new shell and re-run."
 
 extras="browser,router"
-if [ "${XAGENT_SKIP_ROUTER_INSTALL:-}" = "1" ]; then
+if is_truthy "${XAGENT_SKIP_ROUTER_INSTALL:-}"; then
   extras="browser"
-  warn "Skipping OpenRouter auto-routing runtime (XAGENT_SKIP_ROUTER_INSTALL=1)."
+  warn "Skipping OpenRouter auto-routing runtime (XAGENT_SKIP_ROUTER_INSTALL is set)."
 fi
 
 spec="${APP}[$extras]"
@@ -73,13 +79,13 @@ fi
 info "Installing $spec ..."
 uv tool install --upgrade "$spec"
 
-if [ "${XAGENT_SKIP_BROWSER_INSTALL:-}" != "1" ]; then
+if is_truthy "${XAGENT_SKIP_BROWSER_INSTALL:-}"; then
+  warn "Skipping Playwright Chromium installation (XAGENT_SKIP_BROWSER_INSTALL is set)."
+else
   tool_python="$(uv tool dir)/$APP/bin/python"
   [ -x "$tool_python" ] || err "Xagent tool Python not found at '$tool_python'."
   info "Installing Playwright Chromium browser..."
   "$tool_python" -m playwright install chromium
-else
-  warn "Skipping Playwright Chromium installation (XAGENT_SKIP_BROWSER_INSTALL=1)."
 fi
 
 printf '\n'


### PR DESCRIPTION
## What changed

- Install the existing `xagent-ai[browser,router]` extras in the one-line installer.
- Download Playwright's Chromium runtime with the Python interpreter from the installed uv tool environment.
- Add explicit opt-outs for the Chromium download and the heavier OpenRouter auto-routing runtime.
- Extend the Linux/macOS installer smoke test to verify Playwright, Chromium, and `xrouter_llm`.

## Why

The Docker image already installs Playwright Chromium and the router runtime during image construction, but `scripts/install.sh` only installed Xagent's core dependencies. As a result, users of the one-line installer could start Xagent successfully but encounter a Playwright package/browser download during their first browser-enabled task, or this error when testing OpenRouter's virtual `auto` model:

```text
xrouter-llm routing failed: No module named 'xrouter_llm'
```

Installing both layers up front makes the one-line installation consistent with the Docker runtime and avoids first-task setup latency or failure:

1. `xagent-ai[browser,router]` installs the Python Playwright package and OpenRouter auto-routing runtime.
2. `python -m playwright install chromium` installs the matching browser binary.

## User impact

Browser-enabled tasks can launch Chromium immediately after the one-line installer completes, and OpenRouter's `auto` model can load its in-process router. `XAGENT_SKIP_BROWSER_INSTALL=1` skips the Chromium binary download; `XAGENT_SKIP_ROUTER_INSTALL=1` avoids the larger router/ML dependency set for users who do not need automatic model routing.

## Validation

- `sh -n scripts/install.sh`
- Verified `xagent-ai[browser,router]==<version>` is a valid pinned PEP 508 requirement
- `node --check scripts/get.xagent.co/worker.js`
- `node --test` in `scripts/get.xagent.co` — 6 passed
- `git diff --check`
- Installer CI now verifies `import playwright`, `import xrouter_llm`, and asserts Playwright's Chromium executable exists on Ubuntu and macOS
