### PR TITLE
fix(memory): skip malformed rows in LanceDB search instead of truncating results

### DIFF
--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -448,16 +448,24 @@ class LanceDBMemoryStore(MemoryStore):
         except (json.JSONDecodeError, TypeError):
             metadata = {}
 
-        return MemoryNote(
-            id=data.get("id"),
-            content=metadata.pop("content", data.get("text", "")),
-            keywords=metadata.pop("keywords", []),
-            tags=metadata.pop("tags", []),
-            category=metadata.pop("category", "general"),
-            timestamp=metadata.pop("timestamp", None),
-            mime_type=metadata.pop("mime_type", "text/plain"),
-            metadata=metadata,
-        )
+        note_kwargs: dict[str, Any] = {
+            "id": data.get("id"),
+            "content": metadata.pop("content", data.get("text", "")),
+            "keywords": metadata.pop("keywords", []),
+            "tags": metadata.pop("tags", []),
+            "category": metadata.pop("category", "general"),
+            "mime_type": metadata.pop("mime_type", "text/plain"),
+            "metadata": metadata,
+        }
+        # #847: legacy rows may lack `timestamp`. MemoryNote.timestamp is a
+        # non-optional datetime with a default_factory, and pydantic only
+        # applies the factory when the field is omitted — an explicit None
+        # raises ValidationError.
+        timestamp = metadata.pop("timestamp", None)
+        if timestamp is not None:
+            note_kwargs["timestamp"] = timestamp
+
+        return MemoryNote(**note_kwargs)
 
     def _apply_filters(self, note: MemoryNote, filters: dict[str, Any]) -> bool:
         """Apply filters to a MemoryNote for vector search results.
@@ -734,7 +742,20 @@ class LanceDBMemoryStore(MemoryStore):
                                     "text": row.get("text", ""),
                                     "metadata": row.get("metadata", "{}"),
                                 }
-                                note = self._dict_to_memory_note(note_data)
+                                # #847: a malformed row must not abort the whole
+                                # vector branch — escaping to the outer except
+                                # after earlier appends would skip the text
+                                # fallback and silently truncate the results.
+                                try:
+                                    note = self._dict_to_memory_note(note_data)
+                                except Exception as row_error:
+                                    logger.warning(
+                                        "Skipping malformed memory row %r in "
+                                        "vector search results: %s",
+                                        note_data["id"],
+                                        row_error,
+                                    )
+                                    continue
 
                                 # user_id + scope dimensions were already applied
                                 # as a `where` prefilter; only residual filters
@@ -803,7 +824,18 @@ class LanceDBMemoryStore(MemoryStore):
                             "text": text,
                             "metadata": metadata,
                         }
-                        note = self._dict_to_memory_note(note_data)
+                        # #847: here a malformed row would escape to the outer
+                        # except and turn the whole query into an empty result.
+                        try:
+                            note = self._dict_to_memory_note(note_data)
+                        except Exception as row_error:
+                            logger.warning(
+                                "Skipping malformed memory row %r in text "
+                                "search results: %s",
+                                note_data["id"],
+                                row_error,
+                            )
+                            continue
                         results.append(note)
 
                         if len(results) >= k:

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -499,6 +499,34 @@ def test_dict_to_memory_note_missing_timestamp(memory_store):
     assert "timestamp" not in note.metadata
 
 
+def test_get_returns_legacy_row_missing_timestamp(memory_store):
+    """get() uses the same converter, so a timestamp-less legacy row must load
+    with the default timestamp instead of surfacing a generic failure (#847)."""
+    # Settle the table schema (vector column dimension) with a regular add
+    # before bypassing it with a raw legacy row.
+    assert memory_store.add(MemoryNote(content="schema-settling note")).success
+
+    _insert_raw_row(
+        memory_store,
+        "test_memories",
+        {
+            "id": "legacy-get-no-ts",
+            "vector": [0.1] * 64,
+            "text": "legacy get target",
+            "metadata": json.dumps({"content": "legacy get target"}),
+            "user_id": None,
+            "scope_dims": [],
+        },
+    )
+
+    response = memory_store.get("legacy-get-no-ts")
+    assert response.success
+    note = response.content
+    assert isinstance(note, MemoryNote)
+    assert note.content == "legacy get target"
+    assert note.timestamp is not None
+
+
 def test_search_returns_legacy_rows_missing_timestamp(memory_store):
     """A vector search whose top-k contains a timestamp-less legacy row must
     return all matching rows, including the legacy one (#847)."""
@@ -531,8 +559,12 @@ def test_search_skips_malformed_row_without_truncation(memory_store, caplog):
     which used to suppress the text fallback and silently truncate the
     results (#847).
 
-    The malformed row is seeded BETWEEN well-formed rows so that, pre-fix, the
-    mid-loop escape would drop the rows inserted after it."""
+    The malformed row is seeded between well-formed rows so that, pre-fix, the
+    mid-loop escape would drop whichever rows the scan happened to visit after
+    it (LanceDB does not guarantee tied-distance iteration order, so exactly
+    which rows those are is an implementation detail). The assertions below
+    are order-independent — set membership plus log presence — so the test
+    stays valid regardless of how tied rows are iterated."""
     for i in range(2):
         assert memory_store.add(MemoryNote(content=f"well-formed note {i}")).success
 

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -1,10 +1,11 @@
+import json
 import shutil
 import tempfile
 
 import pytest
 
 from xagent.core.memory.core import MemoryNote
-from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.memory.lancedb import LanceDBMemoryStore, _safe_close_table
 
 
 @pytest.fixture
@@ -467,6 +468,142 @@ def test_invalid_memory_id(memory_store):
     response = memory_store.delete("non-existent-id")
     # This might succeed or fail depending on implementation
     # The important thing is that it doesn't crash
+
+
+# --- #847: search() must not silently truncate on a mid-loop row failure ---
+
+
+def _insert_raw_row(store, collection_name, record):
+    """Insert a row directly into the LanceDB table, bypassing add()."""
+    conn = store._vector_store.get_raw_connection()
+    table = conn.open_table(collection_name)
+    try:
+        table.add([record])
+    finally:
+        _safe_close_table(table)
+
+
+def test_dict_to_memory_note_missing_timestamp(memory_store):
+    """A legacy row whose metadata lacks `timestamp` must convert using the
+    model default instead of raising ValidationError (#847 root cause)."""
+    note = memory_store._dict_to_memory_note(
+        {
+            "id": "legacy-1",
+            "text": "legacy content",
+            "metadata": json.dumps({"content": "legacy content"}),
+        }
+    )
+    assert note.content == "legacy content"
+    assert note.timestamp is not None
+    assert "timestamp" not in note.metadata
+
+
+def test_search_returns_legacy_rows_missing_timestamp(memory_store):
+    """A vector search whose top-k contains a timestamp-less legacy row must
+    return all matching rows, including the legacy one (#847)."""
+    for i in range(3):
+        assert memory_store.add(MemoryNote(content=f"well-formed note {i}")).success
+
+    _insert_raw_row(
+        memory_store,
+        "test_memories",
+        {
+            "id": "legacy-no-ts",
+            "vector": [0.1] * 64,
+            "text": "legacy note without timestamp",
+            "metadata": json.dumps({"content": "legacy note without timestamp"}),
+            "user_id": None,
+            "scope_dims": [],
+        },
+    )
+
+    results = memory_store.search("note", k=10)
+    ids = {r.id for r in results}
+    contents = {r.content for r in results}
+    assert {f"well-formed note {i}" for i in range(3)} <= contents
+    assert "legacy-no-ts" in ids
+
+
+def test_search_skips_malformed_row_without_truncation(memory_store):
+    """A row whose conversion genuinely fails (unparseable timestamp) must be
+    skipped, not abort the vector branch after earlier appends — which used to
+    suppress the text fallback and silently truncate the results (#847).
+
+    The malformed row is seeded BETWEEN well-formed rows so that, pre-fix, the
+    mid-loop escape would drop the rows inserted after it."""
+    for i in range(2):
+        assert memory_store.add(MemoryNote(content=f"well-formed note {i}")).success
+
+    _insert_raw_row(
+        memory_store,
+        "test_memories",
+        {
+            "id": "malformed-ts",
+            "vector": [0.1] * 64,
+            "text": "malformed note",
+            "metadata": json.dumps(
+                {"content": "malformed note", "timestamp": "not-a-datetime"}
+            ),
+            "user_id": None,
+            "scope_dims": [],
+        },
+    )
+
+    for i in range(2, 4):
+        assert memory_store.add(MemoryNote(content=f"well-formed note {i}")).success
+
+    results = memory_store.search("note", k=10)
+    contents = {r.content for r in results}
+    assert {f"well-formed note {i}" for i in range(4)} <= contents
+    assert all(r.id != "malformed-ts" for r in results)
+
+
+def test_text_fallback_skips_malformed_row(temp_db_dir):
+    """The text-search fallback must also skip a malformed row instead of
+    escaping to the outer except and returning an empty result set (#847)."""
+    from xagent.core.model.embedding import BaseEmbedding
+
+    class FailingEmbedding(BaseEmbedding):
+        def __init__(self):
+            self._dimension = 64
+
+        def encode(self, text, dimension=None, instruct=None):
+            raise Exception("Embedding failed")
+
+        def get_dimension(self):
+            return self._dimension
+
+        @property
+        def abilities(self):
+            return ["embed"]
+
+    store = LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="test_text_fallback_847",
+        embedding_model=FailingEmbedding(),
+    )
+
+    for i in range(3):
+        assert store.add(MemoryNote(content=f"well-formed note {i}")).success
+
+    _insert_raw_row(
+        store,
+        "test_text_fallback_847",
+        {
+            "id": "malformed-ts",
+            "text": "malformed note",
+            "metadata": json.dumps(
+                {"content": "malformed note", "timestamp": "not-a-datetime"}
+            ),
+            "user_id": None,
+            "scope_dims": [],
+        },
+    )
+
+    results = store.search("note", k=10)
+    contents = {r.content for r in results}
+    assert {f"well-formed note {i}" for i in range(3)} <= contents
+    assert all(r.id != "malformed-ts" for r in results)
 
 
 if __name__ == "__main__":

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -525,7 +525,7 @@ def test_search_returns_legacy_rows_missing_timestamp(memory_store):
 
 
 def test_search_skips_malformed_row_without_truncation(memory_store):
-    """A row whose conversion genuinely fails (unparseable timestamp) must be
+    """A row whose conversion genuinely fails (unparsable timestamp) must be
     skipped, not abort the vector branch after earlier appends — which used to
     suppress the text fallback and silently truncate the results (#847).
 

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import shutil
 import tempfile
 
@@ -524,10 +525,11 @@ def test_search_returns_legacy_rows_missing_timestamp(memory_store):
     assert "legacy-no-ts" in ids
 
 
-def test_search_skips_malformed_row_without_truncation(memory_store):
+def test_search_skips_malformed_row_without_truncation(memory_store, caplog):
     """A row whose conversion genuinely fails (unparsable timestamp) must be
-    skipped, not abort the vector branch after earlier appends — which used to
-    suppress the text fallback and silently truncate the results (#847).
+    skipped *and logged*, not abort the vector branch after earlier appends —
+    which used to suppress the text fallback and silently truncate the
+    results (#847).
 
     The malformed row is seeded BETWEEN well-formed rows so that, pre-fix, the
     mid-loop escape would drop the rows inserted after it."""
@@ -552,15 +554,23 @@ def test_search_skips_malformed_row_without_truncation(memory_store):
     for i in range(2, 4):
         assert memory_store.add(MemoryNote(content=f"well-formed note {i}")).success
 
-    results = memory_store.search("note", k=10)
+    with caplog.at_level(logging.WARNING, logger="xagent.core.memory.lancedb"):
+        results = memory_store.search("note", k=10)
+
     contents = {r.content for r in results}
     assert {f"well-formed note {i}" for i in range(4)} <= contents
     assert all(r.id != "malformed-ts" for r in results)
+    assert any(
+        "Skipping malformed memory row" in record.getMessage()
+        and "malformed-ts" in record.getMessage()
+        for record in caplog.records
+    )
 
 
-def test_text_fallback_skips_malformed_row(temp_db_dir):
-    """The text-search fallback must also skip a malformed row instead of
-    escaping to the outer except and returning an empty result set (#847)."""
+def test_text_fallback_skips_malformed_row(temp_db_dir, caplog):
+    """The text-search fallback must also skip (and log) a malformed row
+    instead of escaping to the outer except and returning an empty result
+    set (#847)."""
     from xagent.core.model.embedding import BaseEmbedding
 
     class FailingEmbedding(BaseEmbedding):
@@ -600,10 +610,18 @@ def test_text_fallback_skips_malformed_row(temp_db_dir):
         },
     )
 
-    results = store.search("note", k=10)
+    with caplog.at_level(logging.WARNING, logger="xagent.core.memory.lancedb"):
+        results = store.search("note", k=10)
+
     contents = {r.content for r in results}
     assert {f"well-formed note {i}" for i in range(3)} <= contents
     assert all(r.id != "malformed-ts" for r in results)
+    assert any(
+        "Skipping malformed memory row" in record.getMessage()
+        and "malformed-ts" in record.getMessage()
+        and "text search" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #847

## Problem

`LanceDBMemoryStore.search()` runs the vector-branch result loop inside the `try` whose `except` is meant to catch vector-query failures. When `_dict_to_memory_note` raised mid-loop (after some rows were already appended), control escaped to that `except`, the `if not results:` fallback guard saw partial results, and the text fallback was skipped — returning a silently truncated result set. If the malformed row was hit with no rows appended yet, the text fallback ran into the same conversion error and the outer `except` turned the whole query into an empty result.

The concrete trigger: `_dict_to_memory_note` passed `timestamp=metadata.pop("timestamp", None)` into `MemoryNote.timestamp`, a non-optional `datetime` with a `default_factory`. Pydantic only applies the factory when the field is omitted — an explicit `None` raises `ValidationError`, so any legacy row whose metadata JSON lacks `timestamp` failed conversion.

## Changes

- `_dict_to_memory_note`: only pass `timestamp` when the key is present and non-`None`, letting the model default apply for legacy rows (root cause).
- Vector branch of `search()`: wrap the per-row conversion in its own `try/except` — a malformed row is skipped and logged instead of aborting the batch and suppressing the text fallback.
- Text fallback of `search()`: same per-row guard, so a malformed row no longer escapes to the outer `except` and empties the whole result set.

Note on blast radius: the root-cause fix in `_dict_to_memory_note` also transparently repairs `LanceDBMemoryStore.get()`, which calls the same converter — a timestamp-less legacy row previously surfaced there as a generic `MemoryResponse(success=False, ...)` and now loads with the default timestamp.

## Tests

Four regression tests in `tests/core/memory/test_lancedb.py`, covering all acceptance criteria from #847:

- missing-`timestamp` metadata converts using the model default instead of raising
- a vector search whose top-k contains a timestamp-less legacy row returns all rows, including the legacy one
- a genuinely unconvertible row (garbage `timestamp`) seeded *between* well-formed rows is skipped without truncating the rows after it, and the skip `logger.warning` is asserted via `caplog`
- the text fallback also skips a malformed row instead of returning an empty result, likewise asserting the warning is logged

All four fail on the pre-fix code and pass with the fix. Full `tests/core/memory/` suite passes; `ruff format`/`ruff check` clean; no new mypy errors.
