### PR TITLE
fix: handle Telegram voice messages and cloning tools

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -924,9 +924,11 @@ class AutoPattern(AgentPattern):
         current_request: str = "",
     ) -> str:
         tool_count = len(tools)
+        tool_names = self._execution_tool_names(tools)
         tool_capability_summary = (
             f"{tool_count} execution tools are available to the downstream "
-            "execution pattern."
+            "execution pattern. Available execution tool names: "
+            f"{', '.join(tool_names) or '(unavailable)'}."
             if tool_count
             else "No execution tools are available to the downstream execution pattern."
         )
@@ -992,6 +994,33 @@ class AutoPattern(AgentPattern):
             "this routing decision; only call the routing tool provided in this "
             "request."
         )
+
+    @staticmethod
+    def _execution_tool_names(tools: list[Any]) -> list[str]:
+        names: list[str] = []
+        seen: set[str] = set()
+        for tool in tools:
+            name: Any = None
+            if isinstance(tool, dict):
+                function = tool.get("function")
+                if isinstance(function, dict):
+                    name = function.get("name")
+                if not name:
+                    name = tool.get("name")
+            else:
+                metadata = getattr(tool, "metadata", None)
+                if metadata is not None:
+                    name = getattr(metadata, "name", None)
+                if not name:
+                    name = getattr(tool, "name", None)
+                if not name:
+                    name = getattr(tool, "__name__", None)
+
+            normalized = str(name or "").strip()
+            if normalized and normalized not in seen:
+                names.append(normalized)
+                seen.add(normalized)
+        return names
 
     def _decision_tool_schema(self) -> dict[str, Any]:
         return {

--- a/src/xagent/core/model/tts/base.py
+++ b/src/xagent/core/model/tts/base.py
@@ -123,3 +123,9 @@ class BaseTTS(ABC):
         raise NotImplementedError(
             f"{self.provider_name} TTS does not support persistent voice cloning"
         )
+
+    async def delete_voice(self, voice_id: str) -> None:
+        """Delete a persistent provider-side voice."""
+        raise NotImplementedError(
+            f"{self.provider_name} TTS does not support persistent voice deletion"
+        )

--- a/src/xagent/core/model/tts/elevenlabs.py
+++ b/src/xagent/core/model/tts/elevenlabs.py
@@ -505,6 +505,22 @@ class ElevenLabsTTS(BaseTTS):
             result["requires_verification"] = bool(requires_verification)
         return result
 
+    async def delete_voice(self, voice_id: str) -> None:
+        """Delete a persistent voice from the configured ElevenLabs account."""
+        normalized_voice_id = voice_id.strip()
+        if not normalized_voice_id:
+            raise ValueError("ElevenLabs voice ID must not be empty")
+
+        client = self._ensure_async_client()
+        try:
+            await client.voices.delete(normalized_voice_id)
+        except Exception as exc:
+            redacted_error = redact_sensitive_text(str(exc))
+            logger.error("ElevenLabs voice deletion failed: %s", redacted_error)
+            raise RuntimeError(
+                f"ElevenLabs voice deletion failed: {redacted_error}"
+            ) from exc
+
     async def synthesize(
         self,
         text: str,

--- a/src/xagent/core/tools/adapters/vibe/audio_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/audio_tool.py
@@ -135,11 +135,12 @@ class AudioTool(AudioToolCore):
                 )
             )
 
-        if any(
+        supports_persistent_elevenlabs_voices = any(
             self._get_tts_provider_name(model) == "elevenlabs"
             and getattr(model, "supports_persistent_voice_cloning", False)
             for model in voice_listing_models
-        ):
+        )
+        if supports_persistent_elevenlabs_voices:
             clone_tts_voice_description = self.CLONE_TTS_VOICE_DESCRIPTION.format(
                 "elevenlabs"
             )
@@ -148,6 +149,17 @@ class AudioTool(AudioToolCore):
                     self.clone_tts_voice,
                     name="clone_tts_voice",
                     description=clone_tts_voice_description,
+                    owner=self,
+                )
+            )
+            delete_tts_voice_description = self.DELETE_TTS_VOICE_DESCRIPTION.format(
+                "elevenlabs"
+            )
+            tools.append(
+                AudioFunctionTool(
+                    self.delete_tts_voice,
+                    name="delete_tts_voice",
+                    description=delete_tts_voice_description,
                     owner=self,
                 )
             )

--- a/src/xagent/core/tools/core/audio_tool.py
+++ b/src/xagent/core/tools/core/audio_tool.py
@@ -21,6 +21,7 @@ from ...model.tts.base import BaseTTS, TTSResult
 from ...workspace import TaskWorkspace
 from .audio_tool_descriptions import (
     CLONE_TTS_VOICE_DESCRIPTION,
+    DELETE_TTS_VOICE_DESCRIPTION,
     LIST_TTS_VOICES_DESCRIPTION,
     SYNTHESIZE_SPEECH_DESCRIPTION,
     SYNTHESIZE_SPEECH_JSON_DESCRIPTION,
@@ -43,6 +44,7 @@ class AudioToolCore:
     SYNTHESIZE_SPEECH_JSON_DESCRIPTION = SYNTHESIZE_SPEECH_JSON_DESCRIPTION
     LIST_TTS_VOICES_DESCRIPTION = LIST_TTS_VOICES_DESCRIPTION
     CLONE_TTS_VOICE_DESCRIPTION = CLONE_TTS_VOICE_DESCRIPTION
+    DELETE_TTS_VOICE_DESCRIPTION = DELETE_TTS_VOICE_DESCRIPTION
 
     def __init__(
         self,
@@ -1165,6 +1167,73 @@ class AudioToolCore:
             return {
                 "success": False,
                 "supported": True,
+                "error": str(e),
+                "provider": provider,
+                "model_used": actual_model_id,
+            }
+
+    async def delete_tts_voice(
+        self,
+        voice_id: str,
+        provider: Literal["elevenlabs"] = "elevenlabs",
+        model_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Permanently delete a voice from a configured provider account."""
+        try:
+            tts_model, actual_model_id = self._get_provider_tts_model(
+                provider=provider,
+                capability="supports_persistent_voice_cloning",
+                model_id=model_id,
+            )
+            if not tts_model:
+                return {
+                    "success": False,
+                    "supported": False,
+                    "error": f"No {provider} TTS model is configured",
+                    "provider": provider,
+                    "model_used": actual_model_id,
+                }
+
+            provider_name = self._get_tts_provider_name(tts_model)
+            if provider_name != provider:
+                return {
+                    "success": False,
+                    "supported": False,
+                    "error": (
+                        f"delete_tts_voice provider is '{provider}', but model "
+                        f"'{actual_model_id}' uses provider '{provider_name}'."
+                    ),
+                    "provider": provider_name,
+                    "model_used": actual_model_id,
+                }
+            if not getattr(tts_model, "supports_persistent_voice_cloning", False):
+                return {
+                    "success": False,
+                    "supported": False,
+                    "error": f"The configured {provider} client does not support persistent voice deletion",
+                    "provider": provider_name,
+                    "model_used": actual_model_id,
+                }
+
+            normalized_voice_id = voice_id.strip()
+            await tts_model.delete_voice(normalized_voice_id)
+            return {
+                "success": True,
+                "supported": True,
+                "deleted": True,
+                "voice_id": normalized_voice_id,
+                "provider": provider_name,
+                "model_used": actual_model_id,
+            }
+        except Exception as e:
+            logger.error(f"Failed to delete TTS voice: {e}")
+            actual_model_id = (
+                model_id if model_id and model_id in self._tts_models else "default"
+            )
+            return {
+                "success": False,
+                "supported": True,
+                "deleted": False,
                 "error": str(e),
                 "provider": provider,
                 "model_used": actual_model_id,

--- a/src/xagent/core/tools/core/audio_tool_descriptions.py
+++ b/src/xagent/core/tools/core/audio_tool_descriptions.py
@@ -253,3 +253,25 @@ Important:
 - The voice remains in the selected ElevenLabs account after the task ends. It is not deleted during tool teardown.
 - For ElevenLabs Instant Voice Cloning, prefer approximately 1-2 minutes of clear, consistent, single-speaker audio without background noise or reverb.
 """.strip()
+
+# Description for delete_tts_voice tool
+DELETE_TTS_VOICE_DESCRIPTION = """
+Permanently delete a voice from the configured provider account.
+
+Currently supported providers: {}.
+
+Parameters:
+- voice_id (required): Exact provider voice ID returned by list_tts_voices or clone_tts_voice.
+- provider (optional): Voice provider. Currently the only supported value is "elevenlabs".
+- model_id (optional): Provider TTS configuration whose API key and base URL should be used. Omit to select the first configured model for provider.
+
+Output:
+- deleted: True when the provider accepted the deletion.
+- voice_id: Deleted provider voice ID.
+- provider: Provider account from which the voice was deleted.
+- model_used: TTS configuration used for the provider request.
+
+Important:
+- This operation is irreversible. Only call it when the user explicitly asks to delete the voice.
+- The voice ID belongs to a specific provider account. Select the same provider configuration that created or listed it.
+""".strip()

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -25,6 +25,11 @@ from ...models.uploaded_file import UploadedFile
 from ...models.user import User
 from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
+from ...services.file_turn import (
+    append_uploaded_files_context,
+    build_uploaded_files_context,
+    normalize_attachments_for_persistence,
+)
 from ...services.managed_task_lease import (
     ManagedTaskLease,
     claim_managed_task_lease,
@@ -714,6 +719,8 @@ class TelegramBotInstance:
                     return
 
                 uploaded_info: list[dict[str, Any]] = []
+                persisted_attachments: list[dict[str, Any]] = []
+                execution_text = text
                 if files:
                     uploaded_info = await self._download_and_register_files(
                         files=files,
@@ -727,6 +734,9 @@ class TelegramBotInstance:
                             "Telegram voice input was not downloaded"
                         )
                     if uploaded_info:
+                        persisted_attachments = normalize_attachments_for_persistence(
+                            uploaded_info
+                        )
                         voice_transcripts: dict[str, str] = {}
                         if voice_file_ids:
                             voice_transcripts = (
@@ -744,6 +754,11 @@ class TelegramBotInstance:
                             voice_transcripts,
                         )
                         voice_file_id_set = set(voice_file_ids)
+                        voice_uploaded_info = [
+                            info
+                            for info in uploaded_info
+                            if str(info.get("telegram_file_id")) in voice_file_id_set
+                        ]
                         regular_uploaded_info = [
                             info
                             for info in uploaded_info
@@ -758,6 +773,10 @@ class TelegramBotInstance:
                             text += f"\n\n{' '.join(file_info_list)}"
                         elif file_info_list:
                             text = " ".join(file_info_list)
+                        execution_text = append_uploaded_files_context(
+                            text,
+                            build_uploaded_files_context(voice_uploaded_info),
+                        )
                         if is_new_task:
                             task.description = text  # type: ignore
                             if voice_file_ids or not task.title:
@@ -771,6 +790,8 @@ class TelegramBotInstance:
                         context["uploaded_files"] = [
                             str(info["path"]) for info in uploaded_info
                         ]
+                        context["files"] = persisted_attachments
+                        context["display_message"] = text
 
                 if self._consume_user_stop_request(user_id):
                     apply_task_control_transition(
@@ -787,6 +808,7 @@ class TelegramBotInstance:
                     task_id=int(task.id),  # type: ignore
                     user_id=int(user.id),  # type: ignore
                     content=text,
+                    attachments=persisted_attachments or None,
                     turn_id=message_turn_id,
                 )
 
@@ -826,7 +848,7 @@ class TelegramBotInstance:
                             user_id,
                             agent_manager.execute_task(
                                 agent_service=agent_service,
-                                task=text,
+                                task=execution_text,
                                 context=context,
                                 task_id=actual_task_id,
                                 tracking_task_id=str(task.id),

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -431,7 +431,8 @@ class TelegramBotInstance:
                     "Telegram voice transcription failed"
                 ) from exc
 
-            transcript = str(result).strip()
+            raw_text = getattr(result, "text", result)
+            transcript = str(raw_text).strip()
             if not transcript:
                 raise TelegramVoiceTranscriptionError(
                     "Telegram voice transcription returned empty text"
@@ -460,7 +461,7 @@ class TelegramBotInstance:
     async def _close_voice_asr_model(asr_model: Any) -> None:
         from inspect import isawaitable
 
-        close = getattr(asr_model, "aclose", None)
+        close = getattr(asr_model, "aclose", None) or getattr(asr_model, "close", None)
         if not callable(close):
             return
         try:

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -51,8 +51,13 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+class TelegramVoiceTranscriptionError(RuntimeError):
+    """Raised when a Telegram voice prompt cannot be transcribed."""
+
+
 class TelegramBotInstance:
     queue_flush_delay_seconds = 1.0
+    voice_transcription_timeout_seconds = 180.0
     stop_text_aliases = {"/stop", "/pause", "stop", "pause", "停止", "暂停"}
 
     def __init__(
@@ -167,6 +172,7 @@ class TelegramBotInstance:
                     if message.document
                     or message.photo
                     or message.audio
+                    or message.voice
                     or message.video
                     else "Unknown"
                 )
@@ -344,10 +350,120 @@ class TelegramBotInstance:
             files.append(message.photo[-1])
         elif message.audio:
             files.append(message.audio)
+        elif message.voice:
+            files.append(message.voice)
         elif message.video:
             files.append(message.video)
 
         return text, files
+
+    def _resolve_voice_asr_model(self, db: Session, user: User) -> Any | None:
+        from fastapi import HTTPException
+
+        from ....core.model.asr.adapter import get_asr_model_instance
+        from ...api.model import _resolve_asr_model_for_transcription
+
+        try:
+            db_model = _resolve_asr_model_for_transcription(db, user)
+        except HTTPException as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+        return get_asr_model_instance(db_model)
+
+    @staticmethod
+    def _audio_format_from_file_info(file_info: dict[str, Any]) -> str | None:
+        mime_type = str(file_info.get("type") or "").lower()
+        if mime_type.startswith("audio/"):
+            subtype = mime_type.split("/", 1)[1].split(";", 1)[0].strip()
+            if subtype:
+                return "mp3" if subtype == "mpeg" else subtype
+
+        suffix = Path(str(file_info.get("name") or "")).suffix.lower().lstrip(".")
+        if suffix in {"oga", "opus"}:
+            return "ogg"
+        return suffix or None
+
+    async def _transcribe_uploaded_voice_files(
+        self,
+        voice_file_ids: list[str],
+        uploaded_info: list[dict[str, Any]],
+        asr_model: Any,
+    ) -> dict[str, str]:
+        uploaded_by_source_id = {
+            str(info.get("telegram_file_id")): info
+            for info in uploaded_info
+            if info.get("telegram_file_id")
+        }
+        transcripts: dict[str, str] = {}
+
+        for voice_file_id in voice_file_ids:
+            file_info = uploaded_by_source_id.get(voice_file_id)
+            if file_info is None:
+                raise TelegramVoiceTranscriptionError(
+                    "Telegram voice input was not downloaded"
+                )
+
+            try:
+                result = await asyncio.wait_for(
+                    asr_model.transcribe(
+                        audio=str(file_info["path"]),
+                        format=self._audio_format_from_file_info(file_info),
+                    ),
+                    timeout=self.voice_transcription_timeout_seconds,
+                )
+            except asyncio.TimeoutError as exc:
+                raise TelegramVoiceTranscriptionError(
+                    "Telegram voice transcription timed out"
+                ) from exc
+            except Exception as exc:
+                logger.error(
+                    "Failed to transcribe Telegram voice input %s: %s",
+                    voice_file_id,
+                    exc,
+                )
+                raise TelegramVoiceTranscriptionError(
+                    "Telegram voice transcription failed"
+                ) from exc
+
+            transcript = str(result).strip()
+            if not transcript:
+                raise TelegramVoiceTranscriptionError(
+                    "Telegram voice transcription returned empty text"
+                )
+            transcripts[voice_file_id] = transcript
+
+        return transcripts
+
+    @staticmethod
+    def _compose_prompt_text(
+        message_contents: list[tuple[types.Message, str, list]],
+        voice_transcripts: dict[str, str],
+    ) -> str:
+        prompt_parts: list[str] = []
+        for message, message_text, _files in message_contents:
+            if message_text:
+                prompt_parts.append(message_text)
+            voice = getattr(message, "voice", None)
+            if voice is not None:
+                transcript = voice_transcripts.get(str(voice.file_id))
+                if transcript:
+                    prompt_parts.append(transcript)
+        return "\n".join(prompt_parts)
+
+    @staticmethod
+    async def _close_voice_asr_model(asr_model: Any) -> None:
+        from inspect import isawaitable
+
+        close = getattr(asr_model, "aclose", None)
+        if not callable(close):
+            return
+        try:
+            result = close()
+            if isawaitable(result):
+                await result
+        except Exception:
+            logger.warning("Failed to close Telegram voice ASR model", exc_info=True)
 
     async def _download_and_register_files(
         self,
@@ -407,11 +523,13 @@ class TelegramBotInstance:
 
                 await self.bot.download_file(tg_file.file_path, destination=target_path)
 
-                mime_type, _ = mimetypes.guess_type(str(target_path))
+                mime_type = getattr(f, "mime_type", None)
+                if not mime_type:
+                    mime_type, _ = mimetypes.guess_type(str(target_path))
                 if not mime_type:
                     mime_type = "application/octet-stream"
 
-                file_size = getattr(f, "file_size", target_path.stat().st_size)
+                file_size = getattr(f, "file_size", None) or target_path.stat().st_size
 
                 file_record = UploadedFileStore(db).create_from_local_path(
                     local_path=target_path,
@@ -436,6 +554,7 @@ class TelegramBotInstance:
                         "path": str(target_path),
                         "type": mime_type,
                         "size": file_size,
+                        "telegram_file_id": str(file_id),
                     }
                 )
                 logger.info(
@@ -451,24 +570,23 @@ class TelegramBotInstance:
     async def _process_user_messages_batch(
         self, user_id: int, messages: list[types.Message]
     ) -> None:
-        combined_text = ""
-        combined_files = []
+        message_contents: list[tuple[types.Message, str, list]] = []
+        files = []
 
         # We'll use the last message for answering
         last_message = messages[-1]
 
         for msg in messages:
-            text, files = await self._extract_message_content(msg)
-            if text:
-                if combined_text:
-                    combined_text += "\n" + text
-                else:
-                    combined_text = text
-            if files:
-                combined_files.extend(files)
+            message_text, message_files = await self._extract_message_content(msg)
+            message_contents.append((msg, message_text, message_files))
+            files.extend(message_files)
 
-        text = combined_text
-        files = combined_files
+        text = self._compose_prompt_text(message_contents, {})
+        voice_file_ids = [
+            str(voice.file_id)
+            for msg in messages
+            if (voice := getattr(msg, "voice", None)) is not None
+        ]
 
         if not text and not files:
             return
@@ -478,6 +596,7 @@ class TelegramBotInstance:
         claimed_task_id: int | None = None
         claimed_run_id: str | None = None
         managed_lease: ManagedTaskLease | None = None
+        voice_asr_model: Any | None = None
         try:
             db_gen = get_db()
             db = next(db_gen)
@@ -510,6 +629,16 @@ class TelegramBotInstance:
 
                 if self._consume_user_stop_request(user_id):
                     return
+
+                if voice_file_ids:
+                    voice_asr_model = self._resolve_voice_asr_model(db, user)
+                    if voice_asr_model is None:
+                        await last_message.answer(
+                            "I couldn't understand that voice message because no "
+                            "speech recognition model is configured. Configure an "
+                            "ASR model or send the request as text."
+                        )
+                        return
 
                 active_task_id = self.active_tasks.get(user_id)
                 task = None
@@ -584,6 +713,7 @@ class TelegramBotInstance:
                     db.commit()
                     return
 
+                uploaded_info: list[dict[str, Any]] = []
                 if files:
                     uploaded_info = await self._download_and_register_files(
                         files=files,
@@ -592,26 +722,55 @@ class TelegramBotInstance:
                         user_id=int(user.id),  # type: ignore
                         db=db,
                     )
+                    if voice_file_ids and not uploaded_info:
+                        raise TelegramVoiceTranscriptionError(
+                            "Telegram voice input was not downloaded"
+                        )
                     if uploaded_info:
+                        voice_transcripts: dict[str, str] = {}
+                        if voice_file_ids:
+                            voice_transcripts = (
+                                await self._transcribe_uploaded_voice_files(
+                                    voice_file_ids,
+                                    uploaded_info,
+                                    voice_asr_model,
+                                )
+                            )
+                            await self._close_voice_asr_model(voice_asr_model)
+                            voice_asr_model = None
+
+                        text = self._compose_prompt_text(
+                            message_contents,
+                            voice_transcripts,
+                        )
+                        voice_file_id_set = set(voice_file_ids)
+                        regular_uploaded_info = [
+                            info
+                            for info in uploaded_info
+                            if str(info.get("telegram_file_id"))
+                            not in voice_file_id_set
+                        ]
                         file_info_list = [
                             f"[{info['name']}](file://{info['file_id']})"
-                            for info in uploaded_info
+                            for info in regular_uploaded_info
                         ]
-                        if text:
+                        if text and file_info_list:
                             text += f"\n\n{' '.join(file_info_list)}"
-                        else:
+                        elif file_info_list:
                             text = " ".join(file_info_list)
                         if is_new_task:
                             task.description = text  # type: ignore
-                            if not task.title:
-                                title_str = (
-                                    text if len(text) <= 50 else f"{text[:50]}..."
-                                )
-                                task.title = title_str  # type: ignore
+                            if voice_file_ids or not task.title:
+                                title = text if len(text) <= 50 else f"{text[:50]}..."
+                                task.title = title  # type: ignore[assignment]
                             db.commit()
 
                         context["state"] = context.get("state", {})
                         context["state"]["file_info"] = uploaded_info
+                        context["file_info"] = uploaded_info
+                        context["uploaded_files"] = [
+                            str(info["path"]) for info in uploaded_info
+                        ]
 
                 if self._consume_user_stop_request(user_id):
                     apply_task_control_transition(
@@ -799,10 +958,18 @@ class TelegramBotInstance:
                         claimed_task_id,
                         exc_info=True,
                     )
-            await last_message.answer(
-                "Sorry, an error occurred while processing your request."
-            )
+            if isinstance(e, TelegramVoiceTranscriptionError):
+                await last_message.answer(
+                    "I couldn't transcribe that voice message. Please try again "
+                    "or send the request as text."
+                )
+            else:
+                await last_message.answer(
+                    "Sorry, an error occurred while processing your request."
+                )
         finally:
+            if voice_asr_model is not None:
+                await self._close_voice_asr_model(voice_asr_model)
             if managed_lease is not None:
                 await managed_lease.close()
             self.user_preparing_executions.discard(user_id)

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -2,6 +2,7 @@ import asyncio
 import html
 import json
 import logging
+import mimetypes
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, Optional, cast
@@ -389,6 +390,24 @@ class TelegramBotInstance:
             return "ogg"
         return suffix or None
 
+    @staticmethod
+    def _mime_type_for_telegram_file(file_input: Any, target_path: Path) -> str:
+        declared_mime_type = getattr(file_input, "mime_type", None)
+        guessed_mime_type, _ = mimetypes.guess_type(str(target_path))
+        if isinstance(file_input, types.Voice) and declared_mime_type:
+            return str(declared_mime_type)
+        if guessed_mime_type and guessed_mime_type != "application/octet-stream":
+            return guessed_mime_type
+        return str(
+            declared_mime_type or guessed_mime_type or "application/octet-stream"
+        )
+
+    @staticmethod
+    def _display_message_for_user(message: str, has_files: bool) -> str:
+        if message.strip():
+            return message
+        return "Uploaded file(s)" if has_files else message
+
     async def _transcribe_uploaded_voice_files(
         self,
         voice_file_ids: list[str],
@@ -479,9 +498,6 @@ class TelegramBotInstance:
         user_id: int,
         db: Session,
     ) -> list:
-        import mimetypes
-        from pathlib import Path
-
         from ...services.uploaded_file_store import UploadedFileStore
 
         uploaded_files_info: list[dict] = []
@@ -529,11 +545,7 @@ class TelegramBotInstance:
 
                 await self.bot.download_file(tg_file.file_path, destination=target_path)
 
-                mime_type = getattr(f, "mime_type", None)
-                if not mime_type:
-                    mime_type, _ = mimetypes.guess_type(str(target_path))
-                if not mime_type:
-                    mime_type = "application/octet-stream"
+                mime_type = self._mime_type_for_telegram_file(f, target_path)
 
                 file_size = getattr(f, "file_size", None) or target_path.stat().st_size
 
@@ -722,6 +734,7 @@ class TelegramBotInstance:
                 uploaded_info: list[dict[str, Any]] = []
                 persisted_attachments: list[dict[str, Any]] = []
                 execution_text = text
+                display_message = text
                 if files:
                     uploaded_info = await self._download_and_register_files(
                         files=files,
@@ -753,6 +766,10 @@ class TelegramBotInstance:
                         text = self._compose_prompt_text(
                             message_contents,
                             voice_transcripts,
+                        )
+                        display_message = self._display_message_for_user(
+                            text,
+                            bool(uploaded_info),
                         )
                         voice_file_id_set = set(voice_file_ids)
                         voice_uploaded_info = [
@@ -792,7 +809,7 @@ class TelegramBotInstance:
                             str(info["path"]) for info in uploaded_info
                         ]
                         context["files"] = persisted_attachments
-                        context["display_message"] = text
+                        context["display_message"] = display_message
 
                 if self._consume_user_stop_request(user_id):
                     apply_task_control_transition(
@@ -808,7 +825,7 @@ class TelegramBotInstance:
                     db=db,
                     task_id=int(task.id),  # type: ignore
                     user_id=int(user.id),  # type: ignore
-                    content=text,
+                    content=display_message,
                     attachments=persisted_attachments or None,
                     turn_id=message_turn_id,
                 )

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -596,7 +596,7 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert "Simplified Chinese" in decision_prompt
     assert "Traditional Chinese" in decision_prompt
     assert "do not use generic Chinese" in decision_prompt
-    assert "Available tool names" not in decision_prompt
+    assert "Available execution tool names" not in decision_prompt
     tool_schema = llm.calls[0]["tools"][0]["function"]
     assert "answer argument is mandatory" in tool_schema["description"]
     response_language_schema = tool_schema["parameters"]["properties"][
@@ -782,7 +782,7 @@ async def test_auto_pattern_does_not_stream_non_final_decision() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auto_decision_prompt_does_not_expose_execution_tool_names() -> None:
+async def test_auto_decision_prompt_exposes_execution_tool_names() -> None:
     llm = FakeLLM([decision_tool_response("react", "Needs an execution tool.")])
     child = CapturingChildPattern()
     pattern = AutoPattern(react_pattern=child)  # type: ignore[arg-type]
@@ -796,7 +796,8 @@ async def test_auto_decision_prompt_does_not_expose_execution_tool_names() -> No
                 "description": "List knowledge bases",
                 "parameters": {"type": "object", "properties": {}},
             },
-        }
+        },
+        FakeSearchTool(),
     ]
 
     result = await pattern.run(
@@ -812,8 +813,11 @@ async def test_auto_decision_prompt_does_not_expose_execution_tool_names() -> No
         DECISION_TOOL_NAME
     ]
     decision_prompt = decision_call["messages"][-1]["content"]
-    assert "1 execution tools are available" in decision_prompt
-    assert "list_knowledge_bases" not in decision_prompt
+    assert "2 execution tools are available" in decision_prompt
+    assert (
+        "Available execution tool names: list_knowledge_bases, zhipu_web_search."
+        in decision_prompt
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -409,6 +409,30 @@ async def test_clone_voice_creates_persistent_voice_without_cleanup(
     delete.assert_not_awaited()
 
 
+async def test_delete_voice_deletes_persistent_voice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delete = AsyncMock()
+    fake_client = SimpleNamespace(voices=SimpleNamespace(delete=delete))
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    tts = ElevenLabsTTS(api_key="test-key")
+    await tts.delete_voice(" persistent-voice ")
+
+    delete.assert_awaited_once_with("persistent-voice")
+
+
+async def test_delete_voice_rejects_empty_voice_id() -> None:
+    tts = ElevenLabsTTS(api_key="test-key")
+
+    with pytest.raises(ValueError, match="voice ID must not be empty"):
+        await tts.delete_voice("  ")
+
+
 async def test_synthesize_redacts_sensitive_sdk_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -433,6 +433,33 @@ async def test_delete_voice_rejects_empty_voice_id() -> None:
         await tts.delete_voice("  ")
 
 
+async def test_delete_voice_redacts_sensitive_sdk_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delete = AsyncMock(
+        side_effect=RuntimeError(
+            "request failed api_key=sk-elevenlabs-secret123 "
+            "Authorization: Bearer bearer-secret456"
+        )
+    )
+    fake_client = SimpleNamespace(voices=SimpleNamespace(delete=delete))
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    tts = ElevenLabsTTS(api_key="test-key")
+    with pytest.raises(RuntimeError) as exc_info:
+        await tts.delete_voice("persistent-voice")
+
+    message = str(exc_info.value)
+    assert "sk-elevenlabs-secret123" not in message
+    assert "bearer-secret456" not in message
+    assert "api_key=***t123" in message
+    assert "Authorization: Bearer ***t456" in message
+
+
 async def test_synthesize_redacts_sensitive_sdk_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tools/test_audio_tool.py
+++ b/tests/core/tools/test_audio_tool.py
@@ -602,6 +602,48 @@ async def test_delete_tts_voice_deletes_persistent_provider_voice() -> None:
     assert tts.delete_calls == ["persistent-voice"]
 
 
+async def test_delete_tts_voice_rejects_other_provider_model() -> None:
+    elevenlabs = FakeTTS(
+        provider_name="elevenlabs",
+        abilities=["tts", "persistent_voice_cloning"],
+    )
+    xinference = FakeTTS(
+        provider_name="xinference",
+        abilities=["tts", "persistent_voice_cloning"],
+    )
+    tool = AudioToolCore(tts_models={"eleven_v3": elevenlabs, "other": xinference})
+
+    result = await tool.delete_tts_voice(
+        voice_id="persistent-voice",
+        model_id="other",
+    )
+
+    assert result["success"] is False
+    assert result["supported"] is False
+    assert "provider is 'elevenlabs'" in result["error"]
+    assert elevenlabs.delete_calls == []
+    assert xinference.delete_calls == []
+
+
+async def test_delete_tts_voice_rejects_unsupported_model() -> None:
+    tts = FakeTTS(provider_name="elevenlabs", abilities=["tts"])
+    tool = AudioToolCore(tts_models={"eleven_v3": tts})
+
+    result = await tool.delete_tts_voice(
+        voice_id="persistent-voice",
+        model_id="eleven_v3",
+    )
+
+    assert result == {
+        "success": False,
+        "supported": False,
+        "error": "The configured elevenlabs client does not support persistent voice deletion",
+        "provider": "elevenlabs",
+        "model_used": "eleven_v3",
+    }
+    assert tts.delete_calls == []
+
+
 def test_persistent_voice_tools_expose_provider_enum() -> None:
     elevenlabs_tool = AudioTool(
         tts_models={

--- a/tests/core/tools/test_audio_tool.py
+++ b/tests/core/tools/test_audio_tool.py
@@ -22,6 +22,7 @@ class FakeTTS(BaseTTS):
         self._voices = voices or []
         self.calls: list[dict[str, Any]] = []
         self.clone_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[str] = []
         self.model_name = "fake-tts"
 
     async def synthesize(
@@ -94,6 +95,9 @@ class FakeTTS(BaseTTS):
             "persistent": True,
             "requires_verification": False,
         }
+
+    async def delete_voice(self, voice_id: str) -> None:
+        self.delete_calls.append(voice_id)
 
 
 class ClosableTTS(FakeTTS):
@@ -574,7 +578,31 @@ async def test_clone_tts_voice_selects_provider_not_default_tts() -> None:
     assert xinference.clone_calls == []
 
 
-def test_clone_tts_voice_tool_exposes_provider_enum() -> None:
+async def test_delete_tts_voice_deletes_persistent_provider_voice() -> None:
+    tts = FakeTTS(
+        provider_name="elevenlabs",
+        abilities=["tts", "persistent_voice_cloning"],
+    )
+    tool = AudioToolCore(tts_models={"eleven_v3": tts})
+
+    result = await tool.delete_tts_voice(
+        voice_id=" persistent-voice ",
+        provider="elevenlabs",
+        model_id="eleven_v3",
+    )
+
+    assert result == {
+        "success": True,
+        "supported": True,
+        "deleted": True,
+        "voice_id": "persistent-voice",
+        "provider": "elevenlabs",
+        "model_used": "eleven_v3",
+    }
+    assert tts.delete_calls == ["persistent-voice"]
+
+
+def test_persistent_voice_tools_expose_provider_enum() -> None:
     elevenlabs_tool = AudioTool(
         tts_models={
             "eleven_v3": FakeTTS(
@@ -598,7 +626,9 @@ def test_clone_tts_voice_tool_exposes_provider_enum() -> None:
     other_tool_names = {candidate.name for candidate in other_provider_tool.get_tools()}
 
     assert "clone_tts_voice" in elevenlabs_tools
+    assert "delete_tts_voice" in elevenlabs_tools
     assert "clone_tts_voice" not in other_tool_names
+    assert "delete_tts_voice" not in other_tool_names
     schema = elevenlabs_tools["clone_tts_voice"].args_type().model_json_schema()
     assert set(schema["properties"]) == {
         "name",
@@ -610,6 +640,10 @@ def test_clone_tts_voice_tool_exposes_provider_enum() -> None:
         "model_id",
     }
     assert schema["properties"]["provider"]["const"] == "elevenlabs"
+
+    delete_schema = elevenlabs_tools["delete_tts_voice"].args_type().model_json_schema()
+    assert set(delete_schema["properties"]) == {"voice_id", "provider", "model_id"}
+    assert delete_schema["properties"]["provider"]["const"] == "elevenlabs"
 
 
 def test_list_tts_voices_tool_exposes_provider_enum() -> None:

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -21,6 +21,7 @@ from xagent.web.api.widget import widget_router
 from xagent.web.channels.feishu.bot import FeishuBotInstance
 from xagent.web.channels.telegram.bot import TelegramBotInstance
 from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.task import Task, TaskConnectorRuntimeContext, TaskStatus
@@ -710,10 +711,6 @@ async def test_telegram_voice_is_transcribed_as_prompt_and_kept_as_input_file(
             _restore_telegram_task_context,
         )
         monkeypatch.setattr(
-            "xagent.web.channels.telegram.bot.persist_user_message",
-            lambda **_kwargs: None,
-        )
-        monkeypatch.setattr(
             "xagent.web.channels.telegram.bot.persist_telegram_assistant_turn",
             lambda **_kwargs: None,
         )
@@ -787,7 +784,8 @@ async def test_telegram_voice_is_transcribed_as_prompt_and_kept_as_input_file(
 
         assert len(agent_manager.execute_calls) == 1
         execute_call = agent_manager.execute_calls[0]
-        assert execute_call["task"] == "今晚有世界杯比赛吗？"
+        assert execute_call["task"].startswith("今晚有世界杯比赛吗？")
+        assert "voice.oga: file_id=workspace-file-id" in execute_call["task"]
         assert execute_call["context"]["file_info"] == [
             {
                 "file_id": "workspace-file-id",
@@ -801,6 +799,16 @@ async def test_telegram_voice_is_transcribed_as_prompt_and_kept_as_input_file(
         assert execute_call["context"]["uploaded_files"] == [
             "/workspace/input/voice.oga"
         ]
+        expected_attachments = [
+            {
+                "file_id": "workspace-file-id",
+                "name": "voice.oga",
+                "size": 123,
+                "type": "audio/ogg",
+            }
+        ]
+        assert execute_call["context"]["files"] == expected_attachments
+        assert execute_call["context"]["display_message"] == "今晚有世界杯比赛吗？"
         assert asr_model.closed is True
 
         task = (
@@ -809,5 +817,15 @@ async def test_telegram_voice_is_transcribed_as_prompt_and_kept_as_input_file(
             .one_or_none()
         )
         assert task is not None
+        user_message = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task.id,
+                TaskChatMessage.role == "user",
+            )
+            .one()
+        )
+        assert user_message.content == "今晚有世界杯比赛吗？"
+        assert user_message.attachments == expected_attachments
     finally:
         db.close()

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -223,6 +223,7 @@ class _FakeAgentService:
 class _FakeAgentManager:
     def __init__(self) -> None:
         self.service = _FakeAgentService()
+        self.execute_calls: list[dict[str, Any]] = []
 
     async def get_agent_for_task(
         self,
@@ -234,6 +235,7 @@ class _FakeAgentManager:
         return self.service
 
     async def execute_task(self, **_kwargs: Any) -> dict[str, Any]:
+        self.execute_calls.append(_kwargs)
         return {"success": True, "output": "done"}
 
 
@@ -670,5 +672,142 @@ async def test_telegram_new_task_fallback_snapshots_empty(
         assert task is not None
         assert task.connector_runtime_selected_refs == []
         assert _context_row_count(int(task.id)) == 0
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_telegram_voice_is_transcribed_as_prompt_and_kept_as_input_file(
+    e2e_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _setup_admin_headers()
+    db = _db_session()
+    try:
+        user = _admin_user(db)
+        channel = UserChannel(
+            user_id=user.id,
+            channel_type="telegram",
+            channel_name="Telegram voice test",
+            config={},
+            is_active=True,
+        )
+        db.add(channel)
+        db.commit()
+        db.refresh(channel)
+
+        agent_manager = _FakeAgentManager()
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.get_agent_manager",
+            lambda: agent_manager,
+        )
+
+        async def _restore_telegram_task_context(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.restore_telegram_task_context",
+            _restore_telegram_task_context,
+        )
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.persist_user_message",
+            lambda **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.persist_telegram_assistant_turn",
+            lambda **_kwargs: None,
+        )
+
+        class _FakeASR:
+            def __init__(self) -> None:
+                self.closed = False
+
+            async def transcribe(self, *, audio: str, format: str | None = None) -> str:
+                assert audio == "/workspace/input/voice.oga"
+                assert format == "ogg"
+                return "今晚有世界杯比赛吗？"
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        asr_model = _FakeASR()
+        voice = SimpleNamespace(file_id="telegram-voice-id")
+        bot = object.__new__(TelegramBotInstance)
+        bot.channel_id = int(channel.id)
+        bot.channel_name = "Telegram voice test"
+        bot.active_tasks = {}
+        bot.bot = object()
+        bot.user_preparing_executions = set()
+        bot.user_stop_events = {}
+        bot.user_active_executions = {}
+        bot._save_active_tasks = lambda: None
+        bot._clear_user_stop_request = lambda _user_id: None
+        bot._consume_user_stop_request = lambda _user_id: False
+        bot._resolve_voice_asr_model = lambda _db, _user: asr_model
+
+        async def _extract_message_content(_message: Any) -> tuple[str, list[Any]]:
+            return "", [voice]
+
+        async def _download_and_register_files(**_kwargs: Any) -> list[dict[str, Any]]:
+            return [
+                {
+                    "file_id": "workspace-file-id",
+                    "telegram_file_id": "telegram-voice-id",
+                    "name": "voice.oga",
+                    "path": "/workspace/input/voice.oga",
+                    "type": "audio/ogg",
+                    "size": 123,
+                }
+            ]
+
+        async def _await_execution(_user_id: int, execution, *, reason: str) -> dict:
+            return await execution
+
+        bot._extract_message_content = _extract_message_content
+        bot._download_and_register_files = _download_and_register_files
+        bot._await_execution_with_stop_monitor = _await_execution
+
+        class _LoadingMessage:
+            message_id = 33
+
+            async def edit_text(self, _text: str, **_kwargs: Any) -> None:
+                pass
+
+        class _TelegramMessage:
+            from_user = SimpleNamespace(id=123)
+            chat = SimpleNamespace(id=456)
+
+            def __init__(self, voice_input: Any) -> None:
+                self.voice = voice_input
+
+            async def answer(self, _text: str, **_kwargs: Any) -> _LoadingMessage:
+                return _LoadingMessage()
+
+        await bot._process_user_messages_batch(123, [_TelegramMessage(voice)])
+
+        assert len(agent_manager.execute_calls) == 1
+        execute_call = agent_manager.execute_calls[0]
+        assert execute_call["task"] == "今晚有世界杯比赛吗？"
+        assert execute_call["context"]["file_info"] == [
+            {
+                "file_id": "workspace-file-id",
+                "telegram_file_id": "telegram-voice-id",
+                "name": "voice.oga",
+                "path": "/workspace/input/voice.oga",
+                "type": "audio/ogg",
+                "size": 123,
+            }
+        ]
+        assert execute_call["context"]["uploaded_files"] == [
+            "/workspace/input/voice.oga"
+        ]
+        assert asr_model.closed is True
+
+        task = (
+            db.query(Task)
+            .filter(Task.user_id == user.id, Task.title == "今晚有世界杯比赛吗？")
+            .one_or_none()
+        )
+        assert task is not None
     finally:
         db.close()

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -172,6 +172,116 @@ def _task(task_id: int) -> Task:
         db.close()
 
 
+@pytest.mark.parametrize(
+    ("scenario", "expected_message"),
+    [
+        (
+            "no_asr",
+            "I couldn't understand that voice message because no speech "
+            "recognition model is configured. Configure an ASR model or send "
+            "the request as text.",
+        ),
+        (
+            "missing_download",
+            "I couldn't transcribe that voice message. Please try again or send "
+            "the request as text.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_telegram_voice_errors_are_reported_to_user(
+    e2e_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+    expected_message: str,
+) -> None:
+    _setup_admin_headers()
+    db = _db_session()
+    try:
+        user = _admin_user(db)
+        channel = UserChannel(
+            user_id=user.id,
+            channel_type="telegram",
+            channel_name=f"Telegram voice {scenario}",
+            config={},
+            is_active=True,
+        )
+        db.add(channel)
+        db.commit()
+        db.refresh(channel)
+
+        agent_manager = _FakeAgentManager()
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.get_agent_manager",
+            lambda: agent_manager,
+        )
+
+        async def _restore_telegram_task_context(
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.restore_telegram_task_context",
+            _restore_telegram_task_context,
+        )
+
+        class _FakeASR:
+            def __init__(self) -> None:
+                self.closed = False
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        asr_model = _FakeASR()
+        voice = SimpleNamespace(file_id="telegram-voice-id")
+        bot = object.__new__(TelegramBotInstance)
+        bot.channel_id = int(channel.id)
+        bot.channel_name = f"Telegram voice {scenario}"
+        bot.active_tasks = {}
+        bot.bot = object()
+        bot.user_preparing_executions = set()
+        bot.user_stop_events = {}
+        bot.user_active_executions = {}
+        bot._save_active_tasks = lambda: None
+        bot._clear_user_stop_request = lambda _user_id: None
+        bot._consume_user_stop_request = lambda _user_id: False
+        bot._resolve_voice_asr_model = (
+            (lambda _db, _user: None)
+            if scenario == "no_asr"
+            else (lambda _db, _user: asr_model)
+        )
+
+        async def _extract_message_content(_message: Any) -> tuple[str, list[Any]]:
+            return "", [voice]
+
+        async def _download_and_register_files(**_kwargs: Any) -> list[dict[str, Any]]:
+            return []
+
+        bot._extract_message_content = _extract_message_content
+        bot._download_and_register_files = _download_and_register_files
+
+        answers: list[str] = []
+
+        class _TelegramMessage:
+            from_user = SimpleNamespace(id=123)
+            chat = SimpleNamespace(id=456)
+            voice = SimpleNamespace(file_id="telegram-voice-id")
+
+            async def answer(self, text: str, **_kwargs: Any) -> SimpleNamespace:
+                answers.append(text)
+                return SimpleNamespace(message_id=1)
+
+        await bot._process_user_messages_batch(123, [_TelegramMessage()])
+
+        assert answers == [expected_message]
+        if scenario == "missing_download":
+            assert asr_model.closed is True
+    finally:
+        db.close()
+
+
 def _context_row_count(task_id: int) -> int:
     db = _db_session()
     try:

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -1,7 +1,9 @@
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from aiogram import types
 
 from xagent.web.channels.telegram.bot import (
     TelegramBotInstance,
@@ -85,6 +87,59 @@ def test_compose_prompt_text_replaces_voice_with_transcript_in_message_order() -
 )
 def test_audio_format_from_file_info(file_info: dict[str, str], expected: str) -> None:
     assert TelegramBotInstance._audio_format_from_file_info(file_info) == expected
+
+
+@pytest.mark.parametrize(
+    ("telegram_file", "target_path", "expected"),
+    [
+        (
+            types.Voice(
+                file_id="voice-id",
+                file_unique_id="voice-unique-id",
+                duration=1,
+                mime_type="audio/ogg",
+            ),
+            Path("voice.bin"),
+            "audio/ogg",
+        ),
+        (
+            SimpleNamespace(mime_type="application/pdf"),
+            Path("report.jpg"),
+            "image/jpeg",
+        ),
+        (
+            SimpleNamespace(mime_type="application/pdf"),
+            Path("report.bin"),
+            "application/pdf",
+        ),
+    ],
+)
+def test_mime_type_for_telegram_file(
+    telegram_file: object,
+    target_path: Path,
+    expected: str,
+) -> None:
+    assert (
+        TelegramBotInstance._mime_type_for_telegram_file(
+            telegram_file,
+            target_path,
+        )
+        == expected
+    )
+
+
+def test_display_message_for_user_hides_runtime_file_links() -> None:
+    assert (
+        TelegramBotInstance._display_message_for_user(
+            "Please summarize this document",
+            has_files=True,
+        )
+        == "Please summarize this document"
+    )
+    assert (
+        TelegramBotInstance._display_message_for_user("", has_files=True)
+        == "Uploaded file(s)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -125,6 +125,48 @@ async def test_transcribe_uploaded_voice_files_uses_registered_input_file() -> N
 
 
 @pytest.mark.asyncio
+async def test_transcribe_uploaded_voice_files_extracts_result_text() -> None:
+    bot = make_bot()
+
+    class ResultASR:
+        async def transcribe(
+            self, *, audio: str, format: str | None = None
+        ) -> SimpleNamespace:
+            return SimpleNamespace(text="今晚有世界杯比赛吗？")
+
+    transcripts = await bot._transcribe_uploaded_voice_files(
+        ["voice-file-id"],
+        [
+            {
+                "telegram_file_id": "voice-file-id",
+                "name": "voice.oga",
+                "path": "/workspace/input/voice.oga",
+                "type": "audio/ogg",
+            }
+        ],
+        ResultASR(),
+    )
+
+    assert transcripts == {"voice-file-id": "今晚有世界杯比赛吗？"}
+
+
+@pytest.mark.asyncio
+async def test_close_voice_asr_model_supports_sync_close() -> None:
+    class SyncClosableASR:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    asr = SyncClosableASR()
+
+    await TelegramBotInstance._close_voice_asr_model(asr)
+
+    assert asr.closed is True
+
+
+@pytest.mark.asyncio
 async def test_transcribe_uploaded_voice_files_rejects_empty_result() -> None:
     bot = make_bot()
 

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -1,8 +1,12 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
-from xagent.web.channels.telegram.bot import TelegramBotInstance
+from xagent.web.channels.telegram.bot import (
+    TelegramBotInstance,
+    TelegramVoiceTranscriptionError,
+)
 
 
 def make_bot() -> TelegramBotInstance:
@@ -13,6 +17,155 @@ def make_bot() -> TelegramBotInstance:
     bot.user_preparing_executions = set()
     bot.user_stop_events = {}
     return bot
+
+
+@pytest.mark.asyncio
+async def test_extract_message_content_includes_voice_message() -> None:
+    bot = make_bot()
+    voice = SimpleNamespace(file_id="voice-file-id")
+    message = SimpleNamespace(
+        text=None,
+        caption=None,
+        document=None,
+        photo=None,
+        audio=None,
+        voice=voice,
+        video=None,
+    )
+
+    text, files = await bot._extract_message_content(message)  # type: ignore[arg-type]
+
+    assert text == ""
+    assert files == [voice]
+
+
+@pytest.mark.asyncio
+async def test_extract_message_content_keeps_regular_audio_as_attachment() -> None:
+    bot = make_bot()
+    audio = SimpleNamespace(file_id="audio-file-id")
+    message = SimpleNamespace(
+        text=None,
+        caption=None,
+        document=None,
+        photo=None,
+        audio=audio,
+        voice=None,
+        video=None,
+    )
+
+    text, files = await bot._extract_message_content(message)  # type: ignore[arg-type]
+
+    assert text == ""
+    assert files == [audio]
+
+
+def test_compose_prompt_text_replaces_voice_with_transcript_in_message_order() -> None:
+    voice = SimpleNamespace(file_id="voice-file-id")
+    voice_message = SimpleNamespace(voice=voice)
+    text_message = SimpleNamespace(voice=None)
+
+    prompt = TelegramBotInstance._compose_prompt_text(
+        [
+            (voice_message, "", [voice]),
+            (text_message, "请直接回答这个问题", []),
+        ],
+        {"voice-file-id": "今晚有世界杯比赛吗？"},
+    )
+
+    assert prompt == "今晚有世界杯比赛吗？\n请直接回答这个问题"
+
+
+@pytest.mark.parametrize(
+    ("file_info", "expected"),
+    [
+        ({"name": "voice.oga", "type": "audio/ogg"}, "ogg"),
+        ({"name": "voice.mp3", "type": "audio/mpeg"}, "mp3"),
+        ({"name": "voice.opus", "type": ""}, "ogg"),
+    ],
+)
+def test_audio_format_from_file_info(file_info: dict[str, str], expected: str) -> None:
+    assert TelegramBotInstance._audio_format_from_file_info(file_info) == expected
+
+
+@pytest.mark.asyncio
+async def test_transcribe_uploaded_voice_files_uses_registered_input_file() -> None:
+    bot = make_bot()
+
+    class FakeASR:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, str | None]] = []
+
+        async def transcribe(self, *, audio: str, format: str | None = None) -> str:
+            self.calls.append({"audio": audio, "format": format})
+            return "今晚有世界杯比赛吗？"
+
+    asr = FakeASR()
+    uploaded_info = [
+        {
+            "file_id": "workspace-file-id",
+            "telegram_file_id": "voice-file-id",
+            "name": "voice-file-id.oga",
+            "path": "/workspace/input/voice-file-id.oga",
+            "type": "audio/ogg",
+            "size": 123,
+        }
+    ]
+
+    transcripts = await bot._transcribe_uploaded_voice_files(
+        ["voice-file-id"],
+        uploaded_info,
+        asr,
+    )
+
+    assert transcripts == {"voice-file-id": "今晚有世界杯比赛吗？"}
+    assert asr.calls == [
+        {"audio": "/workspace/input/voice-file-id.oga", "format": "ogg"}
+    ]
+    assert uploaded_info[0]["file_id"] == "workspace-file-id"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_uploaded_voice_files_rejects_empty_result() -> None:
+    bot = make_bot()
+
+    class EmptyASR:
+        async def transcribe(self, *, audio: str, format: str | None = None) -> str:
+            return "  "
+
+    with pytest.raises(
+        TelegramVoiceTranscriptionError,
+        match="returned empty text",
+    ):
+        await bot._transcribe_uploaded_voice_files(
+            ["voice-file-id"],
+            [
+                {
+                    "telegram_file_id": "voice-file-id",
+                    "name": "voice.oga",
+                    "path": "/workspace/input/voice.oga",
+                    "type": "audio/ogg",
+                }
+            ],
+            EmptyASR(),
+        )
+
+
+def test_resolve_voice_asr_model_returns_none_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import HTTPException
+
+    bot = make_bot()
+
+    def no_asr_model(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise HTTPException(status_code=404, detail="No ASR model is configured")
+
+    monkeypatch.setattr(
+        "xagent.web.api.model._resolve_asr_model_for_transcription",
+        no_asr_model,
+    )
+
+    assert bot._resolve_voice_asr_model(object(), object()) is None  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- recognize Telegram `voice` messages and transcribe them before agent execution
- use the transcription as the visible user prompt while keeping the original audio registered as an input file
- preserve attachment IDs and structured metadata for Telegram voice, document, photo, audio, and video uploads in execution context and persisted chat history
- keep user-visible attachment messages free of internal `file://` prompt references
- expose downstream tool names to Auto routing so available capabilities such as voice cloning can route to ReAct
- add `delete_tts_voice` for permanently removing a cloned voice from the configured ElevenLabs account
- return clear Telegram messages when no accessible ASR model is configured or voice transcription fails

## Root cause

Telegram voice notes arrive through `message.voice`, not `message.audio`. The voice path reduced recordings to transcript text without durable attachment context, so follow-up requests could not directly identify the original audio. Auto routing also received only the number of downstream tools, which allowed it to incorrectly claim that voice tools were unavailable instead of selecting ReAct. Persistent cloned voices could be created and listed but had no corresponding user-facing deletion tool.

## Impact

Users can send voice prompts naturally, refer to uploaded recordings in follow-up turns, and see consistent attachment metadata for all Telegram upload types without internal prompt references leaking into chat bubbles. Available audio tools can route correctly without explicit reminders, and users can delete cloned ElevenLabs voices when they are no longer needed.

## Validation

- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent/src pytest -q tests/web/test_telegram_message_queue.py tests/web/test_connector_runtime_entrypoints_e2e.py tests/core/tools/test_audio_tool.py tests/core/model/tts/test_elevenlabs.py` (100 passed)
- targeted `ruff check`
- commit hooks: Ruff, Mypy, isort, codespell, and repository hygiene checks
