### PR TITLE
fix(test): poll for detached resume-rejection payload

### DIFF
--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -668,7 +668,21 @@ async def test_resume_rejection_embeds_known_control_state(db_session) -> None:
     ):
         await handle_resume_task(MagicMock(), int(task.id), {"user": owner})
 
-    payload = ws_manager.send_personal_message.await_args.args[0]
+        # The rejection is sent from a dispatched command that
+        # ``dispatch_task_command_promptly`` may detach after its 50ms
+        # deadline, so the "task" payload can land after this call returns.
+        for _ in range(100):
+            for call in ws_manager.send_personal_message.await_args_list:
+                if "task" in call.args[0]:
+                    payload = call.args[0]
+                    break
+            else:
+                await asyncio.sleep(0.01)
+                continue
+            break
+        else:
+            raise AssertionError("resume rejection payload did not arrive in time")
+
     assert payload["task"] == {
         "id": int(task.id),
         "run_id": "run-current",

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -671,15 +671,15 @@ async def test_resume_rejection_embeds_known_control_state(db_session) -> None:
         # The rejection is sent from a dispatched command that
         # ``dispatch_task_command_promptly`` may detach after its 50ms
         # deadline, so the "task" payload can land after this call returns.
+        payload = None
         for _ in range(100):
             for call in ws_manager.send_personal_message.await_args_list:
-                if "task" in call.args[0]:
+                if call.args and "task" in call.args[0]:
                     payload = call.args[0]
                     break
-            else:
-                await asyncio.sleep(0.01)
-                continue
-            break
+            if payload is not None:
+                break
+            await asyncio.sleep(0.01)
         else:
             raise AssertionError("resume rejection payload did not arrive in time")
 


### PR DESCRIPTION
## Summary
- `test_resume_rejection_embeds_known_control_state` flaked once in CI with `KeyError: 'task'` (run 29421033738).
- Root cause: `handle_resume_task` sends the rejection payload from a command dispatched via `dispatch_task_command_promptly`, which detaches onto a background task after a 50ms deadline (`task_command_transport.py`). Under xdist parallel load the dispatch pipeline can exceed 50ms, so the test's `await_args` (last recorded call) sometimes still holds the earlier `task_command_accepted` payload instead of the rejection payload.
- Fix: poll `await_args_list` for the call carrying the `"task"` key instead of asserting on the last call, mirroring the existing poll-wait pattern already used by `test_resume_registration_failure_cancels_coordinator` in the same file.

## Test plan
- [x] `pytest tests/web/api/test_websocket_owner_actor.py::test_resume_rejection_embeds_known_control_state` x5 — all pass
- [x] `pytest tests/web/api/test_websocket_owner_actor.py -m "not slow and not postgresql" -n 4 --dist=loadscope` — full file passes
- [x] `ruff format --diff` / `ruff check` on the changed file — clean

https://claude.ai/code/session_014PcRmwy9ig9EiakYUMkhkz