### PR TITLE
fix: prevent MCP initialization from exhausting the DB connection pool

### DIFF
--- a/example.env
+++ b/example.env
@@ -26,10 +26,12 @@ PORT="80"
 # Or use SQLite (default, no configuration needed):
 # DATABASE_URL="sqlite:///home/xagent/.xagent/xagent.db"
 
-# SQLAlchemy connection pool for the shared web engine (per process).
-# Non-SQLite databases only. Size the total (pool size + max overflow,
-# multiplied by backend/worker process count) below PostgreSQL's
-# max_connections.
+# SQLAlchemy connection pool settings (non-SQLite databases only). These
+# apply to EACH of the two engines a process may create — the shared web
+# engine and the ad-hoc engine behind create_db_session() (workspace file
+# registration etc.) — so the worst case per process is
+# 2 x (pool size + max overflow). Size that, multiplied by backend/worker
+# process count, below PostgreSQL's max_connections.
 # XAGENT_DB_POOL_SIZE="10"
 # XAGENT_DB_MAX_OVERFLOW="20"
 # Seconds to wait for a free pooled connection before raising.

--- a/example.env
+++ b/example.env
@@ -26,6 +26,20 @@ PORT="80"
 # Or use SQLite (default, no configuration needed):
 # DATABASE_URL="sqlite:///home/xagent/.xagent/xagent.db"
 
+# SQLAlchemy connection pool for the shared web engine (per process).
+# Non-SQLite databases only. Size the total (pool size + max overflow,
+# multiplied by backend/worker process count) below PostgreSQL's
+# max_connections.
+# XAGENT_DB_POOL_SIZE="10"
+# XAGENT_DB_MAX_OVERFLOW="20"
+# Seconds to wait for a free pooled connection before raising.
+# XAGENT_DB_POOL_TIMEOUT_SECONDS="30"
+
+# Per-server timeout (seconds) for MCP tool initialization during agent
+# setup (connect + initialize + list-tools, including retries and cleanup).
+# A server that exceeds it is skipped for that task. 0 disables the timeout.
+# XAGENT_MCP_TOOL_INIT_TIMEOUT_SECONDS="60"
+
 # ===========================================
 # Hot Path Cache Configuration
 # ===========================================

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1395,6 +1395,26 @@ def get_db_pool_timeout_seconds() -> int:
     return _get_positive_int_env(DB_POOL_TIMEOUT_SECONDS, 30)
 
 
+def get_db_pool_kwargs() -> dict[str, Any]:
+    """Shared SQLAlchemy pool kwargs for every pooled (non-SQLite) engine.
+
+    Single source for the pool sizing/health knobs so the shared web engine
+    and the ad-hoc storage engine cannot drift apart. Note the same values
+    apply to EACH engine that uses them: a process running both holds up to
+    2 x (pool_size + max_overflow) connections (see example.env).
+
+    Returns:
+        Keyword arguments for :func:`sqlalchemy.create_engine`.
+    """
+    return {
+        "pool_size": get_db_pool_size(),
+        "max_overflow": get_db_max_overflow(),
+        "pool_timeout": get_db_pool_timeout_seconds(),
+        "pool_recycle": 3600,  # Recycle connections after 1 hour
+        "pool_pre_ping": True,  # Verify connections before using
+    }
+
+
 def get_mcp_tool_init_timeout_seconds() -> int:
     """Get the per-server timeout for MCP tool initialization, in seconds.
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -53,6 +53,10 @@ FILE_DELIVERY_ACCEL_REDIRECT_PREFIX = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFI
 SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 DATABASE_URL = "DATABASE_URL"
+DB_POOL_SIZE = "XAGENT_DB_POOL_SIZE"
+DB_MAX_OVERFLOW = "XAGENT_DB_MAX_OVERFLOW"
+DB_POOL_TIMEOUT_SECONDS = "XAGENT_DB_POOL_TIMEOUT_SECONDS"
+MCP_TOOL_INIT_TIMEOUT_SECONDS = "XAGENT_MCP_TOOL_INIT_TIMEOUT_SECONDS"
 SANDBOX_CPUS = "SANDBOX_CPUS"
 SANDBOX_MEMORY = "SANDBOX_MEMORY"
 SANDBOX_ENV = "SANDBOX_ENV"
@@ -1349,6 +1353,64 @@ def get_database_url() -> str:
     # Default: SQLite in storage root
     db_path = get_default_sqlite_db_path()
     return f"sqlite:///{db_path}"
+
+
+def get_db_pool_size() -> int:
+    """Get the SQLAlchemy connection pool size for the shared web engine.
+
+    Priority:
+        1. XAGENT_DB_POOL_SIZE environment variable
+        2. 10
+
+    Returns:
+        Number of persistent connections kept in the pool per process.
+    """
+    return _get_positive_int_env(DB_POOL_SIZE, 10)
+
+
+def get_db_max_overflow() -> int:
+    """Get the SQLAlchemy connection pool max overflow for the shared web engine.
+
+    Priority:
+        1. XAGENT_DB_MAX_OVERFLOW environment variable
+        2. 20
+
+    Returns:
+        Number of extra connections allowed beyond the pool size (0 disables
+        overflow).
+    """
+    return _get_positive_int_env(DB_MAX_OVERFLOW, 20, minimum=0)
+
+
+def get_db_pool_timeout_seconds() -> int:
+    """Get the timeout for acquiring a connection from the pool, in seconds.
+
+    Priority:
+        1. XAGENT_DB_POOL_TIMEOUT_SECONDS environment variable
+        2. 30
+
+    Returns:
+        Seconds to wait for a free pooled connection before raising.
+    """
+    return _get_positive_int_env(DB_POOL_TIMEOUT_SECONDS, 30)
+
+
+def get_mcp_tool_init_timeout_seconds() -> int:
+    """Get the per-server timeout for MCP tool initialization, in seconds.
+
+    Bounds the connect + initialize + list-tools handshake for one MCP server
+    during agent setup, so a hung server cannot stall task startup (and pin
+    resources such as DB connections) indefinitely. A timed-out server is
+    skipped; the remaining servers still load.
+
+    Priority:
+        1. XAGENT_MCP_TOOL_INIT_TIMEOUT_SECONDS environment variable
+        2. 60
+
+    Returns:
+        Seconds allowed per MCP server; 0 disables the timeout.
+    """
+    return _get_positive_int_env(MCP_TOOL_INIT_TIMEOUT_SECONDS, 60, minimum=0)
 
 
 def get_sandbox_cpus() -> int | None:

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -14,6 +14,9 @@ from sqlalchemy.orm import Session, declarative_base, sessionmaker
 # Alias to avoid naming conflict with this module's get_storage_root()
 from ...config import (
     get_database_url,
+    get_db_max_overflow,
+    get_db_pool_size,
+    get_db_pool_timeout_seconds,
     get_default_sqlite_db_path,
 )
 from ...config import get_storage_root as get_config_storage_root
@@ -149,14 +152,28 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
     with _adhoc_engine_lock:
         if _adhoc_engine is None or _adhoc_engine_url != database_url:
             old_engine = _adhoc_engine
-            connect_args = (
-                {"check_same_thread": False} if "sqlite" in database_url else {}
-            )
-            engine = create_engine(database_url, connect_args=connect_args)
-            # WAL + busy_timeout so concurrent writes wait for the lock
-            # instead of failing with "database is locked" (no-op on
-            # non-SQLite engines).
-            apply_sqlite_concurrency_pragmas(engine)
+            if "sqlite" in database_url:
+                engine = create_engine(
+                    database_url,
+                    connect_args={"check_same_thread": False},
+                )
+                # WAL + busy_timeout so concurrent writes wait for the lock
+                # instead of failing with "database is locked".
+                apply_sqlite_concurrency_pragmas(engine)
+            else:
+                # Same pool tunables as the shared web engine so operators
+                # size ONE set of knobs — but remember this is a SECOND
+                # pool in the same process: worst case per process is
+                # 2 x (pool_size + max_overflow) against the database's
+                # max_connections (see example.env).
+                engine = create_engine(
+                    database_url,
+                    pool_size=get_db_pool_size(),
+                    max_overflow=get_db_max_overflow(),
+                    pool_timeout=get_db_pool_timeout_seconds(),
+                    pool_recycle=3600,
+                    pool_pre_ping=True,
+                )
             Base.metadata.create_all(engine)
             _adhoc_engine = engine
             _adhoc_engine_url = database_url

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -14,9 +14,7 @@ from sqlalchemy.orm import Session, declarative_base, sessionmaker
 # Alias to avoid naming conflict with this module's get_storage_root()
 from ...config import (
     get_database_url,
-    get_db_max_overflow,
-    get_db_pool_size,
-    get_db_pool_timeout_seconds,
+    get_db_pool_kwargs,
     get_default_sqlite_db_path,
 )
 from ...config import get_storage_root as get_config_storage_root
@@ -166,14 +164,7 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
                 # pool in the same process: worst case per process is
                 # 2 x (pool_size + max_overflow) against the database's
                 # max_connections (see example.env).
-                engine = create_engine(
-                    database_url,
-                    pool_size=get_db_pool_size(),
-                    max_overflow=get_db_max_overflow(),
-                    pool_timeout=get_db_pool_timeout_seconds(),
-                    pool_recycle=3600,
-                    pool_pre_ping=True,
-                )
+                engine = create_engine(database_url, **get_db_pool_kwargs())
             Base.metadata.create_all(engine)
             _adhoc_engine = engine
             _adhoc_engine_url = database_url

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -142,9 +142,10 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
     global _adhoc_engine, _adhoc_engine_url
 
     database_url = get_database_url()
-    if _adhoc_engine is not None and _adhoc_engine_url == database_url:
-        return _adhoc_engine
-
+    # Check-and-swap runs entirely under the lock: a lock-free fast path
+    # could read a torn (engine, url) pair mid-swap and hand out an engine
+    # that is about to be disposed. This function is not on a hot path —
+    # correctness over the micro-optimization.
     with _adhoc_engine_lock:
         if _adhoc_engine is None or _adhoc_engine_url != database_url:
             old_engine = _adhoc_engine
@@ -161,7 +162,7 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
             _adhoc_engine_url = database_url
             if old_engine is not None:
                 old_engine.dispose()
-    return _adhoc_engine
+        return _adhoc_engine
 
 
 def create_db_session() -> Session:

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -128,21 +128,46 @@ def initialize_storage_manager(
 # Create base model class
 Base = declarative_base()
 
+# Process-wide engine for ad-hoc sessions. ``create_db_session`` used to
+# build a brand-new engine per call and never dispose it; each call left up
+# to a full connection pool alive until GC, which piles real database
+# connections up under load (issue #889). Cache one engine per database URL
+# instead — the URL check lets tests that swap DATABASE_URL still work.
+_adhoc_engine = None
+_adhoc_engine_url: Optional[str] = None
+_adhoc_engine_lock = threading.Lock()
+
+
+def _get_adhoc_engine():  # type: ignore[no-untyped-def]
+    global _adhoc_engine, _adhoc_engine_url
+
+    database_url = get_database_url()
+    if _adhoc_engine is not None and _adhoc_engine_url == database_url:
+        return _adhoc_engine
+
+    with _adhoc_engine_lock:
+        if _adhoc_engine is None or _adhoc_engine_url != database_url:
+            old_engine = _adhoc_engine
+            connect_args = (
+                {"check_same_thread": False} if "sqlite" in database_url else {}
+            )
+            engine = create_engine(database_url, connect_args=connect_args)
+            # WAL + busy_timeout so concurrent writes wait for the lock
+            # instead of failing with "database is locked" (no-op on
+            # non-SQLite engines).
+            apply_sqlite_concurrency_pragmas(engine)
+            Base.metadata.create_all(engine)
+            _adhoc_engine = engine
+            _adhoc_engine_url = database_url
+            if old_engine is not None:
+                old_engine.dispose()
+    return _adhoc_engine
+
 
 def create_db_session() -> Session:
-    database_url = get_database_url()
-    connect_args = {"check_same_thread": False} if "sqlite" in database_url else {}
-    # Create database engine
-    engine = create_engine(database_url, connect_args=connect_args)
-    # WAL + busy_timeout so concurrent writes wait for the lock instead of
-    # failing with "database is locked" (no-op on non-SQLite engines).
-    apply_sqlite_concurrency_pragmas(engine)
-    # Create session factory
+    engine = _get_adhoc_engine()
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-    db = SessionLocal()
-    Base.metadata.create_all(engine)
-    return db
+    return SessionLocal()
 
 
 def get_db_session() -> Generator[Session, None, None]:

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -79,6 +79,17 @@ class BaseToolConfig(ABC):
         """Get MCP server configurations."""
         pass
 
+    def release_db_connection(self) -> None:
+        """Release any pooled DB connection held by this config's session.
+
+        Tool creators call this right before long non-DB awaits (e.g. remote
+        MCP initialize/list-tools) so a config backed by a live SQLAlchemy
+        session does not pin a pool slot in ``idle in transaction`` for the
+        whole wait (issue #889). The session must remain usable afterwards —
+        it re-acquires a connection on its next query. Default: no-op for
+        configs without a DB session.
+        """
+
     @abstractmethod
     def get_file_tools_enabled(self) -> bool:
         """Whether to include file tools."""

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -374,6 +374,14 @@ class ToolFactory:
         # Wrap sandbox-enabled tools if sandbox is available
         sandbox = config.get_sandbox()
         if sandbox is not None:
+            # The override/allowlist loads above may have re-opened a read
+            # transaction on the config session after the MCP creator's
+            # release; workspace setup below awaits sandbox exec (external
+            # I/O), so release the pooled connection again first
+            # (issue #889).
+            release = getattr(config, "release_db_connection", None)
+            if callable(release):
+                release()
             workspace = ToolFactory._create_workspace(config.get_workspace_config())
             if workspace is not None:
                 from .sandboxed_tool.sandboxed_tool_wrapper import (

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1157,9 +1157,17 @@ async def _load_server_tools_bounded(
 
     if timeout_seconds <= 0:
         # Timeout disabled: still bound the fan-out, waiting as long as
-        # needed for a slot.
-        async with gate:
+        # needed for a slot. Cancellation while waiting must close the
+        # never-started coroutine or it warns "was never awaited" at GC.
+        try:
+            await gate.acquire()
+        except asyncio.CancelledError:
+            load_coro.close()
+            raise
+        try:
             return await load_coro
+        finally:
+            gate.release()
 
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout_seconds
@@ -1175,6 +1183,11 @@ async def _load_server_tools_bounded(
             "already in flight, possibly abandoned by earlier timeouts); "
             "skipping without opening another connection"
         ) from None
+    except asyncio.CancelledError:
+        # Caller cancelled while queued at the gate: the load never
+        # started, so just close the coroutine and let the cancel out.
+        load_coro.close()
+        raise
 
     task = asyncio.ensure_future(load_coro)
     # Release the slot only when the task truly finishes — an abandoned

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -9,13 +9,14 @@ import inspect
 import logging
 import os
 import re
-from collections.abc import Iterator
+from collections.abc import Coroutine, Iterator
 from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
 
 import httpx
 from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, Field, create_model
 
+from ..... import config as _root_config
 from .....sandbox.base import Sandbox
 from ...core.mcp.sessions import Connection, create_session
 from ...core.mcp.tools import load_mcp_tools
@@ -1096,6 +1097,50 @@ async def _load_direct_mcp_tools(
     return agent_tools
 
 
+async def _load_server_tools_bounded(
+    server_name: str,
+    load_coro: "Coroutine[Any, Any, list[AbstractBaseTool]]",
+    timeout_seconds: int,
+) -> list[AbstractBaseTool]:
+    """Run one server's tool load with a hard wall-clock bound.
+
+    ``asyncio.wait_for`` alone is not a hard bound: it awaits the cancelled
+    task's cleanup, and a hung streamable-HTTP server can stall inside the
+    session context manager's ``__aexit__`` just as easily as inside
+    ``initialize()`` (issue #889). ``asyncio.wait`` + fire-and-forget cancel
+    guarantees the caller resumes at the deadline even if cleanup never
+    completes; the abandoned task is logged and its eventual exception is
+    consumed by a done-callback so it never surfaces as "exception was never
+    retrieved".
+    """
+    if timeout_seconds <= 0:
+        return await load_coro
+
+    task = asyncio.ensure_future(load_coro)
+    done, _pending = await asyncio.wait({task}, timeout=timeout_seconds)
+    if task in done:
+        return task.result()
+
+    task.cancel()
+
+    def _consume_result(t: "asyncio.Task[Any]") -> None:
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.debug(
+                "Abandoned MCP load task for server %s finished with: %s",
+                server_name,
+                exc,
+            )
+
+    task.add_done_callback(_consume_result)
+    raise TimeoutError(
+        f"MCP server {server_name} initialization timed out after "
+        f"{timeout_seconds}s (including cleanup); abandoning it"
+    )
+
+
 async def load_mcp_tools_as_agent_tools(
     connection_map: Dict[str, Connection],
     *,
@@ -1122,6 +1167,7 @@ async def load_mcp_tools_as_agent_tools(
         The function continues processing remaining servers instead of raising.
     """
     agent_tools: List[AbstractBaseTool] = []
+    timeout_seconds = _root_config.get_mcp_tool_init_timeout_seconds()
 
     for server_name, connection in connection_map.items():
         try:
@@ -1149,13 +1195,13 @@ async def load_mcp_tools_as_agent_tools(
                         concurrent_tools=_concurrent_tools,
                     )
 
-                server_tools = await load_sandboxed_mcp_tools(
+                load_coro = load_sandboxed_mcp_tools(
                     connection,
                     sandbox,
                     tool_builder,
                 )
             else:
-                server_tools = await _load_direct_mcp_tools(
+                load_coro = _load_direct_mcp_tools(
                     server_name,
                     connection,
                     name_prefix=name_prefix,
@@ -1163,6 +1209,9 @@ async def load_mcp_tools_as_agent_tools(
                     allow_users=allow_users,
                 )
 
+            server_tools = await _load_server_tools_bounded(
+                server_name, load_coro, timeout_seconds
+            )
             agent_tools.extend(server_tools)
             logger.info(f"Found {len(server_tools)} tools from server {server_name}")
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1181,13 +1181,6 @@ async def _load_server_tools_bounded(
     # (cancellation-resistant) load keeps counting against the cap.
     task.add_done_callback(lambda _t: gate.release())
 
-    remaining = max(0.0, deadline - loop.time())
-    done, _pending = await asyncio.wait({task}, timeout=remaining)
-    if task in done:
-        return task.result()
-
-    task.cancel()
-
     def _consume_result(t: "asyncio.Task[Any]") -> None:
         if t.cancelled():
             return
@@ -1199,6 +1192,24 @@ async def _load_server_tools_bounded(
                 exc,
             )
 
+    remaining = max(0.0, deadline - loop.time())
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=remaining)
+    except asyncio.CancelledError:
+        # Caller cancelled (run cancelled, lease lost): ``asyncio.wait``
+        # does not cancel its awaited tasks, so propagate the cancel to
+        # the load task ourselves or it would run — and hold its gate
+        # slot and transport — forever. A well-behaved load unwinds and
+        # frees the slot; a cancellation-resistant cleanup keeps its slot
+        # until it truly finishes, same as the timeout path.
+        task.cancel()
+        task.add_done_callback(_consume_result)
+        raise
+
+    if task in done:
+        return task.result()
+
+    task.cancel()
     task.add_done_callback(_consume_result)
     raise TimeoutError(
         f"MCP server {server_name} initialization timed out after "

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1116,6 +1116,13 @@ _server_load_gates: "weakref.WeakKeyDictionary[Any, Dict[str, asyncio.Semaphore]
 )
 
 
+# Strong references to in-flight/abandoned load tasks. The event loop only
+# keeps weak references to tasks; if GC collected a still-pending task its
+# done-callback — which releases the gate slot — would never fire. Tasks
+# remove themselves on completion.
+_active_load_tasks: "set[asyncio.Task[Any]]" = set()
+
+
 def _get_server_load_gate(server_name: str) -> asyncio.Semaphore:
     loop = asyncio.get_running_loop()
     gates = _server_load_gates.get(loop)
@@ -1181,7 +1188,9 @@ async def _load_server_tools_bounded(
             f"MCP server {server_name}: no initialization slot freed within "
             f"{timeout_seconds}s ({_MAX_INFLIGHT_LOADS_PER_SERVER} loads "
             "already in flight, possibly abandoned by earlier timeouts); "
-            "skipping without opening another connection"
+            "skipping without opening another connection. Slots free when "
+            "those loads finish; if the server is permanently hung they "
+            "recover only on process restart"
         ) from None
     except asyncio.CancelledError:
         # Caller cancelled while queued at the gate: the load never
@@ -1190,9 +1199,16 @@ async def _load_server_tools_bounded(
         raise
 
     task = asyncio.ensure_future(load_coro)
-    # Release the slot only when the task truly finishes — an abandoned
-    # (cancellation-resistant) load keeps counting against the cap.
-    task.add_done_callback(lambda _t: gate.release())
+    # Keep a strong reference until completion, then release the slot only
+    # when the task truly finishes — an abandoned (cancellation-resistant)
+    # load keeps counting against the cap.
+    _active_load_tasks.add(task)
+
+    def _on_task_done(t: "asyncio.Task[Any]") -> None:
+        _active_load_tasks.discard(t)
+        gate.release()
+
+    task.add_done_callback(_on_task_done)
 
     def _consume_result(t: "asyncio.Task[Any]") -> None:
         if t.cancelled():

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import os
 import re
+import weakref
 from collections.abc import Coroutine, Iterator
 from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
 
@@ -1097,12 +1098,44 @@ async def _load_direct_mcp_tools(
     return agent_tools
 
 
+# Hard cap on concurrent (including abandoned) initializations per server.
+# The timeout below bounds the CALLER's wait but not the underlying task:
+# a cancellation-resistant cleanup keeps its transport/socket alive after
+# the caller has moved on. Without a per-server bound, a burst of tasks
+# against one hung server accumulates abandoned loads (and CLOSE-WAIT
+# sockets) without limit — the gate slot is only released when the load
+# task actually finishes, so abandoned loads keep counting against the cap
+# and later callers fail fast instead of opening yet another transport.
+_MAX_INFLIGHT_LOADS_PER_SERVER = 4
+
+# Semaphores are bound to an event loop; key by loop (weakly, so a
+# discarded loop doesn't pin its gates) then by server name. Web and
+# Celery processes each get their own gates.
+_server_load_gates: "weakref.WeakKeyDictionary[Any, Dict[str, asyncio.Semaphore]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_server_load_gate(server_name: str) -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    gates = _server_load_gates.get(loop)
+    if gates is None:
+        gates = {}
+        _server_load_gates[loop] = gates
+    gate = gates.get(server_name)
+    if gate is None:
+        gate = asyncio.Semaphore(_MAX_INFLIGHT_LOADS_PER_SERVER)
+        gates[server_name] = gate
+    return gate
+
+
 async def _load_server_tools_bounded(
     server_name: str,
     load_coro: "Coroutine[Any, Any, list[AbstractBaseTool]]",
     timeout_seconds: int,
 ) -> list[AbstractBaseTool]:
-    """Run one server's tool load with a hard wall-clock bound.
+    """Run one server's tool load with a hard wall-clock bound and a
+    per-server in-flight cap.
 
     ``asyncio.wait_for`` alone is not a hard bound: it awaits the cancelled
     task's cleanup, and a hung streamable-HTTP server can stall inside the
@@ -1112,12 +1145,44 @@ async def _load_server_tools_bounded(
     completes; the abandoned task is logged and its eventual exception is
     consumed by a done-callback so it never surfaces as "exception was never
     retrieved".
+
+    The per-server gate bounds the resource side: at most
+    ``_MAX_INFLIGHT_LOADS_PER_SERVER`` load tasks (live or abandoned) exist
+    per server per event loop. Callers that cannot get a slot within their
+    timeout budget fail fast without creating a transport. The acquire and
+    the load share one deadline, so the end-to-end caller bound is
+    unchanged.
     """
+    gate = _get_server_load_gate(server_name)
+
     if timeout_seconds <= 0:
-        return await load_coro
+        # Timeout disabled: still bound the fan-out, waiting as long as
+        # needed for a slot.
+        async with gate:
+            return await load_coro
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    try:
+        await asyncio.wait_for(gate.acquire(), timeout_seconds)
+    except (asyncio.TimeoutError, TimeoutError):
+        # Never started: close the coroutine so it doesn't warn about
+        # being un-awaited, and don't touch the gate (nothing acquired).
+        load_coro.close()
+        raise TimeoutError(
+            f"MCP server {server_name}: no initialization slot freed within "
+            f"{timeout_seconds}s ({_MAX_INFLIGHT_LOADS_PER_SERVER} loads "
+            "already in flight, possibly abandoned by earlier timeouts); "
+            "skipping without opening another connection"
+        ) from None
 
     task = asyncio.ensure_future(load_coro)
-    done, _pending = await asyncio.wait({task}, timeout=timeout_seconds)
+    # Release the slot only when the task truly finishes — an abandoned
+    # (cancellation-resistant) load keeps counting against the cap.
+    task.add_done_callback(lambda _t: gate.release())
+
+    remaining = max(0.0, deadline - loop.time())
+    done, _pending = await asyncio.wait({task}, timeout=remaining)
     if task in done:
         return task.result()
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -66,6 +66,15 @@ async def create_mcp_tools(config: "BaseToolConfig") -> List[Any]:
             if not mcp_configs:
                 return []
 
+    # Everything DB-backed is loaded at this point; what follows is pure
+    # network I/O against remote MCP servers (initialize + list-tools, with
+    # retries). Release the config session's pooled connection first so a
+    # slow or hung server doesn't pin a pool slot in ``idle in transaction``
+    # for the whole handshake (issue #889).
+    release = getattr(config, "release_db_connection", None)
+    if callable(release):
+        release()
+
     try:
         from .factory import ToolFactory
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -38,7 +38,7 @@ from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.chat_message import TaskChatMessage
-from ..models.database import get_db
+from ..models.database import get_db, release_db_connection_if_clean
 from ..models.model import Model as DBModel
 from ..models.task import AgentType, Task, TaskStatus, TraceEvent
 from ..models.user import User
@@ -1289,6 +1289,10 @@ class AgentServiceManager:
             "scope_segments": scope_segments,
         }
 
+        # Sandbox startup is container/network work that can take seconds;
+        # don't hold this session's read transaction (and its pool slot)
+        # across it (issue #889).
+        release_db_connection_if_clean(db)
         sandbox = await self._get_or_create_task_sandbox(
             task_id=task_id,
             workspace_owner_id=workspace_owner_id,
@@ -1846,6 +1850,10 @@ class AgentServiceManager:
                     "scope_segments": scope_segments,
                 }
 
+                # Sandbox startup is container/network work that can take
+                # seconds; don't hold this session's read transaction (and
+                # its pool slot) across it (issue #889).
+                release_db_connection_if_clean(db)
                 sandbox = await self._get_or_create_task_sandbox(
                     task_id=task_id,
                     workspace_owner_id=workspace_owner_id,
@@ -2260,6 +2268,13 @@ class AgentServiceManager:
             logger.info(
                 f"=== About to execute task: task_id={task_id}, has_db_session={db_session is not None} ==="
             )
+
+            # All pre-run DB writes (lease, status sync) are committed by
+            # now; release the session's pooled connection so it isn't
+            # pinned in ``idle in transaction`` for the entire agent run
+            # (issue #889). The tracker re-acquires per update and commits,
+            # so the slot is only held during actual DB work from here on.
+            release_db_connection_if_clean(db_session)
 
             # Execute the task
             result = await agent_service.execute_task(

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -66,10 +66,15 @@ def _mark_session_statement(orm_execute_state: Any) -> None:
         orm_execute_state.session.info[_MAY_HAVE_WRITTEN_KEY] = True
 
 
-@event.listens_for(Session, "after_commit")
-@event.listens_for(Session, "after_rollback")
-def _clear_session_flushed(session: Session) -> None:
-    session.info[_MAY_HAVE_WRITTEN_KEY] = False
+@event.listens_for(Session, "after_transaction_end")
+def _clear_session_flushed(session: Session, transaction: Any) -> None:
+    # Clear only when the ROOT transaction ends (commit, rollback, or
+    # close). ``after_commit``/``after_rollback`` would fire for savepoint
+    # (begin_nested) completion too, while the outer transaction — and its
+    # uncommitted writes — is still open; clearing there would let the
+    # helper roll those writes away.
+    if transaction.parent is None:
+        session.info[_MAY_HAVE_WRITTEN_KEY] = False
 
 
 def release_db_connection_if_clean(db: Session | None) -> bool:

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -6,12 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
 
-from ...config import (
-    get_database_url,
-    get_db_max_overflow,
-    get_db_pool_size,
-    get_db_pool_timeout_seconds,
-)
+from ...config import get_database_url, get_db_pool_kwargs
 from ...db.sqlite import apply_sqlite_concurrency_pragmas
 
 _SessionLocal: sessionmaker[Session] | None = None
@@ -186,11 +181,7 @@ def init_db(db_url: str | None = None) -> None:
         _engine = create_engine(
             database_url,
             poolclass=QueuePool,
-            pool_size=get_db_pool_size(),
-            max_overflow=get_db_max_overflow(),
-            pool_timeout=get_db_pool_timeout_seconds(),
-            pool_recycle=3600,  # Recycle connections after 1 hour
-            pool_pre_ping=True,  # Verify connections before using
+            **get_db_pool_kwargs(),
         )
 
     # Create session factory

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -34,25 +34,42 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-# Flushed-but-uncommitted changes leave ``new``/``dirty``/``deleted`` empty
-# while the transaction still holds unpersisted DML, so those collections
-# alone cannot prove a transaction is safe to roll back. Track flushes on
-# every Session via class-level listeners; the flag lives in ``session.info``
-# and is cleared once the transaction actually ends. ``Session.close()``
-# without commit/rollback may leave the flag set — that fails closed (the
-# helper just keeps the connection), never toward data loss.
-_HAS_FLUSHED_KEY = "xagent_has_flushed"
+# ``new``/``dirty``/``deleted`` alone cannot prove a transaction is safe to
+# roll back: an ORM flush empties them while the DML is still uncommitted,
+# and Core/bulk DML through ``Session.execute()`` never touches them at all.
+# Track "this transaction may have written" on every Session via class-level
+# listeners:
+#
+#   - ``after_flush`` — ORM unit-of-work writes;
+#   - ``do_orm_execute`` — every ``Session.execute()`` statement. Anything
+#     that is not provably a SELECT (Core insert/update/delete, ``text()``
+#     of any kind) sets the flag, deliberately conservative: an unrecognized
+#     statement keeps the connection rather than risking a rollback of work.
+#
+# The flag lives in ``session.info`` and is cleared once the transaction
+# actually ends. ``Session.close()`` without commit/rollback may leave it
+# set — that fails closed (the helper just keeps the connection), never
+# toward data loss. Out of contract: DML issued directly on
+# ``session.connection()`` bypasses session events; don't do that on
+# sessions handed to this helper.
+_MAY_HAVE_WRITTEN_KEY = "xagent_txn_may_have_written"
 
 
 @event.listens_for(Session, "after_flush")
 def _mark_session_flushed(session: Session, _flush_context: Any) -> None:
-    session.info[_HAS_FLUSHED_KEY] = True
+    session.info[_MAY_HAVE_WRITTEN_KEY] = True
+
+
+@event.listens_for(Session, "do_orm_execute")
+def _mark_session_statement(orm_execute_state: Any) -> None:
+    if not orm_execute_state.is_select:
+        orm_execute_state.session.info[_MAY_HAVE_WRITTEN_KEY] = True
 
 
 @event.listens_for(Session, "after_commit")
 @event.listens_for(Session, "after_rollback")
 def _clear_session_flushed(session: Session) -> None:
-    session.info[_HAS_FLUSHED_KEY] = False
+    session.info[_MAY_HAVE_WRITTEN_KEY] = False
 
 
 def release_db_connection_if_clean(db: Session | None) -> bool:
@@ -66,17 +83,18 @@ def release_db_connection_if_clean(db: Session | None) -> bool:
     and transparently re-acquires a connection on its next query.
 
     Only rolls back when the session has no pending ORM changes
-    (new/dirty/deleted) and nothing was flushed in the current transaction,
-    so nothing uncommitted is ever discarded. Callers must not rely on it
-    having released (hence the bool return): a session with pending or
-    flushed writes keeps its connection.
+    (new/dirty/deleted) and the current transaction executed nothing but
+    SELECTs through the session (see ``_MAY_HAVE_WRITTEN_KEY`` above), so
+    nothing uncommitted is ever discarded. Callers must not rely on it
+    having released (hence the bool return): a session that may have
+    written keeps its connection.
     """
     if db is None:
         return False
     try:
         if db.new or db.dirty or db.deleted:
             return False
-        if db.info.get(_HAS_FLUSHED_KEY, False):
+        if db.info.get(_MAY_HAVE_WRITTEN_KEY, False):
             return False
         if not db.in_transaction():
             return True

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -6,7 +6,12 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
 
-from ...config import get_database_url
+from ...config import (
+    get_database_url,
+    get_db_max_overflow,
+    get_db_pool_size,
+    get_db_pool_timeout_seconds,
+)
 from ...db.sqlite import apply_sqlite_concurrency_pragmas
 
 _SessionLocal: sessionmaker[Session] | None = None
@@ -27,6 +32,37 @@ def get_db() -> Generator[Session, None, None]:
         yield db
     finally:
         db.close()
+
+
+def release_db_connection_if_clean(db: Session | None) -> bool:
+    """Return ``db``'s pooled connection by ending its (read-only) transaction.
+
+    SQLAlchemy sessions hold their connection until commit/rollback/close, so
+    a session that ran a SELECT and then awaits slow non-DB work (remote MCP
+    initialization, sandbox startup, the agent run itself) pins a pool slot
+    in ``idle in transaction`` for the whole wait (issue #889). Calling this
+    before such an await releases the connection; the session stays usable
+    and transparently re-acquires a connection on its next query.
+
+    Only rolls back when the session has no pending ORM changes
+    (new/dirty/deleted), so nothing uncommitted is ever discarded. Callers
+    must not rely on it having released (hence the bool return): a session
+    with pending writes keeps its connection.
+    """
+    if db is None:
+        return False
+    try:
+        if db.new or db.dirty or db.deleted:
+            return False
+        if not db.in_transaction():
+            return True
+        db.rollback()
+        return True
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "Failed to release DB connection", exc_info=True
+        )
+        return False
 
 
 def get_session_local() -> sessionmaker[Session]:
@@ -103,9 +139,9 @@ def init_db(db_url: str | None = None) -> None:
         _engine = create_engine(
             database_url,
             poolclass=QueuePool,
-            pool_size=10,
-            max_overflow=20,
-            pool_timeout=30,  # 30 seconds timeout for getting connection from pool
+            pool_size=get_db_pool_size(),
+            max_overflow=get_db_max_overflow(),
+            pool_timeout=get_db_pool_timeout_seconds(),
             pool_recycle=3600,  # Recycle connections after 1 hour
             pool_pre_ping=True,  # Verify connections before using
         )

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Generator
 
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
@@ -34,6 +34,27 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
+# Flushed-but-uncommitted changes leave ``new``/``dirty``/``deleted`` empty
+# while the transaction still holds unpersisted DML, so those collections
+# alone cannot prove a transaction is safe to roll back. Track flushes on
+# every Session via class-level listeners; the flag lives in ``session.info``
+# and is cleared once the transaction actually ends. ``Session.close()``
+# without commit/rollback may leave the flag set — that fails closed (the
+# helper just keeps the connection), never toward data loss.
+_HAS_FLUSHED_KEY = "xagent_has_flushed"
+
+
+@event.listens_for(Session, "after_flush")
+def _mark_session_flushed(session: Session, _flush_context: Any) -> None:
+    session.info[_HAS_FLUSHED_KEY] = True
+
+
+@event.listens_for(Session, "after_commit")
+@event.listens_for(Session, "after_rollback")
+def _clear_session_flushed(session: Session) -> None:
+    session.info[_HAS_FLUSHED_KEY] = False
+
+
 def release_db_connection_if_clean(db: Session | None) -> bool:
     """Return ``db``'s pooled connection by ending its (read-only) transaction.
 
@@ -45,14 +66,17 @@ def release_db_connection_if_clean(db: Session | None) -> bool:
     and transparently re-acquires a connection on its next query.
 
     Only rolls back when the session has no pending ORM changes
-    (new/dirty/deleted), so nothing uncommitted is ever discarded. Callers
-    must not rely on it having released (hence the bool return): a session
-    with pending writes keeps its connection.
+    (new/dirty/deleted) and nothing was flushed in the current transaction,
+    so nothing uncommitted is ever discarded. Callers must not rely on it
+    having released (hence the bool return): a session with pending or
+    flushed writes keeps its connection.
     """
     if db is None:
         return False
     try:
         if db.new or db.dirty or db.deleted:
+            return False
+        if db.info.get(_HAS_FLUSHED_KEY, False):
             return False
         if not db.in_transaction():
             return True

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1091,6 +1091,22 @@ class WebToolConfig(BaseToolConfig):
             self._lazy_db.close()
             self._lazy_db = None
 
+    def release_db_connection(self) -> None:
+        """Return the pooled connection held by this config's session(s).
+
+        See :meth:`BaseToolConfig.release_db_connection`. Rolls back only
+        clean (read-only) transactions via
+        ``release_db_connection_if_clean``; sessions with pending writes are
+        left untouched. Both the caller-owned live session and the lazily
+        minted factory session are released — either one may have run the
+        MCP/agent config SELECTs whose transaction would otherwise stay open
+        across the MCP network await (issue #889).
+        """
+        from ..models.database import release_db_connection_if_clean
+
+        release_db_connection_if_clean(self._live_db)
+        release_db_connection_if_clean(self._lazy_db)
+
     def is_admin(self) -> bool:
         """Whether current user is admin."""
         return self._is_admin_value

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -308,6 +308,12 @@ class TaskTracker:
             )
             if reason is not None:
                 self.quota_interrupt_reason = reason
+            # End the gate's read transaction so this poll doesn't leave the
+            # session's pooled connection pinned in ``idle in transaction``
+            # until the next periodic commit (issue #889).
+            from ..models.database import release_db_connection_if_clean
+
+            release_db_connection_if_clean(self.db_session)
             return reason
         except Exception as e:  # noqa: BLE001
             # Runs per step; log once per run so a persistent failure can't flood.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -18,6 +18,9 @@ from xagent.config import (
     CELERY_ENABLED,
     CELERY_RESULT_BACKEND,
     DATABASE_URL,
+    DB_MAX_OVERFLOW,
+    DB_POOL_SIZE,
+    DB_POOL_TIMEOUT_SECONDS,
     EXTERNAL_SKILLS_LIBRARY_DIRS,
     EXTERNAL_UPLOAD_DIRS,
     FILE_DELIVERY_ACCEL_REDIRECT_ENABLED,
@@ -42,6 +45,7 @@ from xagent.config import (
     MAX_UPLOAD_SIZE,
     MCP_OAUTH_ALLOW_PRIVATE_HOSTS,
     MCP_OAUTH_PROXY_URL,
+    MCP_TOOL_INIT_TIMEOUT_SECONDS,
     OPENROUTER_OFFICIAL_PROVIDERS_ONLY,
     PASSWORD_RESET_EXPIRE_MINUTES,
     PREVIEW_TMP_DIR,
@@ -87,6 +91,9 @@ from xagent.config import (
     get_celery_enabled,
     get_celery_result_backend,
     get_database_url,
+    get_db_max_overflow,
+    get_db_pool_size,
+    get_db_pool_timeout_seconds,
     get_default_sqlite_db_path,
     get_default_task_execution_mode,
     get_external_skills_dirs,
@@ -113,6 +120,7 @@ from xagent.config import (
     get_max_upload_size_bytes,
     get_mcp_oauth_allow_private_hosts,
     get_mcp_oauth_proxy_url,
+    get_mcp_tool_init_timeout_seconds,
     get_openrouter_official_providers_only,
     get_password_reset_expire_minutes,
     get_preview_tmp_dir,
@@ -1050,6 +1058,54 @@ class TestGetDatabaseUrl:
         monkeypatch.setenv(DATABASE_URL, "postgresql://user:pass@localhost/db")
         result = get_database_url()
         assert result == "postgresql://user:pass@localhost/db"
+
+
+class TestDbPoolConfig:
+    """Test DB pool sizing getters."""
+
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv(DB_POOL_SIZE, raising=False)
+        monkeypatch.delenv(DB_MAX_OVERFLOW, raising=False)
+        monkeypatch.delenv(DB_POOL_TIMEOUT_SECONDS, raising=False)
+        assert get_db_pool_size() == 10
+        assert get_db_max_overflow() == 20
+        assert get_db_pool_timeout_seconds() == 30
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv(DB_POOL_SIZE, "25")
+        monkeypatch.setenv(DB_MAX_OVERFLOW, "0")
+        monkeypatch.setenv(DB_POOL_TIMEOUT_SECONDS, "5")
+        assert get_db_pool_size() == 25
+        assert get_db_max_overflow() == 0
+        assert get_db_pool_timeout_seconds() == 5
+
+    def test_invalid_values_fall_back(self, monkeypatch):
+        monkeypatch.setenv(DB_POOL_SIZE, "abc")
+        monkeypatch.setenv(DB_MAX_OVERFLOW, "-1")
+        monkeypatch.setenv(DB_POOL_TIMEOUT_SECONDS, "0")
+        assert get_db_pool_size() == 10
+        assert get_db_max_overflow() == 20
+        assert get_db_pool_timeout_seconds() == 30
+
+
+class TestMcpToolInitTimeout:
+    """Test get_mcp_tool_init_timeout_seconds() function."""
+
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv(MCP_TOOL_INIT_TIMEOUT_SECONDS, raising=False)
+        assert get_mcp_tool_init_timeout_seconds() == 60
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(MCP_TOOL_INIT_TIMEOUT_SECONDS, "120")
+        assert get_mcp_tool_init_timeout_seconds() == 120
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv(MCP_TOOL_INIT_TIMEOUT_SECONDS, "0")
+        assert get_mcp_tool_init_timeout_seconds() == 0
+
+    def test_invalid_falls_back(self, monkeypatch):
+        monkeypatch.setenv(MCP_TOOL_INIT_TIMEOUT_SECONDS, "not-a-number")
+        assert get_mcp_tool_init_timeout_seconds() == 60
 
 
 class TestGetSandboxCpus:

--- a/tests/core/test_storage_adhoc_engine.py
+++ b/tests/core/test_storage_adhoc_engine.py
@@ -33,6 +33,26 @@ def test_create_db_session_reuses_one_engine(tmp_path, monkeypatch):
         db2.close()
 
 
+def test_non_sqlite_engine_uses_configured_pool(monkeypatch):
+    """The ad-hoc engine is a SECOND pool in the process; it must honor the
+    same XAGENT_DB_POOL_* tunables as the shared web engine. create_all is
+    stubbed out so no live PostgreSQL is needed — the assertions only
+    concern engine/pool construction."""
+    pytest.importorskip("psycopg2")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:1/nowhere")
+    monkeypatch.setenv("XAGENT_DB_POOL_SIZE", "3")
+    monkeypatch.setenv("XAGENT_DB_MAX_OVERFLOW", "7")
+    monkeypatch.setenv("XAGENT_DB_POOL_TIMEOUT_SECONDS", "11")
+    monkeypatch.setattr(
+        storage_manager.Base.metadata, "create_all", lambda *a, **k: None
+    )
+
+    engine = storage_manager._get_adhoc_engine()
+    assert engine.pool.size() == 3
+    assert engine.pool._max_overflow == 7
+    assert engine.pool._timeout == 11
+
+
 def test_engine_swaps_when_database_url_changes(tmp_path, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/a.db")
     db1 = storage_manager.create_db_session()

--- a/tests/core/test_storage_adhoc_engine.py
+++ b/tests/core/test_storage_adhoc_engine.py
@@ -1,0 +1,47 @@
+"""Tests for the shared ad-hoc engine behind create_db_session (issue #889)."""
+
+import pytest
+
+from xagent.core.storage import manager as storage_manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_adhoc_engine():
+    """Isolate the module-level engine cache between tests."""
+
+    def reset():
+        engine = storage_manager._adhoc_engine
+        storage_manager._adhoc_engine = None
+        storage_manager._adhoc_engine_url = None
+        if engine is not None:
+            engine.dispose()
+
+    reset()
+    yield
+    reset()
+
+
+def test_create_db_session_reuses_one_engine(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/a.db")
+
+    db1 = storage_manager.create_db_session()
+    db2 = storage_manager.create_db_session()
+    try:
+        assert db1.get_bind() is db2.get_bind()
+    finally:
+        db1.close()
+        db2.close()
+
+
+def test_engine_swaps_when_database_url_changes(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/a.db")
+    db1 = storage_manager.create_db_session()
+    bind1 = db1.get_bind()
+    db1.close()
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/b.db")
+    db2 = storage_manager.create_db_session()
+    try:
+        assert db2.get_bind() is not bind1
+    finally:
+        db2.close()

--- a/tests/core/tools/adapters/vibe/test_factory_sandbox_release.py
+++ b/tests/core/tools/adapters/vibe/test_factory_sandbox_release.py
@@ -1,0 +1,87 @@
+"""Regression test for issue #889: the config's DB connection is released
+again before sandbox workspace setup (which awaits external sandbox exec),
+because the override/allowlist loads after the MCP creator's release may
+have re-opened a read transaction."""
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.factory import ToolFactory, ToolRegistry
+
+
+class _FakeSandbox:
+    pass
+
+
+class _FakeConfig:
+    def __init__(self, calls):
+        self._calls = calls
+
+    def get_tool_selection_spec(self):
+        return None
+
+    def get_allowed_tools(self):
+        return None
+
+    def get_user_tool_overrides(self):
+        self._calls.append("load_overrides")
+        return {}
+
+    def get_user_tool_allowlist(self):
+        self._calls.append("load_allowlist")
+        return None
+
+    def release_db_connection(self):
+        self._calls.append("release_db")
+
+    def get_sandbox(self):
+        return _FakeSandbox()
+
+    def get_workspace_config(self):
+        # ``_mock_`` selects MockWorkspace: no on-disk directories.
+        return {"task_id": "_mock_", "base_dir": "/tmp"}
+
+    def get_max_output_length(self):
+        return 10000
+
+    def get_max_field_count(self):
+        return 100
+
+    def get_max_recursion_depth(self):
+        return 5
+
+
+@pytest.mark.asyncio
+async def test_release_db_before_sandbox_workspace_setup(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_create_registered_tools(config):
+        return []
+
+    monkeypatch.setattr(
+        ToolRegistry,
+        "create_registered_tools",
+        staticmethod(fake_create_registered_tools),
+    )
+
+    from xagent.core.tools.adapters.vibe.sandboxed_tool import (
+        sandboxed_tool_wrapper,
+    )
+
+    async def fake_create_workspace_in_sandbox(sandbox, workspace):
+        calls.append("sandbox_exec")
+
+    monkeypatch.setattr(
+        sandboxed_tool_wrapper,
+        "create_workspace_in_sandbox",
+        fake_create_workspace_in_sandbox,
+    )
+
+    await ToolFactory.create_all_tools(_FakeConfig(calls))
+
+    assert "sandbox_exec" in calls
+    assert "release_db" in calls
+    # The DB release happens after the last config DB reads (overrides /
+    # allowlist) and before the sandbox workspace exec.
+    assert calls.index("release_db") > calls.index("load_overrides")
+    assert calls.index("release_db") > calls.index("load_allowlist")
+    assert calls.index("release_db") < calls.index("sandbox_exec")

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #889: a stalled MCP server must not stall
+agent setup (or pin resources) indefinitely."""
+
+import asyncio
+import time
+
+import pytest
+
+from xagent.config import MCP_TOOL_INIT_TIMEOUT_SECONDS
+from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
+from xagent.core.tools.adapters.vibe.mcp_adapter import (
+    _load_server_tools_bounded,
+    load_mcp_tools_as_agent_tools,
+)
+
+
+@pytest.mark.asyncio
+async def test_stalled_server_times_out_and_other_servers_still_load(monkeypatch):
+    """A server whose initialize/list-tools stalls is skipped at the timeout;
+    the remaining servers still load."""
+    monkeypatch.setenv(MCP_TOOL_INIT_TIMEOUT_SECONDS, "1")
+
+    healthy_tool = object()
+
+    async def fake_load_direct(server_name, connection, **kwargs):
+        if server_name == "stalled":
+            await asyncio.Event().wait()  # never completes
+        return [healthy_tool]
+
+    monkeypatch.setattr(mcp_adapter_module, "_load_direct_mcp_tools", fake_load_direct)
+
+    started = time.monotonic()
+    tools = await load_mcp_tools_as_agent_tools(
+        {
+            "stalled": {"transport": "streamable_http", "url": "http://x"},
+            "healthy": {"transport": "streamable_http", "url": "http://y"},
+        }
+    )
+    elapsed = time.monotonic() - started
+
+    assert tools == [healthy_tool]
+    # 1s timeout for the stalled server plus fast healthy load; the old
+    # behavior blocked forever.
+    assert elapsed < 5
+
+
+@pytest.mark.asyncio
+async def test_bounded_load_returns_even_when_cleanup_hangs():
+    """The bound must hold even if the load task ignores cancellation (e.g. a
+    hung streamable-HTTP session blocking in __aexit__)."""
+
+    cleanup_entered = asyncio.Event()
+    # Set by the test AFTER the bounded call returns, so a cleanup exit
+    # before it proves the caller didn't wait. Also lets the abandoned task
+    # finish so pytest-asyncio's loop teardown doesn't hang on it.
+    release_cleanup = asyncio.Event()
+
+    async def uncancellable_load():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_entered.set()
+            # Simulate hung cleanup: swallow cancellation until released.
+            while not release_cleanup.is_set():
+                try:
+                    await asyncio.sleep(0.05)
+                except asyncio.CancelledError:
+                    continue
+        return []  # pragma: no cover
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await _load_server_tools_bounded("hung", uncancellable_load(), 1)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5
+    # The load was cancelled (cleanup began) but the caller did not wait on
+    # it: the bounded call returned while cleanup was still blocked.
+    await asyncio.wait_for(cleanup_entered.wait(), timeout=5)
+    release_cleanup.set()
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_bounded_load_disabled_with_zero_timeout():
+    async def quick_load():
+        return ["tool"]
+
+    assert await _load_server_tools_bounded("s", quick_load(), 0) == ["tool"]
+
+
+@pytest.mark.asyncio
+async def test_bounded_load_passes_result_through():
+    async def quick_load():
+        return ["tool"]
+
+    assert await _load_server_tools_bounded("s", quick_load(), 30) == ["tool"]
+
+
+@pytest.mark.asyncio
+async def test_create_mcp_tools_releases_db_before_network_init(monkeypatch):
+    """The tool config's DB connection is released before the MCP network
+    phase begins, so the handshake never runs inside an open transaction."""
+    from xagent.core.tools.adapters.vibe.factory import ToolFactory
+    from xagent.core.tools.adapters.vibe.mcp_tools import create_mcp_tools
+
+    calls: list[str] = []
+
+    class FakeConfig:
+        def get_tool_selection_spec(self):
+            return None
+
+        async def get_mcp_server_configs(self):
+            calls.append("load_configs")
+            return [
+                {
+                    "name": "srv",
+                    "transport": "streamable_http",
+                    "config": {"url": "http://x"},
+                }
+            ]
+
+        def release_db_connection(self):
+            calls.append("release_db")
+
+        def get_sandbox(self):
+            return None
+
+    async def fake_create(mcp_configs, sandbox=None):
+        calls.append("network_init")
+        return []
+
+    monkeypatch.setattr(
+        ToolFactory,
+        "_create_mcp_tools_from_configs",
+        staticmethod(fake_create),
+    )
+
+    await create_mcp_tools(FakeConfig())
+
+    assert calls == ["load_configs", "release_db", "network_init"]

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -131,6 +131,46 @@ async def test_burst_larger_than_gate_does_not_fan_out(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_caller_cancellation_cancels_child_and_frees_slot(monkeypatch):
+    """Cancelling the caller must propagate to the owned load task —
+    asyncio.wait doesn't do it — or cancelled requests would strand live
+    loads that hold gate slots and transports forever."""
+    monkeypatch.setattr(mcp_adapter_module, "_MAX_INFLIGHT_LOADS_PER_SERVER", 1)
+
+    load_started = asyncio.Event()
+    child_cancelled = asyncio.Event()
+
+    async def hung_but_cancellable_load():
+        load_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            child_cancelled.set()
+            raise
+        return []  # pragma: no cover
+
+    caller = asyncio.create_task(
+        _load_server_tools_bounded("cancel-server", hung_but_cancellable_load(), 30)
+    )
+    await asyncio.wait_for(load_started.wait(), timeout=5)
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    # The child observed the cancellation (it would previously run forever)...
+    await asyncio.wait_for(child_cancelled.wait(), timeout=5)
+
+    # ...and released its slot: with a cap of 1, a fresh load on the same
+    # server can start and complete.
+    async def quick_load():
+        return ["tool"]
+
+    assert await _load_server_tools_bounded("cancel-server", quick_load(), 5) == [
+        "tool"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_bounded_load_disabled_with_zero_timeout():
     async def quick_load():
         return ["tool"]

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -82,6 +82,55 @@ async def test_bounded_load_returns_even_when_cleanup_hangs():
 
 
 @pytest.mark.asyncio
+async def test_burst_larger_than_gate_does_not_fan_out(monkeypatch):
+    """A burst of concurrent loads for the same hung server must not create
+    more underlying load tasks (transports/sockets) than the per-server cap:
+    callers beyond the cap fail fast at the gate without starting a load."""
+    monkeypatch.setattr(mcp_adapter_module, "_MAX_INFLIGHT_LOADS_PER_SERVER", 2)
+
+    started_loads = 0
+    release_cleanup = asyncio.Event()
+
+    async def uncancellable_load():
+        nonlocal started_loads
+        started_loads += 1
+        try:
+            await asyncio.Event().wait()
+        finally:
+            while not release_cleanup.is_set():
+                try:
+                    await asyncio.sleep(0.05)
+                except asyncio.CancelledError:
+                    continue
+        return []  # pragma: no cover
+
+    async def one_caller():
+        with pytest.raises(TimeoutError):
+            await _load_server_tools_bounded("burst-server", uncancellable_load(), 1)
+
+    began = time.monotonic()
+    await asyncio.gather(*(one_caller() for _ in range(6)))
+    elapsed = time.monotonic() - began
+
+    # Every caller returned within its own bound...
+    assert elapsed < 5
+    # ...but only cap-many loads (transports) ever started; the abandoned
+    # ones keep holding their slots so the other four callers failed fast
+    # at the gate.
+    assert started_loads == 2
+
+    # A follow-up caller while both slots are still held by abandoned loads
+    # also fails fast without starting a load.
+    with pytest.raises(TimeoutError):
+        await _load_server_tools_bounded("burst-server", uncancellable_load(), 1)
+    assert started_loads == 2
+
+    # Let the abandoned tasks finish so loop teardown doesn't hang.
+    release_cleanup.set()
+    await asyncio.sleep(0.2)
+
+
+@pytest.mark.asyncio
 async def test_bounded_load_disabled_with_zero_timeout():
     async def quick_load():
         return ["tool"]

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -171,6 +171,45 @@ async def test_caller_cancellation_cancels_child_and_frees_slot(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("timeout_seconds", [0, 30])
+async def test_cancel_while_queued_at_gate_closes_unstarted_coro(
+    monkeypatch, timeout_seconds
+):
+    """Cancelling a caller that is still waiting for a gate slot must close
+    the never-started load coroutine (no 'was never awaited' at GC), in both
+    the timed and the timeout-disabled branches."""
+    import inspect as inspect_mod
+
+    monkeypatch.setattr(mcp_adapter_module, "_MAX_INFLIGHT_LOADS_PER_SERVER", 1)
+    server = f"queued-cancel-{timeout_seconds}"
+
+    release_holder = asyncio.Event()
+
+    async def slot_holder_load():
+        await release_holder.wait()
+        return []
+
+    holder = asyncio.create_task(
+        _load_server_tools_bounded(server, slot_holder_load(), 30)
+    )
+    await asyncio.sleep(0.05)  # holder occupies the single slot
+
+    queued_coro = slot_holder_load()
+    queued = asyncio.create_task(
+        _load_server_tools_bounded(server, queued_coro, timeout_seconds)
+    )
+    await asyncio.sleep(0.05)  # queued caller is waiting at the gate
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await queued
+
+    assert inspect_mod.getcoroutinestate(queued_coro) == "CORO_CLOSED"
+
+    release_holder.set()
+    assert await holder == []
+
+
+@pytest.mark.asyncio
 async def test_bounded_load_disabled_with_zero_timeout():
     async def quick_load():
         return ["tool"]

--- a/tests/web/test_release_db_connection.py
+++ b/tests/web/test_release_db_connection.py
@@ -1,6 +1,6 @@
 """Tests for release_db_connection_if_clean (issue #889)."""
 
-from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy import Column, Integer, String, create_engine, insert, text, update
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from xagent.web.models.database import release_db_connection_if_clean
@@ -59,6 +59,48 @@ def test_keeps_flushed_but_uncommitted_changes():
 
     # After the commit the flush flag is cleared: a fresh read-only
     # transaction is releasable again.
+    db.query(Item).all()
+    assert release_db_connection_if_clean(db) is True
+
+
+def test_keeps_core_dml_insert():
+    """Core DML via Session.execute() never touches new/dirty/deleted and
+    emits no after_flush; the do_orm_execute listener must catch it."""
+    db = _make_session()
+    db.execute(insert(Item).values(name="core"))
+    assert not (db.new or db.dirty or db.deleted)
+
+    assert release_db_connection_if_clean(db) is False
+
+    db.commit()
+    assert db.query(Item).count() == 1
+
+
+def test_keeps_core_dml_update():
+    db = _make_session()
+    db.add(Item(name="one"))
+    db.commit()
+
+    db.execute(update(Item).values(name="core-updated"))
+    assert release_db_connection_if_clean(db) is False
+
+    db.commit()
+    assert db.query(Item).first().name == "core-updated"
+
+
+def test_keeps_textual_statements_conservatively():
+    """text() statements can't be proven read-only; the helper must keep the
+    connection even for a textual SELECT."""
+    db = _make_session()
+    db.execute(text("UPDATE items SET name = 'via-text'"))
+    assert release_db_connection_if_clean(db) is False
+    db.commit()
+
+    db.execute(text("SELECT 1"))
+    assert release_db_connection_if_clean(db) is False
+    db.rollback()
+
+    # A provable ORM SELECT after the rollback is releasable again.
     db.query(Item).all()
     assert release_db_connection_if_clean(db) is True
 

--- a/tests/web/test_release_db_connection.py
+++ b/tests/web/test_release_db_connection.py
@@ -44,6 +44,25 @@ def test_keeps_pending_writes():
     assert db.query(Item).count() == 1
 
 
+def test_keeps_flushed_but_uncommitted_changes():
+    """flush() empties new/dirty/deleted while the transaction still holds
+    unpersisted DML; the helper must not roll that back."""
+    db = _make_session()
+    db.add(Item(name="one"))
+    db.flush()
+    assert not (db.new or db.dirty or db.deleted)
+
+    assert release_db_connection_if_clean(db) is False
+
+    db.commit()
+    assert db.query(Item).count() == 1
+
+    # After the commit the flush flag is cleared: a fresh read-only
+    # transaction is releasable again.
+    db.query(Item).all()
+    assert release_db_connection_if_clean(db) is True
+
+
 def test_keeps_flushed_dirty_changes():
     db = _make_session()
     db.add(Item(name="one"))

--- a/tests/web/test_release_db_connection.py
+++ b/tests/web/test_release_db_connection.py
@@ -105,6 +105,45 @@ def test_keeps_textual_statements_conservatively():
     assert release_db_connection_if_clean(db) is True
 
 
+def test_savepoint_commit_preserves_outer_write_flag():
+    """Savepoint completion must not clear the write flag: after_commit-style
+    events fire for begin_nested() too while the outer transaction (and its
+    flushed writes) is still open."""
+    db = _make_session()
+    db.add(Item(name="outer"))
+    db.flush()
+
+    nested = db.begin_nested()
+    nested.commit()
+
+    assert release_db_connection_if_clean(db) is False
+    db.commit()
+    assert db.query(Item).count() == 1
+
+
+def test_savepoint_rollback_preserves_outer_write_flag():
+    db = _make_session()
+    db.add(Item(name="outer"))
+    db.flush()
+
+    nested = db.begin_nested()
+    nested.rollback()
+
+    assert release_db_connection_if_clean(db) is False
+    db.commit()
+    assert db.query(Item).count() == 1
+
+
+def test_root_rollback_clears_write_flag():
+    db = _make_session()
+    db.add(Item(name="discarded"))
+    db.flush()
+    db.rollback()
+
+    db.query(Item).all()
+    assert release_db_connection_if_clean(db) is True
+
+
 def test_keeps_flushed_dirty_changes():
     db = _make_session()
     db.add(Item(name="one"))

--- a/tests/web/test_release_db_connection.py
+++ b/tests/web/test_release_db_connection.py
@@ -1,0 +1,66 @@
+"""Tests for release_db_connection_if_clean (issue #889)."""
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from xagent.web.models.database import release_db_connection_if_clean
+
+Base = declarative_base()
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+
+
+def _make_session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+
+def test_releases_read_only_transaction():
+    db = _make_session()
+    db.query(Item).all()
+    assert db.in_transaction()
+
+    assert release_db_connection_if_clean(db) is True
+    assert not db.in_transaction()
+
+    # Session stays usable and re-acquires a connection on the next query.
+    assert db.query(Item).all() == []
+
+
+def test_keeps_pending_writes():
+    db = _make_session()
+    db.add(Item(name="pending"))
+
+    assert release_db_connection_if_clean(db) is False
+    assert Item in {type(obj) for obj in db.new} or len(db.new) == 1
+
+    db.commit()
+    assert db.query(Item).count() == 1
+
+
+def test_keeps_flushed_dirty_changes():
+    db = _make_session()
+    db.add(Item(name="one"))
+    db.commit()
+
+    item = db.query(Item).first()
+    item.name = "changed"
+
+    assert release_db_connection_if_clean(db) is False
+    db.commit()
+    assert db.query(Item).first().name == "changed"
+
+
+def test_none_session_is_noop():
+    assert release_db_connection_if_clean(None) is False
+
+
+def test_no_transaction_returns_true():
+    db = _make_session()
+    assert release_db_connection_if_clean(db) is True


### PR DESCRIPTION
## Summary

Fixes #889.

A burst of SDK tasks pointing at a slow or hung Streamable HTTP MCP server pinned every pooled connection in `idle in transaction` (exactly `pool_size + max_overflow = 30` observed in production) and took down unrelated APIs — login, token refresh, task endpoints, health checks.

Two root causes, both fixed:

1. **The task setup/run path held one DB session across external waits.** `execute_task_background` opened a session, ran SELECTs (opening a transaction), then kept the session while awaiting remote MCP initialize/list-tools, sandbox startup, and the entire agent run.
2. **MCP initialization had no timeout.** `session.initialize()` / `load_mcp_tools()` could block forever (plus 3 retries, servers loaded sequentially), so a hung server held the pinned connection indefinitely.

## Changes

### Bounded MCP initialization
- New `_load_server_tools_bounded` wraps each server's load (connect + initialize + list-tools, including retries) with `XAGENT_MCP_TOOL_INIT_TIMEOUT_SECONDS` (default 60s, 0 disables).
- Deliberately not a bare `asyncio.wait_for`: that awaits the cancelled task's cleanup, and a hung streamable-HTTP session can block in `__aexit__` just as easily as in `initialize()`. `asyncio.wait` + fire-and-forget cancel guarantees the caller resumes at the deadline; the abandoned task's eventual result is consumed by a done-callback.
- A timed-out server is skipped; remaining servers still load (existing per-server failure semantics).

### Release the pooled connection across external waits
- New `release_db_connection_if_clean()` ends a session's read transaction and returns the connection to the pool; the session stays usable and re-acquires on its next query. It only rolls back when the session has no pending ORM changes, so nothing uncommitted is ever discarded.
- Called at the four wait boundaries: before the MCP network handshake (via `BaseToolConfig.release_db_connection()` / `WebToolConfig` override), before sandbox startup, before the agent run in `execute_task`, and after each mid-run quota poll in `TaskTracker`.

### Configurable pool sizing
- `XAGENT_DB_POOL_SIZE` / `XAGENT_DB_MAX_OVERFLOW` / `XAGENT_DB_POOL_TIMEOUT_SECONDS` (defaults unchanged: 10/20/30). Documented in `example.env`.

### Ad-hoc engine leak
- `create_db_session()` built a brand-new engine per call and never disposed it, leaving up to a full pool of connections alive until GC (called from workspace file registration among others). It now reuses one process-wide engine, swapped and disposed when `DATABASE_URL` changes.

## Verification (per the issue's criteria)

New regression tests:
- `tests/core/tools/adapters/vibe/test_mcp_init_timeout.py` — a stalled fake MCP server is skipped at the timeout while healthy servers still load; the bound holds even when the load task ignores cancellation (hung cleanup); the tool config's DB connection is released before the network phase begins.
- `tests/web/test_release_db_connection.py` — releases read-only transactions, never touches pending writes (new/dirty), session stays usable afterwards.
- `tests/core/test_storage_adhoc_engine.py` — one engine reused across `create_db_session()` calls; swapped when `DATABASE_URL` changes.
- Config getter tests in `tests/core/test_config.py`.

Existing suites around the touched code (MCP adapter, task tracker, execute-task lease, workspace registration, web tools config) pass; `ruff`, `mypy`, and pre-commit hooks pass.

## Out of scope (follow-ups)
- Per-server single-flight/dedup of concurrent MCP initialization and tool-list caching.
- Queueing/backpressure for task-creation bursts (e.g. via Celery).
