### PR TITLE
fix: make database startup failures self-explanatory

### DIFF
--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1178,7 +1178,9 @@ def get_storage_root() -> Path:
     """
     env_dir = os.getenv(STORAGE_ROOT)
     if env_dir:
-        return Path(env_dir)
+        # Expand ~ here so every consumer (including sqlite3, which opens a
+        # literal ./~/... path) sees the same absolute location.
+        return Path(env_dir).expanduser()
 
     # Default: ~/.xagent
     return Path.home() / ".xagent"

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -18,7 +18,10 @@ from ...config import (
     get_default_sqlite_db_path,
 )
 from ...config import get_storage_root as get_config_storage_root
-from ...db.sqlite import apply_sqlite_concurrency_pragmas
+from ...db.sqlite import (
+    apply_sqlite_concurrency_pragmas,
+    ensure_sqlite_parent_directory,
+)
 
 __all__ = [
     "StorageRootManager",
@@ -151,6 +154,7 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
         if _adhoc_engine is None or _adhoc_engine_url != database_url:
             old_engine = _adhoc_engine
             if "sqlite" in database_url:
+                ensure_sqlite_parent_directory(database_url)
                 engine = create_engine(
                     database_url,
                     connect_args={"check_same_thread": False},

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -154,9 +154,10 @@ def _get_adhoc_engine():  # type: ignore[no-untyped-def]
         if _adhoc_engine is None or _adhoc_engine_url != database_url:
             old_engine = _adhoc_engine
             if "sqlite" in database_url:
-                ensure_sqlite_parent_directory(database_url)
+                # The cache key stays the raw URL; only the engine gets the
+                # ~-expanded path (sqlite3 does not expand ~ itself).
                 engine = create_engine(
-                    database_url,
+                    ensure_sqlite_parent_directory(database_url),
                     connect_args={"check_same_thread": False},
                 )
                 # WAL + busy_timeout so concurrent writes wait for the lock

--- a/src/xagent/db/migration.py
+++ b/src/xagent/db/migration.py
@@ -3,6 +3,9 @@ from typing import Any, cast
 
 from alembic import command
 from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from alembic.script.revision import RevisionError
+from alembic.util.exc import CommandError
 from sqlalchemy import Engine, inspect
 
 from .config import create_alembic_config
@@ -23,6 +26,32 @@ def get_alembic_revision(engine: Engine) -> str | None:
         return cast(str | None, context.get_current_revision())
 
 
+def _check_revision_is_known(alembic_cfg: Any, engine: Engine, version: str) -> None:
+    """Fail with an actionable message when the DB revision is unknown.
+
+    A database whose ``alembic_version`` points at a revision missing from the
+    installed package was almost always created or upgraded by a *newer*
+    xagent release (e.g. a source checkout or Docker image sharing the same
+    storage root). Alembic cannot downgrade without the newer migration
+    scripts, so surface what happened and how to recover instead of letting
+    ``command.upgrade`` fail with a bare "Can't locate revision" error.
+    """
+    script = ScriptDirectory.from_config(alembic_cfg)
+    try:
+        script.get_revisions(version)
+    except (CommandError, RevisionError):
+        db_url = engine.url.render_as_string(hide_password=True)
+        raise RuntimeError(
+            f"The database at '{db_url}' is at schema revision '{version}', "
+            "which this xagent installation does not know about. It was most "
+            "likely created or upgraded by a newer version of xagent (for "
+            "example a source checkout or Docker image using the same "
+            "storage root). To fix this, upgrade xagent to that version or "
+            "newer, or point DATABASE_URL / XAGENT_STORAGE_ROOT at a "
+            "different database."
+        ) from None
+
+
 def try_upgrade_db(engine: Engine) -> None:
     """Upgrade database to latest migration (or stamp head for brand-new databases)."""
     try:
@@ -41,6 +70,7 @@ def try_upgrade_db(engine: Engine) -> None:
                     "Database exists without alembic revision information. Please initialize the database schema version manually by running: alembic stamp <revision>"
                 )
         else:
+            _check_revision_is_known(alembic_cfg, engine, version)
             logger.info(f"Current version: {version}, upgrading to head")
             with engine.begin() as conn:
                 alembic_cfg.attributes["connection"] = conn

--- a/src/xagent/db/migration.py
+++ b/src/xagent/db/migration.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 from alembic import command
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
-from alembic.script.revision import RevisionError
 from alembic.util.exc import CommandError
 from sqlalchemy import Engine, inspect
 
@@ -39,7 +38,7 @@ def _check_revision_is_known(alembic_cfg: Any, engine: Engine, version: str) -> 
     script = ScriptDirectory.from_config(alembic_cfg)
     try:
         script.get_revisions(version)
-    except (CommandError, RevisionError):
+    except CommandError:
         db_url = engine.url.render_as_string(hide_password=True)
         raise RuntimeError(
             f"The database at '{db_url}' is at schema revision '{version}', "
@@ -59,7 +58,10 @@ def try_upgrade_db(engine: Engine) -> None:
         alembic_cfg = create_alembic_config(engine)
         version = get_alembic_revision(engine)
 
-        if version is None:
+        # An empty-string version_num (tampered/corrupted alembic_version)
+        # is treated like a missing revision: get_revisions("") dies with a
+        # bare AssertionError instead of a catchable error.
+        if not version:
             if is_database_empty(engine):
                 logger.info("Creating new database, stamping to latest revision.")
                 with engine.begin() as conn:

--- a/src/xagent/db/sqlite.py
+++ b/src/xagent/db/sqlite.py
@@ -12,14 +12,35 @@ row-level locks).
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from sqlalchemy import Engine, event
+from sqlalchemy.engine import make_url
 
 logger = logging.getLogger(__name__)
 
 # 5s gives concurrent writers room to wait out a short-lived write lock without
 # unbounded blocking.
 DEFAULT_BUSY_TIMEOUT_MS = 5000
+
+
+def ensure_sqlite_parent_directory(database_url: str) -> None:
+    """Create the SQLite database file's parent directory if it is missing.
+
+    sqlite3 creates a missing database file on connect but not missing parent
+    directories: on a fresh install the default ``~/.xagent`` storage root does
+    not exist yet, so the first connection fails with "unable to open database
+    file". Call this before creating an engine for a file-backed SQLite URL.
+
+    Non-SQLite, in-memory, and ``file:`` URI databases are ignored.
+    """
+    url = make_url(database_url)
+    if url.get_backend_name() != "sqlite":
+        return
+    database = url.database
+    if not database or database == ":memory:" or database.startswith("file:"):
+        return
+    Path(database).expanduser().parent.mkdir(parents=True, exist_ok=True)
 
 
 def apply_sqlite_concurrency_pragmas(

--- a/src/xagent/db/sqlite.py
+++ b/src/xagent/db/sqlite.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_BUSY_TIMEOUT_MS = 5000
 
 
-def ensure_sqlite_parent_directory(database_url: str) -> None:
+def ensure_sqlite_parent_directory(database_url: str) -> str:
     """Create the SQLite database file's parent directory if it is missing.
 
     sqlite3 creates a missing database file on connect but not missing parent
@@ -32,15 +32,23 @@ def ensure_sqlite_parent_directory(database_url: str) -> None:
     not exist yet, so the first connection fails with "unable to open database
     file". Call this before creating an engine for a file-backed SQLite URL.
 
-    Non-SQLite, in-memory, and ``file:`` URI databases are ignored.
+    Returns the URL to hand to ``create_engine``: sqlite3 does not expand
+    ``~`` (it would open a literal ``./~/...`` path), so a ``~``-prefixed
+    database path is rewritten to its expanded absolute form — the same path
+    whose parent was just created. Other URLs are returned unchanged;
+    non-SQLite, in-memory, and ``file:`` URI databases are ignored.
     """
     url = make_url(database_url)
     if url.get_backend_name() != "sqlite":
-        return
+        return database_url
     database = url.database
     if not database or database == ":memory:" or database.startswith("file:"):
-        return
-    Path(database).expanduser().parent.mkdir(parents=True, exist_ok=True)
+        return database_url
+    path = Path(database).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if str(path) != database:
+        return str(url.set(database=str(path)))
+    return database_url
 
 
 def apply_sqlite_concurrency_pragmas(

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -7,7 +7,10 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
 
 from ...config import get_database_url, get_db_pool_kwargs
-from ...db.sqlite import apply_sqlite_concurrency_pragmas
+from ...db.sqlite import (
+    apply_sqlite_concurrency_pragmas,
+    ensure_sqlite_parent_directory,
+)
 
 _SessionLocal: sessionmaker[Session] | None = None
 
@@ -169,6 +172,7 @@ def init_db(db_url: str | None = None) -> None:
     # For SQLite, use NullPool to prevent connection pool issues
     # For other databases, use QueuePool with timeout settings
     if "sqlite" in database_url:
+        ensure_sqlite_parent_directory(database_url)
         _engine = create_engine(
             database_url,
             connect_args={"check_same_thread": False},

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -172,7 +172,7 @@ def init_db(db_url: str | None = None) -> None:
     # For SQLite, use NullPool to prevent connection pool issues
     # For other databases, use QueuePool with timeout settings
     if "sqlite" in database_url:
-        ensure_sqlite_parent_directory(database_url)
+        database_url = ensure_sqlite_parent_directory(database_url)
         _engine = create_engine(
             database_url,
             connect_args={"check_same_thread": False},

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -992,6 +992,13 @@ class TestGetStorageRoot:
         result = get_storage_root()
         assert result == Path("/custom/storage")
 
+    def test_storage_root_expands_tilde(self, monkeypatch, tmp_path):
+        """A ~-prefixed env value resolves to the home directory."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(STORAGE_ROOT, "~/custom-root")
+        result = get_storage_root()
+        assert result == tmp_path / "custom-root"
+
 
 class TestGetSandboxImage:
     """Test get_sandbox_image() function."""

--- a/tests/core/test_sqlite_parent_directory.py
+++ b/tests/core/test_sqlite_parent_directory.py
@@ -39,3 +39,21 @@ def test_ignores_in_memory_and_non_sqlite_urls(tmp_path) -> None:
     ensure_sqlite_parent_directory("sqlite://")
     ensure_sqlite_parent_directory("sqlite:///file:shared?mode=memory&uri=true")
     ensure_sqlite_parent_directory("postgresql://user:pw@localhost/xagent")
+
+
+def test_relative_path_without_parent_segment_is_a_noop(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    ensure_sqlite_parent_directory("sqlite:///relative.db")
+
+    # Parent of "relative.db" is "." — nothing gets created, nothing raises.
+    assert not (tmp_path / "relative.db").exists()
+
+
+def test_tilde_path_expands_to_home(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    ensure_sqlite_parent_directory("sqlite:///~/storage-root/xagent.db")
+
+    assert (tmp_path / "storage-root").is_dir()

--- a/tests/core/test_sqlite_parent_directory.py
+++ b/tests/core/test_sqlite_parent_directory.py
@@ -50,10 +50,23 @@ def test_relative_path_without_parent_segment_is_a_noop(tmp_path, monkeypatch) -
     assert not (tmp_path / "relative.db").exists()
 
 
-def test_tilde_path_expands_to_home(tmp_path, monkeypatch) -> None:
+def test_tilde_path_expands_to_home_and_connects(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
-    ensure_sqlite_parent_directory("sqlite:///~/storage-root/xagent.db")
+    url = ensure_sqlite_parent_directory("sqlite:///~/storage-root/xagent.db")
 
+    # The returned URL must point at the expanded path (sqlite3 does not
+    # expand ~), so connecting with it works end-to-end.
     assert (tmp_path / "storage-root").is_dir()
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        assert conn.exec_driver_sql("SELECT 1").scalar() == 1
+    engine.dispose()
+    assert (tmp_path / "storage-root" / "xagent.db").exists()
+
+
+def test_plain_urls_are_returned_unchanged(tmp_path) -> None:
+    url = f"sqlite:///{tmp_path / 'xagent.db'}"
+
+    assert ensure_sqlite_parent_directory(url) == url
+    assert ensure_sqlite_parent_directory("sqlite:///:memory:") == "sqlite:///:memory:"

--- a/tests/core/test_sqlite_parent_directory.py
+++ b/tests/core/test_sqlite_parent_directory.py
@@ -1,0 +1,41 @@
+"""ensure_sqlite_parent_directory — fresh-install SQLite bootstrap.
+
+sqlite3 creates a missing database file on connect but not missing parent
+directories, so on a fresh install the default ``~/.xagent`` storage root made
+the very first connection fail with "unable to open database file".
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+
+from xagent.db.sqlite import ensure_sqlite_parent_directory
+
+
+def test_creates_missing_parent_directories(tmp_path) -> None:
+    db_path = tmp_path / "storage-root" / "nested" / "xagent.db"
+    url = f"sqlite:///{db_path}"
+
+    ensure_sqlite_parent_directory(url)
+
+    assert db_path.parent.is_dir()
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        assert conn.exec_driver_sql("SELECT 1").scalar() == 1
+    engine.dispose()
+
+
+def test_existing_parent_directory_is_left_alone(tmp_path) -> None:
+    db_path = tmp_path / "xagent.db"
+    db_path.write_bytes(b"")
+
+    ensure_sqlite_parent_directory(f"sqlite:///{db_path}")
+
+    assert db_path.exists()
+
+
+def test_ignores_in_memory_and_non_sqlite_urls(tmp_path) -> None:
+    ensure_sqlite_parent_directory("sqlite:///:memory:")
+    ensure_sqlite_parent_directory("sqlite://")
+    ensure_sqlite_parent_directory("sqlite:///file:shared?mode=memory&uri=true")
+    ensure_sqlite_parent_directory("postgresql://user:pw@localhost/xagent")

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -128,11 +128,29 @@ class TestTryUpgradeDb:
         assert first_rows == expected_rows
         assert rows == expected_rows
 
+    def test_raises_friendly_error_when_db_revision_is_unknown(self):
+        engine = create_engine("sqlite:///:memory:")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO alembic_version (version_num) "
+                    "VALUES ('29991231_revision_from_the_future')"
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="newer version of xagent"):
+            try_upgrade_db(engine)
+
+    @patch("xagent.db.migration._check_revision_is_known")
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")
     @patch("xagent.db.migration.get_alembic_revision")
     def test_successful_upgrade(
-        self, mock_get_revision, mock_create_config, mock_upgrade
+        self, mock_get_revision, mock_create_config, mock_upgrade, _mock_check
     ):
         engine = MagicMock()
         mock_get_revision.return_value = "abc123"
@@ -186,11 +204,12 @@ class TestTryUpgradeDb:
         ):
             try_upgrade_db(engine)
 
+    @patch("xagent.db.migration._check_revision_is_known")
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")
     @patch("xagent.db.migration.get_alembic_revision")
     def test_raises_error_on_upgrade_failure(
-        self, mock_get_revision, mock_create_config, mock_upgrade
+        self, mock_get_revision, mock_create_config, mock_upgrade, _mock_check
     ):
         engine = MagicMock()
         mock_get_revision.return_value = "abc123"
@@ -199,12 +218,18 @@ class TestTryUpgradeDb:
         with pytest.raises(Exception, match="Upgrade failed"):
             try_upgrade_db(engine)
 
+    @patch("xagent.db.migration._check_revision_is_known")
     @patch("xagent.db.migration.logger")
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")
     @patch("xagent.db.migration.get_alembic_revision")
     def test_logs_upgrade_process(
-        self, mock_get_revision, mock_create_config, mock_upgrade, mock_logger
+        self,
+        mock_get_revision,
+        mock_create_config,
+        mock_upgrade,
+        mock_logger,
+        _mock_check,
     ):
         engine = MagicMock()
         mock_get_revision.return_value = "abc123"

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -128,6 +128,51 @@ class TestTryUpgradeDb:
         assert first_rows == expected_rows
         assert rows == expected_rows
 
+    def test_upgrades_through_check_from_known_older_revision(self):
+        engine = create_engine("sqlite:///:memory:")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO alembic_version (version_num) "
+                    "VALUES ('20260616_add_agent_triggers')"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TABLE tasks ("
+                    "id INTEGER PRIMARY KEY, "
+                    "source VARCHAR(20), "
+                    "is_visible BOOLEAN NOT NULL)"
+                )
+            )
+
+        try_upgrade_db(engine)
+
+        with engine.begin() as conn:
+            version = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
+        script = ScriptDirectory.from_config(create_alembic_config(engine))
+        assert version == script.get_current_head()
+
+    def test_treats_empty_string_revision_as_unversioned(self):
+        engine = create_engine("sqlite:///:memory:")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+            )
+            conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('')"))
+
+        with pytest.raises(
+            RuntimeError, match="Database exists without alembic revision"
+        ):
+            try_upgrade_db(engine)
+
     def test_raises_friendly_error_when_db_revision_is_unknown(self):
         engine = create_engine("sqlite:///:memory:")
 


### PR DESCRIPTION
## Problem

Two classes of startup crashes reported with pip / one-line (uv tool) installs, both surfacing as an opaque traceback right after `Initializing database...`:

1. **Fresh install**: `sqlite3.OperationalError: unable to open database file`. Nothing created the storage root (`~/.xagent`) before the first connection — sqlite creates a missing database file, but not missing parent directories.
2. **Database newer than the package**: a database migrated by a newer version (e.g. a source checkout or Docker image sharing the same storage root, then started with an older PyPI release) crashed with a bare alembic `Can't locate revision identified by '...'` and a full lifespan traceback. Alembic cannot downgrade without the newer migration scripts, so the old release genuinely cannot proceed — but the error never said why or what to do.

## Changes

- Add `ensure_sqlite_parent_directory()` to `xagent/db/sqlite.py` and call it before engine creation in both `web/models/database.py::init_db` and `core/storage/manager.py::create_db_session`. In-memory, `file:` URI, and non-SQLite URLs are ignored.
- In `try_upgrade_db`, verify the database's current revision is known to the installed migration scripts before upgrading. If not, raise a `RuntimeError` that names the database, the offending revision, the likely cause, and the two recovery options (upgrade xagent, or point `DATABASE_URL` / `XAGENT_STORAGE_ROOT` elsewhere):

```
The database at 'sqlite:////root/.xagent/xagent.db' is at schema revision
'20260713_add_agent_visibility', which this xagent installation does not know
about. It was most likely created or upgraded by a newer version of xagent
(for example a source checkout or Docker image using the same storage root).
To fix this, upgrade xagent to that version or newer, or point DATABASE_URL /
XAGENT_STORAGE_ROOT at a different database.
```

## Tests

- `tests/core/test_sqlite_parent_directory.py`: missing nested parent dirs are created and the engine connects; existing dirs untouched; in-memory / `file:` URI / non-SQLite URLs ignored.
- `tests/migration/test_migration.py`: a database stamped with an unknown (future) revision raises the friendly `RuntimeError`; existing mocked upgrade tests updated for the new check.
- Verified end-to-end: `init_db()` against a nonexistent nested directory now bootstraps and migrates; a DB stamped with an unreleased revision produces the message above instead of the alembic traceback.