### PR TITLE
feat(agents): opt-in team-scoped ownership and admins-only visibility

### DIFF
--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -20,7 +20,14 @@ import { createFileChipHTML } from "@/components/chat/FileChip"
 import { MultiSelect } from "@/components/ui/multi-select"
 import { useFileMention } from "@/hooks/use-file-mention"
 import { FileMentionDropdown } from "@/components/chat/FileMentionDropdown"
-import { Select } from "@/components/ui/select"
+import {
+  Select,
+  SelectRadix,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
 import {
   InfoTooltip,
 } from "@/components/ui/tooltip"
@@ -109,7 +116,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const { state, setTaskId, sendMessage, dispatch, closeFilePreview } = useApp()
   const { t, locale } = useI18n()
   const { apps: officialApps, getAppIcon, refresh: refreshMcpApps } = useMcpApps()
-  const { user } = useAuth()
+  const { user, inTeam, teamRole } = useAuth()
+  // inTeam gates the whole control (standard xagent has no teams);
+  // canSetAdminsOnly gates the "admins" option to team admins.
+  const canSetAdminsOnly = teamRole === "admin"
   // Set once loadAgent decides to load an owner-scoped MCP list for an admin
   // cross-user view, so the mount-time self-scoped fetch won't clobber it.
   const ownerScopedMcpRef = useRef(false)
@@ -126,6 +136,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const [instructions, setInstructions] = useState("")
   const [executionMode, setExecutionMode] = useState("balanced") // "flash", "balanced", "think"
   const [suggestedPrompts, setSuggestedPrompts] = useState<string[]>([])
+  const [visibility, setVisibility] = useState<"team" | "admins">("team")
   const [modelConfig, setModelConfig] = useState<AgentModelConfig>({
     general: null,
     small_fast: null,
@@ -596,6 +607,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           setInstructions(agent.instructions || "")
           setExecutionMode(agent.execution_mode || "balanced")
           setSuggestedPrompts(agent.suggested_prompts || [])
+          setVisibility(agent.visibility === "admins" ? "admins" : "team")
           setSelectedKbs(agent.knowledge_bases || [])
           setSelectedSkills(agent.skills || [])
 
@@ -1047,6 +1059,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           instructions: instructions.trim() || undefined,
           execution_mode: executionMode,
           suggested_prompts: suggestedPrompts.filter(p => p.trim()),
+          visibility,
           models: modelConfig,
           knowledge_bases: selectedKbs,
           skills: selectedSkills,
@@ -2165,6 +2178,32 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             </Button>
           </div>
         </div>
+
+        {/* Visibility (SaaS team context only) */}
+        {inTeam && (
+          <div className="space-y-2">
+            <Label>{t("builds.configForm.visibility.label")}</Label>
+            <div className="text-xs text-muted-foreground mb-2">
+              {t("builds.configForm.visibility.desc")}
+            </div>
+            <SelectRadix value={visibility} onValueChange={(v) => setVisibility(v as "team" | "admins")}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="team">{t("builds.configForm.visibility.team")}</SelectItem>
+                <SelectItem value="admins" disabled={!canSetAdminsOnly}>
+                  {t("builds.configForm.visibility.admins")}
+                </SelectItem>
+              </SelectContent>
+            </SelectRadix>
+            {!canSetAdminsOnly && (
+              <div className="text-xs text-muted-foreground">
+                {t("builds.configForm.visibility.adminsHint")}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </fieldset>
     </div>

--- a/frontend/src/components/chat/TokenUsageDisplay.tsx
+++ b/frontend/src/components/chat/TokenUsageDisplay.tsx
@@ -27,35 +27,40 @@ interface ModelTokenUsage {
   output_tokens: number;
 }
 
-const compactTokenFormatters: Record<Locale, Intl.NumberFormat> = {
-  en: new Intl.NumberFormat('en', {
-    notation: 'compact',
-    compactDisplay: 'short',
-    maximumFractionDigits: 2,
-  }),
-  zh: new Intl.NumberFormat('zh', {
-    notation: 'compact',
-    compactDisplay: 'short',
-    maximumFractionDigits: 2,
-  }),
-};
-const exactTokenFormatters: Record<Locale, Intl.NumberFormat> = {
-  en: new Intl.NumberFormat('en'),
-  zh: new Intl.NumberFormat('zh'),
-};
+// Build formatters lazily per locale so this file stays valid regardless of the
+// locale set (the SaaS overlay adds more locales than the standalone build).
+const compactTokenFormatters = new Map<Locale, Intl.NumberFormat>();
+const exactTokenFormatters = new Map<Locale, Intl.NumberFormat>();
+
+function getFormatter(
+  cache: Map<Locale, Intl.NumberFormat>,
+  locale: Locale,
+  options?: Intl.NumberFormatOptions,
+): Intl.NumberFormat {
+  let formatter = cache.get(locale);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    cache.set(locale, formatter);
+  }
+  return formatter;
+}
 
 function normalizeTokenCount(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
 }
 
 export function formatTokenCount(value: number, locale: Locale = 'en'): string {
-  return compactTokenFormatters[locale]
+  return getFormatter(compactTokenFormatters, locale, {
+    notation: 'compact',
+    compactDisplay: 'short',
+    maximumFractionDigits: 2,
+  })
     .format(normalizeTokenCount(value))
     .toLowerCase();
 }
 
 export function formatExactTokenCount(value: number, locale: Locale = 'en'): string {
-  return exactTokenFormatters[locale].format(normalizeTokenCount(value));
+  return getFormatter(exactTokenFormatters, locale).format(normalizeTokenCount(value));
 }
 
 export function TokenUsageDisplay({ taskId, isRunning, className }: TokenUsageDisplayProps) {

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -17,12 +17,17 @@ import {
 
 type User = AuthCacheUser
 
+type TeamRole = "admin" | "member" | null
+
 interface AuthContextType {
   user: User | null
   isAuthenticated: boolean
   token: string | null
   refreshToken: string | null
   isLoading: boolean
+  // SaaS team context; on standard xagent (no teams / my-team 404) inTeam=false, teamRole=null.
+  inTeam: boolean
+  teamRole: TeamRole
   login: (username: string, password: string) => Promise<boolean>
   logout: () => void
   checkAuth: () => Promise<boolean>
@@ -37,6 +42,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [refreshToken, setRefreshToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [lastCheckTime, setLastCheckTime] = useState(0)
+  const [inTeam, setInTeam] = useState(false)
+  const [teamRole, setTeamRole] = useState<TeamRole>(null)
   const refreshAccessTokenRef = useRef<() => Promise<boolean>>(async () => false)
 
   // Timer for active token refresh
@@ -137,6 +144,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     window.addEventListener(AUTH_TOKEN_UPDATED_EVENT, handleTokenUpdate)
     return () => window.removeEventListener(AUTH_TOKEN_UPDATED_EVENT, handleTokenUpdate)
   }, [])
+
+  // Resolve SaaS team role once we have a session. my-team 404 / any failure =>
+  // standard xagent with no team concept; keep inTeam=false, teamRole=null.
+  useEffect(() => {
+    if (!token) {
+      setInTeam(false)
+      setTeamRole(null)
+      return
+    }
+    let active = true
+    ;(async () => {
+      try {
+        const res = await apiRequest(`${getApiUrl()}/api/teams/my-team`)
+        if (!active || !res.ok) return
+        const team = await res.json()
+        if (!active) return
+        setInTeam(true)
+        setTeamRole(team?.team_role === "admin" ? "admin" : "member")
+      } catch {
+        // no team context; keep defaults
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [token])
 
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
@@ -299,6 +332,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     token,
     refreshToken,
     isLoading,
+    inTeam,
+    teamRole,
     login,
     logout,
     checkAuth,

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -148,9 +148,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Resolve SaaS team role once we have a session. my-team 404 / any failure =>
   // standard xagent with no team concept; keep inTeam=false, teamRole=null.
   useEffect(() => {
+    // Reset first so a token change / failed or non-team response never leaves
+    // a previous user's team context behind.
+    setInTeam(false)
+    setTeamRole(null)
     if (!token) {
-      setInTeam(false)
-      setTeamRole(null)
       return
     }
     let active = true

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2447,6 +2447,13 @@ Build when you need.`,
         add: "+ Add Prompt",
         delete: "Delete",
       },
+      visibility: {
+        label: "Visibility",
+        desc: "Control who in your team can see and use this agent",
+        team: "Team — all members can view & use",
+        admins: "Admins only — only team admins",
+        adminsHint: "Only team admins can choose this.",
+      },
       chat: {
         title: "{appName} Assistant",
         subtitle: "Chat to configure your agent",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2447,6 +2447,13 @@ Build when you need.`,
         add: "+ 添加提示词",
         delete: "删除",
       },
+      visibility: {
+        label: "可见性",
+        desc: "控制团队中谁可以看到并使用此 Agent",
+        team: "团队全体可见",
+        admins: "仅团队管理员可见",
+        adminsHint: "仅团队管理员可设置此项",
+      },
       chat: {
         title: "{appName} 助手",
         subtitle: "通过对话配置你的 Agent",

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -124,7 +124,13 @@ def _apply_agent_visibility_filters(
     user_id: int,
     allowed_agent_ids: Optional[list[int]],
     allow_cross_user_agent_ids: bool,
+    db: Any,
 ) -> Any | None:
+    from .....web.services.agent_team_scope import (
+        get_agent_team_scope,
+        owned_agent_clause,
+    )
+
     normalized_allowed_agent_ids = _normalize_agent_ids(allowed_agent_ids)
     if normalized_allowed_agent_ids is not None:
         if not normalized_allowed_agent_ids:
@@ -132,9 +138,12 @@ def _apply_agent_visibility_filters(
         query = query.filter(agent_model.id.in_(normalized_allowed_agent_ids))
 
     # Cross-user execution is only valid for explicit allowlists. Global
-    # discovery and direct execution remain owner-scoped.
+    # discovery and direct execution stay scoped to what the user owns, which
+    # under a team scope means team-visible agents (admins-only stay hidden).
     if not allow_cross_user_agent_ids or normalized_allowed_agent_ids is None:
-        query = query.filter(agent_model.user_id == user_id)
+        query = query.filter(
+            owned_agent_clause(user_id, get_agent_team_scope(db, user_id))
+        )
 
     query = _exclude_private_workforce_manager_agents(query, agent_model)
 
@@ -150,9 +159,14 @@ def _exclude_private_workforce_manager_agents(query: Any, agent_model: Any) -> A
 
 
 def _apply_owned_agent_tool_filters(
-    query: Any, agent_model: Any, *, user_id: int
+    query: Any, agent_model: Any, *, user_id: int, db: Any
 ) -> Any:
-    query = query.filter(agent_model.user_id == user_id)
+    from .....web.services.agent_team_scope import (
+        get_agent_team_scope,
+        owned_agent_clause,
+    )
+
+    query = query.filter(owned_agent_clause(user_id, get_agent_team_scope(db, user_id)))
     query = _exclude_private_workforce_manager_agents(query, agent_model)
     return query
 
@@ -963,6 +977,7 @@ class UpdateAgentTool(AbstractBaseTool):
                     query,
                     Agent,
                     user_id=self._user_id,
+                    db=db,
                 )
                 agent = query.first()
 
@@ -1004,6 +1019,7 @@ class UpdateAgentTool(AbstractBaseTool):
                         ),
                         Agent,
                         user_id=self._user_id,
+                        db=db,
                     ).first()
                     if existing:
                         return UpdateAgentToolResult(
@@ -1245,6 +1261,7 @@ class ListAgentsTool(AbstractBaseTool):
                     db.query(Agent),
                     Agent,
                     user_id=self._user_id,
+                    db=db,
                 )
 
                 # Apply status filter if provided
@@ -1721,6 +1738,7 @@ class AgentTool(AbstractBaseTool):
                     user_id=self._user_id,
                     allowed_agent_ids=self._target_allowed_agent_ids,
                     allow_cross_user_agent_ids=self._target_allow_cross_user_agent_ids,
+                    db=db,
                 )
                 agent = agent.first() if agent is not None else None
 
@@ -2001,6 +2019,7 @@ def get_published_agents_tools(
                     user_id=user_id,
                     allowed_agent_ids=normalized_injected_agent_ids,
                     allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+                    db=db,
                 )
                 if query is None:
                     return []
@@ -2011,13 +2030,17 @@ def get_published_agents_tools(
                 query = db.query(Agent).filter(
                     Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
                 )
-                query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
+                query = _apply_owned_agent_tool_filters(
+                    query, Agent, user_id=user_id, db=db
+                )
             else:
                 # Only PUBLISHED agents
                 query = db.query(Agent).filter(
                     Agent.status == "published",
                 )
-                query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
+                query = _apply_owned_agent_tool_filters(
+                    query, Agent, user_id=user_id, db=db
+                )
 
             # Exclude the active delegation stack to prevent recursive self-calls.
             if excluded_agent_ids:
@@ -2045,6 +2068,7 @@ def get_published_agents_tools(
                         ),
                         Agent,
                         user_id=user_id,
+                        db=db,
                     ).all()
                     # Merge without duplicates
                     existing_ids = {agent.id for agent in agents}

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -603,13 +603,21 @@ class CreateAgentTool(AbstractBaseTool):
         self, requested_name: str, db: Any
     ) -> tuple[str, Optional[str]]:
         from .....web.models.agent import Agent
+        from .....web.services.agent_team_scope import (
+            get_agent_team_scope,
+            owned_agent_clause,
+        )
 
         normalized_name = requested_name.strip()[:MAX_AGENT_NAME_LENGTH].rstrip()
 
         existing_names = {
             name
             for (name,) in db.query(Agent.name)
-            .filter(Agent.user_id == self._user_id)
+            .filter(
+                owned_agent_clause(
+                    self._user_id, get_agent_team_scope(db, self._user_id)
+                )
+            )
             .all()
         }
 

--- a/src/xagent/migrations/versions/20260713_add_agent_visibility.py
+++ b/src/xagent/migrations/versions/20260713_add_agent_visibility.py
@@ -1,0 +1,47 @@
+"""Add visibility column to agents
+
+Revision ID: 20260713_add_agent_visibility
+Revises: 20260713_add_team_id_to_agents
+Create Date: 2026-07-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+revision = "20260713_add_agent_visibility"
+down_revision = "20260713_add_team_id_to_agents"
+branch_labels = None
+depends_on = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+    if "visibility" not in _column_names("agents"):
+        op.add_column(
+            "agents",
+            sa.Column(
+                "visibility",
+                sa.String(length=20),
+                nullable=False,
+                server_default="team",
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+    if "visibility" in _column_names("agents"):
+        op.drop_column("agents", "visibility")

--- a/src/xagent/migrations/versions/20260713_add_team_id_to_agents.py
+++ b/src/xagent/migrations/versions/20260713_add_team_id_to_agents.py
@@ -1,7 +1,7 @@
 """Add team_id scope column to agents
 
 Revision ID: 20260713_add_team_id_to_agents
-Revises: 20260711_task_commands
+Revises: 20260713_mcp_oauth_dcr
 Create Date: 2026-07-13
 """
 
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy.engine.reflection import Inspector
 
 revision = "20260713_add_team_id_to_agents"
-down_revision = "20260711_task_commands"
+down_revision = "20260713_mcp_oauth_dcr"
 branch_labels = None
 depends_on = None
 

--- a/src/xagent/migrations/versions/20260713_add_team_id_to_agents.py
+++ b/src/xagent/migrations/versions/20260713_add_team_id_to_agents.py
@@ -1,0 +1,41 @@
+"""Add team_id scope column to agents
+
+Revision ID: 20260713_add_team_id_to_agents
+Revises: 20260711_task_commands
+Create Date: 2026-07-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+revision = "20260713_add_team_id_to_agents"
+down_revision = "20260711_task_commands"
+branch_labels = None
+depends_on = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+    if "team_id" not in _column_names("agents"):
+        op.add_column("agents", sa.Column("team_id", sa.Integer(), nullable=True))
+        op.create_index("ix_agents_team_id", "agents", ["team_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+    if "team_id" in _column_names("agents"):
+        op.drop_index("ix_agents_team_id", table_name="agents")
+        op.drop_column("agents", "team_id")

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -5,7 +5,7 @@ import os
 import secrets
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -37,6 +37,7 @@ from ..services.agent_management import (
     TemplateNotFoundError,
 )
 from ..services.agent_store import AgentStore, new_widget_key
+from ..services.agent_team_scope import get_agent_team_scope, owned_agent_clause
 from ..services.api_keys import AgentApiKeyService, KeyRotationConflict
 from ..services.llm_utils import UserAwareModelStorage
 from ..services.workforce_access import get_visible_agent_ids
@@ -76,6 +77,7 @@ class AgentCreateRequest(BaseModel):
     logo_base64: Optional[str] = Field(
         None, description="Logo image as base64 data URL"
     )
+    visibility: Optional[Literal["team", "admins"]] = None
 
 
 class AgentUpdateRequest(BaseModel):
@@ -97,6 +99,9 @@ class AgentUpdateRequest(BaseModel):
     logo_base64: Optional[str] = None
     widget_enabled: Optional[bool] = None
     allowed_domains: Optional[List[str]] = None
+    visibility: Optional[Literal["team", "admins"]] = Field(
+        None, description="Team visibility: 'team' or 'admins' (team admins only)"
+    )
 
 
 class AgentResponse(BaseModel):
@@ -115,6 +120,7 @@ class AgentResponse(BaseModel):
     suggested_prompts: List[str]
     logo_url: Optional[str]
     status: str
+    visibility: str
     published_at: Optional[str]
     created_at: str
     updated_at: str
@@ -137,6 +143,7 @@ class AgentListItem(BaseModel):
     description: Optional[str]
     logo_url: Optional[str]
     status: str
+    visibility: str = "team"
     created_at: str
     updated_at: str
     widget_enabled: bool
@@ -371,7 +378,9 @@ def _get_owned_agent_or_404(agent_id: int, current_user: User, db: Session) -> A
         db.query(Agent)
         .filter(
             Agent.id == agent_id,
-            Agent.user_id == current_user.id,
+            owned_agent_clause(
+                int(current_user.id), get_agent_team_scope(db, int(current_user.id))
+            ),
             Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
         )
         .first()
@@ -515,6 +524,7 @@ async def create_agent(
             skills=agent_data.skills,
             tool_categories=agent_data.tool_categories,
             suggested_prompts=agent_data.suggested_prompts,
+            visibility=agent_data.visibility,
         )
 
         # Save logo if provided
@@ -533,6 +543,8 @@ async def create_agent(
 
     except HTTPException:
         raise
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to create agent: {e}")
         db.rollback()
@@ -612,7 +624,11 @@ async def update_agent(
     try:
         store = AgentStore(db)
         user_id = int(current_user.id)
-        agent = store.get_owned_agent(user_id, agent_id)
+        # Resolve team scope once and reuse it for the read, the name check,
+        # and the write, instead of re-resolving (extra TeamMember query) and
+        # re-SELECTing the agent inside each store call.
+        team_scope = get_agent_team_scope(db, user_id)
+        agent = store.get_owned_agent(user_id, agent_id, team_scope)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
@@ -636,7 +652,10 @@ async def update_agent(
         if agent_data.name is not None:
             # Check for duplicate name (excluding current agent)
             if store.agent_name_exists(
-                user_id, agent_data.name, exclude_agent_id=agent_id
+                user_id,
+                agent_data.name,
+                exclude_agent_id=agent_id,
+                team_scope=team_scope,
             ):
                 raise HTTPException(
                     status_code=400, detail="Agent with this name already exists"
@@ -667,6 +686,8 @@ async def update_agent(
                 updates["widget_key"] = new_widget_key()
         if agent_data.allowed_domains is not None:
             updates["allowed_domains"] = agent_data.allowed_domains
+        if agent_data.visibility is not None:
+            updates["visibility"] = agent_data.visibility
 
         # Handle logo
         if agent_data.logo_base64 is not None:
@@ -679,13 +700,24 @@ async def update_agent(
             updates["logo_url"] = logo_url
 
         if updates:
-            agent = store.update_agent_fields(user_id, agent_id, updates) or agent
+            agent = (
+                store.update_agent_fields(
+                    user_id,
+                    agent_id,
+                    updates,
+                    team_scope=team_scope,
+                    agent=agent,
+                )
+                or agent
+            )
 
         logger.info(f"Updated agent {agent_id} for user {current_user.id}")
         return AgentResponse.model_validate(store.agent_to_response_dict(agent))
 
     except HTTPException:
         raise
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     except Exception as e:
         logger.error(f"Failed to update agent {agent_id}: {e}")
         db.rollback()

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -51,6 +51,7 @@ from ..sandbox_keys import (
 )
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.agent_access import list_accessible_published_agents
+from ..services.agent_team_scope import get_agent_team_scope, owned_agent_clause
 from ..services.chat_history_service import (
     get_latest_waiting_question,
     load_task_transcript,
@@ -136,8 +137,19 @@ def _load_agent_for_task_create(
         return None
     if is_workforce_generated_manager_agent(agent):
         return None
-    if int(agent.user_id) == int(user.id):
-        return agent
+    # Team-scoped ownership: teammates may run a team-visible agent, and an
+    # admins-only agent stays hidden from non-admins. Falls back to the
+    # published-visibility path below when the caller does not own it.
+    owned = (
+        db.query(Agent)
+        .filter(
+            Agent.id == agent_id,
+            owned_agent_clause(int(user.id), get_agent_team_scope(db, int(user.id))),
+        )
+        .first()
+    )
+    if owned is not None:
+        return owned
     if not _is_published_agent(agent):
         return None
     visible_agent_ids = {
@@ -170,8 +182,19 @@ def _load_agent_for_task_runtime(
         ):
             return agent
         return None
-    if int(agent.user_id) == int(task.user_id):
-        return agent
+    # Team-scoped ownership keyed on the task owner: a teammate's task may run
+    # a team-visible agent; admins-only stays hidden from non-admins.
+    task_user_id = int(task.user_id)
+    owned = (
+        db.query(Agent)
+        .filter(
+            Agent.id == task_agent_id,
+            owned_agent_clause(task_user_id, get_agent_team_scope(db, task_user_id)),
+        )
+        .first()
+    )
+    if owned is not None:
+        return owned
     if (
         workforce_runtime is not None
         and workforce_runtime.manager_agent_id == task_agent_id

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1272,11 +1272,14 @@ class AgentServiceManager:
                 "agent tools"
             )
         elif agent_config and agent_config.get("preview_agent_id"):
+            preview_user_id = int(task.user_id)
             current_agent = (
                 db.query(Agent)
                 .filter(
                     Agent.id == agent_config["preview_agent_id"],
-                    Agent.user_id == task.user_id,
+                    owned_agent_clause(
+                        preview_user_id, get_agent_team_scope(db, preview_user_id)
+                    ),
                 )
                 .first()
             )
@@ -1824,11 +1827,15 @@ class AgentServiceManager:
                         raise ValueError(
                             f"Task {task_id} missing while resolving preview agent"
                         )
+                    preview_user_id = int(task.user_id)
                     current_agent = (
                         db.query(Agent)
                         .filter(
                             Agent.id == agent_config["preview_agent_id"],
-                            Agent.user_id == task.user_id,
+                            owned_agent_clause(
+                                preview_user_id,
+                                get_agent_team_scope(db, preview_user_id),
+                            ),
                         )
                         .first()
                     )

--- a/src/xagent/web/api/triggers.py
+++ b/src/xagent/web/api/triggers.py
@@ -225,9 +225,11 @@ async def list_triggers(
 ) -> list[TriggerResponse]:
     user_id = int(current_user.id)
     _agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    # The agent is already confirmed manageable above; list all its triggers
+    # regardless of which teammate created them.
     rows = (
         db.query(AgentTrigger)
-        .filter(AgentTrigger.user_id == user_id, AgentTrigger.agent_id == agent_id)
+        .filter(AgentTrigger.agent_id == agent_id)
         .order_by(AgentTrigger.created_at.desc(), AgentTrigger.id.desc())
         .all()
     )

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -19,6 +19,11 @@ from ..services.agent_access import (
     accessible_agent_permissions,
     list_accessible_published_agent_items,
 )
+from ..services.agent_team_scope import (
+    AgentTeamScope,
+    get_agent_team_scope,
+    owns_agent,
+)
 from ..services.workforce_access import (
     can_create_workforce,
     ensure_agent_access,
@@ -120,7 +125,11 @@ def _serialize_datetime(value: Any) -> str | None:
     return value.isoformat() if value else None
 
 
-def _serialize_agent(agent: Agent, user: User | None = None) -> dict[str, Any]:
+def _serialize_agent(
+    agent: Agent,
+    user: User | None = None,
+    scope: AgentTeamScope | None = None,
+) -> dict[str, Any]:
     item = {
         "id": agent.id,
         "name": agent.name,
@@ -131,7 +140,7 @@ def _serialize_agent(agent: Agent, user: User | None = None) -> dict[str, Any]:
     if user is None:
         return item
 
-    is_owner = int(agent.user_id) == int(user.id)
+    is_owner = owns_agent(agent, int(user.id), scope)
     is_generated_manager = is_workforce_generated_manager_agent(agent)
     can_edit = is_owner and not is_generated_manager
     item.update(
@@ -162,11 +171,13 @@ def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
 
 
 def _serialize_worker(
-    worker: WorkforceAgent, user: User | None = None
+    worker: WorkforceAgent,
+    user: User | None = None,
+    scope: AgentTeamScope | None = None,
 ) -> dict[str, Any]:
     return {
         "id": worker.id,
-        "agent": _serialize_agent(worker.agent, user),
+        "agent": _serialize_agent(worker.agent, user, scope),
         "alias": worker.alias,
         "assignment_instructions": worker.assignment_instructions,
         "source_type": worker.source_type,
@@ -180,17 +191,20 @@ def _serialize_worker(
 
 
 def _serialize_workforce_detail(
-    workforce: Workforce, user: User | None = None
+    workforce: Workforce,
+    user: User | None = None,
+    scope: AgentTeamScope | None = None,
 ) -> dict[str, Any]:
     return {
         "id": workforce.id,
         "name": workforce.name,
         "description": workforce.description,
         "status": workforce.status,
-        "manager": _serialize_agent(workforce.manager_agent, user),
+        "manager": _serialize_agent(workforce.manager_agent, user, scope),
         "manager_instructions": workforce.manager_instructions,
         "workers": [
-            _serialize_worker(worker, user) for worker in _sorted_workers(workforce)
+            _serialize_worker(worker, user, scope)
+            for worker in _sorted_workers(workforce)
         ],
         "canvas_layout": workforce.canvas_layout,
         "scope_type": workforce.scope_type,
@@ -428,7 +442,9 @@ async def create_workforce(
         db.rollback()
         raise
 
-    return _serialize_workforce_detail(_reload_workforce(db, workforce), user)
+    return _serialize_workforce_detail(
+        _reload_workforce(db, workforce), user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.post("/from-prompt")
@@ -439,7 +455,9 @@ async def create_workforce_from_prompt_endpoint(
 ) -> dict[str, Any]:
     result = await create_workforce_from_prompt(db, user, prompt=request.prompt)
     workforce = _reload_workforce(db, result.workforce)
-    return _serialize_workforce_detail(workforce, user)
+    return _serialize_workforce_detail(
+        workforce, user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.get("/agent-options")
@@ -469,7 +487,9 @@ async def get_workforce(
         _load_workforce(db, workforce_id),
         action="view",
     )
-    return _serialize_workforce_detail(workforce, user)
+    return _serialize_workforce_detail(
+        workforce, user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.patch("/{workforce_id}")
@@ -531,7 +551,9 @@ async def update_workforce(
         db.rollback()
         raise
 
-    return _serialize_workforce_detail(_reload_workforce(db, workforce), user)
+    return _serialize_workforce_detail(
+        _reload_workforce(db, workforce), user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.delete("/{workforce_id}")
@@ -573,7 +595,9 @@ async def publish_workforce(
         db.rollback()
         raise
 
-    return _serialize_workforce_detail(_reload_workforce(db, workforce), user)
+    return _serialize_workforce_detail(
+        _reload_workforce(db, workforce), user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.post("/{workforce_id}/unpublish")
@@ -591,7 +615,9 @@ async def unpublish_workforce(
     _ensure_publish_state_mutable(workforce)
     cast(Any, workforce).status = "draft"
     db.commit()
-    return _serialize_workforce_detail(_reload_workforce(db, workforce), user)
+    return _serialize_workforce_detail(
+        _reload_workforce(db, workforce), user, get_agent_team_scope(db, int(user.id))
+    )
 
 
 @router.post("/{workforce_id}/agents")
@@ -627,7 +653,7 @@ async def add_workforce_agent(
         raise
 
     db.refresh(worker)
-    return _serialize_worker(worker, user)
+    return _serialize_worker(worker, user, get_agent_team_scope(db, int(user.id)))
 
 
 @router.patch("/{workforce_id}/agents/{member_id}")
@@ -674,7 +700,7 @@ async def update_workforce_agent(
         raise
 
     db.refresh(worker)
-    return _serialize_worker(worker, user)
+    return _serialize_worker(worker, user, get_agent_team_scope(db, int(user.id)))
 
 
 @router.delete("/{workforce_id}/agents/{member_id}")

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -42,6 +42,18 @@ class Agent(Base):  # type: ignore
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    # SaaS-overlay team ownership. No DB ForeignKey: the ``teams`` table is a
+    # SaaS-only overlay table and does not exist in standalone xagent. When the
+    # SaaS agent-team-scope hook is not installed this stays NULL and agents
+    # remain purely user-owned.
+    team_id = Column(Integer, nullable=True, index=True)
+    # Team-internal visibility. "team" (default) = every team member; "admins"
+    # = only team admins (and the team API key) can see/manage/run it. Only a
+    # team admin may switch this. Standalone xagent (no team-scope hook) ignores
+    # it. Distinct from external share_enabled/widget exposure.
+    visibility = Column(
+        String(20), nullable=False, default="team", server_default="team"
+    )
     name = Column(String(200), nullable=False)
     description = Column(Text, nullable=True)
     instructions = Column(Text, nullable=True)  # System prompt/instructions

--- a/src/xagent/web/services/agent_access.py
+++ b/src/xagent/web/services/agent_access.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.user import User
+from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .workforce_access import get_visible_agent_ids
 
 AgentAccessLevel = Literal["owner", "policy"]
@@ -99,7 +100,8 @@ def list_accessible_agents(
     excluded = _normalize_excluded_agent_ids(exclude_agent_ids)
     items_by_id: dict[int, AccessibleAgent] = {}
 
-    owned_query = db.query(Agent).filter(Agent.user_id == int(user.id))
+    team_scope = get_agent_team_scope(db, int(user.id))
+    owned_query = db.query(Agent).filter(owned_agent_clause(int(user.id), team_scope))
     if excluded:
         owned_query = owned_query.filter(Agent.id.notin_(excluded))
     if not include_private_workforce_manager_agents:
@@ -113,7 +115,11 @@ def list_accessible_agents(
         visible_agent_ids = get_visible_agent_ids(db, user, purpose)
         if not visible_agent_ids:
             return _sort_by_created_desc(list(items_by_id.values()))
-        policy_query = db.query(Agent).filter(Agent.id.in_(visible_agent_ids))
+        # Admins-only agents surface only through the owned clause (team admin);
+        # the policy/published path must never leak them to non-admins.
+        policy_query = db.query(Agent).filter(
+            Agent.id.in_(visible_agent_ids), Agent.visibility != "admins"
+        )
 
     if excluded:
         policy_query = policy_query.filter(Agent.id.notin_(excluded))

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -194,7 +194,9 @@ class AgentManagementService:
             raise KeyRotationConflict(str(exc)) from exc
 
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, int(agent.id), agent.team_id)
+        invalidate_agent_cache(
+            user_id, int(agent.id), cast("int | None", agent.team_id)
+        )
 
         key_resp: APIKeyGenerateResponse | None = None
         if staged_key is not None:

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -194,7 +194,7 @@ class AgentManagementService:
             raise KeyRotationConflict(str(exc)) from exc
 
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, int(agent.id))
+        invalidate_agent_cache(user_id, int(agent.id), agent.team_id)
 
         key_resp: APIKeyGenerateResponse | None = None
         if staged_key is not None:

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -12,6 +12,11 @@ from ...core.utils.type_check import ensure_list
 from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.task import Task
+from .agent_team_scope import (
+    get_agent_team_scope,
+    owned_agent_clause,
+    team_id_of,
+)
 from .hot_path_cache import (
     agent_detail_key,
     agent_list_key,
@@ -38,7 +43,47 @@ _AGENT_UPDATE_FIELDS = {
     "share_enabled",
     "share_token",
     "share_updated_at",
+    "visibility",
 }
+
+
+# Sentinel so callers can pass an already-resolved scope (even a real ``None``)
+# and skip the second team-scope lookup within a single write method.
+_UNRESOLVED = object()
+
+
+_VALID_VISIBILITIES = {"team", "admins"}
+
+
+def _assert_can_set_visibility(
+    team_scope: Any,
+    visibility: str | None,
+    current_visibility: str | None = None,
+) -> None:
+    """Guard visibility writes: value-domain (#14) + admins-only gate (#8/#9).
+
+    - Unknown values raise ``ValueError`` (store-layer domain check, not just
+      the API Pydantic Literal).
+    - Setting ``admins`` requires a resolved team scope with admin rights;
+      no scope (standalone / legacy) is fail-closed, not fail-open (#8).
+    - A team admin is also required to change an agent that is *currently*
+      admins-only, so a non-admin cannot downgrade it (#9).
+    """
+    is_team_admin = bool(team_scope and getattr(team_scope, "is_team_admin", False))
+    if visibility is not None and visibility not in _VALID_VISIBILITIES:
+        raise ValueError(f"Unsupported agent visibility: {visibility}")
+    if visibility == "admins" and not is_team_admin:
+        raise PermissionError(
+            "Only team admins can set an agent to admins-only visibility"
+        )
+    if (
+        visibility is not None
+        and current_visibility == "admins"
+        and not is_team_admin
+    ):
+        raise PermissionError(
+            "Only team admins can change the visibility of an admins-only agent"
+        )
 
 
 def clean_tool_categories(categories: Any) -> list[str]:
@@ -71,6 +116,7 @@ class AgentStore:
             "suggested_prompts": ensure_list(agent.suggested_prompts) or [],
             "logo_url": agent.logo_url,
             "status": agent.status.value,
+            "visibility": agent.visibility,
             "published_at": agent.published_at.isoformat()
             if agent.published_at
             else None,
@@ -91,6 +137,7 @@ class AgentStore:
             "description": agent.description,
             "logo_url": agent.logo_url,
             "status": agent.status.value,
+            "visibility": agent.visibility,
             "created_at": agent.created_at.isoformat(),
             "updated_at": agent.updated_at.isoformat()
             if agent.updated_at
@@ -104,14 +151,19 @@ class AgentStore:
         }
 
     def list_agent_items(self, user_id: int) -> list[dict[str, Any]]:
-        cache_key = agent_list_key(user_id)
+        team_scope = get_agent_team_scope(self.db, user_id)
+        cache_key = agent_list_key(
+            user_id,
+            team_id_of(team_scope),
+            bool(team_scope and team_scope.is_team_admin),
+        )
         cached = cache_get(cache_key)
         if isinstance(cached, list):
             return cached
 
         agents = (
             self.db.query(Agent)
-            .filter(Agent.user_id == user_id)
+            .filter(owned_agent_clause(user_id, team_scope))
             .filter(Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value)
             .order_by(Agent.created_at.desc())
             .all()
@@ -121,12 +173,18 @@ class AgentStore:
         return response
 
     def get_agent_response(self, user_id: int, agent_id: int) -> dict[str, Any] | None:
-        cache_key = agent_detail_key(user_id, agent_id)
+        team_scope = get_agent_team_scope(self.db, user_id)
+        cache_key = agent_detail_key(
+            user_id,
+            agent_id,
+            team_id_of(team_scope),
+            bool(team_scope and team_scope.is_team_admin),
+        )
         cached = cache_get(cache_key)
         if isinstance(cached, dict):
             return cached
 
-        agent = self.get_owned_agent(user_id, agent_id)
+        agent = self.get_owned_agent(user_id, agent_id, team_scope)
         if agent is None:
             return None
 
@@ -134,12 +192,16 @@ class AgentStore:
         cache_set(cache_key, response)
         return response
 
-    def get_owned_agent(self, user_id: int, agent_id: int) -> Agent | None:
+    def get_owned_agent(
+        self, user_id: int, agent_id: int, team_scope: Any = _UNRESOLVED
+    ) -> Agent | None:
+        if team_scope is _UNRESOLVED:
+            team_scope = get_agent_team_scope(self.db, user_id)
         return (
             self.db.query(Agent)
             .filter(
                 Agent.id == agent_id,
-                Agent.user_id == user_id,
+                owned_agent_clause(user_id, team_scope),
                 Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
             )
             .first()
@@ -165,10 +227,17 @@ class AgentStore:
         return self.agent_to_response_dict(agent)
 
     def agent_name_exists(
-        self, user_id: int, name: str, *, exclude_agent_id: int | None = None
+        self,
+        user_id: int,
+        name: str,
+        *,
+        exclude_agent_id: int | None = None,
+        team_scope: Any = _UNRESOLVED,
     ) -> bool:
+        if team_scope is _UNRESOLVED:
+            team_scope = get_agent_team_scope(self.db, user_id)
         query = self.db.query(Agent.id).filter(
-            Agent.user_id == user_id,
+            owned_agent_clause(user_id, team_scope),
             Agent.name == name,
             Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
         )
@@ -197,6 +266,7 @@ class AgentStore:
         share_enabled: bool = False,
         share_token: str | None = None,
         share_updated_at: datetime | None = None,
+        visibility: str | None = None,
     ) -> Agent:
         agent = self.add_agent(
             user_id=user_id,
@@ -217,10 +287,12 @@ class AgentStore:
             share_enabled=share_enabled,
             share_token=share_token,
             share_updated_at=share_updated_at,
+            visibility=visibility,
         )
         self.db.commit()
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, int(agent.id))
+        # add_agent already stamped agent.team_id from the resolved scope.
+        invalidate_agent_cache(user_id, int(agent.id), agent.team_id)
         return agent
 
     def add_agent(
@@ -244,14 +316,18 @@ class AgentStore:
         share_enabled: bool = False,
         share_token: str | None = None,
         share_updated_at: datetime | None = None,
+        visibility: str | None = None,
     ) -> Agent:
         if status == AgentStatus.PUBLISHED and published_at is None:
             published_at = datetime.now(timezone.utc)
         # Widget-enabled agents always carry an embed credential; agents
         # created disabled get one when the widget is first enabled.
+        team_scope = get_agent_team_scope(self.db, user_id)
+        _assert_can_set_visibility(team_scope, visibility)
         widget_key = new_widget_key() if widget_enabled else None
         agent = Agent(
             user_id=user_id,
+            team_id=team_id_of(team_scope),
             name=name,
             description=description,
             instructions=instructions,
@@ -270,17 +346,32 @@ class AgentStore:
             share_enabled=share_enabled,
             share_token=share_token,
             share_updated_at=share_updated_at,
+            visibility=visibility or "team",
         )
         self.db.add(agent)
         self.db.flush()
         return agent
 
     def update_agent_fields(
-        self, user_id: int, agent_id: int, updates: dict[str, Any]
+        self,
+        user_id: int,
+        agent_id: int,
+        updates: dict[str, Any],
+        *,
+        team_scope: Any = _UNRESOLVED,
+        agent: Agent | None = None,
     ) -> Agent | None:
-        agent = self.get_owned_agent(user_id, agent_id)
+        if team_scope is _UNRESOLVED:
+            team_scope = get_agent_team_scope(self.db, user_id)
+        if agent is None:
+            agent = self.get_owned_agent(user_id, agent_id, team_scope)
         if agent is None:
             return None
+
+        if "visibility" in updates:
+            _assert_can_set_visibility(
+                team_scope, updates.get("visibility"), agent.visibility
+            )
 
         unknown_fields = set(updates) - _AGENT_UPDATE_FIELDS
         if unknown_fields:
@@ -295,11 +386,12 @@ class AgentStore:
 
         self.db.commit()
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, agent_id)
+        invalidate_agent_cache(user_id, agent_id, team_id_of(team_scope))
         return agent
 
     def delete_agent(self, user_id: int, agent_id: int) -> Agent | None:
-        agent = self.get_owned_agent(user_id, agent_id)
+        team_scope = get_agent_team_scope(self.db, user_id)
+        agent = self.get_owned_agent(user_id, agent_id, team_scope)
         if agent is None:
             return None
 
@@ -309,11 +401,12 @@ class AgentStore:
         )
         self.db.delete(agent)
         self.db.commit()
-        invalidate_agent_cache(user_id, agent_id)
+        invalidate_agent_cache(user_id, agent_id, team_id_of(team_scope))
         return agent
 
     def publish_agent(self, user_id: int, agent_id: int) -> Agent | None:
-        agent = self.get_owned_agent(user_id, agent_id)
+        team_scope = get_agent_team_scope(self.db, user_id)
+        agent = self.get_owned_agent(user_id, agent_id, team_scope)
         if agent is None:
             return None
         if agent.status == AgentStatus.PUBLISHED:
@@ -323,11 +416,12 @@ class AgentStore:
         agent.published_at = datetime.now(timezone.utc)  # type: ignore[assignment]
         self.db.commit()
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, agent_id)
+        invalidate_agent_cache(user_id, agent_id, team_id_of(team_scope))
         return agent
 
     def unpublish_agent(self, user_id: int, agent_id: int) -> Agent | None:
-        agent = self.get_owned_agent(user_id, agent_id)
+        team_scope = get_agent_team_scope(self.db, user_id)
+        agent = self.get_owned_agent(user_id, agent_id, team_scope)
         if agent is None:
             return None
         if agent.status != AgentStatus.PUBLISHED:
@@ -337,5 +431,5 @@ class AgentStore:
         agent.published_at = None  # type: ignore[assignment]
         self.db.commit()
         self.db.refresh(agent)
-        invalidate_agent_cache(user_id, agent_id)
+        invalidate_agent_cache(user_id, agent_id, team_id_of(team_scope))
         return agent

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy.orm import Session
 
@@ -288,7 +288,9 @@ class AgentStore:
         self.db.commit()
         self.db.refresh(agent)
         # add_agent already stamped agent.team_id from the resolved scope.
-        invalidate_agent_cache(user_id, int(agent.id), agent.team_id)
+        invalidate_agent_cache(
+            user_id, int(agent.id), cast("int | None", agent.team_id)
+        )
         return agent
 
     def add_agent(
@@ -366,7 +368,9 @@ class AgentStore:
 
         if "visibility" in updates:
             _assert_can_set_visibility(
-                team_scope, updates.get("visibility"), agent.visibility
+                team_scope,
+                updates.get("visibility"),
+                cast("str | None", agent.visibility),
             )
 
         unknown_fields = set(updates) - _AGENT_UPDATE_FIELDS

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -76,11 +76,7 @@ def _assert_can_set_visibility(
         raise PermissionError(
             "Only team admins can set an agent to admins-only visibility"
         )
-    if (
-        visibility is not None
-        and current_visibility == "admins"
-        and not is_team_admin
-    ):
+    if visibility is not None and current_visibility == "admins" and not is_team_admin:
         raise PermissionError(
             "Only team admins can change the visibility of an admins-only agent"
         )

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -62,9 +62,7 @@ def owned_agent_clause(
     if scope.is_team_admin:
         team_clause = Agent.team_id == scope.team_id
     else:
-        team_clause = and_(
-            Agent.team_id == scope.team_id, Agent.visibility == "team"
-        )
+        team_clause = and_(Agent.team_id == scope.team_id, Agent.visibility == "team")
     return or_(
         and_(Agent.team_id.is_(None), Agent.user_id == user_id),
         team_clause,

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -9,7 +9,7 @@ and whether that user is a team admin.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
@@ -39,7 +39,7 @@ def get_agent_team_scope(
     """Return the caller's team scope, or ``None`` when unscoped."""
     if _agent_team_scope_hook is None or user_id is None:
         return None
-    return _agent_team_scope_hook(db, user_id)
+    return cast(Optional[AgentTeamScope], _agent_team_scope_hook(db, user_id))
 
 
 def team_id_of(scope: Optional[AgentTeamScope]) -> Optional[int]:

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -47,6 +47,20 @@ def team_id_of(scope: Optional[AgentTeamScope]) -> Optional[int]:
     return scope.team_id if scope is not None else None
 
 
+def owns_agent(agent: Agent, user_id: int, scope: Optional[AgentTeamScope]) -> bool:
+    """Per-agent (in-memory) mirror of :func:`owned_agent_clause`.
+
+    Use this wherever a single loaded ``Agent`` is authorized/serialized so the
+    workforce gates and ownership serialization stay in lockstep with the list
+    query. Keep the branches identical to ``owned_agent_clause``.
+    """
+    if scope is None or agent.team_id is None:
+        return int(agent.user_id) == int(user_id)
+    if int(agent.team_id) != int(scope.team_id):
+        return False
+    return bool(scope.is_team_admin or agent.visibility == "team")
+
+
 def owned_agent_clause(
     user_id: int, scope: Optional[AgentTeamScope]
 ) -> ColumnElement[bool]:

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -1,0 +1,71 @@
+"""Team-scope seam for agent ownership and visibility.
+
+Standalone xagent leaves the hook unset, so ``get_agent_team_scope`` returns
+``None`` and agents stay purely user-owned with no visibility gating. The SaaS
+overlay installs a hook that maps a user id to the team that owns their agents
+and whether that user is a team admin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
+
+from ..models.agent import Agent
+
+
+@dataclass(frozen=True)
+class AgentTeamScope:
+    team_id: int
+    is_team_admin: bool
+
+
+_agent_team_scope_hook = None  # (db, user_id) -> AgentTeamScope | None
+
+
+def set_agent_team_scope_hook(hook: Any) -> None:
+    """Install (or clear, with ``None``) the user-id -> AgentTeamScope resolver."""
+    global _agent_team_scope_hook
+    _agent_team_scope_hook = hook
+
+
+def get_agent_team_scope(
+    db: Session, user_id: Optional[int]
+) -> Optional[AgentTeamScope]:
+    """Return the caller's team scope, or ``None`` when unscoped."""
+    if _agent_team_scope_hook is None or user_id is None:
+        return None
+    return _agent_team_scope_hook(db, user_id)
+
+
+def team_id_of(scope: Optional[AgentTeamScope]) -> Optional[int]:
+    """Extract the team id from a scope (for stamping/cache keys)."""
+    return scope.team_id if scope is not None else None
+
+
+def owned_agent_clause(
+    user_id: int, scope: Optional[AgentTeamScope]
+) -> ColumnElement[bool]:
+    """Predicate for agents *user_id* may see/manage.
+
+    - No scope (standalone / no hook): exactly ``Agent.user_id == user_id``.
+    - Scoped team admin: every agent in the team, regardless of visibility.
+    - Scoped non-admin: team agents whose ``visibility == 'team'`` only.
+    A legacy ``team_id IS NULL`` row still resolves via its own ``user_id``.
+    """
+    if scope is None:
+        return Agent.user_id == user_id
+    if scope.is_team_admin:
+        team_clause = Agent.team_id == scope.team_id
+    else:
+        team_clause = and_(
+            Agent.team_id == scope.team_id, Agent.visibility == "team"
+        )
+    return or_(
+        and_(Agent.team_id.is_(None), Agent.user_id == user_id),
+        team_clause,
+    )

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -26,6 +26,7 @@ from ..schemas.user_api_key import (
     PersonalAPIKeyMetadata,
     PersonalAPIKeyRevokeResponse,
 )
+from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 
 logger = logging.getLogger(__name__)
 
@@ -182,13 +183,14 @@ class AgentApiKeyService:
     #
     # Unlike the rotate/get/revoke trio above -- which enforce "at most one
     # active key" by construction -- these let a caller hold any number of
-    # simultaneously-active keys per agent. All are scoped by an inner join
-    # on ``Agent.user_id`` so a caller can never list/mutate another user's
-    # keys, mirroring ``_get_owned_agent_or_404`` in ``api/agents.py``.
+    # simultaneously-active keys per agent. All are scoped by
+    # ``owned_agent_clause`` so a caller can only list/mutate keys for agents
+    # they own or co-own within their team, mirroring
+    # ``_get_owned_agent_or_404`` in ``api/agents.py``.
 
     def _owned_agents_query(self, user_id: int) -> Any:
         return self.db.query(Agent.id).filter(
-            Agent.user_id == user_id,
+            owned_agent_clause(user_id, get_agent_team_scope(self.db, user_id)),
             Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
         )
 

--- a/src/xagent/web/services/hot_path_cache.py
+++ b/src/xagent/web/services/hot_path_cache.py
@@ -299,20 +299,18 @@ def invalidate_agent_cache(
     user_id: int, agent_id: int | None = None, team_id: int | None = None
 ) -> None:
     if team_id is not None:
-        cache_delete(
-            agent_list_key(user_id, team_id, True),
-            agent_list_key(user_id, team_id, False),
-        )
-    else:
-        cache_delete(agent_list_key(user_id))
+        # Team keys are per-member (see agent_list_key): a write by one member
+        # changes what every teammate may see (e.g. flipping visibility to
+        # admins-only), so nuke the whole team namespace rather than just the
+        # caller's variants. ponytail: prefix-nuke over-invalidates other agents'
+        # detail entries; enumerate members if write churn ever becomes hot.
+        cache_delete_prefix(f"agent:list:team:{team_id}:")
+        if agent_id is not None:
+            cache_delete_prefix(f"agent:detail:team:{team_id}:")
+        return
+    cache_delete(agent_list_key(user_id))
     if agent_id is not None:
-        if team_id is not None:
-            cache_delete(
-                agent_detail_key(user_id, agent_id, team_id, True),
-                agent_detail_key(user_id, agent_id, team_id, False),
-            )
-        else:
-            cache_delete(agent_detail_key(user_id, agent_id))
+        cache_delete(agent_detail_key(user_id, agent_id))
 
 
 def invalidate_model_cache(user_id: int | None = None) -> None:

--- a/src/xagent/web/services/hot_path_cache.py
+++ b/src/xagent/web/services/hot_path_cache.py
@@ -230,11 +230,24 @@ def web_task_history_key(task_id: int) -> str:
     return f"task:web:history:{task_id}"
 
 
-def agent_list_key(user_id: int) -> str:
+def agent_list_key(
+    user_id: int, team_id: int | None = None, is_team_admin: bool = False
+) -> str:
+    if team_id is not None:
+        return f"agent:list:team:{team_id}:{'a' if is_team_admin else 'm'}"
     return f"agent:list:{user_id}"
 
 
-def agent_detail_key(user_id: int, agent_id: int) -> str:
+def agent_detail_key(
+    user_id: int,
+    agent_id: int,
+    team_id: int | None = None,
+    is_team_admin: bool = False,
+) -> str:
+    if team_id is not None:
+        return (
+            f"agent:detail:team:{team_id}:{'a' if is_team_admin else 'm'}:{agent_id}"
+        )
     return f"agent:detail:{user_id}:{agent_id}"
 
 
@@ -275,10 +288,24 @@ def invalidate_task_cache(task_id: int) -> None:
     )
 
 
-def invalidate_agent_cache(user_id: int, agent_id: int | None = None) -> None:
-    cache_delete(agent_list_key(user_id))
+def invalidate_agent_cache(
+    user_id: int, agent_id: int | None = None, team_id: int | None = None
+) -> None:
+    if team_id is not None:
+        cache_delete(
+            agent_list_key(user_id, team_id, True),
+            agent_list_key(user_id, team_id, False),
+        )
+    else:
+        cache_delete(agent_list_key(user_id))
     if agent_id is not None:
-        cache_delete(agent_detail_key(user_id, agent_id))
+        if team_id is not None:
+            cache_delete(
+                agent_detail_key(user_id, agent_id, team_id, True),
+                agent_detail_key(user_id, agent_id, team_id, False),
+            )
+        else:
+            cache_delete(agent_detail_key(user_id, agent_id))
 
 
 def invalidate_model_cache(user_id: int | None = None) -> None:

--- a/src/xagent/web/services/hot_path_cache.py
+++ b/src/xagent/web/services/hot_path_cache.py
@@ -234,7 +234,10 @@ def agent_list_key(
     user_id: int, team_id: int | None = None, is_team_admin: bool = False
 ) -> str:
     if team_id is not None:
-        return f"agent:list:team:{team_id}:{'a' if is_team_admin else 'm'}"
+        # user_id is part of the key: owned_agent_clause still matches a user's
+        # own legacy (team_id IS NULL) agents, so the result set is user-specific
+        # and must never be served from a key shared across team members.
+        return f"agent:list:team:{team_id}:{user_id}:{'a' if is_team_admin else 'm'}"
     return f"agent:list:{user_id}"
 
 
@@ -245,8 +248,12 @@ def agent_detail_key(
     is_team_admin: bool = False,
 ) -> str:
     if team_id is not None:
+        # user_id in the key: see agent_list_key -- a user's own legacy
+        # (team_id IS NULL) agents are visible only to them, so the detail
+        # cache must be per-user even within a team.
         return (
-            f"agent:detail:team:{team_id}:{'a' if is_team_admin else 'm'}:{agent_id}"
+            f"agent:detail:team:{team_id}:{user_id}:"
+            f"{'a' if is_team_admin else 'm'}:{agent_id}"
         )
     return f"agent:detail:{user_id}:{agent_id}"
 

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -1128,6 +1128,7 @@ def _load_agent_for_task_runtime(
     )
     from ..models.user import User
     from .agent_access import list_accessible_published_agents
+    from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 
     task_agent_id = getattr(task_row, "agent_id", None)
     if task_agent_id is None:
@@ -1140,8 +1141,21 @@ def _load_agent_for_task_runtime(
         if workforce is not None and workforce.manager_agent_id == task_agent_id:
             return agent
         return None
-    if int(agent.user_id) == int(task_row.user_id):
-        return agent
+    # Team-scoped ownership keyed on the task owner: a teammate's task may run
+    # a team-visible agent; admins-only stays hidden from non-admins.
+    task_user_id = int(task_row.user_id)
+    owned = (
+        session.query(Agent)
+        .filter(
+            Agent.id == task_agent_id,
+            owned_agent_clause(
+                task_user_id, get_agent_team_scope(session, task_user_id)
+            ),
+        )
+        .first()
+    )
+    if owned is not None:
+        return owned
     if workforce is not None and workforce.manager_agent_id == task_agent_id:
         return agent
     if getattr(agent.status, "value", agent.status) != AgentStatus.PUBLISHED.value:

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -27,6 +27,7 @@ from ..models.background_job import BackgroundJob, BackgroundJobType
 from ..models.task import Task, TaskStatus
 from ..models.trigger import AgentTrigger, TriggerRun, TriggerRunStatus, TriggerType
 from ..models.user_oauth import UserOAuth
+from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .background_jobs import create_background_job, enqueue_background_job
 from .connector_runtime import (
     persist_create_connector_runtime_context,
@@ -423,7 +424,12 @@ def _unregister_trigger_binding(
 
 def get_owned_agent(db: Session, *, user_id: int, agent_id: int) -> Agent | None:
     return (
-        db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == user_id).first()
+        db.query(Agent)
+        .filter(
+            Agent.id == agent_id,
+            owned_agent_clause(user_id, get_agent_team_scope(db, user_id)),
+        )
+        .first()
     )
 
 
@@ -434,12 +440,16 @@ def get_owned_trigger(
     agent_id: int,
     trigger_id: int,
 ) -> AgentTrigger | None:
+    # Visibility follows the trigger's agent, not its creator: a teammate/team
+    # admin who can manage the (co-owned) agent can also read/update/delete
+    # triggers others created on it. Confirm the caller manages the agent first.
+    if get_owned_agent(db, user_id=user_id, agent_id=agent_id) is None:
+        return None
     return (
         db.query(AgentTrigger)
         .filter(
             AgentTrigger.id == trigger_id,
             AgentTrigger.agent_id == agent_id,
-            AgentTrigger.user_id == user_id,
         )
         .first()
     )

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -12,6 +12,7 @@ from xagent.web.models.agent import (
 from xagent.web.models.user import User
 
 from ..models.workforce import Workforce
+from .agent_team_scope import get_agent_team_scope, owns_agent
 
 
 class WorkforcePolicy:
@@ -72,10 +73,10 @@ class WorkforcePolicy:
         workforce: Workforce,
         agent: Agent,
     ) -> bool:
-        del db
+        scope = get_agent_team_scope(db, int(user.id))
         return bool(
             int(workforce.owner_user_id) == int(user.id)
-            and int(agent.user_id) == int(user.id)
+            and owns_agent(agent, int(user.id), scope)
         )
 
     def after_workforce_run_created(
@@ -198,7 +199,8 @@ def ensure_agent_access(
         raise HTTPException(status_code=404, detail="Agent not found")
     if is_workforce_generated_manager_agent(agent):
         raise HTTPException(status_code=404, detail="Agent not found")
-    if user.is_admin or int(agent.user_id) == int(user.id):
+    scope = get_agent_team_scope(db, int(user.id))
+    if user.is_admin or owns_agent(agent, int(user.id), scope):
         if require_published and agent.status != AgentStatus.PUBLISHED:
             raise HTTPException(
                 status_code=400,

--- a/src/xagent/web/services/workforce_names.py
+++ b/src/xagent/web/services/workforce_names.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from xagent.web.models.agent import Agent
 
 from ..models.workforce import Workforce
+from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .workforce_snapshot import normalize_text
 
 
@@ -69,7 +70,7 @@ def agent_name_exists(
 ) -> bool:
     normalized_name = normalize_text(name, "name", required=True)
     query = db.query(Agent.id).filter(
-        Agent.user_id == user_id,
+        owned_agent_clause(user_id, get_agent_team_scope(db, user_id)),
         func.lower(cast(Any, Agent.name)) == normalized_name.lower(),
     )
     if exclude_agent_id is not None:

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -167,7 +167,7 @@ class TestCreateAgentTool:
                 assert "test_agent" in result["markdown_link"]
                 assert "agent://" in result["markdown_link"]
                 mock_invalidate_agent_cache.assert_called_once_with(
-                    user_id, result["agent_id"]
+                    user_id, result["agent_id"], None
                 )
 
                 # Verify agent was created in database (use a fresh session)
@@ -1110,7 +1110,7 @@ class TestUpdateAgentTool:
                     }
                 )
                 mock_invalidate_agent_cache.assert_called_once_with(
-                    user.id, existing_agent.id
+                    user.id, existing_agent.id, None
                 )
 
             # Verify result

--- a/tests/web/services/test_hot_path_cache.py
+++ b/tests/web/services/test_hot_path_cache.py
@@ -4,9 +4,12 @@ from xagent.web.services import hot_path_cache
 from xagent.web.services.hot_path_cache import (
     InMemoryTTLCache,
     RedisJsonCache,
+    agent_detail_key,
+    agent_list_key,
     cache_delete_prefix,
     cache_get,
     cache_set,
+    invalidate_agent_cache,
     set_cache_backend_for_testing,
 )
 
@@ -39,6 +42,25 @@ def test_delete_prefix_only_removes_matching_keys() -> None:
     assert cache_get("model:list:1") is None
     assert cache_get("model:defaults:1") is None
     assert cache_get("agent:list:1") == {"hit": True}
+
+
+def test_team_agent_write_invalidates_every_member_cache() -> None:
+    # Team keys are per-member; a write by member A must also drop member B's
+    # cached list/detail so a visibility change can't linger.
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    team_id = 100
+    a_list = agent_list_key(1, team_id, False)
+    b_list = agent_list_key(2, team_id, False)
+    b_detail = agent_detail_key(2, 5, team_id, False)
+    cache_set(a_list, {"hit": True}, ttl_seconds=30)
+    cache_set(b_list, {"hit": True}, ttl_seconds=30)
+    cache_set(b_detail, {"hit": True}, ttl_seconds=30)
+
+    invalidate_agent_cache(1, agent_id=5, team_id=team_id)
+
+    assert cache_get(a_list) is None
+    assert cache_get(b_list) is None
+    assert cache_get(b_detail) is None
 
 
 def test_redis_delete_prefix_deletes_in_batches(monkeypatch) -> None:

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -72,6 +72,37 @@ def test_owned_clause_shape():
     assert "team_id" in str(team) and "user_id" in str(team)
 
 
+def _agent(user_id, team_id=None, visibility="team"):
+    return Agent(user_id=user_id, team_id=team_id, visibility=visibility)
+
+
+def test_owns_agent_mirrors_owned_clause_branches():
+    admin = AgentTeamScope(team_id=100, is_team_admin=True)
+    member = AgentTeamScope(team_id=100, is_team_admin=False)
+
+    # No scope: pure user_id equality.
+    assert ats.owns_agent(_agent(7), 7, None) is True
+    assert ats.owns_agent(_agent(9), 7, None) is False
+
+    # Legacy row (no team) resolves via its own user_id even under a scope.
+    assert ats.owns_agent(_agent(7, team_id=None), 7, member) is True
+    assert ats.owns_agent(_agent(9, team_id=None), 7, member) is False
+
+    # Team admin owns every team agent regardless of visibility.
+    assert ats.owns_agent(_agent(9, team_id=100, visibility="admins"), 7, admin) is True
+
+    # Non-admin teammate owns team-visible agents only...
+    assert ats.owns_agent(_agent(9, team_id=100, visibility="team"), 7, member) is True
+    # ...and loses access once an admin flips it to admins-only (the workforce
+    # bypass the raw user_id check used to leave open for the creator).
+    assert (
+        ats.owns_agent(_agent(7, team_id=100, visibility="admins"), 7, member) is False
+    )
+
+    # Foreign team never owned.
+    assert ats.owns_agent(_agent(9, team_id=200, visibility="team"), 7, member) is False
+
+
 def test_cache_keys_are_team_scoped_when_scope_present():
     from xagent.web.services import hot_path_cache as hpc
 

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -75,12 +75,15 @@ def test_cache_keys_are_team_scoped_when_scope_present():
     from xagent.web.services import hot_path_cache as hpc
 
     assert hpc.agent_list_key(7) == "agent:list:7"
-    assert hpc.agent_list_key(7, team_id=42, is_team_admin=True) == "agent:list:team:42:a"
+    assert (
+        hpc.agent_list_key(7, team_id=42, is_team_admin=True)
+        == "agent:list:team:42:7:a"
+    )
     assert hpc.agent_detail_key(7, 5) == "agent:detail:7:5"
-    assert hpc.agent_detail_key(7, 5, team_id=42) == "agent:detail:team:42:m:5"
+    assert hpc.agent_detail_key(7, 5, team_id=42) == "agent:detail:team:42:7:m:5"
     assert (
         hpc.agent_detail_key(7, 5, team_id=42, is_team_admin=True)
-        == "agent:detail:team:42:a:5"
+        == "agent:detail:team:42:7:a:5"
     )
 
 

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -44,9 +44,9 @@ def test_scope_is_none_without_hook():
 
 def test_scope_uses_hook_when_installed():
     ats.set_agent_team_scope_hook(
-        lambda db, uid: AgentTeamScope(team_id=42, is_team_admin=False)
-        if uid == 7
-        else None
+        lambda db, uid: (
+            AgentTeamScope(team_id=42, is_team_admin=False) if uid == 7 else None
+        )
     )
     try:
         assert ats.get_agent_team_scope(None, 7).team_id == 42
@@ -94,9 +94,11 @@ def two_users_one_team(db):
     db.flush()
     # Both users resolve to the same team scope (id 100).
     ats.set_agent_team_scope_hook(
-        lambda _db, uid: AgentTeamScope(team_id=100, is_team_admin=False)
-        if uid in {a.id, b.id}
-        else None
+        lambda _db, uid: (
+            AgentTeamScope(team_id=100, is_team_admin=False)
+            if uid in {a.id, b.id}
+            else None
+        )
     )
     yield a, b
     ats.set_agent_team_scope_hook(None)

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -1,0 +1,234 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+from xagent.web.services import agent_team_scope as ats
+from xagent.web.services.agent_store import AgentStore
+from xagent.web.services.agent_team_scope import AgentTeamScope
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+def _make_user(db, email):
+    # username/password_hash are NOT NULL in the User model.
+    user = User(username=email, email=email, password_hash="x", is_admin=False)
+    db.add(user)
+    db.flush()
+    return user
+
+
+def test_agent_model_has_team_id_column():
+    # team_id is a nullable scoping column owned by the SaaS overlay.
+    col = Agent.__table__.columns["team_id"]
+    assert col.nullable is True
+
+
+def test_scope_is_none_without_hook():
+    ats.set_agent_team_scope_hook(None)
+    assert ats.get_agent_team_scope(None, 7) is None
+
+
+def test_scope_uses_hook_when_installed():
+    ats.set_agent_team_scope_hook(
+        lambda db, uid: AgentTeamScope(team_id=42, is_team_admin=False)
+        if uid == 7
+        else None
+    )
+    try:
+        assert ats.get_agent_team_scope(None, 7).team_id == 42
+        assert ats.get_agent_team_scope(None, 9) is None
+        assert ats.get_agent_team_scope(None, None) is None  # None user -> no scope
+    finally:
+        ats.set_agent_team_scope_hook(None)
+
+
+def test_owned_clause_shape():
+    # No scope: a single equality on exactly the agents.user_id column.
+    user_only = ats.owned_agent_clause(7, None)
+    assert isinstance(user_only, BinaryExpression)
+    assert user_only.operator is operators.eq
+    assert user_only.left.table is Agent.__table__
+    assert user_only.left.name == "user_id"
+
+    # Scoped: an OR combining the legacy user-only row and the team clause.
+    team = ats.owned_agent_clause(7, AgentTeamScope(team_id=42, is_team_admin=True))
+    assert isinstance(team, BooleanClauseList)
+    assert team.operator is operators.or_
+    assert "team_id" in str(team) and "user_id" in str(team)
+
+
+def test_cache_keys_are_team_scoped_when_scope_present():
+    from xagent.web.services import hot_path_cache as hpc
+
+    assert hpc.agent_list_key(7) == "agent:list:7"
+    assert hpc.agent_list_key(7, team_id=42, is_team_admin=True) == "agent:list:team:42:a"
+    assert hpc.agent_detail_key(7, 5) == "agent:detail:7:5"
+    assert hpc.agent_detail_key(7, 5, team_id=42) == "agent:detail:team:42:m:5"
+    assert (
+        hpc.agent_detail_key(7, 5, team_id=42, is_team_admin=True)
+        == "agent:detail:team:42:a:5"
+    )
+
+
+@pytest.fixture
+def two_users_one_team(db):
+    a = _make_user(db, "a@t.co")
+    b = _make_user(db, "b@t.co")
+    db.flush()
+    # Both users resolve to the same team scope (id 100).
+    ats.set_agent_team_scope_hook(
+        lambda _db, uid: AgentTeamScope(team_id=100, is_team_admin=False)
+        if uid in {a.id, b.id}
+        else None
+    )
+    yield a, b
+    ats.set_agent_team_scope_hook(None)
+
+
+def test_member_can_read_and_manage_teammates_agent(db, two_users_one_team):
+    a, b = two_users_one_team
+    store = AgentStore(db)
+    created = store.create_agent(
+        user_id=int(a.id), name="Shared", description=None, instructions=None
+    )
+    # B sees it in the list...
+    b_list = store.list_agent_items(int(b.id))
+    assert any(item["id"] == int(created.id) for item in b_list)
+    # ...can fetch it as an owned agent...
+    assert store.get_owned_agent(int(b.id), int(created.id)) is not None
+    # ...and it was stamped with the team scope on create.
+    assert db.query(Agent).get(int(created.id)).team_id == 100
+
+
+def test_name_uniqueness_is_per_team(db, two_users_one_team):
+    a, b = two_users_one_team
+    store = AgentStore(db)
+    store.create_agent(
+        user_id=int(a.id), name="Dup", description=None, instructions=None
+    )
+    assert store.agent_name_exists(int(b.id), "Dup") is True
+
+
+def test_teammate_agent_is_owner_access(db, two_users_one_team):
+    from xagent.web.services.agent_access import list_accessible_agents
+
+    a, b = two_users_one_team
+    AgentStore(db).create_agent(
+        user_id=int(a.id), name="Shared2", description=None, instructions=None
+    )
+    items = list_accessible_agents(db, b)
+    match = [i for i in items if i.agent.name == "Shared2"]
+    assert match and match[0].access == "owner"
+    assert match[0].can_edit and match[0].can_delete
+
+
+# ===== Agent sub-resources: API keys and triggers are team-co-managed =====
+
+
+def test_member_can_manage_teammates_agent_api_key(db, two_users_one_team):
+    from xagent.web.services.api_keys import AgentApiKeyService
+
+    a, b = two_users_one_team
+    agent = AgentStore(db).create_agent(
+        user_id=int(a.id), name="KeyShared", description=None, instructions=None
+    )
+    svc = AgentApiKeyService(db)
+    # B (teammate) can create and then list a key on A's agent.
+    created = svc.create_key(int(b.id), int(agent.id), label="from-b")
+    assert created is not None
+    keys = svc.list_keys_for_user(int(b.id), agent_id=int(agent.id))
+    assert [k.label for k in keys] == ["from-b"]
+
+
+def test_member_can_manage_teammates_agent_trigger(db, two_users_one_team):
+    from xagent.web.services.triggers import get_owned_agent
+
+    a, b = two_users_one_team
+    agent = AgentStore(db).create_agent(
+        user_id=int(a.id), name="TrigShared", description=None, instructions=None
+    )
+    # B (teammate) resolves A's agent as owned -- the gate every trigger
+    # endpoint routes through.
+    assert get_owned_agent(db, user_id=int(b.id), agent_id=int(agent.id)) is not None
+
+
+def test_member_can_read_and_edit_teammates_trigger(db, two_users_one_team):
+    # A trigger created by A on a co-owned agent must be visible/editable/
+    # deletable by teammate B, whose user_id differs from the trigger creator's.
+    from xagent.web.services.triggers import (
+        create_agent_trigger,
+        get_owned_trigger,
+        update_agent_trigger,
+    )
+
+    a, b = two_users_one_team
+    agent = AgentStore(db).create_agent(
+        user_id=int(a.id), name="TrigCoManage", description=None, instructions=None
+    )
+    trigger, _ = create_agent_trigger(
+        db,
+        user_id=int(a.id),
+        agent_id=int(agent.id),
+        trigger_type="scheduled",
+        config={"interval_seconds": 3600},
+    )
+    assert int(trigger.user_id) == int(a.id)
+
+    # B resolves the trigger even though B did not create it.
+    resolved = get_owned_trigger(
+        db, user_id=int(b.id), agent_id=int(agent.id), trigger_id=int(trigger.id)
+    )
+    assert resolved is not None and int(resolved.id) == int(trigger.id)
+
+    # B can update it; the creator's user_id is preserved.
+    updated, _ = update_agent_trigger(
+        db,
+        user_id=int(b.id),
+        agent_id=int(agent.id),
+        trigger_id=int(trigger.id),
+        updates={"name": "renamed-by-b"},
+    )
+    assert str(updated.name) == "renamed-by-b"
+    assert int(updated.user_id) == int(a.id)
+
+
+def test_workforce_names_agent_name_exists_is_per_team(db, two_users_one_team):
+    from xagent.web.services.workforce_names import agent_name_exists
+
+    a, b = two_users_one_team
+    AgentStore(db).create_agent(
+        user_id=int(a.id), name="WFDup", description=None, instructions=None
+    )
+    # B's name-existence check sees A's team-visible agent.
+    assert agent_name_exists(db, user_id=int(b.id), name="WFDup") is True
+
+
+def test_non_team_user_still_gets_404_on_subresources(db):
+    # No hook installed -> user-only ownership; an outsider sees nothing.
+    from xagent.web.services.api_keys import AgentApiKeyService
+    from xagent.web.services.triggers import get_owned_agent
+
+    ats.set_agent_team_scope_hook(None)
+    a = _make_user(db, "owner@t.co")
+    outsider = _make_user(db, "out@t.co")
+    db.flush()
+    agent = AgentStore(db).create_agent(
+        user_id=int(a.id), name="Solo", description=None, instructions=None
+    )
+    assert get_owned_agent(db, user_id=int(outsider.id), agent_id=int(agent.id)) is None
+    svc = AgentApiKeyService(db)
+    assert svc.create_key(int(outsider.id), int(agent.id), label="x") is None

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import operators
 from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
+
 from xagent.web.models.agent import Agent
 from xagent.web.models.database import Base
 from xagent.web.models.user import User

--- a/tests/web/test_agent_visibility.py
+++ b/tests/web/test_agent_visibility.py
@@ -120,9 +120,11 @@ def team_of_admin_and_member(db):
     db.flush()
     admins = {int(admin.id)}
     ats.set_agent_team_scope_hook(
-        lambda _db, uid: AgentTeamScope(team_id=200, is_team_admin=uid in admins)
-        if uid in {int(admin.id), int(member.id)}
-        else None
+        lambda _db, uid: (
+            AgentTeamScope(team_id=200, is_team_admin=uid in admins)
+            if uid in {int(admin.id), int(member.id)}
+            else None
+        )
     )
     yield admin, member
     ats.set_agent_team_scope_hook(None)
@@ -155,7 +157,9 @@ def test_member_cannot_set_visibility_admins(db, team_of_admin_and_member):
         user_id=int(member.id), name="Mine", description=None, instructions=None
     )
     with pytest.raises(PermissionError):
-        store.update_agent_fields(int(member.id), int(agent.id), {"visibility": "admins"})
+        store.update_agent_fields(
+            int(member.id), int(agent.id), {"visibility": "admins"}
+        )
 
 
 def test_admin_can_create_admins_only_agent(db, team_of_admin_and_member):
@@ -399,9 +403,7 @@ def test_run_path_team_member_can_load_team_agent(db, two_users_one_team_via_sco
         visibility="admins",
         status=AgentStatus.PUBLISHED,
     )
-    assert (
-        _load_agent_for_task_create(db, member, int(team_agent.id)) is not None
-    )
+    assert _load_agent_for_task_create(db, member, int(team_agent.id)) is not None
     assert _load_agent_for_task_create(db, member, int(secret.id)) is None
 
 
@@ -419,9 +421,11 @@ def two_users_one_team_via_scope(db):
     db.flush()
     admins = {int(admin.id)}
     ats.set_agent_team_scope_hook(
-        lambda _db, uid: AgentTeamScope(team_id=300, is_team_admin=uid in admins)
-        if uid in {int(admin.id), int(member.id)}
-        else None
+        lambda _db, uid: (
+            AgentTeamScope(team_id=300, is_team_admin=uid in admins)
+            if uid in {int(admin.id), int(member.id)}
+            else None
+        )
     )
     yield admin, member
     ats.set_agent_team_scope_hook(None)

--- a/tests/web/test_agent_visibility.py
+++ b/tests/web/test_agent_visibility.py
@@ -1,0 +1,408 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_agent_has_visibility_column_defaulting_to_team():
+    col = Agent.__table__.columns["visibility"]
+    assert col.nullable is False
+    assert col.server_default is not None
+
+
+def test_serializers_include_visibility(db):
+    # db: in-memory sqlite fixture matching tests/web/test_agent_team_scope.py
+    from xagent.web.models.user import User
+    from xagent.web.services.agent_store import AgentStore
+
+    u = User(username="ser", password_hash="h", is_admin=False)
+    db.add(u)
+    db.flush()
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(u.id), name="Ser", description=None, instructions=None
+    )
+    assert store.agent_to_response_dict(agent)["visibility"] == "team"
+    assert store.agent_to_list_item_dict(agent)["visibility"] == "team"
+
+
+def test_team_id_of():
+    from xagent.web.services.agent_team_scope import AgentTeamScope, team_id_of
+
+    assert team_id_of(None) is None
+    assert team_id_of(AgentTeamScope(team_id=5, is_team_admin=True)) == 5
+
+
+def test_clause_admin_sees_all_team_agents():
+    from xagent.web.services.agent_team_scope import (
+        AgentTeamScope,
+        owned_agent_clause,
+    )
+
+    clause = owned_agent_clause(7, AgentTeamScope(team_id=42, is_team_admin=True))
+    # admin branch scopes by team_id only, no visibility filter
+    text = str(clause)
+    assert "visibility" not in text
+    assert "team_id" in text
+
+
+def test_clause_member_filtered_by_visibility():
+    from xagent.web.services.agent_team_scope import (
+        AgentTeamScope,
+        owned_agent_clause,
+    )
+
+    clause = owned_agent_clause(7, AgentTeamScope(team_id=42, is_team_admin=False))
+    text = str(clause)
+    assert "visibility" in text
+    assert "team_id" in text
+
+
+def test_clause_no_scope_is_user_only():
+    from xagent.web.models.agent import Agent
+    from xagent.web.services.agent_team_scope import owned_agent_clause
+
+    clause = owned_agent_clause(7, None)
+    assert str(clause) == str(Agent.user_id == 7)
+
+
+def test_team_list_key_splits_by_role():
+    from xagent.web.services import hot_path_cache as hpc
+
+    assert hpc.agent_list_key(7) == "agent:list:7"
+    assert hpc.agent_list_key(7, team_id=42, is_team_admin=True) == "agent:list:team:42:a"
+    assert (
+        hpc.agent_list_key(7, team_id=42, is_team_admin=False) == "agent:list:team:42:m"
+    )
+
+
+@pytest.fixture
+def team_of_admin_and_member(db):
+    from xagent.web.models.user import User
+    from xagent.web.services import agent_team_scope as ats
+    from xagent.web.services.agent_team_scope import AgentTeamScope
+
+    admin = User(username="adm", password_hash="h", is_admin=False)
+    member = User(username="mem", password_hash="h", is_admin=False)
+    db.add_all([admin, member])
+    db.flush()
+    admins = {int(admin.id)}
+    ats.set_agent_team_scope_hook(
+        lambda _db, uid: AgentTeamScope(team_id=200, is_team_admin=uid in admins)
+        if uid in {int(admin.id), int(member.id)}
+        else None
+    )
+    yield admin, member
+    ats.set_agent_team_scope_hook(None)
+
+
+def test_member_cannot_see_admins_only_agent(db, team_of_admin_and_member):
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, member = team_of_admin_and_member
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(admin.id), name="Secret", description=None, instructions=None
+    )
+    store.update_agent_fields(int(admin.id), int(agent.id), {"visibility": "admins"})
+
+    assert store.get_owned_agent(int(member.id), int(agent.id)) is None
+    assert all(i["id"] != int(agent.id) for i in store.list_agent_items(int(member.id)))
+    # admin still sees + lists it
+    assert store.get_owned_agent(int(admin.id), int(agent.id)) is not None
+    assert any(i["id"] == int(agent.id) for i in store.list_agent_items(int(admin.id)))
+
+
+def test_member_cannot_set_visibility_admins(db, team_of_admin_and_member):
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, member = team_of_admin_and_member
+    store = AgentStore(db)
+    # member-created, team-visible agent
+    agent = store.create_agent(
+        user_id=int(member.id), name="Mine", description=None, instructions=None
+    )
+    with pytest.raises(PermissionError):
+        store.update_agent_fields(int(member.id), int(agent.id), {"visibility": "admins"})
+
+
+def test_admin_can_create_admins_only_agent(db, team_of_admin_and_member):
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, _member = team_of_admin_and_member
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(admin.id),
+        name="Secret",
+        description=None,
+        instructions=None,
+        visibility="admins",
+    )
+    assert agent.visibility == "admins"
+
+
+def test_member_cannot_create_admins_only_agent(db, team_of_admin_and_member):
+    from xagent.web.services.agent_store import AgentStore
+
+    _admin, member = team_of_admin_and_member
+    store = AgentStore(db)
+    with pytest.raises(PermissionError):
+        store.create_agent(
+            user_id=int(member.id),
+            name="Nope",
+            description=None,
+            instructions=None,
+            visibility="admins",
+        )
+
+
+def test_create_defaults_visibility_to_team(db, team_of_admin_and_member):
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, _member = team_of_admin_and_member
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(admin.id), name="Plain", description=None, instructions=None
+    )
+    assert agent.visibility == "team"
+
+
+def test_create_request_carries_visibility():
+    from xagent.web.api.agents import AgentCreateRequest
+
+    assert "visibility" in AgentCreateRequest.model_fields
+    assert AgentCreateRequest(name="x", visibility="admins").visibility == "admins"
+    assert AgentCreateRequest(name="x").visibility is None
+
+
+def test_update_request_and_response_carry_visibility():
+    from xagent.web.api.agents import (
+        AgentListItem,
+        AgentResponse,
+        AgentUpdateRequest,
+    )
+
+    assert "visibility" in AgentUpdateRequest.model_fields
+    assert "visibility" in AgentResponse.model_fields
+    assert "visibility" in AgentListItem.model_fields
+    # update request accepts the value
+    assert AgentUpdateRequest(visibility="admins").visibility == "admins"
+
+
+def test_update_request_rejects_bad_visibility():
+    import pytest
+    from pydantic import ValidationError
+
+    from xagent.web.api.agents import AgentUpdateRequest
+
+    with pytest.raises(ValidationError):
+        AgentUpdateRequest(visibility="public")
+    # 合法值仍通过
+    assert AgentUpdateRequest(visibility="admins").visibility == "admins"
+    assert AgentUpdateRequest(visibility="team").visibility == "team"
+
+
+# ===== Regression coverage for the review findings =====
+
+
+def test_detail_cache_does_not_leak_admins_only_to_member(db, team_of_admin_and_member):
+    """#1: admin reading an admins-only detail must not seed a cache entry a
+    member's read then hits (member and admin key different role variants)."""
+    from xagent.web.services.agent_store import AgentStore
+    from xagent.web.services.hot_path_cache import (
+        InMemoryTTLCache,
+        set_cache_backend_for_testing,
+    )
+
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        admin, member = team_of_admin_and_member
+        store = AgentStore(db)
+        agent = store.create_agent(
+            user_id=int(admin.id),
+            name="Secret",
+            description=None,
+            instructions=None,
+            visibility="admins",
+        )
+        # Admin reads (and caches) the detail first.
+        assert store.get_agent_response(int(admin.id), int(agent.id)) is not None
+        # Member must not hit the admin's cache entry -> no detail.
+        assert store.get_agent_response(int(member.id), int(agent.id)) is None
+    finally:
+        set_cache_backend_for_testing(None)
+
+
+def test_list_accessible_agents_hides_published_admins_only_from_member(
+    db, team_of_admin_and_member
+):
+    """#4: a published admins-only agent must not surface via the policy path."""
+    from xagent.web.models.agent import AgentStatus
+    from xagent.web.services.agent_access import list_accessible_agents
+    from xagent.web.services.agent_store import AgentStore
+    from xagent.web.services import workforce_access
+
+    admin, member = team_of_admin_and_member
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(admin.id),
+        name="SecretPub",
+        description=None,
+        instructions=None,
+        visibility="admins",
+        status=AgentStatus.PUBLISHED,
+    )
+    # Force the policy branch to "see" this id, as if a workforce policy did.
+    orig = workforce_access.get_visible_agent_ids
+    workforce_access.get_visible_agent_ids = lambda _db, _u, _p: {int(agent.id)}
+    # agent_access imported the symbol directly; patch there too.
+    import xagent.web.services.agent_access as aa
+
+    orig_aa = aa.get_visible_agent_ids
+    aa.get_visible_agent_ids = lambda _db, _u, _p: {int(agent.id)}
+    try:
+        items = list_accessible_agents(db, member)
+        assert all(int(i.agent.id) != int(agent.id) for i in items)
+        # admin still gets it (owner branch).
+        admin_items = list_accessible_agents(db, admin)
+        assert any(int(i.agent.id) == int(agent.id) for i in admin_items)
+    finally:
+        workforce_access.get_visible_agent_ids = orig
+        aa.get_visible_agent_ids = orig_aa
+
+
+def test_set_admins_visibility_fail_closed_without_scope(db):
+    """#8: with no team scope, the store must refuse to set admins-only."""
+    from xagent.web.models.user import User
+    from xagent.web.services import agent_team_scope as ats
+    from xagent.web.services.agent_store import AgentStore
+
+    ats.set_agent_team_scope_hook(None)
+    u = User(username="solo", password_hash="h", is_admin=False)
+    db.add(u)
+    db.flush()
+    store = AgentStore(db)
+    with pytest.raises(PermissionError):
+        store.create_agent(
+            user_id=int(u.id),
+            name="Nope",
+            description=None,
+            instructions=None,
+            visibility="admins",
+        )
+
+
+def test_store_rejects_unknown_visibility_value(db, team_of_admin_and_member):
+    """#14: store-layer domain check rejects values outside {team, admins}."""
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, _member = team_of_admin_and_member
+    store = AgentStore(db)
+    with pytest.raises(ValueError):
+        store.create_agent(
+            user_id=int(admin.id),
+            name="Bad",
+            description=None,
+            instructions=None,
+            visibility="public",
+        )
+
+
+def test_non_admin_cannot_downgrade_admins_only_agent(db, team_of_admin_and_member):
+    """#9: the visibility guard rejects a non-admin changing (downgrading) an
+    agent that is currently admins-only, even when the agent is handed in
+    pre-fetched (the endpoint's reuse path). Members normally 404 at the
+    ownership layer; this asserts the guard itself is the second line."""
+    from xagent.web.services.agent_store import (
+        AgentStore,
+        _assert_can_set_visibility,
+    )
+    from xagent.web.services.agent_team_scope import AgentTeamScope
+
+    admin, member = team_of_admin_and_member
+    store = AgentStore(db)
+    agent = store.create_agent(
+        user_id=int(admin.id),
+        name="SecretDown",
+        description=None,
+        instructions=None,
+        visibility="admins",
+    )
+    non_admin_scope = AgentTeamScope(team_id=200, is_team_admin=False)
+    # Guard rejects a downgrade attempt with a non-admin scope.
+    with pytest.raises(PermissionError):
+        _assert_can_set_visibility(non_admin_scope, "team", agent.visibility)
+    # And through the store when the owned agent is passed in explicitly.
+    with pytest.raises(PermissionError):
+        store.update_agent_fields(
+            int(member.id),
+            int(agent.id),
+            {"visibility": "team"},
+            team_scope=non_admin_scope,
+            agent=agent,
+        )
+
+
+def test_run_path_team_member_can_load_team_agent(db, two_users_one_team_via_scope):
+    """#2: a teammate can load a team-visible agent for a task; admins-only
+    stays hidden from a non-admin runner."""
+    from xagent.web.api.chat import _load_agent_for_task_create
+    from xagent.web.models.agent import AgentStatus
+    from xagent.web.services.agent_store import AgentStore
+
+    admin, member = two_users_one_team_via_scope
+    store = AgentStore(db)
+    team_agent = store.create_agent(
+        user_id=int(admin.id),
+        name="TeamRun",
+        description=None,
+        instructions=None,
+        status=AgentStatus.PUBLISHED,
+    )
+    secret = store.create_agent(
+        user_id=int(admin.id),
+        name="AdminRun",
+        description=None,
+        instructions=None,
+        visibility="admins",
+        status=AgentStatus.PUBLISHED,
+    )
+    assert (
+        _load_agent_for_task_create(db, member, int(team_agent.id)) is not None
+    )
+    assert _load_agent_for_task_create(db, member, int(secret.id)) is None
+
+
+@pytest.fixture
+def two_users_one_team_via_scope(db):
+    """Admin + member on one team, member is non-admin (like the visibility
+    fixture but exposing both User rows for the run-path test)."""
+    from xagent.web.models.user import User
+    from xagent.web.services import agent_team_scope as ats
+    from xagent.web.services.agent_team_scope import AgentTeamScope
+
+    admin = User(username="radm", password_hash="h", is_admin=False)
+    member = User(username="rmem", password_hash="h", is_admin=False)
+    db.add_all([admin, member])
+    db.flush()
+    admins = {int(admin.id)}
+    ats.set_agent_team_scope_hook(
+        lambda _db, uid: AgentTeamScope(team_id=300, is_team_admin=uid in admins)
+        if uid in {int(admin.id), int(member.id)}
+        else None
+    )
+    yield admin, member
+    ats.set_agent_team_scope_hook(None)

--- a/tests/web/test_agent_visibility.py
+++ b/tests/web/test_agent_visibility.py
@@ -1,6 +1,7 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from xagent.web.models.agent import Agent
 from xagent.web.models.database import Base
 
@@ -274,9 +275,9 @@ def test_list_accessible_agents_hides_published_admins_only_from_member(
 ):
     """#4: a published admins-only agent must not surface via the policy path."""
     from xagent.web.models.agent import AgentStatus
+    from xagent.web.services import workforce_access
     from xagent.web.services.agent_access import list_accessible_agents
     from xagent.web.services.agent_store import AgentStore
-    from xagent.web.services import workforce_access
 
     admin, member = team_of_admin_and_member
     store = AgentStore(db)

--- a/tests/web/test_agent_visibility.py
+++ b/tests/web/test_agent_visibility.py
@@ -83,10 +83,29 @@ def test_team_list_key_splits_by_role():
     from xagent.web.services import hot_path_cache as hpc
 
     assert hpc.agent_list_key(7) == "agent:list:7"
-    assert hpc.agent_list_key(7, team_id=42, is_team_admin=True) == "agent:list:team:42:a"
     assert (
-        hpc.agent_list_key(7, team_id=42, is_team_admin=False) == "agent:list:team:42:m"
+        hpc.agent_list_key(7, team_id=42, is_team_admin=True)
+        == "agent:list:team:42:7:a"
     )
+    assert (
+        hpc.agent_list_key(7, team_id=42, is_team_admin=False)
+        == "agent:list:team:42:7:m"
+    )
+
+
+def test_team_cache_keys_are_per_user():
+    # owned_agent_clause still matches a user's own legacy (team_id IS NULL)
+    # agents, so two users in the same team + role must get DIFFERENT cache
+    # keys -- otherwise one member's private agents leak to another on a hit.
+    from xagent.web.services import hot_path_cache as hpc
+
+    assert hpc.agent_list_key(1, team_id=9, is_team_admin=False) != hpc.agent_list_key(
+        2, team_id=9, is_team_admin=False
+    )
+    assert hpc.agent_detail_key(1, 5, team_id=9) != hpc.agent_detail_key(
+        2, 5, team_id=9
+    )
+    assert ":1:" in hpc.agent_list_key(1, team_id=9)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds an **opt-in** extension seam that lets a host application scope agents to a *team* (account) instead of a single user, and restrict an individual agent to *admins-only* visibility. Standalone xagent is unchanged — with no hook installed, ownership is exactly `user_id == self` and the new columns lie dormant.

## What changed — backend

- `agents` gains two nullable columns: `team_id` (owning team) and `visibility` (`team` default / `admins`), via idempotent migrations. `visibility` has a server default so existing rows are safe; `team_id` stays NULL until a host backfills it.
- New seam `web/services/agent_team_scope.py`:
  - `set_agent_team_scope_hook(hook)` — host installs `hook(db, user_id) -> AgentTeamScope(team_id, is_team_admin) | None`.
  - `owned_agent_clause(user_id, scope)` — the single predicate every ownership/visibility decision routes through. No scope → `Agent.user_id == user_id` (unchanged). Scoped → team-mates co-own team-visible agents; admins-only agents are visible only to team admins.
- Every access path now goes through the seam: list, detail, update, delete, publish, per-agent API keys, triggers, run (`chat`), and name-uniqueness.
- Hot-path cache keys become team- and role-aware when scoped, so an admin's cached view can't leak an admins-only agent to a member.
- A guard ensures only a team admin can set an agent to `admins`.

## What changed — frontend

- Auth context exposes `inTeam` / `teamRole`, resolved once from `/api/teams/my-team` (absent → `inTeam = false`).
- Agent builder gains a visibility selector (team / admins-only); the admins-only option is gated to team admins, and the control is hidden when there is no team context — standalone xagent shows nothing new.

## Backward compatibility

Fully additive and dormant. With no hook installed, every path falls back to the exact prior user-scoped behavior and the frontend control is hidden. Team/visibility behavior only activates when a host installs the hook and serves `/api/teams/my-team`.

## Testing

Unit + integration tests for the ownership clause, visibility gating (a member cannot see / run / manage / cache-read an admins-only agent; a team admin can), the admin-only write guard, and standalone fallback. Existing agent / access / chat / cache suites pass with no regressions.
