### PR TITLE
feat(models): show provider details across model selectors

### DIFF
--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
+import { isBuiltinModel } from "@/lib/models"
 import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain, Webhook, CalendarClock, Mail, Eye, Workflow } from "lucide-react"
 import { ConnectMcpDialog } from "@/components/mcp/connect-mcp-dialog"
 import { useI18n } from "@/contexts/i18n-context"
@@ -79,6 +80,11 @@ interface Model {
   model_name: string
   model_provider: string
   category: string
+  base_url?: string
+  is_default?: boolean
+  is_small_fast?: boolean
+  is_visual?: boolean
+  is_compact?: boolean
 }
 
 interface UserDefaultModel {
@@ -718,11 +724,29 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     description: skill.description || skill.when_to_use || undefined,
   }))
 
+  const modelHost = (model: Model): string => {
+    let host = ""
+    if (model.base_url) {
+      try {
+        host = new URL(model.base_url).hostname
+      } catch {
+        host = model.base_url
+      }
+    }
+    return host ? `${host} (${model.model_provider})` : model.model_provider
+  }
+
   const modelOptions = [
     { value: "", label: "--" },
     ...(Array.isArray(models) ? models : []).map((model) => ({
       value: model.id.toString(),
       label: model.model_name,
+      host: modelHost(model),
+      isBuiltin: isBuiltinModel(model),
+      isDefault: model.is_default,
+      isSmallFast: model.is_small_fast,
+      isVisual: model.is_visual,
+      isCompact: model.is_compact,
     }))
   ]
 

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
-import { isBuiltinModel } from "@/lib/models"
+import { isBuiltinModel, hostnameFromUrl } from "@/lib/models"
 import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain, Webhook, CalendarClock, Mail, Eye, Workflow } from "lucide-react"
 import { ConnectMcpDialog } from "@/components/mcp/connect-mcp-dialog"
 import { useI18n } from "@/contexts/i18n-context"
@@ -725,14 +725,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   }))
 
   const modelHost = (model: Model): string => {
-    let host = ""
-    if (model.base_url) {
-      try {
-        host = new URL(model.base_url).hostname
-      } catch {
-        host = model.base_url
-      }
-    }
+    const host = hostnameFromUrl(model.base_url)
     return host ? `${host} (${model.model_provider})` : model.model_provider
   }
 

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -735,6 +735,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       value: model.id.toString(),
       label: model.model_name,
       host: modelHost(model),
+      description: model.model_id,
       isBuiltin: isBuiltinModel(model),
       isDefault: model.is_default,
       isSmallFast: model.is_small_fast,

--- a/frontend/src/components/config-dialog.tsx
+++ b/frontend/src/components/config-dialog.tsx
@@ -63,12 +63,19 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
   })
   const { t } = useI18n()
 
-  // Platform (built-in) models show a locale-aware badge next to the name
-  // (isBuiltinModel); their seeded "Built-in" placeholder is then kept out of
-  // the option detail line, while a real description (if one is ever added)
-  // still shows since the badge already conveys built-in.
-  const modelDesc = (m: Model): string | undefined =>
-    isBuiltinModel(m) && m.description?.toLowerCase() === "built-in" ? undefined : m.description
+  // Provider host line shown under the model name: "hostname (provider)",
+  // falling back to just the provider when there's no base_url.
+  const modelHost = (m: Model): string => {
+    let host = ""
+    if (m.base_url) {
+      try {
+        host = new URL(m.base_url).hostname
+      } catch {
+        host = m.base_url
+      }
+    }
+    return host ? `${host} (${m.model_provider})` : m.model_provider
+  }
 
   // Fetch models when dialog opens
   useEffect(() => {
@@ -224,7 +231,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                     options={models.map(m => ({
                       value: m.model_id,
                       label: m.model_name,
-                      description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider}) [${m.model_id}]`,
+                      host: modelHost(m),
                       isBuiltin: isBuiltinModel(m),
                       isDefault: m.is_default,
                       isSmallFast: m.is_small_fast,
@@ -250,7 +257,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider}) [${m.model_id}]${m.is_small_fast ? t('agent.configDialog.modelSelect.smallFast.options.tagFast') : ''}`,
+                        host: modelHost(m),
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
@@ -277,7 +284,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider})[${m.model_id}]${m.is_visual ? t('agent.configDialog.modelSelect.visual.options.tagVisual') : ''}`,
+                        host: modelHost(m),
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
@@ -304,7 +311,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       ...models.map(m => ({
                         value: m.model_id,
                         label: m.model_name,
-                        description: `${m.model_name}${modelDesc(m) ? ' - ' + modelDesc(m) : ''} (${m.model_provider})[${m.model_id}]${m.is_compact ? t('agent.configDialog.modelSelect.compact.options.tagCompact') : ''}`,
+                        host: modelHost(m),
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,

--- a/frontend/src/components/config-dialog.tsx
+++ b/frontend/src/components/config-dialog.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Settings, X, Loader2, ArrowRight } from "lucide-react"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
-import { isBuiltinModel } from "@/lib/models"
+import { isBuiltinModel, hostnameFromUrl } from "@/lib/models"
 import { useAuth } from "@/contexts/auth-context"
 import { Select } from "@/components/ui/select"
 import { Slider } from "@/components/ui/slider"
@@ -66,14 +66,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
   // Provider host line shown under the model name: "hostname (provider)",
   // falling back to just the provider when there's no base_url.
   const modelHost = (m: Model): string => {
-    let host = ""
-    if (m.base_url) {
-      try {
-        host = new URL(m.base_url).hostname
-      } catch {
-        host = m.base_url
-      }
-    }
+    const host = hostnameFromUrl(m.base_url)
     return host ? `${host} (${m.model_provider})` : m.model_provider
   }
 
@@ -232,6 +225,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                       value: m.model_id,
                       label: m.model_name,
                       host: modelHost(m),
+                      description: m.model_id,
                       isBuiltin: isBuiltinModel(m),
                       isDefault: m.is_default,
                       isSmallFast: m.is_small_fast,
@@ -258,6 +252,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                         value: m.model_id,
                         label: m.model_name,
                         host: modelHost(m),
+                        description: m.model_id,
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
@@ -285,6 +280,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                         value: m.model_id,
                         label: m.model_name,
                         host: modelHost(m),
+                        description: m.model_id,
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,
@@ -312,6 +308,7 @@ export function ConfigDialog({ onConfigChange, currentConfig, trigger }: ConfigD
                         value: m.model_id,
                         label: m.model_name,
                         host: modelHost(m),
+                        description: m.model_id,
                         isBuiltin: isBuiltinModel(m),
                         isDefault: m.is_default,
                         isSmallFast: m.is_small_fast,

--- a/frontend/src/components/pages/model-management-dialog.tsx
+++ b/frontend/src/components/pages/model-management-dialog.tsx
@@ -15,6 +15,7 @@ import { apiRequest } from "@/lib/api-wrapper"
 import {
   DefaultModelType,
   getProviderModels,
+  hostnameFromUrl,
   isBuiltinModel,
   ProviderModel,
   removeUserDefaultModel,
@@ -258,12 +259,7 @@ export function ModelManagementDialog({
 
   const getProviderHost = (model: Model) => {
     const url = model.base_url || getDefaultBaseUrlForProvider(model.model_provider, model.category)
-    if (!url) return ""
-    try {
-      return new URL(url).hostname
-    } catch {
-      return url
-    }
+    return hostnameFromUrl(url)
   }
 
   // Determine initial form data based on editing model or prefill provider
@@ -767,6 +763,7 @@ export function ModelManagementDialog({
                   {managingProviderModels.map(model => {
                     const defaultTypes = getModelDefaultTypes(model.id)
                     const audioTypeLabels = getAudioTypeLabels(model)
+                    const host = getProviderHost(model)
                     return (
                       <div key={model.model_id} className="flex items-center justify-between p-4">
                         <div>
@@ -804,11 +801,11 @@ export function ModelManagementDialog({
                               </Badge>
                             )}
                           </div>
-                          {getProviderHost(model) && (
+                          {host && (
                             <div className="mt-1">
                               <Badge variant="outline" className="font-normal text-muted-foreground">
                                 <Globe />
-                                {getProviderHost(model)}
+                                {host}
                               </Badge>
                             </div>
                           )}

--- a/frontend/src/components/pages/model-management-dialog.tsx
+++ b/frontend/src/components/pages/model-management-dialog.tsx
@@ -39,7 +39,8 @@ import {
   Check,
   Video,
   Volume2,
-  Music
+  Music,
+  Globe
 } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -253,6 +254,16 @@ export function ModelManagementDialog({
       return provider.categoryBaseUrls[category]
     }
     return provider.defaultBaseUrl || ""
+  }
+
+  const getProviderHost = (model: Model) => {
+    const url = model.base_url || getDefaultBaseUrlForProvider(model.model_provider, model.category)
+    if (!url) return ""
+    try {
+      return new URL(url).hostname
+    } catch {
+      return url
+    }
   }
 
   // Determine initial form data based on editing model or prefill provider
@@ -793,6 +804,14 @@ export function ModelManagementDialog({
                               </Badge>
                             )}
                           </div>
+                          {getProviderHost(model) && (
+                            <div className="mt-1">
+                              <Badge variant="outline" className="font-normal text-muted-foreground">
+                                <Globe />
+                                {getProviderHost(model)}
+                              </Badge>
+                            </div>
+                          )}
                         </div>
                         <div className="flex items-center gap-1">
                           {!model.is_owner && getDefaultOptionsForModel(model.category, model.abilities).length > 0 && (

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from "react"
 import { cn } from "@/lib/utils"
-import { ChevronDown, Check } from "lucide-react"
+import { ChevronDown, Check, Globe } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 
 export interface SelectOption {
@@ -14,6 +14,7 @@ export interface SelectOption {
   isVisual?: boolean
   isCompact?: boolean
   isBuiltin?: boolean
+  host?: string
   actionIcon?: React.ReactNode
   onAction?: (e: React.MouseEvent) => void
 }
@@ -110,25 +111,33 @@ export function Select({
       >
         <div className="flex items-center gap-2 flex-1 min-w-0">
           {selectedOption ? (
-            <div className="flex items-center gap-2 min-w-0 flex-1">
-              <span className="font-medium truncate">{selectedOption.label}</span>
-              {(selectedOption.isBuiltin || selectedOption.isDefault || selectedOption.isSmallFast || selectedOption.isVisual || selectedOption.isCompact) && (
-                <div className="flex gap-1 flex-shrink-0">
-                  {selectedOption.isBuiltin && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600">{t('models.defaults.builtin')}</span>
-                  )}
-                  {selectedOption.isDefault && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">Default</span>
-                  )}
-                  {selectedOption.isSmallFast && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500">Fast</span>
-                  )}
-                  {selectedOption.isVisual && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-500">Visual</span>
-                  )}
-                  {selectedOption.isCompact && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/10 text-green-500">Long Context</span>
-                  )}
+            <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="font-medium truncate">{selectedOption.label}</span>
+                {(selectedOption.isBuiltin || selectedOption.isDefault || selectedOption.isSmallFast || selectedOption.isVisual || selectedOption.isCompact) && (
+                  <div className="flex gap-1 flex-shrink-0">
+                    {selectedOption.isBuiltin && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600">{t('models.defaults.builtin')}</span>
+                    )}
+                    {selectedOption.isDefault && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">Default</span>
+                    )}
+                    {selectedOption.isSmallFast && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500">Fast</span>
+                    )}
+                    {selectedOption.isVisual && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-500">Visual</span>
+                    )}
+                    {selectedOption.isCompact && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/10 text-green-500">Long Context</span>
+                    )}
+                  </div>
+                )}
+              </div>
+              {selectedOption.host && (
+                <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Globe className="h-3 w-3 flex-shrink-0" />
+                  <span className="truncate">{selectedOption.host}</span>
                 </div>
               )}
             </div>
@@ -196,6 +205,12 @@ export function Select({
                       <Check className="h-4 w-4 text-primary flex-shrink-0" />
                     )}
                   </div>
+                  {option.host && (
+                    <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                      <Globe className="h-3 w-3 flex-shrink-0" />
+                      <span className="truncate">{option.host}</span>
+                    </div>
+                  )}
                   {option.description && (
                     <div className="text-xs text-muted-foreground mt-1 truncate">{option.description}</div>
                   )}

--- a/frontend/src/lib/models.test.ts
+++ b/frontend/src/lib/models.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { hostnameFromUrl } from "./models"
+
+describe("hostnameFromUrl", () => {
+  it("returns empty string for missing url", () => {
+    expect(hostnameFromUrl(undefined)).toBe("")
+    expect(hostnameFromUrl(null)).toBe("")
+    expect(hostnameFromUrl("")).toBe("")
+  })
+
+  it("keeps non-standard ports so same-host models stay distinguishable", () => {
+    expect(hostnameFromUrl("http://localhost:9997/v1")).toBe("localhost:9997")
+    expect(hostnameFromUrl("http://localhost:11434")).toBe("localhost:11434")
+  })
+
+  it("drops default ports per URL semantics", () => {
+    expect(hostnameFromUrl("https://api.openai.com/v1")).toBe("api.openai.com")
+  })
+
+  it("returns empty string for non-absolute urls instead of a garbled fallback", () => {
+    expect(hostnameFromUrl("/v1")).toBe("")
+    expect(hostnameFromUrl("not a url")).toBe("")
+  })
+})

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -47,6 +47,20 @@ export interface Model {
 export const isBuiltinModel = (model: { model_id?: string | null }): boolean =>
   Boolean(model.model_id?.startsWith("platform/"));
 
+// Host (including port) extracted from a base URL, for disambiguating
+// same-named models across endpoints. Uses `.host` so non-standard ports
+// (xinference :9997, Ollama :11434) survive. Returns "" for empty or
+// non-absolute URLs so callers fall back to a provider-only label instead
+// of rendering a garbled raw string.
+export const hostnameFromUrl = (url?: string | null): string => {
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+};
+
 export interface UserDefaultModel {
   id: number;
   user_id: number;


### PR DESCRIPTION
## Summary

- show the provider host on model cards in the model management dialog
- display `hostname (provider)` in task and Agent Builder model selectors
- show built-in, default, fast, visual, and long-context badges consistently
- support platform built-in models identified by the `platform/` model ID prefix
- fall back to the provider name when a model has no configured base URL

## Why

Models can share the same display name while pointing to different providers or endpoints. Showing the host and provider in model selection surfaces makes those models distinguishable before users select them, while keeping platform-provided models clearly identified.

## User impact

Users can now identify where a model is hosted and whether it is platform built-in from the model management dialog, task configuration, and Agent Builder model selectors.

## Testing

- `npm run type-check`
- `npm run test:run -- src/components/build/agent-builder-preview.test.tsx src/components/build/agent-builder-admin-mcp.test.tsx`
- pre-commit hooks, including frontend lint and type checking

All 10 targeted Agent Builder tests passed.
