### PR TITLE
fix: cancel in-flight tool executions

### DIFF
--- a/src/xagent/core/agent/__init__.py
+++ b/src/xagent/core/agent/__init__.py
@@ -70,6 +70,7 @@ from .pattern import (
 from .registry import ExecutionHandle, ExecutionLifecycleStatus, ExecutionRegistry
 from .runner import AgentRunner
 from .runtime import (
+    ExecutionInterrupted,
     LLMCallInterrupted,
     PatternRuntime,
     ToolCallInterrupted,
@@ -107,6 +108,7 @@ __all__ = [
     "ExecutionSnapshot",
     "ExecutionStatus",
     "ExecutionContext",
+    "ExecutionInterrupted",
     "GenericComponent",
     "LLMCallInterrupted",
     "ToolCallInterrupted",

--- a/src/xagent/core/agent/__init__.py
+++ b/src/xagent/core/agent/__init__.py
@@ -69,7 +69,12 @@ from .pattern import (
 )
 from .registry import ExecutionHandle, ExecutionLifecycleStatus, ExecutionRegistry
 from .runner import AgentRunner
-from .runtime import LLMCallInterrupted, PatternRuntime, load_pattern_checkpoint
+from .runtime import (
+    LLMCallInterrupted,
+    PatternRuntime,
+    ToolCallInterrupted,
+    load_pattern_checkpoint,
+)
 from .service import AgentService
 from .tracing import TraceEventCallback
 
@@ -104,6 +109,7 @@ __all__ = [
     "ExecutionContext",
     "GenericComponent",
     "LLMCallInterrupted",
+    "ToolCallInterrupted",
     "LLMCallRecord",
     "LLMPlanGenerator",
     "MemoryComponent",

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -187,6 +187,9 @@ class _AutoChildRuntime:
     async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
         return await self.parent.run_llm_call(llm, **kwargs)
 
+    async def run_tool_call(self, invoke: Any) -> Any:
+        return await self.parent.run_tool_call(invoke)
+
     async def stream_final_answer(self, llm: Any, **kwargs: Any) -> Any:
         return await self.parent.stream_final_answer(llm, **kwargs)
 
@@ -270,6 +273,14 @@ class _AutoChildRuntime:
         result: Any | None = None,
     ) -> None:
         await self.parent.on_tool_error(tool_call=tool_call, error=error, result=result)
+
+    async def on_tool_cancelled(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        reason: str | None = None,
+    ) -> None:
+        await self.parent.on_tool_cancelled(tool_call=tool_call, reason=reason)
 
     async def on_llm_start(
         self,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -81,6 +81,9 @@ class _DAGStepRuntime:
     async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
         return await self.parent.run_llm_call(llm, **kwargs)
 
+    async def run_tool_call(self, invoke: Any) -> Any:
+        return await self.parent.run_tool_call(invoke)
+
     async def run_streaming_llm_call(
         self,
         llm: Any,
@@ -173,6 +176,16 @@ class _DAGStepRuntime:
     ) -> None:
         await self.parent.on_tool_error(
             tool_call=self._with_step(tool_call), error=error, result=result
+        )
+
+    async def on_tool_cancelled(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        reason: str | None = None,
+    ) -> None:
+        await self.parent.on_tool_cancelled(
+            tool_call=self._with_step(tool_call), reason=reason
         )
 
     async def on_llm_start(

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -19,7 +19,7 @@ from ...language import (
     output_language_policy,
 )
 from ...result import unwrap_final_answer_content
-from ...runtime import LLMCallInterrupted, PatternRuntime
+from ...runtime import ExecutionInterrupted, LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult, RequiredToolCallError
 from ..final_answer_stream import FinalAnswerStreamSession, ToolCallStringFieldStreamer
 from ..react import ReActPattern, ReActReasoningMode
@@ -888,7 +888,7 @@ class DAGPattern(AgentPattern):
                 skill_manager=skill_manager,
                 allowed_skills=allowed_skills,
             )
-        except LLMCallInterrupted:
+        except ExecutionInterrupted:
             raise
         except Exception as exc:
             step.status = "failed"

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -50,6 +50,7 @@ from ...result import tool_result_succeeded, unwrap_final_answer_content
 from ...runtime import (
     LLMCallInterrupted,
     PatternRuntime,
+    ToolCallInterrupted,
     prepare_llm_for_context,
     resolved_llm_metadata,
 )
@@ -1671,10 +1672,9 @@ class ReActPattern(AgentPattern):
                     pattern=self,
                     metadata={"tool_calls": segment},
                 )
-                # In-flight tools are not cancellable, so an interrupt that
-                # arrives during the batch is honored here, at the segment
-                # boundary. The completed (read-only, concurrency-safe) results
-                # are already recorded, which is correct for resume.
+                # Catch interrupts that arrive after the batch completed but
+                # before the next segment begins. Interrupts during the batch
+                # cancel its runtime-owned tool tasks immediately.
                 interrupted = await self._interrupt_if_requested(
                     runtime=runtime,
                     context=context,
@@ -2196,7 +2196,21 @@ class ReActPattern(AgentPattern):
         try:
             await runtime.on_tool_start(tool_call=tool_call)
             try:
-                result = await self._execute_tool(tool_call, tools)
+                result = await runtime.run_tool_call(
+                    lambda: self._execute_tool(tool_call, tools)
+                )
+            except ToolCallInterrupted as exc:
+                await runtime.on_tool_cancelled(
+                    tool_call=tool_call,
+                    reason=str(exc),
+                )
+                self._record_tool_call(
+                    tool_call,
+                    status="interrupted",
+                    error=str(exc),
+                )
+                recorded_terminal = True
+                raise
             except Exception as exc:  # noqa: BLE001
                 error_result = {
                     "success": False,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -15,9 +15,12 @@ flag never changes observable results, only latency:
 - I4 (control short-circuit): a control tool (final_answer / send_message /
   ask_user_question) owns its segment and ends the turn's tool execution; later
   tool calls in the same turn do not run.
-- I5 (interrupt / resume): an interrupt is honored at a segment boundary with
-  the remaining calls left pending; a crash mid-batch leaves the whole segment
-  pending so resume re-runs it (safe because batched tools are read-only).
+- I5 (interrupt / resume): an interrupt during a concurrent batch preserves
+  calls that already completed and leaves only interrupted calls pending. A
+  cancelled call may still have committed externally before cancellation was
+  observed, so ``concurrency_safe`` is an explicit idempotency contract as well
+  as a concurrency contract. A crash before backfill leaves the whole segment
+  pending for resume under the same contract.
 - I6 (trace pairing): tool trace spans pair START with END/ERROR by
   ``tool_call_id`` rather than tool name, so concurrent same-name calls do not
   cross-attribute (see ``tracing/langfuse/handler.py``).
@@ -48,6 +51,7 @@ from ...context.enrichment import (
 from ...language import final_answer_language_rule
 from ...result import tool_result_succeeded, unwrap_final_answer_content
 from ...runtime import (
+    ExecutionInterrupted,
     LLMCallInterrupted,
     PatternRuntime,
     ToolCallInterrupted,
@@ -294,11 +298,15 @@ class ReActPattern(AgentPattern):
                 compact_llm=compact_llm,
                 runtime=runtime,
             )
-        except LLMCallInterrupted:
+        except ExecutionInterrupted as exc:
             interrupted = await self._interrupt_if_requested(
                 runtime=runtime,
                 context=context,
-                label="during_enrichment",
+                label=(
+                    "during_tool"
+                    if isinstance(exc, ToolCallInterrupted)
+                    else "during_enrichment"
+                ),
             )
             if interrupted is None:
                 raise
@@ -1454,8 +1462,10 @@ class ReActPattern(AgentPattern):
     def _tool_is_concurrency_safe(self, name: str, tools: list[Any]) -> bool:
         """Whether ``name`` may run concurrently with other safe tools.
 
-        Conservative: unknown tools and tools without the metadata flag are
-        treated as not safe.
+        The metadata flag is also the tool author's idempotency declaration:
+        an interrupted call can be retried on resume when cancellation races
+        with an external side effect. Unknown tools and tools without the flag
+        are conservatively kept serial.
         """
         try:
             tool = self._find_tool(name, tools)
@@ -1559,11 +1569,36 @@ class ReActPattern(AgentPattern):
         # bug. The serial path lets those propagate and halt the turn; re-raise
         # here so the concurrent path behaves identically instead of
         # mis-reporting infrastructure breakage to the model as a tool failure.
-        # Re-raising before backfill leaves the whole (idempotent) segment
-        # pending, so resume re-runs it cleanly (I5).
+        # Infrastructure failures preserve the historical all-or-nothing
+        # behavior: do not backfill any result before propagating the failure.
         for result in raw_results:
-            if isinstance(result, BaseException):
+            if isinstance(result, BaseException) and not isinstance(
+                result, ToolCallInterrupted
+            ):
                 raise result
+
+        interrupted = next(
+            (
+                result
+                for result in raw_results
+                if isinstance(result, ToolCallInterrupted)
+            ),
+            None,
+        )
+        if interrupted is not None:
+            completed_ids: set[str] = set()
+            for tool_call, result in zip(batch, raw_results):
+                if isinstance(result, BaseException):
+                    continue
+                self._backfill_result(tool_call, result, context)
+                completed_ids.add(str(tool_call.get("id") or ""))
+            self._reorder_ledger_for_batch(batch)
+            self.pending_tool_calls = [
+                tool_call
+                for tool_call in self.pending_tool_calls
+                if str(tool_call.get("id") or "") not in completed_ids
+            ]
+            raise interrupted
 
         for tool_call, result in zip(batch, raw_results):
             self._backfill_result(tool_call, result, context)

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1588,16 +1588,13 @@ class ReActPattern(AgentPattern):
             None,
         )
         if infra_error is not None or interrupted is not None:
+            completed_call_objects: set[int] = set()
             for tool_call, result in zip(batch, raw_results):
                 if isinstance(result, BaseException):
                     continue
                 self._backfill_result(tool_call, result, context)
+                completed_call_objects.add(id(tool_call))
             self._reorder_ledger_for_batch(batch)
-            completed_call_objects = {
-                id(tool_call)
-                for tool_call, result in zip(batch, raw_results)
-                if not isinstance(result, BaseException)
-            }
             self.pending_tool_calls = [
                 tool_call
                 for tool_call in self.pending_tool_calls

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1564,19 +1564,21 @@ class ReActPattern(AgentPattern):
         )
 
         # Tool-level failures are already converted to error dicts inside
-        # _execute_tool_safely, so anything coming back as a real exception is an
-        # infra-callback failure (on_tool_start/on_tool_end) or an unexpected
-        # bug. The serial path lets those propagate and halt the turn; re-raise
-        # here so the concurrent path behaves identically instead of
-        # mis-reporting infrastructure breakage to the model as a tool failure.
-        # Infrastructure failures preserve the historical all-or-nothing
-        # behavior: do not backfill any result before propagating the failure.
-        for result in raw_results:
-            if isinstance(result, BaseException) and not isinstance(
-                result, ToolCallInterrupted
-            ):
-                raise result
-
+        # _execute_tool_safely. Reconcile the successful calls before propagating
+        # any real exception so a mixed infra-failure/interrupt batch cannot
+        # replay work that already completed. Keep exceptional calls pending by
+        # their object identity in this batch: provider-supplied ids are not
+        # guaranteed unique, so id-based filtering could accidentally drop a
+        # different call.
+        infra_error = next(
+            (
+                result
+                for result in raw_results
+                if isinstance(result, BaseException)
+                and not isinstance(result, ToolCallInterrupted)
+            ),
+            None,
+        )
         interrupted = next(
             (
                 result
@@ -1585,19 +1587,28 @@ class ReActPattern(AgentPattern):
             ),
             None,
         )
-        if interrupted is not None:
-            completed_ids: set[str] = set()
+        if infra_error is not None or interrupted is not None:
             for tool_call, result in zip(batch, raw_results):
                 if isinstance(result, BaseException):
                     continue
                 self._backfill_result(tool_call, result, context)
-                completed_ids.add(str(tool_call.get("id") or ""))
             self._reorder_ledger_for_batch(batch)
+            completed_call_objects = {
+                id(tool_call)
+                for tool_call, result in zip(batch, raw_results)
+                if not isinstance(result, BaseException)
+            }
             self.pending_tool_calls = [
                 tool_call
                 for tool_call in self.pending_tool_calls
-                if str(tool_call.get("id") or "") not in completed_ids
+                if id(tool_call) not in completed_call_objects
             ]
+            # Preserve the serial path's infra-error priority while keeping the
+            # ledger, context, and pending queue consistent for diagnostics or
+            # an explicit retry.
+            if infra_error is not None:
+                raise infra_error
+            assert interrupted is not None
             raise interrupted
 
         for tool_call, result in zip(batch, raw_results):

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -11,7 +11,7 @@ from ..model.intent import enter_goal, exit_goal
 from ..workspace import WorkspaceManager
 from .context import ContextManager, ExecutionContext
 from .result import extract_assistant_message
-from .runtime import LLMCallInterrupted, PatternRuntime, load_pattern_checkpoint
+from .runtime import ExecutionInterrupted, PatternRuntime, load_pattern_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +162,7 @@ class AgentRunner:
                                 streaming_handler=streaming_handler,
                             )
                         )
-                    except LLMCallInterrupted as exc:
+                    except ExecutionInterrupted as exc:
                         normalized = {
                             "success": False,
                             "status": "interrupted",

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -28,6 +28,15 @@ class LLMCallInterrupted(Exception):
     """Raised when an active LLM call is cancelled by an execution interrupt."""
 
 
+class ToolCallInterrupted(LLMCallInterrupted):
+    """Raised when an active tool call is cancelled by an execution interrupt.
+
+    Subclassing the existing interruption signal keeps pattern and runner
+    boundaries compatible while allowing tool execution to distinguish the
+    cancellation and close its trace cleanly.
+    """
+
+
 async def prepare_llm_for_context(
     *,
     llm: Any,
@@ -104,11 +113,19 @@ class PatternRuntime:
         init=False,
         repr=False,
     )
+    _active_tool_tasks: set[asyncio.Future[Any]] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
 
     def request_interrupt(self, reason: str | None = None) -> None:
         self._interrupt_requested = True
         self.interrupt_reason = reason
         for task in list(self._active_llm_tasks):
+            if not task.done():
+                task.cancel()
+        for task in list(self._active_tool_tasks):
             if not task.done():
                 task.cancel()
 
@@ -156,6 +173,33 @@ class PatternRuntime:
             raise
         finally:
             self._active_llm_tasks.discard(task)
+
+    async def run_tool_call(self, invoke: Callable[[], Any]) -> Any:
+        """Run a tool call as a cancellable subtask owned by this runtime."""
+
+        if self._interrupt_requested:
+            raise ToolCallInterrupted(
+                self.interrupt_reason or "interrupted before tool call"
+            )
+
+        call = invoke()
+        if not inspect.isawaitable(call):
+            return call
+
+        task: asyncio.Future[Any] = asyncio.ensure_future(call)
+        self._active_tool_tasks.add(task)
+        try:
+            return await task
+        except asyncio.CancelledError as exc:
+            if self._interrupt_requested:
+                raise ToolCallInterrupted(
+                    self.interrupt_reason or "interrupted during tool call"
+                ) from exc
+            raise
+        finally:
+            if not task.done():
+                task.cancel()
+            self._active_tool_tasks.discard(task)
 
     async def stream_final_answer(self, llm: Any, **kwargs: Any) -> Any:
         """Stream only the final user-facing answer through the outbound boundary."""
@@ -781,6 +825,43 @@ class PatternRuntime:
             "name": f"tool.{tool_call['name']}",
             "status": "error",
             "output": {"error": str(error)},
+        }
+        self.finished_spans.append(payload)
+        finish_span = getattr(self.tracer, "finish_span", None)
+        if callable(finish_span):
+            await self._maybe_await(finish_span(**payload))
+
+    async def on_tool_cancelled(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        reason: str | None = None,
+    ) -> None:
+        """Close an in-flight tool trace without reporting a pause as an error."""
+
+        cancellation_reason = reason or "Tool execution interrupted"
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL),
+            task_id=self._task_id_from_payload(tool_call),
+            step_id=self._step_id_from_payload(tool_call),
+            data={
+                "tool_name": tool_call.get("name"),
+                "tool_params": tool_call.get("args", {}),
+                "tool_call_id": tool_call.get("id"),
+                "success": False,
+                "interrupted": True,
+                "interrupt_reason": cancellation_reason,
+            },
+        )
+        if self.tracer is None:
+            return
+        payload = {
+            "name": f"tool.{tool_call['name']}",
+            "status": "cancelled",
+            "output": {
+                "interrupted": True,
+                "reason": cancellation_reason,
+            },
         }
         self.finished_spans.append(payload)
         finish_span = getattr(self.tracer, "finish_span", None)

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -24,17 +24,16 @@ from .streaming import merge_streamed_tool_call_arguments
 logger = logging.getLogger(__name__)
 
 
-class LLMCallInterrupted(Exception):
+class ExecutionInterrupted(Exception):
+    """Base signal for an execution interrupted at an active I/O boundary."""
+
+
+class LLMCallInterrupted(ExecutionInterrupted):
     """Raised when an active LLM call is cancelled by an execution interrupt."""
 
 
-class ToolCallInterrupted(LLMCallInterrupted):
-    """Raised when an active tool call is cancelled by an execution interrupt.
-
-    Subclassing the existing interruption signal keeps pattern and runner
-    boundaries compatible while allowing tool execution to distinguish the
-    cancellation and close its trace cleanly.
-    """
+class ToolCallInterrupted(ExecutionInterrupted):
+    """Raised when an active tool call is cancelled by an execution interrupt."""
 
 
 async def prepare_llm_for_context(
@@ -779,17 +778,11 @@ class PatternRuntime:
                 "success": True,
             },
         )
-        if self.tracer is None:
-            return
-        payload = {
-            "name": f"tool.{tool_call['name']}",
-            "status": "success",
-            "output": result,
-        }
-        self.finished_spans.append(payload)
-        finish_span = getattr(self.tracer, "finish_span", None)
-        if callable(finish_span):
-            await self._maybe_await(finish_span(**payload))
+        await self._finish_tool_span(
+            tool_call=tool_call,
+            status="success",
+            output=result,
+        )
 
     async def on_tool_error(
         self,
@@ -819,17 +812,11 @@ class PatternRuntime:
             step_id=self._step_id_from_payload(tool_call),
             data=data,
         )
-        if self.tracer is None:
-            return
-        payload = {
-            "name": f"tool.{tool_call['name']}",
-            "status": "error",
-            "output": {"error": str(error)},
-        }
-        self.finished_spans.append(payload)
-        finish_span = getattr(self.tracer, "finish_span", None)
-        if callable(finish_span):
-            await self._maybe_await(finish_span(**payload))
+        await self._finish_tool_span(
+            tool_call=tool_call,
+            status="error",
+            output={"error": str(error)},
+        )
 
     async def on_tool_cancelled(
         self,
@@ -853,15 +840,30 @@ class PatternRuntime:
                 "interrupt_reason": cancellation_reason,
             },
         )
+        await self._finish_tool_span(
+            tool_call=tool_call,
+            status="cancelled",
+            output={
+                "interrupted": True,
+                "reason": cancellation_reason,
+            },
+        )
+
+    async def _finish_tool_span(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        status: str,
+        output: Any,
+    ) -> None:
+        """Finish one tool span with the common tracer bookkeeping."""
+
         if self.tracer is None:
             return
         payload = {
             "name": f"tool.{tool_call['name']}",
-            "status": "cancelled",
-            "output": {
-                "interrupted": True,
-                "reason": cancellation_reason,
-            },
+            "status": status,
+            "output": output,
         }
         self.finished_spans.append(payload)
         finish_span = getattr(self.tracer, "finish_span", None)

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -378,8 +378,9 @@ class MCPToolAdapter(AbstractBaseTool):
                 (``normalize_mcp_server_name``), surfaced on
                 ``metadata.source_server`` so server-scoped selection matches
                 by structured equality rather than re-parsing the tool name.
-            concurrency_safe: Whether the server operator has opted this MCP
-                server into concurrent tool execution.
+            concurrency_safe: Whether the server operator guarantees these MCP
+                tools are both concurrency-safe and idempotent when retried
+                after interruption.
             concurrent_tools: Optional allowlist of raw MCP tool names. Empty
                 means every tool from an opted-in server is safe.
         """

--- a/src/xagent/core/tools/core/mcp/data_config.py
+++ b/src/xagent/core/tools/core/mcp/data_config.py
@@ -64,7 +64,10 @@ class MCPServerConfig(BaseModel):
     )
     concurrency_safe: bool = Field(
         False,
-        description="Whether this server's MCP tools may run concurrently",
+        description=(
+            "Whether this server's MCP tools may run concurrently and are "
+            "idempotent when retried after interruption"
+        ),
     )
     concurrent_tools: List[str] = Field(
         default_factory=list,

--- a/tests/core/agent/concurrency_harness.py
+++ b/tests/core/agent/concurrency_harness.py
@@ -24,6 +24,7 @@ This is test-support code (no production logic); it is exercised by
 from __future__ import annotations
 
 import asyncio
+import inspect
 import itertools
 from typing import Any
 
@@ -229,6 +230,12 @@ class FakeRuntime:
         self._interrupt = True
         self.interrupt_reason = reason
 
+    async def run_tool_call(self, invoke: Any) -> Any:
+        result = invoke()
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def checkpoint(
         self,
         status: str,
@@ -273,6 +280,20 @@ class FakeRuntime:
                     "tool_call_id": self._tool_call_id(tool_call),
                     "error": str(error),
                     "result": result,
+                },
+            )
+        )
+
+    async def on_tool_cancelled(
+        self, *, tool_call: dict[str, Any], reason: str | None = None
+    ) -> None:
+        self.events.append(
+            (
+                "on_tool_cancelled",
+                {
+                    "tool_name": tool_call.get("name"),
+                    "tool_call_id": self._tool_call_id(tool_call),
+                    "reason": reason,
                 },
             )
         )

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -955,6 +956,66 @@ async def test_auto_react_repetition_stays_in_single_react_trace() -> None:
     assert "auto_child_reroute" not in [
         checkpoint["label"] for checkpoint in runtime.checkpoints
     ]
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_cancels_child_react_tool() -> None:
+    class SlowVisionTool:
+        name = "understand_images"
+        description = "Analyze an image."
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        async def ainvoke(self, _args: dict[str, Any]) -> Any:
+            self.started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+            return {"success": True, "answer": "never"}
+
+    llm = FakeLLM(
+        [
+            decision_tool_response("react", "Image inspection needs a tool."),
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "vision-1",
+                        "function": {
+                            "name": "understand_images",
+                            "arguments": json.dumps(
+                                {
+                                    "images": "file-id",
+                                    "question": "What is shown?",
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    runtime = PatternRuntime(execution_id="auto-cancel-tool")
+    pattern = AutoPattern(react_pattern=ReActPattern(max_iterations=2))
+    context = ExecutionContext(execution_id="auto-cancel-tool")
+    context.add_user_message("Inspect this image.")
+    tool = SlowVisionTool()
+
+    task = asyncio.create_task(
+        pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+    )
+    await tool.started.wait()
+    runtime.request_interrupt("paused by websocket")
+    result = await task
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert result["interrupt_reason"] == "paused by websocket"
+    assert tool.cancelled.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1417,6 +1417,99 @@ async def test_dag_pattern_concurrent_interrupt_cancels_sibling_and_replans(
 
 
 @pytest.mark.asyncio
+async def test_dag_interrupt_cancels_in_flight_step_tool() -> None:
+    class SlowVisionTool:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+            self.metadata = type(
+                "Metadata",
+                (),
+                {
+                    "name": "understand_images",
+                    "description": "Analyze an image.",
+                },
+            )()
+
+        def args_type(self) -> type:
+            class Args:
+                @staticmethod
+                def model_json_schema() -> dict[str, Any]:
+                    return {
+                        "type": "object",
+                        "properties": {
+                            "images": {"type": "string"},
+                            "question": {"type": "string"},
+                        },
+                    }
+
+            return Args
+
+        async def run_json_async(self, _args: dict[str, Any]) -> Any:
+            self.started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+            return {"success": True, "answer": "never"}
+
+    runtime = PatternRuntime(execution_id="dag-cancel-tool")
+    tool = SlowVisionTool()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(
+                id="inspect",
+                task="Inspect the image",
+                tool_names=["understand_images"],
+            )
+        ),
+        react_max_iterations=2,
+    )
+    context = ExecutionContext(execution_id="dag-cancel-tool")
+    context.add_user_message("Inspect this image.")
+    llm = SequenceLLM(
+        [
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "dag-vision-1",
+                        "function": {
+                            "name": "understand_images",
+                            "arguments": json.dumps(
+                                {
+                                    "images": "file-id",
+                                    "question": "What is shown?",
+                                }
+                            ),
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+    task = asyncio.create_task(
+        pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+    )
+    await tool.started.wait()
+    runtime.request_interrupt("pause DAG tool")
+    result = await task
+
+    assert result["status"] == "interrupted"
+    assert result["active_step_id"] == "inspect"
+    assert tool.cancelled.is_set()
+    child_checkpoint = next(
+        checkpoint
+        for checkpoint in runtime.checkpoints
+        if checkpoint["label"] == "dag_interrupted"
+        and checkpoint["metadata"].get("child_label") == "interrupted"
+    )
+    assert child_checkpoint["metadata"]["safe_point"] == "during_tool"
+
+
+@pytest.mark.asyncio
 async def test_dag_pattern_concurrent_failure_clears_cancelled_sibling() -> None:
     class FailingAndSlowLLM:
         def __init__(self) -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -15,6 +15,7 @@ from xagent.core.agent import (
     PatternRuntime,
     ReActPattern,
     ReActReasoningMode,
+    ToolCallInterrupted,
     ToolCallRecord,
 )
 from xagent.core.model.chat.basic.router import RouterLLM
@@ -1342,6 +1343,45 @@ async def test_react_passes_runtime_step_to_browser_tool_call() -> None:
             "_xagent_step_id": "render_english_poster",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_react_interrupt_cancels_in_flight_tool() -> None:
+    class SlowVisionTool:
+        name = "understand_images"
+        description = "Analyze an image."
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        async def ainvoke(self, _args: dict[str, Any]) -> Any:
+            self.started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+            return {"success": True, "answer": "never"}
+
+    pattern = ReActPattern()
+    runtime = PatternRuntime()
+    tool = SlowVisionTool()
+    tool_call = {
+        "id": "call-vision",
+        "name": "understand_images",
+        "args": {"images": "file-id", "question": "What is shown?"},
+    }
+    task = asyncio.create_task(pattern._execute_tool_safely(tool_call, [tool], runtime))
+    await tool.started.wait()
+
+    runtime.request_interrupt("paused by websocket")
+
+    with pytest.raises(ToolCallInterrupted, match="paused by websocket"):
+        await task
+    assert tool.cancelled.is_set()
+    assert pattern.tool_ledger["call-vision"].status == "interrupted"
+    assert pattern.tool_ledger["call-vision"].error == "paused by websocket"
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -1385,6 +1385,66 @@ async def test_react_interrupt_cancels_in_flight_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_tool_interrupt_checkpoint_uses_tool_safe_point() -> None:
+    class SlowVisionTool:
+        name = "understand_images"
+        description = "Analyze an image."
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+
+        async def ainvoke(self, _args: dict[str, Any]) -> Any:
+            self.started.set()
+            await asyncio.sleep(60)
+            return {"success": True, "answer": "never"}
+
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="react-tool-safe-point")
+    context = ExecutionContext(execution_id="react-tool-safe-point")
+    context.add_user_message("Inspect this image.")
+    tool = SlowVisionTool()
+    llm = FakeLLM(
+        [
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "vision-1",
+                        "function": {
+                            "name": "understand_images",
+                            "arguments": json.dumps(
+                                {
+                                    "images": "file-id",
+                                    "question": "What is shown?",
+                                }
+                            ),
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+    task = asyncio.create_task(
+        pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+    )
+    await tool.started.wait()
+    runtime.request_interrupt("paused by websocket")
+    result = await task
+
+    assert result["status"] == "interrupted"
+    checkpoint = next(
+        checkpoint
+        for checkpoint in reversed(runtime.checkpoints)
+        if checkpoint["label"] == "interrupted"
+    )
+    assert checkpoint["metadata"] == {
+        "safe_point": "during_tool",
+        "reason": "paused by websocket",
+    }
+
+
+@pytest.mark.asyncio
 async def test_react_sanitizes_tool_args_before_trace_and_execution() -> None:
     class CapturingRuntime(PatternRuntime):
         def __init__(self) -> None:

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -27,6 +27,7 @@ from tests.core.agent.concurrency_harness import (
     make_react,
     make_tool_call,
 )
+from xagent.core.agent import PatternRuntime, ToolCallInterrupted
 
 
 async def test_ordered_backfill_despite_out_of_order_completion() -> None:
@@ -188,8 +189,8 @@ async def test_concurrent_batch_propagates_infra_callback_failure() -> None:
     # failure. The serial path lets it propagate and halt the turn; the
     # concurrent path must do the same instead of mis-reporting infrastructure
     # breakage to the model as a tool-failure result. The exception is re-raised
-    # before backfill, so nothing is committed to the context and the whole
-    # (idempotent) segment stays pending for a clean re-run on resume.
+    # after successful neighbors are back-filled so an explicit retry cannot
+    # repeat work that already completed.
     class _BoomOnFirst(FakeRuntime):
         async def on_tool_start(self, *, tool_call: dict) -> None:
             if tool_call["name"] == "boom":
@@ -208,10 +209,79 @@ async def test_concurrent_batch_propagates_infra_callback_failure() -> None:
     with pytest.raises(RuntimeError, match="trace down"):
         await pattern._run_concurrent_batch(batch, tools, _BoomOnFirst(), context)
 
-    # Nothing was back-filled (the turn halts; the segment re-runs on resume)...
-    assert context.tool_results == []
-    # ...but the failing call still reaches a terminal ledger state (I3 walk).
+    assert [result["tool_name"] for result in context.tool_results] == ["s1", "s3"]
+    # The failing call still reaches a terminal ledger state (I3 walk).
     assert pattern.tool_ledger[batch[1]["id"]].status == "failed"
+
+
+async def test_mixed_infra_failure_and_interrupt_reconciles_batch_before_raise() -> (
+    None
+):
+    class _BoomOnStart(PatternRuntime):
+        async def on_tool_start(self, *, tool_call: dict) -> None:
+            if tool_call["name"] == "boom":
+                raise RuntimeError("trace down")
+            await super().on_tool_start(tool_call=tool_call)
+
+    blocked = asyncio.Event()
+    tools = [
+        FakeTool("done", concurrency_safe=True),
+        FakeTool("boom", concurrency_safe=True),
+        FakeTool("paused", concurrency_safe=True, gate=blocked),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in ("done", "boom", "paused")]
+    pattern.pending_tool_calls = list(batch)
+    runtime = _BoomOnStart(execution_id="mixed-batch-failure")
+
+    task = asyncio.create_task(
+        pattern._run_concurrent_batch(batch, tools, runtime, context)
+    )
+    while not tools[0].calls or not tools[2].calls:
+        await asyncio.sleep(0)
+    runtime.request_interrupt("pause mixed batch")
+
+    with pytest.raises(RuntimeError, match="trace down"):
+        await task
+
+    assert [result["tool_name"] for result in context.tool_results] == ["done"]
+    assert [call["name"] for call in pattern.pending_tool_calls] == [
+        "boom",
+        "paused",
+    ]
+    assert pattern.tool_ledger[batch[0]["id"]].status == "completed"
+    assert pattern.tool_ledger[batch[1]["id"]].status == "failed"
+    assert pattern.tool_ledger[batch[2]["id"]].status == "interrupted"
+
+
+async def test_interrupt_filter_uses_batch_position_when_ids_repeat() -> None:
+    blocked = asyncio.Event()
+    tools = [
+        FakeTool("done", concurrency_safe=True),
+        FakeTool("paused", concurrency_safe=True, gate=blocked),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=2)
+    context = RecordingContext()
+    batch = [
+        make_tool_call("done", id="provider-duplicate"),
+        make_tool_call("paused", id="provider-duplicate"),
+    ]
+    pattern.pending_tool_calls = list(batch)
+    runtime = PatternRuntime(execution_id="duplicate-provider-ids")
+
+    task = asyncio.create_task(
+        pattern._run_concurrent_batch(batch, tools, runtime, context)
+    )
+    while not tools[0].calls or not tools[1].calls:
+        await asyncio.sleep(0)
+    runtime.request_interrupt("pause duplicate ids")
+
+    with pytest.raises(ToolCallInterrupted, match="pause duplicate ids"):
+        await task
+
+    assert [result["tool_name"] for result in context.tool_results] == ["done"]
+    assert pattern.pending_tool_calls == [batch[1]]
 
 
 # --- Inc.4: tool_ledger ordering after a concurrent batch (I3) -------------

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -16,6 +16,8 @@ behavior:
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from tests.core.agent.concurrency_harness import (
@@ -25,6 +27,7 @@ from tests.core.agent.concurrency_harness import (
     make_react,
     make_tool_call,
 )
+from xagent.core.agent import PatternRuntime, ToolCallInterrupted
 
 
 def _checkpoint_statuses(runtime: FakeRuntime) -> list[str]:
@@ -143,6 +146,43 @@ async def test_interrupt_after_capped_batch_preserves_remaining() -> None:
     # Only the first capped batch ran; the remainder is preserved for resume.
     assert [r["tool_name"] for r in context.tool_results] == ["s1", "s2"]
     assert [tc["name"] for tc in pattern.pending_tool_calls] == ["s3", "s4"]
+
+
+async def test_interrupt_during_batch_preserves_completed_results() -> None:
+    blocked = asyncio.Event()
+    tools = [
+        FakeTool("s1", read_only=True),
+        FakeTool("s2", read_only=True, gate=blocked),
+    ]
+    pattern = _make_pattern(max_concurrency=2)
+    calls = [make_tool_call("s1"), make_tool_call("s2")]
+    pattern.pending_tool_calls = list(calls)
+    context = RecordingContext()
+    runtime = PatternRuntime(execution_id="partial-batch-interrupt")
+
+    task = asyncio.create_task(
+        pattern._execute_pending_tool_calls(
+            context=context,
+            tools=tools,
+            llm=None,
+            runtime=runtime,
+        )
+    )
+    while (
+        pattern.tool_ledger.get(calls[0]["id"]) is None
+        or pattern.tool_ledger[calls[0]["id"]].status != "completed"
+        or not tools[1].calls
+    ):
+        await asyncio.sleep(0)
+
+    runtime.request_interrupt("pause partial batch")
+    with pytest.raises(ToolCallInterrupted, match="pause partial batch"):
+        await task
+
+    assert [result["tool_name"] for result in context.tool_results] == ["s1"]
+    assert [call["name"] for call in pattern.pending_tool_calls] == ["s2"]
+    assert pattern.tool_ledger[calls[0]["id"]].status == "completed"
+    assert pattern.tool_ledger[calls[1]["id"]].status == "interrupted"
 
 
 async def test_concurrent_batch_then_unsafe_serial_preserves_order() -> None:

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -12,6 +12,7 @@ from xagent.core.agent.pattern.final_answer_stream import (
 )
 from xagent.core.agent.runtime import (
     LLMCallInterrupted,
+    ToolCallInterrupted,
     prepare_llm_for_context,
     resolved_llm_metadata,
 )
@@ -318,6 +319,76 @@ async def test_runtime_interrupt_converts_active_llm_cancel() -> None:
 
     with pytest.raises(LLMCallInterrupted, match="stop now"):
         await task
+
+
+@pytest.mark.asyncio
+async def test_runtime_interrupt_cancels_active_tool_call() -> None:
+    runtime = PatternRuntime()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow_tool() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "never"
+
+    task = asyncio.create_task(runtime.run_tool_call(slow_tool))
+    await started.wait()
+    runtime.request_interrupt("pause now")
+
+    with pytest.raises(ToolCallInterrupted, match="pause now"):
+        await task
+    assert cancelled.is_set()
+    assert not runtime._active_tool_tasks
+
+
+@pytest.mark.asyncio
+async def test_external_cancellation_cleans_up_active_tool_call() -> None:
+    runtime = PatternRuntime()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow_tool() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "never"
+
+    outer_task = asyncio.create_task(runtime.run_tool_call(slow_tool))
+    await started.wait()
+    tool_task = next(iter(runtime._active_tool_tasks))
+
+    outer_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer_task
+
+    assert tool_task.cancelled()
+    assert cancelled.is_set()
+    assert not runtime._active_tool_tasks
+
+
+@pytest.mark.asyncio
+async def test_runtime_does_not_start_tool_after_interrupt() -> None:
+    runtime = PatternRuntime()
+    invoked = False
+
+    async def tool() -> str:
+        nonlocal invoked
+        invoked = True
+        return "never"
+
+    runtime.request_interrupt("already paused")
+
+    with pytest.raises(ToolCallInterrupted, match="already paused"):
+        await runtime.run_tool_call(tool)
+    assert invoked is False
 
 
 @pytest.mark.asyncio
@@ -685,6 +756,27 @@ async def test_runtime_trace_events_are_best_effort() -> None:
     )
 
     await runtime.on_llm_start(context=ExecutionContext(), messages=[], tools=[])
+
+
+@pytest.mark.asyncio
+async def test_on_tool_cancelled_closes_trace_without_error_event() -> None:
+    tracer = CheckpointTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="task-cancelled-tool")
+
+    await runtime.on_tool_cancelled(
+        tool_call={"name": "understand_images", "args": {}, "id": "vision-1"},
+        reason="paused by user",
+    )
+
+    assert [event["event_type"] for event in tracer.events] == ["action_end_tool"]
+    assert tracer.events[0]["data"] == {
+        "tool_name": "understand_images",
+        "tool_params": {},
+        "tool_call_id": "vision-1",
+        "success": False,
+        "interrupted": True,
+        "interrupt_reason": "paused by user",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- track active tool awaitables in `PatternRuntime` and cancel them when an execution interrupt is requested
- propagate cancellable tool execution through Auto and DAG child runtimes
- record interrupted tool calls as a non-error terminal trace so the UI does not leave them spinning

## Root cause

Execution interrupts only cancelled runtime-owned LLM tasks. ReAct awaited tool calls directly, so a pause received during a long `understand_images` request could not take effect until the vision request returned.

## Impact

Pausing a task now immediately interrupts asynchronous tools such as `understand_images`, and the behavior is consistent in ReAct, Auto, and DAG execution. Thread-backed synchronous tools stop blocking the agent promptly, although Python cannot forcibly terminate an already-running worker thread.

## Validation

- `PYTHONPATH=src pytest -q tests/core/agent/test_runtime.py tests/core/agent/test_react.py tests/core/agent/test_react_concurrent_batch.py tests/core/agent/test_react_segment_loop.py`
- `PYTHONPATH=src pytest -q tests/core/agent/test_dag.py tests/core/agent/test_runner.py tests/core/agent/test_auto.py`
- focused Auto child cancellation regression test
- `pre-commit run`