### PR TITLE
fix(task): surface failed task reason live and add a coded-error seam

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { getThemeFromEnv, themes } from "@/lib/theme";
 import { Toaster } from "@/components/ui/sonner";
 import { McpAppsProvider } from "@/contexts/mcp-apps-context";
 import { VoiceInputController } from "@/components/voice-input-controller";
+import { TaskErrorController } from "@/components/task-error-controller";
 
 const branding = getBrandingFromEnv();
 
@@ -121,6 +122,7 @@ export default function RootLayout({
                 <AuthGuard>
                   <LayoutContent>{children}</LayoutContent>
                   <VoiceInputController />
+                  <TaskErrorController />
                   <Toaster />
                 </AuthGuard>
               </McpAppsProvider>

--- a/frontend/src/components/task-error-controller.tsx
+++ b/frontend/src/components/task-error-controller.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+// Reserved seam for surfacing coded terminal task failures (see
+// `@/lib/task-error-events`). Stock xagent has no product-specific errors to
+// present, so this is a no-op. An app-layer overlay can replace this file
+// with a controller that listens for the `xagent:task-error` event and
+// presents its own UI.
+export function TaskErrorController(): null {
+  return null
+}

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -283,6 +283,46 @@ describe("TaskConversationPanel", () => {
     expect(renderedMessages[2]).toHaveTextContent("Done")
   })
 
+  it("renders a terminal failure reason instead of a virtual unknown-error placeholder", () => {
+    // A quota-gate refusal produces a failed result bubble and no trace events.
+    // The bubble must render as the turn's outcome; without it the panel would
+    // fall back to a virtual failed message that shows "unknown error".
+    const quotaReason = "Team quota exhausted for this billing period."
+    appState.messages = [
+      {
+        id: "msg-user",
+        role: "user",
+        content: "Run analysis",
+        timestamp: "1000",
+      },
+      {
+        id: "msg-task-failed",
+        role: "assistant",
+        content: quotaReason,
+        timestamp: "2000",
+        status: "failed",
+        isResult: true,
+      },
+    ] as any
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Task",
+      description: "Task",
+      status: "failed",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as any
+    appState.isHistoryLoading = false
+
+    render(<TaskConversationPanel mode="page" />)
+
+    const renderedMessages = screen.getAllByTestId("chat-message")
+    // Only the user turn and the failure reason — no extra virtual message.
+    expect(renderedMessages).toHaveLength(2)
+    expect(renderedMessages[1]).toHaveTextContent(quotaReason)
+  })
+
   it("applies current task status only to the latest trace process group", () => {
     appState.messages = [
       {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -779,6 +779,44 @@ describe("AppProvider websocket message routing", () => {
     window.removeEventListener(TASK_ERROR_EVENT, listener)
   })
 
+  it("tags the coded-error event with the event's own task id, not the viewed one", async () => {
+    // SeedExistingTask puts the viewer on task 1. A terminal event for a
+    // different task (99) must attribute its dialog to 99 — using the
+    // currently-viewed id would pop the dialog against the wrong task under a
+    // reconnect/task-switch race.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const events: TaskErrorEventDetail[] = []
+    const listener = (e: Event) => events.push((e as CustomEvent<TaskErrorEventDetail>).detail)
+    window.addEventListener(TASK_ERROR_EVENT, listener)
+
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task: { id: 99, status: "failed" },
+        success: false,
+        error_code: "quota_exceeded",
+        error_details: { code: "quota_exceeded", limit: 0 },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(events).toHaveLength(1)
+    })
+    expect(events[0].taskId).toBe(99)
+
+    window.removeEventListener(TASK_ERROR_EVENT, listener)
+  })
+
   it("ignores out-of-order and semantically stale task state events", async () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -599,6 +599,68 @@ describe("AppProvider websocket message routing", () => {
     expect(failureBubble?.content).toBe(quotaReason)
   })
 
+  it("does not suppress a failure reason contained within the user's message", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        data: {
+          event_id: "user-event-with-reason",
+          event_type: "user_message",
+          data: {
+            message: "Why did this quota failure happen?",
+            turn_id: "turn-with-reason",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Why did this quota failure happen?"
+      )
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task: { id: 1, status: "failed" },
+        success: false,
+        output: "quota failure",
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ role: string; content: string; isResult?: boolean }>
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "assistant",
+            content: "quota failure",
+            isResult: true,
+          }),
+        ])
+      )
+    })
+  })
+
   it("emits a coded-error event for the app layer and still shows the reason", async () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -15,9 +15,22 @@ type TestWebSocketMessage = {
 }
 
 const webSocketOptions = vi.hoisted(() => ({
-  current: null as null | { onMessage?: (message: TestWebSocketMessage) => void },
+  current: null as null | {
+    onMessage?: (message: TestWebSocketMessage) => void
+    onConnect?: () => void
+  },
 }))
 const sendChatMessageMock = vi.hoisted(() => vi.fn())
+const wsHarness = vi.hoisted(() => ({ isConnected: true }))
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-wrapper")>()
+  return {
+    ...actual,
+    apiRequest: (...args: unknown[]) => apiRequestMock(...args),
+  }
+})
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
@@ -34,10 +47,11 @@ vi.mock("@/contexts/i18n-context", () => ({
 vi.mock("@/hooks/use-websocket", () => ({
   useWebSocket: (options: {
     onMessage?: (message: TestWebSocketMessage) => void
+    onConnect?: () => void
   }) => {
     webSocketOptions.current = options
     return {
-      isConnected: true,
+      isConnected: wsHarness.isConnected,
       connectionError: null,
       sendChatMessage: sendChatMessageMock,
       executeTask: vi.fn(),
@@ -63,6 +77,7 @@ import {
   extractTaskControlEnvelope,
   useApp,
 } from "./app-context-chat"
+import { TASK_ERROR_EVENT, type TaskErrorEventDetail } from "@/lib/task-error-events"
 
 type TaskControlMessage = Parameters<typeof extractTaskControlEnvelope>[0]
 
@@ -82,6 +97,7 @@ function StateProbe() {
             content:
               typeof message.content === "string" ? message.content : "react-node",
             isOptimistic: message.isOptimistic,
+            isResult: message.isResult,
           }))
         )}
       </div>
@@ -198,6 +214,8 @@ describe("task control envelope parsing", () => {
 describe("AppProvider websocket message routing", () => {
   beforeEach(() => {
     webSocketOptions.current = null
+    wsHarness.isConnected = true
+    apiRequestMock.mockReset()
     sendChatMessageMock.mockReset()
     sendChatMessageMock.mockResolvedValue({
       client_message_id: "turn-optimistic",
@@ -416,6 +434,66 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("shows the sender's message live when a new task's run dies before tracing", async () => {
+    // A run refused at the quota gate returns before agent tracing starts, so
+    // the live user_message trace event is never emitted. The sender's bubble
+    // must come from the optimistic copy added once delivery is acknowledged —
+    // without it the message only appears after a reload replays the transcript.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        task_id: 7,
+        title: "hello quota",
+        description: "hello quota",
+        status: "pending",
+      }),
+    })
+
+    let send: ((message: string) => Promise<void>) | undefined
+    function CreateTaskProbe() {
+      const { sendMessage } = useApp()
+      send = (message: string) =>
+        sendMessage(message, { clientMessageId: "turn-create" })
+      return null
+    }
+
+    // The freshly created task's socket has not connected yet.
+    wsHarness.isConnected = false
+    render(
+      <AppProvider token="token">
+        <CreateTaskProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = send?.("hello quota")
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // The socket for task 7 connects; the queued message is delivered and acked.
+    await act(async () => {
+      wsHarness.isConnected = true
+      webSocketOptions.current?.onConnect?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await act(async () => {
+      await delivery
+    })
+
+    const messages = JSON.parse(
+      screen.getByTestId("messages").textContent || "[]"
+    ) as Array<{ role: string; content: string; isOptimistic?: boolean }>
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "hello quota",
+        isOptimistic: true,
+      }),
+    ])
+  })
+
   it("does not crash on a trace event without data", () => {
     render(
       <AppProvider token="token">
@@ -470,6 +548,115 @@ describe("AppProvider websocket message routing", () => {
       expect(screen.getByTestId("task-status").textContent).toBe("failed")
       expect(screen.getByTestId("processing").textContent).toBe("false")
     })
+  })
+
+  it("surfaces the failure reason from a failed task_completed payload", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    // Quota-gate refusals never stream a message; the reason arrives only in the
+    // terminal event's output. It must render live, not just after a reload.
+    const quotaReason =
+      "Team quota exhausted for this billing period."
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task: {
+          id: 1,
+          status: "failed",
+        },
+        success: false,
+        output: quotaReason,
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      expect(screen.getByTestId("messages").textContent).toContain(quotaReason)
+    })
+    // The bubble must be flagged as the turn's result; the conversation panel
+    // filters out assistant messages without it, so an unflagged reason never
+    // renders and the UI degrades to a generic "unknown error" until reload.
+    const messages = JSON.parse(screen.getByTestId("messages").textContent || "[]")
+    const failureBubble = messages.find((m: { content: string }) =>
+      m.content.includes(quotaReason)
+    )
+    expect(failureBubble?.isResult).toBe(true)
+    // Verbatim, no live-only prefix: reload replays the persisted transcript
+    // row with this exact text, and the two views must match.
+    expect(failureBubble?.content).toBe(quotaReason)
+  })
+
+  it("emits a coded-error event for the app layer and still shows the reason", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    const events: TaskErrorEventDetail[] = []
+    const listener = (e: Event) => events.push((e as CustomEvent<TaskErrorEventDetail>).detail)
+    window.addEventListener(TASK_ERROR_EVENT, listener)
+
+    // Real coded-gate terminal events omit output/result; the reason rides in
+    // error_details.message.
+    const details = {
+      code: "quota_exceeded",
+      metric: "runs_per_month",
+      limit: 0,
+      message: "Team quota exhausted.",
+    }
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task: { id: 1, status: "failed" },
+        success: false,
+        error_code: "quota_exceeded",
+        error_details: details,
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      // The code is handed to the app layer via the event (drives the dialog)...
+      expect(events).toHaveLength(1)
+    })
+    expect(events[0].code).toBe("quota_exceeded")
+    expect(events[0].details).toEqual(details)
+    // ...and the reason (from error_details.message) still shows live in chat,
+    // matching a page reload, instead of an empty "unknown error" turn.
+    expect(screen.getByTestId("messages").textContent).toContain(
+      "Team quota exhausted."
+    )
+    const codedMessages = JSON.parse(screen.getByTestId("messages").textContent || "[]")
+    const codedBubble = codedMessages.find((m: { content: string }) =>
+      m.content.includes("Team quota exhausted.")
+    )
+    expect(codedBubble?.isResult).toBe(true)
+    expect(codedBubble?.content).toBe("Team quota exhausted.")
+
+    window.removeEventListener(TASK_ERROR_EVENT, listener)
   })
 
   it("ignores out-of-order and semantically stale task state events", async () => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -434,6 +434,64 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("does not append an acknowledged optimistic message after switching tasks", async () => {
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({
+              client_message_id: "turn-switch",
+              turn_id: "turn-switch",
+            })
+        })
+    )
+
+    let send: (() => Promise<void>) | undefined
+    let switchTask: (() => void) | undefined
+    function SwitchingTaskProbe() {
+      const { sendMessage, setTaskId } = useApp()
+      send = () =>
+        sendMessage("Message for task one", {
+          clientMessageId: "turn-switch",
+        })
+      switchTask = () => setTaskId(2, { navigate: false })
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SwitchingTaskProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = send?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    act(() => {
+      switchTask?.()
+    })
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+
+    const messages = JSON.parse(
+      screen.getByTestId("messages").textContent || "[]"
+    ) as Array<{ content: string }>
+    expect(messages).toEqual([])
+  })
+
   it("shows the sender's message live when a new task's run dies before tracing", async () => {
     // A run refused at the quota gate returns before agent tracing starts, so
     // the live user_message trace event is never emitted. The sender's bubble

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -131,6 +131,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 import { normalizeTaskCompletedMessage } from "@/lib/task-completion"
+import { emitTaskError } from "@/lib/task-error-events"
 import { isStoppedTaskStatus, normalizeTaskStatus, type TaskStatus } from "@/lib/task-status"
 import {
   getFinalAnswerStreamActionPayload,
@@ -3975,6 +3976,56 @@ export function AppProvider({
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
         dispatch({ type: "SET_PROCESSING", payload: false })  // Stop processing on task completion
 
+        if (!taskData.success) {
+          // error_details carries the structured reason ({code, ..., message});
+          // fall back to its message when the terminal event omits output/result,
+          // so the reason still shows instead of an empty turn degrading to
+          // "unknown error".
+          const failureReason =
+            getString(taskData.output) ||
+            getString(taskData.result) ||
+            getString(taskData.errorDetails?.message)
+          // Coded failures (e.g. a quota-gate refusal) also notify the app
+          // layer so it can surface them richly (see task-error-events). Stock
+          // xagent has a no-op controller and only an app layer ever sets a code.
+          if (taskData.errorCode) {
+            emitTaskError({
+              code: taskData.errorCode,
+              details: taskData.errorDetails,
+              message: failureReason,
+              taskId: currentState.taskId ?? null,
+            })
+          }
+          // Surface the reason live as a failed assistant message so the
+          // conversation matches what a page reload shows. Guard only against an
+          // adjacent duplicate (same reason already the last message) rather than
+          // a TTL cache — a re-executed turn re-emits the same terminal event and
+          // a content-TTL dedup would drop the bubble, leaving an empty turn.
+          const lastMessage = currentState.messages[currentState.messages.length - 1]
+          const lastContent =
+            typeof lastMessage?.content === "string" ? lastMessage.content : ""
+          if (failureReason && !lastContent.includes(failureReason)) {
+            dispatch({
+              type: "ADD_MESSAGE",
+              payload: {
+                id: generateMessageId("msg-task-failed"),
+                role: "assistant",
+                // The reason verbatim, no prefix: a reload replays the
+                // persisted transcript row (this same text), so any live-only
+                // decoration would make the two views diverge.
+                content: failureReason,
+                timestamp: message.timestamp,
+                status: "failed",
+                // Terminal failure IS this turn's result. Without the flag the
+                // conversation panel (which only shows user / isResult /
+                // system-notice messages) filters the bubble out and falls back
+                // to a virtual "unknown error" placeholder until reload.
+                isResult: true,
+              },
+            })
+          }
+        }
+
         // Update DAG execution status to completed
         if (state.dagExecution) {
           const updatedDAGExecution = {
@@ -4333,6 +4384,40 @@ export function AppProvider({
     const clientMessageId = typeof config?.clientMessageId === 'string'
       ? config.clientMessageId
       : generateClientMessageId()
+
+    // Optimistic copy of the sender's own bubble, added once delivery is
+    // acknowledged. The live user_message trace event only exists after the
+    // agent run actually starts — a run refused before that (e.g. the quota
+    // gate) never emits it, so without this copy the sender's message stays
+    // invisible until a reload replays the persisted transcript row. The
+    // reducer reconciles by turn id / content, keeping the persisted event
+    // when it already arrived and replacing this copy when it arrives later.
+    const addOptimisticUserMessage = () => {
+      let content: React.ReactNode = message
+      if (files && files.length > 0) {
+        content = (
+          <UserMessageContent
+            message={message}
+            files={files.map(f => ({
+              name: f.name,
+              type: f.type,
+              size: f.size,
+            }))}
+          />
+        )
+      }
+      dispatch({
+        type: "ADD_MESSAGE",
+        payload: {
+          id: userTurnMessageId(clientMessageId),
+          role: "user",
+          content: content,
+          timestamp: Date.now().toString(),
+          isOptimistic: true,
+        }
+      })
+    }
+
     const targetTaskId = typeof config?.targetTaskId === 'number' ? config.targetTaskId : null
     if (targetTaskId !== null && state.taskId !== targetTaskId) {
       await queuePendingMessage({
@@ -4342,6 +4427,7 @@ export function AppProvider({
         force: config?.force,
         clientMessageId,
       })
+      addOptimisticUserMessage()
       return
     }
 
@@ -4499,6 +4585,7 @@ export function AppProvider({
             force: config?.force,
             clientMessageId,
           })
+          addOptimisticUserMessage()
         } else {
           const parsed = await parseApiResponse(response)
           const errorMessage = getApiErrorMessage(
@@ -4537,34 +4624,7 @@ export function AppProvider({
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
       }
 
-      // The user_message trace usually arrives before the acknowledgement. Add
-      // a stable optimistic copy either way; the reducer keeps the persisted
-      // event when it already arrived and replaces this copy when it arrives
-      // later.
-      let content: React.ReactNode = message
-      if (files && files.length > 0) {
-        content = (
-          <UserMessageContent
-            message={message}
-            files={files.map(f => ({
-              name: f.name,
-              type: f.type,
-              size: f.size,
-            }))}
-          />
-        )
-      }
-
-      dispatch({
-        type: "ADD_MESSAGE",
-        payload: {
-          id: userTurnMessageId(clientMessageId),
-          role: "user",
-          content: content,
-          timestamp: Date.now().toString(),
-          isOptimistic: true,
-        }
-      })
+      addOptimisticUserMessage()
     }
   }, [state.taskId, sendChatMessage, wsExecuteTask, state.currentTask?.status, queuePendingMessage])
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -4004,7 +4004,7 @@ export function AppProvider({
           const lastMessage = currentState.messages[currentState.messages.length - 1]
           const lastContent =
             typeof lastMessage?.content === "string" ? lastMessage.content : ""
-          if (failureReason && !lastContent.includes(failureReason)) {
+          if (failureReason && lastContent !== failureReason) {
             dispatch({
               type: "ADD_MESSAGE",
               payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -3978,22 +3978,25 @@ export function AppProvider({
 
         if (!taskData.success) {
           // error_details carries the structured reason ({code, ..., message});
-          // fall back to its message when the terminal event omits output/result,
-          // so the reason still shows instead of an empty turn degrading to
-          // "unknown error".
+          // fall back to its message when the terminal event omits output. The
+          // broadcast always sets `result` === `output`, so `result` is not a
+          // distinct source and is intentionally not consulted here.
           const failureReason =
             getString(taskData.output) ||
-            getString(taskData.result) ||
             getString(taskData.errorDetails?.message)
           // Coded failures (e.g. a quota-gate refusal) also notify the app
           // layer so it can surface them richly (see task-error-events). Stock
           // xagent has a no-op controller and only an app layer ever sets a code.
+          // Not gated on failureReason: the coded dialog carries its own copy
+          // and must still fire when the reason is empty. Tag it with the
+          // event's own task id (not the currently-viewed one) so a dialog
+          // cannot be attributed to the wrong task under a task-switch race.
           if (taskData.errorCode) {
             emitTaskError({
               code: taskData.errorCode,
               details: taskData.errorDetails,
               message: failureReason,
-              taskId: currentState.taskId ?? null,
+              taskId: controlEnvelope.taskId ?? currentState.taskId ?? null,
             })
           }
           // Surface the reason live as a failed assistant message so the

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -4392,7 +4392,13 @@ export function AppProvider({
     // invisible until a reload replays the persisted transcript row. The
     // reducer reconciles by turn id / content, keeping the persisted event
     // when it already arrived and replacing this copy when it arrives later.
-    const addOptimisticUserMessage = () => {
+    const addOptimisticUserMessage = (intendedTaskId: number) => {
+      // Delivery acknowledgement can arrive after the user has navigated to a
+      // different task. Never append this turn to whichever task happens to be
+      // active when the async send resumes.
+      if (stateRef.current.taskId !== intendedTaskId) {
+        return
+      }
       let content: React.ReactNode = message
       if (files && files.length > 0) {
         content = (
@@ -4427,7 +4433,7 @@ export function AppProvider({
         force: config?.force,
         clientMessageId,
       })
-      addOptimisticUserMessage()
+      addOptimisticUserMessage(targetTaskId)
       return
     }
 
@@ -4585,7 +4591,7 @@ export function AppProvider({
             force: config?.force,
             clientMessageId,
           })
-          addOptimisticUserMessage()
+          addOptimisticUserMessage(newTaskId)
         } else {
           const parsed = await parseApiResponse(response)
           const errorMessage = getApiErrorMessage(
@@ -4624,7 +4630,7 @@ export function AppProvider({
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
       }
 
-      addOptimisticUserMessage()
+      addOptimisticUserMessage(state.taskId)
     }
   }, [state.taskId, sendChatMessage, wsExecuteTask, state.currentTask?.status, queuePendingMessage])
 

--- a/frontend/src/lib/task-completion.test.ts
+++ b/frontend/src/lib/task-completion.test.ts
@@ -78,4 +78,23 @@ describe("task-completion", () => {
       expect(payload.errorDetails).toBeUndefined()
     }
   )
+
+  it("normalizes a coded failure's error_code and plain-object error_details", () => {
+    const payload = normalizeTaskCompletedMessage({
+      type: "task_completed",
+      task: { status: "failed" },
+      success: false,
+      output: "quota reason",
+      error_code: "quota_exceeded",
+      error_details: { code: "quota_exceeded", limit: 0, plan: "free" },
+    })
+
+    expect(payload.status).toBe("failed")
+    expect(payload.errorCode).toBe("quota_exceeded")
+    expect(payload.errorDetails).toEqual({
+      code: "quota_exceeded",
+      limit: 0,
+      plan: "free",
+    })
+  })
 })

--- a/frontend/src/lib/task-completion.test.ts
+++ b/frontend/src/lib/task-completion.test.ts
@@ -65,4 +65,17 @@ describe("task-completion", () => {
     expect(payload.status).toBe("completed")
     expect(payload.success).toBe(true)
   })
+
+  it.each([null, "invalid", ["invalid"]])(
+    "rejects malformed error details: %j",
+    (errorDetails) => {
+      const payload = normalizeTaskCompletedMessage({
+        type: "task_completed",
+        success: false,
+        error_details: errorDetails,
+      })
+
+      expect(payload.errorDetails).toBeUndefined()
+    }
+  )
 })

--- a/frontend/src/lib/task-completion.ts
+++ b/frontend/src/lib/task-completion.ts
@@ -73,7 +73,9 @@ export const normalizeTaskCompletedMessage = (
     metadata: payload.metadata,
     errorCode: typeof payload.error_code === "string" ? payload.error_code : undefined,
     errorDetails:
-      payload.error_details && typeof payload.error_details === "object"
+      payload.error_details &&
+      typeof payload.error_details === "object" &&
+      !Array.isArray(payload.error_details)
         ? (payload.error_details as Record<string, unknown>)
         : undefined,
   }

--- a/frontend/src/lib/task-completion.ts
+++ b/frontend/src/lib/task-completion.ts
@@ -15,6 +15,8 @@ type TaskCompletedRecord = {
   file_outputs?: unknown
   chat_response?: unknown
   metadata?: unknown
+  error_code?: unknown
+  error_details?: unknown
 }
 
 export type NormalizedTaskCompletion = {
@@ -26,6 +28,8 @@ export type NormalizedTaskCompletion = {
   fileOutputs: Array<string | Record<string, unknown>>
   chatResponse?: unknown
   metadata?: unknown
+  errorCode?: string
+  errorDetails?: Record<string, unknown>
 }
 
 const asRecord = (value: unknown): TaskCompletedRecord | null => {
@@ -67,5 +71,10 @@ export const normalizeTaskCompletedMessage = (
     fileOutputs,
     chatResponse: payload.chat_response,
     metadata: payload.metadata,
+    errorCode: typeof payload.error_code === "string" ? payload.error_code : undefined,
+    errorDetails:
+      payload.error_details && typeof payload.error_details === "object"
+        ? (payload.error_details as Record<string, unknown>)
+        : undefined,
   }
 }

--- a/frontend/src/lib/task-error-events.ts
+++ b/frontend/src/lib/task-error-events.ts
@@ -1,0 +1,25 @@
+// Seam for surfacing coded terminal task failures to an app layer.
+//
+// Core stays quota/billing-agnostic: when a task ends with a machine-readable
+// error_code (e.g. "quota_exceeded"), the chat context emits this event instead
+// of hardcoding any product-specific copy or UI. Stock xagent mounts a no-op
+// `TaskErrorController`, so nothing happens. An app layer (e.g. xagent-cloud)
+// replaces that controller to present its own dialog — mirroring the backend
+// quota-hook seam, where core forwards a code and the app layer decides what
+// it means.
+
+export const TASK_ERROR_EVENT = "xagent:task-error"
+
+export interface TaskErrorEventDetail {
+  code: string
+  details?: Record<string, unknown>
+  // Backend's human-readable fallback message; the app layer can show its own
+  // localized copy instead and keep this as a fallback.
+  message: string
+  taskId: number | null
+}
+
+export function emitTaskError(detail: TaskErrorEventDetail): void {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent<TaskErrorEventDetail>(TASK_ERROR_EVENT, { detail }))
+}

--- a/frontend/src/lib/task-error-events.ts
+++ b/frontend/src/lib/task-error-events.ts
@@ -7,14 +7,19 @@
 // replaces that controller to present its own dialog — mirroring the backend
 // quota-hook seam, where core forwards a code and the app layer decides what
 // it means.
+//
+// The event fires only on the live terminal task_completed event, not on
+// history replay after a reload — a reloaded failed task shows its reason in
+// the transcript bubble, but the transient dialog is not re-raised.
 
 export const TASK_ERROR_EVENT = "xagent:task-error"
 
 export interface TaskErrorEventDetail {
   code: string
   details?: Record<string, unknown>
-  // Backend's human-readable fallback message; the app layer can show its own
-  // localized copy instead and keep this as a fallback.
+  // Backend's human-readable fallback message. May be an empty string when the
+  // terminal event carried a code but no reason text; the app layer can show
+  // its own localized copy instead and keep this as a fallback.
   message: string
   taskId: number | null
 }

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2230,6 +2230,11 @@ class AgentServiceManager:
                         error_code = gate_reason.get("code")
                         error_details = dict(gate_reason)
                     else:
+                        # Legacy/plain-string path: a hook that returns a bare
+                        # message (the pre-structured shape) is assumed to be a
+                        # quota refusal. The only shipped hook returns a Mapping,
+                        # so this stays for back-compat with string-returning
+                        # app layers.
                         reason_message = str(gate_reason)
                         error_code = "quota_exceeded"
                         error_details = None
@@ -2338,6 +2343,10 @@ class AgentServiceManager:
                         "status": "quota_exceeded",
                         "output": quota_reason,
                         "error": quota_reason,
+                        # A mid-run interrupt is always the quota checker, so the
+                        # code is known even though the reason is a plain string.
+                        # Match the start gate so the client pops the same dialog.
+                        "error_code": "quota_exceeded",
                     }
 
             logger.info("=== Task executed successfully, updating title if needed ===")

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2219,14 +2219,27 @@ class AgentServiceManager:
                     db_session, getattr(gate_task, "user_id", None)
                 )
                 if gate_reason:
-                    # `output` is what every result consumer surfaces as the
-                    # assistant message; set it so the quota reason reaches the
-                    # user instead of a misleading "Task completed".
+                    # The gate returns either a plain message or a structured
+                    # mapping ({code, metric, limit, plan, message}). Surface the
+                    # message as `output` (what every result consumer shows as
+                    # the assistant reply) and forward the structured fields as
+                    # error_code/error_details so the client can localise and
+                    # branch (e.g. Free vs paid) without parsing the message.
+                    if isinstance(gate_reason, Mapping):
+                        reason_message = str(gate_reason.get("message") or "")
+                        error_code = gate_reason.get("code")
+                        error_details = dict(gate_reason)
+                    else:
+                        reason_message = str(gate_reason)
+                        error_code = "quota_exceeded"
+                        error_details = None
                     return {
                         "success": False,
                         "status": "quota_exceeded",
-                        "output": gate_reason,
-                        "error": gate_reason,
+                        "output": reason_message,
+                        "error": reason_message,
+                        "error_code": error_code,
+                        "error_details": error_details,
                     }
             except Exception:
                 logger.warning("Quota gate check failed open", exc_info=True)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1770,6 +1770,11 @@ async def execute_task_background(
                 "output": ai_response,
                 "file_outputs": normalized_outputs,
                 "success": result.get("success", False),
+                # Machine-readable failure classification (e.g. "quota_exceeded")
+                # plus its structured details, so the client can localise and
+                # branch instead of parsing the message. Absent for normal turns.
+                "error_code": result.get("error_code"),
+                "error_details": result.get("error_details"),
                 **control_event_state,
                 "chat_response": chat_response
                 if isinstance(chat_response, dict)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1464,14 +1464,19 @@ async def execute_task_background(
         if normalized_outputs:
             result["file_outputs"] = normalized_outputs
 
-        # Get AI response
+        # Get AI response. A failed turn has no assistant reply, so it must not
+        # inherit the "Task completed" success sentinel: the frontend reads
+        # `output` as the failure reason, so the sentinel would render (and
+        # persist) a misleading "Task completed" bubble on a failed task. Fall
+        # back to the sentinel only when the turn actually succeeded.
+        default_response = "Task completed" if result.get("success", False) else ""
         chat_response = result.get("chat_response")
         if isinstance(chat_response, dict):
             ai_response = chat_response.get("message") or result.get(
-                "output", "Task completed"
+                "output", default_response
             )
         else:
-            ai_response = result.get("output", "Task completed")
+            ai_response = result.get("output", default_response)
 
         # Rewrite file links to file_id
         ai_response = _rewrite_file_links_to_file_id(
@@ -2117,6 +2122,9 @@ async def execute_resume_background(
                     "status": "quota_exceeded",
                     "output": _quota_reason,
                     "error": _quota_reason,
+                    # A mid-run interrupt is always the quota checker, so forward
+                    # the code the way the start gate does (see chat.py).
+                    "error_code": "quota_exceeded",
                 }
 
         status = str(result.get("status") or "")
@@ -2260,6 +2268,10 @@ async def execute_resume_background(
                 "output": output,
                 "file_outputs": normalized_outputs,
                 "success": success,
+                # Forward the coded reason so a mid-run quota interrupt on a
+                # resumed run pops the same dialog as the start-gate path.
+                "error_code": result.get("error_code"),
+                "error_details": result.get("error_details"),
                 **control_event_state,
                 "metadata": result.get("metadata", {}),
                 "timestamp": datetime.now(timezone.utc).timestamp(),
@@ -4394,6 +4406,11 @@ async def handle_execute_task(
                     "status": task.status.value,
                     "result": result.get("output", ""),
                     "output": result.get("output", ""),
+                    # Same coded-reason forwarding as the primary completion
+                    # broadcast, so a coded failure on this path (e.g. a mid-run
+                    # quota interrupt) still reaches the app-layer dialog.
+                    "error_code": result.get("error_code"),
+                    "error_details": result.get("error_details"),
                     "chat_response": result.get("chat_response"),
                     "metadata": result.get("metadata", {}),
                     "file_outputs": file_outputs,  # Add file output info

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -10,10 +10,15 @@ Follows the same setter/getter idiom as set_user_tool_overrides_hook etc.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Callable
 
-# (db, user_id) -> reason str if the team is out of quota (block the run), else None
-_run_gate_hook: Callable[[Any, Any], str | None] | None = None
+# (db, user_id) -> reason if the team is out of quota (block the run), else None.
+# The reason is either a plain message str or a structured mapping the app layer
+# builds (e.g. {"code","metric","limit","plan","message"}). Core does not
+# interpret the structure — it forwards it to the run result so the client can
+# localise / branch on it; ``message`` is the human-readable fallback.
+_run_gate_hook: Callable[[Any, Any], "str | Mapping[str, Any] | None"] | None = None
 # (db, user_id, delta_details, delta_actions) -> None; best-effort post-run
 # metering. delta_details is this turn's per-model token breakdown (list of
 # {"type","tokens","model"}) for cost-based credits; delta_actions counts tool
@@ -75,7 +80,7 @@ def set_trigger_record_hook(hook: Callable[[Any], None] | None) -> None:
     _trigger_record_hook = hook
 
 
-def check_run_gate(db: Any, user_id: Any) -> str | None:
+def check_run_gate(db: Any, user_id: Any) -> "str | Mapping[str, Any] | None":
     if _run_gate_hook is None or user_id is None:
         return None
     return _run_gate_hook(db, user_id)

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -18,7 +18,7 @@ from typing import Any, Callable
 # builds (e.g. {"code","metric","limit","plan","message"}). Core does not
 # interpret the structure — it forwards it to the run result so the client can
 # localise / branch on it; ``message`` is the human-readable fallback.
-_run_gate_hook: Callable[[Any, Any], "str | Mapping[str, Any] | None"] | None = None
+_run_gate_hook: Callable[[Any, Any], str | Mapping[str, Any] | None] | None = None
 # (db, user_id, delta_details, delta_actions) -> None; best-effort post-run
 # metering. delta_details is this turn's per-model token breakdown (list of
 # {"type","tokens","model"}) for cost-based credits; delta_actions counts tool
@@ -80,7 +80,7 @@ def set_trigger_record_hook(hook: Callable[[Any], None] | None) -> None:
     _trigger_record_hook = hook
 
 
-def check_run_gate(db: Any, user_id: Any) -> "str | Mapping[str, Any] | None":
+def check_run_gate(db: Any, user_id: Any) -> str | Mapping[str, Any] | None:
     if _run_gate_hook is None or user_id is None:
         return None
     return _run_gate_hook(db, user_id)

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -214,6 +214,9 @@ async def test_execute_task_surfaces_mid_run_quota_reason(db_session) -> None:
     assert result["success"] is False
     assert result["output"] == reason
     assert result["error"] == reason
+    # A mid-run interrupt is always the quota checker, so the result carries the
+    # code (matching the start gate) to drive the app-layer dialog.
+    assert result["error_code"] == "quota_exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -217,6 +217,51 @@ async def test_execute_task_surfaces_mid_run_quota_reason(db_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_task_start_gate_forwards_structured_reason(db_session) -> None:
+    """When the start gate returns a structured reason (mapping), the run result
+    carries its message plus error_code/error_details so the client can localise
+    and branch, instead of only a plain string."""
+    user = User(username="quota-start-user", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    task = Task(
+        user_id=user.id,
+        title="quota start test",
+        description="test",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+    )
+    db_session.add(task)
+    db_session.commit()
+
+    manager = AgentServiceManager()
+    block = {
+        "code": "quota_exceeded",
+        "metric": "runs_per_month",
+        "limit": 0,
+        "plan": "basic",
+        "message": "Team quota exhausted for this billing period.",
+    }
+
+    # The gate short-circuits before lease/tracker/execution, so a patched
+    # check_run_gate returning the structured block is enough.
+    with patch("xagent.web.services.quota_hooks.check_run_gate", return_value=block):
+        result = await manager.execute_task(
+            agent_service=_FakeAgentService(),
+            task="hello",
+            tracking_task_id=str(task.id),
+            db_session=db_session,
+            manage_task_lease=False,
+        )
+
+    assert result["status"] == "quota_exceeded"
+    assert result["success"] is False
+    assert result["output"] == block["message"]
+    assert result["error_code"] == "quota_exceeded"
+    assert result["error_details"] == block
+
+
+@pytest.mark.asyncio
 async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
     db_session,
 ) -> None:


### PR DESCRIPTION
## Problem

Creating a task whose first run is refused before execution starts (e.g. an
app-layer quota gate) degraded badly in the live view, and only a page reload
showed the truth:

1. The chat showed a generic red "unknown error" instead of the refusal reason.
2. The sender's own message was invisible.
3. After a reload both rendered correctly, so the live view and the replayed
   view disagreed.

## Root causes

- **Reason dropped by the conversation panel.** The failed turn's reason rides
  in the terminal `task_completed` event and the chat context did add a failed
  assistant bubble — but without `isResult`, and the conversation panel only
  renders user / result / system-notice messages. The invisible bubble left an
  empty failed turn, which the panel rendered as a virtual "unknown error"
  placeholder.
- **No user_message event before tracing.** The sender's bubble normally comes
  from the `user_message` trace event, emitted once the agent run starts. A run
  refused at the run-start gate returns before tracing, so the event never
  fires. The new-task send path (unlike the existing-task path) never added an
  optimistic copy, so nothing rendered until a reload replayed the persisted
  transcript row.

## Changes

Frontend:
- Flag the terminal failure bubble as the turn's result (`isResult: true`) so
  the conversation panel renders it, and use the reason verbatim (no live-only
  "execution error" prefix) — a reload replays the persisted transcript row
  with the exact same text, so the two views now match.
- Add the optimistic sender bubble on the new-task and queued send paths once
  delivery is acknowledged, reusing the existing reconciliation machinery
  (turn id / content matching), so a run that dies before tracing still shows
  the sender's message. The existing-task path already did this.
- Coded-error seam: when a terminal event carries an `error_code`, the chat
  context emits an `xagent:task-error` CustomEvent with the code, structured
  details and fallback message. A no-op `TaskErrorController` is mounted as the
  reserved seam; an app layer can replace it to present product-specific UI
  (e.g. a plan-aware quota dialog). Stock xagent never sets a code, so behavior
  is unchanged there.

Backend:
- The run-start gate hook may now return a structured reason
  (`{code, metric, limit, plan, message}`) instead of a plain string. Core
  forwards it opaquely into the run result and the `task_completed` broadcast
  as `error_code` / `error_details`; the quota-hook seam stays quota-agnostic.

## Tests

- `task_completed` failure payloads: reason surfaces live, bubble is
  result-flagged and verbatim, coded failures emit the `xagent:task-error`
  event with code + details.
- Conversation panel renders a terminal failure reason instead of the virtual
  unknown-error placeholder.
- New-task send: the sender's bubble appears after delivery acknowledgement
  even when no `user_message` trace event ever arrives.
- Run-start gate: structured mappings and plain strings both propagate into
  the run result (`tests/web/test_execute_task_manage_task_lease.py`).
