### PR TITLE
feat: scope connector runtime resolution by task identity

### DIFF
--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -17,7 +17,7 @@ by the WebSocket UI path so both transports share one state machine.
 import logging
 from typing import Any, NoReturn, Optional, Tuple, cast
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -87,21 +87,40 @@ _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE = "Connector runtime setup failed."
 @router.post("/chat/files", response_model=UploadFilesResponse)
 async def upload_task_files(
     files: list[UploadFile] = File(...),
+    task_id: Optional[int] = Query(
+        default=None,
+        gt=0,
+        description=(
+            "Existing SDK task whose persisted runtime owner should own "
+            "the uploaded files."
+        ),
+    ),
     authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
     db: Session = Depends(get_db),
 ) -> UploadFilesResponse:
     """Store files for later attachment to a task turn.
 
     API-key-gated counterpart to the JWT-only ``POST /api/files/upload``.
-    Files are stored unbound (``task_id`` NULL) and owned by the agent's
-    user; the returned ``file_id`` values are passed back in
-    ``message.files`` on ``POST /v1/chat/tasks`` (or ``.../messages``),
-    where they get bound to the task and exposed to the agent.
+    Files are stored unbound (``UploadedFile.task_id`` NULL); the returned
+    ``file_id`` values are passed back in ``message.files`` on
+    ``POST /v1/chat/tasks`` (or ``.../messages``), where they get bound to
+    the task and exposed to the agent.
+
+    When ``task_id`` is omitted, the upload is owned by the agent's current
+    user for a future create request. When ``task_id`` is provided, the task
+    is authorized through the key-bound agent and its persisted ``Task.user_id``
+    owns the upload. This keeps historical tasks usable after agent ownership
+    changes without transferring file ownership during append.
     """
     from ..files import store_uploaded_files
 
     agent, _key = authed
-    owner = db.query(User).filter(User.id == agent.user_id).first()
+    upload_owner_user_id = int(agent.user_id)
+    if task_id is not None:
+        task = _resolve_task_or_404(task_id, agent, db)
+        upload_owner_user_id = int(task.user_id)
+
+    owner = db.query(User).filter(User.id == upload_owner_user_id).first()
     if owner is None:
         raise V1ApiError(V1ErrorCode.INTERNAL_ERROR, 500)
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -40,6 +40,7 @@ from ...schemas.v1 import (
     UploadFilesResponse,
 )
 from ...services.connector_runtime import (
+    bind_create_connector_runtime_plan,
     persist_create_connector_runtime_context,
     pop_ephemeral_runtime_values,
     prepare_append_connector_runtime,
@@ -343,6 +344,8 @@ async def create_chat_task(
             exception message stays out of the response.
     """
     agent, _key = authed
+    task_source = "sdk"
+    task_owner_user_id = int(agent.user_id)
 
     # Server-side agent_id consistency check. The key already binds an
     # agent; ``body.agent_id`` is required by the SDK contract for
@@ -363,15 +366,6 @@ async def create_chat_task(
         task_id=None,
     )
 
-    try:
-        runtime_plan = prepare_create_connector_runtime(
-            db=db,
-            agent=agent,
-            payload_items=request.connector_runtime_context,
-        )
-    except ConnectorRuntimeError as exc:
-        _raise_v1_connector_runtime_error(exc)
-
     # title is what the web UI shows in its task list. Truncate to
     # 50 chars (matches the WS handler convention) so very long
     # user inputs don't fill the sidebar with a one-line wall of
@@ -387,18 +381,27 @@ async def create_chat_task(
     # user message so GET endpoint can return it without going through
     # task_chat_messages.
     task = Task(
-        user_id=agent.user_id,
+        user_id=task_owner_user_id,
         title=title,
         description=request.message.content,
         status=TaskStatus.PENDING,
         agent_id=agent.id,
         input=request.message.content,
-        source="sdk",
+        source=task_source,
         is_visible=False,
-        connector_runtime_selected_refs=[
-            ref.to_wire() for ref in runtime_plan.selected_refs
-        ],
     )
+    try:
+        runtime_plan = prepare_create_connector_runtime(
+            db=db,
+            agent=agent,
+            task_source=task_source,
+            connector_user_id=task_owner_user_id,
+            payload_items=request.connector_runtime_context,
+        )
+        bind_create_connector_runtime_plan(task=task, plan=runtime_plan)
+    except ConnectorRuntimeError as exc:
+        _raise_v1_connector_runtime_error(exc)
+
     db.add(task)
     db.flush()
     persist_create_connector_runtime_context(
@@ -598,6 +601,7 @@ async def append_message_to_task(
             db=db,
             agent=agent,
             task=task,
+            connector_user_id=int(task.user_id),
             payload_items=request.connector_runtime_context,
         )
     except ConnectorRuntimeError as exc:

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -346,6 +346,7 @@ async def create_chat_task(
     agent, _key = authed
     task_source = "sdk"
     task_owner_user_id = int(agent.user_id)
+    actor_user_id = int(agent.user_id)
 
     # Server-side agent_id consistency check. The key already binds an
     # agent; ``body.agent_id`` is required by the SDK contract for
@@ -361,7 +362,7 @@ async def create_chat_task(
     # happens after the turn is claimed (below).
     file_infos = _resolve_turn_files_or_400(
         file_ids=request.message.files or [],
-        owner_user_id=int(agent.user_id),
+        owner_user_id=task_owner_user_id,
         db=db,
         task_id=None,
     )
@@ -426,9 +427,9 @@ async def create_chat_task(
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
-            task_owner_user_id=int(agent.user_id),
+            task_owner_user_id=task_owner_user_id,
             # SDK key resolves to the agent owner; actor == owner here.
-            actor_user_id=int(agent.user_id),
+            actor_user_id=actor_user_id,
             payload=payload,
             kind=TurnKind.CREATE,
             force_fresh=False,
@@ -452,7 +453,7 @@ async def create_chat_task(
     bind_turn_files(
         file_ids=[info["file_id"] for info in file_infos],
         task_id=int(task.id),
-        owner_user_id=int(agent.user_id),
+        owner_user_id=task_owner_user_id,
         db=db,
     )
 
@@ -588,6 +589,8 @@ async def append_message_to_task(
     # Resolve task first so cross-agent leak protection (404 instead
     # of 403 for "not yours") fires before any body-level checks.
     task = _resolve_task_or_404(task_id, agent, db)
+    task_owner_user_id = int(task.user_id)
+    actor_user_id = int(agent.user_id)
 
     # body.agent_id mismatch is also a 404 -- but agent_not_found,
     # not task_not_found, because that's the field the caller got
@@ -601,7 +604,7 @@ async def append_message_to_task(
             db=db,
             agent=agent,
             task=task,
-            connector_user_id=int(task.user_id),
+            connector_user_id=task_owner_user_id,
             payload_items=request.connector_runtime_context,
         )
     except ConnectorRuntimeError as exc:
@@ -613,7 +616,7 @@ async def append_message_to_task(
     # bound to this task re-resolve idempotently. Binding runs after the claim.
     file_infos = _resolve_turn_files_or_400(
         file_ids=request.message.files or [],
-        owner_user_id=int(agent.user_id),
+        owner_user_id=task_owner_user_id,
         db=db,
         task_id=int(task.id),
     )
@@ -633,9 +636,10 @@ async def append_message_to_task(
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
-            task_owner_user_id=int(agent.user_id),
-            # SDK key resolves to the agent owner; actor == owner here.
-            actor_user_id=int(agent.user_id),
+            task_owner_user_id=task_owner_user_id,
+            # The key-bound agent authorizes access; the persisted task owner
+            # remains the runtime identity when those identities have drifted.
+            actor_user_id=actor_user_id,
             payload=payload,
             kind=TurnKind.APPEND,
             force_fresh=False,
@@ -657,7 +661,7 @@ async def append_message_to_task(
     bind_turn_files(
         file_ids=[info["file_id"] for info in file_infos],
         task_id=int(task.id),
-        owner_user_id=int(agent.user_id),
+        owner_user_id=task_owner_user_id,
         db=db,
     )
 

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -56,6 +56,9 @@ class MessageBody(BaseModel):
         default=None,
         description=(
             "file_id values previously returned by ``POST /v1/chat/files``. "
+            "For an existing task, pass its id to that endpoint as the "
+            "``task_id`` query parameter so the upload uses the persisted "
+            "task runtime owner. "
             "The referenced files are attached to this turn and exposed to "
             "the agent via file references."
         ),
@@ -128,7 +131,8 @@ class UploadFilesResponse(BaseModel):
 
     Pass the returned ``file_id`` values in a subsequent
     ``POST /v1/chat/tasks`` (or ``.../messages``) under ``message.files``
-    to attach them to a turn.
+    to attach them to a turn. For an existing task, supply ``task_id`` to
+    the upload endpoint so the file is stored under that task's runtime owner.
     """
 
     files: List[UploadedFileInfo]

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -156,6 +156,8 @@ def _normalize_resolver_task_sources(
         raise ValueError("task_sources must contain at least one source")
     if any(not isinstance(source, str) or not source for source in normalized):
         raise ValueError("task_sources must contain non-empty strings")
+    if any(source != source.strip() for source in normalized):
+        raise ValueError("task_sources must not contain surrounding whitespace")
     return normalized
 
 
@@ -408,6 +410,8 @@ def bind_create_connector_runtime_plan(
 ) -> None:
     """Validate and bind a create plan before the Task is persisted."""
 
+    # Keep this service-boundary assertion even when a caller derives the Task
+    # and plan from the same owner/source values.
     if (
         int(task.user_id) != plan.connector_user_id
         or _task_source(task) != plan.task_source
@@ -813,6 +817,8 @@ def _binding_missing_ephemeral_error_code(task: Task) -> str:
 
 def _require_task_runtime_owner(task: Task, *, expected_user_id: int | None) -> int:
     task_owner_user_id = int(task.user_id)
+    # ``Task.user_id`` remains the owner SSOT; the optional expected value is a
+    # defensive assertion for service callers that carry an independent owner.
     if expected_user_id is not None and int(expected_user_id) != task_owner_user_id:
         raise ConnectorRuntimeError(
             ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -8,7 +8,7 @@ consume the resolved runtime view later in the execution path.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from threading import RLock
 from typing import Any, Iterable, cast
@@ -19,6 +19,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     CONNECTOR_TYPE_CUSTOM_API,
     CONNECTOR_TYPE_MCP,
     ERROR_CONNECTOR_NOT_FOUND,
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
     ERROR_INVALID_RUNTIME_CONTEXT,
     ERROR_MISSING_RUNTIME_CONTEXT,
     ERROR_RUNTIME_CONTEXT_IMMUTABLE,
@@ -55,6 +56,8 @@ class ConnectorRuntimePayload:
 
 @dataclass(frozen=True)
 class ConnectorRuntimeCreatePlan:
+    task_source: str | None
+    connector_user_id: int
     selected_refs: tuple[ConnectorRef, ...]
     context_by_ref: dict[ConnectorRef, dict[str, Any]]
     ephemeral_by_ref: dict[ConnectorRef, dict[str, dict[str, Any]]]
@@ -86,11 +89,18 @@ class ConnectorRuntimeRequest:
     user_id: int | None
     connector_ref: ConnectorRef
     values: ConnectorRuntimeValues
+    task_source: str | None = None
 
 
 ConnectorRuntimeResolver = Callable[
     [ConnectorRuntimeRequest], ConnectorRuntimeValues | None
 ]
+
+
+@dataclass(frozen=True)
+class _ConnectorRuntimeResolverRegistration:
+    resolver: ConnectorRuntimeResolver
+    task_sources: frozenset[str] | None
 
 
 # The default OSS store is process-local and single-turn: it is only reliable
@@ -100,22 +110,67 @@ ConnectorRuntimeResolver = Callable[
 _EPHEMERAL_RUNTIME_VALUES: dict[str, dict[str, Any]] = {}
 _EPHEMERAL_RUNTIME_MANIFESTS: dict[str, dict[str, dict[str, set[str]]]] = {}
 _EPHEMERAL_RUNTIME_VALUES_LOCK = RLock()
-_RUNTIME_RESOLVER: ConnectorRuntimeResolver | None = None
+_RUNTIME_RESOLVER_REGISTRATION: _ConnectorRuntimeResolverRegistration | None = None
 
 
 def set_connector_runtime_resolver(
     resolver: ConnectorRuntimeResolver | None,
+    *,
+    task_sources: Collection[str] | None = None,
 ) -> None:
-    """Install the server-side hook that can supply runtime values."""
+    """Install the server-side hook that can supply runtime values.
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolver
+    ``task_sources=None`` preserves the legacy global behavior. A supplied
+    non-empty collection limits the hook to exact ``Task.source`` matches.
+    """
+
+    global _RUNTIME_RESOLVER_REGISTRATION
+    if resolver is None:
+        if task_sources is not None:
+            raise ValueError("task_sources requires a resolver")
+        _RUNTIME_RESOLVER_REGISTRATION = None
+        return
+    _RUNTIME_RESOLVER_REGISTRATION = _ConnectorRuntimeResolverRegistration(
+        resolver=resolver,
+        task_sources=_normalize_resolver_task_sources(task_sources),
+    )
 
 
 def set_connector_runtime_resolver_for_testing(
     resolver: ConnectorRuntimeResolver | None,
+    *,
+    task_sources: Collection[str] | None = None,
 ) -> None:
-    set_connector_runtime_resolver(resolver)
+    set_connector_runtime_resolver(resolver, task_sources=task_sources)
+
+
+def _normalize_resolver_task_sources(
+    task_sources: Collection[str] | None,
+) -> frozenset[str] | None:
+    if task_sources is None:
+        return None
+    if isinstance(task_sources, (str, bytes)):
+        raise TypeError("task_sources must be a collection of strings")
+    normalized = frozenset(task_sources)
+    if not normalized:
+        raise ValueError("task_sources must contain at least one source")
+    if any(not isinstance(source, str) or not source for source in normalized):
+        raise ValueError("task_sources must contain non-empty strings")
+    return normalized
+
+
+def _runtime_resolver_for_task_source(
+    task_source: str | None,
+) -> ConnectorRuntimeResolver | None:
+    registration = _RUNTIME_RESOLVER_REGISTRATION
+    if registration is None:
+        return None
+    if (
+        registration.task_sources is not None
+        and task_source not in registration.task_sources
+    ):
+        return None
+    return registration.resolver
 
 
 def store_ephemeral_runtime_values(
@@ -193,6 +248,8 @@ def load_connector_runtime_view(
     task = db.query(Task).filter(Task.id == task_id).first()
     if task is None:
         return {}
+    task_owner_user_id = _require_task_runtime_owner(task, expected_user_id=user_id)
+    task_source = _task_source(task)
 
     selected_refs = _load_task_selected_refs(task)
     if not selected_refs:
@@ -205,11 +262,7 @@ def load_connector_runtime_view(
     ephemeral_manifest = (
         get_ephemeral_runtime_manifest(turn_id) if isinstance(turn_id, str) else None
     )
-    visible = (
-        _load_visible_runtime_connectors(db, user_id=user_id)
-        if user_id is not None
-        else {}
-    )
+    visible = _load_visible_runtime_connectors(db, user_id=task_owner_user_id)
 
     runtime_view: dict[str, dict[str, Any]] = {}
     for ref in selected_refs:
@@ -240,7 +293,8 @@ def load_connector_runtime_view(
         values = _resolve_runtime_values(
             task_id=task_id,
             turn_id=turn_id,
-            user_id=user_id,
+            task_source=task_source,
+            user_id=task_owner_user_id,
             ref=ref,
             values=values,
         )
@@ -261,15 +315,19 @@ def prepare_create_connector_runtime(
     *,
     db: Session,
     agent: Agent,
+    task_source: str | None,
+    connector_user_id: int,
     payload_items: Iterable[Any] | None,
     allow_ephemeral: bool = True,
     missing_ephemeral_error_code: str = ERROR_RUNTIME_SECRET_UNAVAILABLE,
 ) -> ConnectorRuntimeCreatePlan:
-    # This create-plan helper is for entrypoints where the task runtime owner is
-    # the agent owner (currently /v1 SDK tasks and triggers). Entrypoints where a
-    # published/shared agent runs under a different task owner must use
-    # prepare_connector_runtime_selection_snapshot(..., connector_user_id=...).
-    visible = _load_visible_runtime_connectors(db, user_id=int(agent.user_id))
+    """Prepare runtime values for a task identity chosen by the caller.
+
+    ``agent`` supplies tool-selection policy. ``connector_user_id`` supplies
+    connector visibility and must be the same owner later persisted on Task.
+    """
+
+    visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
     selected_refs = _plan_selected_refs(agent, visible)
     payload_by_ref = _parse_payload_items(payload_items)
     if not allow_ephemeral:
@@ -287,7 +345,7 @@ def prepare_create_connector_runtime(
         auth_selector = dict(payload.auth_selector) if payload is not None else {}
         _validate_values_against_schema(ref, connector, context, secrets, auth_selector)
         _require_context_values(ref, connector, context)
-        if _RUNTIME_RESOLVER is None:
+        if _runtime_resolver_for_task_source(task_source) is None:
             _require_ephemeral_values(
                 ref,
                 connector,
@@ -304,6 +362,8 @@ def prepare_create_connector_runtime(
             }
 
     return ConnectorRuntimeCreatePlan(
+        task_source=task_source,
+        connector_user_id=int(connector_user_id),
         selected_refs=_sort_connector_refs(selected_refs),
         context_by_ref=context_by_ref,
         ephemeral_by_ref=ephemeral_by_ref,
@@ -343,6 +403,26 @@ def bind_connector_runtime_selection_snapshot(
     ]
 
 
+def bind_create_connector_runtime_plan(
+    *, task: Task, plan: ConnectorRuntimeCreatePlan
+) -> None:
+    """Validate and bind a create plan before the Task is persisted."""
+
+    if (
+        int(task.user_id) != plan.connector_user_id
+        or _task_source(task) != plan.task_source
+    ):
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector runtime context is unavailable.",
+            details={"reason": "runtime_task_identity_mismatch"},
+            status_code=503,
+        )
+    bind_connector_runtime_selection_snapshot(
+        task=task, selected_refs=plan.selected_refs
+    )
+
+
 def reject_ephemeral_connector_runtime_payload(
     payload_items: Iterable[Any] | None,
 ) -> None:
@@ -370,11 +450,16 @@ def prepare_append_connector_runtime(
     db: Session,
     agent: Agent,
     task: Task,
+    connector_user_id: int,
     payload_items: Iterable[Any] | None,
 ) -> ConnectorRuntimeAppendPlan:
+    task_owner_user_id = _require_task_runtime_owner(
+        task, expected_user_id=connector_user_id
+    )
+    task_source = _task_source(task)
     selected_refs = _load_task_selected_refs(task)
     payload_by_ref = _parse_payload_items(payload_items)
-    visible = _load_visible_runtime_connectors(db, user_id=int(agent.user_id))
+    visible = _load_visible_runtime_connectors(db, user_id=task_owner_user_id)
     _validate_payload_refs(payload_by_ref, visible=visible, selected_refs=selected_refs)
 
     persisted_context = _load_task_context_rows(db, task_id=int(task.id))
@@ -392,7 +477,7 @@ def prepare_append_connector_runtime(
         secrets = dict(payload.secrets) if payload is not None else {}
         auth_selector = dict(payload.auth_selector) if payload is not None else {}
         _validate_values_against_schema(ref, connector, context, secrets, auth_selector)
-        if _RUNTIME_RESOLVER is None:
+        if _runtime_resolver_for_task_source(task_source) is None:
             _require_ephemeral_values(ref, connector, secrets, auth_selector)
         stored = persisted_context.get(ref, {})
         _require_context_values(ref, connector, stored)
@@ -726,23 +811,43 @@ def _binding_missing_ephemeral_error_code(task: Task) -> str:
     return ERROR_RUNTIME_SECRET_UNAVAILABLE
 
 
+def _require_task_runtime_owner(task: Task, *, expected_user_id: int | None) -> int:
+    task_owner_user_id = int(task.user_id)
+    if expected_user_id is not None and int(expected_user_id) != task_owner_user_id:
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector runtime context is unavailable.",
+            details={"reason": "runtime_owner_mismatch"},
+            status_code=503,
+        )
+    return task_owner_user_id
+
+
+def _task_source(task: Task) -> str | None:
+    source = task.source
+    return source if isinstance(source, str) else None
+
+
 def _resolve_runtime_values(
     *,
     task_id: int,
     turn_id: str | None,
-    user_id: int | None,
+    task_source: str | None,
+    user_id: int,
     ref: ConnectorRef,
     values: ConnectorRuntimeValues,
 ) -> ConnectorRuntimeValues:
-    if _RUNTIME_RESOLVER is None:
+    resolver = _runtime_resolver_for_task_source(task_source)
+    if resolver is None:
         return values
-    resolved = _RUNTIME_RESOLVER(
+    resolved = resolver(
         ConnectorRuntimeRequest(
             task_id=task_id,
             turn_id=turn_id,
             user_id=user_id,
             connector_ref=ref,
             values=values,
+            task_source=task_source,
         )
     )
     return resolved if resolved is not None else values

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -30,6 +30,7 @@ from ..models.user_oauth import UserOAuth
 from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .background_jobs import create_background_job, enqueue_background_job
 from .connector_runtime import (
+    bind_create_connector_runtime_plan,
     persist_create_connector_runtime_context,
     prepare_create_connector_runtime,
     reject_ephemeral_connector_runtime_payload,
@@ -783,21 +784,25 @@ def _attach_task_to_trigger_run(
         if str(trigger.type) == TriggerType.SCHEDULED.value
         else ERROR_RUNTIME_SECRET_UNAVAILABLE
     )
+    task_source = "trigger"
+    task_owner_user_id = int(trigger.user_id)
     runtime_plan = prepare_create_connector_runtime(
         db=db,
         agent=agent,
+        task_source=task_source,
+        connector_user_id=task_owner_user_id,
         payload_items=_trigger_connector_runtime_payload(trigger.config),
         allow_ephemeral=False,
         missing_ephemeral_error_code=missing_secret_error_code,
     )
     task = Task(
-        user_id=int(trigger.user_id),
+        user_id=task_owner_user_id,
         title=_trigger_task_title(trigger, prompt),
         description=prompt,
         status=TaskStatus.PENDING,
         agent_id=int(trigger.agent_id),
         execution_mode=getattr(agent, "execution_mode", None) or "balanced",
-        source="trigger",
+        source=task_source,
         is_visible=False,
         input=prompt,
         agent_config=_trigger_execution_context(
@@ -805,10 +810,8 @@ def _attach_task_to_trigger_run(
             run=run,
             test=test,
         ),
-        connector_runtime_selected_refs=[
-            ref.to_wire() for ref in runtime_plan.selected_refs
-        ],
     )
+    bind_create_connector_runtime_plan(task=task, plan=runtime_plan)
     db.add(task)
     db.flush()
     persist_create_connector_runtime_context(

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -21,6 +21,10 @@ from xagent.web.models.trigger import (
 )
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services.agent_team_scope import (
+    AgentTeamScope,
+    set_agent_team_scope_hook,
+)
 from xagent.web.services.connector_runtime import (
     ConnectorRuntimeValues,
     load_connector_runtime_view,
@@ -35,9 +39,21 @@ from xagent.web.services.triggers import (
     scan_due_scheduled_triggers,
 )
 
-from .conftest import _admin_headers, _direct_db_session, client
+from .conftest import (
+    _admin_headers,
+    _direct_db_session,
+    _register_second_user,
+    client,
+)
 
 pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+@pytest.fixture(autouse=True)
+def reset_connector_runtime_resolver():
+    set_connector_runtime_resolver_for_testing(None)
+    yield
+    set_connector_runtime_resolver_for_testing(None)
 
 
 @pytest.fixture(autouse=True)
@@ -92,6 +108,7 @@ def _install_runtime_mcp_connector(
     *,
     context_required: bool = True,
     secret_required: bool = False,
+    connector_user_id: int | None = None,
 ) -> int:
     db = _direct_db_session()
     try:
@@ -138,7 +155,11 @@ def _install_runtime_mcp_connector(
         db.flush()
         db.add(
             UserMCPServer(
-                user_id=int(agent.user_id),
+                user_id=(
+                    int(connector_user_id)
+                    if connector_user_id is not None
+                    else int(agent.user_id)
+                ),
                 mcpserver_id=int(server.id),
                 is_owner=True,
                 can_edit=True,
@@ -1501,6 +1522,80 @@ def test_scheduled_scan_persists_connector_runtime_context() -> None:
         db.close()
 
 
+def test_trigger_runtime_visibility_uses_trigger_task_owner() -> None:
+    admin_headers = _admin_headers()
+    teammate_headers = _register_second_user("trigger-teammate")
+    db = _direct_db_session()
+    try:
+        admin_user_id = int(db.query(User).filter(User.username == "admin").one().id)
+        trigger_owner_id = int(
+            db.query(User).filter(User.username == "trigger-teammate").one().id
+        )
+    finally:
+        db.close()
+
+    set_agent_team_scope_hook(
+        lambda _db, user_id: (
+            AgentTeamScope(team_id=100, is_team_admin=False)
+            if user_id in {admin_user_id, trigger_owner_id}
+            else None
+        )
+    )
+    try:
+        agent_id = _create_agent(admin_headers)
+        server_id = _install_runtime_mcp_connector(
+            agent_id,
+            connector_user_id=trigger_owner_id,
+        )
+        created = client.post(
+            f"/api/agents/{agent_id}/triggers",
+            headers=teammate_headers,
+            json={
+                "type": "scheduled",
+                "name": "Task owner connector visibility",
+                "config": {
+                    "interval_seconds": 60,
+                    "connector_runtime_context": [
+                        {
+                            "connector_ref": {
+                                "connector_type": "mcp",
+                                "connector_id": server_id,
+                            },
+                            "context": {"account_id": "owner-account"},
+                        }
+                    ],
+                },
+            },
+        )
+        assert created.status_code == 200, created.text
+
+        db = _direct_db_session()
+        try:
+            trigger = (
+                db.query(AgentTrigger)
+                .filter(AgentTrigger.id == created.json()["id"])
+                .one()
+            )
+            assert int(trigger.user_id) == trigger_owner_id
+            trigger.next_run_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+            db.add(trigger)
+            db.commit()
+
+            runs = scan_due_scheduled_triggers(db, now=datetime.now(timezone.utc))
+            assert len(runs) == 1
+            run = db.query(TriggerRun).filter(TriggerRun.id == runs[0].id).one()
+            assert run.status == TriggerRunStatus.PENDING.value
+            task = db.query(Task).filter(Task.id == run.task_id).one()
+            assert int(task.user_id) == trigger_owner_id
+            assert task.connector_runtime_selected_refs == [
+                {"connector_type": "mcp", "connector_id": server_id}
+            ]
+        finally:
+            db.close()
+    finally:
+        set_agent_team_scope_hook(None)
+
+
 def test_scheduled_scan_fails_fast_when_required_runtime_secret_has_no_source() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers)
@@ -1538,6 +1633,56 @@ def test_scheduled_scan_fails_fast_when_required_runtime_secret_has_no_source() 
         db.close()
 
 
+def test_external_scoped_resolver_does_not_defer_scheduled_secret() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    _install_runtime_mcp_connector(
+        agent_id,
+        context_required=False,
+        secret_required=True,
+    )
+    resolver_calls = 0
+
+    def resolver(request):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return request.values
+
+    set_connector_runtime_resolver_for_testing(resolver, task_sources={"external"})
+    try:
+        created = client.post(
+            f"/api/agents/{agent_id}/triggers",
+            headers=headers,
+            json={
+                "type": "scheduled",
+                "name": "External-only resolver",
+                "config": {"interval_seconds": 60},
+            },
+        )
+        assert created.status_code == 200, created.text
+        trigger_id = created.json()["id"]
+
+        db = _direct_db_session()
+        try:
+            trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+            trigger.next_run_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+            db.add(trigger)
+            db.commit()
+
+            runs = scan_due_scheduled_triggers(db, now=datetime.now(timezone.utc))
+            assert len(runs) == 1
+            run = db.query(TriggerRun).filter(TriggerRun.id == runs[0].id).one()
+            assert run.status == TriggerRunStatus.FAILED.value
+            assert run.task_id is None
+            assert "scheduled_secret_unavailable" in str(run.error_message)
+        finally:
+            db.close()
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert resolver_calls == 0
+
+
 def test_scheduled_scan_allows_resolver_to_supply_required_runtime_secret() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers)
@@ -1547,14 +1692,17 @@ def test_scheduled_scan_allows_resolver_to_supply_required_runtime_secret() -> N
         secret_required=True,
     )
 
-    def resolver(_request):
+    resolver_requests = []
+
+    def resolver(request):
+        resolver_requests.append(request)
         return ConnectorRuntimeValues(
             context={},
             secrets={"authorization": "Bearer fresh"},
             auth_selector={},
         )
 
-    set_connector_runtime_resolver_for_testing(resolver)
+    set_connector_runtime_resolver_for_testing(resolver, task_sources={"trigger"})
     try:
         created = client.post(
             f"/api/agents/{agent_id}/triggers",
@@ -1581,13 +1729,25 @@ def test_scheduled_scan_allows_resolver_to_supply_required_runtime_secret() -> N
             assert run.status == TriggerRunStatus.PENDING.value
             assert run.task_id is not None
             task = db.query(Task).filter(Task.id == run.task_id).one()
+            task_owner_user_id = int(task.user_id)
             assert task.connector_runtime_selected_refs == [
                 {"connector_type": "mcp", "connector_id": server_id}
             ]
+            view = load_connector_runtime_view(
+                db=db,
+                task_id=int(task.id),
+                turn_id="scheduled-turn",
+                user_id=None,
+            )
         finally:
             db.close()
     finally:
         set_connector_runtime_resolver_for_testing(None)
+
+    assert view[f"mcp:{server_id}"]["secrets"] == {"authorization": "Bearer fresh"}
+    assert len(resolver_requests) == 1
+    assert resolver_requests[0].task_source == "trigger"
+    assert resolver_requests[0].user_id == task_owner_user_id
 
 
 def test_scheduled_runtime_view_reports_scheduled_secret_when_resolver_omits_secret() -> (

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -36,6 +36,7 @@ from xagent.web.models.task import (
     TaskStatus,
     TraceEvent,
 )
+from xagent.web.models.user import User
 from xagent.web.services.connector_runtime import (
     ConnectorRuntimeValues,
     drop_ephemeral_runtime_values_for_testing,
@@ -1771,6 +1772,29 @@ def _force_task_status(task_id: int, status: TaskStatus) -> None:
         db.close()
 
 
+def _change_agent_owner_for_existing_task(
+    *, task_id: int, agent_id: int, username: str
+) -> tuple[int, int]:
+    """Change the agent owner while preserving the task's persisted owner."""
+    _register_second_user(username=username)
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        persisted_task_owner_id = int(task.user_id)
+        current_agent_owner_id = int(
+            db.query(User.id).filter(User.username == username).one()[0]
+        )
+        assert current_agent_owner_id != persisted_task_owner_id
+
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.user_id = current_agent_owner_id
+        task.status = TaskStatus.COMPLETED
+        db.commit()
+        return persisted_task_owner_id, current_agent_owner_id
+    finally:
+        db.close()
+
+
 def test_append_message_happy_path(mock_start_task):
     """Returns 202 + accepted_at, persists new user message, kicks off bg."""
     agent_id, full_key = _create_agent_with_key()
@@ -1819,6 +1843,112 @@ def test_append_message_happy_path(mock_start_task):
         db.close()
 
     assert mock_start_task.call_count == 1
+
+
+def test_append_message_uses_persisted_task_owner_after_agent_owner_changes(
+    mock_start_task,
+):
+    """A key-bound agent may append while the task keeps its runtime owner."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id, content="first turn")
+
+    persisted_task_owner_id, current_agent_owner_id = (
+        _change_agent_owner_for_existing_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            username="sdk-owner-drift",
+        )
+    )
+    mock_start_task.reset_mock()
+
+    with patch.object(
+        v1_tasks.TaskTurnOrchestrator,
+        "begin_turn",
+        wraps=v1_tasks.TaskTurnOrchestrator.begin_turn,
+    ) as begin_turn:
+        response = client.post(
+            f"/v1/chat/tasks/{task_id}/messages",
+            headers=_bearer(full_key),
+            json={
+                "agent_id": agent_id,
+                "message": {"role": "user", "content": "second turn"},
+            },
+        )
+
+    assert response.status_code == 202, response.text
+    assert begin_turn.await_count == 1
+    assert begin_turn.await_args.kwargs["task_owner_user_id"] == (
+        persisted_task_owner_id
+    )
+    assert begin_turn.await_args.kwargs["actor_user_id"] == current_agent_owner_id
+
+    from xagent.web.models.chat_message import TaskChatMessage
+
+    db = _direct_db_session()
+    try:
+        messages = (
+            db.query(TaskChatMessage)
+            .filter(TaskChatMessage.task_id == task_id)
+            .order_by(TaskChatMessage.id)
+            .all()
+        )
+        assert [message.user_id for message in messages] == [
+            persisted_task_owner_id,
+            persisted_task_owner_id,
+        ]
+    finally:
+        db.close()
+
+
+def test_append_message_uses_persisted_task_owner_for_files_after_owner_changes(
+    mock_start_task,
+):
+    """Task-owned files remain attachable after the agent owner changes."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id, content="first turn")
+    upload_response = client.post(
+        "/v1/chat/files",
+        headers=_bearer(full_key),
+        files=[("files", ("owner-file.txt", b"owner data", "text/plain"))],
+    )
+    assert upload_response.status_code == 200, upload_response.text
+    file_id = upload_response.json()["files"][0]["file_id"]
+
+    persisted_task_owner_id, _current_agent_owner_id = (
+        _change_agent_owner_for_existing_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            username="sdk-file-owner-drift",
+        )
+    )
+    mock_start_task.reset_mock()
+
+    response = client.post(
+        f"/v1/chat/tasks/{task_id}/messages",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {
+                "role": "user",
+                "content": "use the existing file",
+                "files": [file_id],
+            },
+        },
+    )
+
+    assert response.status_code == 202, response.text
+
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        uploaded_file = (
+            db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        )
+        assert uploaded_file.user_id == persisted_task_owner_id
+        assert uploaded_file.task_id == task_id
+    finally:
+        db.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -14,6 +14,7 @@ real :class:`TraceEvent` rows inserted directly into the test DB to
 drive the mapping.
 """
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -21,10 +22,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from xagent.core.tools.adapters.vibe.connector_runtime import (
-    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
-    ConnectorRuntimeError,
-)
 from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.models.agent import Agent
@@ -914,19 +911,19 @@ def test_create_task_maps_runtime_plan_identity_mismatch_to_domain_error(
     mock_start_task,
 ) -> None:
     agent_id, full_key = _create_agent_with_key()
+    prepare_runtime_plan = v1_tasks.prepare_create_connector_runtime
 
-    def reject_mismatched_identity(*, task, plan) -> None:
-        raise ConnectorRuntimeError(
-            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
-            "Connector runtime context is unavailable.",
-            details={"reason": "runtime_task_identity_mismatch"},
-            status_code=503,
+    def prepare_mismatched_identity(**kwargs):
+        plan = prepare_runtime_plan(**kwargs)
+        return replace(
+            plan,
+            connector_user_id=plan.connector_user_id + 1,
         )
 
     monkeypatch.setattr(
         v1_tasks,
-        "bind_create_connector_runtime_plan",
-        reject_mismatched_identity,
+        "prepare_create_connector_runtime",
+        prepare_mismatched_identity,
     )
 
     response = client.post(

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -1903,17 +1903,9 @@ def test_append_message_uses_persisted_task_owner_after_agent_owner_changes(
 def test_append_message_uses_persisted_task_owner_for_files_after_owner_changes(
     mock_start_task,
 ):
-    """Task-owned files remain attachable after the agent owner changes."""
+    """Task-aware uploads use the persisted owner after agent-owner drift."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id, content="first turn")
-    upload_response = client.post(
-        "/v1/chat/files",
-        headers=_bearer(full_key),
-        files=[("files", ("owner-file.txt", b"owner data", "text/plain"))],
-    )
-    assert upload_response.status_code == 200, upload_response.text
-    file_id = upload_response.json()["files"][0]["file_id"]
-
     persisted_task_owner_id, _current_agent_owner_id = (
         _change_agent_owner_for_existing_task(
             task_id=task_id,
@@ -1922,6 +1914,29 @@ def test_append_message_uses_persisted_task_owner_for_files_after_owner_changes(
         )
     )
     mock_start_task.reset_mock()
+
+    upload_response = client.post(
+        f"/v1/chat/files?task_id={task_id}",
+        headers=_bearer(full_key),
+        files=[("files", ("owner-file.txt", b"owner data", "text/plain"))],
+    )
+    assert upload_response.status_code == 200, upload_response.text
+    file_id = upload_response.json()["files"][0]["file_id"]
+
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        uploaded_file = (
+            db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        )
+        assert uploaded_file.user_id == persisted_task_owner_id
+        assert uploaded_file.task_id is None
+        assert str(uploaded_file.storage_key).startswith(
+            f"users/{persisted_task_owner_id}/uploads/"
+        )
+    finally:
+        db.close()
 
     response = client.post(
         f"/v1/chat/tasks/{task_id}/messages",
@@ -1938,8 +1953,6 @@ def test_append_message_uses_persisted_task_owner_for_files_after_owner_changes(
 
     assert response.status_code == 202, response.text
 
-    from xagent.web.models.uploaded_file import UploadedFile
-
     db = _direct_db_session()
     try:
         uploaded_file = (
@@ -1947,6 +1960,39 @@ def test_append_message_uses_persisted_task_owner_for_files_after_owner_changes(
         )
         assert uploaded_file.user_id == persisted_task_owner_id
         assert uploaded_file.task_id == task_id
+    finally:
+        db.close()
+
+
+def test_task_aware_upload_rejects_other_agents_task_without_writing_file(
+    mock_start_task,
+):
+    """A key cannot select another agent's task runtime owner for upload."""
+    owner_agent_id, owner_key = _create_agent_with_key()
+    owner_task_id = _create_task(owner_key, owner_agent_id)
+    mock_start_task.reset_mock()
+
+    other_headers = _register_second_user(username="sdk-task-upload-other")
+    _other_agent_id, other_key = _create_agent_with_key_for(other_headers)
+    response = client.post(
+        f"/v1/chat/files?task_id={owner_task_id}",
+        headers=_bearer(other_key),
+        files=[("files", ("forbidden-owner.txt", b"private", "text/plain"))],
+    )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["error"]["code"] == "task_not_found"
+
+    from xagent.web.models.uploaded_file import UploadedFile
+
+    db = _direct_db_session()
+    try:
+        assert (
+            db.query(UploadedFile)
+            .filter(UploadedFile.filename == "forbidden-owner.txt")
+            .count()
+            == 0
+        )
     finally:
         db.close()
 

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -21,6 +21,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from xagent.core.tools.adapters.vibe.connector_runtime import (
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+    ConnectorRuntimeError,
+)
 from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.models.agent import Agent
@@ -86,6 +90,13 @@ def _create_agent_with_key_for(headers: dict[str, str]) -> tuple[int, str]:
 # note in test_agent_api_keys.py for why we use ``usefixtures`` with a
 # string name rather than importing the fixture.
 pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+@pytest.fixture(autouse=True)
+def reset_connector_runtime_resolver():
+    set_connector_runtime_resolver_for_testing(None)
+    yield
+    set_connector_runtime_resolver_for_testing(None)
 
 
 # ===== helpers =====
@@ -863,6 +874,82 @@ def test_create_task_rejects_missing_required_secret_without_resolver(mock_start
     assert resp.json()["error"]["code"] == "runtime_secret_unavailable"
     assert resp.json()["error"]["details"]["reason"] == "not_provided"
     assert mock_start_task.call_count == 0
+
+
+def test_external_scoped_resolver_does_not_defer_sdk_required_secret(
+    mock_start_task,
+):
+    agent_id, full_key = _create_agent_with_key()
+    _install_runtime_mcp_connector(agent_id, required=False, secret_required=True)
+    resolver_calls = 0
+
+    def _resolver(request):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return request.values
+
+    set_connector_runtime_resolver_for_testing(_resolver, task_sources={"external"})
+    try:
+        resp = client.post(
+            "/v1/chat/tasks",
+            headers=_bearer(full_key),
+            json={
+                "agent_id": agent_id,
+                "message": {"role": "user", "content": "first user message"},
+            },
+        )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "runtime_secret_unavailable"
+    assert resp.json()["error"]["details"]["reason"] == "not_provided"
+    assert mock_start_task.call_count == 0
+    assert resolver_calls == 0
+
+
+def test_create_task_maps_runtime_plan_identity_mismatch_to_domain_error(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_start_task,
+) -> None:
+    agent_id, full_key = _create_agent_with_key()
+
+    def reject_mismatched_identity(*, task, plan) -> None:
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector runtime context is unavailable.",
+            details={"reason": "runtime_task_identity_mismatch"},
+            status_code=503,
+        )
+
+    monkeypatch.setattr(
+        v1_tasks,
+        "bind_create_connector_runtime_plan",
+        reject_mismatched_identity,
+    )
+
+    response = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "identity mismatch"},
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"] == {
+        "code": "connector_runtime_unavailable",
+        "message": "Connector runtime context is unavailable.",
+        "details": {"reason": "runtime_task_identity_mismatch"},
+    }
+    assert mock_start_task.call_count == 0
+
+    db = _direct_db_session()
+    try:
+        assert db.query(Task).filter(Task.agent_id == agent_id).count() == 0
+    finally:
+        db.close()
 
 
 def test_connector_runtime_view_loads_task_context(mock_start_task):
@@ -1732,6 +1819,123 @@ def test_append_message_happy_path(mock_start_task):
         db.close()
 
     assert mock_start_task.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("task_sources", "expected_status"),
+    [
+        (None, 202),
+        ({"sdk"}, 202),
+        ({"external"}, 400),
+    ],
+    ids=["legacy-global", "matching-sdk", "non-matching-external"],
+)
+def test_append_message_resolver_scope_follows_persisted_sdk_source(
+    mock_start_task,
+    task_sources: set[str] | None,
+    expected_status: int,
+) -> None:
+    agent_id, full_key = _create_agent_with_key()
+    server_id = _install_runtime_mcp_connector(
+        agent_id,
+        required=False,
+        secret_required=True,
+    )
+    create_response = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "first turn"},
+            "connector_runtime_context": [
+                {
+                    "connector_ref": {
+                        "connector_type": "mcp",
+                        "connector_id": server_id,
+                    },
+                    "secrets": {"authorization": "Bearer initial-token"},
+                }
+            ],
+        },
+    )
+    assert create_response.status_code == 202, create_response.text
+    task_id = create_response.json()["task_id"]
+    initial_turn_id = mock_start_task.call_args.kwargs["payload"].turn_id
+    _force_task_status(task_id, TaskStatus.COMPLETED)
+    mock_start_task.reset_mock()
+
+    db = _direct_db_session()
+    try:
+        task_owner_user_id = int(
+            db.query(Task.user_id).filter(Task.id == task_id).one()[0]
+        )
+    finally:
+        db.close()
+
+    resolver_requests = []
+
+    def resolver(request):
+        resolver_requests.append(request)
+        return ConnectorRuntimeValues(
+            context=request.values.context,
+            secrets={"authorization": "Bearer resolver-token"},
+            auth_selector=request.values.auth_selector,
+        )
+
+    append_turn_id: str | None = None
+    set_connector_runtime_resolver_for_testing(
+        resolver,
+        task_sources=task_sources,
+    )
+    try:
+        response = client.post(
+            f"/v1/chat/tasks/{task_id}/messages",
+            headers=_bearer(full_key),
+            json={
+                "agent_id": agent_id,
+                "message": {"role": "user", "content": "second turn"},
+            },
+        )
+        assert response.status_code == expected_status, response.text
+
+        if expected_status == 202:
+            assert mock_start_task.call_count == 1
+            append_turn_id = mock_start_task.call_args.kwargs["payload"].turn_id
+            runtime_turn_id = append_turn_id
+        else:
+            assert response.json()["error"]["code"] == "runtime_secret_unavailable"
+            assert response.json()["error"]["details"]["reason"] == "not_provided"
+            assert mock_start_task.call_count == 0
+            runtime_turn_id = initial_turn_id
+
+        db = _direct_db_session()
+        try:
+            view = load_connector_runtime_view(
+                db=db,
+                task_id=task_id,
+                turn_id=runtime_turn_id,
+                user_id=task_owner_user_id,
+            )
+        finally:
+            db.close()
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+        pop_ephemeral_runtime_values(initial_turn_id)
+        if append_turn_id is not None:
+            pop_ephemeral_runtime_values(append_turn_id)
+
+    if expected_status == 202:
+        assert view[f"mcp:{server_id}"]["secrets"] == {
+            "authorization": "Bearer resolver-token"
+        }
+        assert len(resolver_requests) == 1
+        assert resolver_requests[0].task_source == "sdk"
+        assert resolver_requests[0].user_id == task_owner_user_id
+    else:
+        assert view[f"mcp:{server_id}"]["secrets"] == {
+            "authorization": "Bearer initial-token"
+        }
+        assert resolver_requests == []
 
 
 def test_append_message_rejects_changed_connector_runtime_context(mock_start_task):

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -607,6 +607,20 @@ def test_resolver_registration_rejects_empty_source_scope() -> None:
         )
 
 
+@pytest.mark.parametrize("task_source", [" external", "external ", "\texternal\n"])
+def test_resolver_registration_rejects_source_scope_with_surrounding_whitespace(
+    task_source: str,
+) -> None:
+    try:
+        with pytest.raises(ValueError, match="surrounding whitespace"):
+            set_connector_runtime_resolver_for_testing(
+                lambda request: request.values,
+                task_sources={task_source},
+            )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+
 def test_resolver_registration_copies_mutable_source_scope(
     db_session: Session,
 ) -> None:

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -7,14 +7,29 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from xagent.web.models import Agent, Base, MCPServer, Task, User, UserMCPServer
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.models.task import TaskStatus
+from xagent.web.services import connector_runtime as connector_runtime_service
 from xagent.web.services.connector_runtime import (
+    ConnectorRuntimeValues,
     bind_connector_runtime_selection_snapshot,
+    bind_create_connector_runtime_plan,
+    load_connector_runtime_view,
+    prepare_append_connector_runtime,
     prepare_connector_runtime_selection_snapshot,
+    prepare_create_connector_runtime,
+    set_connector_runtime_resolver_for_testing,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_connector_runtime_resolver() -> Iterator[None]:
+    set_connector_runtime_resolver_for_testing(None)
+    yield
+    set_connector_runtime_resolver_for_testing(None)
 
 
 @pytest.fixture()
@@ -42,22 +57,46 @@ def _create_user(db: Session, username: str) -> User:
     return user
 
 
-def _create_runtime_mcp(db: Session, user: User, name: str) -> MCPServer:
+def _create_runtime_mcp(
+    db: Session,
+    user: User,
+    name: str,
+    *,
+    secret_required: bool = False,
+) -> MCPServer:
+    runtime_input_schema = {
+        "context": {"account_id": {"type": "string", "required": False}}
+    }
+    runtime_bindings = [
+        {
+            "source": {"input_type": "context", "key": "account_id"},
+            "target": {"target_type": "mcp_meta", "key": "account_id"},
+        }
+    ]
+    if secret_required:
+        runtime_input_schema["secrets"] = {
+            "authorization": {"type": "string", "required": True}
+        }
+        runtime_bindings.append(
+            {
+                "source": {
+                    "input_type": "secrets",
+                    "key": "authorization",
+                },
+                "target": {
+                    "target_type": "transport_headers",
+                    "key": "Authorization",
+                },
+            }
+        )
     server = MCPServer(
         name=name,
         description=f"{name} description",
         managed="external",
         transport="streamable_http",
         url="https://example.com/mcp",
-        runtime_input_schema={
-            "context": {"account_id": {"type": "string", "required": False}}
-        },
-        runtime_bindings=[
-            {
-                "source": {"input_type": "context", "key": "account_id"},
-                "target": {"target_type": "mcp_meta", "key": "account_id"},
-            }
-        ],
+        runtime_input_schema=runtime_input_schema,
+        runtime_bindings=runtime_bindings,
     )
     db.add(server)
     db.flush()
@@ -213,3 +252,393 @@ def test_selection_snapshot_scopes_custom_api_by_source_server_name(
         "connector_type": "custom_api",
         "connector_id": int(unselected_api.id),
     } not in (task.connector_runtime_selected_refs or [])
+
+
+def test_scoped_resolver_applies_consistently_to_create_and_binding(
+    db_session: Session,
+) -> None:
+    agent_owner = _create_user(db_session, "agent-owner")
+    task_owner = _create_user(db_session, "task-owner")
+    agent = Agent(
+        user_id=agent_owner.id,
+        name="External Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(
+        db_session, task_owner, "external-runtime", secret_required=True
+    )
+    requests = []
+
+    def resolver(request):
+        requests.append(request)
+        return ConnectorRuntimeValues(
+            context=request.values.context,
+            secrets={"authorization": "Bearer external"},
+            auth_selector=request.values.auth_selector,
+        )
+
+    set_connector_runtime_resolver_for_testing(resolver, task_sources={"external"})
+    try:
+        plan = prepare_create_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task_source="external",
+            connector_user_id=int(task_owner.id),
+            payload_items=None,
+        )
+        task = Task(
+            user_id=task_owner.id,
+            agent_id=agent.id,
+            title="external task",
+            source="external",
+            status=TaskStatus.PENDING,
+        )
+        bind_create_connector_runtime_plan(task=task, plan=plan)
+        db_session.add(task)
+        db_session.flush()
+
+        view = load_connector_runtime_view(
+            db=db_session,
+            task_id=int(task.id),
+            turn_id="external-turn",
+            user_id=int(task_owner.id),
+        )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert task.connector_runtime_selected_refs == [
+        {"connector_type": "mcp", "connector_id": int(server.id)}
+    ]
+    assert view[f"mcp:{server.id}"]["secrets"] == {"authorization": "Bearer external"}
+    assert len(requests) == 1
+    assert requests[0].task_source == "external"
+    assert requests[0].user_id == int(task_owner.id)
+
+
+@pytest.mark.parametrize("task_source", ["sdk", "unknown"])
+def test_scoped_resolver_does_not_bypass_other_create_sources(
+    db_session: Session,
+    task_source: str,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="SDK Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    _create_runtime_mcp(db_session, owner, "sdk-runtime", secret_required=True)
+
+    set_connector_runtime_resolver_for_testing(
+        lambda request: request.values,
+        task_sources={"external"},
+    )
+    try:
+        with pytest.raises(ConnectorRuntimeError) as exc_info:
+            prepare_create_connector_runtime(
+                db=db_session,
+                agent=agent,
+                task_source=task_source,
+                connector_user_id=int(owner.id),
+                payload_items=None,
+            )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert exc_info.value.code == "runtime_secret_unavailable"
+    assert exc_info.value.details["reason"] == "not_provided"
+
+
+@pytest.mark.parametrize(
+    ("task_user", "task_source"),
+    [("other", "external"), ("owner", "sdk")],
+)
+def test_create_plan_rejects_task_identity_mismatch(
+    db_session: Session,
+    task_user: str,
+    task_source: str,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    agent = Agent(
+        user_id=owner.id,
+        name="Identity Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    _create_runtime_mcp(db_session, owner, "identity-runtime")
+    plan = prepare_create_connector_runtime(
+        db=db_session,
+        agent=agent,
+        task_source="external",
+        connector_user_id=int(owner.id),
+        payload_items=None,
+    )
+    task = Task(
+        user_id=owner.id if task_user == "owner" else other.id,
+        agent_id=agent.id,
+        title="mismatched task",
+        source=task_source,
+        status=TaskStatus.PENDING,
+    )
+
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        bind_create_connector_runtime_plan(task=task, plan=plan)
+
+    assert exc_info.value.code == "connector_runtime_unavailable"
+    assert exc_info.value.details["reason"] == "runtime_task_identity_mismatch"
+    assert task.connector_runtime_selected_refs is None
+
+
+def test_append_uses_persisted_task_owner_connector_visibility(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_owner = _create_user(db_session, "agent-owner")
+    task_owner = _create_user(db_session, "task-owner")
+    agent = Agent(
+        user_id=agent_owner.id,
+        name="Historical Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(db_session, task_owner, "task-owner-runtime")
+    task = Task(
+        user_id=task_owner.id,
+        agent_id=agent.id,
+        title="historical task",
+        source="sdk",
+        status=TaskStatus.COMPLETED,
+        connector_runtime_selected_refs=[
+            {"connector_type": "mcp", "connector_id": int(server.id)}
+        ],
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    plan = prepare_append_connector_runtime(
+        db=db_session,
+        agent=agent,
+        task=task,
+        connector_user_id=int(task_owner.id),
+        payload_items=[
+            {
+                "connector_ref": {
+                    "connector_type": "mcp",
+                    "connector_id": int(server.id),
+                }
+            }
+        ],
+    )
+
+    assert plan.ephemeral_by_ref == {}
+
+    def reject_visibility_query(*args, **kwargs):
+        raise AssertionError("owner mismatch must fail before connector visibility")
+
+    monkeypatch.setattr(
+        connector_runtime_service,
+        "_load_visible_runtime_connectors",
+        reject_visibility_query,
+    )
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        prepare_append_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task=task,
+            connector_user_id=int(agent_owner.id),
+            payload_items=None,
+        )
+    assert exc_info.value.code == "connector_runtime_unavailable"
+    assert exc_info.value.details["reason"] == "runtime_owner_mismatch"
+
+
+def test_runtime_binding_rejects_owner_mismatch_before_resolver(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    agent = Agent(
+        user_id=owner.id,
+        name="Binding Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(db_session, owner, "binding-runtime")
+    task = Task(
+        user_id=owner.id,
+        agent_id=agent.id,
+        title="binding task",
+        source="external",
+        status=TaskStatus.PENDING,
+        connector_runtime_selected_refs=[
+            {"connector_type": "mcp", "connector_id": int(server.id)}
+        ],
+    )
+    db_session.add(task)
+    db_session.flush()
+    view = load_connector_runtime_view(
+        db=db_session,
+        task_id=int(task.id),
+        turn_id="binding-turn",
+        user_id=None,
+    )
+    assert f"mcp:{server.id}" in view
+    resolver_calls = 0
+
+    def resolver(request):
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return request.values
+
+    def reject_visibility_query(*args, **kwargs):
+        raise AssertionError("owner mismatch must fail before connector visibility")
+
+    monkeypatch.setattr(
+        connector_runtime_service,
+        "_load_visible_runtime_connectors",
+        reject_visibility_query,
+    )
+    set_connector_runtime_resolver_for_testing(resolver, task_sources={"external"})
+    try:
+        with pytest.raises(ConnectorRuntimeError) as exc_info:
+            load_connector_runtime_view(
+                db=db_session,
+                task_id=int(task.id),
+                turn_id="binding-turn",
+                user_id=int(other.id),
+            )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert exc_info.value.code == "connector_runtime_unavailable"
+    assert exc_info.value.details["reason"] == "runtime_owner_mismatch"
+    assert resolver_calls == 0
+
+
+def test_unscoped_resolver_preserves_legacy_none_source_behavior(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="Legacy Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(
+        db_session, owner, "legacy-runtime", secret_required=True
+    )
+    task = Task(
+        user_id=owner.id,
+        agent_id=agent.id,
+        title="legacy task",
+        source=None,
+        status=TaskStatus.PENDING,
+        connector_runtime_selected_refs=[
+            {"connector_type": "mcp", "connector_id": int(server.id)}
+        ],
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    def resolver(request):
+        return ConnectorRuntimeValues(
+            context=request.values.context,
+            secrets={"authorization": "Bearer legacy"},
+            auth_selector=request.values.auth_selector,
+        )
+
+    set_connector_runtime_resolver_for_testing(resolver)
+    try:
+        view = load_connector_runtime_view(
+            db=db_session,
+            task_id=int(task.id),
+            turn_id="legacy-turn",
+            user_id=int(owner.id),
+        )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert view[f"mcp:{server.id}"]["secrets"] == {"authorization": "Bearer legacy"}
+
+    set_connector_runtime_resolver_for_testing(resolver, task_sources={"external"})
+    try:
+        with pytest.raises(ConnectorRuntimeError) as exc_info:
+            load_connector_runtime_view(
+                db=db_session,
+                task_id=int(task.id),
+                turn_id="legacy-turn",
+                user_id=int(owner.id),
+            )
+    finally:
+        set_connector_runtime_resolver_for_testing(None)
+
+    assert exc_info.value.code == "runtime_secret_unavailable"
+
+
+def test_resolver_registration_rejects_string_source_scope() -> None:
+    with pytest.raises(TypeError):
+        set_connector_runtime_resolver_for_testing(
+            lambda request: request.values,
+            task_sources="external",  # type: ignore[arg-type]
+        )
+
+
+def test_resolver_registration_rejects_empty_source_scope() -> None:
+    with pytest.raises(ValueError, match="at least one source"):
+        set_connector_runtime_resolver_for_testing(
+            lambda request: request.values,
+            task_sources=set(),
+        )
+
+
+def test_resolver_registration_copies_mutable_source_scope(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "mutable-scope-owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="Mutable Scope Agent",
+        instructions="Use tools.",
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    _create_runtime_mcp(
+        db_session,
+        owner,
+        "mutable-scope-runtime",
+        secret_required=True,
+    )
+    task_sources = {"external"}
+    set_connector_runtime_resolver_for_testing(
+        lambda request: request.values,
+        task_sources=task_sources,
+    )
+    task_sources.add("sdk")
+
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        prepare_create_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task_source="sdk",
+            connector_user_id=int(owner.id),
+            payload_items=None,
+        )
+
+    assert exc_info.value.code == "runtime_secret_unavailable"


### PR DESCRIPTION
## Summary

- allow connector runtime resolvers to opt into exact `Task.source` values while preserving legacy global registration behavior
- make create and append preparation use an explicit connector owner and bind create plans to the persisted task identity
- derive runtime binding source and owner from `Task`, failing closed when a supplied owner does not match
- preserve synchronous missing-secret validation for SDK, trigger, unknown, and unscoped task sources

## Why

A process-global resolver previously caused preparation to defer required ephemeral-value validation for every task source, even when the deployment resolver only supported one entrypoint. Append preparation also used the current agent owner instead of the persisted task owner, which could make preparation and execution observe different connector visibility.

## Compatibility

Calling `set_connector_runtime_resolver(resolver)` without `task_sources` retains the existing global behavior. Scoped registrations require a non-empty source collection and use exact source matching. This change does not add persistence schema or SaaS-specific concepts.

## Verification

- 592 connector-runtime-related tests passed
- Ruff format and lint checks passed
- mypy passed for the three changed production modules
- repository pre-commit hooks passed