### PR TITLE
ref(memory): hoist shared filter dispatch into MemoryStore base + None date-bound guard + top-k post-filter docs (#916)

### DIFF
--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Collection, List, Optional
 
 from .core import MemoryNote, MemoryResponse
-from .scope_columns import encode_scope_dims, scope_dim_element
+from .scope_columns import (
+    SCOPE_EXCLUSIVE_FILTER_KEY,
+    encode_scope_dims,
+    scope_dim_element,
+)
 
 
 def comparable_timestamp(value: Any) -> Any:
@@ -138,6 +142,149 @@ class MemoryStore(ABC):
             Dict[str, Any]: Statistics including total count, counts by category, etc.
         """
         pass
+
+    # ------------------------------------------------------------------
+    # Shared filter dispatch (#916)
+    #
+    # Single implementation of filter matching used by every store's
+    # search()/list_all(), hoisted here so backends cannot drift apart on
+    # filter semantics. #906/#909/#910 unified the dispatch *within* each
+    # store; this hoists it *across* stores, mirroring what #910 did for
+    # comparable_timestamp(). Store-specific behavior belongs in overrides,
+    # not in copies.
+    # ------------------------------------------------------------------
+
+    # Filter keys with dedicated handling in _matches_filters; anything else
+    # is treated as a flat metadata-equality filter.
+    _KNOWN_FILTER_KEYS = frozenset(
+        {
+            "category",
+            "metadata",
+            "date_from",
+            "date_to",
+            "tags",
+            "keywords",
+            SCOPE_EXCLUSIVE_FILTER_KEY,
+        }
+    )
+
+    @staticmethod
+    def _matches_metadata_filters(
+        metadata: dict[str, Any], metadata_filters: dict[str, Any]
+    ) -> bool:
+        """Metadata equality for both the nested ``filters["metadata"]`` dict
+        and flat metadata keys. String-coerced on both sides so
+        ``UserIsolatedMemoryStore`` isolation and ad-hoc filters behave the
+        same on every store (#842). A non-dict filter value cannot match
+        anything (rather than crashing on a malformed caller-supplied
+        ``filters["metadata"]``)."""
+        if not isinstance(metadata_filters, dict):
+            return False
+        return all(
+            str(metadata.get(key, "")) == str(value)
+            for key, value in metadata_filters.items()
+        )
+
+    @staticmethod
+    def _required_items(value: Any) -> Optional[Collection[Any]]:
+        """Normalize a ``tags``/``keywords`` filter value: a plain string is a
+        single required item (not iterated per character), an iterable is many,
+        and anything else can't match (rather than raising ``TypeError`` on
+        malformed caller-supplied filters — the same no-match policy as
+        ``_matches_metadata_filters``)."""
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return value
+        return None
+
+    @classmethod
+    def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
+        """Filter keys without dedicated handling, applied as flat metadata
+        equality. Note-independent — compute once per call, not per note."""
+        return {
+            key: value
+            for key, value in (filters or {}).items()
+            if key not in cls._KNOWN_FILTER_KEYS
+        }
+
+    @classmethod
+    def _matches_filters(
+        cls,
+        note: MemoryNote,
+        filters: dict[str, Any],
+        other_filters: dict[str, Any],
+    ) -> bool:
+        """Single filter dispatch shared by every store's ``search()`` and
+        ``list_all()``, so backends cannot drift apart on filter semantics
+        (#916; previously near-identical per-store copies).
+
+        ``category`` comparison is string-coerced on both sides — a deliberate
+        decision (#916): before the hoist the stores accidentally disagreed
+        (InMemory exact, LanceDB coerced), and coercion is consistent with the
+        string-coerced metadata-equality policy used everywhere else in this
+        dispatch.
+
+        An explicit ``None`` for ``date_from``/``date_to`` means "no bound"
+        (#916) — matching how absent keys behave — rather than raising
+        ``TypeError`` inside the date comparison.
+
+        ``other_filters`` is ``_flat_other_filters(filters)``, precomputed by
+        the caller so the per-note check does not rebuild it.
+        """
+        # #822: strict dimension-less exclusion (the ``__scope_exclusive__``
+        # directive, ``SCOPE_EXCLUSIVE_FILTER_KEY``) — a note carrying any
+        # scope dimension is excluded. Scope-dimension stamps live in
+        # note.metadata.
+        if filters.get(SCOPE_EXCLUSIVE_FILTER_KEY) and encode_scope_dims(note.metadata):
+            return False
+
+        if "category" in filters and str(note.category) != str(filters["category"]):
+            return False
+
+        # Nested metadata filters (the shape UserIsolatedMemoryStore emits
+        # for user_id/scope isolation — before #842 search() never matched
+        # them and list_all() ignored them, fail-open)
+        if "metadata" in filters and not cls._matches_metadata_filters(
+            note.metadata, filters["metadata"]
+        ):
+            return False
+
+        # Date range filters (both sides tz-normalized so an aware filter
+        # against the naive default timestamps cannot raise TypeError;
+        # explicit None = no bound)
+        date_from = filters.get("date_from")
+        date_to = filters.get("date_to")
+        if date_from is not None or date_to is not None:
+            note_ts = comparable_timestamp(note.timestamp)
+            if date_from is not None and note_ts < comparable_timestamp(date_from):
+                return False
+            if date_to is not None and note_ts > comparable_timestamp(date_to):
+                return False
+
+        # Tag filter (all required tags present)
+        if "tags" in filters:
+            required_tags = cls._required_items(filters["tags"])
+            if required_tags is None or not all(
+                tag in note.tags for tag in required_tags
+            ):
+                return False
+
+        # Keyword filter (all required keywords present)
+        if "keywords" in filters:
+            required_keywords = cls._required_items(filters["keywords"])
+            if required_keywords is None or not all(
+                keyword in note.keywords for keyword in required_keywords
+            ):
+                return False
+
+        # Other flat metadata filters (string-coerced equality)
+        if other_filters and not cls._matches_metadata_filters(
+            note.metadata, other_filters
+        ):
+            return False
+
+        return True
 
     def delete_by_scope_dimension(self, dim_key: str, value: Any) -> MemoryResponse:
         """

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -1,143 +1,18 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Collection, List, Optional
+from typing import Any, List, Optional
 
-from .base import MemoryStore, comparable_timestamp
+from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
-from .scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY, encode_scope_dims
 
 
 class InMemoryMemoryStore(MemoryStore):
-    # Filter keys with dedicated handling in _matches_filters; anything else
-    # is treated as a flat metadata-equality filter.
-    _KNOWN_FILTER_KEYS = frozenset(
-        {
-            "category",
-            "metadata",
-            "date_from",
-            "date_to",
-            "tags",
-            "keywords",
-            SCOPE_EXCLUSIVE_FILTER_KEY,
-        }
-    )
+    # Filter matching (_matches_filters and friends) is inherited from the
+    # MemoryStore base so stores cannot drift apart on filter semantics (#916).
 
     def __init__(self) -> None:
         self._store: dict[str, MemoryNote] = {}
-
-    @staticmethod
-    def _is_scope_excluded(note: MemoryNote, filters: dict[str, Any]) -> bool:
-        """#822: strict dimension-less exclusion (the ``__scope_exclusive__``
-        directive, ``SCOPE_EXCLUSIVE_FILTER_KEY``) — a note carrying any scope
-        dimension is excluded."""
-        return bool(filters.get(SCOPE_EXCLUSIVE_FILTER_KEY)) and bool(
-            encode_scope_dims(note.metadata)
-        )
-
-    @staticmethod
-    def _matches_metadata_filters(
-        metadata: dict[str, Any], metadata_filters: dict[str, Any]
-    ) -> bool:
-        """Metadata equality for both the nested ``filters["metadata"]`` dict
-        and flat metadata keys, matching the string-coerced semantics of
-        ``LanceDBMemoryStore`` so ``UserIsolatedMemoryStore`` isolation and
-        ad-hoc filters behave the same on both stores (#842). A non-dict
-        filter value cannot match anything (rather than crashing on a
-        malformed caller-supplied ``filters["metadata"]``)."""
-        if not isinstance(metadata_filters, dict):
-            return False
-        return all(
-            str(metadata.get(key, "")) == str(value)
-            for key, value in metadata_filters.items()
-        )
-
-    @staticmethod
-    def _required_items(value: Any) -> Optional[Collection[Any]]:
-        """Normalize a ``tags``/``keywords`` filter value: a plain string is a
-        single required item (not iterated per character), an iterable is many,
-        and anything else can't match (rather than raising ``TypeError`` on
-        malformed caller-supplied filters — the same no-match policy as
-        ``_matches_metadata_filters``)."""
-        if isinstance(value, str):
-            return (value,)
-        if isinstance(value, (list, tuple, set, frozenset)):
-            return value
-        return None
-
-    @classmethod
-    def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
-        """Filter keys without dedicated handling, applied as flat metadata
-        equality. Note-independent — compute once per call, not per note."""
-        return {
-            key: value
-            for key, value in (filters or {}).items()
-            if key not in cls._KNOWN_FILTER_KEYS
-        }
-
-    @classmethod
-    def _matches_filters(
-        cls,
-        note: MemoryNote,
-        filters: dict[str, Any],
-        other_filters: dict[str, Any],
-    ) -> bool:
-        """Single filter dispatch shared by ``search()`` and ``list_all()``,
-        so the two methods cannot drift apart on filter semantics (#842).
-
-        ``other_filters`` is ``_flat_other_filters(filters)``, precomputed by
-        the caller so the per-note check does not rebuild it.
-        """
-        if cls._is_scope_excluded(note, filters):
-            return False
-
-        if "category" in filters and note.category != filters["category"]:
-            return False
-
-        # Nested metadata filters (the shape UserIsolatedMemoryStore emits
-        # for user_id/scope isolation — before #842 search() never matched
-        # them and list_all() ignored them, fail-open)
-        if "metadata" in filters and not cls._matches_metadata_filters(
-            note.metadata, filters["metadata"]
-        ):
-            return False
-
-        # Date range filters (both sides tz-normalized so an aware filter
-        # against the naive default timestamps cannot raise TypeError)
-        if "date_from" in filters or "date_to" in filters:
-            note_ts = comparable_timestamp(note.timestamp)
-            if "date_from" in filters and note_ts < comparable_timestamp(
-                filters["date_from"]
-            ):
-                return False
-            if "date_to" in filters and note_ts > comparable_timestamp(
-                filters["date_to"]
-            ):
-                return False
-
-        # Tag filter (all required tags present)
-        if "tags" in filters:
-            required_tags = cls._required_items(filters["tags"])
-            if required_tags is None or not all(
-                tag in note.tags for tag in required_tags
-            ):
-                return False
-
-        # Keyword filter (all required keywords present)
-        if "keywords" in filters:
-            required_keywords = cls._required_items(filters["keywords"])
-            if required_keywords is None or not all(
-                keyword in note.keywords for keyword in required_keywords
-            ):
-                return False
-
-        # Other flat metadata filters (string-coerced, like LanceDBMemoryStore)
-        if other_filters and not cls._matches_metadata_filters(
-            note.metadata, other_filters
-        ):
-            return False
-
-        return True
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         note_id = note.id or str(uuid.uuid4())

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Collection, List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
@@ -16,7 +16,7 @@ from ..model.embedding import BaseEmbedding, DashScopeEmbedding
 from ..model.embedding.adapter import create_embedding_adapter
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
-from .base import MemoryStore, comparable_timestamp
+from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
     MemoryMismatchKind,
@@ -25,7 +25,6 @@ from .schema_migration import (
 )
 from .scope_columns import (
     SCOPE_DIMS_COLUMN,
-    SCOPE_EXCLUSIVE_FILTER_KEY,
     USER_ID_COLUMN,
     build_scope_where,
     coerce_user_id,
@@ -469,132 +468,15 @@ class LanceDBMemoryStore(MemoryStore):
 
         return MemoryNote(**note_kwargs)
 
-    # Filter keys with dedicated handling in _matches_filters; anything else
-    # is treated as a flat metadata-equality filter. Mirrors
-    # InMemoryMemoryStore._KNOWN_FILTER_KEYS so the two stores cannot drift
-    # apart on filter semantics (#909).
-    _KNOWN_FILTER_KEYS = frozenset(
-        {
-            "category",
-            "metadata",
-            "date_from",
-            "date_to",
-            "tags",
-            "keywords",
-            SCOPE_EXCLUSIVE_FILTER_KEY,
-        }
-    )
-
-    @staticmethod
-    def _required_items(value: Any) -> Optional[Collection[Any]]:
-        """Normalize a ``tags``/``keywords`` filter value: a plain string is a
-        single required item (not iterated per character), an iterable is many,
-        and anything else can't match (rather than raising ``TypeError`` on
-        malformed caller-supplied filters — the same no-match policy as
-        ``_apply_metadata_filters``)."""
-        if isinstance(value, str):
-            return (value,)
-        if isinstance(value, (list, tuple, set, frozenset)):
-            return value
-        return None
-
-    @classmethod
-    def _flat_other_filters(cls, filters: Optional[dict[str, Any]]) -> dict[str, Any]:
-        """Filter keys without dedicated handling, applied as flat metadata
-        equality. Note-independent — compute once per call, not per note."""
-        return {
-            key: value
-            for key, value in (filters or {}).items()
-            if key not in cls._KNOWN_FILTER_KEYS
-        }
-
-    def _matches_filters(
-        self,
-        note: MemoryNote,
-        filters: dict[str, Any],
-        other_filters: dict[str, Any],
-    ) -> bool:
-        """Single filter dispatch shared by the vector path, the text fallback,
-        and (via search) ``list_all()``, so they cannot drift apart on filter
-        semantics (#909 — previously ``tags``/``keywords``/``date_from``/
-        ``date_to`` fell through to flat metadata equality on both search paths
-        and never matched, while ``list_all()`` handled them correctly).
-
-        On the vector path ``filters`` is the residual dict left by
-        ``build_scope_where``: ``SCOPE_EXCLUSIVE_FILTER_KEY`` and the
-        user_id/scope-dimension entries of the nested ``metadata`` filter were
-        already pushed into the ``where`` prefilter, so those checks simply do
-        not trigger there. The text fallback passes the full filters and relies
-        on the checks here.
-
-        ``other_filters`` is ``_flat_other_filters(filters)``, precomputed by
-        the caller so the per-note check does not rebuild it.
-        """
-        # #822: strict dimension-less exclusion — only notes carrying no scope
-        # dimensions pass. Scope-dimension stamps live in note.metadata (they
-        # are not popped by _dict_to_memory_note).
-        if filters.get(SCOPE_EXCLUSIVE_FILTER_KEY) and encode_scope_dims(note.metadata):
-            return False
-
-        if "category" in filters and str(note.category) != str(filters["category"]):
-            return False
-
-        # Nested metadata filters (the shape UserIsolatedMemoryStore emits
-        # for user_id/scope isolation)
-        if "metadata" in filters and not self._apply_metadata_filters(
-            note.metadata, filters["metadata"]
-        ):
-            return False
-
-        # Date range filters (both sides tz-normalized so an aware filter
-        # against the naive default timestamps cannot raise TypeError)
-        if "date_from" in filters or "date_to" in filters:
-            note_ts = comparable_timestamp(note.timestamp)
-            if "date_from" in filters and note_ts < comparable_timestamp(
-                filters["date_from"]
-            ):
-                return False
-            if "date_to" in filters and note_ts > comparable_timestamp(
-                filters["date_to"]
-            ):
-                return False
-
-        # Tag filter (all required tags present)
-        if "tags" in filters:
-            required_tags = self._required_items(filters["tags"])
-            if required_tags is None or not all(
-                tag in note.tags for tag in required_tags
-            ):
-                return False
-
-        # Keyword filter (all required keywords present)
-        if "keywords" in filters:
-            required_keywords = self._required_items(filters["keywords"])
-            if required_keywords is None or not all(
-                keyword in note.keywords for keyword in required_keywords
-            ):
-                return False
-
-        # Other flat metadata filters (string-coerced equality)
-        if other_filters and not self._apply_metadata_filters(
-            note.metadata, other_filters
-        ):
-            return False
-
-        return True
-
-    def _apply_metadata_filters(
-        self, metadata: dict[str, Any], metadata_filters: dict[str, Any]
-    ) -> bool:
-        """Apply nested metadata filters. A non-dict filter value cannot match
-        anything (rather than crashing on a malformed caller-supplied
-        ``filters["metadata"]``)."""
-        if not isinstance(metadata_filters, dict):
-            return False
-        for key, value in metadata_filters.items():
-            if str(metadata.get(key, "")) != str(value):
-                return False
-        return True
+    # Filter matching (_matches_filters and friends) is inherited from the
+    # MemoryStore base so stores cannot drift apart on filter semantics (#916).
+    #
+    # On the vector path the dispatch receives the residual dict left by
+    # ``build_scope_where``: ``SCOPE_EXCLUSIVE_FILTER_KEY`` and the
+    # user_id/scope-dimension entries of the nested ``metadata`` filter were
+    # already pushed into the ``where`` prefilter, so those checks simply do
+    # not trigger there. The text fallback passes the full filters and relies
+    # on all the base checks.
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         """Add a memory note to the store."""
@@ -820,7 +702,21 @@ class LanceDBMemoryStore(MemoryStore):
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
     ) -> list[MemoryNote]:
-        """Search memory notes by query text with optional filters."""
+        """Search memory notes by query text with optional filters.
+
+        Known limitation (#916): on the vector path, residual filters —
+        ``category``, ``tags``/``keywords``, ``date_from``/``date_to``, and
+        arbitrary metadata keys — are applied as a Python post-filter *after*
+        ANN top-k retrieval (``vector_query.limit(k)``). A note that matches
+        the filters but falls outside the ANN's top-k window will therefore
+        not surface, even though it exists in the store. Only user_id and
+        scope dimensions are pushed into the ``where`` prefilter, because
+        cross-principal crowd-out is an isolation-recall problem (#822);
+        pushing more filter keys into the prefilter was considered and
+        deliberately deferred as a possible future recall improvement (#916).
+        Callers that need filter-complete results should use ``list_all()``
+        (full scan) or pass a large ``k`` (the web route uses k=1000).
+        """
         table = None
         try:
             table = self._vector_store.get_raw_connection().open_table(

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -709,8 +709,10 @@ class LanceDBMemoryStore(MemoryStore):
         arbitrary metadata keys — are applied as a Python post-filter *after*
         ANN top-k retrieval (``vector_query.limit(k)``). A note that matches
         the filters but falls outside the ANN's top-k window will therefore
-        not surface, even though it exists in the store. Only user_id and
-        scope dimensions are pushed into the ``where`` prefilter, because
+        not surface, even though it exists in the store. Only user_id, the
+        scope dimensions, and the scope-exclusive directive
+        (``SCOPE_EXCLUSIVE_FILTER_KEY``, compiled to an empty-``scope_dims``
+        clause) are pushed into the ``where`` prefilter, because
         cross-principal crowd-out is an isolation-recall problem (#822);
         pushing more filter keys into the prefilter was considered and
         deliberately deferred as a possible future recall improvement (#916).

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -364,9 +364,10 @@ def test_clear(memory_store):
 class TestInMemoryMemoryStoreNestedMetadataFilters:
     """#842: nested ``filters["metadata"]`` dicts (the shape
     ``UserIsolatedMemoryStore._add_user_filter`` emits) must be interpreted
-    with the same string-coerced equality semantics as
-    ``LanceDBMemoryStore._apply_metadata_filters`` — previously search()
-    never matched them and list_all() silently ignored them (fail-open)."""
+    with the same string-coerced equality semantics as the LanceDB store
+    (now the shared ``MemoryStore._matches_metadata_filters``, #916) —
+    previously search() never matched them and list_all() silently ignored
+    them (fail-open)."""
 
     @pytest.fixture(autouse=True)
     def seed(self, memory_store):
@@ -614,11 +615,60 @@ class TestSearchListOnlyFilterParity:
             n.id for n in memory_store.list_all(filters={"keywords": "groceries"})
         ] == ["new-home"]
 
+    def test_explicit_none_date_bounds_mean_no_bound(self, memory_store):
+        # #916: an explicit None date_from/date_to means "no bound" — same as
+        # an absent key — instead of raising TypeError inside the date
+        # comparison (this store has no outer exception guard, so the
+        # TypeError used to propagate uncaught).
+        for filters in (
+            {"date_from": None},
+            {"date_to": None},
+            {"date_from": None, "date_to": None},
+        ):
+            assert {
+                n.id for n in memory_store.search("report", k=10, filters=filters)
+            } == {"old-work", "new-home"}
+            assert {n.id for n in memory_store.list_all(filters=filters)} == {
+                "old-work",
+                "new-home",
+            }
+
+    def test_none_date_bound_combines_with_real_bound(self, memory_store):
+        # A None bound on one side must not disable the real bound on the
+        # other side.
+        cutoff = self.now - timedelta(days=1)
+        assert [
+            n.id
+            for n in memory_store.search(
+                "report", k=10, filters={"date_from": cutoff, "date_to": None}
+            )
+        ] == ["new-home"]
+
+    def test_category_filter_is_string_coerced(self, memory_store):
+        # #916: the deliberate cross-store decision — category comparison is
+        # string-coerced on both stores, consistent with the metadata-equality
+        # policy of the shared dispatch (previously this store compared
+        # exactly while LanceDB coerced).
+        memory_store.add(
+            MemoryNote(
+                id="cat-42",
+                content="numeric category report",
+                category="42",
+            )
+        )
+        assert [
+            n.id for n in memory_store.search("report", k=10, filters={"category": 42})
+        ] == ["cat-42"]
+        assert [n.id for n in memory_store.list_all(filters={"category": 42})] == [
+            "cat-42"
+        ]
+
 
 def test_scope_exclusive_filters_scoped_notes(memory_store):
     """#822: the `__scope_exclusive__` directive (strict dimension-less
     isolation) excludes any scope-stamped note on the real InMemoryMemoryStore,
-    via `_is_scope_excluded`, on both search() and list_all()."""
+    via the shared `_matches_filters` dispatch, on both search() and
+    list_all()."""
     prefix = MEMORY_DIMENSION_METADATA_PREFIX
     memory_store.add(MemoryNote(id="u", content="hello unscoped", metadata={}))
     memory_store.add(

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -635,7 +635,7 @@ class TestSearchListOnlyFilterParity:
 
     def test_none_date_bound_combines_with_real_bound(self, memory_store):
         # A None bound on one side must not disable the real bound on the
-        # other side.
+        # other side — both directions.
         cutoff = self.now - timedelta(days=1)
         assert [
             n.id
@@ -643,6 +643,12 @@ class TestSearchListOnlyFilterParity:
                 "report", k=10, filters={"date_from": cutoff, "date_to": None}
             )
         ] == ["new-home"]
+        assert [
+            n.id
+            for n in memory_store.search(
+                "report", k=10, filters={"date_from": None, "date_to": cutoff}
+            )
+        ] == ["old-work"]
 
     def test_category_filter_is_string_coerced(self, memory_store):
         # #916: the deliberate cross-store decision — category comparison is

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -840,7 +840,7 @@ class TestSearchListOnlyFilterParity:
 
     def test_none_date_bound_combines_with_real_bound(self, parity_store):
         # A None bound on one side must not disable the real bound on the
-        # other side.
+        # other side — both directions.
         cutoff = self.now - timedelta(days=1)
         assert [
             n.id
@@ -848,6 +848,12 @@ class TestSearchListOnlyFilterParity:
                 "report", k=10, filters={"date_from": cutoff, "date_to": None}
             )
         ] == ["new-home"]
+        assert [
+            n.id
+            for n in parity_store.search(
+                "report", k=10, filters={"date_from": None, "date_to": cutoff}
+            )
+        ] == ["old-work"]
 
     def test_category_filter_is_string_coerced(self, parity_store):
         # #916: the deliberate cross-store decision — category comparison is

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -820,6 +820,54 @@ class TestSearchListOnlyFilterParity:
                 "new-home",
             }
 
+    def test_explicit_none_date_bounds_mean_no_bound(self, parity_store):
+        # #916: an explicit None date_from/date_to means "no bound" — same as
+        # an absent key — instead of raising TypeError inside the date
+        # comparison, which search()'s broad exception handler used to swallow
+        # into a silently empty result.
+        for filters in (
+            {"date_from": None},
+            {"date_to": None},
+            {"date_from": None, "date_to": None},
+        ):
+            assert {
+                n.id for n in parity_store.search("report", k=10, filters=filters)
+            } == {"old-work", "new-home"}
+            assert {n.id for n in parity_store.list_all(filters=filters)} == {
+                "old-work",
+                "new-home",
+            }
+
+    def test_none_date_bound_combines_with_real_bound(self, parity_store):
+        # A None bound on one side must not disable the real bound on the
+        # other side.
+        cutoff = self.now - timedelta(days=1)
+        assert [
+            n.id
+            for n in parity_store.search(
+                "report", k=10, filters={"date_from": cutoff, "date_to": None}
+            )
+        ] == ["new-home"]
+
+    def test_category_filter_is_string_coerced(self, parity_store):
+        # #916: the deliberate cross-store decision — category comparison is
+        # string-coerced on both stores, consistent with the metadata-equality
+        # policy of the shared dispatch (a non-str filter value still matches
+        # its string-rendered category).
+        assert parity_store.add(
+            MemoryNote(
+                id="cat-42",
+                content="numeric category report",
+                category="42",
+            )
+        ).success
+        assert [
+            n.id for n in parity_store.search("report", k=10, filters={"category": 42})
+        ] == ["cat-42"]
+        assert [n.id for n in parity_store.list_all(filters={"category": 42})] == [
+            "cat-42"
+        ]
+
 
 if __name__ == "__main__":
     # Run the tests


### PR DESCRIPTION
Closes #916. Follow-ups from the #910 review (all three items).

## 1. Shared filter dispatch hoisted into `MemoryStore` base

`_KNOWN_FILTER_KEYS`, `_required_items()`, `_flat_other_filters()`, the metadata-equality helper (LanceDB's `_apply_metadata_filters` and InMemory's `_matches_metadata_filters` were already logically identical), the scope-exclusive check, and the full `_matches_filters()` dispatch now live once on the `MemoryStore` base — mirroring what #910 did for `comparable_timestamp()`. Both stores inherit them; ~250 lines of near-identical duplication removed.

**Deliberate decision on `category` semantics:** comparison is now string-coerced on both stores (`str(note.category) != str(filters["category"])`), consistent with the string-coerced metadata-equality policy used everywhere else in the dispatch. This is the only behavioral change for `InMemoryMemoryStore` (previously exact `!=`); the decision and rationale are recorded in the `_matches_filters()` docstring and pinned by tests on both stores.

## 2. Explicit `None` `date_from`/`date_to` = "no bound"

The shared dispatch now treats an explicit `None` bound the same as an absent key, instead of raising `TypeError` inside the date comparison — which propagated uncaught on `InMemoryMemoryStore` and was swallowed into a silently empty result by `LanceDBMemoryStore.search()`'s broad exception guard. A `None` bound on one side does not disable a real bound on the other.

## 3. Vector-path top-k post-filter limitation documented

`LanceDBMemoryStore.search()`'s docstring now records the known limitation: residual filters (category/tags/keywords/dates/metadata keys) are a Python post-filter after ANN top-k, so a matching note outside the top-k window will not surface. Only user_id/scope dims are pushed into the `where` prefilter (#822, isolation recall); pushing more filter keys down was considered and deliberately deferred as a possible future recall improvement.

## Tests

- 3 new tests per store in the parity suites (LanceDB side runs them on both the vector path and the text fallback): explicit-`None` bounds match everything, one-sided `None` keeps the real bound, category coercion.
- Stale docstring references to the removed per-store helpers updated.
- `tests/core/memory/` (162) and memory-related `tests/web/` suites (55) pass; `ruff format`, `ruff check`, `mypy` clean.

## Acceptance criteria from #916

- [x] Single shared filter-dispatch implementation; deliberate, tested `category` decision; existing per-store parity suites pass unchanged.
- [x] Explicit `None` `date_from`/`date_to` no longer raises/empty-swallows in either store, with regression tests.
- [x] Vector-path top-k post-filter limitation documented, where-pushdown decision recorded (deferred).
