### PR TITLE
enh: improve ElevenLabs pronunciation and interruption messaging

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -13,6 +13,10 @@ from .tracing import TraceEventCallback
 
 logger = logging.getLogger(__name__)
 
+INTERRUPTED_USER_MESSAGE = (
+    "The previous run was stopped. You can send another message to continue."
+)
+
 
 @dataclass
 class AgentExecutionConfig:
@@ -314,13 +318,20 @@ class AgentExecutionAdapter:
         execution_type: str,
         execution_id: str,
     ) -> dict[str, Any]:
-        output = result.get("output", result.get("response", result.get("error")))
-        if not output:
-            output = self._latest_assistant_message(result.get("context"))
         status = result.get(
             "status",
             "completed" if result.get("success") else "failed",
         )
+        output: Any
+        if status == "interrupted":
+            # Keep the pattern-specific error in ``error``/``agent_result`` for
+            # diagnostics, but never expose implementation names such as
+            # ``ReActPattern`` as user-facing output.
+            output = INTERRUPTED_USER_MESSAGE
+        else:
+            output = result.get("output", result.get("response", result.get("error")))
+            if not output:
+                output = self._latest_assistant_message(result.get("context"))
         normalized = {
             "status": status,
             "output": output or "No output provided",

--- a/src/xagent/core/model/tts/elevenlabs.py
+++ b/src/xagent/core/model/tts/elevenlabs.py
@@ -247,7 +247,20 @@ class ElevenLabsTTS(BaseTTS):
         # alias is never processed by a later rule. Prefer longer phrases when
         # rules overlap, which keeps phrase-level corrections deterministic.
         source_phrases = sorted(normalized_aliases, key=len, reverse=True)
-        pattern = re.compile("|".join(re.escape(source) for source in source_phrases))
+        escaped_sources: list[str] = []
+        for source in source_phrases:
+            escaped = re.escape(source)
+            # Guard ASCII word-like edges against partial matches such as
+            # replacing "UN" inside "RUN". Do not use Unicode ``\w`` here:
+            # it treats CJK characters as word characters and would prevent
+            # aliases from matching inside unspaced text.
+            if source[0].isascii() and (source[0].isalnum() or source[0] == "_"):
+                escaped = rf"(?<![A-Za-z0-9_]){escaped}"
+            if source[-1].isascii() and (source[-1].isalnum() or source[-1] == "_"):
+                escaped = rf"{escaped}(?![A-Za-z0-9_])"
+            escaped_sources.append(escaped)
+
+        pattern = re.compile("|".join(escaped_sources))
         return pattern.sub(
             lambda match: normalized_aliases[match.group(0)],
             text,

--- a/src/xagent/core/model/tts/elevenlabs.py
+++ b/src/xagent/core/model/tts/elevenlabs.py
@@ -7,6 +7,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 import uuid
 from collections.abc import Iterable
 from inspect import isawaitable
@@ -32,6 +33,7 @@ _ELEVENLABS_VOICE_SETTING_FIELDS = (
 _ELEVENLABS_PROVIDER_OPTION_FIELDS = (
     "enable_logging",
     "optimize_streaming_latency",
+    "pronunciation_aliases",
     "pronunciation_dictionary_locators",
     "seed",
     "previous_text",
@@ -210,6 +212,46 @@ class ElevenLabsTTS(BaseTTS):
                 "Unsupported ElevenLabs provider_options keys: "
                 f"{unsupported}. Supported keys: {supported}."
             )
+
+    @staticmethod
+    def _apply_pronunciation_aliases(
+        text: str, aliases: Optional[dict[str, str]]
+    ) -> str:
+        """Apply case-sensitive, non-cascading aliases to ElevenLabs input text."""
+        if aliases is None:
+            return text
+        if not isinstance(aliases, dict):
+            raise ValueError(
+                "ElevenLabs pronunciation_aliases must be an object mapping "
+                "source phrases to spoken aliases"
+            )
+
+        normalized_aliases: dict[str, str] = {}
+        for source, alias in aliases.items():
+            if not isinstance(source, str) or not source.strip():
+                raise ValueError(
+                    "ElevenLabs pronunciation_aliases source phrases must be "
+                    "non-empty strings"
+                )
+            if not isinstance(alias, str) or not alias.strip():
+                raise ValueError(
+                    "ElevenLabs pronunciation_aliases spoken aliases must be "
+                    "non-empty strings"
+                )
+            normalized_aliases[source] = alias
+
+        if not normalized_aliases:
+            return text
+
+        # Match all source phrases against the original text in one pass so an
+        # alias is never processed by a later rule. Prefer longer phrases when
+        # rules overlap, which keeps phrase-level corrections deterministic.
+        source_phrases = sorted(normalized_aliases, key=len, reverse=True)
+        pattern = re.compile("|".join(re.escape(source) for source in source_phrases))
+        return pattern.sub(
+            lambda match: normalized_aliases[match.group(0)],
+            text,
+        )
 
     @staticmethod
     async def _close_client(client: Any) -> None:
@@ -544,6 +586,11 @@ class ElevenLabsTTS(BaseTTS):
         final_sample_rate = _sample_rate_from_output_format(final_output_format)
         language_code = kwargs.pop("language_code", None) or language or self.language
         voice_settings = kwargs.pop("voice_settings", None)
+        pronunciation_aliases = kwargs.pop("pronunciation_aliases", None)
+        synthesis_text = self._apply_pronunciation_aliases(
+            text,
+            pronunciation_aliases,
+        )
 
         request_kwargs = {k: v for k, v in kwargs.items() if v is not None}
         self._validate_provider_options(request_kwargs)
@@ -559,7 +606,7 @@ class ElevenLabsTTS(BaseTTS):
             if reference_audio:
                 voice_id = await self._get_or_create_cloned_voice(reference_audio)
             response = client.text_to_speech.convert(
-                text=text,
+                text=synthesis_text,
                 voice_id=voice_id,
                 model_id=self.model,
                 output_format=final_output_format,

--- a/src/xagent/core/tools/core/audio_tool_descriptions.py
+++ b/src/xagent/core/tools/core/audio_tool_descriptions.py
@@ -111,7 +111,8 @@ Voice options depend on the model:
 
 Provider-specific options:
 - ElevenLabs supports voice_settings keys: stability, similarity_boost, style, speed, use_speaker_boost.
-- ElevenLabs supports provider_options keys such as seed, previous_text, next_text, optimize_streaming_latency, apply_text_normalization, apply_language_text_normalization, and pronunciation_dictionary_locators.
+- ElevenLabs supports provider_options keys such as seed, previous_text, next_text, optimize_streaming_latency, apply_text_normalization, apply_language_text_normalization, pronunciation_dictionary_locators, and pronunciation_aliases.
+- ElevenLabs pronunciation_aliases is a case-sensitive object that maps exact source words or phrases to text that produces the intended spoken pronunciation. It changes only the text sent to ElevenLabs; keep text and written artifacts correctly spelled. Prefer phrase-level aliases over replacing one ambiguous character globally. For example: {{"Claughton": "Cloffton", "UN": "United Nations"}}.
 - Xinference currently does not expose dynamic voice listing through this tool. Some Xinference TTS models may still accept model-specific voice IDs or extra synthesis parameters.
 
 Audio format options:

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -907,15 +907,14 @@ class TelegramBotInstance:
                             run_snapshot.run_id,
                         )
 
-                if projection.transcript_content or projection.interactions:
-                    persist_telegram_assistant_turn(
-                        db=db,
-                        task_id=int(task.id),  # type: ignore
-                        user_id=int(user.id),  # type: ignore
-                        content=projection.transcript_content,
-                        interactions=projection.interactions,
-                        message_type=projection.message_type,
-                    )
+                persist_telegram_assistant_turn(
+                    db=db,
+                    task_id=int(task.id),  # type: ignore
+                    user_id=int(user.id),  # type: ignore
+                    content=projection.transcript_content,
+                    interactions=projection.interactions,
+                    message_type=projection.message_type,
+                )
 
                 output, image_refs, file_refs = self._extract_telegram_output_refs(
                     projection.visible_text,

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -907,14 +907,15 @@ class TelegramBotInstance:
                             run_snapshot.run_id,
                         )
 
-                persist_telegram_assistant_turn(
-                    db=db,
-                    task_id=int(task.id),  # type: ignore
-                    user_id=int(user.id),  # type: ignore
-                    content=projection.transcript_content,
-                    interactions=projection.interactions,
-                    message_type=projection.message_type,
-                )
+                if projection.transcript_content or projection.interactions:
+                    persist_telegram_assistant_turn(
+                        db=db,
+                        task_id=int(task.id),  # type: ignore
+                        user_id=int(user.id),  # type: ignore
+                        content=projection.transcript_content,
+                        interactions=projection.interactions,
+                        message_type=projection.message_type,
+                    )
 
                 output, image_refs, file_refs = self._extract_telegram_output_refs(
                     projection.visible_text,

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ...core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
 from ..models.task import TaskStatus
 
 EMPTY_CHANNEL_OUTPUT_FALLBACK = "Task completed, but no output was generated."
@@ -35,16 +36,26 @@ def project_execution_result_for_channel(
             interactions = [item for item in raw_interactions if isinstance(item, dict)]
 
     output = str(result.get("output") or "")
-    base_text = chat_message or output
-    if not base_text.strip() and not interactions:
+    if status == "interrupted":
+        # An interruption is control state, not an assistant answer. Show a
+        # friendly status in every chat channel without adding it to the
+        # conversation transcript used by later model turns.
+        base_text = INTERRUPTED_USER_MESSAGE
+        transcript_content = ""
+        interactions = []
+    else:
+        base_text = chat_message or output
+        transcript_content = base_text
+    if status != "interrupted" and not base_text.strip() and not interactions:
         base_text = EMPTY_CHANNEL_OUTPUT_FALLBACK
+        transcript_content = base_text
 
     visible_text = _append_interactions(base_text, interactions)
 
     return ChannelExecutionProjection(
         task_status=_project_task_status(result, status),
         visible_text=visible_text,
-        transcript_content=base_text,
+        transcript_content=transcript_content,
         message_type="question"
         if status == "waiting_for_user" or interactions
         else "assistant_message",

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -36,6 +36,8 @@ def project_execution_result_for_channel(
             interactions = [item for item in raw_interactions if isinstance(item, dict)]
 
     output = str(result.get("output") or "")
+    base_text = chat_message or output
+    transcript_content = base_text
     if status == "interrupted":
         # An interruption is control state, not an assistant answer. Show a
         # friendly status in every chat channel without adding it to the
@@ -43,10 +45,7 @@ def project_execution_result_for_channel(
         base_text = INTERRUPTED_USER_MESSAGE
         transcript_content = ""
         interactions = []
-    else:
-        base_text = chat_message or output
-        transcript_content = base_text
-    if status != "interrupted" and not base_text.strip() and not interactions:
+    elif not base_text.strip() and not interactions:
         base_text = EMPTY_CHANNEL_OUTPUT_FALLBACK
         transcript_content = base_text
 

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 
 from xagent.core.agent import AgentExecutionAdapter, AgentExecutionConfig
+from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
 from xagent.core.agent.service import AgentService
 
 
@@ -955,9 +956,7 @@ def test_execution_adapter_hides_internal_error_for_interrupted_result() -> None
         execution_id="interrupted-exec",
     )
 
-    assert result["output"] == (
-        "The previous run was stopped. You can send another message to continue."
-    )
+    assert result["output"] == INTERRUPTED_USER_MESSAGE
     assert result["error"] == "ReActPattern interrupted."
 
 

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -935,6 +935,32 @@ def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> 
     assert result["output"] == "answer from context"
 
 
+def test_execution_adapter_hides_internal_error_for_interrupted_result() -> None:
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="interrupted",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = adapter._normalize_result(
+        result={
+            "status": "interrupted",
+            "success": False,
+            "error": "ReActPattern interrupted.",
+        },
+        execution_type="agent_react",
+        execution_id="interrupted-exec",
+    )
+
+    assert result["output"] == (
+        "The previous run was stopped. You can send another message to continue."
+    )
+    assert result["error"] == "ReActPattern interrupted."
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_resume_restores_from_tracer_after_restart() -> None:
     tracer = TracerCheckpointStore()

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -76,6 +76,84 @@ async def test_synthesize_uses_sdk_convert_and_joins_chunks(
     assert call["voice_settings"].stability == 0.5
 
 
+async def test_synthesize_applies_official_pronunciation_alias_examples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    convert_calls: list[dict[str, object]] = []
+
+    async def convert(**kwargs: object):
+        convert_calls.append(kwargs)
+        yield b"fake-audio"
+
+    fake_client = SimpleNamespace(text_to_speech=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    source_text = "Claughton addressed the UN."
+    result = await ElevenLabsTTS(api_key="test-key").synthesize(
+        source_text,
+        pronunciation_aliases={
+            "Claughton": "Cloffton",
+            "UN": "United Nations",
+        },
+    )
+
+    assert result == b"fake-audio"
+    assert source_text == "Claughton addressed the UN."
+    assert convert_calls[0]["text"] == "Cloffton addressed the United Nations."
+    assert "pronunciation_aliases" not in convert_calls[0]
+
+
+async def test_synthesize_pronunciation_aliases_are_non_cascading_and_longest_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    convert_calls: list[dict[str, object]] = []
+
+    async def convert(**kwargs: object):
+        convert_calls.append(kwargs)
+        yield b"fake-audio"
+
+    fake_client = SimpleNamespace(text_to_speech=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    await ElevenLabsTTS(api_key="test-key").synthesize(
+        "The United Nations welcomed Claughton.",
+        pronunciation_aliases={
+            "UN": "United Nations",
+            "United Nations": "UN",
+            "Claughton": "Cloffton",
+            "Cloffton": "Claughton",
+        },
+    )
+
+    assert convert_calls[0]["text"] == "The UN welcomed Cloffton."
+
+
+@pytest.mark.parametrize(
+    ("aliases", "error"),
+    [
+        (["Claughton"], "must be an object"),
+        ({"": "Cloffton"}, "source phrases must be non-empty strings"),
+        ({"Claughton": ""}, "spoken aliases must be non-empty strings"),
+    ],
+)
+async def test_synthesize_rejects_invalid_pronunciation_aliases(
+    aliases: object,
+    error: str,
+) -> None:
+    tts = ElevenLabsTTS(api_key="test-key")
+
+    with pytest.raises(ValueError, match=error):
+        await tts.synthesize("Claughton", pronunciation_aliases=aliases)
+
+
 async def test_synthesize_supports_direct_async_generator_sdk_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -732,6 +810,7 @@ def test_elevenlabs_advertises_voice_capabilities() -> None:
         "use_speaker_boost",
     ]
     assert "seed" in tts.supported_provider_options
+    assert "pronunciation_aliases" in tts.supported_provider_options
 
 
 def test_list_available_models_requires_api_key(

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -145,6 +145,15 @@ def test_pronunciation_aliases_skip_partial_ascii_word_matches() -> None:
     assert result == ("RUN, United Nations, FUN, UNwelcomed, and (United Nations).")
 
 
+def test_pronunciation_aliases_match_non_ascii_source_in_continuous_text() -> None:
+    result = ElevenLabsTTS._apply_pronunciation_aliases(
+        "alpha: αβγ",
+        {"β": "bee"},
+    )
+
+    assert result == "alpha: αbeeγ"
+
+
 @pytest.mark.parametrize(
     ("aliases", "error"),
     [

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -136,6 +136,15 @@ async def test_synthesize_pronunciation_aliases_are_non_cascading_and_longest_fi
     assert convert_calls[0]["text"] == "The UN welcomed Cloffton."
 
 
+def test_pronunciation_aliases_skip_partial_ascii_word_matches() -> None:
+    result = ElevenLabsTTS._apply_pronunciation_aliases(
+        "RUN, UN, FUN, UNwelcomed, and (UN).",
+        {"UN": "United Nations"},
+    )
+
+    assert result == ("RUN, United Nations, FUN, UNwelcomed, and (United Nations).")
+
+
 @pytest.mark.parametrize(
     ("aliases", "error"),
     [

--- a/tests/core/tools/test_audio_tool.py
+++ b/tests/core/tools/test_audio_tool.py
@@ -471,6 +471,8 @@ def test_synthesize_speech_schema_exposes_structured_options() -> None:
 
     assert "Never invent" in synthesize_tool.description
     assert "exact voice_id returned by list_tts_voices" in synthesize_tool.description
+    assert '"Claughton": "Cloffton"' in synthesize_tool.description
+    assert '"UN": "United Nations"' in synthesize_tool.description
     assert "en-male" not in synthesize_tool.description
     assert "zh-female" not in synthesize_tool.description
 

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -747,11 +747,6 @@ async def test_telegram_new_task_fallback_snapshots_empty(
             "xagent.web.channels.telegram.bot.persist_user_message",
             lambda **_kwargs: None,
         )
-        persisted_turns: list[dict[str, Any]] = []
-        monkeypatch.setattr(
-            "xagent.web.channels.telegram.bot.persist_telegram_assistant_turn",
-            lambda **kwargs: persisted_turns.append(kwargs),
-        )
 
         agent_manager = _FakeAgentManager(execution_result)
         monkeypatch.setattr(
@@ -803,7 +798,15 @@ async def test_telegram_new_task_fallback_snapshots_empty(
         assert task is not None
         assert task.connector_runtime_selected_refs == []
         assert _context_row_count(int(task.id)) == 0
-        assert len(persisted_turns) == expected_persisted_turns
+        persisted_turns = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task.id,
+                TaskChatMessage.role == "assistant",
+            )
+            .count()
+        )
+        assert persisted_turns == expected_persisted_turns
     finally:
         db.close()
 

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -332,9 +332,10 @@ class _FakeAgentService:
 
 
 class _FakeAgentManager:
-    def __init__(self) -> None:
+    def __init__(self, execution_result: dict[str, Any] | None = None) -> None:
         self.service = _FakeAgentService()
         self.execute_calls: list[dict[str, Any]] = []
+        self.execution_result = execution_result or {"success": True, "output": "done"}
 
     async def get_agent_for_task(
         self,
@@ -347,7 +348,7 @@ class _FakeAgentManager:
 
     async def execute_task(self, **_kwargs: Any) -> dict[str, Any]:
         self.execute_calls.append(_kwargs)
-        return {"success": True, "output": "done"}
+        return dict(self.execution_result)
 
 
 def test_web_chat_create_filters_runtime_declared_connectors_and_ignores_payload(
@@ -698,10 +699,27 @@ async def test_feishu_new_task_fallback_snapshots_empty(
         db.close()
 
 
+@pytest.mark.parametrize(
+    ("execution_result", "expected_persisted_turns"),
+    [
+        ({"success": True, "output": "done"}, 1),
+        (
+            {
+                "status": "interrupted",
+                "success": False,
+                "output": "ReActPattern interrupted.",
+            },
+            0,
+        ),
+    ],
+    ids=["completed", "interrupted"],
+)
 @pytest.mark.asyncio
 async def test_telegram_new_task_fallback_snapshots_empty(
     e2e_db: None,
     monkeypatch: pytest.MonkeyPatch,
+    execution_result: dict[str, Any],
+    expected_persisted_turns: int,
 ) -> None:
     _setup_admin_headers()
     db = _db_session()
@@ -718,11 +736,6 @@ async def test_telegram_new_task_fallback_snapshots_empty(
         db.commit()
         db.refresh(channel)
 
-        monkeypatch.setattr(
-            "xagent.web.channels.telegram.bot.get_agent_manager",
-            lambda: _FakeAgentManager(),
-        )
-
         async def _restore_telegram_task_context(*_args: Any, **_kwargs: Any) -> None:
             return None
 
@@ -734,9 +747,16 @@ async def test_telegram_new_task_fallback_snapshots_empty(
             "xagent.web.channels.telegram.bot.persist_user_message",
             lambda **_kwargs: None,
         )
+        persisted_turns: list[dict[str, Any]] = []
         monkeypatch.setattr(
             "xagent.web.channels.telegram.bot.persist_telegram_assistant_turn",
-            lambda **_kwargs: None,
+            lambda **kwargs: persisted_turns.append(kwargs),
+        )
+
+        agent_manager = _FakeAgentManager(execution_result)
+        monkeypatch.setattr(
+            "xagent.web.channels.telegram.bot.get_agent_manager",
+            lambda: agent_manager,
         )
 
         bot = object.__new__(TelegramBotInstance)
@@ -783,6 +803,7 @@ async def test_telegram_new_task_fallback_snapshots_empty(
         assert task is not None
         assert task.connector_runtime_selected_refs == []
         assert _context_row_count(int(task.id)) == 0
+        assert len(persisted_turns) == expected_persisted_turns
     finally:
         db.close()
 

--- a/tests/web/test_execution_result_projection.py
+++ b/tests/web/test_execution_result_projection.py
@@ -1,3 +1,4 @@
+from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
 from xagent.web.models.task import TaskStatus
 from xagent.web.services.execution_result_projection import (
     EMPTY_CHANNEL_OUTPUT_FALLBACK,
@@ -72,8 +73,6 @@ def test_project_execution_result_maps_interrupted_to_paused():
     )
 
     assert projection.task_status == TaskStatus.PAUSED
-    assert projection.visible_text == (
-        "The previous run was stopped. You can send another message to continue."
-    )
+    assert projection.visible_text == INTERRUPTED_USER_MESSAGE
     assert projection.transcript_content == ""
     assert projection.interactions == []

--- a/tests/web/test_execution_result_projection.py
+++ b/tests/web/test_execution_result_projection.py
@@ -64,8 +64,16 @@ def test_project_execution_result_falls_back_for_empty_output():
 
 def test_project_execution_result_maps_interrupted_to_paused():
     projection = project_execution_result_for_channel(
-        {"status": "interrupted", "success": False, "output": "Paused."}
+        {
+            "status": "interrupted",
+            "success": False,
+            "output": "ReActPattern interrupted.",
+        }
     )
 
     assert projection.task_status == TaskStatus.PAUSED
-    assert projection.visible_text == "Paused."
+    assert projection.visible_text == (
+        "The previous run was stopped. You can send another message to continue."
+    )
+    assert projection.transcript_content == ""
+    assert projection.interactions == []


### PR DESCRIPTION
## Summary

- add ElevenLabs-only `provider_options.pronunciation_aliases` for exact, non-cascading text substitutions before synthesis
- document the option with ElevenLabs' official English alias examples
- replace internal pattern interruption errors with a human-readable message across shared execution surfaces
- keep diagnostic errors in traces while excluding interruption status text from assistant conversation history

## Why

ElevenLabs can mispronounce uncommon names and titles, while the prior synthesis interface had no direct way to provide deterministic spoken aliases. Separately, interrupted runs exposed implementation details such as `ReActPattern interrupted.` to end users and persisted them into later model context.

## Impact

Callers can now correct ElevenLabs pronunciation without changing the stored source text. Telegram, Feishu, Web, and API consumers receive a consistent user-facing interruption status without leaking internal pattern class names.

## Validation

- `pytest -q tests/core/agent/test_execution_adapter.py tests/core/model/tts/test_elevenlabs.py tests/core/tools/test_audio_tool.py tests/web/test_execution_result_projection.py tests/web/test_telegram_message_queue.py` (124 passed)
- repository pre-commit hooks, including Ruff, Ruff format, mypy, isort, codespell, and Alembic checks