### PR TITLE
fix(memory): honor tags/keywords/date filters in LanceDBMemoryStore.search()

### DIFF
--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, List, Optional
 
 from .core import MemoryNote, MemoryResponse
+
+
+def comparable_timestamp(value: Any) -> Any:
+    """Normalize a datetime for cross-comparison in date-range filters.
+
+    Stored note timestamps default to naive local time
+    (``MemoryNote.timestamp``'s ``datetime.now`` factory), while caller-supplied
+    ``date_from``/``date_to`` filter values may be timezone-aware (FastAPI
+    parses ISO date query params with an offset into aware datetimes).
+    Comparing the two directly raises ``TypeError``, which the stores' outer
+    exception handlers would swallow into a silently empty result. Aware
+    datetimes are therefore converted to naive local time before comparison;
+    naive datetimes and non-datetime values pass through unchanged.
+
+    Shared by every ``MemoryStore`` implementation's filter dispatch so the
+    stores cannot drift apart on this policy.
+    """
+    if isinstance(value, datetime) and value.tzinfo is not None:
+        return value.astimezone().replace(tzinfo=None)
+    return value
 
 
 class MemoryStore(ABC):

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import Any, Collection, List, Optional
 
-from .base import MemoryStore
+from .base import MemoryStore, comparable_timestamp
 from .core import MemoryNote, MemoryResponse
 from .scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY, encode_scope_dims
 
@@ -102,11 +102,18 @@ class InMemoryMemoryStore(MemoryStore):
         ):
             return False
 
-        # Date range filters
-        if "date_from" in filters and note.timestamp < filters["date_from"]:
-            return False
-        if "date_to" in filters and note.timestamp > filters["date_to"]:
-            return False
+        # Date range filters (both sides tz-normalized so an aware filter
+        # against the naive default timestamps cannot raise TypeError)
+        if "date_from" in filters or "date_to" in filters:
+            note_ts = comparable_timestamp(note.timestamp)
+            if "date_from" in filters and note_ts < comparable_timestamp(
+                filters["date_from"]
+            ):
+                return False
+            if "date_to" in filters and note_ts > comparable_timestamp(
+                filters["date_to"]
+            ):
+                return False
 
         # Tag filter (all required tags present)
         if "tags" in filters:

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, Collection, List, Optional, Union
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
@@ -467,49 +467,111 @@ class LanceDBMemoryStore(MemoryStore):
 
         return MemoryNote(**note_kwargs)
 
-    def _apply_filters(self, note: MemoryNote, filters: dict[str, Any]) -> bool:
-        """Apply filters to a MemoryNote for vector search results.
+    # Filter keys with dedicated handling in _matches_filters; anything else
+    # is treated as a flat metadata-equality filter. Mirrors
+    # InMemoryMemoryStore._KNOWN_FILTER_KEYS so the two stores cannot drift
+    # apart on filter semantics (#909).
+    _KNOWN_FILTER_KEYS = frozenset(
+        {
+            "category",
+            "metadata",
+            "date_from",
+            "date_to",
+            "tags",
+            "keywords",
+            SCOPE_EXCLUSIVE_FILTER_KEY,
+        }
+    )
 
-        Unlike ``_apply_text_search_filters``, this never checks
-        ``SCOPE_EXCLUSIVE_FILTER_KEY``: on the vector path that directive is
-        already turned into an ``array_length`` ``where`` term and popped out of
-        the residual filters by ``build_scope_where`` before it reaches here, so
-        it can only appear among these residual filters on the text fallback.
-        """
-        for key, value in filters.items():
-            # Special handling for category - check note.category first
-            if key == "category":
-                if str(note.category) != str(value):
-                    return False
-            elif key == "metadata":
-                # Handle nested metadata filters
-                if not self._apply_metadata_filters(note.metadata, value):
-                    return False
-            else:
-                # For other fields, check metadata
-                if str(note.metadata.get(key, "")) != str(value):
-                    return False
-        return True
+    @staticmethod
+    def _required_items(value: Any) -> Optional[Collection[Any]]:
+        """Normalize a ``tags``/``keywords`` filter value: a plain string is a
+        single required item (not iterated per character), an iterable is many,
+        and anything else can't match (rather than raising ``TypeError`` on
+        malformed caller-supplied filters — the same no-match policy as
+        ``_apply_metadata_filters``)."""
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return value
+        return None
 
-    def _apply_text_search_filters(
-        self, metadata_dict: dict[str, Any], filters: dict[str, Any]
+    @classmethod
+    def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
+        """Filter keys without dedicated handling, applied as flat metadata
+        equality. Note-independent — compute once per call, not per note."""
+        return {
+            key: value
+            for key, value in (filters or {}).items()
+            if key not in cls._KNOWN_FILTER_KEYS
+        }
+
+    def _matches_filters(
+        self,
+        note: MemoryNote,
+        filters: dict[str, Any],
+        other_filters: dict[str, Any],
     ) -> bool:
-        """Apply filters to metadata dict for text search results."""
-        for key, value in filters.items():
-            if key == SCOPE_EXCLUSIVE_FILTER_KEY:
-                # #822: the text-fallback form of the strict dimension-less
-                # exclusion the vector path pushes into `where`. Only notes
-                # carrying no scope dimensions pass.
-                if value and encode_scope_dims(metadata_dict):
-                    return False
-            elif key == "metadata":
-                # Handle nested metadata filters
-                if not self._apply_metadata_filters(metadata_dict, value):
-                    return False
-            else:
-                # Direct field comparison
-                if str(metadata_dict.get(key, "")) != str(value):
-                    return False
+        """Single filter dispatch shared by the vector path, the text fallback,
+        and (via search) ``list_all()``, so they cannot drift apart on filter
+        semantics (#909 — previously ``tags``/``keywords``/``date_from``/
+        ``date_to`` fell through to flat metadata equality on both search paths
+        and never matched, while ``list_all()`` handled them correctly).
+
+        On the vector path ``filters`` is the residual dict left by
+        ``build_scope_where``: ``SCOPE_EXCLUSIVE_FILTER_KEY`` and the
+        user_id/scope-dimension entries of the nested ``metadata`` filter were
+        already pushed into the ``where`` prefilter, so those checks simply do
+        not trigger there. The text fallback passes the full filters and relies
+        on the checks here.
+
+        ``other_filters`` is ``_flat_other_filters(filters)``, precomputed by
+        the caller so the per-note check does not rebuild it.
+        """
+        # #822: strict dimension-less exclusion — only notes carrying no scope
+        # dimensions pass. Scope-dimension stamps live in note.metadata (they
+        # are not popped by _dict_to_memory_note).
+        if filters.get(SCOPE_EXCLUSIVE_FILTER_KEY) and encode_scope_dims(note.metadata):
+            return False
+
+        if "category" in filters and str(note.category) != str(filters["category"]):
+            return False
+
+        # Nested metadata filters (the shape UserIsolatedMemoryStore emits
+        # for user_id/scope isolation)
+        if "metadata" in filters and not self._apply_metadata_filters(
+            note.metadata, filters["metadata"]
+        ):
+            return False
+
+        # Date range filters
+        if "date_from" in filters and note.timestamp < filters["date_from"]:
+            return False
+        if "date_to" in filters and note.timestamp > filters["date_to"]:
+            return False
+
+        # Tag filter (all required tags present)
+        if "tags" in filters:
+            required_tags = self._required_items(filters["tags"])
+            if required_tags is None or not all(
+                tag in note.tags for tag in required_tags
+            ):
+                return False
+
+        # Keyword filter (all required keywords present)
+        if "keywords" in filters:
+            required_keywords = self._required_items(filters["keywords"])
+            if required_keywords is None or not all(
+                keyword in note.keywords for keyword in required_keywords
+            ):
+                return False
+
+        # Other flat metadata filters (string-coerced equality)
+        if other_filters and not self._apply_metadata_filters(
+            note.metadata, other_filters
+        ):
+            return False
+
         return True
 
     def _apply_metadata_filters(
@@ -699,8 +761,10 @@ class LanceDBMemoryStore(MemoryStore):
 
             # #822: push user_id + scope-dimension filters into a `where`
             # prefilter so the ANN returns k already-scoped neighbours; the rest
-            # (category, arbitrary metadata keys) stays a Python post-filter.
+            # (category, tags/keywords/dates, arbitrary metadata keys) stays a
+            # Python post-filter.
             where_sql, residual_filters = build_scope_where(filters)
+            residual_other_filters = self._flat_other_filters(residual_filters)
 
             # Try vector search first
             try:
@@ -763,13 +827,12 @@ class LanceDBMemoryStore(MemoryStore):
 
                                 # user_id + scope dimensions were already applied
                                 # as a `where` prefilter; only residual filters
-                                # (category, arbitrary metadata keys) remain.
-                                if residual_filters:
-                                    filter_match = self._apply_filters(
-                                        note, residual_filters
-                                    )
-                                    if not filter_match:
-                                        continue
+                                # (category, tags/keywords/dates, arbitrary
+                                # metadata keys) remain.
+                                if residual_filters and not self._matches_filters(
+                                    note, residual_filters, residual_other_filters
+                                ):
+                                    continue
 
                                 results.append(note)
                         except Exception as vector_error:
@@ -802,48 +865,46 @@ class LanceDBMemoryStore(MemoryStore):
             if not results:
                 # Text search
                 df = table.search().to_pandas()
+                other_filters = self._flat_other_filters(filters)
 
                 # Filter by query text and apply filters
                 for _, row in df.iterrows():
                     text = row.get("text", "")
-                    metadata = row.get("metadata", "{}")
-
-                    try:
-                        metadata_dict = json.loads(metadata)
-                    except (json.JSONDecodeError, TypeError):
-                        metadata_dict = {}
-
-                    # Apply metadata filters if specified
-                    if filters:
-                        filter_match = self._apply_text_search_filters(
-                            metadata_dict, filters
-                        )
-                        if not filter_match:
-                            continue
 
                     # Simple text matching
-                    if not query or query.lower() in text.lower():
-                        note_data = {
-                            "id": row.get("id", ""),
-                            "text": text,
-                            "metadata": metadata,
-                        }
-                        # #847: here a malformed row would escape to the outer
-                        # except and turn the whole query into an empty result.
-                        try:
-                            note = self._dict_to_memory_note(note_data)
-                        except Exception as row_error:
-                            logger.warning(
-                                "Skipping malformed memory row %r in text "
-                                "search results: %s",
-                                note_data["id"],
-                                row_error,
-                            )
-                            continue
-                        results.append(note)
+                    if query and query.lower() not in text.lower():
+                        continue
 
-                        if len(results) >= k:
-                            break
+                    note_data = {
+                        "id": row.get("id", ""),
+                        "text": text,
+                        "metadata": row.get("metadata", "{}"),
+                    }
+                    # #847: here a malformed row would escape to the outer
+                    # except and turn the whole query into an empty result.
+                    try:
+                        note = self._dict_to_memory_note(note_data)
+                    except Exception as row_error:
+                        logger.warning(
+                            "Skipping malformed memory row %r in text "
+                            "search results: %s",
+                            note_data["id"],
+                            row_error,
+                        )
+                        continue
+
+                    # Unlike the vector path, nothing was pushed into `where`
+                    # here, so the full filters apply (including the
+                    # scope-exclusive directive and nested metadata isolation).
+                    if filters and not self._matches_filters(
+                        note, filters, other_filters
+                    ):
+                        continue
+
+                    results.append(note)
+
+                    if len(results) >= k:
+                        break
 
             return results[:k]
 
@@ -860,51 +921,17 @@ class LanceDBMemoryStore(MemoryStore):
         except Exception as e:
             logger.error(f"Failed to clear memory store: {e}")
 
-    # Filters that search() does not understand and must be applied here.
-    # Everything else (category, nested `metadata`, direct-field equality) is
-    # delegated to search()'s proven filter path so list_all cannot diverge.
-    _LIST_ONLY_FILTERS = frozenset({"date_from", "date_to", "tags", "keywords"})
-
-    def _matches_list_only_filters(
-        self, note: MemoryNote, filters: dict[str, Any]
-    ) -> bool:
-        """Apply the date-range/tags/keywords filters search() does not handle."""
-        if "date_from" in filters and note.timestamp < filters["date_from"]:
-            return False
-        if "date_to" in filters and note.timestamp > filters["date_to"]:
-            return False
-        if "tags" in filters and not all(tag in note.tags for tag in filters["tags"]):
-            return False
-        if "keywords" in filters and not all(
-            keyword in note.keywords for keyword in filters["keywords"]
-        ):
-            return False
-        return True
-
     def list_all(self, filters: Optional[dict[str, Any]] = None) -> List[MemoryNote]:
         """List all memory notes with optional filtering.
 
-        Delegates category / nested-``metadata`` / direct-field filters to
-        search() (its filter logic is the single source of truth, including the
-        nested ``{"metadata": {...}}`` shape the user-isolation layer relies on),
-        and applies the date-range/tags/keywords filters here. Results are sorted
+        Delegates all filtering to search(): its ``_matches_filters`` dispatch
+        is the single source of truth (category, nested ``{"metadata": {...}}``
+        isolation filters, tags/keywords/date ranges, flat metadata equality),
+        so list_all and search cannot diverge (#909). Results are sorted
         newest-first to match InMemoryStore.list_all.
         """
         try:
-            filters = filters or {}
-            # Let search() handle everything it understands...
-            search_filters = {
-                k: v for k, v in filters.items() if k not in self._LIST_ONLY_FILTERS
-            }
-            notes = self.search(query="", k=10000, filters=search_filters or None)
-            # ...then apply the list-only filters it does not.
-            list_only = {
-                k: v for k, v in filters.items() if k in self._LIST_ONLY_FILTERS
-            }
-            if list_only:
-                notes = [
-                    n for n in notes if self._matches_list_only_filters(n, list_only)
-                ]
+            notes = self.search(query="", k=10000, filters=filters or None)
             # Mirror InMemoryStore: newest first.
             notes.sort(key=lambda n: n.timestamp, reverse=True)
             return notes

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -15,7 +15,7 @@ from ..model.embedding import BaseEmbedding, DashScopeEmbedding
 from ..model.embedding.adapter import create_embedding_adapter
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
-from .base import MemoryStore
+from .base import MemoryStore, comparable_timestamp
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
     MemoryMismatchKind,
@@ -544,11 +544,18 @@ class LanceDBMemoryStore(MemoryStore):
         ):
             return False
 
-        # Date range filters
-        if "date_from" in filters and note.timestamp < filters["date_from"]:
-            return False
-        if "date_to" in filters and note.timestamp > filters["date_to"]:
-            return False
+        # Date range filters (both sides tz-normalized so an aware filter
+        # against the naive default timestamps cannot raise TypeError)
+        if "date_from" in filters or "date_to" in filters:
+            note_ts = comparable_timestamp(note.timestamp)
+            if "date_from" in filters and note_ts < comparable_timestamp(
+                filters["date_from"]
+            ):
+                return False
+            if "date_to" in filters and note_ts > comparable_timestamp(
+                filters["date_to"]
+            ):
+                return False
 
         # Tag filter (all required tags present)
         if "tags" in filters:

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -1,6 +1,6 @@
 """Test cases for InMemory memory store implementation."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -545,6 +545,37 @@ class TestSearchListOnlyFilterParity:
             n.id
             for n in memory_store.search("report", k=10, filters={"date_to": cutoff})
         ] == ["old-work"]
+
+    def test_timezone_aware_date_filters(self, memory_store):
+        # A tz-aware filter (FastAPI parses ISO date query params with an
+        # offset into aware datetimes) must compare against the naive stored
+        # timestamps instead of raising TypeError.
+        cutoff_utc = (self.now - timedelta(days=1)).astimezone(timezone.utc)
+        assert [
+            n.id
+            for n in memory_store.search(
+                "report", k=10, filters={"date_from": cutoff_utc}
+            )
+        ] == ["new-home"]
+        assert [
+            n.id for n in memory_store.list_all(filters={"date_from": cutoff_utc})
+        ] == ["new-home"]
+
+    def test_timezone_aware_stored_timestamp_with_naive_filter(self, memory_store):
+        # The other direction: an aware stored timestamp must compare against
+        # a naive filter value.
+        memory_store.add(
+            MemoryNote(
+                id="aware-note",
+                content="weekly report summary",
+                tags=["work"],
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+        results = memory_store.search(
+            "report", k=10, filters={"date_from": self.now - timedelta(days=1)}
+        )
+        assert {n.id for n in results} == {"new-home", "aware-note"}
 
     def test_search_and_list_all_agree(self, memory_store):
         filters = {"tags": ["work"], "keywords": ["report"]}

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -8,6 +8,24 @@ import pytest
 
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore, _safe_close_table
+from xagent.core.model.embedding import BaseEmbedding
+
+
+class FailingEmbedding(BaseEmbedding):
+    """Embedding model that always fails, forcing the text-search fallback."""
+
+    def __init__(self):
+        self._dimension = 64
+
+    def encode(self, text, dimension=None, instruct=None):
+        raise Exception("Embedding failed")
+
+    def get_dimension(self):
+        return self._dimension
+
+    @property
+    def abilities(self):
+        return ["embed"]
 
 
 @pytest.fixture
@@ -22,7 +40,6 @@ def temp_db_dir():
 @pytest.fixture
 def mock_embedding_model():
     """Create a mock embedding model for testing."""
-    from xagent.core.model.embedding import BaseEmbedding
 
     class MockEmbedding(BaseEmbedding):
         def __init__(self):
@@ -397,22 +414,6 @@ def test_embedding_fallback(memory_store):
     # Create a memory store with failing embedding model
     temp_dir = tempfile.mkdtemp()
     try:
-        from xagent.core.model.embedding import BaseEmbedding
-
-        class FailingEmbedding(BaseEmbedding):
-            def __init__(self):
-                self._dimension = 64
-
-            def encode(self, text, dimension=None, instruct=None):
-                raise Exception("Embedding failed")
-
-            def get_dimension(self):
-                return self._dimension
-
-            @property
-            def abilities(self):
-                return ["embed"]
-
         failing_model = FailingEmbedding()
 
         fallback_store = LanceDBMemoryStore(
@@ -616,22 +617,6 @@ def test_text_fallback_skips_malformed_row(temp_db_dir, caplog):
     """The text-search fallback must also skip (and log) a malformed row
     instead of escaping to the outer except and returning an empty result
     set (#847)."""
-    from xagent.core.model.embedding import BaseEmbedding
-
-    class FailingEmbedding(BaseEmbedding):
-        def __init__(self):
-            self._dimension = 64
-
-        def encode(self, text, dimension=None, instruct=None):
-            raise Exception("Embedding failed")
-
-        def get_dimension(self):
-            return self._dimension
-
-        @property
-        def abilities(self):
-            return ["embed"]
-
     store = LanceDBMemoryStore(
         db_dir=temp_db_dir,
         collection_name="test_text_fallback_847",
@@ -672,22 +657,6 @@ def test_text_fallback_skips_malformed_row(temp_db_dir, caplog):
 @pytest.fixture
 def failing_embedding_store(temp_db_dir):
     """A store whose embedding model always fails, forcing the text fallback."""
-    from xagent.core.model.embedding import BaseEmbedding
-
-    class FailingEmbedding(BaseEmbedding):
-        def __init__(self):
-            self._dimension = 64
-
-        def encode(self, text, dimension=None, instruct=None):
-            raise Exception("Embedding failed")
-
-        def get_dimension(self):
-            return self._dimension
-
-        @property
-        def abilities(self):
-            return ["embed"]
-
     return LanceDBMemoryStore(
         db_dir=temp_db_dir,
         collection_name="test_memories_text_fallback",

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -2,7 +2,7 @@ import json
 import logging
 import shutil
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -766,6 +766,44 @@ class TestSearchListOnlyFilterParity:
             n.id
             for n in parity_store.search("report", k=10, filters={"date_to": cutoff})
         ] == ["old-work"]
+
+    def test_timezone_aware_date_filters(self, parity_store):
+        # A tz-aware filter (FastAPI parses ISO date query params with an
+        # offset into aware datetimes) must compare against the naive stored
+        # timestamps instead of raising TypeError — which the outer exception
+        # handlers would swallow into a silently empty result.
+        cutoff_utc = (self.now - timedelta(days=1)).astimezone(timezone.utc)
+        assert [
+            n.id
+            for n in parity_store.search(
+                "report", k=10, filters={"date_from": cutoff_utc}
+            )
+        ] == ["new-home"]
+        assert [
+            n.id
+            for n in parity_store.search(
+                "report", k=10, filters={"date_to": cutoff_utc}
+            )
+        ] == ["old-work"]
+        assert [
+            n.id for n in parity_store.list_all(filters={"date_from": cutoff_utc})
+        ] == ["new-home"]
+
+    def test_timezone_aware_stored_timestamp_with_naive_filter(self, parity_store):
+        # The other direction: an aware stored timestamp must compare against
+        # a naive filter value.
+        assert parity_store.add(
+            MemoryNote(
+                id="aware-note",
+                content="weekly report summary",
+                tags=["work"],
+                timestamp=datetime.now(timezone.utc),
+            )
+        ).success
+        results = parity_store.search(
+            "report", k=10, filters={"date_from": self.now - timedelta(days=1)}
+        )
+        assert {n.id for n in results} == {"new-home", "aware-note"}
 
     def test_search_combines_text_query_with_tag_filter(self, parity_store):
         # The production shape (web memory list route): a text query PLUS a

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -2,6 +2,7 @@ import json
 import logging
 import shutil
 import tempfile
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -666,6 +667,151 @@ def test_text_fallback_skips_malformed_row(temp_db_dir, caplog):
         and "text search" in record.getMessage()
         for record in caplog.records
     )
+
+
+@pytest.fixture
+def failing_embedding_store(temp_db_dir):
+    """A store whose embedding model always fails, forcing the text fallback."""
+    from xagent.core.model.embedding import BaseEmbedding
+
+    class FailingEmbedding(BaseEmbedding):
+        def __init__(self):
+            self._dimension = 64
+
+        def encode(self, text, dimension=None, instruct=None):
+            raise Exception("Embedding failed")
+
+        def get_dimension(self):
+            return self._dimension
+
+        @property
+        def abilities(self):
+            return ["embed"]
+
+    return LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="test_memories_text_fallback",
+        embedding_model=FailingEmbedding(),
+    )
+
+
+@pytest.fixture(params=["vector", "text_fallback"])
+def parity_store(request, temp_db_dir, mock_embedding_model, failing_embedding_store):
+    """Run the filter-parity suite on both search paths.
+
+    ``vector``: mock embeddings (identical vectors, distance 0), so every note
+    is an accepted ANN neighbour and filters are exercised as the residual
+    Python post-filter of the vector path. ``text_fallback``: the embedding
+    model always fails, so filters are exercised on the text-search fallback.
+    """
+    if request.param == "vector":
+        return LanceDBMemoryStore(
+            db_dir=temp_db_dir,
+            collection_name="test_memories_parity",
+            embedding_model=mock_embedding_model,
+        )
+    return failing_embedding_store
+
+
+class TestSearchListOnlyFilterParity:
+    """#909: search() and list_all() share one filter dispatch — tags /
+    keywords / date_from / date_to must behave identically on both, on both
+    the vector path and the text fallback. Previously search() let these keys
+    fall through to flat metadata equality — they live on note.tags /
+    note.keywords / note.timestamp, never note.metadata, so any query
+    combining text search with one of them silently returned empty (reachable
+    via the web memory list route, which calls search() whenever a text query
+    is present), while list_all() handled them correctly."""
+
+    @pytest.fixture(autouse=True)
+    def seed(self, parity_store):
+        now = datetime.now()
+        assert parity_store.add(
+            MemoryNote(
+                id="old-work",
+                content="quarterly report draft",
+                tags=["work"],
+                keywords=["report"],
+                timestamp=now - timedelta(days=2),
+            )
+        ).success
+        assert parity_store.add(
+            MemoryNote(
+                id="new-home",
+                content="grocery report list",
+                tags=["home"],
+                keywords=["groceries"],
+                timestamp=now,
+            )
+        ).success
+        self.now = now
+
+    def test_search_with_tags_filter(self, parity_store):
+        results = parity_store.search("report", k=10, filters={"tags": ["work"]})
+        assert [n.id for n in results] == ["old-work"]
+
+    def test_search_with_keywords_filter(self, parity_store):
+        results = parity_store.search(
+            "report", k=10, filters={"keywords": ["groceries"]}
+        )
+        assert [n.id for n in results] == ["new-home"]
+
+    def test_search_with_date_filters(self, parity_store):
+        cutoff = self.now - timedelta(days=1)
+        assert [
+            n.id
+            for n in parity_store.search("report", k=10, filters={"date_from": cutoff})
+        ] == ["new-home"]
+        assert [
+            n.id
+            for n in parity_store.search("report", k=10, filters={"date_to": cutoff})
+        ] == ["old-work"]
+
+    def test_search_combines_text_query_with_tag_filter(self, parity_store):
+        # The production shape (web memory list route): a text query PLUS a
+        # tag filter. Pre-#909 this returned [] on the LanceDB store.
+        assert parity_store.search("quarterly", k=10) != []
+        results = parity_store.search("quarterly", k=10, filters={"tags": ["work"]})
+        assert [n.id for n in results] == ["old-work"]
+
+    def test_search_and_list_all_agree(self, parity_store):
+        filters = {"tags": ["work"], "keywords": ["report"]}
+        search_ids = {
+            n.id for n in parity_store.search("report", k=10, filters=filters)
+        }
+        list_ids = {n.id for n in parity_store.list_all(filters=filters)}
+        assert search_ids == list_ids == {"old-work"}
+
+    def test_string_tags_keywords_are_single_items(self, parity_store):
+        # A bare string is one required tag/keyword, not iterated per
+        # character (per-char iteration would require single-letter tags and
+        # never match "work" against tags=["work"]).
+        assert [
+            n.id for n in parity_store.search("report", k=10, filters={"tags": "work"})
+        ] == ["old-work"]
+        assert [n.id for n in parity_store.list_all(filters={"tags": "work"})] == [
+            "old-work"
+        ]
+
+    def test_non_iterable_tags_keywords_match_nothing(self, parity_store):
+        # Malformed (non-iterable) tags/keywords values can't match anything —
+        # same no-match policy as a non-dict filters["metadata"], no TypeError
+        # on either method.
+        for key in ("tags", "keywords"):
+            assert parity_store.search("report", k=10, filters={key: 5}) == []
+            assert parity_store.list_all(filters={key: 5}) == []
+
+    def test_empty_tags_keywords_match_everything(self, parity_store):
+        # An empty list means "no tags/keywords required" — vacuously matches
+        # every note, distinct from the malformed no-match case above.
+        for key in ("tags", "keywords"):
+            assert {
+                n.id for n in parity_store.search("report", k=10, filters={key: []})
+            } == {"old-work", "new-home"}
+            assert {n.id for n in parity_store.list_all(filters={key: []})} == {
+                "old-work",
+                "new-home",
+            }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #909. The exact LanceDB parallel of the `InMemoryMemoryStore` fix in #906.

## Problem

`LanceDBMemoryStore.search()` had no dedicated handling for `tags` / `keywords` / `date_from` / `date_to` filter keys: on both the vector path (`_apply_filters`) and the text fallback (`_apply_text_search_filters`) they fell through to flat `str(note.metadata.get(key, "")) != str(value)` equality. Those values live on `note.tags` / `note.keywords` / `note.timestamp`, never in per-key metadata, so the comparison always failed — any text search combined with one of these filters silently returned wrong/empty results. `list_all()` already handled the same keys correctly via `_LIST_ONLY_FILTERS` / `_matches_list_only_filters()`.

Reachable in production through `src/xagent/web/api/memory.py`'s `list_memories` route, which builds a flat filters dict from category/tags/keywords/date query params and calls `.search()` whenever a `search` query param is present.

## Change

Mirrors the single-dispatch unification #906 applied to `InMemoryMemoryStore`:

- Replace `_apply_filters` / `_apply_text_search_filters` with a single `_matches_filters()` dispatch (plus `_KNOWN_FILTER_KEYS`, `_required_items()`, `_flat_other_filters()`), used by the vector path's residual post-filter, the text fallback, and — by delegation through `search()` — `list_all()`. The three paths can no longer drift apart on filter semantics.
- `tags` / `keywords`: all-required membership against `note.tags` / `note.keywords`; `date_from` / `date_to`: range checks against `note.timestamp` — same semantics `list_all()` already had.
- Malformed-input semantics aligned with `InMemoryMemoryStore` as fixed in #906: a non-iterable `tags`/`keywords` value matches nothing (no `TypeError`), a bare string is a single required item (not iterated per character). The removed `_matches_list_only_filters()` had both of the old behaviors, so `list_all()` picks up the fix too.
- The text fallback now constructs the `MemoryNote` before filtering (keeping the #847 malformed-row skip-and-log), so filters evaluate against typed note fields exactly like the vector path. Scope stamps (`execution_scope_*`, `user_id`) are not popped by `_dict_to_memory_note`, so the scope-exclusive directive and nested-metadata isolation checks are unaffected.
- `list_all()` now just delegates all filtering to `search()` and sorts newest-first; `_LIST_ONLY_FILTERS` / `_matches_list_only_filters()` are gone.

## Tests

New `TestSearchListOnlyFilterParity` in `tests/core/memory/test_lancedb.py`, parallel to the same-named suite in `test_in_memory.py`, parametrized to run against **both** search paths (vector path via mock embeddings, text fallback via a failing embedding model):

- text query combined with `tags` / `keywords` / `date_from` / `date_to` filters returns the matching notes (the empirical repro from the issue: `search("quarterly", filters={"tags": ["work"]})`)
- `search()` and `list_all()` agree on these filters
- bare-string `tags`/`keywords` = single required item; non-iterable values match nothing without crashing; empty list vacuously matches everything

`pytest tests/core/memory/ tests/web/test_memory_api.py tests/web/test_user_isolated_in_memory.py tests/web/test_execution_scope_memory.py` — 191 passed. `ruff format` / `ruff check` / `mypy` clean.

## Acceptance criteria from #909

- [x] `LanceDBMemoryStore.search()` returns matching notes when combining a text query with `tags`, `keywords`, `date_from`, or `date_to` filters (both the vector path and the text fallback)
- [x] `search()` and `list_all()` agree on these filters for the same data
- [x] Malformed `tags`/`keywords` values behave as in `InMemoryMemoryStore`: no crash, string = single required item
- [x] Regression tests for the above

## Follow-up: tz-aware vs naive datetime comparison (Gemini review)

Gemini flagged that comparing a tz-aware `date_from`/`date_to` filter value (FastAPI parses ISO date query params with an offset into aware datetimes) against the naive default note timestamps raises `TypeError`, which the outer exception handlers swallow into a silently empty result. This was pre-existing — the removed `_matches_list_only_filters()` had the same bare comparison, and so does `InMemoryMemoryStore._matches_filters()` as merged in #906 — so it is fixed in **both stores** here rather than only at the flagged call site: a shared `comparable_timestamp()` helper in `memory.base` (aware → naive local; naive and non-datetime values pass through) is applied to both sides of the date-range comparisons in each store's `_matches_filters`. Covered by new tests in both directions (aware filter vs naive stored timestamp, aware stored timestamp vs naive filter) on the InMemory store and on both LanceDB search paths.
