### PR TITLE
feat(memory): add scope-dimension reap and enumeration to memory stores

### DIFF
--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -130,11 +130,21 @@ class MemoryStore(ABC):
         ``client_application_id=4`` — and notes carrying no scope dimensions are
         never candidates. Idempotent: re-running deletes nothing further.
 
+        ``value`` is matched by its ``str()`` form, which must render exactly
+        the string stamped at write time (write-time values are validated
+        non-empty strings). A non-canonical representation — a float, a bool,
+        leading zeros, alternate UUID casing — silently matches nothing
+        (``success=True``, ``deleted_count=0``).
+
         This default walks ``list_all()`` and deletes note-by-note; backends
         with a native bulk predicate delete should override it.
 
         Returns:
             MemoryResponse: ``success`` plus ``metadata["deleted_count"]``.
+            On failure, ``deleted_count`` is backend-specific: this fallback
+            deletes note-by-note and may report a nonzero partial count, while
+            bulk-predicate overrides (e.g. LanceDB) are all-or-nothing and
+            report 0.
         """
         element = scope_dim_element(dim_key, value)
         deleted = 0

--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -137,7 +137,10 @@ class MemoryStore(ABC):
         (``success=True``, ``deleted_count=0``).
 
         This default walks ``list_all()`` and deletes note-by-note; backends
-        with a native bulk predicate delete should override it.
+        with a native bulk predicate delete should override it. It assumes
+        ``list_all()`` returns the complete store — a backend whose
+        ``list_all()`` is bounded or paginated must override this method
+        directly.
 
         Returns:
             MemoryResponse: ``success`` plus ``metadata["deleted_count"]``.
@@ -173,8 +176,10 @@ class MemoryStore(ABC):
         query on the database side can recover. Values are returned in their
         stamped string form.
 
-        This default walks ``list_all()``; backends able to project the
-        dimension column should override it. Raises on backend failure rather
+        This default walks ``list_all()``, and assumes it returns the complete
+        store — a backend whose ``list_all()`` is bounded or paginated must
+        override this method directly, as should backends able to project the
+        dimension column. Raises on backend failure rather
         than returning a partial set, so a reconciler never mistakes an error
         for "no values".
         """

--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Optional
 
 from .core import MemoryNote, MemoryResponse
+from .scope_columns import encode_scope_dims, scope_dim_element
 
 
 class MemoryStore(ABC):
@@ -116,3 +117,61 @@ class MemoryStore(ABC):
             Dict[str, Any]: Statistics including total count, counts by category, etc.
         """
         pass
+
+    def delete_by_scope_dimension(self, dim_key: str, value: Any) -> MemoryResponse:
+        """
+        Delete every note stamped with the execution-scope dimension
+        ``dim_key=value``.
+
+        Maintenance operation for reaping notes whose scope dimension no longer
+        maps to a live principal (e.g. all memories of a revoked client
+        application). Matching is exact per-dimension string equality — a note
+        carrying ``client_application_id=42`` is never touched by a delete for
+        ``client_application_id=4`` — and notes carrying no scope dimensions are
+        never candidates. Idempotent: re-running deletes nothing further.
+
+        This default walks ``list_all()`` and deletes note-by-note; backends
+        with a native bulk predicate delete should override it.
+
+        Returns:
+            MemoryResponse: ``success`` plus ``metadata["deleted_count"]``.
+        """
+        element = scope_dim_element(dim_key, value)
+        deleted = 0
+        failures = 0
+        for note in self.list_all():
+            if note.id and element in encode_scope_dims(note.metadata):
+                if self.delete(note.id).success:
+                    deleted += 1
+                else:
+                    failures += 1
+        if failures:
+            return MemoryResponse(
+                success=False,
+                error=f"Failed to delete {failures} matching note(s)",
+                metadata={"deleted_count": deleted},
+            )
+        return MemoryResponse(success=True, metadata={"deleted_count": deleted})
+
+    def list_scope_dimension_values(self, dim_key: str) -> set[str]:
+        """
+        Distinct values stamped for one execution-scope dimension, store-wide.
+
+        Lets a control plane reconcile a dimension against its own records —
+        e.g. find the ``client_application_id`` values still present in memory
+        whose rows have since been hard-deleted from the database, which no
+        query on the database side can recover. Values are returned in their
+        stamped string form.
+
+        This default walks ``list_all()``; backends able to project the
+        dimension column should override it. Raises on backend failure rather
+        than returning a partial set, so a reconciler never mistakes an error
+        for "no values".
+        """
+        prefix = f"{dim_key}="
+        values: set[str] = set()
+        for note in self.list_all():
+            for element in encode_scope_dims(note.metadata):
+                if element.startswith(prefix):
+                    values.add(element[len(prefix) :])
+        return values

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -723,8 +723,6 @@ class LanceDBMemoryStore(MemoryStore):
             arrow_table = (
                 table.search().select([SCOPE_DIMS_COLUMN]).limit(None).to_arrow()
             )
-            if arrow_table.num_rows == 0:
-                return set()
             # Filter in Arrow: flatten the list<string> column (null rows drop
             # out), keep only this dimension's elements, then dedupe — only the
             # distinct values ever cross into Python.

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Union
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
+import pyarrow.compute as pc  # type: ignore
 
 from ...providers.vector_store.lancedb import (
     LanceDBConnectionManager,
@@ -717,15 +718,17 @@ class LanceDBMemoryStore(MemoryStore):
             total = table.count_rows()
             if not total:
                 return set()
-            df = table.search().select([SCOPE_DIMS_COLUMN]).limit(total).to_pandas()
-            values: set[str] = set()
-            for dims in df[SCOPE_DIMS_COLUMN]:
-                if dims is None:
-                    continue
-                for element in dims:
-                    if element.startswith(prefix):
-                        values.add(element[len(prefix) :])
-            return values
+            arrow_table = (
+                table.search().select([SCOPE_DIMS_COLUMN]).limit(total).to_arrow()
+            )
+            # Filter in Arrow: flatten the list<string> column (null rows drop
+            # out), keep only this dimension's elements, then dedupe — only the
+            # distinct values ever cross into Python.
+            flat = pc.list_flatten(arrow_table[SCOPE_DIMS_COLUMN])
+            matched = flat.filter(pc.starts_with(flat, pattern=prefix))
+            return {
+                element[len(prefix) :] for element in matched.unique().to_pylist()
+            }
         finally:
             _safe_close_table(table)
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -30,6 +30,7 @@ from .scope_columns import (
     coerce_user_id,
     derive_scope_columns,
     encode_scope_dims,
+    scope_dim_where_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -669,6 +670,64 @@ class LanceDBMemoryStore(MemoryStore):
                 error=f"Failed to delete memory: {str(e)}",
                 memory_id=note_id,
             )
+
+    def delete_by_scope_dimension(self, dim_key: str, value: Any) -> MemoryResponse:
+        """Bulk-delete every note stamped with dimension ``dim_key=value``.
+
+        Pushes a single ``array_contains(scope_dims, 'key=value')`` predicate
+        into LanceDB instead of the base class's list-and-delete walk, so the
+        whole matching set goes in one table operation. Exact per-element
+        equality (see scope_columns), so similar values never collide.
+        """
+        where = scope_dim_where_term(dim_key, value)
+        table = None
+        try:
+            # The table always exists after construction (the vector store
+            # creates it in __init__), so open directly like get()/search().
+            table = self._vector_store.get_raw_connection().open_table(
+                self._collection_name
+            )
+            count = table.count_rows(where)
+            if count:
+                table.delete(where)
+            return MemoryResponse(success=True, metadata={"deleted_count": count})
+        except Exception as e:
+            logger.error(f"Failed to delete memories by scope dimension {dim_key}: {e}")
+            return MemoryResponse(
+                success=False,
+                error=f"Failed to delete memories by scope dimension: {str(e)}",
+                metadata={"deleted_count": 0},
+            )
+        finally:
+            _safe_close_table(table)
+
+    def list_scope_dimension_values(self, dim_key: str) -> set[str]:
+        """Distinct stamped values for one scope dimension, store-wide.
+
+        Projects only the ``scope_dims`` column (no vectors, no metadata JSON)
+        so the scan stays cheap on large tables. Raises on backend failure —
+        see the base class contract.
+        """
+        prefix = f"{dim_key}="
+        table = None
+        try:
+            table = self._vector_store.get_raw_connection().open_table(
+                self._collection_name
+            )
+            total = table.count_rows()
+            if not total:
+                return set()
+            df = table.search().select([SCOPE_DIMS_COLUMN]).limit(total).to_pandas()
+            values: set[str] = set()
+            for dims in df[SCOPE_DIMS_COLUMN]:
+                if dims is None:
+                    continue
+                for element in dims:
+                    if element.startswith(prefix):
+                        values.add(element[len(prefix) :])
+            return values
+        finally:
+            _safe_close_table(table)
 
     def search(
         self,

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -720,12 +720,11 @@ class LanceDBMemoryStore(MemoryStore):
             table = self._vector_store.get_raw_connection().open_table(
                 self._collection_name
             )
-            total = table.count_rows()
-            if not total:
-                return set()
             arrow_table = (
-                table.search().select([SCOPE_DIMS_COLUMN]).limit(total).to_arrow()
+                table.search().select([SCOPE_DIMS_COLUMN]).limit(None).to_arrow()
             )
+            if arrow_table.num_rows == 0:
+                return set()
             # Filter in Arrow: flatten the list<string> column (null rows drop
             # out), keep only this dimension's elements, then dedupe — only the
             # distinct values ever cross into Python.

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -731,9 +731,7 @@ class LanceDBMemoryStore(MemoryStore):
             # distinct values ever cross into Python.
             flat = pc.list_flatten(arrow_table[SCOPE_DIMS_COLUMN])
             matched = flat.filter(pc.starts_with(flat, pattern=prefix))
-            return {
-                element[len(prefix) :] for element in matched.unique().to_pylist()
-            }
+            return {element[len(prefix) :] for element in matched.unique().to_pylist()}
         finally:
             _safe_close_table(table)
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -679,6 +679,11 @@ class LanceDBMemoryStore(MemoryStore):
         into LanceDB instead of the base class's list-and-delete walk, so the
         whole matching set goes in one table operation. Exact per-element
         equality (see scope_columns), so similar values never collide.
+
+        ``deleted_count`` is best-effort under concurrent writers: LanceDB's
+        ``delete()`` reports only the new table version, not a row count, so
+        the count comes from a ``count_rows`` on the same predicate just
+        before the delete. The operation itself stays idempotent either way.
         """
         where = scope_dim_where_term(dim_key, value)
         table = None

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -242,6 +242,11 @@ class UserIsolatedMemoryStore(MemoryStore):
         is not gated by the per-user context, because the dimension predicate
         itself bounds the deletion to notes explicitly stamped with that
         dimension — dimension-less (creator-direct) notes are never touched.
+
+        Trusted-caller-only: because it bypasses per-user isolation, this must
+        only be reachable from control-plane maintenance jobs — never wire it
+        to a per-user/per-request route, or one tenant could delete another
+        tenant's notes.
         """
         return self._base_store.delete_by_scope_dimension(dim_key, value)
 
@@ -249,7 +254,8 @@ class UserIsolatedMemoryStore(MemoryStore):
         """Distinct stamped values for one scope dimension, store-wide.
 
         Reconciliation primitive for the same maintenance flows as
-        ``delete_by_scope_dimension`` — delegated ungated for the same reason.
+        ``delete_by_scope_dimension`` — delegated ungated, and trusted-caller-
+        only, for the same reasons: it enumerates values across every user.
         """
         return self._base_store.list_scope_dimension_values(dim_key)
 

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -234,6 +234,25 @@ class UserIsolatedMemoryStore(MemoryStore):
 
         return self._base_store.delete(note_id)
 
+    def delete_by_scope_dimension(self, dim_key: str, value: Any) -> MemoryResponse:
+        """Bulk-delete notes stamped with dimension ``dim_key=value``.
+
+        Maintenance operation (reaping memories of a dead principal, e.g. a
+        revoked client application), delegated straight to the base store: it
+        is not gated by the per-user context, because the dimension predicate
+        itself bounds the deletion to notes explicitly stamped with that
+        dimension — dimension-less (creator-direct) notes are never touched.
+        """
+        return self._base_store.delete_by_scope_dimension(dim_key, value)
+
+    def list_scope_dimension_values(self, dim_key: str) -> set[str]:
+        """Distinct stamped values for one scope dimension, store-wide.
+
+        Reconciliation primitive for the same maintenance flows as
+        ``delete_by_scope_dimension`` — delegated ungated for the same reason.
+        """
+        return self._base_store.list_scope_dimension_values(dim_key)
+
     def search(
         self,
         query: str,

--- a/tests/core/memory/test_delete_by_scope_dimension.py
+++ b/tests/core/memory/test_delete_by_scope_dimension.py
@@ -16,7 +16,7 @@ import tempfile
 import pytest
 
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
-from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.core import MemoryNote, MemoryResponse
 from xagent.core.memory.in_memory import InMemoryMemoryStore
 from xagent.core.memory.lancedb import LanceDBMemoryStore
 from xagent.web.user_isolated_memory import UserContext, UserIsolatedMemoryStore
@@ -123,6 +123,56 @@ def test_lancedb_list_values_before_any_write(lancedb_store):
 
 def test_base_default_list_values_via_in_memory():
     _assert_enumeration_semantics(InMemoryMemoryStore())
+
+
+def test_base_default_reap_reports_partial_failure():
+    """Base fallback: one per-note delete failing yields success=False while
+    deleted_count still reports the notes that did go (best-effort)."""
+    store = InMemoryMemoryStore()
+    ids = [
+        store.add(_note(f"ca42 note {i}", client_application_id=42)).memory_id
+        for i in range(3)
+    ]
+    stuck_id = ids[1]
+    real_delete = store.delete
+
+    def flaky_delete(note_id):
+        if note_id == stuck_id:
+            return MemoryResponse(success=False, error="simulated backend failure")
+        return real_delete(note_id)
+
+    store.delete = flaky_delete
+
+    response = store.delete_by_scope_dimension("client_application_id", 42)
+    assert not response.success
+    assert response.metadata["deleted_count"] == 2
+    assert "1" in response.error
+
+
+def test_lancedb_reap_failure_on_backend_error(lancedb_store, monkeypatch):
+    """LanceDB override: a backend error during the bulk delete surfaces as
+    success=False with deleted_count=0 (all-or-nothing), not an exception."""
+    _seed(lancedb_store)
+
+    class ExplodingTable:
+        def count_rows(self, *args, **kwargs):
+            return 2
+
+        def delete(self, *args, **kwargs):
+            raise RuntimeError("simulated backend failure")
+
+    class StubConnection:
+        def open_table(self, name):
+            return ExplodingTable()
+
+    monkeypatch.setattr(
+        lancedb_store._vector_store, "get_raw_connection", lambda: StubConnection()
+    )
+
+    response = lancedb_store.delete_by_scope_dimension("client_application_id", 42)
+    assert not response.success
+    assert response.metadata["deleted_count"] == 0
+    assert "simulated backend failure" in response.error
 
 
 def test_user_isolated_store_delegates_ungated():

--- a/tests/core/memory/test_delete_by_scope_dimension.py
+++ b/tests/core/memory/test_delete_by_scope_dimension.py
@@ -1,0 +1,144 @@
+"""Tests for MemoryStore.delete_by_scope_dimension.
+
+Bulk-reaping every note stamped with one execution-scope dimension
+(``key=value``) — the primitive a control plane needs to clean up memories
+whose dimension no longer maps to a live principal (e.g. a revoked client
+application, xagent-saas#91). Covers the LanceDB predicate-pushdown override,
+the base class's generic list-and-delete fallback (via InMemoryMemoryStore),
+and the UserIsolatedMemoryStore delegation.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import pytest
+
+from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.web.user_isolated_memory import UserContext, UserIsolatedMemoryStore
+
+from .conftest import ConstantEmbedding
+
+P = MEMORY_DIMENSION_METADATA_PREFIX
+
+
+@pytest.fixture
+def temp_db_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def lancedb_store(temp_db_dir):
+    return LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="test_memories",
+        embedding_model=ConstantEmbedding(64),
+    )
+
+
+def _note(content, **dims):
+    return MemoryNote(
+        content=content,
+        metadata={f"{P}{key}": str(value) for key, value in dims.items()},
+    )
+
+
+def _seed(store):
+    """Notes for CA 42 (two end users), CA 4 (the prefix of 42), and a
+    dimension-less creator-direct note. Returns their ids."""
+    ids = {}
+    ids["ca42_a"] = store.add(
+        _note("ca42 user a", client_application_id=42, end_user_id=7)
+    ).memory_id
+    ids["ca42_b"] = store.add(
+        _note("ca42 user b", client_application_id=42, end_user_id=8)
+    ).memory_id
+    ids["ca4"] = store.add(
+        _note("ca4 user", client_application_id=4, end_user_id=9)
+    ).memory_id
+    ids["plain"] = store.add(MemoryNote(content="creator-direct note")).memory_id
+    return ids
+
+
+def _assert_reap_semantics(store):
+    """The contract shared by every implementation: exact-match bulk delete,
+    no prefix collisions, dimension-less notes untouched, idempotent."""
+    ids = _seed(store)
+
+    # int value must match the string-stamped dimension (control planes pass
+    # integer surrogate keys; stamps are strings).
+    response = store.delete_by_scope_dimension("client_application_id", 42)
+    assert response.success
+    assert response.metadata["deleted_count"] == 2
+
+    assert not store.get(ids["ca42_a"]).success
+    assert not store.get(ids["ca42_b"]).success
+    # "client_application_id=4" is a prefix of "...=42" — must survive.
+    assert store.get(ids["ca4"]).success
+    assert store.get(ids["plain"]).success
+
+    # Idempotent: nothing left to reap.
+    again = store.delete_by_scope_dimension("client_application_id", 42)
+    assert again.success
+    assert again.metadata["deleted_count"] == 0
+
+
+def test_lancedb_pushdown_reap(lancedb_store):
+    _assert_reap_semantics(lancedb_store)
+
+
+def test_lancedb_reap_before_any_write(lancedb_store):
+    """Empty store (no note ever written) — reap is a successful no-op."""
+    response = lancedb_store.delete_by_scope_dimension("client_application_id", 42)
+    assert response.success
+    assert response.metadata["deleted_count"] == 0
+
+
+def test_base_default_reap_via_in_memory():
+    _assert_reap_semantics(InMemoryMemoryStore())
+
+
+def _assert_enumeration_semantics(store):
+    """list_scope_dimension_values: distinct stamped values for one dimension,
+    other dimensions and dimension-less notes invisible."""
+    _seed(store)
+    assert store.list_scope_dimension_values("client_application_id") == {"42", "4"}
+    assert store.list_scope_dimension_values("end_user_id") == {"7", "8", "9"}
+    assert store.list_scope_dimension_values("no_such_dimension") == set()
+
+
+def test_lancedb_list_scope_dimension_values(lancedb_store):
+    _assert_enumeration_semantics(lancedb_store)
+
+
+def test_lancedb_list_values_before_any_write(lancedb_store):
+    assert lancedb_store.list_scope_dimension_values("client_application_id") == set()
+
+
+def test_base_default_list_values_via_in_memory():
+    _assert_enumeration_semantics(InMemoryMemoryStore())
+
+
+def test_user_isolated_store_delegates_ungated():
+    """The wrapper reaps regardless of the current user context: the dimension
+    predicate itself bounds the deletion, and a maintenance job runs with no
+    (or an unrelated) user bound."""
+    base = InMemoryMemoryStore()
+    store = UserIsolatedMemoryStore(base)
+
+    note = _note("ca42 note", client_application_id=42, end_user_id=7)
+    note.metadata["user_id"] = 1
+    note_id = base.add(note).memory_id
+
+    with UserContext(99):  # some other principal entirely
+        response = store.delete_by_scope_dimension("client_application_id", 42)
+
+    assert response.success
+    assert response.metadata["deleted_count"] == 1
+    assert not base.get(note_id).success

--- a/tests/core/memory/test_delete_by_scope_dimension.py
+++ b/tests/core/memory/test_delete_by_scope_dimension.py
@@ -125,6 +125,35 @@ def test_base_default_list_values_via_in_memory():
     _assert_enumeration_semantics(InMemoryMemoryStore())
 
 
+def _assert_special_character_values(store):
+    """Values containing ``=`` and a single quote survive both the SQL-literal
+    escaping on the delete pushdown and the fixed-length prefix strip on
+    enumeration."""
+    kept = store.add(_note("equals value", session_ref="a=b")).memory_id
+    quoted = store.add(_note("quoted value", session_ref="o'brien")).memory_id
+
+    assert store.list_scope_dimension_values("session_ref") == {"a=b", "o'brien"}
+
+    response = store.delete_by_scope_dimension("session_ref", "o'brien")
+    assert response.success
+    assert response.metadata["deleted_count"] == 1
+    assert not store.get(quoted).success
+    assert store.get(kept).success
+
+    response = store.delete_by_scope_dimension("session_ref", "a=b")
+    assert response.success
+    assert response.metadata["deleted_count"] == 1
+    assert store.list_scope_dimension_values("session_ref") == set()
+
+
+def test_lancedb_special_character_values(lancedb_store):
+    _assert_special_character_values(lancedb_store)
+
+
+def test_base_default_special_character_values():
+    _assert_special_character_values(InMemoryMemoryStore())
+
+
 def test_base_default_reap_reports_partial_failure():
     """Base fallback: one per-note delete failing yields success=False while
     deleted_count still reports the notes that did go (best-effort)."""


### PR DESCRIPTION
## Motivation

Upstream half of xorbitsai/xagent-saas#91 (clean up orphaned end-user memories after client-application revocation). A control plane that stamps execution-scope dimensions onto memories (#822 / xagent-saas#80) needs two maintenance primitives on the store, agreed in the issue discussion:

- **Reap by dimension** — delete every note stamped with one `key=value` dimension, as a store-level bulk operation rather than search-then-delete-by-id (which would bypass predicate pushdown and cap out at top-k).
- **Enumerate a dimension** — list the distinct values stamped for one dimension, so the control plane can reconcile memories against its own records. This covers the case where the principal was *hard-deleted* (e.g. a revoked client application removed by a team-deletion cascade): its id is unrecoverable from the control plane's database and only the memory store still knows it.

## Changes

- `MemoryStore.delete_by_scope_dimension(dim_key, value)` — non-abstract base implementation (walks `list_all()`, deletes matches), so existing third-party stores keep working. Returns `MemoryResponse` with `metadata["deleted_count"]`. Idempotent; exact per-element matching (`client_application_id=4` never touches `...=42`); dimension-less (creator-direct) notes are never candidates.
- `LanceDBMemoryStore` override — pushes a single `array_contains(scope_dims, 'key=value')` predicate into `table.delete()`, reusing the existing `scope_columns` where-clause builders; counts via `count_rows(where)` first.
- `MemoryStore.list_scope_dimension_values(dim_key)` — base implementation over `list_all()`; the LanceDB override scans with a `select([scope_dims])` projection (no vectors, no metadata JSON). Raises on backend failure rather than returning a partial set, so a reconciler never mistakes an error for "no values".
- `UserIsolatedMemoryStore` delegates both straight to the base store: maintenance operations whose blast radius is bounded by the dimension predicate itself, not by the per-user context.

## Tests

`tests/core/memory/test_delete_by_scope_dimension.py` — shared contract asserted against both the LanceDB pushdown and the base fallback (via `InMemoryMemoryStore`): bulk delete with prefix-collision guard, dimension-less notes untouched, idempotent re-run, empty-store no-op, enumeration semantics, and ungated wrapper delegation under an unrelated user context.

`tests/core/memory/` passes (102), plus memory/scope/isolation-related tests across core+web (328).
