### PR TITLE
fix: harden DeepSeek tool protocol recovery

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1390,8 +1390,6 @@ class ReActPattern(AgentPattern):
                 result={"message": message, "status": "sent"},
                 tool_call_id=tool_call.get("id"),
             )
-            if message:
-                context.add_assistant_message(message)
             return {
                 "success": True,
                 "status": "message_sent",
@@ -1931,6 +1929,9 @@ class ReActPattern(AgentPattern):
             f"{REACT_DECISION_TOOL_CALL} only when a specific missing fact, source, "
             "verification, or work step remains; the next normal ReAct turn will "
             "choose and call the actual work tool from the full available tool set. "
+            "In the tool arguments, write reason and missing_verification before "
+            "action so you assess completion before committing to the decision. "
+            "Use an empty missing_verification only when no work remains. "
             "Do not call work tools in this decision. Do not put user-facing final "
             "answer text in this decision; the next normal ReAct step will produce "
             "the final answer if you choose final_answer. Treat the completed-call "
@@ -1953,6 +1954,22 @@ class ReActPattern(AgentPattern):
                 "parameters": {
                     "type": "object",
                     "properties": {
+                        "reason": {
+                            "type": "string",
+                            "description": (
+                                "Assess whether every requested work result already "
+                                "exists. Write this assessment before choosing action."
+                            ),
+                        },
+                        "missing_verification": {
+                            "type": "string",
+                            "description": (
+                                "When action is tool_call, the specific missing "
+                                "fact, source, verification, or work step that "
+                                "requires another tool call. Empty only when no work "
+                                "remains."
+                            ),
+                        },
                         "action": {
                             "type": "string",
                             "enum": [
@@ -1960,24 +1977,14 @@ class ReActPattern(AgentPattern):
                                 REACT_DECISION_TOOL_CALL,
                             ],
                             "description": (
-                                "final_answer when current context is sufficient; "
-                                "tool_call when one more work-tool call is needed."
-                            ),
-                        },
-                        "reason": {
-                            "type": "string",
-                            "description": "Brief reason for this decision.",
-                        },
-                        "missing_verification": {
-                            "type": "string",
-                            "description": (
-                                "When action is tool_call, the specific missing "
-                                "fact, source, verification, or work step that "
-                                "requires another tool call."
+                                "Choose final_answer only when the preceding "
+                                "assessment found no missing work; otherwise choose "
+                                "tool_call."
                             ),
                         },
                     },
-                    "required": ["action", "reason"],
+                    "required": ["reason", "missing_verification", "action"],
+                    "additionalProperties": False,
                 },
             },
         }
@@ -1996,10 +2003,13 @@ class ReActPattern(AgentPattern):
                 REACT_DECISION_TOOL_CALL,
             }:
                 return None
+            missing_verification = str(args.get("missing_verification") or "")
+            if action == REACT_DECISION_FINAL_ANSWER and missing_verification.strip():
+                action = REACT_DECISION_TOOL_CALL
             return {
                 "action": action,
                 "reason": str(args.get("reason") or ""),
-                "missing_verification": str(args.get("missing_verification") or ""),
+                "missing_verification": missing_verification,
             }
         return None
 

--- a/src/xagent/core/model/chat/basic/adapter.py
+++ b/src/xagent/core/model/chat/basic/adapter.py
@@ -166,5 +166,6 @@ def create_base_llm(
         llm,
         BaseLLM,  # type: ignore[type-abstract]
         retry_methods={"chat", "vision_chat", "stream_chat"},
+        max_retries=model.max_retries,
         retry_on=retry_on,
     )

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -8,7 +8,7 @@ import openai
 from openai import AsyncOpenAI
 
 from ....utils.security import redact_sensitive_text
-from ..exceptions import LLMRetryableError, LLMTimeoutError
+from ..exceptions import LLMEmptyContentError, LLMRetryableError, LLMTimeoutError
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage
 from ..types import ChunkType, StreamChunk
@@ -486,7 +486,7 @@ class OpenAICompatibleLLM(BaseLLM):
                         "raw": resp.model_dump(),
                     }
                 # If there are no tool calls and no content, this is an error
-                raise RuntimeError(
+                raise LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                 )
 
@@ -540,6 +540,9 @@ class OpenAICompatibleLLM(BaseLLM):
                         result = _process_response(response)
 
             return result
+
+        except LLMRetryableError:
+            raise
 
         except openai.BadRequestError as e:
             # Handle bad request errors
@@ -802,7 +805,7 @@ class OpenAICompatibleLLM(BaseLLM):
                         "raw": response.model_dump(),
                     }
                 # If there are no tool calls and no content, this is an error
-                raise RuntimeError(
+                raise LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                 )
 
@@ -815,6 +818,9 @@ class OpenAICompatibleLLM(BaseLLM):
                 text_result["reasoning_content"] = reasoning_content
                 text_result["reasoning"] = reasoning_content
             return text_result
+
+        except LLMRetryableError:
+            raise
 
         except openai.APITimeoutError as e:
             # Handle timeout errors

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -2,7 +2,9 @@ import logging
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from .....config import get_openrouter_official_providers_only
+from ..exceptions import LLMRetryableError
 from ..timeout_config import TimeoutConfig
+from ..tool_protocol import TOOL_PROTOCOL_ERROR_KEY, get_tool_protocol_error
 from ..types import StreamChunk
 from .deepseek_tool_protocol import (
     adapt_deepseek_stream,
@@ -94,6 +96,15 @@ def _force_single_required_deepseek_tool(
         "type": "function",
         "function": {"name": name},
     }
+
+
+def _deepseek_tool_protocol_retry_error(response: Any) -> LLMRetryableError | None:
+    error = get_tool_protocol_error(response)
+    if error is None:
+        return None
+    code = str(error.get("code") or "invalid_tool_protocol")
+    message = str(error.get("message") or "DeepSeek returned an invalid tool call.")
+    return LLMRetryableError(f"DeepSeek tool protocol error ({code}): {message}")
 
 
 class OpenRouterLLM(OpenAILLM):
@@ -191,7 +202,11 @@ class OpenRouterLLM(OpenAILLM):
 
         if not self._uses_deepseek_tool_protocol:
             return response
-        return normalize_deepseek_response(response, tools=tools)
+        response = normalize_deepseek_response(response, tools=tools)
+        retry_error = _deepseek_tool_protocol_retry_error(response)
+        if retry_error is not None:
+            raise retry_error
+        return response
 
     async def _stream_chat_with_prefix_retry(
         self,
@@ -274,7 +289,33 @@ class OpenRouterLLM(OpenAILLM):
             async for chunk in stream:
                 yield chunk
             return
-        async for chunk in adapt_deepseek_stream(stream, tools=tools):
+        adapted_stream = adapt_deepseek_stream(stream, tools=tools)
+
+        # A named tool choice cannot validly finish as assistant text. Buffer
+        # this narrow stream until DeepSeek's tool protocol has been validated,
+        # so a malformed serialized call raises before any chunk escapes and the
+        # shared LLM retry wrapper can safely replay the request.
+        if isinstance(tool_choice, dict):
+            buffered_chunks: list[StreamChunk] = []
+            async for chunk in adapted_stream:
+                if chunk.is_protocol_error():
+                    retry_error = _deepseek_tool_protocol_retry_error(
+                        {TOOL_PROTOCOL_ERROR_KEY: chunk.protocol_error}
+                    )
+                    if retry_error is not None:
+                        raise retry_error
+                buffered_chunks.append(chunk)
+            for chunk in buffered_chunks:
+                yield chunk
+            return
+
+        async for chunk in adapted_stream:
+            if chunk.is_protocol_error():
+                retry_error = _deepseek_tool_protocol_retry_error(
+                    {TOOL_PROTOCOL_ERROR_KEY: chunk.protocol_error}
+                )
+                if retry_error is not None:
+                    raise retry_error
             yield chunk
 
     def _prepare_extra_body(self, extra_body: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -38,7 +38,7 @@ def _openrouter_model_author(model_name: str) -> str:
 def _strip_assistant_tool_call_prefixes(
     messages: List[Dict[str, Any]],
 ) -> tuple[List[Dict[str, Any]], bool]:
-    """Remove text prefixes from historical assistant function-call messages."""
+    """Remove assistant prefixes that DeepSeek cannot combine with tools."""
     sanitized: List[Dict[str, Any]] = []
     changed = False
     for message in messages:
@@ -51,7 +51,46 @@ def _strip_assistant_tool_call_prefixes(
             sanitized_message["content"] = ""
             changed = True
         sanitized.append(sanitized_message)
+
+    # A non-blocking ``send_message`` control call records its result and may
+    # leave a standalone assistant progress message at the end of older
+    # checkpoints. OpenRouter treats that trailing assistant turn as prefix
+    # completion, which DeepSeek rejects when tools are also present. The tool
+    # result already contains the same progress text, so dropping only trailing
+    # assistant-only turns preserves the tool chain and avoids replaying stale
+    # progress as a generation prefix.
+    has_completed_tool_chain = any(
+        message.get("role") == "assistant" and message.get("tool_calls")
+        for message in sanitized
+    ) and any(message.get("role") == "tool" for message in sanitized)
+    if has_completed_tool_chain:
+        while (
+            sanitized
+            and sanitized[-1].get("role") == "assistant"
+            and not sanitized[-1].get("tool_calls")
+        ):
+            sanitized.pop()
+            changed = True
     return sanitized, changed
+
+
+def _force_single_required_deepseek_tool(
+    tools: Optional[List[Dict[str, Any]]],
+    tool_choice: Optional[str | Dict[str, Any]],
+) -> Optional[str | Dict[str, Any]]:
+    """Turn DeepSeek's ambiguous single-tool requirement into a named choice."""
+    if tool_choice != "required" or not tools or len(tools) != 1:
+        return tool_choice
+    function = tools[0].get("function")
+    if not isinstance(function, dict):
+        return tool_choice
+    name = function.get("name")
+    if not isinstance(name, str) or not name:
+        return tool_choice
+    return {
+        "type": "function",
+        "function": {"name": name},
+    }
 
 
 class OpenRouterLLM(OpenAILLM):
@@ -110,6 +149,8 @@ class OpenRouterLLM(OpenAILLM):
         output_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
+        if self._uses_deepseek_tool_protocol:
+            tool_choice = _force_single_required_deepseek_tool(tools, tool_choice)
         try:
             response = await super().chat(
                 messages=messages,
@@ -213,6 +254,8 @@ class OpenRouterLLM(OpenAILLM):
         output_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
+        if self._uses_deepseek_tool_protocol:
+            tool_choice = _force_single_required_deepseek_tool(tools, tool_choice)
         stream = self._stream_chat_with_prefix_retry(
             messages=messages,
             temperature=temperature,

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -75,13 +75,16 @@ def _strip_assistant_tool_call_prefixes(
 
 
 def _force_single_required_deepseek_tool(
-    tools: Optional[List[Dict[str, Any]]],
+    tools: Optional[List[Any]],
     tool_choice: Optional[str | Dict[str, Any]],
 ) -> Optional[str | Dict[str, Any]]:
     """Turn DeepSeek's ambiguous single-tool requirement into a named choice."""
     if tool_choice != "required" or not tools or len(tools) != 1:
         return tool_choice
-    function = tools[0].get("function")
+    tool = tools[0]
+    if not isinstance(tool, dict):
+        return tool_choice
+    function = tool.get("function")
     if not isinstance(function, dict):
         return tool_choice
     name = function.get("name")

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -2847,6 +2847,51 @@ async def test_react_pattern_final_answer_clears_trailing_pending_before_checkpo
     assert final_checkpoint["pattern_state"]["pending_tool_calls"] == []
 
 
+def test_react_decision_schema_assesses_work_before_choosing_action() -> None:
+    schema = ReActPattern()._react_decision_tool_schema()
+    parameters = schema["function"]["parameters"]
+
+    assert list(parameters["properties"]) == [
+        "reason",
+        "missing_verification",
+        "action",
+    ]
+    assert parameters["required"] == [
+        "reason",
+        "missing_verification",
+        "action",
+    ]
+    assert parameters["additionalProperties"] is False
+
+
+def test_react_decision_does_not_finalize_with_missing_work() -> None:
+    response = {
+        "tool_calls": [
+            {
+                "id": "decision_contradictory",
+                "function": {
+                    "name": "react_decision",
+                    "arguments": json.dumps(
+                        {
+                            "reason": "One more audio clip must be synthesized.",
+                            "missing_verification": "Synthesize the final audio clip.",
+                            "action": "final_answer",
+                        }
+                    ),
+                },
+            }
+        ]
+    }
+
+    decision = ReActPattern()._parse_react_decision(response)
+
+    assert decision == {
+        "action": "tool_call",
+        "reason": "One more audio clip must be synthesized.",
+        "missing_verification": "Synthesize the final audio clip.",
+    }
+
+
 @pytest.mark.asyncio
 async def test_react_pattern_accepts_plain_text_response() -> None:
     llm = FakeLLM(responses=["Direct answer"])
@@ -2932,6 +2977,11 @@ async def test_react_pattern_send_message_without_response_continues() -> None:
     tool_messages = context.get_messages_by_role("tool")
     assert len(tool_messages) == 1
     assert tool_messages[0].metadata["tool_name"] == "send_message"
+    next_call_messages = llm.calls[1]["messages"]
+    assert next_call_messages[-1]["role"] == "tool"
+    assert all(
+        message.get("content") != "Still working" for message in next_call_messages
+    )
     assert pattern.tool_ledger["call_message"].status == "completed"
 
 

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -7,12 +7,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.openai import (
     PROVIDER_STATE_METADATA_KEY,
     OpenAILLM,
     _format_openai_error,
 )
-from xagent.core.model.chat.exceptions import LLMRetryableError
+from xagent.core.model.chat.error import retry_on
+from xagent.core.model.chat.exceptions import LLMEmptyContentError, LLMRetryableError
+from xagent.core.retry.strategy import FixedDelay
+from xagent.core.retry.wrapper import create_retry_wrapper
 
 
 class TestOpenAILLM:
@@ -679,9 +683,10 @@ class TestOpenAILLM:
 
         llm = OpenAILLM(**openai_llm_config)
 
-        # Should raise RuntimeError when content is None and no tool calls
+        # The shared model wrapper retries this transient provider response.
         with pytest.raises(
-            RuntimeError, match="LLM returned None content and no tool calls"
+            LLMEmptyContentError,
+            match="LLM returned None content and no tool calls",
         ):
             await llm.chat([{"role": "user", "content": "Hello"}])
 
@@ -711,11 +716,57 @@ class TestOpenAILLM:
 
         llm = OpenAILLM(**openai_llm_config)
 
-        # Should raise RuntimeError when content is empty and no tool calls
+        # The shared model wrapper retries this transient provider response.
         with pytest.raises(
-            RuntimeError, match="LLM returned empty content and no tool calls"
+            LLMEmptyContentError,
+            match="LLM returned empty content and no tool calls",
         ):
             await llm.chat([{"role": "user", "content": "Hello"}])
+
+    @pytest.mark.asyncio
+    async def test_empty_content_uses_shared_retry(
+        self,
+        openai_llm_config,
+        mock_chat_completion,
+        mocker,
+    ):
+        empty_message = SimpleNamespace(
+            content="",
+            tool_calls=None,
+            reasoning_content=None,
+        )
+        empty_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=empty_message,
+                )
+            ],
+            usage=None,
+        )
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            empty_response,
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        inner = OpenAILLM(**openai_llm_config)
+        llm = create_retry_wrapper(
+            inner,
+            BaseLLM,  # type: ignore[type-abstract]
+            retry_methods={"chat"},
+            strategy=FixedDelay(delay_ms=0),
+            max_retries=2,
+            retry_on=retry_on,
+        )
+
+        result = await llm.chat([{"role": "user", "content": "Hello"}])
+
+        assert result["content"] == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 2
 
     @pytest.mark.asyncio
     async def test_empty_content_falls_back_to_reasoning_content(

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -157,6 +157,24 @@ def _single_tool_schema(name: str = "select_execution_pattern") -> list[dict]:
     ]
 
 
+@pytest.mark.parametrize(
+    "tools",
+    [
+        [None],
+        ["invalid"],
+        [{}],
+        [{"function": None}],
+    ],
+)
+def test_openrouter_deepseek_preserves_required_for_malformed_single_tool(
+    tools,
+):
+    assert (
+        openrouter_module._force_single_required_deepseek_tool(tools, "required")
+        == "required"
+    )
+
+
 @pytest.mark.asyncio
 async def test_openrouter_official_provider_pinning_disabled_by_default(
     mock_chat_completion, mocker, monkeypatch

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -133,6 +133,30 @@ def _tool_call_history() -> list[dict]:
     ]
 
 
+def _tool_call_history_with_trailing_progress() -> list[dict]:
+    messages = _tool_call_history()
+    messages[1]["content"] = ""
+    messages.append(
+        {
+            "role": "assistant",
+            "content": "Still working on the generated audio.",
+        }
+    )
+    return messages
+
+
+def _single_tool_schema(name: str = "select_execution_pattern") -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_openrouter_official_provider_pinning_disabled_by_default(
     mock_chat_completion, mocker, monkeypatch
@@ -247,6 +271,91 @@ async def test_openrouter_provider_override_is_preserved(
 
 
 @pytest.mark.asyncio
+async def test_openrouter_deepseek_names_the_only_required_tool(mocker, monkeypatch):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    tool_call = SimpleNamespace(
+        id="call_route",
+        type="function",
+        function=SimpleNamespace(
+            name="select_execution_pattern",
+            arguments="{}",
+        ),
+    )
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[tool_call],
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-deepseek-route"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+
+    await llm.chat(
+        [{"role": "user", "content": "Route this request"}],
+        tools=_single_tool_schema(),
+        tool_choice="required",
+    )
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "select_execution_pattern"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_names_the_only_required_tool(
+    mocker, monkeypatch
+):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+
+    async def empty_stream():
+        if False:
+            yield None
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = empty_stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Route this request"}],
+            tools=_single_tool_schema(),
+            tool_choice="required",
+        )
+    ]
+
+    assert chunks == []
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "select_execution_pattern"},
+    }
+
+
+@pytest.mark.asyncio
 async def test_openrouter_deepseek_retries_function_call_without_assistant_prefix(
     mock_chat_completion, mocker, monkeypatch
 ):
@@ -282,6 +391,41 @@ async def test_openrouter_deepseek_retries_function_call_without_assistant_prefi
     assert retry_messages[1]["content"] == ""
     assert retry_messages[1]["tool_calls"] == messages[1]["tool_calls"]
     assert messages[1]["content"] == "I will generate the music first."
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_retries_without_trailing_assistant_progress(
+    mock_chat_completion, mocker, monkeypatch
+):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        _deepseek_function_prefix_error(),
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+    messages = _tool_call_history_with_trailing_progress()
+
+    result = await llm.chat(messages)
+
+    assert result["content"] == "Hello World"
+    assert mock_client.chat.completions.create.await_count == 2
+    retry_messages = mock_client.chat.completions.create.call_args_list[1].kwargs[
+        "messages"
+    ]
+    assert retry_messages[-1]["role"] == "tool"
+    assert all(
+        message.get("content") != "Still working on the generated audio."
+        for message in retry_messages
+    )
+    assert messages[-1]["content"] == "Still working on the generated audio."
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -7,8 +7,13 @@ import openai
 import pytest
 
 from xagent.core.model.chat.basic import openrouter as openrouter_module
+from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
-from xagent.core.model.chat.tool_protocol import get_tool_protocol_error
+from xagent.core.model.chat.error import retry_on
+from xagent.core.model.chat.exceptions import LLMRetryableError
+from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.retry.strategy import FixedDelay
+from xagent.core.retry.wrapper import create_retry_wrapper
 
 
 @pytest.mark.parametrize(
@@ -28,7 +33,7 @@ def test_openrouter_uses_deepseek_tool_protocol_only_for_deepseek_models(
 
 
 @pytest.mark.asyncio
-async def test_openrouter_deepseek_rejects_serialized_tool_protocol_content(
+async def test_openrouter_deepseek_marks_serialized_tool_protocol_retryable(
     mocker,
 ):
     message = SimpleNamespace(
@@ -52,22 +57,151 @@ async def test_openrouter_deepseek_rejects_serialized_tool_protocol_content(
         api_key="test-key",
     )
 
-    result = await llm.chat(
-        [{"role": "user", "content": "Use a tool"}],
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "search",
-                    "parameters": {"type": "object", "properties": {}},
-                },
-            }
+    with pytest.raises(
+        LLMRetryableError,
+        match="serialized_tool_call_content",
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Use a tool"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_protocol_error_uses_shared_chat_retry(mocker):
+    invalid_message = SimpleNamespace(
+        content="<｜｜DSML｜｜tool_calls>",
+        tool_calls=None,
+        reasoning_content=None,
+    )
+    invalid_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=invalid_message)],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-deepseek-invalid-protocol"},
+    )
+    tool_call = SimpleNamespace(
+        id="call_route",
+        type="function",
+        function=SimpleNamespace(
+            name="select_execution_pattern",
+            arguments="{}",
+        ),
+    )
+    valid_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="", tool_calls=[tool_call]))
         ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-deepseek-valid-protocol"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        invalid_response,
+        valid_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    inner = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+    llm = create_retry_wrapper(
+        inner,
+        BaseLLM,  # type: ignore[type-abstract]
+        retry_methods={"chat"},
+        strategy=FixedDelay(delay_ms=0),
+        max_retries=2,
+        retry_on=retry_on,
     )
 
-    error = get_tool_protocol_error(result)
-    assert error is not None
-    assert error["code"] == "serialized_tool_call_content"
+    result = await llm.chat(
+        [{"role": "user", "content": "Route this request"}],
+        tools=_single_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["tool_calls"][0]["function"]["name"] == ("select_execution_pattern")
+    assert mock_client.chat.completions.create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_protocol_error_uses_shared_stream_retry(mocker):
+    attempts = 0
+
+    async def invalid_stream():
+        yield StreamChunk(
+            type=ChunkType.TOKEN,
+            delta="Let me route this. <｜｜DSML｜｜tool_calls>",
+        )
+        yield StreamChunk(type=ChunkType.END, finish_reason="stop")
+
+    async def valid_stream():
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_route",
+                    "type": "function",
+                    "function": {
+                        "name": "select_execution_pattern",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        )
+        yield StreamChunk(type=ChunkType.END, finish_reason="tool_calls")
+
+    def fake_stream(**kwargs):
+        nonlocal attempts
+        del kwargs
+        attempts += 1
+        return invalid_stream() if attempts == 1 else valid_stream()
+
+    inner = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+    mocker.patch.object(
+        inner,
+        "_stream_chat_with_prefix_retry",
+        side_effect=fake_stream,
+    )
+    llm = create_retry_wrapper(
+        inner,
+        BaseLLM,  # type: ignore[type-abstract]
+        retry_methods={"stream_chat"},
+        strategy=FixedDelay(delay_ms=0),
+        max_retries=2,
+        retry_on=retry_on,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Route this request"}],
+            tools=_single_tool_schema(),
+            tool_choice="required",
+        )
+    ]
+
+    assert attempts == 2
+    assert not any(chunk.is_protocol_error() for chunk in chunks)
+    assert any(
+        chunk.is_tool_call()
+        and chunk.tool_calls[0]["function"]["name"] == "select_execution_pattern"
+        for chunk in chunks
+    )
 
 
 def _deepseek_function_prefix_error() -> openai.BadRequestError:

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -65,11 +65,13 @@ def test_create_base_llm_stamps_model_id():
         model_provider="deepseek",
         model_name="deepseek-v4-flash",
         api_key="test-api-key",
+        max_retries=3,
     )
     llm = create_base_llm(config)
     # The retry wrapper delegates attribute access to the inner LLM.
     assert llm._inner.model_id == "deepseek-plat-abc"
     assert llm.model_id == "deepseek-plat-abc"
+    assert llm._retry_wrapper.max_retries == 3
 
 
 def test_add_token_usage_records_model_id():


### PR DESCRIPTION
## Summary

- force OpenRouter DeepSeek requests with one required tool to name that function explicitly
- remove duplicate assistant progress turns and sanitize legacy histories that DeepSeek rejects as prefixes
- make repeated-tool completion decisions assess missing work before selecting the final action

## Root cause

DeepSeek could reject a tool-enabled continuation when a non-blocking progress message was recorded both as a tool result and as a trailing assistant prefix. In single-tool control calls, the generic `required` choice could also yield an empty response or an unavailable tool call. Separately, the repeated-tool decision schema asked for `action` before the completion assessment, allowing a response to commit to `final_answer` before discovering missing work in its reason.

## Impact

Auto routing and ReAct execution now keep the native tool protocol intact across progress messages, force the intended control function when it is the only available tool, and continue work when a completion decision reports a missing step.

## Validation

- `PYTHONWARNINGS=ignore PYTHONPATH=src pytest -q --tb=short tests/core/agent/test_auto.py tests/core/agent/test_react.py tests/core/model/chat/basic/test_openrouter.py`
- `ruff check src/xagent/core/agent/pattern/react/react.py src/xagent/core/model/chat/basic/openrouter.py tests/core/agent/test_react.py tests/core/model/chat/basic/test_openrouter.py`
- repository pre-commit hooks
