### PR TITLE
fix: Gmail trigger OAuth expiry timezone and Pub/Sub provisioning (#807)

### DIFF
--- a/example.env
+++ b/example.env
@@ -115,6 +115,10 @@ PORT="80"
 # Deterministic per-mailbox resource names: {prefix}-{mailbox-hash}.
 # XAGENT_GMAIL_PUBSUB_TOPIC_PREFIX="xagent-gmail"
 # XAGENT_GMAIL_PUBSUB_SUBSCRIPTION_PREFIX="xagent-gmail-push"
+# Pub/Sub client transport: "grpc" (default) or "rest". Use "rest" behind
+# egress proxies that cannot tunnel gRPC (the gRPC channel hangs there and
+# Gmail provisioning stays pending without an error).
+# XAGENT_GMAIL_PUBSUB_TRANSPORT="grpc"
 # Public base URL of this backend API. A2A Agent Cards advertise interfaces
 # under this base; MCP OAuth and Pub/Sub use it for externally reachable
 # callbacks. This is NOT the frontend URL (XAGENT_APP_BASE_URL).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,7 @@ module = [
   "joblib",
   "xrouter_llm",
   "xrouter_llm.*",
+  "google.pubsub_v1",
 ]
 ignore_missing_imports = true
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -103,6 +103,7 @@ GMAIL_PUBSUB_PROJECT_ID = "XAGENT_GMAIL_PUBSUB_PROJECT_ID"
 GMAIL_PUBSUB_TOPIC_PREFIX = "XAGENT_GMAIL_PUBSUB_TOPIC_PREFIX"
 GMAIL_PUBSUB_SUBSCRIPTION_PREFIX = "XAGENT_GMAIL_PUBSUB_SUBSCRIPTION_PREFIX"
 GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT = "XAGENT_GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT"
+GMAIL_PUBSUB_TRANSPORT = "XAGENT_GMAIL_PUBSUB_TRANSPORT"
 GMAIL_REGISTRATION_TIMEOUT_SECONDS = "XAGENT_GMAIL_REGISTRATION_TIMEOUT_SECONDS"
 PUBLIC_API_BASE_URL = "XAGENT_PUBLIC_API_BASE_URL"
 GMAIL_WATCH_ENABLED = "XAGENT_GMAIL_WATCH_ENABLED"
@@ -685,6 +686,21 @@ def get_gmail_pubsub_subscription_prefix() -> str:
     """
     value = (os.getenv(GMAIL_PUBSUB_SUBSCRIPTION_PREFIX) or "").strip()
     return value or "xagent-gmail-push"
+
+
+def get_gmail_pubsub_transport() -> str:
+    """Transport used by the Gmail Pub/Sub provisioning clients.
+
+    Priority:
+        1. XAGENT_GMAIL_PUBSUB_TRANSPORT environment variable ("grpc" or "rest")
+        2. Default "grpc"
+
+    "rest" exists for environments whose egress proxy cannot tunnel gRPC:
+    the default gRPC channel hangs indefinitely there, leaving Gmail watch
+    provisioning stuck at pending with no recorded error.
+    """
+    value = (os.getenv(GMAIL_PUBSUB_TRANSPORT) or "").strip().lower()
+    return value if value in ("grpc", "rest") else "grpc"
 
 
 def get_gmail_pubsub_push_service_account() -> str | None:

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -29,6 +29,7 @@ from ...config import (
     get_gmail_pubsub_push_service_account,
     get_gmail_pubsub_subscription_prefix,
     get_gmail_pubsub_topic_prefix,
+    get_gmail_pubsub_transport,
     get_gmail_registration_timeout_seconds,
     get_public_api_base_url,
 )
@@ -54,12 +55,20 @@ class GmailProvisioningError(RuntimeError):
 
 
 def _default_publisher() -> Any:
+    if get_gmail_pubsub_transport() == "rest":
+        from google.pubsub_v1 import PublisherClient
+
+        return PublisherClient(transport="rest")
     from google.cloud import pubsub_v1  # type: ignore[import-untyped]
 
     return pubsub_v1.PublisherClient()
 
 
 def _default_subscriber() -> Any:
+    if get_gmail_pubsub_transport() == "rest":
+        from google.pubsub_v1 import SubscriberClient
+
+        return SubscriberClient(transport="rest")
     from google.cloud import pubsub_v1
 
     return pubsub_v1.SubscriberClient()
@@ -97,11 +106,13 @@ def _new_callback_id() -> str:
 
 def _is_already_exists(exc: Exception) -> bool:
     try:
-        from google.api_core.exceptions import AlreadyExists
+        # gRPC raises AlreadyExists; the REST transport maps HTTP 409 to its
+        # parent class Conflict, so match the whole 409 family.
+        from google.api_core.exceptions import Conflict
 
-        return isinstance(exc, AlreadyExists)
+        return isinstance(exc, Conflict)
     except ImportError:  # pragma: no cover - google libs are a core dep
-        return type(exc).__name__ == "AlreadyExists"
+        return type(exc).__name__ in ("AlreadyExists", "Conflict")
 
 
 def _is_not_found(exc: Exception) -> bool:

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -107,10 +107,12 @@ def _new_callback_id() -> str:
 def _is_already_exists(exc: Exception) -> bool:
     try:
         # gRPC raises AlreadyExists; the REST transport maps HTTP 409 to its
-        # parent class Conflict, so match the whole 409 family.
-        from google.api_core.exceptions import Conflict
+        # parent class Conflict. Match exactly those two — Aborted is also a
+        # Conflict subclass but signals a transient concurrency error, not
+        # "already exists", and must propagate.
+        from google.api_core.exceptions import AlreadyExists, Conflict
 
-        return isinstance(exc, Conflict)
+        return isinstance(exc, AlreadyExists) or type(exc) is Conflict
     except ImportError:  # pragma: no cover - google libs are a core dep
         return type(exc).__name__ in ("AlreadyExists", "Conflict")
 

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable
+from typing import Any, Callable, cast
 from urllib.parse import quote
 
 from google.auth.exceptions import RefreshError
@@ -197,7 +197,9 @@ def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
         client_id=client_id,
         client_secret=client_secret,
         scopes=_gmail_oauth_scopes(oauth_account),
-        expiry=_credentials_expiry(getattr(oauth_account, "expires_at", None)),
+        # cast: legacy Column[...] typing on UserOAuth; runtime value is the
+        # datetime (or None) loaded from the row.
+        expiry=_credentials_expiry(cast("datetime | None", oauth_account.expires_at)),
     )
     if creds.expired and creds.refresh_token:
         try:

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -172,6 +172,18 @@ def _gmail_oauth_scopes(oauth_account: UserOAuth) -> list[str]:
     return scopes or DEFAULT_GMAIL_SCOPES
 
 
+def _credentials_expiry(value: datetime | None) -> datetime | None:
+    """google-auth requires Credentials.expiry to be a naive UTC datetime.
+
+    Timezone-aware databases (PostgreSQL) return aware datetimes for
+    UserOAuth.expires_at; passing one through makes creds.expired raise
+    "can't compare offset-naive and offset-aware datetimes".
+    """
+    if value is None or value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
     """Build an authenticated Gmail API client for a connected Gmail account."""
     client_id, client_secret = _get_google_oauth_config(db)
@@ -185,7 +197,7 @@ def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
         client_id=client_id,
         client_secret=client_secret,
         scopes=_gmail_oauth_scopes(oauth_account),
-        expiry=oauth_account.expires_at,
+        expiry=_credentials_expiry(getattr(oauth_account, "expires_at", None)),
     )
     if creds.expired and creds.refresh_token:
         try:
@@ -197,7 +209,8 @@ def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
             ) from exc
         setattr(oauth_account, "access_token", creds.token)
         if creds.expiry:
-            setattr(oauth_account, "expires_at", creds.expiry)
+            # google-auth hands back naive UTC; store it timezone-aware.
+            setattr(oauth_account, "expires_at", _coerce_utc(creds.expiry))
         db.commit()
 
     return _GmailApiService(AuthorizedSession(creds))

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1534,6 +1534,16 @@ class TestGmailPubSubProvisioningConfig:
         monkeypatch.setenv("XAGENT_GMAIL_REGISTRATION_TIMEOUT_SECONDS", "not-a-number")
         assert get_gmail_registration_timeout_seconds() == 10
 
+    def test_pubsub_transport_defaults_to_grpc(self, monkeypatch):
+        from xagent.config import get_gmail_pubsub_transport
+
+        monkeypatch.delenv("XAGENT_GMAIL_PUBSUB_TRANSPORT", raising=False)
+        assert get_gmail_pubsub_transport() == "grpc"
+        monkeypatch.setenv("XAGENT_GMAIL_PUBSUB_TRANSPORT", " REST ")
+        assert get_gmail_pubsub_transport() == "rest"
+        monkeypatch.setenv("XAGENT_GMAIL_PUBSUB_TRANSPORT", "carrier-pigeon")
+        assert get_gmail_pubsub_transport() == "grpc"
+
 
 class TestTrustedProxyHopsConfig:
     """Config for proxy-aware remote IP derivation."""

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -29,6 +29,7 @@ from xagent.web.services.gmail_provisioning import gmail_topic_path
 from xagent.web.services.gmail_triggers import (
     GmailPubsubNotification,
     GmailWatchConfigurationError,
+    _credentials_expiry,
     _get_google_oauth_config,
     build_gmail_service,
     collect_gmail_pubsub_events,
@@ -926,56 +927,18 @@ def test_build_gmail_service_passes_persisted_token_expiry_to_credentials(
         db.close()
 
 
-def test_build_gmail_service_converts_aware_expiry_to_naive_utc_for_credentials(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_credentials_expiry_converts_aware_expiry_to_naive_utc() -> None:
     """Timezone-aware expires_at (PostgreSQL) must reach google-auth as naive UTC."""
-    monkeypatch.setenv("GOOGLE_CLIENT_ID", "env-client-id")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "env-client-secret")
-    captured_kwargs: dict[str, object] = {}
+    aware = datetime(2026, 6, 29, 20, tzinfo=timezone(timedelta(hours=8)))
 
-    class FakeCredentials:
-        def __init__(self, **kwargs: object) -> None:
-            captured_kwargs.update(kwargs)
-            self.expired = False
-            self.refresh_token = kwargs.get("refresh_token")
+    converted = _credentials_expiry(aware)
 
-    monkeypatch.setattr(
-        "xagent.web.services.gmail_triggers.Credentials",
-        FakeCredentials,
-    )
-    monkeypatch.setattr(
-        "xagent.web.services.gmail_triggers.AuthorizedSession",
-        lambda creds: object(),
-    )
-
-    db = _direct_db_session()
-    try:
-        provider = (
-            db.query(OAuthProvider)
-            .filter(OAuthProvider.provider_name == "google")
-            .one()
-        )
-        provider.client_id = ""
-        provider.client_secret = ""
-        user = _create_user(db, "gmail-aware-expiry-user")
-        oauth = _create_gmail_oauth(db, user)
-        db.add(provider)
-        db.commit()
-        # SQLite round-trips naive datetimes, so assign in memory to simulate
-        # the aware value PostgreSQL returns for DateTime(timezone=True).
-        oauth.expires_at = datetime(
-            2026, 6, 29, 20, tzinfo=timezone(timedelta(hours=8))
-        )
-
-        build_gmail_service(db, oauth)
-
-        expiry = captured_kwargs["expiry"]
-        assert isinstance(expiry, datetime)
-        assert expiry.tzinfo is None
-        assert expiry == datetime(2026, 6, 29, 12)
-    finally:
-        db.close()
+    assert converted is not None
+    assert converted.tzinfo is None
+    assert converted == datetime(2026, 6, 29, 12)
+    # Naive values (SQLite) and None pass through untouched.
+    assert _credentials_expiry(datetime(2026, 6, 29, 12)) == datetime(2026, 6, 29, 12)
+    assert _credentials_expiry(None) is None
 
 
 def test_build_gmail_service_accepts_aware_expiry_with_real_credentials(

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -44,6 +44,24 @@ from .conftest import _direct_db_session, client
 pytestmark = pytest.mark.usefixtures("_test_db")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_gmail_push_service_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the developer .env for OIDC verification defaults.
+
+    tests/conftest.py loads the project .env with override=True; a push
+    service account configured there makes verify() demand a matching email
+    claim, flipping outcomes for every test whose fake OIDC verifier returns
+    no email claim. Tests that exercise the service-account check set the
+    variable explicitly via monkeypatch.setenv.
+
+    Set to "" rather than deleted: fixtures running later (e.g. _test_db ->
+    init_db -> migrations/env.py) call load_dotenv(override=False), which
+    would re-populate a deleted variable but leaves an empty one alone, and
+    the config getter normalizes "" to None.
+    """
+    monkeypatch.setenv("XAGENT_GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT", "")
+
+
 class _FakeHttpError(Exception):
     def __init__(self, status_code: int, message: str = "gmail error") -> None:
         super().__init__(message)

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -904,6 +904,147 @@ def test_build_gmail_service_passes_persisted_token_expiry_to_credentials(
         build_gmail_service(db, oauth)
 
         assert captured_kwargs["expiry"] == oauth.expires_at
+    finally:
+        db.close()
+
+
+def test_build_gmail_service_converts_aware_expiry_to_naive_utc_for_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timezone-aware expires_at (PostgreSQL) must reach google-auth as naive UTC."""
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "env-client-id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "env-client-secret")
+    captured_kwargs: dict[str, object] = {}
+
+    class FakeCredentials:
+        def __init__(self, **kwargs: object) -> None:
+            captured_kwargs.update(kwargs)
+            self.expired = False
+            self.refresh_token = kwargs.get("refresh_token")
+
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.Credentials",
+        FakeCredentials,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.AuthorizedSession",
+        lambda creds: object(),
+    )
+
+    db = _direct_db_session()
+    try:
+        provider = (
+            db.query(OAuthProvider)
+            .filter(OAuthProvider.provider_name == "google")
+            .one()
+        )
+        provider.client_id = ""
+        provider.client_secret = ""
+        user = _create_user(db, "gmail-aware-expiry-user")
+        oauth = _create_gmail_oauth(db, user)
+        db.add(provider)
+        db.commit()
+        # SQLite round-trips naive datetimes, so assign in memory to simulate
+        # the aware value PostgreSQL returns for DateTime(timezone=True).
+        oauth.expires_at = datetime(
+            2026, 6, 29, 20, tzinfo=timezone(timedelta(hours=8))
+        )
+
+        build_gmail_service(db, oauth)
+
+        expiry = captured_kwargs["expiry"]
+        assert isinstance(expiry, datetime)
+        assert expiry.tzinfo is None
+        assert expiry == datetime(2026, 6, 29, 12)
+    finally:
+        db.close()
+
+
+def test_build_gmail_service_accepts_aware_expiry_with_real_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #807: aware expiry made creds.expired raise TypeError."""
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "env-client-id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "env-client-secret")
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.AuthorizedSession",
+        lambda creds: object(),
+    )
+
+    db = _direct_db_session()
+    try:
+        provider = (
+            db.query(OAuthProvider)
+            .filter(OAuthProvider.provider_name == "google")
+            .one()
+        )
+        provider.client_id = ""
+        provider.client_secret = ""
+        user = _create_user(db, "gmail-real-creds-user")
+        oauth = _create_gmail_oauth(db, user)
+        db.add(provider)
+        db.commit()
+        oauth.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        service = build_gmail_service(db, oauth)
+
+        assert service is not None
+    finally:
+        db.close()
+
+
+def test_build_gmail_service_persists_refreshed_expiry_as_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refreshed naive-UTC expiry from google-auth is stored UTC-normalized."""
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "env-client-id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "env-client-secret")
+    refreshed_expiry = datetime(2026, 6, 29, 13)
+
+    class FakeCredentials:
+        def __init__(self, **kwargs: object) -> None:
+            self.expired = True
+            self.refresh_token = kwargs.get("refresh_token")
+            self.token = kwargs.get("token")
+            self.expiry: datetime | None = None
+
+        def refresh(self, _request: object) -> None:
+            self.token = "refreshed-access-token"
+            self.expiry = refreshed_expiry
+
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.Credentials",
+        FakeCredentials,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.AuthorizedSession",
+        lambda creds: object(),
+    )
+
+    db = _direct_db_session()
+    try:
+        provider = (
+            db.query(OAuthProvider)
+            .filter(OAuthProvider.provider_name == "google")
+            .one()
+        )
+        provider.client_id = ""
+        provider.client_secret = ""
+        user = _create_user(db, "gmail-refresh-persist-user")
+        oauth = _create_gmail_oauth(db, user)
+        oauth.expires_at = datetime(2026, 6, 29, 12, tzinfo=timezone.utc)
+        db.add_all([provider, oauth])
+        db.commit()
+        db.refresh(oauth)
+
+        build_gmail_service(db, oauth)
+
+        assert str(oauth.access_token) == "refreshed-access-token"
+        stored = oauth.expires_at
+        assert stored is not None
+        if stored.tzinfo is None:  # SQLite drops tzinfo on the round-trip
+            stored = stored.replace(tzinfo=timezone.utc)
+        assert stored == refreshed_expiry.replace(tzinfo=timezone.utc)
     finally:
         db.close()
 

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -1001,12 +1001,42 @@ def test_provisioning_requires_account_email(db_session: Session) -> None:
     assert db_session.query(GmailWatchState).count() == 0
 
 
+def test_default_clients_select_rest_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XAGENT_GMAIL_PUBSUB_TRANSPORT=rest must pick the GAPIC REST clients."""
+    import google.pubsub_v1
+
+    from xagent.web.services import gmail_provisioning
+
+    captured: list[tuple[str, object]] = []
+
+    class FakePublisher:
+        def __init__(self, transport: str | None = None) -> None:
+            captured.append(("publisher", transport))
+
+    class FakeSubscriber:
+        def __init__(self, transport: str | None = None) -> None:
+            captured.append(("subscriber", transport))
+
+    monkeypatch.setattr(google.pubsub_v1, "PublisherClient", FakePublisher)
+    monkeypatch.setattr(google.pubsub_v1, "SubscriberClient", FakeSubscriber)
+    monkeypatch.setenv("XAGENT_GMAIL_PUBSUB_TRANSPORT", "rest")
+
+    assert isinstance(gmail_provisioning._default_publisher(), FakePublisher)
+    assert isinstance(gmail_provisioning._default_subscriber(), FakeSubscriber)
+    assert captured == [("publisher", "rest"), ("subscriber", "rest")]
+
+
 def test_is_already_exists_matches_both_transports() -> None:
     """gRPC raises AlreadyExists; REST maps HTTP 409 to its parent Conflict."""
-    from google.api_core.exceptions import AlreadyExists, Conflict
+    from google.api_core.exceptions import Aborted, AlreadyExists, Conflict
 
     from xagent.web.services.gmail_provisioning import _is_already_exists
 
     assert _is_already_exists(AlreadyExists("grpc duplicate topic"))
     assert _is_already_exists(Conflict("409 PUT .../topics/x: already exists"))
     assert not _is_already_exists(RuntimeError("unrelated"))
+    # Aborted is also a Conflict subclass but signals a transient concurrency
+    # error, not "already exists" — it must propagate, not be swallowed.
+    assert not _is_already_exists(Aborted("transaction aborted"))

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -999,3 +999,14 @@ def test_provisioning_requires_account_email(db_session: Session) -> None:
             subscriber_factory=lambda: FakeSubscriber(),
         )
     assert db_session.query(GmailWatchState).count() == 0
+
+
+def test_is_already_exists_matches_both_transports() -> None:
+    """gRPC raises AlreadyExists; REST maps HTTP 409 to its parent Conflict."""
+    from google.api_core.exceptions import AlreadyExists, Conflict
+
+    from xagent.web.services.gmail_provisioning import _is_already_exists
+
+    assert _is_already_exists(AlreadyExists("grpc duplicate topic"))
+    assert _is_already_exists(Conflict("409 PUT .../topics/x: already exists"))
+    assert not _is_already_exists(RuntimeError("unrelated"))


### PR DESCRIPTION
## Summary

Fixes the Gmail trigger being completely non-functional (#807). Three code-level fixes, all verified end-to-end against real Gmail + Google Cloud Pub/Sub.

### 1. OAuth token expiry timezone crash (blocks every Gmail code path)

`build_gmail_service` passed the timezone-aware `UserOAuth.expires_at` (PostgreSQL `DateTime(timezone=True)`) straight into google-auth's `Credentials(expiry=...)`, which requires **naive UTC**. Checking `creds.expired` then raised:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

This blocked watch provisioning, push callbacks, and polling on every PostgreSQL deployment. SQLite returns naive datetimes, which is why local runs and CI never reproduced it.

Fix: convert to naive UTC on the way into google-auth, and re-attach `tzinfo=utc` when persisting the refreshed expiry back to the database.

### 2. Pub/Sub gRPC channel hangs behind gRPC-hostile egress proxies

Behind proxies that cannot tunnel gRPC, the Pub/Sub client hangs indefinitely — watch provisioning stays `pending` forever **with no recorded error**, which also makes the failure invisible to operators. Added `XAGENT_GMAIL_PUBSUB_TRANSPORT=rest` to switch the provisioning clients to the REST transport (every call used is unary, so REST is equivalent).

### 3. REST transport 409 not recognized as "already exists"

The REST transport maps HTTP 409 to `google.api_core.exceptions.Conflict`, not gRPC's `AlreadyExists` (its subclass), so idempotent topic/subscription re-creation was treated as a provisioning failure. `_is_already_exists` now matches the whole `Conflict` family, covering both transports.

### Test isolation fix

`tests/conftest.py` loads the developer `.env` with `override=True`; a configured `XAGENT_GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT` there flipped verify outcomes for Gmail callback tests whose fake OIDC verifiers return no email claim. Added an autouse fixture that blanks the variable (set to `""` rather than deleted, because `init_db` → `migrations/env.py` re-runs `load_dotenv` and would re-populate a deleted variable).

## Verification

- New regression tests fail with the exact production `TypeError` without the fix (exercised against the real google-auth `Credentials` class, not a stub).
- 333 tests pass across `test_gmail_auto_triggers.py`, `test_gmail_provisioning.py`, `test_config.py`; ruff + mypy clean.
- **Full E2E verified locally**: OAuth connect (`gmail.modify`) → trigger create → provisioning `active` (topic + push subscription + Gmail watch) → real inbound email → Pub/Sub push → OIDC-verified callback (`accepted` audit) → `gmail:<message_id>` TriggerRun → agent execution completed.

## Deployment notes

- Gmail triggers additionally require deploy-side config that is currently missing in production: `XAGENT_GMAIL_WATCH_ENABLED=true` (defaults to false), `XAGENT_GMAIL_PUBSUB_PROJECT_ID`, `XAGENT_GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT`, `XAGENT_PUBLIC_API_BASE_URL`, and Google ADC credentials. Once configured, the provisioning sweep converges existing failed triggers automatically — no manual rebuild needed.
- Frontend still ignores `provisioning_status`/`provisioning_error` (shows success even when provisioning failed); tracked separately.

Fixes #807
