### PR TITLE
enh: track provider prompt-cache token usage

### DIFF
--- a/frontend/src/components/chat/TokenUsageDisplay.test.tsx
+++ b/frontend/src/components/chat/TokenUsageDisplay.test.tsx
@@ -313,6 +313,30 @@ describe("TokenUsageDisplay cached tokens", () => {
     expect(screen.getByText("75k")).toHaveAttribute("title", "75,000")
   })
 
+  it("suppresses the cached share when input tokens are zero", async () => {
+    // Malformed/partial backend data: cached > 0 with input == 0 must not
+    // render a NaN/Infinity percentage.
+    apiRequestMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          input_tokens: 0,
+          output_tokens: 5,
+          total_tokens: 5,
+          llm_calls: 1,
+          cached_input_tokens: 75_000,
+          model_usage: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    render(<TokenUsageDisplay taskId={13} isRunning={false} />)
+
+    await screen.findByText("Input")
+    expect(screen.queryByText(/% cached/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/NaN|Infinity/)).not.toBeInTheDocument()
+  })
+
   it("hides the cached share when the backend reports no cache usage", async () => {
     apiRequestMock.mockResolvedValue(
       new Response(

--- a/frontend/src/components/chat/TokenUsageDisplay.test.tsx
+++ b/frontend/src/components/chat/TokenUsageDisplay.test.tsx
@@ -22,8 +22,11 @@ vi.mock("@/contexts/i18n-context", () => ({
       const message = {
         "chatPage.tokenUsage.input": "Input tokens",
         "chatPage.tokenUsage.output": "Output tokens",
+        "chatPage.tokenUsage.cached": "Cached input tokens",
         "chatPage.tokenUsage.inputShort": "Input",
         "chatPage.tokenUsage.outputShort": "Output",
+        "chatPage.tokenUsage.cachedShort": "Cached",
+        "chatPage.tokenUsage.cachedShare": "{pct}% cached",
         "chatPage.tokenUsage.oneModel": "{count} model",
         "chatPage.tokenUsage.models": "{count} models",
         "chatPage.tokenUsage.oneModelWithUnattributed": "{count} model + {unattributed} unattributed",
@@ -132,7 +135,7 @@ describe("TokenUsageDisplay", () => {
     fireEvent.click(screen.getByRole("button", { name: /2 models/ }))
 
     const modelUsageDialog = await screen.findByRole("dialog")
-    expect(modelUsageDialog).toHaveClass("w-[28rem]")
+    expect(modelUsageDialog).toHaveClass("w-[32rem]")
     expect(screen.getAllByText("Input")).toHaveLength(2)
     expect(screen.getAllByText("Output")).toHaveLength(2)
     expect(screen.getByText("deepseek/deepseek-v4-pro")).toBeInTheDocument()
@@ -260,4 +263,82 @@ describe("TokenUsageDisplay", () => {
       expect(screen.queryByRole("button")).not.toBeInTheDocument()
     },
   )
+})
+
+describe("TokenUsageDisplay cached tokens", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    i18nMock.locale = "en"
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("shows the cached share and a per-model cached column", async () => {
+    apiRequestMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          input_tokens: 100_000,
+          output_tokens: 5_000,
+          total_tokens: 105_000,
+          llm_calls: 2,
+          cached_input_tokens: 75_000,
+          model_usage: [
+            {
+              model_id: "main",
+              model_name: "claude-sonnet-5",
+              input_tokens: 100_000,
+              output_tokens: 5_000,
+              cached_input_tokens: 75_000,
+              cache_write_input_tokens: 1_000,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    render(<TokenUsageDisplay taskId={11} isRunning={false} />)
+
+    const share = await screen.findByText("75% cached")
+    expect(share).toHaveAttribute("title", "Cached input tokens: 75,000")
+
+    fireEvent.click(screen.getByRole("button", { name: /^1 model$/ }))
+    await screen.findByRole("dialog")
+    expect(screen.getByText("Cached")).toHaveAttribute(
+      "title",
+      "Cached input tokens",
+    )
+    expect(screen.getByText("75k")).toHaveAttribute("title", "75,000")
+  })
+
+  it("hides the cached share when the backend reports no cache usage", async () => {
+    apiRequestMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          input_tokens: 100,
+          output_tokens: 5,
+          total_tokens: 105,
+          llm_calls: 1,
+          model_usage: [
+            {
+              model_id: "main",
+              model_name: "gpt-4.1",
+              input_tokens: 100,
+              output_tokens: 5,
+              cached_input_tokens: 0,
+              cache_write_input_tokens: 0,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    render(<TokenUsageDisplay taskId={12} isRunning={false} />)
+
+    await screen.findByText("Input")
+    expect(screen.queryByText(/% cached/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/chat/TokenUsageDisplay.tsx
+++ b/frontend/src/components/chat/TokenUsageDisplay.tsx
@@ -17,6 +17,7 @@ interface TokenUsage {
   output_tokens: number;
   total_tokens: number;
   llm_calls: number;
+  cached_input_tokens: number;
   model_usage: ModelTokenUsage[];
 }
 
@@ -25,6 +26,7 @@ interface ModelTokenUsage {
   model_name: string;
   input_tokens: number;
   output_tokens: number;
+  cached_input_tokens?: number;
 }
 
 // Build formatters lazily per locale so this file stays valid regardless of the
@@ -83,6 +85,7 @@ export function TokenUsageDisplay({ taskId, isRunning, className }: TokenUsageDi
             output_tokens: data.output_tokens || 0,
             total_tokens: data.total_tokens || 0,
             llm_calls: data.llm_calls || 0,
+            cached_input_tokens: data.cached_input_tokens || 0,
             model_usage: Array.isArray(data.model_usage) ? data.model_usage : [],
           });
         }
@@ -138,6 +141,19 @@ export function TokenUsageDisplay({ taskId, isRunning, className }: TokenUsageDi
         >
           {t('chatPage.tokenUsage.inputShort')}
         </span>
+        {usage.cached_input_tokens > 0 && usage.input_tokens > 0 && (
+          <span
+            className="text-muted-foreground"
+            title={`${t('chatPage.tokenUsage.cached')}: ${formatExactTokenCount(usage.cached_input_tokens, locale)}`}
+          >
+            {t('chatPage.tokenUsage.cachedShare', {
+              pct: Math.min(
+                100,
+                Math.round((usage.cached_input_tokens / usage.input_tokens) * 100),
+              ),
+            })}
+          </span>
+        )}
       </span>
       <span className="flex items-center gap-1.5 whitespace-nowrap">
         <span className="font-medium text-foreground" title={formatExactTokenCount(usage.output_tokens, locale)}>
@@ -163,15 +179,21 @@ export function TokenUsageDisplay({ taskId, isRunning, className }: TokenUsageDi
           </PopoverTrigger>
           <PopoverContent
             align="end"
-            className="w-[28rem] max-w-[calc(100vw-2rem)] p-0"
+            className="w-[32rem] max-w-[calc(100vw-2rem)] p-0"
           >
             <div className="border-b px-3 py-2.5 text-sm font-medium">
               {t('chatPage.tokenUsage.byModel')}
             </div>
-            <div className="grid grid-cols-[minmax(0,1fr)_5rem_5rem] gap-x-4 gap-y-2 p-3 text-xs">
+            <div className="grid grid-cols-[minmax(0,1fr)_5rem_5rem_5rem] gap-x-4 gap-y-2 p-3 text-xs">
               <span className="text-muted-foreground">{t('chatPage.tokenUsage.model')}</span>
               <span className="text-right text-muted-foreground">
                 {t('chatPage.tokenUsage.inputShort')}
+              </span>
+              <span
+                className="text-right text-muted-foreground"
+                title={t('chatPage.tokenUsage.cached')}
+              >
+                {t('chatPage.tokenUsage.cachedShort')}
               </span>
               <span className="text-right text-muted-foreground">
                 {t('chatPage.tokenUsage.outputShort')}
@@ -195,6 +217,12 @@ export function TokenUsageDisplay({ taskId, isRunning, className }: TokenUsageDi
                   </span>
                   <span className="text-right tabular-nums" title={formatExactTokenCount(model.input_tokens, locale)}>
                     {formatTokenCount(model.input_tokens, locale)}
+                  </span>
+                  <span
+                    className="text-right tabular-nums text-muted-foreground"
+                    title={formatExactTokenCount(model.cached_input_tokens ?? 0, locale)}
+                  >
+                    {formatTokenCount(model.cached_input_tokens ?? 0, locale)}
                   </span>
                   <span className="text-right tabular-nums" title={formatExactTokenCount(model.output_tokens, locale)}>
                     {formatTokenCount(model.output_tokens, locale)}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -275,8 +275,11 @@ const en = {
     tokenUsage: {
       input: "Input tokens",
       output: "Output tokens",
+      cached: "Cached input tokens",
       inputShort: "Input",
       outputShort: "Output",
+      cachedShort: "Cached",
+      cachedShare: "{pct}% cached",
       oneModel: "{count} model",
       models: "{count} models",
       oneModelWithUnattributed: "{count} model + {unattributed} unattributed",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -275,8 +275,11 @@ const zh = {
     tokenUsage: {
       input: "输入tokens",
       output: "输出tokens",
+      cached: "缓存命中tokens",
       inputShort: "输入",
       outputShort: "输出",
+      cachedShort: "缓存",
+      cachedShare: "{pct}% 缓存命中",
       oneModel: "{count} 个模型",
       models: "{count} 个模型",
       oneModelWithUnattributed: "{count} 个模型 + {unattributed} 个未归属",

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -16,6 +16,7 @@ from ..agent.trace import (
     normalize_llm_trace_payload,
 )
 from ..model.chat.basic.base import BaseLLM
+from ..model.chat.token_context import extract_cached_input_tokens
 from ..model.chat.tool_protocol import TOOL_PROTOCOL_ERROR_KEY
 from ..model.chat.types import ChunkType
 from .result import normalize_tool_failure_code, tool_result_succeeded
@@ -328,21 +329,27 @@ class PatternRuntime:
         if not usage:
             return {}
         if isinstance(usage, dict):
-            return dict(usage)
-        payload: dict[str, Any] = {}
-        for key in (
-            "prompt_tokens",
-            "completion_tokens",
-            "total_tokens",
-            "input_tokens",
-            "output_tokens",
-            "prompt_token_count",
-            "completion_token_count",
-            "candidates_token_count",
-        ):
-            value = getattr(usage, key, None)
-            if value is not None:
-                payload[key] = value
+            payload = dict(usage)
+        else:
+            payload = {}
+            for key in (
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "input_tokens",
+                "output_tokens",
+                "prompt_token_count",
+                "completion_token_count",
+                "candidates_token_count",
+                "cached_input_tokens",
+            ):
+                value = getattr(usage, key, None)
+                if value is not None:
+                    payload[key] = value
+        if "cached_input_tokens" not in payload:
+            cached = extract_cached_input_tokens(usage)
+            if cached:
+                payload["cached_input_tokens"] = cached
         return payload
 
     def _merge_usage(
@@ -847,6 +854,7 @@ class PatternRuntime:
                 output_tokens=usage[1],
                 prompt_message_count=len(getattr(context, "messages", [])),
             )
+        cached_tokens = self._extract_cached_tokens(response)
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.LLM),
             task_id=str(event_metadata.get("task_id") or self._task_id(context)),
@@ -863,6 +871,7 @@ class PatternRuntime:
                     if usage is not None
                     else {}
                 ),
+                **({"cached_input_tokens": cached_tokens} if cached_tokens else {}),
                 **event_metadata,
             },
         )
@@ -898,6 +907,16 @@ class PatternRuntime:
                 return input_tokens, output_tokens
 
         return None
+
+    def _extract_cached_tokens(self, response: Any) -> int:
+        """Prompt-cache-hit tokens from a response's usage payload, 0 if absent."""
+        usage = self._get_value(response, "usage")
+        if usage is None:
+            return 0
+        direct = self._first_int(usage, ("cached_input_tokens",))
+        if direct > 0:
+            return direct
+        return extract_cached_input_tokens(usage)
 
     def _first_int(self, source: Any, keys: tuple[str, ...]) -> int:
         for key in keys:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -913,7 +913,9 @@ class PatternRuntime:
         usage = self._get_value(response, "usage")
         if usage is None:
             return 0
-        direct = self._first_int(usage, ("cached_input_tokens",))
+        direct = self._first_int(
+            usage, ("cached_input_tokens", "cache_read_input_tokens")
+        )
         if direct > 0:
             return direct
         return extract_cached_input_tokens(usage)

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -90,6 +90,7 @@ _RESERVED_TRACE_FIELDS = frozenset(
         "input_tokens",
         "output_tokens",
         "total_tokens",
+        "cached_input_tokens",
         # cardinality counters (not the values they count)
         "messages_count",
         "candidates_count",

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -798,6 +798,12 @@ class ClaudeLLM(BaseLLM):
         tool_id_by_content_block_index: Dict[int, str] = {}
         current_content = ""
 
+        # Input-side usage arrives on message_start; the final usage chunk is
+        # yielded at message_delta, so carry the values across events.
+        stream_input_tokens = 0
+        stream_cache_read = 0
+        stream_cache_write = 0
+
         try:
             # Convert messages to Anthropic format
             system_message, anthropic_messages = (
@@ -1040,6 +1046,9 @@ class ClaudeLLM(BaseLLM):
                         input_tokens, cache_read, cache_write = _anthropic_input_usage(
                             usage
                         )
+                        stream_input_tokens = input_tokens
+                        stream_cache_read = cache_read
+                        stream_cache_write = cache_write
                         if input_tokens:
                             add_token_usage(
                                 input_tokens=input_tokens,
@@ -1063,13 +1072,22 @@ class ClaudeLLM(BaseLLM):
                                 call_type="stream_chat",
                             )
 
-                        # Yield usage chunk
+                        # Yield usage chunk. Input-side counts come from
+                        # message_start; message_delta usually only carries
+                        # output tokens.
+                        input_total = stream_input_tokens or (
+                            getattr(usage, "input_tokens", 0) or 0
+                        )
+                        output_total = getattr(usage, "output_tokens", 0) or 0
                         usage_dict = {
-                            "input_tokens": getattr(usage, "input_tokens", 0),
-                            "output_tokens": getattr(usage, "output_tokens", 0),
-                            "total_tokens": getattr(usage, "input_tokens", 0)
-                            + getattr(usage, "output_tokens", 0),
+                            "input_tokens": input_total,
+                            "output_tokens": output_total,
+                            "total_tokens": input_total + output_total,
                         }
+                        if stream_cache_read:
+                            usage_dict["cached_input_tokens"] = stream_cache_read
+                        if stream_cache_write:
+                            usage_dict["cache_write_input_tokens"] = stream_cache_write
                         yield StreamChunk(
                             type=ChunkType.USAGE,
                             usage=usage_dict,

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -35,7 +35,13 @@ def _anthropic_input_usage(usage: Any) -> tuple[int, int, int]:
     """
 
     def _count(name: str) -> int:
-        value = getattr(usage, name, 0)
+        # Missing/None/non-numeric values are normal (older SDKs, cache
+        # disabled, message_delta usage) — treat them as 0; token accounting
+        # must never raise out of an LLM call.
+        if isinstance(usage, dict):
+            value = usage.get(name, 0)
+        else:
+            value = getattr(usage, name, 0)
         try:
             return max(0, int(value))
         except (TypeError, ValueError):

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -25,6 +25,27 @@ from .base import BaseLLM
 logger = logging.getLogger(__name__)
 
 
+def _anthropic_input_usage(usage: Any) -> tuple[int, int, int]:
+    """Normalize Anthropic usage to (input_tokens, cache_read, cache_write).
+
+    Anthropic's ``usage.input_tokens`` excludes tokens read from or written to
+    the prompt cache. The normalized total re-adds both so input counts stay
+    comparable across providers, where cached tokens are a subset of the
+    reported input tokens.
+    """
+
+    def _count(name: str) -> int:
+        value = getattr(usage, name, 0)
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return 0
+
+    cache_read = _count("cache_read_input_tokens")
+    cache_write = _count("cache_creation_input_tokens")
+    return _count("input_tokens") + cache_read + cache_write, cache_read, cache_write
+
+
 def _anthropic_stream_tool_calls(
     accumulated_tool_calls: Dict[str, Dict],
 ) -> List[Dict[str, Any]]:
@@ -626,7 +647,7 @@ class ClaudeLLM(BaseLLM):
             # Record token usage
             if hasattr(response, "usage"):
                 usage = response.usage
-                input_tokens = getattr(usage, "input_tokens", 0)
+                input_tokens, cache_read, cache_write = _anthropic_input_usage(usage)
                 output_tokens = getattr(usage, "output_tokens", 0)
                 add_token_usage(
                     input_tokens=input_tokens,
@@ -634,6 +655,8 @@ class ClaudeLLM(BaseLLM):
                     model=self._model_name,
                     model_id=self.model_id,
                     call_type="chat",
+                    cached_input_tokens=cache_read,
+                    cache_write_input_tokens=cache_write,
                 )
 
             # Check for tool use in response
@@ -1012,13 +1035,19 @@ class ClaudeLLM(BaseLLM):
                     # Message start (contains usage info)
                     if hasattr(event, "message") and hasattr(event.message, "usage"):
                         usage = event.message.usage
-                        # Record input tokens
-                        if hasattr(usage, "input_tokens"):
+                        # Record input tokens (cache reads/writes are excluded
+                        # from Anthropic's input_tokens; re-add them)
+                        input_tokens, cache_read, cache_write = _anthropic_input_usage(
+                            usage
+                        )
+                        if input_tokens:
                             add_token_usage(
-                                input_tokens=usage.input_tokens,
+                                input_tokens=input_tokens,
                                 model=self._model_name,
                                 model_id=self.model_id,
                                 call_type="stream_chat",
+                                cached_input_tokens=cache_read,
+                                cache_write_input_tokens=cache_write,
                             )
 
                 elif event.type == "message_delta":

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -725,9 +725,10 @@ class GeminiLLM(BaseLLM):
                     output_tokens = (
                         getattr(usage_metadata, "candidates_token_count", 0) or 0
                     )
-                    cached_tokens = (
-                        getattr(usage_metadata, "cached_content_token_count", 0) or 0
+                    raw_cached = getattr(
+                        usage_metadata, "cached_content_token_count", 0
                     )
+                    cached_tokens = raw_cached if isinstance(raw_cached, int) else 0
 
                     if input_tokens > 0 or output_tokens > 0:
                         usage_received = True
@@ -741,13 +742,16 @@ class GeminiLLM(BaseLLM):
                             cached_input_tokens=cached_tokens,
                         )
 
+                        usage_payload: Dict[str, Any] = {
+                            "prompt_tokens": input_tokens,
+                            "completion_tokens": output_tokens,
+                            "total_tokens": input_tokens + output_tokens,
+                        }
+                        if cached_tokens:
+                            usage_payload["cached_input_tokens"] = cached_tokens
                         yield StreamChunk(
                             type=ChunkType.USAGE,
-                            usage={
-                                "prompt_tokens": input_tokens,
-                                "completion_tokens": output_tokens,
-                                "total_tokens": input_tokens + output_tokens,
-                            },
+                            usage=usage_payload,
                             raw=chunk,
                         )
 

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -485,6 +485,9 @@ class GeminiLLM(BaseLLM):
                 usage_metadata = response.usage_metadata
                 input_tokens = getattr(usage_metadata, "prompt_token_count", 0)
                 output_tokens = getattr(usage_metadata, "candidates_token_count", 0)
+                cached_tokens = (
+                    getattr(usage_metadata, "cached_content_token_count", 0) or 0
+                )
 
                 if input_tokens > 0 or output_tokens > 0:
                     add_token_usage(
@@ -493,6 +496,7 @@ class GeminiLLM(BaseLLM):
                         model=self._model_name,
                         model_id=self.model_id,
                         call_type="chat",
+                        cached_input_tokens=cached_tokens,
                     )
             else:
                 logger.warning("No usage_metadata in Gemini SDK response")
@@ -721,6 +725,9 @@ class GeminiLLM(BaseLLM):
                     output_tokens = (
                         getattr(usage_metadata, "candidates_token_count", 0) or 0
                     )
+                    cached_tokens = (
+                        getattr(usage_metadata, "cached_content_token_count", 0) or 0
+                    )
 
                     if input_tokens > 0 or output_tokens > 0:
                         usage_received = True
@@ -731,6 +738,7 @@ class GeminiLLM(BaseLLM):
                             model=self._model_name,
                             model_id=self.model_id,
                             call_type="stream_chat",
+                            cached_input_tokens=cached_tokens,
                         )
 
                         yield StreamChunk(

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -10,36 +10,13 @@ from openai import AsyncOpenAI
 from ....utils.security import redact_sensitive_text
 from ..exceptions import LLMEmptyContentError, LLMRetryableError, LLMTimeoutError
 from ..timeout_config import TimeoutConfig
-from ..token_context import add_token_usage
+from ..token_context import add_token_usage, extract_cached_input_tokens
 from ..types import ChunkType, StreamChunk
 from .base import BaseLLM
 
 logger = logging.getLogger(__name__)
 
 PROVIDER_STATE_METADATA_KEY = "_xagent_provider_state"
-
-
-def _cached_input_tokens(usage: Any) -> int:
-    """Prompt-cache-hit input tokens from an OpenAI-style usage object.
-
-    DeepSeek reports ``prompt_cache_hit_tokens``; OpenAI/DashScope report
-    ``prompt_tokens_details.cached_tokens``. Returns 0 when unavailable.
-    """
-    if usage is None:
-        return 0
-    hit = getattr(usage, "prompt_cache_hit_tokens", None)
-    if hit is not None:
-        try:
-            return int(hit)
-        except (TypeError, ValueError):
-            return 0
-    details = getattr(usage, "prompt_tokens_details", None)
-    if details is not None:
-        try:
-            return int(getattr(details, "cached_tokens", 0) or 0)
-        except (TypeError, ValueError):
-            return 0
-    return 0
 
 
 def _truncate_error_detail(value: Any, limit: int = 4000) -> str:
@@ -397,7 +374,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=resp.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
-                    cached_input_tokens=_cached_input_tokens(resp.usage),
+                    cached_input_tokens=extract_cached_input_tokens(resp.usage),
                     call_type="chat",
                 )
 
@@ -724,7 +701,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=response.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
-                    cached_input_tokens=_cached_input_tokens(response.usage),
+                    cached_input_tokens=extract_cached_input_tokens(response.usage),
                     call_type="chat",
                 )
 
@@ -1064,7 +1041,7 @@ class OpenAICompatibleLLM(BaseLLM):
                             output_tokens=output_tokens,
                             model=self._model_name,
                             model_id=self.model_id,
-                            cached_input_tokens=_cached_input_tokens(usage),
+                            cached_input_tokens=extract_cached_input_tokens(usage),
                             call_type="stream_chat",
                         )
 
@@ -1155,7 +1132,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=raw_chunk.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
-                    cached_input_tokens=_cached_input_tokens(raw_chunk.usage),
+                    cached_input_tokens=extract_cached_input_tokens(raw_chunk.usage),
                     call_type="stream_chat",
                 )
 

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -8,7 +8,7 @@ from xinference_client import RESTfulClient as XinferenceClient
 
 from ..exceptions import LLMTimeoutError
 from ..timeout_config import TimeoutConfig
-from ..token_context import add_token_usage
+from ..token_context import add_token_usage, extract_cached_input_tokens
 from ..types import ChunkType, StreamChunk
 from .base import BaseLLM
 
@@ -248,6 +248,7 @@ class XinferenceLLM(BaseLLM):
                 model=self._model_name,
                 model_id=self.model_id,
                 call_type="chat",
+                cached_input_tokens=extract_cached_input_tokens(usage),
             )
 
         # Check for tool calls
@@ -508,6 +509,7 @@ class XinferenceLLM(BaseLLM):
                 model=self._model_name,
                 model_id=self.model_id,
                 call_type="stream_chat",
+                cached_input_tokens=extract_cached_input_tokens(usage),
             )
 
         # Check choices

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -532,6 +532,14 @@ class ZhipuLLM(BaseLLM):
                                 )
                                 or getattr(usage, "output_tokens", 0),
                             }
+                            # Preserve cache telemetry across the dict
+                            # conversion in OpenAI shape so the consumer's
+                            # extract_cached_input_tokens still sees it.
+                            cached = extract_cached_input_tokens(usage)
+                            if cached:
+                                usage_dict["prompt_tokens_details"] = {
+                                    "cached_tokens": cached
+                                }
                             chunk_dict["usage"] = usage_dict
 
                         # Put chunk in queue using the event loop from main thread
@@ -685,6 +693,8 @@ class ZhipuLLM(BaseLLM):
                     input_tokens = usage.get("prompt_tokens", 0)
                     output_tokens = usage.get("completion_tokens", 0)
 
+                    cached_tokens = extract_cached_input_tokens(usage)
+
                     # Record token usage
                     add_token_usage(
                         input_tokens=input_tokens,
@@ -692,7 +702,7 @@ class ZhipuLLM(BaseLLM):
                         model=self._model_name,
                         model_id=self.model_id,
                         call_type="stream_chat",
-                        cached_input_tokens=extract_cached_input_tokens(usage),
+                        cached_input_tokens=cached_tokens,
                     )
 
                     # Yield usage chunk
@@ -701,6 +711,8 @@ class ZhipuLLM(BaseLLM):
                         "output_tokens": output_tokens,
                         "total_tokens": input_tokens + output_tokens,
                     }
+                    if cached_tokens:
+                        usage_dict["cached_input_tokens"] = cached_tokens
                     yield StreamChunk(
                         type=ChunkType.USAGE,
                         usage=usage_dict,

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from ..exceptions import LLMRetryableError, LLMTimeoutError
 from ..timeout_config import TimeoutConfig
-from ..token_context import add_token_usage
+from ..token_context import add_token_usage, extract_cached_input_tokens
 from ..types import ChunkType, StreamChunk
 from .base import BaseLLM
 
@@ -236,6 +236,7 @@ class ZhipuLLM(BaseLLM):
                     model=self._model_name,
                     model_id=self.model_id,
                     call_type="chat",
+                    cached_input_tokens=extract_cached_input_tokens(usage),
                 )
 
             # Extract the choice
@@ -691,6 +692,7 @@ class ZhipuLLM(BaseLLM):
                         model=self._model_name,
                         model_id=self.model_id,
                         call_type="stream_chat",
+                        cached_input_tokens=extract_cached_input_tokens(usage),
                     )
 
                     # Yield usage chunk
@@ -862,6 +864,7 @@ class ZhipuLLM(BaseLLM):
                     model=self._model_name,
                     model_id=self.model_id,
                     call_type="vision_chat",
+                    cached_input_tokens=extract_cached_input_tokens(usage),
                 )
 
             # Extract the choice

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -229,7 +229,11 @@ def extract_cached_input_tokens(usage: Any) -> int:
         return 0
     hit = _usage_field(usage, "prompt_cache_hit_tokens")
     if hit is not None:
-        return max(0, _coerce_int(hit))
+        value = max(0, _coerce_int(hit))
+        if value:
+            return value
+        # Some proxies emit prompt_cache_hit_tokens=0 as a default while the
+        # real count sits in prompt_tokens_details; fall through to it.
     details = _usage_field(usage, "prompt_tokens_details")
     if details is not None:
         return max(0, _coerce_int(_usage_field(details, "cached_tokens")))

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -42,11 +42,14 @@ class TokenUsage:
         call_type: str = "",
         model_id: str = "",
         cached_tokens: int = 0,
+        cache_write_tokens: int = 0,
     ) -> None:
         """Add input tokens from a prompt.
 
         ``cached_tokens`` is the subset of ``tokens`` served from the provider's
         prompt cache (usually billed cheaper); 0 when unknown/unsupported.
+        ``cache_write_tokens`` is the subset of ``tokens`` written to the cache
+        this call (Claude bills these at a premium); 0 when unknown.
         """
         self.input_tokens += tokens
         if model or call_type:
@@ -55,6 +58,7 @@ class TokenUsage:
                     "type": "input",
                     "tokens": tokens,
                     "cached_tokens": cached_tokens,
+                    "cache_write_tokens": cache_write_tokens,
                     "model": model,
                     "model_id": model_id,
                     "call_type": call_type,
@@ -206,6 +210,32 @@ def _coerce_int(value: Any) -> int:
         return 0
 
 
+def _usage_field(usage: Any, name: str) -> Any:
+    """Read a field from a provider usage payload (SDK object or plain dict)."""
+    if isinstance(usage, dict):
+        return usage.get(name)
+    return getattr(usage, name, None)
+
+
+def extract_cached_input_tokens(usage: Any) -> int:
+    """Prompt-cache-hit input tokens from an OpenAI-style usage payload.
+
+    Handles both attribute-style SDK objects and plain dicts (streaming chunks
+    often arrive as dicts). DeepSeek reports ``prompt_cache_hit_tokens``;
+    OpenAI/DashScope/Zhipu report ``prompt_tokens_details.cached_tokens``.
+    Returns 0 when unavailable.
+    """
+    if usage is None:
+        return 0
+    hit = _usage_field(usage, "prompt_cache_hit_tokens")
+    if hit is not None:
+        return max(0, _coerce_int(hit))
+    details = _usage_field(usage, "prompt_tokens_details")
+    if details is not None:
+        return max(0, _coerce_int(_usage_field(details, "cached_tokens")))
+    return 0
+
+
 def aggregate_token_usage_by_model(details: Any) -> List[Dict[str, Any]]:
     """Aggregate persisted token detail entries by the actual model used.
 
@@ -296,6 +326,7 @@ def add_token_usage(
     call_type: str = "",
     model_id: str = "",
     cached_input_tokens: int = 0,
+    cache_write_input_tokens: int = 0,
 ) -> None:
     """Add token usage to the current context.
 
@@ -306,12 +337,14 @@ def add_token_usage(
         call_type: Type of call (chat, stream_chat, vision_chat, etc.)
         model_id: Unique model id (disambiguates identically-named models)
         cached_input_tokens: Subset of input_tokens served from prompt cache
+        cache_write_input_tokens: Subset of input_tokens written to the cache
     """
     # Coerce defensively: a provider/response that yields a non-int token count
     # (or a mock in tests) must never crash the LLM call over accounting.
     input_tokens = _coerce_int(input_tokens)
     output_tokens = _coerce_int(output_tokens)
     cached_input_tokens = _coerce_int(cached_input_tokens)
+    cache_write_input_tokens = _coerce_int(cache_write_input_tokens)
 
     usage = get_token_usage()
     if input_tokens or output_tokens:
@@ -319,7 +352,12 @@ def add_token_usage(
         usage.increment_llm_calls()
     if input_tokens:
         usage.add_input_tokens(
-            input_tokens, model, call_type, model_id, cached_input_tokens
+            input_tokens,
+            model,
+            call_type,
+            model_id,
+            cached_input_tokens,
+            cache_write_input_tokens,
         )
     if output_tokens:
         usage.add_output_tokens(output_tokens, model, call_type, model_id)

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -275,6 +275,8 @@ def aggregate_token_usage_by_model(details: Any) -> List[Dict[str, Any]]:
                 "input_tokens": 0,
                 "output_tokens": 0,
                 "total_tokens": 0,
+                "cached_input_tokens": 0,
+                "cache_write_input_tokens": 0,
             },
         )
         # Some legacy adapters only stamped the name on one of the pair.
@@ -282,6 +284,15 @@ def aggregate_token_usage_by_model(details: Any) -> List[Dict[str, Any]]:
             aggregate["model_name"] = model_name
         aggregate[f"{token_type}_tokens"] += tokens
         aggregate["total_tokens"] += tokens
+        if token_type == "input":
+            # Legacy entries predate cache tracking; clamp to the entry's
+            # own input tokens so malformed data can't exceed the total.
+            cached = min(tokens, max(0, _coerce_int(detail.get("cached_tokens"))))
+            cache_write = min(
+                tokens, max(0, _coerce_int(detail.get("cache_write_tokens")))
+            )
+            aggregate["cached_input_tokens"] += cached
+            aggregate["cache_write_input_tokens"] += cache_write
 
     id_keys_by_name: Dict[str, List[tuple[str, str]]] = {}
     for key, aggregate in grouped.items():
@@ -298,6 +309,8 @@ def aggregate_token_usage_by_model(details: Any) -> List[Dict[str, Any]]:
         target["input_tokens"] += aggregate["input_tokens"]
         target["output_tokens"] += aggregate["output_tokens"]
         target["total_tokens"] += aggregate["total_tokens"]
+        target["cached_input_tokens"] += aggregate["cached_input_tokens"]
+        target["cache_write_input_tokens"] += aggregate["cache_write_input_tokens"]
         del grouped[key]
 
     sorted_groups = sorted(
@@ -314,6 +327,8 @@ def aggregate_token_usage_by_model(details: Any) -> List[Dict[str, Any]]:
             "model_name": item["model_name"],
             "input_tokens": item["input_tokens"],
             "output_tokens": item["output_tokens"],
+            "cached_input_tokens": item["cached_input_tokens"],
+            "cache_write_input_tokens": item["cache_write_input_tokens"],
         }
         for item in sorted_groups
     ]

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3413,6 +3413,7 @@ async def get_task(
             agent_name = task.agent.name if task.agent else None
             agent_logo_url = task.agent.logo_url if task.agent else None
 
+            model_usage = aggregate_token_usage_by_model(task.token_usage_details)
             response = {
                 "task_id": task.id,
                 "title": task.title,
@@ -3436,7 +3437,10 @@ async def get_task(
                 "output_tokens": task.output_tokens or 0,
                 "total_tokens": task.total_tokens or 0,
                 "llm_calls": task.llm_calls or 0,
-                "model_usage": aggregate_token_usage_by_model(task.token_usage_details),
+                "cached_input_tokens": sum(
+                    entry["cached_input_tokens"] for entry in model_usage
+                ),
+                "model_usage": model_usage,
                 "agent_id": task.agent_id,
                 "agent_name": agent_name,
                 "agent_logo_url": agent_logo_url,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3440,6 +3440,9 @@ async def get_task(
                 "cached_input_tokens": sum(
                     entry["cached_input_tokens"] for entry in model_usage
                 ),
+                "cache_write_input_tokens": sum(
+                    entry["cache_write_input_tokens"] for entry in model_usage
+                ),
                 "model_usage": model_usage,
                 "agent_id": task.agent_id,
                 "agent_name": agent_name,

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -825,3 +825,54 @@ async def test_concurrent_tool_calls_all_count() -> None:
     )
 
     assert get_token_usage().tool_calls == 8
+
+
+class StreamingLLMWithCachedUsage:
+    async def stream_chat(self, **_: Any) -> Any:
+        yield StreamChunk(type=ChunkType.TOKEN, delta="hello")
+        yield StreamChunk(
+            type=ChunkType.USAGE,
+            usage={
+                "prompt_tokens": 7,
+                "completion_tokens": 3,
+                "total_tokens": 10,
+                "prompt_tokens_details": {"cached_tokens": 4},
+            },
+        )
+        yield StreamChunk(type=ChunkType.END)
+
+
+@pytest.mark.asyncio
+async def test_runtime_surfaces_cached_tokens_in_usage_and_trace() -> None:
+    """Provider cache telemetry reaches the merged usage payload and the
+    LLM end trace event as a normalized cached_input_tokens count."""
+    events: list[dict[str, Any]] = []
+
+    class _CaptureTracer:
+        async def trace_event(
+            self,
+            event_type: Any,
+            task_id: Any = None,
+            step_id: Any = None,
+            data: Any = None,
+            parent_id: Any = None,
+        ) -> str:
+            events.append({"data": dict(data or {})})
+            return "evt"
+
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(
+        execution_id="task-123",
+        outbound_message_handler=outbound,
+        tracer=_CaptureTracer(),
+    )
+    context = ExecutionContext(execution_id="task-123")
+
+    result = await runtime.stream_final_answer(
+        StreamingLLMWithCachedUsage(), messages=[]
+    )
+    assert result["usage"]["cached_input_tokens"] == 4
+
+    await runtime.on_llm_end(context=context, response=result)
+    assert events[-1]["data"]["cached_input_tokens"] == 4
+    assert events[-1]["data"]["input_tokens"] == 7

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -1116,6 +1116,16 @@ class TestClaudePromptCacheUsage:
         )
         assert _anthropic_input_usage(bad) == (10, 0, 0)
 
+        # Dict-shaped payloads are handled like the shared cache helper.
+        assert _anthropic_input_usage(
+            {
+                "input_tokens": 10,
+                "cache_read_input_tokens": 80,
+                "cache_creation_input_tokens": 30,
+            }
+        ) == (120, 80, 30)
+        assert _anthropic_input_usage({}) == (0, 0, 0)
+
     @pytest.mark.asyncio
     async def test_chat_records_normalized_cache_usage(self, llm, mocker):
         from xagent.core.model.chat.token_context import TokenContextManager

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -1195,8 +1195,10 @@ class TestClaudePromptCacheUsage:
         )
 
         with TokenContextManager() as manager:
-            async for _chunk in llm.stream_chat([{"role": "user", "content": "hi"}]):
-                pass
+            chunks = [
+                chunk
+                async for chunk in llm.stream_chat([{"role": "user", "content": "hi"}])
+            ]
             usage = manager.get_usage()
 
         assert usage.input_tokens == 65
@@ -1205,3 +1207,14 @@ class TestClaudePromptCacheUsage:
         assert inp["tokens"] == 65
         assert inp["cached_tokens"] == 40
         assert inp["cache_write_tokens"] == 15
+
+        # The yielded usage chunk carries the message_start input counts so
+        # downstream consumers (runtime usage/trace) see cache telemetry.
+        usage_chunk = next(c for c in chunks if c.type == ChunkType.USAGE)
+        assert usage_chunk.usage == {
+            "input_tokens": 65,
+            "output_tokens": 5,
+            "total_tokens": 70,
+            "cached_input_tokens": 40,
+            "cache_write_input_tokens": 15,
+        }

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator
 
 from xagent.core.model.chat.basic.claude import (
     ClaudeLLM,
+    _anthropic_input_usage,
     _fix_pydantic_schema_for_claude,
 )
 from xagent.core.model.chat.types import ChunkType
@@ -1087,3 +1088,120 @@ class TestClaudeLLM:
         assert len(anthropic_tools) == 1
         assert anthropic_tools[0]["strict"] is True
         assert anthropic_tools[0]["name"] == "search_flights"
+
+
+class TestClaudePromptCacheUsage:
+    """Anthropic reports cache reads/writes outside input_tokens; we re-add them."""
+
+    @pytest.fixture
+    def llm(self, claude_llm_config):
+        return ClaudeLLM(**claude_llm_config)
+
+    def test_anthropic_input_usage_normalization(self):
+        usage = SimpleNamespace(
+            input_tokens=10,
+            cache_read_input_tokens=80,
+            cache_creation_input_tokens=30,
+        )
+        assert _anthropic_input_usage(usage) == (120, 80, 30)
+
+        # Missing cache fields (older SDK / cache disabled) fall back to 0.
+        assert _anthropic_input_usage(SimpleNamespace(input_tokens=10)) == (10, 0, 0)
+
+        # Non-numeric values (e.g. Mock attributes in tests) must not raise.
+        bad = SimpleNamespace(
+            input_tokens=10,
+            cache_read_input_tokens=object(),
+            cache_creation_input_tokens=None,
+        )
+        assert _anthropic_input_usage(bad) == (10, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_chat_records_normalized_cache_usage(self, llm, mocker):
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        mock_text_block = mocker.Mock()
+        mock_text_block.type = "text"
+        mock_text_block.text = "ok"
+
+        mock_response = mocker.Mock()
+        mock_response.stop_reason = "stop"
+        mock_response.content = [mock_text_block]
+        mock_response.usage = SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=80,
+            cache_creation_input_tokens=30,
+        )
+        mock_response.model_dump = mocker.Mock(return_value={"content": "ok"})
+
+        mock_client = mocker.AsyncMock()
+        mock_client.messages.create.return_value = mock_response
+        mocker.patch(
+            "xagent.core.model.chat.basic.claude.AsyncAnthropic",
+            return_value=mock_client,
+        )
+
+        with TokenContextManager() as manager:
+            await llm.chat([{"role": "user", "content": "hi"}])
+            usage = manager.get_usage()
+
+        assert usage.input_tokens == 120
+        assert usage.output_tokens == 5
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["tokens"] == 120
+        assert inp["cached_tokens"] == 80
+        assert inp["cache_write_tokens"] == 30
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_records_cache_usage_from_message_start(
+        self, llm, mocker
+    ):
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        events = [
+            SimpleNamespace(
+                type="message_start",
+                message=SimpleNamespace(
+                    usage=SimpleNamespace(
+                        input_tokens=10,
+                        cache_read_input_tokens=40,
+                        cache_creation_input_tokens=15,
+                    )
+                ),
+            ),
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(type="text", text=""),
+            ),
+            SimpleNamespace(
+                type="content_block_delta",
+                index=0,
+                delta=SimpleNamespace(type="text_delta", text="ok"),
+            ),
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(stop_reason="end_turn"),
+                usage=SimpleNamespace(output_tokens=5),
+            ),
+        ]
+
+        mock_client = mocker.AsyncMock()
+        mock_client.messages.create.return_value = _AsyncEventStream(events)
+        mocker.patch(
+            "xagent.core.model.chat.basic.claude.AsyncAnthropic",
+            return_value=mock_client,
+        )
+
+        with TokenContextManager() as manager:
+            async for _chunk in llm.stream_chat([{"role": "user", "content": "hi"}]):
+                pass
+            usage = manager.get_usage()
+
+        assert usage.input_tokens == 65
+        assert usage.output_tokens == 5
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["tokens"] == 65
+        assert inp["cached_tokens"] == 40
+        assert inp["cache_write_tokens"] == 15

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -724,3 +724,45 @@ class TestGeminiPromptCacheUsage:
         assert usage.input_tokens == 100
         inp = next(d for d in usage.details if d["type"] == "input")
         assert inp["cached_tokens"] == 60
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_usage_chunk_carries_cached_tokens(
+        self, llm: GeminiLLM, mocker: pytest_mock.MockerFixture
+    ) -> None:
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        usage_chunk = MagicMock()
+        usage_chunk.usage_metadata = MagicMock()
+        usage_chunk.usage_metadata.prompt_token_count = 100
+        usage_chunk.usage_metadata.candidates_token_count = 5
+        usage_chunk.usage_metadata.cached_content_token_count = 60
+        usage_chunk.candidates = None
+
+        end_chunk = MagicMock()
+        end_chunk.candidates = None
+        end_chunk.usage_metadata = None
+
+        async def mock_stream():
+            for chunk in [usage_chunk, end_chunk]:
+                yield chunk
+
+        async def mock_generate_content_stream(*args, **kwargs):
+            return mock_stream()
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = mock_generate_content_stream
+        mocker.patch.object(llm, "_ensure_client")
+        llm._client = mock_client
+
+        with TokenContextManager() as manager:
+            chunks = [
+                chunk
+                async for chunk in llm.stream_chat([{"role": "user", "content": "hi"}])
+            ]
+            usage = manager.get_usage()
+
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["cached_tokens"] == 60
+
+        usage_payloads = [c.usage for c in chunks if c.is_usage()]
+        assert usage_payloads and usage_payloads[0]["cached_input_tokens"] == 60

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -679,3 +679,48 @@ class TestGeminiLLMSDK:
 
         with pytest.raises(LLMRetryableError, match="code=504"):
             await llm.chat(messages)
+
+
+class TestGeminiPromptCacheUsage:
+    """cached_content_token_count is recorded as cached input tokens."""
+
+    @pytest.fixture
+    def llm(self, gemini_llm_config: Dict[str, str]) -> GeminiLLM:
+        return GeminiLLM(**gemini_llm_config)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_chat_records_cached_content_tokens(
+        self, llm: GeminiLLM, mocker: pytest_mock.MockerFixture
+    ) -> None:
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        mock_part = MagicMock()
+        mock_part.text = "ok"
+        mock_part.function_call = None
+        mock_content = MagicMock()
+        mock_content.parts = [mock_part]
+        mock_candidate = MagicMock()
+        mock_candidate.content = mock_content
+
+        mock_response = MagicMock()
+        mock_response.candidates = [mock_candidate]
+        mock_response.usage_metadata = MagicMock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 5
+        mock_response.usage_metadata.cached_content_token_count = 60
+
+        mock_sdk_client = MagicMock()
+        mocker.patch("google.genai.Client", return_value=mock_sdk_client)
+
+        async def mock_generate_content(*args, **kwargs):
+            return mock_response
+
+        mock_sdk_client.aio.models.generate_content = mock_generate_content
+
+        with TokenContextManager() as manager:
+            await llm.chat([{"role": "user", "content": "hi"}])
+            usage = manager.get_usage()
+
+        assert usage.input_tokens == 100
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["cached_tokens"] == 60

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -487,3 +487,34 @@ class TestProcessChatResponse:
                     ]
                 }
             )
+
+
+class TestXinferencePromptCacheUsage:
+    """Dict-shaped usage payloads surface cached input tokens."""
+
+    def test_process_chat_response_records_cached_tokens(self) -> None:
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        llm = XinferenceLLM(model_name="qwen3-thinking")
+
+        with TokenContextManager() as manager:
+            llm._process_chat_response(
+                {
+                    "choices": [
+                        {
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 100,
+                        "completion_tokens": 5,
+                        "prompt_tokens_details": {"cached_tokens": 60},
+                    },
+                }
+            )
+            usage = manager.get_usage()
+
+        assert usage.input_tokens == 100
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["cached_tokens"] == 60

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -477,3 +477,52 @@ class TestZhipuLLM:
         # Should raise ValueError for invalid API key
         with pytest.raises(ValueError, match="Invalid API key"):
             await ZhipuLLM.list_available_models("invalid-key")
+
+
+class TestZhipuPromptCacheUsage:
+    """prompt_tokens_details.cached_tokens is recorded as cached input tokens."""
+
+    @pytest.fixture
+    def mock_zhipu_client(self):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock()
+        return mock_client
+
+    @pytest.fixture
+    def zhipu_llm(self, mock_zhipu_client):
+        with patch(
+            "xagent.core.model.chat.basic.zhipu.ZhipuAiClient",
+            return_value=mock_zhipu_client,
+        ):
+            llm = ZhipuLLM(api_key="test_key")
+            llm._client = mock_zhipu_client
+            return llm
+
+    @pytest.mark.asyncio
+    async def test_chat_records_cached_tokens(self, zhipu_llm, mock_zhipu_client):
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        mock_choice = MagicMock()
+        mock_choice.finish_reason = "stop"
+        mock_message = MagicMock()
+        mock_message.content = "ok"
+        mock_message.tool_calls = None
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=5,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=60),
+        )
+
+        mock_zhipu_client.chat.completions.create.return_value = mock_response
+
+        with TokenContextManager() as manager:
+            await zhipu_llm.chat([{"role": "user", "content": "hi"}])
+            usage = manager.get_usage()
+
+        assert usage.input_tokens == 100
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["cached_tokens"] == 60

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -526,3 +526,42 @@ class TestZhipuPromptCacheUsage:
         assert usage.input_tokens == 100
         inp = next(d for d in usage.details if d["type"] == "input")
         assert inp["cached_tokens"] == 60
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_usage_chunk_carries_cached_tokens(
+        self, zhipu_llm, mock_zhipu_client
+    ):
+        from xagent.core.model.chat.token_context import TokenContextManager
+
+        mock_zhipu_client.chat.completions.create.return_value = [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="ok", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=100,
+                    completion_tokens=5,
+                    prompt_tokens_details=SimpleNamespace(cached_tokens=60),
+                ),
+            ),
+        ]
+
+        with TokenContextManager() as manager:
+            chunks = [
+                chunk
+                async for chunk in zhipu_llm.stream_chat(
+                    [{"role": "user", "content": "hi"}]
+                )
+            ]
+            usage = manager.get_usage()
+
+        inp = next(d for d in usage.details if d["type"] == "input")
+        assert inp["cached_tokens"] == 60
+
+        usage_payloads = [
+            c.usage for c in chunks if c.type == ChunkType.USAGE and c.usage
+        ]
+        assert usage_payloads and usage_payloads[0]["cached_input_tokens"] == 60

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -202,12 +202,16 @@ def test_aggregate_token_usage_by_model_prefers_model_id_and_sorts_by_total():
             "model_name": "shared-name",
             "input_tokens": 100,
             "output_tokens": 25,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
         {
             "model_id": "compact-model",
             "model_name": "shared-name",
             "input_tokens": 20,
             "output_tokens": 5,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
     ]
 
@@ -226,6 +230,8 @@ def test_aggregate_token_usage_by_model_keeps_legacy_unattributed_tokens():
             "model_name": "",
             "input_tokens": 12,
             "output_tokens": 3,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         }
     ]
 
@@ -254,6 +260,8 @@ def test_aggregate_token_usage_by_model_merges_unique_legacy_name_group():
             "model_name": "gpt-4o",
             "input_tokens": 150,
             "output_tokens": 30,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         }
     ]
 
@@ -281,18 +289,24 @@ def test_aggregate_token_usage_by_model_keeps_ambiguous_legacy_name_group():
             "model_name": "shared-name",
             "input_tokens": 30,
             "output_tokens": 0,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
         {
             "model_id": "main-model",
             "model_name": "shared-name",
             "input_tokens": 20,
             "output_tokens": 0,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
         {
             "model_id": "compact-model",
             "model_name": "shared-name",
             "input_tokens": 10,
             "output_tokens": 0,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
     ]
 
@@ -327,11 +341,57 @@ async def test_openrouter_auto_usage_is_attributed_to_each_selected_model():
             "model_name": "deepseek/deepseek-v4-flash",
             "input_tokens": 100,
             "output_tokens": 50,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
         {
             "model_id": "router:anthropic/claude-opus-4.8",
             "model_name": "anthropic/claude-opus-4.8",
             "input_tokens": 20,
             "output_tokens": 10,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
+    ]
+
+
+def test_aggregate_token_usage_by_model_sums_and_clamps_cache_tokens():
+    details = [
+        {
+            "type": "input",
+            "tokens": 100,
+            "model": "m",
+            "model_id": "main",
+            "cached_tokens": 60,
+            "cache_write_tokens": 10,
+        },
+        {
+            "type": "input",
+            "tokens": 50,
+            "model": "m",
+            "model_id": "main",
+            "cached_tokens": 20,
+        },
+        # Malformed entry claims more cached tokens than its own input;
+        # it must be clamped to the entry total instead of inflating sums.
+        {
+            "type": "input",
+            "tokens": 10,
+            "model": "m",
+            "model_id": "main",
+            "cached_tokens": 999,
+            "cache_write_tokens": -5,
+        },
+        {"type": "output", "tokens": 5, "model": "m", "model_id": "main"},
+    ]
+
+    assert aggregate_token_usage_by_model(details) == [
+        {
+            "model_id": "main",
+            "model_name": "m",
+            "input_tokens": 160,
+            "output_tokens": 5,
+            "cached_input_tokens": 90,
+            "cache_write_input_tokens": 10,
+        }
     ]

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -166,6 +166,16 @@ def test_cached_input_tokens_helper_dict_shapes():
     assert extract_cached_input_tokens({"prompt_tokens_details": None}) == 0
     assert extract_cached_input_tokens({"prompt_tokens": 10}) == 0
     assert extract_cached_input_tokens({"prompt_cache_hit_tokens": "bad"}) == 0
+    # A default hit=0 must not shadow a real prompt_tokens_details value.
+    assert (
+        extract_cached_input_tokens(
+            {
+                "prompt_cache_hit_tokens": 0,
+                "prompt_tokens_details": {"cached_tokens": 25},
+            }
+        )
+        == 25
+    )
 
 
 def test_aggregate_token_usage_by_model_prefers_model_id_and_sorts_by_total():

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -116,8 +116,25 @@ def test_add_token_usage_records_cached_tokens():
     assert inp["cached_tokens"] == 40
 
 
+def test_add_token_usage_records_cache_write_tokens():
+    with TokenContextManager() as mgr:
+        add_token_usage(
+            input_tokens=100,
+            model="m",
+            model_id="platform/x",
+            call_type="chat",
+            cached_input_tokens=40,
+            cache_write_input_tokens=25,
+        )
+        details = mgr.get_usage().details
+
+    inp = next(d for d in details if d["type"] == "input")
+    assert inp["cached_tokens"] == 40
+    assert inp["cache_write_tokens"] == 25
+
+
 def test_cached_input_tokens_helper():
-    from xagent.core.model.chat.basic.openai import _cached_input_tokens
+    from xagent.core.model.chat.token_context import extract_cached_input_tokens
 
     class DeepSeekUsage:
         prompt_cache_hit_tokens = 30
@@ -131,10 +148,24 @@ def test_cached_input_tokens_helper():
     class NoCache:
         pass
 
-    assert _cached_input_tokens(DeepSeekUsage()) == 30  # deepseek field
-    assert _cached_input_tokens(OpenAIUsage()) == 25  # openai/dashscope field
-    assert _cached_input_tokens(NoCache()) == 0
-    assert _cached_input_tokens(None) == 0
+    assert extract_cached_input_tokens(DeepSeekUsage()) == 30  # deepseek field
+    assert extract_cached_input_tokens(OpenAIUsage()) == 25  # openai/dashscope field
+    assert extract_cached_input_tokens(NoCache()) == 0
+    assert extract_cached_input_tokens(None) == 0
+
+
+def test_cached_input_tokens_helper_dict_shapes():
+    """Streaming chunks often surface usage as plain dicts."""
+    from xagent.core.model.chat.token_context import extract_cached_input_tokens
+
+    assert extract_cached_input_tokens({"prompt_cache_hit_tokens": 30}) == 30
+    assert (
+        extract_cached_input_tokens({"prompt_tokens_details": {"cached_tokens": 25}})
+        == 25
+    )
+    assert extract_cached_input_tokens({"prompt_tokens_details": None}) == 0
+    assert extract_cached_input_tokens({"prompt_tokens": 10}) == 0
+    assert extract_cached_input_tokens({"prompt_cache_hit_tokens": "bad"}) == 0
 
 
 def test_aggregate_token_usage_by_model_prefers_model_id_and_sorts_by_total():

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -586,6 +586,7 @@ def test_get_task_returns_token_usage_grouped_by_actual_model(test_db, user1_hea
                 "tokens": 100,
                 "model": "gpt-4.1",
                 "model_id": "main",
+                "cached_tokens": 60,
             },
             {
                 "type": "output",
@@ -612,20 +613,26 @@ def test_get_task_returns_token_usage_grouped_by_actual_model(test_db, user1_hea
 
     response = client.get(f"/api/chat/task/{task_id}", headers=user1_headers)
     assert response.status_code == 200
-    assert response.json()["model_usage"] == [
+    payload = response.json()
+    assert payload["model_usage"] == [
         {
             "model_id": "main",
             "model_name": "gpt-4.1",
             "input_tokens": 100,
             "output_tokens": 25,
+            "cached_input_tokens": 60,
+            "cache_write_input_tokens": 0,
         },
         {
             "model_id": "compact",
             "model_name": "gpt-4.1-mini",
             "input_tokens": 20,
             "output_tokens": 5,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
         },
     ]
+    assert payload["cached_input_tokens"] == 60
 
 
 def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -587,6 +587,7 @@ def test_get_task_returns_token_usage_grouped_by_actual_model(test_db, user1_hea
                 "model": "gpt-4.1",
                 "model_id": "main",
                 "cached_tokens": 60,
+                "cache_write_tokens": 15,
             },
             {
                 "type": "output",
@@ -621,7 +622,7 @@ def test_get_task_returns_token_usage_grouped_by_actual_model(test_db, user1_hea
             "input_tokens": 100,
             "output_tokens": 25,
             "cached_input_tokens": 60,
-            "cache_write_input_tokens": 0,
+            "cache_write_input_tokens": 15,
         },
         {
             "model_id": "compact",
@@ -633,6 +634,7 @@ def test_get_task_returns_token_usage_grouped_by_actual_model(test_db, user1_hea
         },
     ]
     assert payload["cached_input_tokens"] == 60
+    assert payload["cache_write_input_tokens"] == 15
 
 
 def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):


### PR DESCRIPTION
Fixes #425

## What this does

Providers report prompt-cache usage in their API responses, but the token tracker dropped those fields, and Claude's input totals were under-reported when caching was active. This PR normalizes cache telemetry end to end: adapters → per-call details → per-model aggregation → task API → usage indicator UI → LLM call traces.

Normalized semantics (OpenAI-style): `input_tokens` is the full prompt total including cached tokens; `cached_input_tokens` and `cache_write_input_tokens` are subsets of it.

## Changes

**Adapters** (`core/model/chat`)
- Shared `extract_cached_input_tokens()` helper in `token_context.py`, handling both SDK objects and dict-shaped streaming payloads; covers OpenAI/DashScope/Zhipu `prompt_tokens_details.cached_tokens` and DeepSeek `prompt_cache_hit_tokens`.
- **Claude**: Anthropic's `usage.input_tokens` excludes cache reads/writes, so input totals were under-counted with caching enabled. `cache_read_input_tokens` and `cache_creation_input_tokens` are now re-added to the input total and recorded as cached / cache-write tokens (non-streaming + streaming). Note: input counts for cached Claude runs will be higher after this change — that is the correction, not a regression.
- **Gemini**: records `cached_content_token_count` (already a subset of `prompt_token_count`).
- **Zhipu / Xinference**: extract cached tokens via the shared helper.
- `add_token_usage()` gains a `cache_write_input_tokens` passthrough stored as `cache_write_tokens` in per-call details (Claude bills cache writes at a premium; kept for future cost calculation).

**Aggregation + API**
- `aggregate_token_usage_by_model()` sums `cached_input_tokens` / `cache_write_input_tokens` per model group, clamped to each entry's own input tokens; legacy detail entries without cache fields aggregate as 0.
- `GET /api/chat/task/{id}` adds a top-level `cached_input_tokens` plus per-model fields in `model_usage`, computed from `token_usage_details` at read time — no schema change or migration needed.

**Frontend**
- Usage popover gains a per-model Cached column (Model / Input / Cached / Output, the table shape from #425).
- Top bar shows an "N% cached" hint next to input tokens when the task had cache hits (exact count in tooltip); hidden when the provider reports no cache usage.
- New en/zh locale keys.

**Traces**
- LLM end trace events include `cached_input_tokens` when the response usage carries it, and the field is preserved through trace normalization, so per-call cache hits are inspectable.
- The Claude streaming usage chunk now carries input-side counts from `message_start` (previously `input_tokens` was usually 0 there) plus cache fields, so the runtime's merged usage payload sees them.

Not in scope (tracked by #685): prompt hashes, segment counts, and other cache diagnostics; cache-write-based cost display.

## Testing

- New unit tests per provider (streaming + non-streaming), helper dict shapes, aggregation clamping, task API response, runtime usage/trace propagation, and frontend component tests for the cached column/share.
- `tests/core/model` + `tests/core/agent` pass; frontend vitest passes except 6 pre-existing failures (KB dialog / workforce routes) reproduced on a pristine upstream/main; ruff, mypy, tsc clean.