### PR TITLE
fix(workforce): stop unconfigured agents from inheriting user custom APIs

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1794,7 +1794,12 @@ class AgentTool(AbstractBaseTool):
 
             # Delegated-agent tool selection goes through the shared
             # ``ToolSelectionSpec.from_raw`` normalizer.
-            # ``None`` → _SpecAll (unconfigured legacy agent, all tools).
+            # ``None`` → _SpecAll (unconfigured legacy agent, all built-in
+            #            tools) — but WITHOUT the user-level Custom API
+            #            registry: a delegated agent may only call Custom
+            #            APIs it explicitly selected via an ``mcp:<server>``
+            #            connector, never inherit every API the *user* has
+            #            configured (issue #798).
             # ``[]``  → _SpecNone (agent explicitly saved with zero tools).
             # Non-empty list → _SpecByCategories (scoped to declared tools).
             from .selection_spec import (
@@ -1804,6 +1809,7 @@ class AgentTool(AbstractBaseTool):
 
             tool_selection_spec = ToolSelectionSpec.from_raw(
                 tool_categories=agent_tool_categories,
+                exclude_custom_api_when_unconfigured=True,
             )
 
             parent_db_task_id = _coerce_db_task_id(self._parent_task_id)

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -211,6 +211,7 @@ class ToolSelectionSpec(ABC):
         name_allowlist: Optional[Set[str]] = None,
         explicit_none: bool = False,
         extras_only_when_unconfigured: bool = False,
+        exclude_custom_api_when_unconfigured: bool = False,
     ) -> "ToolSelectionSpec":
         """Build a spec from raw ORM / dict / SDK fields.
 
@@ -232,6 +233,14 @@ class ToolSelectionSpec(ABC):
             filters to the worker tool names (or ``_SpecNone`` when there
             is no ``published_agent_ids``). Lets an unconfigured manager
             delegate only to its workers without inheriting the full set.
+          - ``exclude_custom_api_when_unconfigured=True`` with
+            ``tool_categories=None`` → ``_SpecAll`` that still builds every
+            default tool but does NOT run the Custom API creator. Delegated
+            workforce workers use this: an unconfigured (legacy) worker
+            keeps built-in tools, but must not bulk-inherit every user-level
+            Custom API it never selected (issue #798). No effect in
+            BY_CATEGORIES / NONE modes, which already scope Custom APIs to
+            explicit ``mcp:<server>`` connectors.
           - Otherwise → ``_SpecByCategories`` after dropping non-assignable
             entries such as ``"other"``; if nothing assignable remains, NONE.
 
@@ -271,7 +280,9 @@ class ToolSelectionSpec(ABC):
             # selected zero tools — return NONE so no tools are injected.
             if tool_categories is not None:
                 return _SpecNone()
-            return _SpecAll()
+            return _SpecAll(
+                include_custom_api=not exclude_custom_api_when_unconfigured,
+            )
 
         # ``tool_categories`` mixes two orthogonal shapes:
         #   - plain category names (``"basic"``, ``"file"``, ``"mcp"``);
@@ -393,6 +404,12 @@ class _SpecAll(ToolSelectionSpec):
     categories: Optional[frozenset[str]] = None
     mcp_servers: Optional[frozenset[str]] = None
     published_agent_ids: Optional[frozenset[int]] = None
+    # Whether the Custom API creator may run in ALL mode. Defaults to
+    # True (legacy unconfigured agents keep their Custom API access);
+    # ``from_raw(exclude_custom_api_when_unconfigured=True)`` sets it to
+    # False so delegated workforce workers never bulk-load user-level
+    # Custom APIs they did not select (issue #798).
+    include_custom_api: bool = True
 
     def is_all(self) -> bool:
         return True
@@ -414,7 +431,7 @@ class _SpecAll(ToolSelectionSpec):
         return True
 
     def includes_custom_api(self) -> bool:
-        return True
+        return self.include_custom_api
 
     def includes_published_agent(self) -> bool:
         if self.published_agent_ids is not None and len(self.published_agent_ids) == 0:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -1248,8 +1248,12 @@ class AgentPreviewRequest(BaseModel):
         default_factory=list, description="Knowledge base names"
     )
     skills: List[str] = Field(default_factory=list, description="Skill names")
-    tool_categories: List[str] = Field(
-        default_factory=list, description="Tool category names"
+    # ``None`` (field omitted) keeps the legacy "unconfigured" semantics
+    # (full default tool set); ``[]`` means the caller explicitly selected
+    # zero tools. This mirrors how ``Agent.tool_categories`` is read at
+    # runtime, so a preview behaves like the saved agent would.
+    tool_categories: Optional[List[str]] = Field(
+        None, description="Tool category names"
     )
     message: str = Field(..., description="User message to preview")
 
@@ -1337,6 +1341,20 @@ async def preview_agent(
         # Generate unique task_id for each preview to avoid workspace conflicts
         preview_task_id = f"preview_{uuid.uuid4().hex[:8]}"
 
+        # Scope the preview's tools to the agent's selection, exactly like
+        # the runtime chat path does. Without a spec, WebToolConfig builds
+        # the unrestricted tool set — including every Custom API / MCP
+        # server the *user* has configured — so the preview could call
+        # APIs the agent never selected (issues #798 / #117).
+        from ...core.tools.adapters.vibe.selection_spec import (
+            ToolSelectionSpec,
+            should_load_mcp_server_configs,
+        )
+
+        tool_selection_spec = ToolSelectionSpec.from_raw(
+            tool_categories=request.tool_categories,
+        )
+
         tool_config = WebToolConfig(
             db=db,
             request=MinimalRequest(int(current_user.id)),
@@ -1347,6 +1365,8 @@ async def preview_agent(
             if request.knowledge_bases is not None
             else None,
             allowed_skills=request.skills if request.skills is not None else None,
+            tool_selection_spec=tool_selection_spec,
+            include_mcp_tools=should_load_mcp_server_configs(tool_selection_spec),
             task_id=preview_task_id,
             workspace_base_dir=str(get_uploads_dir() / "preview"),
         )

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -1345,7 +1345,11 @@ async def preview_agent(
         # the runtime chat path does. Without a spec, WebToolConfig builds
         # the unrestricted tool set — including every Custom API / MCP
         # server the *user* has configured — so the preview could call
-        # APIs the agent never selected (issues #798 / #117).
+        # APIs the agent never selected (issues #798 / #117). Like the
+        # delegated-agent path, the omitted/None (legacy "unconfigured")
+        # case keeps every built-in tool but opts out of the user-level
+        # Custom API registry: a preview must never expose APIs the agent
+        # being previewed did not select.
         from ...core.tools.adapters.vibe.selection_spec import (
             ToolSelectionSpec,
             should_load_mcp_server_configs,
@@ -1353,6 +1357,7 @@ async def preview_agent(
 
         tool_selection_spec = ToolSelectionSpec.from_raw(
             tool_categories=request.tool_categories,
+            exclude_custom_api_when_unconfigured=True,
         )
 
         tool_config = WebToolConfig(

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -1341,15 +1341,17 @@ async def preview_agent(
         # Generate unique task_id for each preview to avoid workspace conflicts
         preview_task_id = f"preview_{uuid.uuid4().hex[:8]}"
 
-        # Scope the preview's tools to the agent's selection, exactly like
-        # the runtime chat path does. Without a spec, WebToolConfig builds
-        # the unrestricted tool set — including every Custom API / MCP
-        # server the *user* has configured — so the preview could call
-        # APIs the agent never selected (issues #798 / #117). Like the
-        # delegated-agent path, the omitted/None (legacy "unconfigured")
-        # case keeps every built-in tool but opts out of the user-level
-        # Custom API registry: a preview must never expose APIs the agent
-        # being previewed did not select.
+        # Scope the preview's tools to the agent's selection. Without a
+        # spec, WebToolConfig builds the unrestricted tool set — including
+        # every Custom API / MCP server the *user* has configured — so the
+        # preview could call APIs the agent never selected (issues #798 /
+        # #117). Explicit categories mirror the runtime chat path; the
+        # omitted/None (legacy "unconfigured") case follows the
+        # delegated-agent path instead — every built-in tool, but no
+        # user-level Custom API registry — which is stricter than the
+        # direct-chat runtime (that path intentionally keeps legacy full
+        # access): a preview must never expose APIs the agent being
+        # previewed did not select.
         from ...core.tools.adapters.vibe.selection_spec import (
             ToolSelectionSpec,
             should_load_mcp_server_configs,

--- a/tests/core/tools/adapters/vibe/test_custom_api_factory.py
+++ b/tests/core/tools/adapters/vibe/test_custom_api_factory.py
@@ -48,6 +48,24 @@ async def test_create_db_custom_api_tools_other_category_does_not_load_configs()
 
 
 @pytest.mark.asyncio
+async def test_create_db_custom_api_tools_unconfigured_delegated_spec_skips_db():
+    """Issue #798: a delegated workforce worker with NULL tool_categories
+    builds an ALL-mode spec that opts out of the Custom API creator, so
+    the user-level Custom API registry is never enumerated."""
+    config = MagicMock()
+    config.get_tool_selection_spec.return_value = ToolSelectionSpec.from_raw(
+        tool_categories=None,
+        exclude_custom_api_when_unconfigured=True,
+    )
+    config.get_user_id.return_value = 1
+
+    tools = await create_db_custom_api_tools(config)
+
+    assert tools == []
+    config.get_custom_api_configs.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_create_db_custom_api_tools_with_configs():
     config = MagicMock(spec=BaseToolConfig)
     config.get_user_id.return_value = 1

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1317,6 +1317,49 @@ def test_by_categories_includes_custom_api_when_mcp_server_scoped():
     assert spec.includes_custom_api() is True
 
 
+def test_from_raw_unconfigured_keeps_custom_api_by_default():
+    """Legacy parity: a plain unconfigured spec (direct chat / no agent)
+    still admits the Custom API creator unless the caller opts out."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=None)
+    assert spec.is_all()
+    assert spec.includes_custom_api() is True
+
+
+def test_from_raw_unconfigured_can_exclude_custom_api():
+    """Issue #798: a delegated workforce worker with NULL tool_categories
+    must keep the legacy ALL-mode built-in tool set but NOT bulk-inherit
+    every user-level Custom API it never selected."""
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=None,
+        exclude_custom_api_when_unconfigured=True,
+    )
+    assert spec.is_all()
+    assert spec.includes_custom_api() is False
+    # Everything else keeps ALL-mode semantics: no name-level filter,
+    # ordinary categories still admitted.
+    assert spec.compute_allowed_names([]) is None
+    assert spec.includes_category("basic") is True
+
+
+def test_exclude_custom_api_flag_is_noop_when_configured():
+    """The opt-out only targets the unconfigured (NULL) legacy shape.
+    Configured agents already scope Custom APIs to explicit
+    ``mcp:<server>`` connectors; explicit ``[]`` stays NONE."""
+    scoped = ToolSelectionSpec.from_raw(
+        tool_categories=["mcp:onedrive"],
+        exclude_custom_api_when_unconfigured=True,
+    )
+    assert scoped.is_by_categories()
+    assert scoped.includes_custom_api() is True
+
+    zero = ToolSelectionSpec.from_raw(
+        tool_categories=[],
+        exclude_custom_api_when_unconfigured=True,
+    )
+    assert zero.is_none()
+    assert zero.includes_custom_api() is False
+
+
 # ----- compute_allowed_names mode dispatch -------------------------------
 
 

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2410,6 +2410,11 @@ class TestCreateAndCallAgent:
                 assert spec.is_none()
                 assert spec.includes_mcp() is False
             assert tool_config._include_mcp_tools is False
+            # Issue #798: whatever the categories shape, a delegated agent
+            # must never bulk-load the user-level Custom API registry.
+            # Custom APIs only load through an explicit mcp:<server>
+            # connector selection (none in this parametrization).
+            assert spec.includes_custom_api() is False
         finally:
             db.close()
             try:

--- a/tests/web/api/test_agents_preview_tool_scope.py
+++ b/tests/web/api/test_agents_preview_tool_scope.py
@@ -34,17 +34,15 @@ async def _run_preview(tool_categories):
     model_record.model_id = "test-model"
     db.query.return_value.filter.return_value.first.return_value = model_record
 
-    request_kwargs = dict(
+    request = AgentPreviewRequest(
         instructions="preview instructions",
         execution_mode="balanced",
         models={"general": 1},
         knowledge_bases=[],
         skills=[],
+        tool_categories=tool_categories,
         message="hello",
     )
-    if tool_categories is not ...:
-        request_kwargs["tool_categories"] = tool_categories
-    request = AgentPreviewRequest(**request_kwargs)
 
     with (
         patch("xagent.web.api.agents.UserAwareModelStorage") as mock_storage_class,
@@ -104,12 +102,14 @@ async def test_preview_empty_categories_yield_zero_tools():
 
 
 @pytest.mark.asyncio
-async def test_preview_omitted_categories_keep_legacy_all_mode():
-    """Field omitted (None) keeps legacy unconfigured semantics, matching
-    how a saved agent with NULL tool_categories behaves at runtime."""
-    tool_config = await _run_preview(...)
+async def test_preview_omitted_categories_keep_builtins_but_not_custom_apis():
+    """Field omitted (None, legacy "unconfigured") keeps the full built-in
+    tool set, but must NOT bulk-load the user-level Custom API registry —
+    the same opt-out the delegated-agent path applies (#798 / #117)."""
+    tool_config = await _run_preview(None)
 
     spec = tool_config.get_tool_selection_spec()
     assert spec.is_all()
+    assert spec.includes_custom_api() is False
     # Legacy ALL mode does not pay MCP server init on the preview path.
     assert tool_config._include_mcp_tools is False

--- a/tests/web/api/test_agents_preview_tool_scope.py
+++ b/tests/web/api/test_agents_preview_tool_scope.py
@@ -1,0 +1,115 @@
+"""REST agent-preview endpoint must scope tools to the request's
+``tool_categories`` (issues #798 / #117).
+
+Before the fix, ``preview_agent`` built its ``WebToolConfig`` without a
+``ToolSelectionSpec`` (and with the default ``include_mcp_tools=True``),
+so a preview loaded every Custom API / MCP server the *user* had
+configured — regardless of what the previewed agent actually selected.
+These tests pin the spec handed to ``WebToolConfig`` for each
+``tool_categories`` shape, mirroring the runtime chat-path semantics.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.web.api.agents import AgentPreviewRequest, preview_agent
+from xagent.web.models.user import User
+
+
+def _make_user() -> User:
+    user = User()
+    user.id = 7
+    user.is_admin = False
+    return user
+
+
+async def _run_preview(tool_categories):
+    """Run preview_agent with a stubbed LLM/AgentService and return the
+    WebToolConfig it was constructed with."""
+    current_user = _make_user()
+
+    db = MagicMock()
+    model_record = MagicMock()
+    model_record.model_id = "test-model"
+    db.query.return_value.filter.return_value.first.return_value = model_record
+
+    request_kwargs = dict(
+        instructions="preview instructions",
+        execution_mode="balanced",
+        models={"general": 1},
+        knowledge_bases=[],
+        skills=[],
+        message="hello",
+    )
+    if tool_categories is not ...:
+        request_kwargs["tool_categories"] = tool_categories
+    request = AgentPreviewRequest(**request_kwargs)
+
+    with (
+        patch("xagent.web.api.agents.UserAwareModelStorage") as mock_storage_class,
+        patch("xagent.web.api.agents.InMemoryMemoryStore"),
+        patch("xagent.web.api.agents.AgentService") as mock_agent_service_class,
+    ):
+        mock_storage = MagicMock()
+        mock_storage.get_llm_by_name_with_access.return_value = MagicMock()
+        mock_storage_class.return_value = mock_storage
+
+        mock_agent_service = mock_agent_service_class.return_value
+        mock_agent_service.execute_task = AsyncMock(
+            return_value={"output": "preview response", "status": "completed"}
+        )
+
+        await preview_agent(request=request, current_user=current_user, db=db)
+
+    return mock_agent_service_class.call_args.kwargs["tool_config"]
+
+
+@pytest.mark.asyncio
+async def test_preview_scoped_categories_exclude_custom_api_and_mcp():
+    """A preview for an agent that selected only ``basic`` must not load
+    the user's Custom API registry nor initialize MCP servers."""
+    tool_config = await _run_preview(["basic"])
+
+    spec = tool_config.get_tool_selection_spec()
+    assert spec.is_by_categories()
+    assert spec.includes_category("basic") is True
+    assert spec.includes_custom_api() is False
+    assert spec.includes_mcp() is False
+    assert tool_config._include_mcp_tools is False
+
+
+@pytest.mark.asyncio
+async def test_preview_mcp_server_scope_loads_only_that_connector():
+    """``mcp:<server>`` selection opts into MCP config loading and admits
+    the matching Custom API wrapper only."""
+    tool_config = await _run_preview(["mcp:LinkedIn"])
+
+    spec = tool_config.get_tool_selection_spec()
+    assert spec.is_by_categories()
+    assert spec.mcp_servers == frozenset({"linkedin"})
+    assert spec.includes_custom_api() is True
+    assert tool_config._include_mcp_tools is True
+
+
+@pytest.mark.asyncio
+async def test_preview_empty_categories_yield_zero_tools():
+    """Explicit ``[]`` mirrors a saved agent with zero tools selected."""
+    tool_config = await _run_preview([])
+
+    spec = tool_config.get_tool_selection_spec()
+    assert spec.is_none()
+    assert spec.includes_custom_api() is False
+    assert tool_config._include_mcp_tools is False
+
+
+@pytest.mark.asyncio
+async def test_preview_omitted_categories_keep_legacy_all_mode():
+    """Field omitted (None) keeps legacy unconfigured semantics, matching
+    how a saved agent with NULL tool_categories behaves at runtime."""
+    tool_config = await _run_preview(...)
+
+    spec = tool_config.get_tool_selection_spec()
+    assert spec.is_all()
+    # Legacy ALL mode does not pay MCP server init on the preview path.
+    assert tool_config._include_mcp_tools is False


### PR DESCRIPTION
## Summary

Fixes #798 — workforce runs could call custom APIs that none of the selected agents (Manager/Child) had configured.

**Root cause:** delegated workforce workers with `tool_categories=NULL` (legacy "unconfigured" agents) fell into the ALL-mode `ToolSelectionSpec`, whose `includes_custom_api()` unconditionally returned `True`. Since `get_custom_api_configs()` enumerates every active `UserCustomApi` for the *user* with no per-agent filter, such a worker loaded the user's entire custom API registry — e.g. the `api_POST_call` tool visible in the issue screenshot. Configured agents were already safe after #716; this closes the remaining unconfigured-worker path, plus the same leak surface in the REST agent preview endpoint (#117).

## Changes

- **selection_spec**: add `exclude_custom_api_when_unconfigured` to `ToolSelectionSpec.from_raw()` and an `include_custom_api` field on `_SpecAll`, so ALL mode can keep the legacy built-in tool set while opting out of the user-level Custom API registry. Default behavior unchanged for all existing callers.
- **agent_tool**: delegated child agents opt out — an unconfigured worker keeps all built-in tools but never bulk-inherits user custom APIs. Workers that explicitly select an `mcp:<server>` connector still get the matching API tool.
- **agents preview (REST)**: `request.tool_categories` is now converted into a `ToolSelectionSpec` and passed to `WebToolConfig` (with MCP config loading gated), instead of building the unrestricted tool set. `tool_categories` becomes `Optional` so an omitted field keeps legacy unconfigured semantics while `[]` means zero tools, mirroring runtime.

## Tests

- `test_selection_spec.py`: new-flag semantics (unconfigured opt-out, default keeps legacy behavior, no-op for configured/`[]` shapes).
- `test_custom_api_factory.py`: creator short-circuits without touching the DB for opted-out ALL-mode specs.
- `test_create_agent_tool.py`: delegated path never enables the custom API creator for any `tool_categories` shape without an explicit connector.
- `test_agents_preview_tool_scope.py` (new): preview spec/MCP gating for all four `tool_categories` shapes.

## E2E verification

Verified end-to-end on a local full stack (real LLM, workforce preview UI), reproducing the issue scenario:

- A workforce child simulating legacy data (`tool_categories=NULL`) lists 48 tools — all built-in — and confirms `api_POST_call` is absent; the custom API's target server receives zero requests.
- A control child that explicitly selects the `mcp:POST` connector still calls `api_POST_call` successfully.
