### PR TITLE
fix(memory): interpret nested metadata filters in InMemoryMemoryStore

### DIFF
--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -52,6 +52,19 @@ class InMemoryMemoryStore(MemoryStore):
             for key, value in metadata_filters.items()
         )
 
+    @staticmethod
+    def _required_items(value: Any) -> Optional[list[Any]]:
+        """Normalize a ``tags``/``keywords`` filter value: a plain string is a
+        single required item (not iterated per character), an iterable is many,
+        and anything else can't match (rather than raising ``TypeError`` on
+        malformed caller-supplied filters — the same no-match policy as
+        ``_matches_metadata_filters``)."""
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return list(value)
+        return None
+
     @classmethod
     def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
         """Filter keys without dedicated handling, applied as flat metadata
@@ -96,14 +109,20 @@ class InMemoryMemoryStore(MemoryStore):
             return False
 
         # Tag filter (all required tags present)
-        if "tags" in filters and not all(tag in note.tags for tag in filters["tags"]):
-            return False
+        if "tags" in filters:
+            required_tags = cls._required_items(filters["tags"])
+            if required_tags is None or not all(
+                tag in note.tags for tag in required_tags
+            ):
+                return False
 
         # Keyword filter (all required keywords present)
-        if "keywords" in filters and not all(
-            keyword in note.keywords for keyword in filters["keywords"]
-        ):
-            return False
+        if "keywords" in filters:
+            required_keywords = cls._required_items(filters["keywords"])
+            if required_keywords is None or not all(
+                keyword in note.keywords for keyword in required_keywords
+            ):
+                return False
 
         # Other flat metadata filters (string-coerced, like LanceDBMemoryStore)
         if other_filters and not cls._matches_metadata_filters(

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -25,10 +25,10 @@ class InMemoryMemoryStore(MemoryStore):
     def _matches_metadata_filters(
         metadata: dict[str, Any], metadata_filters: dict[str, Any]
     ) -> bool:
-        """Nested ``filters["metadata"]`` equality, matching the string-coerced
-        semantics of ``LanceDBMemoryStore._apply_metadata_filters`` so
-        ``UserIsolatedMemoryStore`` isolation behaves the same on both stores
-        (#842)."""
+        """Metadata equality for both the nested ``filters["metadata"]`` dict
+        and flat metadata keys, matching the string-coerced semantics of
+        ``LanceDBMemoryStore`` so ``UserIsolatedMemoryStore`` isolation and
+        ad-hoc filters behave the same on both stores (#842)."""
         return all(
             str(metadata.get(key, "")) == str(value)
             for key, value in metadata_filters.items()
@@ -93,14 +93,15 @@ class InMemoryMemoryStore(MemoryStore):
                     ):
                         match = False
 
-                    # Other metadata filters
+                    # Other flat metadata filters (string-coerced, like
+                    # LanceDBMemoryStore)
                     other_filters = {
                         k: v
                         for k, v in filters.items()
                         if k not in ("category", "metadata", SCOPE_EXCLUSIVE_FILTER_KEY)
                     }
-                    if other_filters and not all(
-                        note.metadata.get(k) == v for k, v in other_filters.items()
+                    if other_filters and not self._matches_metadata_filters(
+                        note.metadata, other_filters
                     ):
                         match = False
 
@@ -155,6 +156,29 @@ class InMemoryMemoryStore(MemoryStore):
                         keyword in note.keywords for keyword in required_keywords
                     ):
                         match = False
+
+                # Other flat metadata filters — same string-coerced equality
+                # as search() and LanceDBMemoryStore.list_all (previously
+                # ignored entirely, the same fail-open shape as the nested
+                # metadata case above)
+                other_filters = {
+                    k: v
+                    for k, v in filters.items()
+                    if k
+                    not in (
+                        "category",
+                        "metadata",
+                        "date_from",
+                        "date_to",
+                        "tags",
+                        "keywords",
+                        SCOPE_EXCLUSIVE_FILTER_KEY,
+                    )
+                }
+                if other_filters and not self._matches_metadata_filters(
+                    note.metadata, other_filters
+                ):
+                    match = False
 
                 if match:
                     filtered_results.append(note)

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -21,6 +21,19 @@ class InMemoryMemoryStore(MemoryStore):
             encode_scope_dims(note.metadata)
         )
 
+    @staticmethod
+    def _matches_metadata_filters(
+        metadata: dict[str, Any], metadata_filters: dict[str, Any]
+    ) -> bool:
+        """Nested ``filters["metadata"]`` equality, matching the string-coerced
+        semantics of ``LanceDBMemoryStore._apply_metadata_filters`` so
+        ``UserIsolatedMemoryStore`` isolation behaves the same on both stores
+        (#842)."""
+        return all(
+            str(metadata.get(key, "")) == str(value)
+            for key, value in metadata_filters.items()
+        )
+
     def add(self, note: MemoryNote) -> MemoryResponse:
         note_id = note.id or str(uuid.uuid4())
         note.id = note_id
@@ -73,11 +86,18 @@ class InMemoryMemoryStore(MemoryStore):
                     if "category" in filters and note.category != filters["category"]:
                         match = False
 
+                    # Nested metadata filters (the shape UserIsolatedMemoryStore
+                    # emits for user_id/scope isolation)
+                    if "metadata" in filters and not self._matches_metadata_filters(
+                        note.metadata, filters["metadata"]
+                    ):
+                        match = False
+
                     # Other metadata filters
                     other_filters = {
                         k: v
                         for k, v in filters.items()
-                        if k not in ("category", SCOPE_EXCLUSIVE_FILTER_KEY)
+                        if k not in ("category", "metadata", SCOPE_EXCLUSIVE_FILTER_KEY)
                     }
                     if other_filters and not all(
                         note.metadata.get(k) == v for k, v in other_filters.items()
@@ -106,6 +126,14 @@ class InMemoryMemoryStore(MemoryStore):
 
                 # Category filter
                 if "category" in filters and note.category != filters["category"]:
+                    match = False
+
+                # Nested metadata filters (the shape UserIsolatedMemoryStore
+                # emits for user_id/scope isolation — previously ignored here,
+                # which made user_id isolation fail-open, #842)
+                if "metadata" in filters and not self._matches_metadata_filters(
+                    note.metadata, filters["metadata"]
+                ):
                     match = False
 
                 # Date range filters

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -9,6 +9,20 @@ from .scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY, encode_scope_dims
 
 
 class InMemoryMemoryStore(MemoryStore):
+    # Filter keys with dedicated handling in _matches_filters; anything else
+    # is treated as a flat metadata-equality filter.
+    _KNOWN_FILTER_KEYS = frozenset(
+        {
+            "category",
+            "metadata",
+            "date_from",
+            "date_to",
+            "tags",
+            "keywords",
+            SCOPE_EXCLUSIVE_FILTER_KEY,
+        }
+    )
+
     def __init__(self) -> None:
         self._store: dict[str, MemoryNote] = {}
 
@@ -28,11 +42,76 @@ class InMemoryMemoryStore(MemoryStore):
         """Metadata equality for both the nested ``filters["metadata"]`` dict
         and flat metadata keys, matching the string-coerced semantics of
         ``LanceDBMemoryStore`` so ``UserIsolatedMemoryStore`` isolation and
-        ad-hoc filters behave the same on both stores (#842)."""
+        ad-hoc filters behave the same on both stores (#842). A non-dict
+        filter value cannot match anything (rather than crashing on a
+        malformed caller-supplied ``filters["metadata"]``)."""
+        if not isinstance(metadata_filters, dict):
+            return False
         return all(
             str(metadata.get(key, "")) == str(value)
             for key, value in metadata_filters.items()
         )
+
+    @classmethod
+    def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
+        """Filter keys without dedicated handling, applied as flat metadata
+        equality. Note-independent — compute once per call, not per note."""
+        return {
+            key: value
+            for key, value in (filters or {}).items()
+            if key not in cls._KNOWN_FILTER_KEYS
+        }
+
+    @classmethod
+    def _matches_filters(
+        cls,
+        note: MemoryNote,
+        filters: dict[str, Any],
+        other_filters: dict[str, Any],
+    ) -> bool:
+        """Single filter dispatch shared by ``search()`` and ``list_all()``,
+        so the two methods cannot drift apart on filter semantics (#842).
+
+        ``other_filters`` is ``_flat_other_filters(filters)``, precomputed by
+        the caller so the per-note check does not rebuild it.
+        """
+        if cls._is_scope_excluded(note, filters):
+            return False
+
+        if "category" in filters and note.category != filters["category"]:
+            return False
+
+        # Nested metadata filters (the shape UserIsolatedMemoryStore emits
+        # for user_id/scope isolation — before #842 search() never matched
+        # them and list_all() ignored them, fail-open)
+        if "metadata" in filters and not cls._matches_metadata_filters(
+            note.metadata, filters["metadata"]
+        ):
+            return False
+
+        # Date range filters
+        if "date_from" in filters and note.timestamp < filters["date_from"]:
+            return False
+        if "date_to" in filters and note.timestamp > filters["date_to"]:
+            return False
+
+        # Tag filter (all required tags present)
+        if "tags" in filters and not all(tag in note.tags for tag in filters["tags"]):
+            return False
+
+        # Keyword filter (all required keywords present)
+        if "keywords" in filters and not all(
+            keyword in note.keywords for keyword in filters["keywords"]
+        ):
+            return False
+
+        # Other flat metadata filters (string-coerced, like LanceDBMemoryStore)
+        if other_filters and not cls._matches_metadata_filters(
+            note.metadata, other_filters
+        ):
+            return False
+
+        return True
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         note_id = note.id or str(uuid.uuid4())
@@ -73,117 +152,29 @@ class InMemoryMemoryStore(MemoryStore):
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
     ) -> list[MemoryNote]:
-        # Flat metadata filters outside the known keys (string-coerced, like
-        # LanceDBMemoryStore) — note-independent, so computed once.
-        other_filters = {
-            key: value
-            for key, value in (filters or {}).items()
-            if key not in ("category", "metadata", SCOPE_EXCLUSIVE_FILTER_KEY)
-        }
+        other_filters = self._flat_other_filters(filters)
         results = []
         for note in self._store.values():
-            if query.lower() in note.content.lower():
-                if filters:
-                    match = True
-
-                    if self._is_scope_excluded(note, filters):
-                        match = False
-
-                    # Category filter
-                    if "category" in filters and note.category != filters["category"]:
-                        match = False
-
-                    # Nested metadata filters (the shape UserIsolatedMemoryStore
-                    # emits for user_id/scope isolation)
-                    if "metadata" in filters and not self._matches_metadata_filters(
-                        note.metadata, filters["metadata"]
-                    ):
-                        match = False
-
-                    if other_filters and not self._matches_metadata_filters(
-                        note.metadata, other_filters
-                    ):
-                        match = False
-
-                    if match:
-                        results.append(note)
-                else:
-                    results.append(note)
+            if query.lower() not in note.content.lower():
+                continue
+            if filters and not self._matches_filters(note, filters, other_filters):
+                continue
+            results.append(note)
         return results[:k]
 
     def clear(self) -> None:
         self._store.clear()
 
     def list_all(self, filters: Optional[dict[str, Any]] = None) -> List[MemoryNote]:
-        results = list(self._store.values())
-
         if filters:
-            # Flat metadata filters outside the known keys — same string-coerced
-            # equality as search() and LanceDBMemoryStore.list_all (previously
-            # ignored entirely, the same fail-open shape as the nested metadata
-            # case). Note-independent, so computed once.
-            other_filters = {
-                key: value
-                for key, value in filters.items()
-                if key
-                not in (
-                    "category",
-                    "metadata",
-                    "date_from",
-                    "date_to",
-                    "tags",
-                    "keywords",
-                    SCOPE_EXCLUSIVE_FILTER_KEY,
-                )
-            }
-            filtered_results = []
-            for note in results:
-                match = True
-
-                if self._is_scope_excluded(note, filters):
-                    match = False
-
-                # Category filter
-                if "category" in filters and note.category != filters["category"]:
-                    match = False
-
-                # Nested metadata filters (the shape UserIsolatedMemoryStore
-                # emits for user_id/scope isolation — previously ignored here,
-                # which made user_id isolation fail-open, #842)
-                if "metadata" in filters and not self._matches_metadata_filters(
-                    note.metadata, filters["metadata"]
-                ):
-                    match = False
-
-                # Date range filters
-                if "date_from" in filters and note.timestamp < filters["date_from"]:
-                    match = False
-                if "date_to" in filters and note.timestamp > filters["date_to"]:
-                    match = False
-
-                # Tag filter
-                if "tags" in filters:
-                    required_tags = filters["tags"]
-                    if not all(tag in note.tags for tag in required_tags):
-                        match = False
-
-                # Keyword filter
-                if "keywords" in filters:
-                    required_keywords = filters["keywords"]
-                    if not all(
-                        keyword in note.keywords for keyword in required_keywords
-                    ):
-                        match = False
-
-                if other_filters and not self._matches_metadata_filters(
-                    note.metadata, other_filters
-                ):
-                    match = False
-
-                if match:
-                    filtered_results.append(note)
-
-            results = filtered_results
+            other_filters = self._flat_other_filters(filters)
+            results = [
+                note
+                for note in self._store.values()
+                if self._matches_filters(note, filters, other_filters)
+            ]
+        else:
+            results = list(self._store.values())
 
         # Sort by timestamp (newest first)
         results.sort(key=lambda x: x.timestamp, reverse=True)

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -73,6 +73,13 @@ class InMemoryMemoryStore(MemoryStore):
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
     ) -> list[MemoryNote]:
+        # Flat metadata filters outside the known keys (string-coerced, like
+        # LanceDBMemoryStore) — note-independent, so computed once.
+        other_filters = {
+            key: value
+            for key, value in (filters or {}).items()
+            if key not in ("category", "metadata", SCOPE_EXCLUSIVE_FILTER_KEY)
+        }
         results = []
         for note in self._store.values():
             if query.lower() in note.content.lower():
@@ -93,13 +100,6 @@ class InMemoryMemoryStore(MemoryStore):
                     ):
                         match = False
 
-                    # Other flat metadata filters (string-coerced, like
-                    # LanceDBMemoryStore)
-                    other_filters = {
-                        k: v
-                        for k, v in filters.items()
-                        if k not in ("category", "metadata", SCOPE_EXCLUSIVE_FILTER_KEY)
-                    }
                     if other_filters and not self._matches_metadata_filters(
                         note.metadata, other_filters
                     ):
@@ -118,6 +118,24 @@ class InMemoryMemoryStore(MemoryStore):
         results = list(self._store.values())
 
         if filters:
+            # Flat metadata filters outside the known keys — same string-coerced
+            # equality as search() and LanceDBMemoryStore.list_all (previously
+            # ignored entirely, the same fail-open shape as the nested metadata
+            # case). Note-independent, so computed once.
+            other_filters = {
+                key: value
+                for key, value in filters.items()
+                if key
+                not in (
+                    "category",
+                    "metadata",
+                    "date_from",
+                    "date_to",
+                    "tags",
+                    "keywords",
+                    SCOPE_EXCLUSIVE_FILTER_KEY,
+                )
+            }
             filtered_results = []
             for note in results:
                 match = True
@@ -157,24 +175,6 @@ class InMemoryMemoryStore(MemoryStore):
                     ):
                         match = False
 
-                # Other flat metadata filters — same string-coerced equality
-                # as search() and LanceDBMemoryStore.list_all (previously
-                # ignored entirely, the same fail-open shape as the nested
-                # metadata case above)
-                other_filters = {
-                    k: v
-                    for k, v in filters.items()
-                    if k
-                    not in (
-                        "category",
-                        "metadata",
-                        "date_from",
-                        "date_to",
-                        "tags",
-                        "keywords",
-                        SCOPE_EXCLUSIVE_FILTER_KEY,
-                    )
-                }
                 if other_filters and not self._matches_metadata_filters(
                     note.metadata, other_filters
                 ):

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, List, Optional
+from typing import Any, Collection, List, Optional
 
 from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
@@ -53,16 +53,16 @@ class InMemoryMemoryStore(MemoryStore):
         )
 
     @staticmethod
-    def _required_items(value: Any) -> Optional[list[Any]]:
+    def _required_items(value: Any) -> Optional[Collection[Any]]:
         """Normalize a ``tags``/``keywords`` filter value: a plain string is a
         single required item (not iterated per character), an iterable is many,
         and anything else can't match (rather than raising ``TypeError`` on
         malformed caller-supplied filters — the same no-match policy as
         ``_matches_metadata_filters``)."""
         if isinstance(value, str):
-            return [value]
+            return (value,)
         if isinstance(value, (list, tuple, set, frozenset)):
-            return list(value)
+            return value
         return None
 
     @classmethod

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -507,7 +507,11 @@ class LanceDBMemoryStore(MemoryStore):
     def _apply_metadata_filters(
         self, metadata: dict[str, Any], metadata_filters: dict[str, Any]
     ) -> bool:
-        """Apply nested metadata filters."""
+        """Apply nested metadata filters. A non-dict filter value cannot match
+        anything (rather than crashing on a malformed caller-supplied
+        ``filters["metadata"]``)."""
+        if not isinstance(metadata_filters, dict):
+            return False
         for key, value in metadata_filters.items():
             if str(metadata.get(key, "")) != str(value):
                 return False

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -554,6 +554,23 @@ class TestSearchListOnlyFilterParity:
         list_ids = {n.id for n in memory_store.list_all(filters=filters)}
         assert search_ids == list_ids == {"old-work"}
 
+    def test_non_iterable_tags_keywords_match_nothing(self, memory_store):
+        # Malformed (non-iterable) tags/keywords values can't match anything —
+        # same no-match policy as a non-dict filters["metadata"], no TypeError
+        # on either method.
+        for key in ("tags", "keywords"):
+            assert memory_store.search("report", k=10, filters={key: 5}) == []
+            assert memory_store.list_all(filters={key: 5}) == []
+
+    def test_string_tags_keywords_treated_as_single_item(self, memory_store):
+        # A bare string is one required item, not a per-character iteration.
+        assert [
+            n.id for n in memory_store.search("report", k=10, filters={"tags": "work"})
+        ] == ["old-work"]
+        assert [
+            n.id for n in memory_store.list_all(filters={"keywords": "groceries"})
+        ] == ["new-home"]
+
 
 def test_scope_exclusive_filters_scoped_notes(memory_store):
     """#822: the `__scope_exclusive__` directive (strict dimension-less

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -562,6 +562,18 @@ class TestSearchListOnlyFilterParity:
             assert memory_store.search("report", k=10, filters={key: 5}) == []
             assert memory_store.list_all(filters={key: 5}) == []
 
+    def test_empty_tags_keywords_match_everything(self, memory_store):
+        # An empty list means "no tags/keywords required" — vacuously matches
+        # every note, distinct from the malformed no-match case above.
+        for key in ("tags", "keywords"):
+            assert {
+                n.id for n in memory_store.search("report", k=10, filters={key: []})
+            } == {"old-work", "new-home"}
+            assert {n.id for n in memory_store.list_all(filters={key: []})} == {
+                "old-work",
+                "new-home",
+            }
+
     def test_string_tags_keywords_treated_as_single_item(self, memory_store):
         # A bare string is one required item, not a per-character iteration.
         assert [

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -455,6 +455,105 @@ class TestInMemoryMemoryStoreNestedMetadataFilters:
         )
         assert [n.id for n in results] == ["alice-system"]
 
+    def test_nested_metadata_filter_combines_with_flat_key(self, memory_store):
+        # Both dispatch paths (nested dict + flat "other" key) applied in one
+        # call — AND semantics across the two.
+        results = memory_store.list_all(
+            filters={"metadata": {"user_id": 1}, "source": "chat"}
+        )
+        assert [n.id for n in results] == ["alice"]
+
+        assert (
+            memory_store.list_all(
+                filters={"metadata": {"user_id": 1}, "source": "email"}
+            )
+            == []
+        )
+
+    def test_non_dict_nested_metadata_filter_matches_nothing(self, memory_store):
+        # A malformed filters["metadata"] value must not crash — it can't
+        # match anything.
+        for bad in (None, "abc", 42):
+            assert memory_store.search("shared", k=10, filters={"metadata": bad}) == []
+            assert memory_store.list_all(filters={"metadata": bad}) == []
+
+    def test_flat_key_combines_with_scope_exclusive(self, memory_store):
+        prefix = MEMORY_DIMENSION_METADATA_PREFIX
+        memory_store.add(
+            MemoryNote(
+                id="alice-scoped",
+                content="shared note text",
+                metadata={"user_id": 1, "source": "chat", f"{prefix}tenant": "acme"},
+            )
+        )
+        # user_id excludes bob (flat), the directive excludes alice-scoped.
+        results = memory_store.list_all(
+            filters={"user_id": 1, "source": "chat", SCOPE_EXCLUSIVE_FILTER_KEY: True}
+        )
+        assert [n.id for n in results] == ["alice"]
+
+
+class TestSearchListOnlyFilterParity:
+    """search() and list_all() share one filter dispatch: tags / keywords /
+    date_from / date_to must behave identically on both. Previously search()
+    let these keys fall through to flat metadata equality — they live on
+    note.tags/note.keywords/note.timestamp, never note.metadata, so any
+    query combining text search with one of them silently returned empty
+    (reachable via the web memory list route, which calls search() whenever
+    a text query is present)."""
+
+    @pytest.fixture(autouse=True)
+    def seed(self, memory_store):
+        now = datetime.now()
+        memory_store.add(
+            MemoryNote(
+                id="old-work",
+                content="quarterly report draft",
+                tags=["work"],
+                keywords=["report"],
+                timestamp=now - timedelta(days=2),
+            )
+        )
+        memory_store.add(
+            MemoryNote(
+                id="new-home",
+                content="grocery report list",
+                tags=["home"],
+                keywords=["groceries"],
+                timestamp=now,
+            )
+        )
+        self.now = now
+
+    def test_search_with_tags_filter(self, memory_store):
+        results = memory_store.search("report", k=10, filters={"tags": ["work"]})
+        assert [n.id for n in results] == ["old-work"]
+
+    def test_search_with_keywords_filter(self, memory_store):
+        results = memory_store.search(
+            "report", k=10, filters={"keywords": ["groceries"]}
+        )
+        assert [n.id for n in results] == ["new-home"]
+
+    def test_search_with_date_filters(self, memory_store):
+        cutoff = self.now - timedelta(days=1)
+        assert [
+            n.id
+            for n in memory_store.search("report", k=10, filters={"date_from": cutoff})
+        ] == ["new-home"]
+        assert [
+            n.id
+            for n in memory_store.search("report", k=10, filters={"date_to": cutoff})
+        ] == ["old-work"]
+
+    def test_search_and_list_all_agree(self, memory_store):
+        filters = {"tags": ["work"], "keywords": ["report"]}
+        search_ids = {
+            n.id for n in memory_store.search("report", k=10, filters=filters)
+        }
+        list_ids = {n.id for n in memory_store.list_all(filters=filters)}
+        assert search_ids == list_ids == {"old-work"}
+
 
 def test_scope_exclusive_filters_scoped_notes(memory_store):
     """#822: the `__scope_exclusive__` directive (strict dimension-less

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -426,6 +426,21 @@ class TestInMemoryMemoryStoreNestedMetadataFilters:
         results = memory_store.list_all(filters={"metadata": {"user_id": "1"}})
         assert [n.id for n in results] == ["alice"]
 
+    def test_list_all_enforces_flat_metadata_filter(self, memory_store):
+        # Flat metadata keys (outside the known category/date/tags/keywords
+        # set) were previously ignored by list_all() — the same fail-open
+        # shape as the nested case.
+        results = memory_store.list_all(filters={"source": "chat", "user_id": 1})
+        assert [n.id for n in results] == ["alice"]
+
+        assert memory_store.list_all(filters={"source": "email"}) == []
+
+    def test_search_flat_metadata_filter_string_coerced(self, memory_store):
+        # Flat keys use the same string-coerced equality as LanceDB: a string
+        # filter value matches an int metadata value.
+        results = memory_store.search("shared", k=10, filters={"user_id": "2"})
+        assert [n.id for n in results] == ["bob"]
+
     def test_nested_metadata_filter_combines_with_category(self, memory_store):
         memory_store.add(
             MemoryNote(

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -361,6 +361,86 @@ def test_clear(memory_store):
     assert len(results) == 0
 
 
+class TestInMemoryMemoryStoreNestedMetadataFilters:
+    """#842: nested ``filters["metadata"]`` dicts (the shape
+    ``UserIsolatedMemoryStore._add_user_filter`` emits) must be interpreted
+    with the same string-coerced equality semantics as
+    ``LanceDBMemoryStore._apply_metadata_filters`` — previously search()
+    never matched them and list_all() silently ignored them (fail-open)."""
+
+    @pytest.fixture(autouse=True)
+    def seed(self, memory_store):
+        memory_store.add(
+            MemoryNote(
+                id="alice",
+                content="shared note text",
+                metadata={"user_id": 1, "source": "chat"},
+            )
+        )
+        memory_store.add(
+            MemoryNote(
+                id="bob",
+                content="shared note text",
+                metadata={"user_id": 2, "source": "chat"},
+            )
+        )
+
+    def test_search_matches_nested_metadata_filter(self, memory_store):
+        results = memory_store.search(
+            "shared", k=10, filters={"metadata": {"user_id": 1}}
+        )
+        assert [n.id for n in results] == ["alice"]
+
+    def test_search_nested_metadata_filter_no_match(self, memory_store):
+        results = memory_store.search(
+            "shared", k=10, filters={"metadata": {"user_id": 3}}
+        )
+        assert results == []
+
+    def test_list_all_enforces_nested_metadata_filter(self, memory_store):
+        results = memory_store.list_all(filters={"metadata": {"user_id": 2}})
+        assert [n.id for n in results] == ["bob"]
+
+    def test_list_all_nested_metadata_filter_no_match_is_empty(self, memory_store):
+        # Previously fail-open: an unmatched nested filter returned every note.
+        results = memory_store.list_all(filters={"metadata": {"user_id": 3}})
+        assert results == []
+
+    def test_nested_metadata_filter_multiple_keys(self, memory_store):
+        assert [
+            n.id
+            for n in memory_store.list_all(
+                filters={"metadata": {"user_id": 1, "source": "chat"}}
+            )
+        ] == ["alice"]
+        assert (
+            memory_store.list_all(
+                filters={"metadata": {"user_id": 1, "source": "email"}}
+            )
+            == []
+        )
+
+    def test_nested_metadata_filter_string_coerced_equality(self, memory_store):
+        # LanceDB compares str(metadata value) == str(filter value); the
+        # in-memory store must match a string filter against an int value.
+        results = memory_store.list_all(filters={"metadata": {"user_id": "1"}})
+        assert [n.id for n in results] == ["alice"]
+
+    def test_nested_metadata_filter_combines_with_category(self, memory_store):
+        memory_store.add(
+            MemoryNote(
+                id="alice-system",
+                content="shared note text",
+                category="system",
+                metadata={"user_id": 1},
+            )
+        )
+        results = memory_store.list_all(
+            filters={"category": "system", "metadata": {"user_id": 1}}
+        )
+        assert [n.id for n in results] == ["alice-system"]
+
+
 def test_scope_exclusive_filters_scoped_notes(memory_store):
     """#822: the `__scope_exclusive__` directive (strict dimension-less
     isolation) excludes any scope-stamped note on the real InMemoryMemoryStore,

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -331,6 +331,18 @@ def test_list_all_with_nested_metadata_filter(memory_store):
     assert results[0].content == "alice note"
 
 
+def test_non_dict_nested_metadata_filter_matches_nothing(memory_store):
+    """A malformed (non-dict) filters["metadata"] value must not crash —
+    it can't match anything."""
+    assert memory_store.add(
+        MemoryNote(content="hello world", metadata={"user_id": 1})
+    ).success
+
+    for bad in (None, "abc", 42):
+        assert memory_store.search("hello", k=10, filters={"metadata": bad}) == []
+        assert memory_store.list_all(filters={"metadata": bad}) == []
+
+
 def test_list_all_with_tag_filters(memory_store):
     """Test listing memories with tag filters."""
     assert memory_store.add(

--- a/tests/web/test_user_isolated_in_memory.py
+++ b/tests/web/test_user_isolated_in_memory.py
@@ -1,0 +1,80 @@
+"""Regression tests for #842: user_id isolation through
+``UserIsolatedMemoryStore(InMemoryMemoryStore())`` — the default production
+path when no embedding model is configured.
+
+``UserIsolatedMemoryStore._add_user_filter`` nests the isolation filters under
+``filters["metadata"]``. Before the fix, ``InMemoryMemoryStore.search()``
+compared that nested dict flat (never matched → always empty) and
+``list_all()`` ignored it entirely (fail-open → cross-user exposure).
+"""
+
+import pytest
+
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.web.user_isolated_memory import UserContext, UserIsolatedMemoryStore
+
+
+@pytest.fixture
+def store() -> UserIsolatedMemoryStore:
+    return UserIsolatedMemoryStore(InMemoryMemoryStore())
+
+
+@pytest.fixture
+def seeded_store(store: UserIsolatedMemoryStore) -> UserIsolatedMemoryStore:
+    with UserContext(1):
+        store.add(MemoryNote(id="a1", content="project deadline friday"))
+        store.add(MemoryNote(id="a2", content="project kickoff notes"))
+    with UserContext(2):
+        store.add(MemoryNote(id="b1", content="project deadline monday"))
+    return store
+
+
+class TestUserIsolationOnInMemoryPath:
+    def test_search_returns_only_own_notes(self, seeded_store):
+        with UserContext(1):
+            results = seeded_store.search("project", k=10)
+        assert {n.id for n in results} == {"a1", "a2"}
+
+        with UserContext(2):
+            results = seeded_store.search("project", k=10)
+        assert {n.id for n in results} == {"b1"}
+
+    def test_list_all_returns_only_own_notes(self, seeded_store):
+        with UserContext(1):
+            results = seeded_store.list_all()
+        assert {n.id for n in results} == {"a1", "a2"}
+
+        with UserContext(2):
+            results = seeded_store.list_all()
+        assert {n.id for n in results} == {"b1"}
+
+    def test_list_all_with_caller_filters_keeps_isolation(self, seeded_store):
+        # A caller-supplied nested metadata filter must be merged with, not
+        # replace, the user_id isolation filter.
+        with UserContext(1):
+            seeded_store.add(
+                MemoryNote(id="a3", content="tagged", metadata={"source": "chat"})
+            )
+        with UserContext(2):
+            seeded_store.add(
+                MemoryNote(id="b2", content="tagged", metadata={"source": "chat"})
+            )
+        with UserContext(1):
+            results = seeded_store.list_all(filters={"metadata": {"source": "chat"}})
+        assert {n.id for n in results} == {"a3"}
+
+    def test_clear_only_removes_own_notes(self, seeded_store):
+        # clear() deletes via list_all(); fail-open list_all made user 1's
+        # clear wipe every user's notes.
+        with UserContext(1):
+            seeded_store.clear()
+            assert seeded_store.list_all() == []
+        with UserContext(2):
+            assert {n.id for n in seeded_store.list_all()} == {"b1"}
+
+    def test_no_user_context_sees_everything(self, seeded_store):
+        # Without a user context no isolation filter is added — unchanged
+        # pre-existing behavior for non-web callers.
+        results = seeded_store.list_all()
+        assert {n.id for n in results} == {"a1", "a2", "b1"}


### PR DESCRIPTION
## Summary

Fixes #842 (surfaced during review of #836; pre-existing bug).

`InMemoryMemoryStore.search()` / `list_all()` matched filters with a flat `note.metadata.get(k) == v` comparison and had no handling for the nested `filters["metadata"]` dict that `UserIsolatedMemoryStore._add_user_filter()` always emits. On the default production path when no embedding model is configured (`UserIsolatedMemoryStore(InMemoryMemoryStore())`):

- `search()` compared `note.metadata.get("metadata")` against the nested dict, never matched, and **always returned empty**.
- `list_all()` ignored the nested `metadata` key entirely, silently dropping the `user_id` filter — **fail-open cross-user exposure**. Since `UserIsolatedMemoryStore.clear()` is built on `list_all()`, this also made one user's `clear()` wipe every user's notes.

## Changes

- Add `InMemoryMemoryStore._matches_metadata_filters()` and apply it in both `search()` and `list_all()`, interpreting a nested `filters["metadata"]` dict with the same string-coerced equality semantics as `LanceDBMemoryStore._apply_metadata_filters` (`str(metadata.get(k, "")) == str(v)`), so `user_id` and scope-dimension isolation behave the same on both stores.
- Exclude the `"metadata"` key from `search()`'s flat comparison so it is no longer mis-compared.

## Tests

- `tests/core/memory/test_in_memory.py`: nested-filter cases directly on `InMemoryMemoryStore` — match, no-match returns empty (no longer fail-open), multi-key AND, string-coerced equality, combination with `category`.
- `tests/web/test_user_isolated_in_memory.py` (new): two users' notes in one in-memory store through `UserIsolatedMemoryStore` — each user's `search()`/`list_all()` sees only their own; `clear()` only removes the caller's notes; no user context keeps the pre-existing see-everything behavior.
- Verified the regression tests catch the bug: with the fix reverted, 9 of the 12 new tests fail.
- 130 tests pass across `tests/core/memory/`, the new isolation tests, and `tests/web/test_execution_scope_memory.py`; `ruff format` / `ruff check` / `mypy` clean.

## Acceptance criteria (#842)

- [x] `InMemoryMemoryStore.search()` returns matching notes when given a nested `{"metadata": {...}}` filter.
- [x] `InMemoryMemoryStore.list_all()` enforces the nested `metadata` filter (no longer fail-open on `user_id`).
- [x] Regression test: two users' notes in one in-memory store; each user's `search`/`list_all` sees only their own.

## Review follow-ups

- `2d5a7699` (gemini): `list_all()` also enforces flat metadata filter keys; flat comparisons aligned to LanceDB's string-coerced equality.
- `d3ed3f7b` (gemini): `other_filters` hoisted out of the per-note loops; comprehension variables renamed to stop shadowing `search()`'s top-k `k`.
- `381e8fa6` (rogercloud): `search()`/`list_all()` collapsed onto a single shared `_matches_filters()` dispatch (one `_KNOWN_FILTER_KEYS` set), which also fixes the pre-existing gap where `search()` silently returned empty when combined with `tags`/`keywords`/`date_from`/`date_to` filters (reachable via the web memory list route); `_matches_metadata_filters` and LanceDB's `_apply_metadata_filters` now treat a non-dict `filters["metadata"]` as no-match instead of raising.

- `c4596f16` (rogercloud, round 2 lows): `tags`/`keywords` filter values normalized via `_required_items()` — non-iterable values match nothing instead of raising `TypeError`, bare strings count as one required item. The LanceDB `search()` tags/keywords/date gap (round-2 major, out of scope here) is tracked in #909.
