### PR TITLE
enh: parallelize KB web ingestion (page + batch concurrency) to fix Step 2 slowdown

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1154,9 +1154,12 @@ class IngestionConfig(BaseModel):
         DEFAULT_EMBEDDING_CONCURRENT,
         gt=0,
         description=(
-            "Maximum concurrent requests for embedding computation when using "
-            "async mode (for models that don't support batch processing, e.g., text-embedding-v4). "
-            "Must be positive. Adjust based on machine configuration and API rate limits."
+            "Maximum concurrent embedding requests within one document: async-mode "
+            "per-chunk encodes (models without batch support, e.g. text-embedding-v4) "
+            "and batch-mode per-batch encodes both honor it. Must be positive. Note "
+            "that during website import the effective provider concurrency is "
+            "page_ingest_concurrency * embedding_concurrent (defaults 4 * 10 = ~40); "
+            "keep that product under your provider's rate limit to avoid 429s."
         ),
     )
     embedding_use_async: bool = Field(
@@ -1178,7 +1181,9 @@ class IngestionConfig(BaseModel):
         description=(
             "Maximum number of web pages ingested concurrently during website "
             "import (Step 2). Pages are independent, so concurrency overlaps their "
-            "parse/chunk/embed cost. Set to 1 for the legacy fully-serial behavior."
+            "parse/chunk/embed cost. Set to 1 for the legacy fully-serial behavior. "
+            "Multiplies with embedding_concurrent for total provider concurrency "
+            "(see that field); lower either if the provider rate-limits (429)."
         ),
     )
     retry_delay: float = Field(

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -28,6 +28,7 @@ DEFAULT_EMBEDDING_MODEL_ID: str = "text-embedding-v4"
 DEFAULT_EMBEDDING_BATCH_SIZE: int = 10
 DEFAULT_EMBEDDING_CONCURRENT: int = 10
 DEFAULT_MAX_RETRIES: int = 3
+DEFAULT_PAGE_INGEST_CONCURRENCY: int = 4
 DEFAULT_RETRY_DELAY_SECONDS: float = 1.0
 
 # LanceDB NULL sentinel values
@@ -1170,6 +1171,15 @@ class IngestionConfig(BaseModel):
         DEFAULT_MAX_RETRIES,
         ge=0,
         description="Maximum number of retries for embedding provider failures; must be non-negative",
+    )
+    page_ingest_concurrency: int = Field(
+        DEFAULT_PAGE_INGEST_CONCURRENCY,
+        gt=0,
+        description=(
+            "Maximum number of web pages ingested concurrently during website "
+            "import (Step 2). Pages are independent, so concurrency overlaps their "
+            "parse/chunk/embed cost. Set to 1 for the legacy fully-serial behavior."
+        ),
     )
     retry_delay: float = Field(
         DEFAULT_RETRY_DELAY_SECONDS,

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1173,7 +1173,12 @@ class IngestionConfig(BaseModel):
     max_retries: int = Field(
         DEFAULT_MAX_RETRIES,
         ge=0,
-        description="Maximum number of retries for embedding provider failures; must be non-negative",
+        description=(
+            "Maximum number of retries for embedding provider failures; must be "
+            "non-negative. Note the two ingestion paths differ at 0: the batch "
+            "path always makes at least one attempt, while the async path makes "
+            "zero (skips embedding). Keep >=1 for consistent behavior."
+        ),
     )
     page_ingest_concurrency: int = Field(
         DEFAULT_PAGE_INGEST_CONCURRENCY,

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -5,13 +5,22 @@ systems, including lazy initialization, embedding configuration, and statistics 
 """
 
 import asyncio
+import contextlib
 import logging
 import os
 import threading
 from contextvars import copy_context
 from datetime import datetime, timezone
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Optional,
+    TypeVar,
+)
 
 import pyarrow as pa  # type: ignore
 
@@ -44,12 +53,11 @@ _collection_locks_lock = threading.Lock()
 # Cross-thread locks for collection metadata read-modify-write. The asyncio locks
 # above are keyed by event-loop id, so they do NOT serialize concurrent web-page
 # ingestion where each page runs in its own executor thread + event loop. These
-# thread locks close that gap for the two RMW critical sections (stats update and
-# embedding init). Ordering: always acquire the asyncio lock first (same-loop
-# reentry) then this thread lock, so a task holding it across an await can never
-# block its own loop.
-# ponytail: per-collection thread lock; only guards the RMW metadata row, not the
-# additive documents/chunks/vectors appends (distinct ids, no logical conflict).
+# thread locks close that gap for the metadata RMW critical sections (stats update,
+# embedding init, and access-timestamp bump). Ordering: always acquire the asyncio
+# lock first (same-loop reentry) then this thread lock, so a task holding it across
+# an await can never block its own loop. Only the RMW metadata row is guarded, not
+# the additive documents/chunks/vectors appends (distinct ids, no logical conflict).
 _collection_thread_locks: dict[str, threading.RLock] = {}
 _collection_thread_locks_guard = threading.Lock()
 
@@ -65,27 +73,23 @@ def _get_collection_thread_lock(collection_name: str) -> threading.RLock:
     return lock
 
 
-class _CollectionThreadGuard:
-    """Async-context wrapper around a collection's cross-thread RLock.
+@contextlib.asynccontextmanager
+async def _collection_thread_guard(collection_name: str) -> AsyncIterator[None]:
+    """Hold a collection's cross-thread RLock across an ``async with`` body.
 
-    Usable in ``async with`` alongside the asyncio lock. Acquired via a
-    non-blocking poll so we never freeze the event loop this coroutine runs on
-    while a different thread holds the lock: yielding with ``asyncio.sleep``
-    lets other tasks on the same loop keep running. The enclosing asyncio lock
-    guarantees we never re-enter on the same event loop while the lock is held
-    across an await; the RLock is reentrant regardless.
+    Acquired via a non-blocking poll so we never freeze the event loop this
+    coroutine runs on while a different thread holds the lock: yielding with
+    ``asyncio.sleep`` lets other tasks on the same loop keep running. The
+    enclosing asyncio lock guarantees we never re-enter on the same event loop
+    while the lock is held across an await; the RLock is reentrant regardless.
     """
-
-    def __init__(self, collection_name: str) -> None:
-        self._lock = _get_collection_thread_lock(collection_name)
-
-    async def __aenter__(self) -> "_CollectionThreadGuard":
-        while not self._lock.acquire(blocking=False):
-            await asyncio.sleep(0.005)
-        return self
-
-    async def __aexit__(self, *exc: object) -> None:
-        self._lock.release()
+    lock = _get_collection_thread_lock(collection_name)
+    while not lock.acquire(blocking=False):
+        await asyncio.sleep(0.005)
+    try:
+        yield
+    finally:
+        lock.release()
 
 
 def reset_locks_for_testing() -> None:
@@ -466,7 +470,7 @@ class CollectionManager:
         lock = _get_collection_lock(collection_name)
         logger.debug("[COLLECTION_INIT] Acquiring lock for '%s'...", collection_name)
 
-        async with lock, _CollectionThreadGuard(collection_name):
+        async with lock, _collection_thread_guard(collection_name):
             logger.debug("[COLLECTION_INIT] Lock acquired for '%s'", collection_name)
             # Get current state
             try:
@@ -580,7 +584,7 @@ class CollectionManager:
         """
         lock = _get_collection_lock(collection_name)
 
-        async with lock, _CollectionThreadGuard(collection_name):
+        async with lock, _collection_thread_guard(collection_name):
             try:
                 collection = await self.get_collection(collection_name)
             except ValueError:
@@ -664,20 +668,24 @@ class CollectionManager:
             return
 
     async def mark_collection_accessed(self, collection_name: str) -> None:
-        """Mark collection as accessed by updating last_accessed_at timestamp.
+        """Update last_accessed_at.
 
-        This is a lightweight operation that updates the access timestamp
-        without acquiring a lock for performance reasons.
+        Takes the same lock as the other stat RMW sites: the write is a full-row
+        overwrite, so a stale read here would clobber a concurrent stat increment
+        on the per-page hot path.
         """
-        # Simple update without lock for performance, timestamp accuracy is not critical
+        lock = _get_collection_lock(collection_name)
         try:
-            collection = await self.get_collection(collection_name)
-            updated = collection.model_copy(
-                update={
-                    "last_accessed_at": datetime.now(timezone.utc).replace(tzinfo=None)
-                }
-            )
-            await self._save_collection_with_retry(updated)
+            async with lock, _collection_thread_guard(collection_name):
+                collection = await self.get_collection(collection_name)
+                updated = collection.model_copy(
+                    update={
+                        "last_accessed_at": datetime.now(timezone.utc).replace(
+                            tzinfo=None
+                        )
+                    }
+                )
+                await self._save_collection_with_retry(updated)
         except Exception as e:
             logger.debug(
                 "Failed to update last_accessed_at for %s: %s", collection_name, e

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -56,14 +56,17 @@ _collection_locks_lock = threading.Lock()
 # thread locks close that gap for the metadata RMW critical sections (stats update,
 # embedding init, and access-timestamp bump). Ordering: always acquire the asyncio
 # lock first (same-loop reentry) then this thread lock, so a task holding it across
-# an await can never block its own loop. Only the RMW metadata row is guarded, not
-# the additive documents/chunks/vectors appends (distinct ids, no logical conflict).
+# an await can never block its own loop. The same per-collection lock also serializes
+# the LanceDB vector writes in write_vectors_to_db (concurrent commits to one table,
+# including the create_index build, can raise CommitConflict); it's an RLock so the
+# metadata sites can nest the write under their own guard on the same thread.
 _collection_thread_locks: dict[str, threading.RLock] = {}
 _collection_thread_locks_guard = threading.Lock()
 
 
 def _get_collection_thread_lock(collection_name: str) -> threading.RLock:
-    """Return a process-global cross-thread RLock for one collection's metadata RMW."""
+    """Return a process-global cross-thread RLock serializing one collection's
+    metadata RMW and LanceDB vector writes across threads."""
     lock = _collection_thread_locks.get(collection_name)
     if lock is None:
         with _collection_thread_locks_guard:

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -314,12 +314,18 @@ class CollectionManager:
     async def save_collection(self, collection: CollectionInfo) -> None:
         """Save collection metadata to storage with retry mechanism.
 
+        Takes the cross-thread guard as well as the asyncio lock: this does a
+        full-row overwrite and is reachable from the concurrent ingestion hot
+        path (the legacy-migration branch of resolve_effective_embedding_model_sync),
+        so without it a stale-read overwrite could clobber a concurrent
+        stats/embedding-init write on the same collection.
+
         Args:
             collection: CollectionInfo to save
         """
         lock = _get_collection_lock(collection.name)
 
-        async with lock:
+        async with lock, _collection_thread_guard(collection.name):
             await self._save_collection_with_retry(collection)
 
     async def delete_collection_metadata(

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -41,11 +41,55 @@ logger = logging.getLogger(__name__)
 _collection_locks: dict[tuple[int, str], asyncio.Lock] = {}
 _collection_locks_lock = threading.Lock()
 
+# Cross-thread locks for collection metadata read-modify-write. The asyncio locks
+# above are keyed by event-loop id, so they do NOT serialize concurrent web-page
+# ingestion where each page runs in its own executor thread + event loop. These
+# thread locks close that gap for the two RMW critical sections (stats update and
+# embedding init). Ordering: always acquire the asyncio lock first (same-loop
+# reentry) then this thread lock, so a task holding it across an await can never
+# block its own loop.
+# ponytail: per-collection thread lock; only guards the RMW metadata row, not the
+# additive documents/chunks/vectors appends (distinct ids, no logical conflict).
+_collection_thread_locks: dict[str, threading.RLock] = {}
+_collection_thread_locks_guard = threading.Lock()
+
+
+def _get_collection_thread_lock(collection_name: str) -> threading.RLock:
+    """Return a process-global cross-thread RLock for one collection's metadata RMW."""
+    lock = _collection_thread_locks.get(collection_name)
+    if lock is None:
+        with _collection_thread_locks_guard:
+            lock = _collection_thread_locks.setdefault(
+                collection_name, threading.RLock()
+            )
+    return lock
+
+
+class _CollectionThreadGuard:
+    """Async-context wrapper around a collection's cross-thread RLock.
+
+    Usable in ``async with`` alongside the asyncio lock. Acquire is a brief
+    blocking call; the enclosing asyncio lock guarantees we never re-enter on the
+    same event loop while the lock is held across an await.
+    """
+
+    def __init__(self, collection_name: str) -> None:
+        self._lock = _get_collection_thread_lock(collection_name)
+
+    async def __aenter__(self) -> "_CollectionThreadGuard":
+        self._lock.acquire()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._lock.release()
+
 
 def reset_locks_for_testing() -> None:
     """Clear in-memory collection locks for test isolation."""
     with _collection_locks_lock:
         _collection_locks.clear()
+    with _collection_thread_locks_guard:
+        _collection_thread_locks.clear()
 
 
 def _normalize_collection_config_user_id(user_id: Optional[int]) -> int:
@@ -418,7 +462,7 @@ class CollectionManager:
         lock = _get_collection_lock(collection_name)
         logger.debug("[COLLECTION_INIT] Acquiring lock for '%s'...", collection_name)
 
-        async with lock:
+        async with lock, _CollectionThreadGuard(collection_name):
             logger.debug("[COLLECTION_INIT] Lock acquired for '%s'", collection_name)
             # Get current state
             try:
@@ -532,7 +576,7 @@ class CollectionManager:
         """
         lock = _get_collection_lock(collection_name)
 
-        async with lock:
+        async with lock, _CollectionThreadGuard(collection_name):
             try:
                 collection = await self.get_collection(collection_name)
             except ValueError:

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -68,16 +68,20 @@ def _get_collection_thread_lock(collection_name: str) -> threading.RLock:
 class _CollectionThreadGuard:
     """Async-context wrapper around a collection's cross-thread RLock.
 
-    Usable in ``async with`` alongside the asyncio lock. Acquire is a brief
-    blocking call; the enclosing asyncio lock guarantees we never re-enter on the
-    same event loop while the lock is held across an await.
+    Usable in ``async with`` alongside the asyncio lock. Acquired via a
+    non-blocking poll so we never freeze the event loop this coroutine runs on
+    while a different thread holds the lock: yielding with ``asyncio.sleep``
+    lets other tasks on the same loop keep running. The enclosing asyncio lock
+    guarantees we never re-enter on the same event loop while the lock is held
+    across an await; the RLock is reentrant regardless.
     """
 
     def __init__(self, collection_name: str) -> None:
         self._lock = _get_collection_thread_lock(collection_name)
 
     async def __aenter__(self) -> "_CollectionThreadGuard":
-        self._lock.acquire()
+        while not self._lock.acquire(blocking=False):
+            await asyncio.sleep(0.005)
         return self
 
     async def __aexit__(self, *exc: object) -> None:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import os
 import time
@@ -1163,34 +1164,62 @@ def _process_document_impl(
 
             else:
                 processed_batches = 0
+                # Split into batches up front so the (network-bound) encode() calls
+                # can overlap. Batch encodes are independent and stateless, so we
+                # fan them out over a bounded thread pool (honoring embedding_concurrent,
+                # the same knob the async path uses) and then write in original order.
+                # embedding_concurrent=1 restores the legacy fully-serial behavior.
+                batch_slices = [
+                    chunks[start : start + cfg.embedding_batch_size]
+                    for start in range(0, len(chunks), cfg.embedding_batch_size)
+                ]
+
+                def _encode_batch(
+                    indexed: Tuple[int, List[ChunkForEmbedding]],
+                ) -> List[List[float]]:
+                    idx, batch_chunks = indexed
+                    batch_texts = [chunk.text for chunk in batch_chunks]
+                    _log_embedding_text_batch_stats(
+                        f"compute_embeddings(batch) doc_id={doc_id}",
+                        batch_texts,
+                        batch_index=idx,
+                    )
+                    raw_vectors = embedding_adapter.encode(batch_texts)
+                    vectors = normalize_raw_embedding_to_vectors(raw_vectors)
+                    if len(vectors) != len(batch_chunks):
+                        raise VectorValidationError(
+                            "Embedding provider returned mismatched batch size",
+                            details={
+                                "batch_index": idx,
+                                "expected": len(batch_chunks),
+                                "actual": len(vectors),
+                            },
+                        )
+                    return vectors
+
+                max_encode_workers = max(1, cfg.embedding_concurrent)
+                if len(batch_slices) > 1 and max_encode_workers > 1:
+                    with concurrent.futures.ThreadPoolExecutor(
+                        max_workers=min(max_encode_workers, len(batch_slices))
+                    ) as encode_pool:
+                        # map preserves input order, so vectors line up with batches.
+                        all_vectors = list(
+                            encode_pool.map(_encode_batch, enumerate(batch_slices))
+                        )
+                else:
+                    all_vectors = [
+                        _encode_batch((idx, bc)) for idx, bc in enumerate(batch_slices)
+                    ]
+
                 with progress_tracker.track_step(
                     "write_vectors_to_db",
                     total_count=len(chunks),
                     message="Writing vectors...",
                 ) as write_step_tracker:
-                    for batch_start in range(0, len(chunks), cfg.embedding_batch_size):
-                        batch_chunks = chunks[
-                            batch_start : batch_start + cfg.embedding_batch_size
-                        ]
-                        batch_texts = [chunk.text for chunk in batch_chunks]
-                        _log_embedding_text_batch_stats(
-                            f"compute_embeddings(batch) doc_id={doc_id}",
-                            batch_texts,
-                            batch_index=processed_batches,
-                        )
-                        raw_vectors = embedding_adapter.encode(batch_texts)
-                        vectors = normalize_raw_embedding_to_vectors(raw_vectors)
-
-                        if len(vectors) != len(batch_chunks):
-                            raise VectorValidationError(
-                                "Embedding provider returned mismatched batch size",
-                                details={
-                                    "batch_index": processed_batches,
-                                    "expected": len(batch_chunks),
-                                    "actual": len(vectors),
-                                },
-                            )
-
+                    for batch_index, (batch_chunks, vectors) in enumerate(
+                        zip(batch_slices, all_vectors)
+                    ):
+                        is_last_batch = batch_index == len(batch_slices) - 1
                         embeddings_batch: List[ChunkEmbeddingData] = [
                             ChunkEmbeddingData(
                                 doc_id=chunk.doc_id,
@@ -1219,10 +1248,7 @@ def _process_document_impl(
                             write_response = write_vectors_to_db(
                                 collection=collection,
                                 embeddings=embeddings_batch,
-                                create_index=(
-                                    batch_start + cfg.embedding_batch_size
-                                    >= len(chunks)
-                                ),
+                                create_index=is_last_batch,
                                 user_id=user_id,
                             )
                             last_write_response = (

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -1184,10 +1184,12 @@ def _process_document_impl(
                         batch_texts,
                         batch_index=idx,
                     )
-                    # Retry transient provider failures with linear backoff,
-                    # mirroring the async path. Runs in a worker thread, so a
-                    # blocking time.sleep between attempts is fine. A size
-                    # mismatch is deterministic and stays terminal (not retried).
+                    # Retry transient provider failures with linear backoff. Runs
+                    # in a worker thread, so a blocking time.sleep between attempts
+                    # is fine. A size mismatch is deterministic and stays terminal.
+                    # On exhaustion this re-raises and fails the whole document
+                    # (unlike the async path, which drops the chunk and continues);
+                    # max_retries=0 still does one attempt here, vs zero on async.
                     attempts = max(1, cfg.max_retries)
                     raw_vectors = None
                     for attempt in range(attempts):
@@ -1355,20 +1357,29 @@ def _process_document_impl(
                 },
             )
         )
+        final_index_status = (
+            last_write_response.index_status
+            if last_write_response is not None
+            else "skipped"
+        )
         logger.info(
             "Step write_vectors_to_db completed",
             extra={
                 "collection": collection,
                 "doc_id": doc_id,
                 "vector_count": vector_count,
-                "index_status": (
-                    last_write_response.index_status
-                    if last_write_response is not None
-                    else "skipped"
-                ),
+                "index_status": final_index_status,
                 "elapsed_ms": write_elapsed_ms,
             },
         )
+        # Index build is non-fatal (vectors are written; search falls back to
+        # brute force), but a corrupted/failed index shouldn't stay buried in a
+        # status field — surface it to the caller as a warning.
+        if final_index_status in ("index_corrupted", "failed"):
+            warnings.append(
+                f"Vector index not ready (status={final_index_status}); "
+                "search will be slower until it rebuilds."
+            )
 
         # Update collection statistics
         try:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -1184,7 +1184,28 @@ def _process_document_impl(
                         batch_texts,
                         batch_index=idx,
                     )
-                    raw_vectors = embedding_adapter.encode(batch_texts)
+                    # Retry transient provider failures with linear backoff,
+                    # mirroring the async path. Runs in a worker thread, so a
+                    # blocking time.sleep between attempts is fine. A size
+                    # mismatch is deterministic and stays terminal (not retried).
+                    attempts = max(1, cfg.max_retries)
+                    raw_vectors = None
+                    for attempt in range(attempts):
+                        try:
+                            raw_vectors = embedding_adapter.encode(batch_texts)
+                            break
+                        except Exception as exc:  # noqa: BLE001
+                            if attempt >= attempts - 1:
+                                raise
+                            logger.warning(
+                                "[RAG][embedding] batch encode failed "
+                                "(batch_index=%s attempt=%s/%s): %s",
+                                idx,
+                                attempt + 1,
+                                attempts,
+                                exc,
+                            )
+                            time.sleep(cfg.retry_delay * (attempt + 1))
                     vectors = normalize_raw_embedding_to_vectors(raw_vectors)
                     if len(vectors) != len(batch_chunks):
                         raise VectorValidationError(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -1062,9 +1062,9 @@ def _process_document_impl(
                     "batch_size": cfg.embedding_batch_size
                     if not cfg.embedding_use_async
                     else None,
-                    "concurrent": cfg.embedding_concurrent
-                    if cfg.embedding_use_async
-                    else None,
+                    # Both paths honor embedding_concurrent: the async path fans out
+                    # per-chunk encodes, the batch path fans out per-batch encodes.
+                    "concurrent": cfg.embedding_concurrent,
                 },
             )
             embedding_start = time.time()
@@ -1164,11 +1164,11 @@ def _process_document_impl(
 
             else:
                 processed_batches = 0
-                # Split into batches up front so the (network-bound) encode() calls
-                # can overlap. Batch encodes are independent and stateless, so we
-                # fan them out over a bounded thread pool (honoring embedding_concurrent,
-                # the same knob the async path uses) and then write in original order.
-                # embedding_concurrent=1 restores the legacy fully-serial behavior.
+                # Fan the independent (network-bound) batch encodes out over a
+                # bounded thread pool (honoring embedding_concurrent; =1 restores
+                # serial), then write in original order. This materializes all
+                # vectors before writing — peak memory scales with the whole doc,
+                # fine for web pages; stream if very large docs ever land here.
                 batch_slices = [
                     chunks[start : start + cfg.embedding_batch_size]
                     for start in range(0, len(chunks), cfg.embedding_batch_size)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -534,10 +534,17 @@ async def _run_web_ingestion_impl(
         total_embeddings = 0
 
         loop = asyncio.get_event_loop()
+        page_semaphore = asyncio.Semaphore(max(1, ing_cfg.page_ingest_concurrency))
 
-        for i, crawl_result in enumerate(crawl_results):
-            if crawl_result.status != "success":
-                continue
+        async def _process_page(i: int, crawl_result: CrawlResult) -> None:
+            # Pages are independent; each runs its blocking ingestion in a worker
+            # thread while sibling pages overlap (issue #912). The shared
+            # accumulators / warnings / failed_urls below are only mutated between
+            # awaits, so cooperative single-thread scheduling keeps them race-free
+            # without locks; the cross-thread DB write hazard is guarded inside
+            # collection_manager.
+            nonlocal documents_created, successful_page_ingestions
+            nonlocal total_chunks, total_embeddings
 
             page_title = crawl_result.title or f"page_{i + 1}"
             with pipeline_facade.web_page_operation(
@@ -651,7 +658,7 @@ async def _run_web_ingestion_impl(
                                 status="error",
                                 message=failure_message,
                             )
-                            continue
+                            return
 
                     try:
                         # Ingest the file
@@ -789,6 +796,18 @@ async def _run_web_ingestion_impl(
                         status="error",
                         message=failure_message,
                     )
+
+        async def _guarded_page(i: int, crawl_result: CrawlResult) -> None:
+            async with page_semaphore:
+                await _process_page(i, crawl_result)
+
+        await asyncio.gather(
+            *(
+                _guarded_page(i, crawl_result)
+                for i, crawl_result in enumerate(crawl_results)
+                if crawl_result.status == "success"
+            )
+        )
 
     # Step 3: Compile results
     elapsed_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -801,13 +801,30 @@ async def _run_web_ingestion_impl(
             async with page_semaphore:
                 await _process_page(i, crawl_result)
 
-        await asyncio.gather(
-            *(
-                _guarded_page(i, crawl_result)
-                for i, crawl_result in enumerate(crawl_results)
-                if crawl_result.status == "success"
-            )
+        pending_pages = [
+            (i, crawl_result)
+            for i, crawl_result in enumerate(crawl_results)
+            if crawl_result.status == "success"
+        ]
+        # return_exceptions=True so an unexpected error in one page (e.g. from
+        # web_page_operation or progress_callback, outside _process_page's own
+        # handling) can't abort every other in-flight page. _process_page records
+        # expected per-page failures itself; here we only surface the escapees.
+        page_outcomes = await asyncio.gather(
+            *(_guarded_page(i, crawl_result) for i, crawl_result in pending_pages),
+            return_exceptions=True,
         )
+        for (_, crawl_result), outcome in zip(pending_pages, page_outcomes):
+            if isinstance(outcome, Exception):
+                logger.error(
+                    "Unexpected error ingesting %s: %s",
+                    crawl_result.url,
+                    outcome,
+                    exc_info=outcome,
+                )
+                failure_message = f"Failed to ingest {crawl_result.url}: {outcome}"
+                failed_urls[crawl_result.url] = failure_message
+                warnings.append(failure_message)
 
     # Step 3: Compile results
     elapsed_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -537,6 +537,12 @@ async def _run_web_ingestion_impl(
         page_semaphore = asyncio.Semaphore(max(1, ing_cfg.page_ingest_concurrency))
 
         async def _process_page(i: int, crawl_result: CrawlResult) -> None:
+            # Bound concurrency, then run the page. Split out so gather() can call
+            # this directly (each page becomes its own semaphore-limited Task).
+            async with page_semaphore:
+                await _ingest_page(i, crawl_result)
+
+        async def _ingest_page(i: int, crawl_result: CrawlResult) -> None:
             # Pages are independent; each runs its blocking ingestion in a worker
             # thread while sibling pages overlap (issue #912). The shared
             # accumulators / warnings / failed_urls below are only mutated between
@@ -561,9 +567,11 @@ async def _run_web_ingestion_impl(
                     )
 
                 try:
-                    # Save crawled content to temporary markdown file
+                    # Index-prefixed so concurrent same-titled pages don't collide
+                    # on one temp path (torn read + shared doc_id when file_handler
+                    # is None).
                     filename = sanitize_for_doc_id(page_title)
-                    temp_file = Path(temp_dir) / f"{filename}.md"
+                    temp_file = Path(temp_dir) / f"{i}_{filename}.md"
 
                     with open(temp_file, "w", encoding="utf-8") as f:
                         # Add metadata header
@@ -797,21 +805,17 @@ async def _run_web_ingestion_impl(
                         message=failure_message,
                     )
 
-        async def _guarded_page(i: int, crawl_result: CrawlResult) -> None:
-            async with page_semaphore:
-                await _process_page(i, crawl_result)
-
         pending_pages = [
             (i, crawl_result)
             for i, crawl_result in enumerate(crawl_results)
             if crawl_result.status == "success"
         ]
-        # return_exceptions=True so an unexpected error in one page (e.g. from
-        # web_page_operation or progress_callback, outside _process_page's own
-        # handling) can't abort every other in-flight page. _process_page records
-        # expected per-page failures itself; here we only surface the escapees.
+        # return_exceptions=True so one page's unexpected error can't abort the
+        # others; per-page failures are already recorded inside _process_page.
+        # gather() runs each page as its own Task, which is what gives per-page
+        # ContextVar isolation — don't collapse this into shared-context awaits.
         page_outcomes = await asyncio.gather(
-            *(_guarded_page(i, crawl_result) for i, crawl_result in pending_pages),
+            *(_process_page(i, crawl_result) for i, crawl_result in pending_pages),
             return_exceptions=True,
         )
         for (_, crawl_result), outcome in zip(pending_pages, page_outcomes):

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -532,6 +532,7 @@ async def _run_web_ingestion_impl(
         successful_page_ingestions = 0
         total_chunks = 0
         total_embeddings = 0
+        pages_started = 0
 
         loop = asyncio.get_event_loop()
         page_semaphore = asyncio.Semaphore(max(1, ing_cfg.page_ingest_concurrency))
@@ -550,7 +551,7 @@ async def _run_web_ingestion_impl(
             # without locks; the cross-thread DB write hazard is guarded inside
             # collection_manager.
             nonlocal documents_created, successful_page_ingestions
-            nonlocal total_chunks, total_embeddings
+            nonlocal total_chunks, total_embeddings, pages_started
 
             page_title = crawl_result.title or f"page_{i + 1}"
             with pipeline_facade.web_page_operation(
@@ -558,11 +559,14 @@ async def _run_web_ingestion_impl(
                 url=crawl_result.url,
                 title=page_title,
             ) as page_operation:
-                # Progress callback
+                # Progress callback. Pages complete out of order under concurrency,
+                # so report a monotonic started-counter rather than the page index.
+                # Safe without a lock: only mutated between awaits on the one loop.
                 if progress_callback:
+                    pages_started += 1
                     progress_callback(
-                        f"Ingesting page {i + 1}/{len(crawl_results)}: {crawl_result.url}",
-                        i + 1,
+                        f"Ingesting {pages_started}/{len(crawl_results)}: {crawl_result.url}",
+                        pages_started,
                         len(crawl_results),
                     )
 

--- a/src/xagent/core/tools/core/RAG_tools/vector_storage/vector_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/vector_storage/vector_manager.py
@@ -85,10 +85,20 @@ def write_vectors_to_db(
     create_index: bool = True,
     user_id: Optional[int] = None,
 ) -> EmbeddingWriteResponse:
-    """Write embedding vectors to database with idempotency through the facade."""
-    return _get_vector_storage_compatibility_facade().write_vectors_to_db(
-        collection=collection,
-        embeddings=embeddings,
-        create_index=create_index,
-        user_id=user_id,
-    )
+    """Write embedding vectors to database with idempotency through the facade.
+
+    Serialized per collection: web ingestion runs up to page_ingest_concurrency
+    pages on separate threads, and concurrent commits to the same LanceDB table
+    (including the create_index build) can raise CommitConflict. The dominant
+    cost, embedding computation, already finished before this call, so the lock
+    only serializes the cheap write and barely dents throughput.
+    """
+    from ..management.collection_manager import _get_collection_thread_lock
+
+    with _get_collection_thread_lock(collection):
+        return _get_vector_storage_compatibility_facade().write_vectors_to_db(
+            collection=collection,
+            embeddings=embeddings,
+            create_index=create_index,
+            user_id=user_id,
+        )

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -294,6 +294,31 @@ class TestSyncFunctions:
         assert saved.documents == saved_before.documents + 2
         assert saved.processed_documents == saved_before.processed_documents + 1
 
+    def test_update_collection_stats_sync_concurrent_no_lost_updates(self, manager):
+        """Concurrent web-page ingestion (#912) runs each page in its own executor
+        thread + event loop. The per-loop asyncio lock cannot serialize those, so
+        the cross-thread lock must prevent read-modify-write from losing stat
+        increments.
+        """
+        import concurrent.futures
+        import uuid
+
+        collection_name = f"concurrent_stats_{str(uuid.uuid4())[:8]}"
+        # Create the collection (auto-created on first stats update).
+        update_collection_stats_sync(collection_name, documents_delta=0)
+
+        n = 24
+
+        def _bump() -> None:
+            # Fresh event loop per thread mimics run_in_executor page ingestion.
+            update_collection_stats_sync(collection_name, documents_delta=1)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: _bump(), range(n)))
+
+        final = get_collection_sync(collection_name)
+        assert final.documents == n
+
 
 class TestHubTagMapping:
     """Test collection-manager hub tag mapping collision handling."""

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -13,6 +13,7 @@ from xagent.core.tools.core.RAG_tools.core.exceptions import (
     EmbeddingAdapterError,
 )
 from xagent.core.tools.core.RAG_tools.core.schemas import (
+    ChunkEmbeddingData,
     ChunkForEmbedding,
     ChunkStrategy,
     CollectionInfo,
@@ -1150,3 +1151,117 @@ def test_process_document_rejects_absolute_paths_outside_allowed_dir(
             or "permission" in message_lower
             or "denied" in message_lower
         ), f"Unexpected error message for {abs_path}: {result.message}"
+
+
+def _make_chunks(n: int) -> List[ChunkForEmbedding]:
+    """n chunks with distinct text lengths (1..n) so a batch's vectors can be
+    traced back to their chunks and cross-batch scrambling is detectable."""
+    return [
+        ChunkForEmbedding(
+            doc_id="doc-1",
+            chunk_id=f"chunk-{i}",
+            parse_hash="hash-1",
+            text="x" * (i + 1),
+            chunk_hash=f"chunk-hash-{i}",
+            index=i,
+        )
+        for i in range(n)
+    ]
+
+
+def _run_batch_embedding(
+    monkeypatch: pytest.MonkeyPatch, *, concurrent: int
+) -> tuple[IngestionResult, int, List[ChunkEmbeddingData]]:
+    """Drive the sync/batch embedding path with a latency-injecting adapter that
+    records peak concurrency. Returns (result, max_inflight, written_embeddings)."""
+    import threading
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    chunks = _make_chunks(6)
+    read_response = EmbeddingReadResponse(
+        chunks=chunks, total_count=6, pending_count=6
+    ).model_dump()
+    monkeypatch.setattr(
+        document_ingestion, "read_chunks_for_embedding", lambda **_: read_response
+    )
+
+    lock = threading.Lock()
+    state = {"inflight": 0, "max": 0}
+
+    class _ConcurrencyProbeAdapter(_StubEmbeddingAdapter):
+        def encode(  # type: ignore[override]
+            self, text, dimension=None, instruct=None
+        ):
+            with lock:
+                state["inflight"] += 1
+                state["max"] = max(state["max"], state["inflight"])
+            try:
+                # Event.wait (unlike time.sleep, which the autouse _no_sleep
+                # fixture stubs out) really blocks, forcing an overlap window.
+                threading.Event().wait(0.05)
+                # vector[0] == len(text) lets the caller verify batch alignment
+                return [[float(len(item)), 0.0] for item in text]
+            finally:
+                with lock:
+                    state["inflight"] -= 1
+
+    stub_config = EmbeddingModelConfig(
+        id="embedding-default",
+        model_name="text-embedding-v3",
+        model_provider="dashscope",
+        dimension=2,
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "_resolve_embedding_adapter",
+        lambda _cfg: (stub_config, _ConcurrencyProbeAdapter()),
+    )
+
+    written: List[ChunkEmbeddingData] = []
+
+    def _capture_write(**kwargs: object) -> dict:
+        written.extend(kwargs.get("embeddings", []))  # type: ignore[arg-type]
+        return EmbeddingWriteResponse(
+            upsert_count=len(kwargs.get("embeddings", [])),  # type: ignore[arg-type]
+            deleted_stale_count=0,
+            index_status="created" if kwargs.get("create_index") else "skipped",
+        ).model_dump()
+
+    monkeypatch.setattr(document_ingestion, "write_vectors_to_db", _capture_write)
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/tmp/doc.md",
+        config=IngestionConfig(
+            embedding_use_async=False,
+            embedding_batch_size=2,
+            embedding_concurrent=concurrent,
+        ),
+    )
+    return result, state["max"], written
+
+
+def test_batch_embedding_runs_concurrently_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """6 chunks / batch_size=2 => 3 batches. With embedding_concurrent=3 the encode
+    round-trips overlap, and vectors must still line up with their chunks in order."""
+    result, max_inflight, written = _run_batch_embedding(monkeypatch, concurrent=3)
+
+    assert result.status == "success"
+    assert max_inflight >= 2, "batch encodes did not overlap"
+    # All 6 embedded, in order, each vector aligned to its own chunk (no scrambling).
+    assert [e.chunk_id for e in written] == [f"chunk-{i}" for i in range(6)]
+    assert [int(e.vector[0]) for e in written] == [len(e.text) for e in written]
+
+
+def test_batch_embedding_concurrency_one_stays_serial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """embedding_concurrent=1 must preserve the legacy fully-serial behavior."""
+    result, max_inflight, written = _run_batch_embedding(monkeypatch, concurrent=1)
+
+    assert result.status == "success"
+    assert max_inflight == 1
+    assert [e.chunk_id for e in written] == [f"chunk-{i}" for i in range(6)]

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -1265,3 +1265,54 @@ def test_batch_embedding_concurrency_one_stays_serial(
     assert result.status == "success"
     assert max_inflight == 1
     assert [e.chunk_id for e in written] == [f"chunk-{i}" for i in range(6)]
+
+
+def test_batch_embedding_retries_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient encode() failure in the sync batch path must be retried
+    (parity with the async path) instead of failing the whole document."""
+    _patch_pipeline_dependencies(monkeypatch)
+
+    chunks = _make_chunks(2)  # one batch of 2 at batch_size=2
+    read_response = EmbeddingReadResponse(
+        chunks=chunks, total_count=2, pending_count=2
+    ).model_dump()
+    monkeypatch.setattr(
+        document_ingestion, "read_chunks_for_embedding", lambda **_: read_response
+    )
+
+    calls = {"n": 0}
+
+    class _FlakyAdapter(_StubEmbeddingAdapter):
+        def encode(self, text, dimension=None, instruct=None):  # type: ignore[override]
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient 429")
+            return super().encode(text, dimension, instruct)
+
+    stub_config = EmbeddingModelConfig(
+        id="embedding-default",
+        model_name="text-embedding-v3",
+        model_provider="dashscope",
+        dimension=2,
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "_resolve_embedding_adapter",
+        lambda _cfg: (stub_config, _FlakyAdapter()),
+    )
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/tmp/doc.md",
+        config=IngestionConfig(
+            embedding_use_async=False,
+            embedding_batch_size=2,
+            embedding_concurrent=1,
+            max_retries=3,
+        ),
+    )
+
+    assert result.status == "success"
+    assert calls["n"] == 2  # first attempt raised, retry succeeded

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -938,6 +938,84 @@ class TestWebIngestionFileHandler:
                 assert "xagent_web_ingest" in call_kwargs["source_path"]
 
     @pytest.mark.asyncio
+    async def test_same_titled_pages_no_file_handler_get_distinct_temp_paths(
+        self, crawl_config
+    ):
+        """Regression (PR #915 M2): with page-level concurrency and no
+        file_handler, two pages sharing a title must not collide on the same
+        temp file — otherwise one page's content overwrites the other's (torn
+        read) and, since the doc_id derives from the temp path, both collapse to
+        a single document. The per-page index prefix keeps the paths distinct.
+        """
+        same_title = "Shared Title"
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title=same_title,
+                content_markdown="# Shared Title\n\nContent A",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=30,
+            ),
+            MagicMock(
+                url="https://example.com/page2",
+                title=same_title,
+                content_markdown="# Shared Title\n\nContent B",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=30,
+            ),
+        ]
+
+        ingestion_config = IngestionConfig(
+            chunk_size=500,
+            chunk_overlap=100,
+            page_ingest_concurrency=2,
+        )
+
+        def _ingest_side_effect(**kwargs: Any) -> IngestionResult:
+            return IngestionResult(
+                status="success",
+                doc_id=kwargs["source_path"],
+                parse_hash="hash",
+                chunk_count=1,
+                embedding_count=1,
+                vector_count=1,
+                completed_steps=[],
+                failed_step=None,
+                message="Success",
+                warnings=[],
+            )
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 2
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.run_document_ingestion",
+                side_effect=_ingest_side_effect,
+            ) as mock_ingest:
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                )
+
+        assert result.status == "success"
+        assert mock_ingest.call_count == 2
+        source_paths = [c.kwargs["source_path"] for c in mock_ingest.call_args_list]
+        # Two distinct temp files → two distinct documents, no clobber.
+        assert len(set(source_paths)) == 2
+        assert result.documents_created == 2
+
+    @pytest.mark.asyncio
     async def test_file_handler_rollback_runs_on_ingestion_error_result(
         self, crawl_config, ingestion_config
     ):

--- a/tests/core/tools/core/RAG_tools/vector_storage/test_vector_manager.py
+++ b/tests/core/tools/core/RAG_tools/vector_storage/test_vector_manager.py
@@ -51,6 +51,59 @@ class TestReadChunksForEmbedding:
 
 
 class TestWriteVectorsToDb:
+    def test_concurrent_writes_same_collection_are_serialized(self) -> None:
+        """Regression (PR #915): concurrent page ingestions write to the same
+        LanceDB table on separate threads; write_vectors_to_db must serialize
+        them per collection so overlapping commits can't raise CommitConflict.
+        """
+        import threading
+        import time
+        from unittest.mock import MagicMock, patch
+
+        from xagent.core.tools.core.RAG_tools.management.collection_manager import (
+            reset_locks_for_testing,
+        )
+
+        reset_locks_for_testing()
+
+        state_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def _fake_write(**kwargs: object) -> EmbeddingWriteResponse:
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.02)
+            with state_lock:
+                active -= 1
+            return EmbeddingWriteResponse(
+                upsert_count=0, deleted_stale_count=0, index_status="skipped"
+            )
+
+        facade = MagicMock()
+        facade.write_vectors_to_db.side_effect = _fake_write
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.vector_storage.vector_manager"
+            "._get_vector_storage_compatibility_facade",
+            return_value=facade,
+        ):
+
+            def _writer() -> None:
+                write_vectors_to_db(collection="same", embeddings=[])
+
+            threads = [threading.Thread(target=_writer) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert facade.write_vectors_to_db.call_count == 4
+        # Serialized: never two writers inside the facade call at once.
+        assert max_active == 1
+
     def test_write_vectors_empty_list(self) -> None:
         result = write_vectors_to_db(
             collection="coll", embeddings=[], create_index=True


### PR DESCRIPTION
## Summary

KB Website Import spent 85–91% of its time in Step 2 (per-page ingestion): ~30–50 min for a ~500-page site. This makes Step 2 concurrent on two independent axes and fixes a latent lost-update bug that concurrency exposed.

## Root cause (corrected)

The original issue suspected per-page LanceDB **store rebuilds**. A runtime probe replicating the exact per-page call path (`copy_context()` + executor thread → `run_document_ingestion`) disproves that:

- Each of the 5 `LanceDB*Store` classes has **distinct `id()` count = 1** across N pages — stores are process-wide singletons, reused across pages.
- `get_connection_from_env` is called only on page 1 (`[3, 0, 0]` over 3 pages); the "5 `Using default LanceDB directory` lines/page" are cheap TTL-cached lookups, not rebuilds.
- `DefaultKBWriteCoordinator` is constructed **0 times** on the ingestion path.
- With embedding stubbed to zero, non-embedding per-page overhead is **~90–140 ms**, not seconds.

The real dominant cost is **serial embedding-provider round-trips over serially-processed pages**. Default `embedding_use_async=False` uses the batch path, which looped batches serially: `ceil(chunks / batch_size)` API round-trips per page, all serial, and the pages themselves serial. Hoisting stores to job scope (the original suggestion) would be a no-op since they are already shared.

## Changes

**Two orthogonal layers of concurrency:**

- **Page level** — process pages concurrently via `asyncio.Semaphore(page_ingest_concurrency)` (default 4) + `gather`, so embedding round-trips and I/O overlap across pages. `page_ingest_concurrency=1` restores the legacy serial behavior.
- **Batch level** — within a page, fan out the independent batch `encode()` calls over a bounded thread pool honoring `embedding_concurrent` (default 10), writing vectors back in original order (`create_index` still on the final batch). `embedding_concurrent=1` restores the fully-serial path.

**Correctness fix exposed by concurrency:** the per-collection `asyncio` lock is keyed by event-loop id, and each `*_sync` call spins a fresh loop, so it never actually serialized the collection-metadata read-modify-write across pages. Under concurrency this loses stat increments. Added a process-global cross-thread `RLock` guard (acquired after the asyncio lock) around the two RMW critical sections.

## Evidence

- Within-page batch concurrency: **3.18×** on a single page (1073 ms → 337 ms) with a 50 ms/batch latency stub, 26 chunks, `batch_size=2`, `embedding_concurrent=8`.
- Page-level concurrency overlaps whole-page embedding streams (default 4×), independent of the above.

## Testing

- `test_update_collection_stats_sync_concurrent_no_lost_updates` — 8 threads × fresh event loops, no lost stat increments.
- `test_batch_embedding_runs_concurrently_and_preserves_order` — batch encodes overlap (peak in-flight ≥ 2) and vectors stay aligned to their chunks in order.
- `test_batch_embedding_concurrency_one_stays_serial` — `embedding_concurrent=1` keeps the serial path.
- Full `RAG_tools/pipelines` + `management` suites pass; ruff + mypy clean.

## Notes

Effective embedding concurrency is `page_ingest_concurrency × embedding_concurrent` (up to ~40 with defaults). Tune both down to your embedding provider's QPS/concurrency limits before high-volume imports to avoid rate-limiting.

Closes #912
