### PR TITLE
fix: prevent concurrent auth refresh logout

### DIFF
--- a/frontend/src/contexts/auth-context.test.tsx
+++ b/frontend/src/contexts/auth-context.test.tsx
@@ -1,0 +1,180 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AuthProvider, useAuth } from "@/contexts/auth-context"
+import { apiRequest } from "@/lib/api-wrapper"
+import { AUTH_CACHE_KEY, clearStoredAuth, writeAuthCache } from "@/lib/auth-cache"
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: vi.fn(async () => new Response(null, { status: 404 })),
+  refreshStoredAccessToken: vi.fn(),
+}))
+
+afterEach(cleanup)
+
+function AuthProbe() {
+  const { checkAuth, token } = useAuth()
+  const [checkResult, setCheckResult] = React.useState("pending")
+  return (
+    <>
+      <span data-testid="access-token">{token || "none"}</span>
+      <span data-testid="check-result">{checkResult}</span>
+      <button onClick={() => {
+        void checkAuth().then(result => setCheckResult(String(result)))
+      }}>
+        Check auth
+      </button>
+    </>
+  )
+}
+
+describe("AuthProvider storage synchronization", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    vi.mocked(apiRequest).mockImplementation(
+      async () => new Response(null, { status: 404 })
+    )
+  })
+
+  it("ignores non-object auth cache payloads without a runtime error", async () => {
+    writeAuthCache(
+      { id: "1", username: "alice", email: null, is_admin: false },
+      "access-token",
+      "refresh-token",
+      120,
+      240
+    )
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token")).toHaveTextContent("access-token")
+    })
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: AUTH_CACHE_KEY,
+        newValue: "null",
+      }))
+    })
+
+    expect(screen.getByTestId("access-token")).toHaveTextContent("access-token")
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it("updates auth state from a valid cross-tab cache payload", async () => {
+    writeAuthCache(
+      { id: "1", username: "alice", email: null, is_admin: false },
+      "alice-access",
+      "alice-refresh",
+      120,
+      240
+    )
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token")).toHaveTextContent("alice-access")
+    })
+
+    writeAuthCache(
+      { id: "2", username: "bob", email: null, is_admin: false },
+      "bob-access",
+      "bob-refresh",
+      120,
+      240
+    )
+    act(() => {
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: AUTH_CACHE_KEY,
+        newValue: localStorage.getItem(AUTH_CACHE_KEY),
+      }))
+    })
+
+    expect(screen.getByTestId("access-token")).toHaveTextContent("bob-access")
+  })
+
+  it("keeps auth state when a 401 leaves the refresh cache intact", async () => {
+    writeAuthCache(
+      { id: "1", username: "alice", email: null, is_admin: false },
+      "alice-access",
+      "alice-refresh",
+      120,
+      240
+    )
+    vi.mocked(apiRequest).mockImplementation(async (url) =>
+      new Response(null, {
+        status: String(url).endsWith("/api/auth/verify") ? 401 : 404,
+        headers: { "Error-Type": "TokenExpired" },
+      })
+    )
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token")).toHaveTextContent("alice-access")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Check auth" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("check-result")).toHaveTextContent("true")
+    })
+    expect(screen.getByTestId("access-token")).toHaveTextContent("alice-access")
+  })
+
+  it("clears auth state when a 401 follows a rejected refresh", async () => {
+    writeAuthCache(
+      { id: "1", username: "alice", email: null, is_admin: false },
+      "alice-access",
+      "alice-refresh",
+      120,
+      240
+    )
+    vi.mocked(apiRequest).mockImplementation(async (url) => {
+      if (String(url).endsWith("/api/auth/verify")) {
+        clearStoredAuth()
+        return new Response(null, {
+          status: 401,
+          headers: { "Error-Type": "TokenExpired" },
+        })
+      }
+      return new Response(null, { status: 404 })
+    })
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token")).toHaveTextContent("alice-access")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Check auth" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("check-result")).toHaveTextContent("false")
+      expect(screen.getByTestId("access-token")).toHaveTextContent("none")
+    })
+  })
+})

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react"
+import React, { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, refreshStoredAccessToken } from "@/lib/api-wrapper"
 import {
   AUTH_CACHE_DURATION_MS,
   AUTH_CACHE_KEY,
   AUTH_TOKEN_UPDATED_EVENT,
+  AuthCache,
   AuthCacheUser,
   clearStoredAuth,
   LEGACY_AUTH_TOKEN_KEY,
@@ -18,6 +19,17 @@ import {
 type User = AuthCacheUser
 
 type TeamRole = "admin" | "member" | null
+
+function isAuthCacheEventPayload(value: unknown): value is AuthCache {
+  if (typeof value !== "object" || value === null) return false
+
+  const candidate = value as Partial<AuthCache>
+  return (
+    typeof candidate.user === "object" &&
+    candidate.user !== null &&
+    typeof candidate.token === "string"
+  )
+}
 
 interface AuthContextType {
   user: User | null
@@ -44,7 +56,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [lastCheckTime, setLastCheckTime] = useState(0)
   const [inTeam, setInTeam] = useState(false)
   const [teamRole, setTeamRole] = useState<TeamRole>(null)
-  const refreshAccessTokenRef = useRef<() => Promise<boolean>>(async () => false)
+  const refreshAccessTokenRef = useRef<(
+    expectedAccessToken?: string | null,
+    expectedUserId?: string | null
+  ) => Promise<boolean>>(
+    async () => false
+  )
 
   // Timer for active token refresh
   useEffect(() => {
@@ -61,11 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         if (shouldRefresh) {
           console.log("Token is about to expire, refreshing actively...")
-          const success = await refreshAccessTokenRef.current()
-          if (!success) {
-            // Refresh failed, stop timer (will automatically redirect to login page)
-            clearInterval(refreshInterval)
-          }
+          await refreshAccessTokenRef.current(cache.token, cache.user?.id || null)
         }
       } else {
         const timeSinceCreation = Date.now() - cache.timestamp
@@ -78,10 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         if (shouldRefresh) {
           console.log("Token cache is missing access expiry info, refreshing actively...")
-          const success = await refreshAccessTokenRef.current()
-          if (!success) {
-            clearInterval(refreshInterval)
-          }
+          await refreshAccessTokenRef.current(cache.token, cache.user?.id || null)
         }
       }
     }, 60000) // Check every minute
@@ -123,14 +133,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => clearTimeout(timer)
   }, [])
 
-  // Listen for token update events
+  // Listen for same-tab refresh events and native cross-tab storage events.
   useEffect(() => {
     const handleTokenUpdate = (event: Event) => {
       const storageEvent = event as StorageEvent
-      if (storageEvent.key === AUTH_CACHE_KEY && storageEvent.newValue) {
+      if (storageEvent.key !== AUTH_CACHE_KEY) return
+
+      if (!storageEvent.newValue) {
+        setUser(null)
+        setToken(null)
+        setRefreshToken(null)
+        return
+      }
+
+      if (storageEvent.newValue) {
         try {
-          const cache = JSON.parse(storageEvent.newValue)
-          if (cache.user && cache.token) {
+          const cache: unknown = JSON.parse(storageEvent.newValue)
+          if (isAuthCacheEventPayload(cache)) {
             setUser(cache.user)
             setToken(cache.token)
             setRefreshToken(cache.refreshToken)
@@ -142,7 +161,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     window.addEventListener(AUTH_TOKEN_UPDATED_EVENT, handleTokenUpdate)
-    return () => window.removeEventListener(AUTH_TOKEN_UPDATED_EVENT, handleTokenUpdate)
+    window.addEventListener("storage", handleTokenUpdate)
+    return () => {
+      window.removeEventListener(AUTH_TOKEN_UPDATED_EVENT, handleTokenUpdate)
+      window.removeEventListener("storage", handleTokenUpdate)
+    }
   }, [])
 
   // Resolve SaaS team role once we have a session. my-team 404 / any failure =>
@@ -252,18 +275,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // Explicitly invalid token, clear state
             logout()
             return false
-          } else {
-            // Token expired but refresh failed, apiRequest has handled redirection
-            // We just need to clear local state
+          }
+
+          // A rejected refresh clears the shared cache in apiRequest. A
+          // temporary refresh outage leaves it intact so the next check can
+          // retry without ejecting the user from the app.
+          if (!readAuthCache()) {
             setUser(null)
             setToken(null)
             setRefreshToken(null)
-            clearStoredAuth()
             return false
           }
+          return true
         }
-        // Network error or server error, keep current state
-        return false  // Changed to false because auth check failed
+        // Network or server errors must not turn a temporary outage into logout.
+        return true
       }
 
       const data = await response.json()
@@ -286,43 +312,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const refreshAccessToken = async (): Promise<boolean> => {
-    if (!refreshToken) return false
-
-    try {
-      const response = await apiRequest(`${getApiUrl()}/api/auth/refresh`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ refresh_token: refreshToken }),
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        if (data.success && data.access_token) {
-          setToken(data.access_token)
-          if (data.refresh_token) {
-            setRefreshToken(data.refresh_token)
-          }
-
-          // Update cache with new tokens and expiration times
-          writeAuthCache(
-            user,
-            data.access_token,
-            data.refresh_token || refreshToken,
-            data.expires_in ? data.expires_in : undefined,
-            data.refresh_expires_in ? data.refresh_expires_in : undefined
-          )
-          return true
-        }
+  const refreshAccessToken = async (
+    expectedAccessToken?: string | null,
+    expectedUserId?: string | null
+  ): Promise<boolean> => {
+    const cache = readAuthCache()
+    const result = await refreshStoredAccessToken(
+      expectedAccessToken === undefined ? cache?.token || null : expectedAccessToken,
+      expectedUserId === undefined ? cache?.user?.id || null : expectedUserId
+    )
+    if (result.accessToken !== null) {
+      const updatedCache = readAuthCache()
+      if (updatedCache?.user && updatedCache.token) {
+        setUser(updatedCache.user)
+        setToken(updatedCache.token)
+        setRefreshToken(updatedCache.refreshToken)
       }
-    } catch (error) {
-      console.error("Token refresh failed:", error)
+      return true
     }
 
-    // If refresh fails, logout and redirect to login
-    logout()
+    if (result.rejected) {
+      logout()
+    }
     return false
   }
 

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { getApiErrorMessage, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import {
+  apiRequest,
+  getApiErrorMessage,
+  getUploadErrorMessage,
+  parseApiResponse,
+  refreshStoredAccessToken,
+} from "@/lib/api-wrapper"
+import { clearStoredAuth, readAuthCache, writeAuthCache } from "@/lib/auth-cache"
+
+function mockNavigatorLocks(
+  beforeCallback: () => void | Promise<void> = () => {}
+) {
+  Object.defineProperty(navigator, "locks", {
+    configurable: true,
+    value: {
+      request: vi.fn(async (
+        _name: string,
+        callback: () => Promise<unknown>
+      ) => {
+        await beforeCallback()
+        return callback()
+      }),
+    },
+  })
+}
 
 const MESSAGES = {
   generic: "Upload failed",
@@ -121,5 +145,239 @@ describe("api-wrapper API error helpers", () => {
     }, "Request failed")
 
     expect(message).toBe("Startup file storage sync failed")
+  })
+})
+
+describe("api-wrapper auth refresh", () => {
+  const user = { id: "1", username: "alice", email: null, is_admin: false }
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    mockNavigatorLocks()
+  })
+
+  it("coalesces concurrent refreshes and retries every waiting request", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, options) => {
+        const url = String(input)
+        const authorization = new Headers(options?.headers).get("Authorization")
+
+        if (url.endsWith("/api/auth/refresh")) {
+          return new Response(JSON.stringify({
+            success: true,
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+            expires_in: 120,
+            refresh_expires_in: 240,
+          }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        if (authorization === "Bearer old-access") {
+          return new Response(null, {
+            status: 401,
+            headers: { "Error-Type": "TokenExpired" },
+          })
+        }
+
+        return new Response(null, { status: 200 })
+      }
+    )
+
+    const [first, second] = await Promise.all([
+      apiRequest("http://api.local/protected"),
+      apiRequest("http://api.local/protected"),
+    ])
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/api/auth/refresh")
+    )).toHaveLength(1)
+    expect(readAuthCache()?.refreshToken).toBe("new-refresh")
+  })
+
+  it("reuses a token refreshed by another tab while waiting for the lock", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+
+    mockNavigatorLocks(() => {
+      writeAuthCache(user, "other-tab-access", "other-tab-refresh", 120, 240)
+    })
+
+    const result = await refreshStoredAccessToken("old-access")
+
+    expect(result).toEqual({ accessToken: "other-tab-access" })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("reuses a token from another tab when the caller started without one", async () => {
+    writeAuthCache(user, null, "old-refresh", 120, 240)
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+
+    mockNavigatorLocks(() => {
+      writeAuthCache(user, "other-tab-access", "other-tab-refresh", 120, 240)
+    })
+
+    const result = await refreshStoredAccessToken(null)
+
+    expect(result).toEqual({ accessToken: "other-tab-access" })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("normalizes numeric user IDs at the refresh boundary", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    const result = await refreshStoredAccessToken("old-access", 1)
+
+    expect(result).toEqual({ accessToken: "new-access" })
+  })
+
+  it("does not restore a session cleared while refresh was in flight", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      clearStoredAuth()
+      return new Response(JSON.stringify({
+        success: true,
+        access_token: "late-access",
+        refresh_token: "late-refresh",
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+
+    const result = await refreshStoredAccessToken("old-access")
+
+    expect(result).toEqual({ accessToken: null, rejected: true })
+    expect(readAuthCache()).toBeNull()
+  })
+
+  it("keeps the session when refresh is temporarily unavailable", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (String(input).endsWith("/api/auth/refresh")) {
+        return new Response(null, { status: 503 })
+      }
+      return new Response(null, {
+        status: 401,
+        headers: { "Error-Type": "TokenExpired" },
+      })
+    })
+
+    const response = await apiRequest("http://api.local/protected")
+
+    expect(response.status).toBe(401)
+    expect(readAuthCache()?.refreshToken).toBe("old-refresh")
+  })
+
+  it.each([401, 403])(
+    "clears the session when refresh returns %i",
+    async (refreshStatus) => {
+      writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+      vi.spyOn(console, "error").mockImplementation(() => {})
+
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        if (String(input).endsWith("/api/auth/refresh")) {
+          return new Response(null, { status: refreshStatus })
+        }
+        return new Response(null, {
+          status: 401,
+          headers: { "Error-Type": "TokenExpired" },
+        })
+      })
+
+      const response = await apiRequest("http://api.local/protected")
+
+      expect(response.status).toBe(401)
+      expect(readAuthCache()).toBeNull()
+    }
+  )
+
+  it("does not replay an old request under a replacement user", async () => {
+    const replacementUser = {
+      id: "2",
+      username: "bob",
+      email: null,
+      is_admin: false,
+    }
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, options) => {
+        if (String(input).endsWith("/api/auth/refresh")) {
+          writeAuthCache(
+            replacementUser,
+            "replacement-access",
+            "replacement-refresh",
+            120,
+            240
+          )
+          return new Response(JSON.stringify({
+            success: true,
+            access_token: "late-access",
+            refresh_token: "late-refresh",
+          }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        const authorization = new Headers(options?.headers).get("Authorization")
+        return new Response(null, {
+          status: authorization === "Bearer old-access" ? 401 : 200,
+          headers: { "Error-Type": "TokenExpired" },
+        })
+      }
+    )
+
+    const response = await apiRequest("http://api.local/protected")
+
+    expect(response.status).toBe(401)
+    expect(readAuthCache()?.user?.id).toBe("2")
+    expect(readAuthCache()?.token).toBe("replacement-access")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("releases the refresh lock when the request times out", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.useFakeTimers()
+
+    try {
+      vi.spyOn(globalThis, "fetch").mockImplementation((_input, options) =>
+        new Promise((_resolve, reject) => {
+          const signal = options?.signal
+          signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"))
+          })
+        })
+      )
+
+      const resultPromise = refreshStoredAccessToken("old-access")
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      await expect(resultPromise).resolves.toEqual({
+        accessToken: null,
+        rejected: false,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -7,12 +7,17 @@ import {
   clearStoredAuth,
   LEGACY_AUTH_TOKEN_KEY,
   readAuthCache,
-  syncLegacyAuthStorage,
   writeAuthCache,
 } from "@/lib/auth-cache"
 
-let isRefreshing = false
-let refreshSubscribers: ((token: string) => void)[] = []
+const AUTH_REFRESH_LOCK_NAME = "xagent-auth-refresh"
+const AUTH_REFRESH_TIMEOUT_MS = 15_000
+
+export type AuthRefreshResult =
+  | { accessToken: string }
+  | { accessToken: null; rejected: boolean }
+
+const refreshPromises = new Map<string, Promise<AuthRefreshResult>>()
 const REFRESH_EXCLUDED_AUTH_ENDPOINTS = [
   "/api/auth/login",
   "/api/auth/register",
@@ -72,25 +77,19 @@ async function fetchWithRetry(
   throw lastError || new Error('All retry attempts failed')
 }
 
-// Add refresh subscriber
-function addRefreshSubscriber(callback: (token: string) => void) {
-  refreshSubscribers.push(callback)
-}
-
-// Notify all subscribers that refresh is complete
-function notifyRefreshSubscribers(token: string) {
-  refreshSubscribers.forEach(callback => callback(token))
-  refreshSubscribers = []
-}
-
 // Get current tokens
-function getCurrentTokens(): { accessToken: string | null; refreshToken: string | null } {
+function getCurrentTokens(): {
+  accessToken: string | null
+  refreshToken: string | null
+  userId: string | null
+} {
   // Try new cache format first
   const authCache = readAuthCache()
   if (authCache) {
     return {
       accessToken: authCache.token || null,
       refreshToken: authCache.refreshToken || null,
+      userId: authCache.user?.id ? String(authCache.user.id) : null,
     }
   }
 
@@ -98,54 +97,149 @@ function getCurrentTokens(): { accessToken: string | null; refreshToken: string 
   return {
     accessToken: localStorage.getItem(LEGACY_AUTH_TOKEN_KEY),
     refreshToken: null,
+    userId: null,
   }
 }
 
-// Refresh token
-async function refreshToken(): Promise<string | null> {
-  const { refreshToken: refresh } = getCurrentTokens()
-  if (!refresh) return null
-
-  try {
-    const response = await fetch(`${getApiUrl()}/api/auth/refresh`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ refresh_token: refresh }),
-    })
-
-    if (response.ok) {
-      const data = await response.json()
-      if (data.success && data.access_token) {
-        const authCache = readAuthCache()
-        if (authCache) {
-          writeAuthCache(
-            authCache.user,
-            data.access_token,
-            data.refresh_token || authCache.refreshToken,
-            data.expires_in ? data.expires_in : undefined,
-            data.refresh_expires_in ? data.refresh_expires_in : undefined
-          )
-        } else {
-          // Use old format
-          syncLegacyAuthStorage(undefined, data.access_token)
-        }
-
-        // Trigger a storage event to notify AuthContext to update state
-        window.dispatchEvent(new StorageEvent(AUTH_TOKEN_UPDATED_EVENT, {
-          key: AUTH_CACHE_KEY,
-          newValue: localStorage.getItem(AUTH_CACHE_KEY)
-        }))
-
-        return data.access_token
-      }
-    }
-  } catch (error) {
-    console.error("Token refresh failed:", error)
+async function withAuthRefreshLock<T>(callback: () => Promise<T>): Promise<T> {
+  if (typeof navigator !== "undefined" && navigator.locks) {
+    return navigator.locks.request(AUTH_REFRESH_LOCK_NAME, callback)
   }
 
-  return null
+  return callback()
+}
+
+function dispatchAuthTokenUpdated() {
+  window.dispatchEvent(new StorageEvent(AUTH_TOKEN_UPDATED_EVENT, {
+    key: AUTH_CACHE_KEY,
+    newValue: localStorage.getItem(AUTH_CACHE_KEY),
+  }))
+}
+
+async function performTokenRefresh(
+  expectedAccessToken: string | null,
+  expectedUserId: string | null
+): Promise<AuthRefreshResult> {
+  return withAuthRefreshLock(async () => {
+    // Another tab may have refreshed while this tab waited for the lock. Reuse
+    // that token instead of rotating its newly-issued refresh token again.
+    const currentTokens = getCurrentTokens()
+    if (currentTokens.userId !== expectedUserId) {
+      return { accessToken: null, rejected: false }
+    }
+
+    if (
+      currentTokens.accessToken &&
+      currentTokens.accessToken !== expectedAccessToken
+    ) {
+      return { accessToken: currentTokens.accessToken }
+    }
+
+    if (!currentTokens.refreshToken) {
+      return { accessToken: null, rejected: true }
+    }
+
+    const abortController = new AbortController()
+    const timeoutId = setTimeout(
+      () => abortController.abort(),
+      AUTH_REFRESH_TIMEOUT_MS
+    )
+
+    try {
+      const response = await fetch(`${getApiUrl()}/api/auth/refresh`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ refresh_token: currentTokens.refreshToken }),
+        signal: abortController.signal,
+      })
+
+      if (!response.ok) {
+        return {
+          accessToken: null,
+          rejected: response.status === 401 || response.status === 403,
+        }
+      }
+
+      const data = await response.json()
+      if (!data.success || !data.access_token) {
+        return { accessToken: null, rejected: true }
+      }
+
+      const authCache = readAuthCache()
+      if (!authCache) {
+        // The session was cleared while refresh was in flight. Do not let an
+        // older response recreate credentials after logout.
+        return { accessToken: null, rejected: true }
+      }
+
+      const authCacheUserId = authCache.user?.id
+        ? String(authCache.user.id)
+        : null
+      if (authCacheUserId !== expectedUserId) {
+        // A different user replaced the session while this request was in
+        // flight. Do not replay the original request with that user's token.
+        return { accessToken: null, rejected: false }
+      }
+
+      if (
+        authCache.refreshToken &&
+        authCache.refreshToken !== currentTokens.refreshToken
+      ) {
+        // A login may replace the session while an older refresh request is in
+        // flight. Never overwrite that newer session with the old response.
+        return authCache.token
+          ? { accessToken: authCache.token }
+          : { accessToken: null, rejected: true }
+      }
+
+      writeAuthCache(
+        authCache.user,
+        data.access_token,
+        data.refresh_token || authCache.refreshToken,
+        data.expires_in ? data.expires_in : undefined,
+        data.refresh_expires_in ? data.refresh_expires_in : undefined
+      )
+
+      dispatchAuthTokenUpdated()
+      return { accessToken: data.access_token }
+    } catch (error) {
+      console.error("Token refresh failed:", error)
+      return { accessToken: null, rejected: false }
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  })
+}
+
+export function refreshStoredAccessToken(
+  expectedAccessToken?: string | null,
+  expectedUserId?: string | number | null
+): Promise<AuthRefreshResult> {
+  const currentTokens = getCurrentTokens()
+  const requestedAccessToken = expectedAccessToken === undefined
+    ? currentTokens.accessToken
+    : expectedAccessToken
+  const requestedUserId = expectedUserId === undefined
+    ? currentTokens.userId
+    : expectedUserId === null
+      ? null
+      : String(expectedUserId)
+  const refreshKey = `${requestedUserId}::${requestedAccessToken}`
+  const pendingRefresh = refreshPromises.get(refreshKey)
+  if (pendingRefresh) {
+    return pendingRefresh
+  }
+
+  const refreshPromise = performTokenRefresh(
+    requestedAccessToken,
+    requestedUserId
+  ).finally(() => {
+    refreshPromises.delete(refreshKey)
+  })
+  refreshPromises.set(refreshKey, refreshPromise)
+  return refreshPromise
 }
 
 // API request wrapper
@@ -153,7 +247,7 @@ export async function apiRequest(
   url: string,
   options: RequestInit = {}
 ): Promise<Response> {
-  const { accessToken } = getCurrentTokens()
+  const { accessToken, userId } = getCurrentTokens()
 
   // If no token, request directly
   if (!accessToken) {
@@ -181,44 +275,19 @@ export async function apiRequest(
       window.location.href = "/login"
       return response
     }
-    if (isRefreshing) {
-      // If refreshing, wait for refresh to complete
-      return new Promise((resolve, reject) => {
-        addRefreshSubscriber((newToken: string) => {
-          const retryHeaders = {
-            ...options.headers,
-            "Authorization": `Bearer ${newToken}`,
-          }
-          fetch(url, { ...options, headers: retryHeaders })
-            .then(resolve)
-            .catch(reject)
-        })
-      })
-    }
+    const refreshResult = await refreshStoredAccessToken(accessToken, userId)
 
-    isRefreshing = true
-
-    try {
-      const newToken = await refreshToken()
-
-      if (newToken) {
-        // Notify all waiting subscribers
-        notifyRefreshSubscribers(newToken)
-
-        // Retry request with new token
-        const retryHeaders = {
-          ...options.headers,
-          "Authorization": `Bearer ${newToken}`,
-        }
-        response = await fetch(url, { ...options, headers: retryHeaders })
-      } else {
-        // Refresh failed, clear auth data and redirect to login page
-        console.error("Token refresh failed, redirecting to login")
-        clearStoredAuth()
-        window.location.href = "/login"
+    if (refreshResult.accessToken !== null) {
+      const retryHeaders = {
+        ...options.headers,
+        "Authorization": `Bearer ${refreshResult.accessToken}`,
       }
-    } finally {
-      isRefreshing = false
+      response = await fetch(url, { ...options, headers: retryHeaders })
+    } else if (refreshResult.rejected) {
+      // Only a definitive refresh-token rejection should end the session.
+      console.error("Refresh token was rejected, redirecting to login")
+      clearStoredAuth()
+      window.location.href = "/login"
     }
   }
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from jose import JWTError, jwt
 from pydantic import BaseModel
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ...config import get_app_base_url, get_password_reset_expire_minutes
@@ -958,9 +958,9 @@ async def refresh_token(
         # Verify refresh token
         payload = verify_refresh_token(request.refresh_token)
         if not payload:
-            return RefreshTokenResponse(
-                success=False,
-                message="Invalid refresh token",
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
             )
 
         # Get user from database
@@ -968,9 +968,9 @@ async def refresh_token(
         user = db.query(User).filter(User.id == user_id).first()
 
         if not user:
-            return RefreshTokenResponse(
-                success=False,
-                message="User does not exist",
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
             )
 
         # Check if refresh token matches and is not expired
@@ -980,9 +980,9 @@ async def refresh_token(
             user_refresh_token != request.refresh_token
             or refresh_token_expires_at is None
         ):
-            return RefreshTokenResponse(
-                success=False,
-                message="Invalid refresh token",
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
             )
 
         # Check expiration - handle timezone-aware and naive datetimes
@@ -993,16 +993,16 @@ async def refresh_token(
         ):
             # Timezone-aware datetime
             if cast(Any, refresh_token_expires_at) < now:
-                return RefreshTokenResponse(
-                    success=False,
-                    message="Refresh token has expired",
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Refresh token has expired",
                 )
         else:
             # Naive datetime - assume UTC
             if cast(Any, refresh_token_expires_at) < now.replace(tzinfo=None):
-                return RefreshTokenResponse(
-                    success=False,
-                    message="Refresh token has expired",
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Refresh token has expired",
                 )
 
         # Create new access token
@@ -1033,10 +1033,13 @@ async def refresh_token(
             refresh_expires_in=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
         )
 
-    except Exception as e:
-        return RefreshTokenResponse(
-            success=False,
-            message=f"Token refresh failed: {str(e)}",
+    except HTTPException:
+        raise
+    except SQLAlchemyError:
+        logger.exception("Token refresh failed")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Token refresh is temporarily unavailable",
         )
 
 

--- a/tests/web/test_auth_api.py
+++ b/tests/web/test_auth_api.py
@@ -8,8 +8,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
+from xagent.web.api import auth as auth_api
 from xagent.web.api.auth import auth_router, hash_password
 from xagent.web.models.database import Base, get_db
 from xagent.web.models.user import User
@@ -166,6 +168,71 @@ class TestAuthAPI:
         assert data["success"] is True
         assert data["user"]["username"] == test_user_data["username"]
         assert data["user"]["email"] == test_user_data["email"]
+
+    def test_refresh_rotates_token_and_rejects_stale_token(
+        self, test_db, test_user_data, monkeypatch
+    ):
+        setup_first_admin()
+        register_response = client.post("/api/auth/register", json=test_user_data)
+        assert register_response.status_code == 200
+
+        login_response = client.post("/api/auth/login", json=test_user_data)
+        old_refresh_token = login_response.json()["refresh_token"]
+        monkeypatch.setattr(
+            auth_api,
+            "create_refresh_token",
+            lambda data: "rotated-refresh-token",
+        )
+
+        refresh_response = client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": old_refresh_token},
+        )
+        assert refresh_response.status_code == 200
+        assert refresh_response.json()["success"] is True
+        assert refresh_response.json()["refresh_token"] == "rotated-refresh-token"
+
+        stale_response = client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": old_refresh_token},
+        )
+        assert stale_response.status_code == 401
+        assert stale_response.json()["detail"] == "Invalid refresh token"
+
+    def test_refresh_rejects_malformed_token(self, test_db):
+        response = client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": "not-a-jwt"},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid refresh token"
+
+    def test_refresh_reports_temporary_server_failure(self, test_db, monkeypatch):
+        def fail_verification(_token):
+            raise SQLAlchemyError("database unavailable")
+
+        monkeypatch.setattr(auth_api, "verify_refresh_token", fail_verification)
+
+        response = client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": "temporarily-unverifiable"},
+        )
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Token refresh is temporarily unavailable"
+
+    def test_refresh_does_not_mask_programming_errors(self, test_db, monkeypatch):
+        def fail_verification(_token):
+            raise RuntimeError("unexpected refresh bug")
+
+        monkeypatch.setattr(auth_api, "verify_refresh_token", fail_verification)
+
+        with pytest.raises(RuntimeError, match="unexpected refresh bug"):
+            client.post(
+                "/api/auth/refresh",
+                json={"refresh_token": "unexpectedly-broken"},
+            )
 
     def test_get_current_user_profile(self, test_db, test_user_data):
         setup_first_admin()


### PR DESCRIPTION
## Summary

- serialize access-token refreshes across concurrent requests and browser tabs
- sync rotated tokens across tabs and keep the session during temporary refresh outages
- distinguish invalid refresh tokens from temporary server failures with 401 and 503 responses

## Root cause

The proactive refresh path and the 401 retry path were independent, and each browser tab kept its own stale refresh-token state. Concurrent refreshes could therefore rotate the single stored refresh token more than once, causing a valid session to be treated as rejected and cleared. The refresh endpoint also returned HTTP 200 for both invalid tokens and internal failures, so the client could not safely distinguish logout from retry.

## Validation

- `PYTHONPATH=src pytest -q tests/web/test_auth_api.py` (31 passed)
- `npm run test:run -- src/lib/api-wrapper.test.ts src/lib/auth-cache.test.ts` (20 passed)
- changed-file pre-commit hooks, including Ruff, mypy, ESLint, TypeScript, codespell, and formatting

## Notes

The full frontend suite reached 469 passing tests and 7 unrelated existing failures in workforce, knowledge-base, and inline-preview tests. The auth-focused tests and all changed-file checks pass.
