### PR TITLE
fix: use public API URL in A2A agent cards

### DIFF
--- a/example.env
+++ b/example.env
@@ -99,10 +99,9 @@ PORT="80"
 # Deterministic per-mailbox resource names: {prefix}-{mailbox-hash}.
 # XAGENT_GMAIL_PUBSUB_TOPIC_PREFIX="xagent-gmail"
 # XAGENT_GMAIL_PUBSUB_SUBSCRIPTION_PREFIX="xagent-gmail-push"
-# Public base URL of this backend API. MCP OAuth uses
-# {base}/api/mcp/oauth/callback, while Pub/Sub push subscriptions use
-# {base}/api/triggers/callback/gmail/{callback_id}. This is NOT the frontend
-# URL (XAGENT_APP_BASE_URL).
+# Public base URL of this backend API. A2A Agent Cards advertise interfaces
+# under this base; MCP OAuth and Pub/Sub use it for externally reachable
+# callbacks. This is NOT the frontend URL (XAGENT_APP_BASE_URL).
 # XAGENT_PUBLIC_API_BASE_URL="https://api.example.com"
 # Service-account email whose OIDC identity signs push deliveries.
 # XAGENT_GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT="pubsub-push@your-gcp-project.iam.gserviceaccount.com"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -711,15 +711,15 @@ def get_gmail_registration_timeout_seconds() -> int:
 
 
 def get_public_api_base_url() -> str | None:
-    """Public base URL of the backend API for provider callbacks.
+    """Public base URL of the backend API for advertised routes and callbacks.
 
     Priority:
         1. XAGENT_PUBLIC_API_BASE_URL environment variable
         2. None (consumers apply their own compatibility or validation policy)
 
     Deliberately separate from XAGENT_APP_BASE_URL (the frontend URL used in
-    e.g. password-reset emails): provider callback URLs should normally use
-    the public backend origin.
+    e.g. password-reset emails): externally advertised API and provider callback
+    URLs should normally use the public backend origin.
     """
     value = (os.getenv(PUBLIC_API_BASE_URL) or "").strip()
     return value.rstrip("/") or None

--- a/src/xagent/web/services/a2a_protocol.py
+++ b/src/xagent/web/services/a2a_protocol.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
+from ...config import get_public_api_base_url
 from ..models.agent import Agent, AgentStatus
 from ..models.task import Task, TaskStatus
 
@@ -100,7 +101,7 @@ def is_published_agent(agent: Agent | None) -> bool:
 
 
 def normalize_agent_card_base_url(request: Request, agent_id: int) -> str:
-    root = str(request.base_url).rstrip("/")
+    root = get_public_api_base_url() or str(request.base_url).rstrip("/")
     return f"{root}/api/a2a/agents/{agent_id}"
 
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -60,7 +60,8 @@ def _create_published_agent_with_key() -> tuple[int, str]:
     return agent_id, key_response.json()["full_key"]
 
 
-def test_agent_card_exposes_published_agent() -> None:
+def test_agent_card_exposes_published_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XAGENT_PUBLIC_API_BASE_URL", raising=False)
     headers = _admin_headers()
     agent_id = _create_agent(headers)
     _publish_agent(headers, agent_id)
@@ -89,6 +90,22 @@ def test_agent_card_exposes_published_agent() -> None:
     }
     assert body["securityRequirements"] == [{"schemes": {"xagentAgentApiKey": {}}}]
     assert body["skills"][0]["examples"] == ["Summarize this"]
+
+
+def test_agent_card_uses_public_api_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", " https://sg.cloud.xagent.co/ ")
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    _publish_agent(headers, agent_id)
+
+    response = client.get(f"/api/a2a/agents/{agent_id}/.well-known/agent-card.json")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["supportedInterfaces"][0]["url"] == (
+        f"https://sg.cloud.xagent.co/api/a2a/agents/{agent_id}"
+    )
 
 
 def test_agent_card_hides_draft_agent() -> None:


### PR DESCRIPTION
## Summary

- prefer `XAGENT_PUBLIC_API_BASE_URL` when advertising A2A HTTP+JSON interfaces
- preserve `request.base_url` as the local and unconfigured fallback
- document the A2A use of the public API base URL and cover both paths in API tests

## Root cause

A2A Agent Cards derived `supportedInterfaces[].url` only from `request.base_url`. Behind a TLS-terminating reverse proxy, the backend can observe the internal HTTP scheme and advertise an `http://` endpoint even though clients reached the public service over HTTPS.

Deployments should set `XAGENT_PUBLIC_API_BASE_URL` to the externally reachable backend origin, for example `https://sg.cloud.xagent.co`.

## Validation

- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent-a2a-public-url/src pytest -q tests/web/api/test_a2a_api.py tests/core/tools/test_a2a_agent_tool.py tests/core/test_config.py`
- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent-a2a-public-url/src pytest -q tests/web/api/test_a2a_api.py -k agent_card`
- `pre-commit run --files example.env src/xagent/config.py src/xagent/web/services/a2a_protocol.py tests/web/api/test_a2a_api.py`