### PR TITLE
feat: add native video understanding and durable file refs

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -124,6 +124,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     openssl \
     libreoffice \
+    ffmpeg \
     fonts-noto-cjk \
     libglib2.0-0 \
     libsm6 \

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -33,7 +33,7 @@ class BaseLLM(ABC):
     def abilities(self) -> List[str]:
         """
         Get the list of abilities supported by this LLM implementation.
-        Possible abilities: ["chat", "vision", "thinking_mode", "tool_calling"]
+        Possible abilities: ["chat", "vision", "video", "thinking_mode", "tool_calling"]
 
         Returns:
             List[str]: List of supported abilities
@@ -81,6 +81,42 @@ class BaseLLM(ABC):
         Defaults to True to preserve existing structured-output routing.
         """
         return True
+
+    @property
+    def supports_native_video_input(self) -> bool:
+        """Whether this model accepts a video as one multimodal input.
+
+        Provider adapters override this when their public API has a known video
+        contract.  OpenAI-compatible or self-hosted models can opt in explicitly
+        by adding ``video`` to their configured abilities.
+        """
+        return self.has_ability("video")
+
+    @property
+    def supports_native_video_with_images(self) -> bool:
+        """Whether native video and image parts may share one model request."""
+        return False
+
+    @property
+    def supports_native_video_time_range(self) -> bool:
+        """Whether native video input enforces start/end offsets."""
+        return False
+
+    def build_native_video_content(
+        self,
+        video_url: str,
+        *,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> dict[str, Any]:
+        """Build the provider-ready content part for one native video input.
+
+        The default is the OpenAI-compatible ``video_url`` shape used by a
+        number of third-party providers.  Provider adapters can translate or
+        enrich it without leaking provider checks into the vision tool.
+        """
+        _ = start_time, end_time
+        return {"type": "video_url", "video_url": {"url": video_url}}
 
     def has_ability(self, ability: str) -> bool:
         """

--- a/src/xagent/core/model/chat/basic/dashscope.py
+++ b/src/xagent/core/model/chat/basic/dashscope.py
@@ -45,6 +45,34 @@ class DashScopeLLM(OpenAILLM):
             timeout_config=timeout_config,
         )
 
+    @property
+    def supports_native_video_input(self) -> bool:
+        """Return whether the configured Qwen model accepts ``video_url``."""
+        if super().supports_native_video_input:
+            return True
+        if not self.has_ability("vision"):
+            return False
+
+        model_name = self._model_name.lower()
+        native_video_families = (
+            "qwen-vl",
+            "qwen2-vl",
+            "qwen2.5-vl",
+            "qwen3-vl",
+            "qwen3.5",
+            "qwen3.6",
+            "qwen3.7",
+            "qwen-omni",
+            "qwen3-omni",
+            "qvq",
+        )
+        return model_name.startswith(native_video_families)
+
+    @property
+    def supports_native_video_with_images(self) -> bool:
+        """Qwen multimodal requests can combine image and video inputs."""
+        return self.supports_native_video_input
+
     @staticmethod
     def _is_strict_tool_choice(
         tool_choice: Optional[Union[str, Dict[str, Any]]],

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -227,6 +227,13 @@ class GeminiLLM(BaseLLM):
         """Gemini supports start and end offsets in video metadata."""
         return self.supports_native_video_input
 
+    @staticmethod
+    def _supports_native_video_url(video_url: str) -> bool:
+        """Return whether Gemini can consume this video reference directly."""
+        return video_url.startswith(("data:video/", "gs://")) or any(
+            host in video_url for host in ("youtube.com/", "youtu.be/")
+        )
+
     def build_native_video_content(
         self,
         video_url: str,
@@ -235,6 +242,12 @@ class GeminiLLM(BaseLLM):
         end_time: float | None = None,
     ) -> Dict[str, Any]:
         """Build the canonical part converted to Gemini inline/file data later."""
+        if not self._supports_native_video_url(video_url):
+            raise ValueError(
+                "Gemini native video input requires an inline local video, "
+                "a Google Cloud Storage URI, or a YouTube URL"
+            )
+
         metadata: Dict[str, Any] = {}
         if start_time is not None:
             metadata["start_offset"] = f"{start_time:g}s"
@@ -382,11 +395,9 @@ class GeminiLLM(BaseLLM):
                                         "data": base64_data,
                                     }
                                 }
-                            elif isinstance(url, str) and (
-                                url.startswith("gs://")
-                                or "youtube.com/" in url
-                                or "youtu.be/" in url
-                            ):
+                            elif isinstance(
+                                url, str
+                            ) and self._supports_native_video_url(url):
                                 video_part = {
                                     "file_data": {
                                         "file_uri": url,

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -195,12 +195,9 @@ class GeminiLLM(BaseLLM):
         if abilities:
             self._abilities = abilities
         else:
-            self._abilities = ["chat", "tool_calling"]
-            if any(
-                vision_keyword in model_name.lower()
-                for vision_keyword in ["vision", "pro-vision", "flash-vision", "2.5"]
-            ):
-                self._abilities.append("vision")
+            # Gemini chat models are natively multimodal; the separate image
+            # generation adapter owns generation-only models.
+            self._abilities = ["chat", "tool_calling", "vision"]
 
         # Initialize the Gemini client (lazy initialization)
         self._client: Optional[Any] = None
@@ -214,6 +211,43 @@ class GeminiLLM(BaseLLM):
     def abilities(self) -> List[str]:
         """Get the list of abilities supported by this Gemini LLM implementation."""
         return self._abilities
+
+    @property
+    def supports_native_video_input(self) -> bool:
+        """Gemini multimodal models process videos natively."""
+        return self.has_ability("vision")
+
+    @property
+    def supports_native_video_with_images(self) -> bool:
+        """Gemini accepts mixed image and native video parts."""
+        return self.supports_native_video_input
+
+    @property
+    def supports_native_video_time_range(self) -> bool:
+        """Gemini supports start and end offsets in video metadata."""
+        return self.supports_native_video_input
+
+    def build_native_video_content(
+        self,
+        video_url: str,
+        *,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> Dict[str, Any]:
+        """Build the canonical part converted to Gemini inline/file data later."""
+        metadata: Dict[str, Any] = {}
+        if start_time is not None:
+            metadata["start_offset"] = f"{start_time:g}s"
+        if end_time is not None:
+            metadata["end_offset"] = f"{end_time:g}s"
+
+        content: Dict[str, Any] = {
+            "type": "video_url",
+            "video_url": {"url": video_url},
+        }
+        if metadata:
+            content["video_metadata"] = metadata
+        return content
 
     def _ensure_client(self) -> None:
         """Ensure the Gemini client is initialized using official SDK."""
@@ -326,6 +360,49 @@ class GeminiLLM(BaseLLM):
                                         }
                                     }
                                 )
+                        elif item.get("type") == "video_url":
+                            video_url = item.get("video_url", {})
+                            if isinstance(video_url, dict):
+                                url = video_url.get("url", "")
+                            else:
+                                url = video_url
+
+                            video_part: Dict[str, Any]
+                            if isinstance(url, str) and url.startswith("data:video/"):
+                                try:
+                                    mime_type = url.split(":", 1)[1].split(";", 1)[0]
+                                    base64_data = url.split(",", 1)[1]
+                                except (IndexError, ValueError) as exc:
+                                    raise ValueError(
+                                        "Invalid video data URL for Gemini"
+                                    ) from exc
+                                video_part = {
+                                    "inline_data": {
+                                        "mime_type": mime_type,
+                                        "data": base64_data,
+                                    }
+                                }
+                            elif isinstance(url, str) and (
+                                url.startswith("gs://")
+                                or "youtube.com/" in url
+                                or "youtu.be/" in url
+                            ):
+                                video_part = {
+                                    "file_data": {
+                                        "file_uri": url,
+                                        "mime_type": "video/mp4",
+                                    }
+                                }
+                            else:
+                                raise ValueError(
+                                    "Gemini native video input requires an inline local "
+                                    "video, a Google Cloud Storage URI, or a YouTube URL"
+                                )
+
+                            metadata = item.get("video_metadata")
+                            if isinstance(metadata, dict) and metadata:
+                                video_part["video_metadata"] = metadata
+                            parts.append(video_part)
 
                 gemini_messages.append({"role": gemini_role, "parts": parts})
 

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -79,7 +79,7 @@ class ZhipuLLM(BaseLLM):
             self._abilities = ["chat", "tool_calling"]
             if any(
                 vision_keyword in model_name.lower()
-                for vision_keyword in ["glm-4v", "glm-4.5v", "vision"]
+                for vision_keyword in ["glm-4v", "glm-4.5v", "glm-4.6v", "vision"]
             ):
                 self._abilities.append("vision")
             if self.supports_thinking_mode:
@@ -97,6 +97,30 @@ class ZhipuLLM(BaseLLM):
     def abilities(self) -> List[str]:
         """Get the list of abilities supported by this Zhipu LLM implementation."""
         return self._abilities
+
+    @property
+    def supports_native_video_input(self) -> bool:
+        """Return whether the configured GLM visual model accepts video input."""
+        if super().supports_native_video_input:
+            return True
+        if not self.has_ability("vision"):
+            return False
+
+        model_name = self._model_name.lower()
+        return model_name.startswith(("glm-4v-plus-0111", "glm-4.5v", "glm-4.6v"))
+
+    def build_native_video_content(
+        self,
+        video_url: str,
+        *,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> Dict[str, Any]:
+        """Build Zhipu's ``video_url`` part, including raw local Base64."""
+        _ = start_time, end_time
+        if video_url.startswith("data:video/") and "," in video_url:
+            video_url = video_url.split(",", 1)[1]
+        return {"type": "video_url", "video_url": {"url": video_url}}
 
     def _ensure_client(self) -> None:
         """Ensure the Zhipu client is initialized."""

--- a/src/xagent/core/tools/adapters/vibe/vision_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/vision_tool.py
@@ -11,7 +11,12 @@ from xagent.core.workspace import TaskWorkspace
 
 from ....file_ref import build_workspace_file_ref
 from ....model.chat.basic.base import BaseLLM
-from ...core.vision_tool import DetectObjectsResult, UnderstandImagesResult, VisionCore
+from ...core.vision_tool import (
+    DetectObjectsResult,
+    UnderstandImagesResult,
+    UnderstandMediaResult,
+    VisionCore,
+)
 from .base import ToolCategory
 from .function import FunctionTool
 
@@ -51,72 +56,83 @@ class VisionTool:
         # Create core instance
         self.core = VisionCore(vision_model, output_directory=output_dir)
 
-    def _resolve_image_path(self, image_path: str) -> str:
-        """
-        Resolve image path using workspace if available.
-
-        Args:
-            image_path: Original image path
-
-        Returns:
-            Resolved image path
-        """
+    def _resolve_media_path(self, media_path: str) -> str:
+        """Resolve an image or video path using the task workspace."""
         # If it's a URL, return as-is
-        if image_path.startswith(("http://", "https://", "data:")):
-            return image_path
+        if media_path.startswith(("http://", "https://", "data:")):
+            return media_path
 
         # Try to resolve using workspace
         if self.workspace:
             try:
-                resolved_path = self.workspace.resolve_path_with_search(image_path)
+                resolved_path = self.workspace.resolve_path_with_search(media_path)
                 return str(resolved_path)
             except (ValueError, FileNotFoundError):
                 pass
 
         # Return original path
-        return image_path
+        return media_path
 
-    def _resolve_images(
+    def _resolve_media(
         self,
-        images: Union[str, List[str]],
+        media: Union[str, List[str]],
     ) -> str | list[str]:
-        """Resolve all image paths using workspace."""
-        if isinstance(images, str):
-            return self._resolve_image_path(images)
-        elif isinstance(images, List):
-            return [self._resolve_image_path(img) for img in images]
-        return images
+        """Resolve all media paths using workspace."""
+        if isinstance(media, str):
+            return self._resolve_media_path(media)
+        if isinstance(media, list):
+            return [self._resolve_media_path(item) for item in media]
+        return media
 
-    def _normalize_images(
+    def _normalize_media(
         self,
-        images: Union[str, List[str]],
+        media: Union[str, List[str]],
     ) -> Union[str, List[str]]:
-        """
-        Normalize and validate image input.
+        """Normalize and validate image/video input."""
+        if media is None:
+            raise ValueError("At least one image or video must be provided")
 
-        Args:
-            images: Single image path/URL or list of image paths/URLs
+        if isinstance(media, str):
+            return media
+        if isinstance(media, list):
+            if not media:
+                raise ValueError("At least one image or video must be provided")
+            if all(isinstance(item, str) for item in media):
+                return media
+            raise ValueError("all items in media must be strings")
+        raise TypeError("media must be a string or a list of strings")
 
-        Returns:
-            Normalized image input (single string or list)
+    # Internal compatibility helpers for image-specific operations.
+    _resolve_image_path = _resolve_media_path
+    _resolve_images = _resolve_media
+    _normalize_images = _normalize_media
 
-        Raises:
-            ValueError: If images is None or invalid
-        """
-        if images is None:
-            raise ValueError("At least one image must be provided")
-
-        if isinstance(images, str):
-            return images
-        elif isinstance(images, list):
-            if not images:
-                raise ValueError("At least one image must be provided")
-            if all(isinstance(x, str) for x in images):
-                return images
-            else:
-                raise ValueError("all items in images must be strings")
-        else:
-            raise TypeError("images must be a string or a list of strings")
+    async def understand_media(
+        self,
+        media: Union[str, List[str]],
+        question: str,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        max_frames: Optional[int] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> UnderstandMediaResult:
+        """Analyze images, videos, or mixed media with one public tool."""
+        try:
+            normalized_media = self._normalize_media(media)
+            resolved_media = self._resolve_media(normalized_media)
+        except Exception as e:
+            logger.error("understand_media: error resolving media: %s", e)
+            return UnderstandMediaResult(success=False, error=str(e))
+        return await self.core.understand_media(
+            resolved_media,
+            question,
+            start_time,
+            end_time,
+            max_frames,
+            temperature,
+            max_tokens,
+        )
 
     async def understand_images(
         self,
@@ -137,14 +153,11 @@ class VisionTool:
         Returns:
             UnderstandImagesResult with analysis result and metadata
         """
-        try:
-            normalized_images = self._normalize_images(images)
-            resolved_images = self._resolve_images(normalized_images)
-        except Exception as e:
-            logger.error(f"understand_images: Error in resolving images: {e}")
-            return UnderstandImagesResult(success=False, error=str(e))
-        return await self.core.understand_images(
-            resolved_images, question, temperature, max_tokens
+        return await self.understand_media(
+            media=images,
+            question=question,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
 
     async def describe_images(
@@ -257,66 +270,40 @@ class VisionTool:
         """Get all tool instances."""
         tools = [
             VisionFunctionTool(
-                self.understand_images,
-                name="understand_images",
+                self.understand_media,
+                name="understand_media",
                 description="""
-Analyze images and answer questions about their content using AI vision capabilities.
+Analyze images, videos, or a mixture of both with one AI vision tool.
 
-This tool can understand and interpret images, including:
+Use this tool to:
 - Identifying objects, people, and scenes
 - Reading text in images (OCR capabilities)
-- Describing actions and activities
-- Analyzing image composition and style
-- Comparing multiple images
-- Answering specific questions about image content
+- Understanding actions and scene changes across a video
+- Comparing multiple images or videos
+- Answering specific questions about visual content
 
 Parameters:
-- images (required): Single image path/URL or list of image paths/URLs. Supports:
-  * Local file paths or file IDs (e.g., MUST use the exact `file_id` or filename from the uploaded files list in the system prompt)
-  * Remote URLs (e.g., "https://example.com/image.jpg")
-  * Multiple images as a list
-- question (required): Question to ask about the images
+- media (required): One image/video path or file_id, or a list of them. Always use
+  the exact file_id or filename from uploaded/generated file metadata.
+- question (required): Question to ask about the media
+- start_time/end_time (optional): Video time range in seconds
+- max_frames (optional): Maximum sampled frames per video when the model has no
+  native video input, 1-10 (default 8)
 - temperature (optional): Sampling temperature (0.0 to 2.0)
 - max_tokens (optional): Maximum tokens in response
 
 Examples:
 - "What is in this image?"
-- "Read the text shown in this image"
-- "Compare these two images and tell me the differences"
-- "What action is being performed in this image?"
-- "Describe the setting and mood of this scene"
+- "What happens in this video from beginning to end?"
+- "Does the cat leave the room?"
+- "Compare these two images and this video"
 
-Image requirements:
-- Formats: JPEG, PNG, WebP, GIF, BMP
-- Size: Up to 10MB per image
-- Maximum: 10 images per request
-- Local files will be automatically resolved in workspace
+Supported images: JPEG, PNG, WebP, GIF, BMP. Supported local/workspace videos:
+MP4, MOV, M4V, WebM, AVI, MKV. Models with native video support receive the
+video directly so motion, timing, and audio-capable model inputs are preserved.
+Other vision models use chronologically sampled, timestamped frames.
 
-The tool uses advanced vision AI models to provide detailed, accurate analysis of image content.
-                """.strip(),
-            ),
-            VisionFunctionTool(
-                self.describe_images,
-                name="describe_images",
-                description="""
-Generate natural language descriptions of images with configurable detail level.
-
-This tool provides automated image description capabilities, perfect for:
-- Generating alt text for accessibility
-- Creating image captions
-- Documenting visual content
-- Automated image analysis workflows
-
-Parameters:
-- images (required): The image parameter name is "images". Provide a single image file path, URL, or a list of multiple image paths/URLs. Supports local file paths or file IDs (e.g., MUST use the exact `file_id` or filename from the uploaded files list in the system prompt)
-- detail_level (optional): Level of detail ("simple", "normal", "detailed") - default: "normal"
-  * "simple": Brief, concise description
-  * "normal": Standard description with main elements
-  * "detailed": Comprehensive analysis with fine details
-- temperature (optional): Sampling temperature (0.0 to 2.0)
-- max_tokens (optional): Maximum tokens in response
-
-Use this tool when you need descriptive text about images without asking specific questions.
+Never pass a video to detect_objects or encode it as image_url; use this tool.
                 """.strip(),
             ),
             VisionFunctionTool(

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, Field
@@ -478,13 +478,6 @@ class VisionCore:
             ]
             image_count = sum(kind == "image" for _, kind in classified)
             video_count = sum(kind == "video" for _, kind in classified)
-            video_budgets = iter(
-                self._video_frame_budgets(
-                    image_count=image_count,
-                    video_count=video_count,
-                    max_frames=max_frames,
-                )
-            )
             use_native_video = self.vision_model.supports_native_video_input and (
                 image_count == 0 or self.vision_model.supports_native_video_with_images
             )
@@ -495,35 +488,64 @@ class VisionCore:
 
             visual_contents: List[Dict[str, Any]] = []
             warnings: List[str] = []
+            native_video_contents: Dict[int, Dict[str, Any]] = {}
+            fallback_video_count = video_count
+            if use_native_video:
+                fallback_video_count = 0
+                for index, (media_path, kind) in enumerate(classified):
+                    if kind != "video":
+                        continue
+                    try:
+                        video_data = await asyncio.to_thread(
+                            self._convert_video_to_base64, media_path
+                        )
+                        native_video_contents[index] = (
+                            self.vision_model.build_native_video_content(
+                                video_data,
+                                start_time=start_time,
+                                end_time=end_time,
+                            )
+                        )
+                    except Exception as exc:
+                        fallback_video_count += 1
+                        warning = (
+                            f"Native video input unavailable for {media_path}: "
+                            f"{exc}; using sampled frames"
+                        )
+                        logger.warning(warning)
+                        warnings.append(warning)
+
             processed_images = 0
             processed_videos = 0
             native_videos = 0
             extracted_frames = 0
-            for media_path, kind in classified:
+            video_budgets: Optional[Iterator[int]] = None
+
+            def next_fallback_frame_budget() -> int:
+                """Allocate the frame budget only when a video needs sampling."""
+
+                nonlocal video_budgets
+                if video_budgets is None:
+                    video_budgets = iter(
+                        self._video_frame_budgets(
+                            image_count=image_count,
+                            video_count=fallback_video_count,
+                            max_frames=max_frames,
+                        )
+                    )
+                return next(video_budgets)
+
+            for index, (media_path, kind) in enumerate(classified):
                 try:
                     if kind == "video":
-                        frame_budget = next(video_budgets)
-                        if use_native_video:
-                            try:
-                                video_data = self._convert_video_to_base64(media_path)
-                                visual_contents.append(
-                                    self.vision_model.build_native_video_content(
-                                        video_data,
-                                        start_time=start_time,
-                                        end_time=end_time,
-                                    )
-                                )
-                                processed_videos += 1
-                                native_videos += 1
-                                continue
-                            except Exception as exc:
-                                warning = (
-                                    f"Native video input unavailable for {media_path}: "
-                                    f"{exc}; using sampled frames"
-                                )
-                                logger.warning(warning)
-                                warnings.append(warning)
+                        native_content = native_video_contents.get(index)
+                        if native_content is not None:
+                            visual_contents.append(native_content)
+                            processed_videos += 1
+                            native_videos += 1
+                            continue
 
+                        frame_budget = next_fallback_frame_budget()
                         frames = await asyncio.to_thread(
                             self._extract_video_frames,
                             media_path,

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, Field
@@ -370,11 +370,12 @@ class VisionCore:
         self,
         *,
         image_count: int,
+        native_video_count: int,
         video_count: int,
         max_frames: int,
     ) -> List[int]:
         """Share the model's ten-visual-input budget across videos."""
-        available = 10 - image_count
+        available = 10 - image_count - native_video_count
         if available < video_count:
             raise ValueError(
                 "Too many images and videos to include at least one frame per video"
@@ -427,7 +428,7 @@ class VisionCore:
         Analyze images, videos, or mixed media and answer a question.
 
         Args:
-            media: Image/video path, URL, file id, or a list of them
+            media: Image/video path, provider-supported URL, file id, or a list of them
             question: Question to ask about the images
             start_time: Optional video sampling start in seconds
             end_time: Optional video sampling end in seconds
@@ -456,6 +457,12 @@ class VisionCore:
                 raise ValueError(
                     "end_time must be a finite number greater than or equal to 0"
                 )
+            if (
+                start_time is not None
+                and end_time is not None
+                and end_time <= start_time
+            ):
+                raise ValueError("end_time must be greater than start_time")
 
             # Validate vision model capability
             if not self.vision_model.has_ability("vision"):
@@ -526,21 +533,16 @@ class VisionCore:
             processed_videos = 0
             native_videos = 0
             extracted_frames = 0
-            video_budgets: Optional[Iterator[int]] = None
-
-            def next_fallback_frame_budget() -> int:
-                """Allocate the frame budget only when a video needs sampling."""
-
-                nonlocal video_budgets
-                if video_budgets is None:
-                    video_budgets = iter(
-                        self._video_frame_budgets(
-                            image_count=image_count,
-                            video_count=fallback_video_count,
-                            max_frames=max_frames,
-                        )
-                    )
-                return next(video_budgets)
+            video_budgets = iter(
+                self._video_frame_budgets(
+                    image_count=image_count,
+                    native_video_count=len(native_video_contents),
+                    video_count=fallback_video_count,
+                    max_frames=max_frames,
+                )
+                if fallback_video_count
+                else []
+            )
 
             for index, (media_path, kind) in enumerate(classified):
                 try:
@@ -552,7 +554,7 @@ class VisionCore:
                             native_videos += 1
                             continue
 
-                        frame_budget = next_fallback_frame_budget()
+                        frame_budget = next(video_budgets)
                         frames = await asyncio.to_thread(
                             self._extract_video_frames,
                             media_path,

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -6,6 +6,7 @@ Standalone vision capabilities without framework dependencies
 import asyncio
 import base64
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -445,10 +446,16 @@ class VisionCore:
             max_frames = self._coerce_optional_int(max_frames, "max_frames") or 8
             if max_frames < 1 or max_frames > 10:
                 raise ValueError("max_frames must be between 1 and 10")
-            if start_time is not None and start_time < 0:
-                raise ValueError("start_time must be greater than or equal to 0")
-            if end_time is not None and end_time < 0:
-                raise ValueError("end_time must be greater than or equal to 0")
+            if start_time is not None and (
+                not math.isfinite(start_time) or start_time < 0
+            ):
+                raise ValueError(
+                    "start_time must be a finite number greater than or equal to 0"
+                )
+            if end_time is not None and (not math.isfinite(end_time) or end_time < 0):
+                raise ValueError(
+                    "end_time must be a finite number greater than or equal to 0"
+                )
 
             # Validate vision model capability
             if not self.vision_model.has_ability("vision"):

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -3,16 +3,20 @@ Pure Vision Tool Core
 Standalone vision capabilities without framework dependencies
 """
 
+import asyncio
 import base64
 import logging
 import mimetypes
 import os
 import re
+import shutil
+import subprocess
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ...model.chat.basic.base import BaseLLM
 
@@ -25,15 +29,28 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+_MAX_INLINE_VIDEO_BYTES = 64 * 1024 * 1024
 
-class UnderstandImagesResult(BaseModel):
-    """Return model for understand_images method"""
+
+class UnderstandMediaResult(BaseModel):
+    """Result returned by the unified image and video understanding entrypoint."""
 
     success: bool
     answer: Optional[str] = None
+    media_processed: Optional[int] = None
     images_processed: Optional[int] = None
+    videos_processed: Optional[int] = None
+    native_videos_processed: Optional[int] = None
+    frames_extracted: Optional[int] = None
     model_used: Optional[str] = None
+    warnings: List[str] = Field(default_factory=list)
     error: Optional[str] = None
+
+
+# Backwards-compatible name for direct/internal callers. The agent-facing tool is
+# ``understand_media`` so image and video understanding do not consume two tool
+# slots.
+UnderstandImagesResult = UnderstandMediaResult
 
 
 class DetectObjectsResult(BaseModel):
@@ -147,6 +164,32 @@ class VisionCore:
         except Exception as e:
             raise RuntimeError(f"Failed to read image file {image_path}: {e}")
 
+    def _convert_video_to_base64(self, video_path: str) -> str:
+        """Convert a local video to a provider-neutral Base64 data URL."""
+        if video_path.startswith(("http://", "https://", "data:")):
+            return video_path
+
+        resolved_path = Path(video_path).resolve()
+        if not resolved_path.is_file():
+            raise FileNotFoundError(f"Video file not found: {video_path}")
+        if resolved_path.stat().st_size > _MAX_INLINE_VIDEO_BYTES:
+            raise ValueError(
+                "Local video is too large for inline native input; "
+                "falling back to sampled frames"
+            )
+
+        mime_type = mimetypes.guess_type(str(resolved_path))[0] or "video/mp4"
+        if not mime_type.startswith("video/"):
+            raise ValueError(f"Unsupported video MIME type: {mime_type}")
+
+        try:
+            encoded = base64.b64encode(resolved_path.read_bytes()).decode("ascii")
+        except OSError as exc:
+            raise RuntimeError(
+                f"Failed to read video file {video_path}: {exc}"
+            ) from exc
+        return f"data:{mime_type};base64,{encoded}"
+
     def _validate_images(self, images: Union[str, List[str]]) -> List[str]:
         """
         Validate and normalize image inputs.
@@ -168,6 +211,189 @@ class VisionCore:
 
         return images
 
+    def _validate_media(self, media: Union[str, List[str]]) -> List[str]:
+        """Validate and normalize media inputs."""
+        if isinstance(media, str):
+            media = [media]
+        if not media:
+            raise ValueError("At least one image or video must be provided")
+        if not all(isinstance(item, str) and item.strip() for item in media):
+            raise ValueError("all items in media must be non-empty strings")
+        if len(media) > 10:
+            raise ValueError("Maximum 10 media files can be analyzed at once")
+        return media
+
+    def _detect_media_kind(self, media_path: str) -> str:
+        """Classify an input without ever treating a video as an image."""
+        if media_path.startswith("data:"):
+            mime_type = media_path[5:].split(";", 1)[0].lower()
+        else:
+            type_source = media_path
+            if media_path.startswith(("http://", "https://")):
+                type_source = urlsplit(media_path).path
+            mime_type = (mimetypes.guess_type(type_source)[0] or "").lower()
+
+        if mime_type.startswith("image/"):
+            return "image"
+        if mime_type.startswith("video/"):
+            return "video"
+
+        suffix = Path(urlsplit(media_path).path).suffix.lower()
+        if suffix in {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"}:
+            return "image"
+        if suffix in {".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv"}:
+            return "video"
+        raise ValueError(
+            f"Unsupported media type for {media_path!r}; provide a supported image "
+            "or video file"
+        )
+
+    def _probe_video_duration(self, video_path: str) -> float:
+        ffprobe = shutil.which("ffprobe")
+        if not ffprobe:
+            raise RuntimeError(
+                "Video understanding requires ffprobe/ffmpeg to sample frames"
+            )
+        try:
+            completed = subprocess.run(
+                [
+                    ffprobe,
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    video_path,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            duration = float(completed.stdout.strip())
+        except (OSError, ValueError, subprocess.SubprocessError) as exc:
+            raise RuntimeError(f"Failed to inspect video {video_path}: {exc}") from exc
+        if duration <= 0:
+            raise RuntimeError(f"Video has no readable duration: {video_path}")
+        return duration
+
+    def _extract_video_frames(
+        self,
+        video_path: str,
+        *,
+        start_time: Optional[float],
+        end_time: Optional[float],
+        max_frames: int,
+    ) -> List[tuple[float, str]]:
+        """Sample video frames as JPEG data URLs for provider-neutral vision input."""
+        if video_path.startswith(("http://", "https://", "data:")):
+            raise ValueError(
+                "Video URLs and data URLs are not sampled directly; upload the video "
+                "or pass a workspace file_id"
+            )
+        resolved_path = str(Path(video_path).resolve())
+        if not Path(resolved_path).is_file():
+            raise FileNotFoundError(f"Video file not found: {video_path}")
+
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            raise RuntimeError(
+                "Video understanding requires ffprobe/ffmpeg to sample frames"
+            )
+
+        duration = self._probe_video_duration(resolved_path)
+        start = max(0.0, start_time or 0.0)
+        end = min(duration, end_time if end_time is not None else duration)
+        if start >= duration:
+            raise ValueError(
+                f"start_time {start:g}s is outside the {duration:.2f}s video"
+            )
+        if end <= start:
+            raise ValueError("end_time must be greater than start_time")
+
+        # Sample the midpoint of equal time buckets. Container duration can be
+        # driven by a longer audio stream, so requesting a frame near exact EOF
+        # may legitimately return no video bytes.
+        bucket_duration = (end - start) / max_frames
+        timestamps = [
+            start + bucket_duration * (index + 0.5) for index in range(max_frames)
+        ]
+
+        frames: List[tuple[float, str]] = []
+        for timestamp in timestamps:
+            try:
+                completed = subprocess.run(
+                    [
+                        ffmpeg,
+                        "-v",
+                        "error",
+                        "-ss",
+                        f"{timestamp:.3f}",
+                        "-i",
+                        resolved_path,
+                        "-frames:v",
+                        "1",
+                        "-f",
+                        "image2pipe",
+                        "-vcodec",
+                        "mjpeg",
+                        "pipe:1",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                logger.warning(
+                    "Failed to sample video frame at %.2fs from %s: %s",
+                    timestamp,
+                    video_path,
+                    exc,
+                )
+                continue
+            if not completed.stdout:
+                logger.warning(
+                    "Video decoder returned an empty frame at %.2fs from %s",
+                    timestamp,
+                    video_path,
+                )
+                continue
+            encoded = base64.b64encode(completed.stdout).decode("ascii")
+            frames.append((timestamp, f"data:image/jpeg;base64,{encoded}"))
+        if not frames:
+            raise RuntimeError(f"No video frames could be decoded from {video_path}")
+        return frames
+
+    def _video_frame_budgets(
+        self,
+        *,
+        image_count: int,
+        video_count: int,
+        max_frames: int,
+    ) -> List[int]:
+        """Share the model's ten-visual-input budget across videos."""
+        available = 10 - image_count
+        if available < video_count:
+            raise ValueError(
+                "Too many images and videos to include at least one frame per video"
+            )
+        budgets = [1] * video_count
+        remaining = available - video_count
+        while remaining:
+            changed = False
+            for index, budget in enumerate(budgets):
+                if budget >= max_frames:
+                    continue
+                budgets[index] += 1
+                remaining -= 1
+                changed = True
+                if not remaining:
+                    break
+            if not changed:
+                break
+        return budgets
+
     def _get_attr_safely(self, obj: Any, attr_name: str) -> Optional[str]:
         """
         Safely get an attribute value from an object, excluding Mock objects.
@@ -186,19 +412,25 @@ class VisionCore:
             return str(value) if value is not None else None
         return None
 
-    async def understand_images(
+    async def understand_media(
         self,
-        images: Union[str, List[str]],
+        media: Union[str, List[str]],
         question: str,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        max_frames: Optional[int] = None,
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
-    ) -> UnderstandImagesResult:
+    ) -> UnderstandMediaResult:
         """
-        Analyze images and answer questions about their content.
+        Analyze images, videos, or mixed media and answer a question.
 
         Args:
-            images: Single image path/URL or list of image paths/URLs
+            media: Image/video path, URL, file id, or a list of them
             question: Question to ask about the images
+            start_time: Optional video sampling start in seconds
+            end_time: Optional video sampling end in seconds
+            max_frames: Maximum sampled frames per video (1-10, default 8)
             temperature: Sampling temperature for generation
             max_tokens: Maximum tokens to generate
 
@@ -208,6 +440,15 @@ class VisionCore:
         try:
             temperature = self._coerce_optional_float(temperature, "temperature")
             max_tokens = self._coerce_optional_int(max_tokens, "max_tokens")
+            start_time = self._coerce_optional_float(start_time, "start_time")
+            end_time = self._coerce_optional_float(end_time, "end_time")
+            max_frames = self._coerce_optional_int(max_frames, "max_frames") or 8
+            if max_frames < 1 or max_frames > 10:
+                raise ValueError("max_frames must be between 1 and 10")
+            if start_time is not None and start_time < 0:
+                raise ValueError("start_time must be greater than or equal to 0")
+            if end_time is not None and end_time < 0:
+                raise ValueError("end_time must be greater than or equal to 0")
 
             # Validate vision model capability
             if not self.vision_model.has_ability("vision"):
@@ -225,43 +466,114 @@ class VisionCore:
                 if provider:
                     model_info += f", Provider: {provider}"
 
-                return UnderstandImagesResult(
+                return UnderstandMediaResult(
                     success=False,
                     error=f"{model_info} does not support vision capabilities",
                 )
 
-            # Validate and normalize images
-            validated_images = self._validate_images(images)
+            validated_media = self._validate_media(media)
+            classified = [
+                (media_path, self._detect_media_kind(media_path))
+                for media_path in validated_media
+            ]
+            image_count = sum(kind == "image" for _, kind in classified)
+            video_count = sum(kind == "video" for _, kind in classified)
+            video_budgets = iter(
+                self._video_frame_budgets(
+                    image_count=image_count,
+                    video_count=video_count,
+                    max_frames=max_frames,
+                )
+            )
+            use_native_video = self.vision_model.supports_native_video_input and (
+                image_count == 0 or self.vision_model.supports_native_video_with_images
+            )
+            if (start_time is not None or end_time is not None) and not (
+                self.vision_model.supports_native_video_time_range
+            ):
+                use_native_video = False
 
-            # Convert images to appropriate format
-            image_contents: List[Dict[str, Any]] = []
-            for img_path in validated_images:
+            visual_contents: List[Dict[str, Any]] = []
+            warnings: List[str] = []
+            processed_images = 0
+            processed_videos = 0
+            native_videos = 0
+            extracted_frames = 0
+            for media_path, kind in classified:
                 try:
-                    if img_path.startswith(("http://", "https://")):
-                        image_contents.append(
-                            {"type": "image_url", "image_url": {"url": img_path}}
+                    if kind == "video":
+                        frame_budget = next(video_budgets)
+                        if use_native_video:
+                            try:
+                                video_data = self._convert_video_to_base64(media_path)
+                                visual_contents.append(
+                                    self.vision_model.build_native_video_content(
+                                        video_data,
+                                        start_time=start_time,
+                                        end_time=end_time,
+                                    )
+                                )
+                                processed_videos += 1
+                                native_videos += 1
+                                continue
+                            except Exception as exc:
+                                warning = (
+                                    f"Native video input unavailable for {media_path}: "
+                                    f"{exc}; using sampled frames"
+                                )
+                                logger.warning(warning)
+                                warnings.append(warning)
+
+                        frames = await asyncio.to_thread(
+                            self._extract_video_frames,
+                            media_path,
+                            start_time=start_time,
+                            end_time=end_time,
+                            max_frames=frame_budget,
                         )
-                    elif img_path.startswith("data:"):
-                        image_contents.append(
-                            {"type": "image_url", "image_url": {"url": img_path}}
-                        )
+                        for timestamp, frame_data in frames:
+                            visual_contents.extend(
+                                [
+                                    {
+                                        "type": "text",
+                                        "text": (
+                                            f"Video {Path(media_path).name}, frame at "
+                                            f"{timestamp:.2f} seconds:"
+                                        ),
+                                    },
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": frame_data},
+                                    },
+                                ]
+                            )
+                        processed_videos += 1
+                        extracted_frames += len(frames)
                     else:
-                        base64_data = self._convert_image_to_base64(img_path)
-                        image_contents.append(
-                            {"type": "image_url", "image_url": {"url": base64_data}}
+                        image_data = (
+                            media_path
+                            if media_path.startswith(("http://", "https://", "data:"))
+                            else self._convert_image_to_base64(media_path)
                         )
+                        visual_contents.append(
+                            {"type": "image_url", "image_url": {"url": image_data}}
+                        )
+                        processed_images += 1
                 except Exception as e:
-                    logger.warning(f"Failed to process image {img_path}: {e}")
+                    warning = f"Failed to process {kind} {media_path}: {e}"
+                    logger.warning(warning)
+                    warnings.append(warning)
                     continue
 
-            if not image_contents:
-                return UnderstandImagesResult(
-                    success=False, error="No valid images could be processed"
+            if not visual_contents:
+                return UnderstandMediaResult(
+                    success=False,
+                    warnings=warnings,
+                    error="No valid images or video frames could be processed",
                 )
 
-            # Prepare the message content with images and question
             content = [{"type": "text", "text": question}]
-            content.extend(image_contents)
+            content.extend(visual_contents)
 
             # Create the message for vision chat
             messages = [{"role": "user", "content": content}]
@@ -281,16 +593,36 @@ class VisionCore:
             else:
                 answer = str(result)
 
-            return UnderstandImagesResult(
+            return UnderstandMediaResult(
                 success=True,
                 answer=answer,
-                images_processed=len(image_contents),
+                media_processed=processed_images + processed_videos,
+                images_processed=processed_images,
+                videos_processed=processed_videos,
+                native_videos_processed=native_videos,
+                frames_extracted=extracted_frames,
                 model_used=self.vision_model.__class__.__name__,
+                warnings=warnings,
             )
 
         except Exception as e:
-            logger.error(f"Image understanding failed: {e}")
-            return UnderstandImagesResult(success=False, error=str(e))
+            logger.error(f"Media understanding failed: {e}")
+            return UnderstandMediaResult(success=False, error=str(e))
+
+    async def understand_images(
+        self,
+        images: Union[str, List[str]],
+        question: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> UnderstandImagesResult:
+        """Backwards-compatible internal image-only entrypoint."""
+        return await self.understand_media(
+            media=images,
+            question=question,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
     async def describe_images(
         self,
@@ -819,6 +1151,30 @@ class VisionCore:
 
 
 # Convenience functions for direct usage
+async def understand_media(
+    vision_model: BaseLLM,
+    media: Union[str, List[str]],
+    question: str,
+    start_time: Optional[float] = None,
+    end_time: Optional[float] = None,
+    max_frames: Optional[int] = None,
+    temperature: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+    output_directory: Optional[str] = None,
+) -> UnderstandMediaResult:
+    """Analyze images, videos, or mixed media with a vision model."""
+    core = VisionCore(vision_model, output_directory)
+    return await core.understand_media(
+        media,
+        question,
+        start_time,
+        end_time,
+        max_frames,
+        temperature,
+        max_tokens,
+    )
+
+
 async def understand_images(
     vision_model: BaseLLM,
     images: Union[str, List[str]],

--- a/src/xagent/web/api/conversation_logs.py
+++ b/src/xagent/web/api/conversation_logs.py
@@ -16,6 +16,9 @@ from ..models.database import get_db
 from ..models.task import Task, TraceEvent
 from ..models.trigger import AgentTrigger, TriggerRun
 from ..models.user import User
+from ..services.file_reference_output_service import (
+    reconcile_assistant_file_references,
+)
 from ..utils.db_timezone import format_datetime_for_api
 
 logger = logging.getLogger(__name__)
@@ -236,6 +239,14 @@ def _serialize_transcript_with_events(
     # assistant (2), since compaction happens before the assistant reply.
     rows: list[tuple[float, int, dict[str, Any]]] = []
     for message in sorted(messages, key=_message_sort_key):
+        content = message.content
+        if message.role == "assistant":
+            content = reconcile_assistant_file_references(
+                db,
+                task_id=int(task.id),
+                user_id=int(task.user_id),
+                content=content,
+            )
         rows.append(
             (
                 _event_epoch(message.created_at) or 0.0,
@@ -243,7 +254,7 @@ def _serialize_transcript_with_events(
                 {
                     "id": int(message.id),
                     "role": message.role,
-                    "content": message.content,
+                    "content": content,
                     "message_type": message.message_type,
                     "interactions": message.interactions,
                     "turn_id": message.turn_id,
@@ -534,7 +545,12 @@ async def get_conversation_log_detail(
             "task": {
                 "task_id": int(task.id),
                 "input": task.input,
-                "output": task.output,
+                "output": reconcile_assistant_file_references(
+                    db,
+                    task_id=int(task.id),
+                    user_id=int(task.user_id),
+                    content=task.output,
+                ),
                 "error_message": task.error_message,
                 "description": task.description,
             },

--- a/src/xagent/web/api/conversation_logs.py
+++ b/src/xagent/web/api/conversation_logs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import math
 from datetime import timezone
-from typing import Any
+from typing import Any, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, case, func, or_
@@ -15,8 +15,10 @@ from ..models.chat_message import TaskChatMessage
 from ..models.database import get_db
 from ..models.task import Task, TraceEvent
 from ..models.trigger import AgentTrigger, TriggerRun
+from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..services.file_reference_output_service import (
+    load_assistant_file_reference_records,
     reconcile_assistant_file_references,
 )
 from ..utils.db_timezone import format_datetime_for_api
@@ -226,7 +228,10 @@ def _serialize_log_summary(task: Task, ui_source: str) -> dict[str, Any]:
 
 
 def _serialize_transcript_with_events(
-    db: Session, task: Task, messages: list[TaskChatMessage]
+    db: Session,
+    task: Task,
+    messages: list[TaskChatMessage],
+    file_reference_records: Sequence[UploadedFile] | None = None,
 ) -> list[dict[str, Any]]:
     """Transcript with successful context-compaction notices interleaved.
 
@@ -234,6 +239,13 @@ def _serialize_transcript_with_events(
     ``action_end_compact`` trace events and merge them in by timestamp to
     surface the same "context compacted" notice the live chat shows.
     """
+
+    if file_reference_records is None:
+        file_reference_records = load_assistant_file_reference_records(
+            db,
+            task_id=int(task.id),
+            user_id=int(task.user_id),
+        )
 
     # (sort_epoch, kind, payload); on ties order user (0) -> compaction (1) ->
     # assistant (2), since compaction happens before the assistant reply.
@@ -246,6 +258,7 @@ def _serialize_transcript_with_events(
                 task_id=int(task.id),
                 user_id=int(task.user_id),
                 content=content,
+                records=file_reference_records,
             )
         rows.append(
             (
@@ -537,9 +550,19 @@ async def get_conversation_log_detail(
         raise HTTPException(status_code=404, detail="Conversation log not found")
 
     messages = list(task.chat_messages or [])
+    file_reference_records = load_assistant_file_reference_records(
+        db,
+        task_id=int(task.id),
+        user_id=int(task.user_id),
+    )
     return {
         "log": _serialize_log_summary(task, ui_source),
-        "transcript": _serialize_transcript_with_events(db, task, messages),
+        "transcript": _serialize_transcript_with_events(
+            db,
+            task,
+            messages,
+            file_reference_records,
+        ),
         "trace_events": _serialize_trace_events(db, int(task.id)),
         "metadata": {
             "task": {
@@ -550,6 +573,7 @@ async def get_conversation_log_detail(
                     task_id=int(task.id),
                     user_id=int(task.user_id),
                     content=task.output,
+                    records=file_reference_records,
                 ),
                 "error_message": task.error_message,
                 "description": task.description,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -57,6 +57,7 @@ from ..services.chat_history_service import (
     mark_user_message_delivery_sync,
 )
 from ..services.file_reference_output_service import (
+    load_assistant_file_reference_records,
     reconcile_assistant_file_references,
 )
 from ..services.file_turn import (
@@ -1683,17 +1684,14 @@ async def execute_task_background(
                         db_new,
                         task_id=task_id,
                         user_id=int(effective_user_id),
-                        content=str(
-                            chat_response.get("message", ai_response)
-                            if isinstance(chat_response, dict)
-                            else ai_response
-                        ),
+                        content=str(ai_response),
                         message_type="chat_response"
                         if isinstance(chat_response, dict)
                         else "final_answer",
                         interactions=chat_response.get("interactions")
                         if isinstance(chat_response, dict)
                         else None,
+                        content_is_reconciled=True,
                     )
                     # Commit the pending terminal status. ``persist_assistant_message``
                     # commits internally when it writes a row, but it
@@ -2249,6 +2247,7 @@ async def execute_resume_background(
                         content=output,
                         message_type="final_answer",
                         turn_id=_latest_result_user_turn_id(result),
+                        content_is_reconciled=True,
                     )
                     orm_task_updated = cast(Any, task_updated)
                     orm_task_updated.output = output
@@ -4784,6 +4783,11 @@ async def send_historical_data_as_stream(
                 .order_by(TaskChatMessage.created_at, TaskChatMessage.id)
                 .all()
             )
+            file_reference_records = load_assistant_file_reference_records(
+                db,
+                task_id=int(task_id),
+                user_id=int(task.user_id),
+            )
             for chat_message in chat_messages:
                 role = str(chat_message.role)
                 content = str(chat_message.content or "").strip()
@@ -4793,6 +4797,7 @@ async def send_historical_data_as_stream(
                         task_id=int(task_id),
                         user_id=int(task.user_id),
                         content=content,
+                        records=file_reference_records,
                     )
                 # Read attachments off the row so file-only turns (empty
                 # content + non-empty attachments) survive replay and so the

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -56,6 +56,9 @@ from ..services.chat_history_service import (
     mark_user_message_delivery,
     mark_user_message_delivery_sync,
 )
+from ..services.file_reference_output_service import (
+    reconcile_assistant_file_references,
+)
 from ..services.file_turn import (
     append_uploaded_files_context as _append_uploaded_files_context_to_message,
 )
@@ -613,6 +616,27 @@ def _agent_outbound_event_type(payload: Dict[str, Any]) -> str:
     return "agent_progress"
 
 
+def _reconcile_streamed_final_answer(task_id: int, content: str) -> str:
+    """Repair the completed stream payload using task-scoped durable FileRefs."""
+    db_gen = get_db()
+    db = next(db_gen)
+    try:
+        task = db.query(Task).filter(Task.id == int(task_id)).first()
+        task_user_id = _task_user_id(task) if task is not None else None
+        if task_user_id is None:
+            return content
+        return str(
+            reconcile_assistant_file_references(
+                db,
+                task_id=int(task_id),
+                user_id=task_user_id,
+                content=content,
+            )
+        )
+    finally:
+        db.close()
+
+
 def make_agent_outbound_handler(task_id: int) -> Any:
     """Create a web bridge for agent agent-to-user messages."""
 
@@ -624,6 +648,15 @@ def make_agent_outbound_handler(task_id: int) -> Any:
             "final_answer_end",
             "final_answer_error",
         }:
+            if payload_type == "final_answer_end" and isinstance(
+                payload.get("content"), str
+            ):
+                payload = dict(payload)
+                payload["content"] = await asyncio.to_thread(
+                    _reconcile_streamed_final_answer,
+                    task_id,
+                    str(payload["content"]),
+                )
             await manager.broadcast_to_task(
                 create_final_answer_stream_event(payload_type, task_id, dict(payload)),
                 task_id,
@@ -1483,6 +1516,15 @@ async def execute_task_background(
             ai_response,
             path_to_file_id,
         )
+        if effective_user_id is not None:
+            ai_response = reconcile_assistant_file_references(
+                db,
+                task_id=int(task_id),
+                user_id=int(effective_user_id),
+                content=ai_response,
+            )
+            if isinstance(chat_response, dict) and chat_response.get("message"):
+                chat_response = {**chat_response, "message": ai_response}
 
         # Task execution result is logged by ConsoleTraceHandler, no need for duplicate logs
 
@@ -2147,6 +2189,12 @@ async def execute_resume_background(
                     if normalized_outputs:
                         result["file_outputs"] = normalized_outputs
                         output = _rewrite_file_links_to_file_id(output, path_to_file_id)
+                    output = reconcile_assistant_file_references(
+                        db_normalize,
+                        task_id=int(task_id),
+                        user_id=int(task_owner_user_id),
+                        content=output,
+                    )
             finally:
                 db_normalize.close()
 
@@ -4388,6 +4436,12 @@ async def handle_execute_task(
                 result.get("output", ""),
                 path_to_file_id,
             )
+            result["output"] = reconcile_assistant_file_references(
+                db,
+                task_id=int(task_id),
+                user_id=int(task.user_id),
+                content=result["output"],
+            )
 
             # Send task completion event (don't duplicate result as trace system already sent)
             await manager.broadcast_to_task(
@@ -4733,6 +4787,13 @@ async def send_historical_data_as_stream(
             for chat_message in chat_messages:
                 role = str(chat_message.role)
                 content = str(chat_message.content or "").strip()
+                if role == "assistant":
+                    content = reconcile_assistant_file_references(
+                        db,
+                        task_id=int(task_id),
+                        user_id=int(task.user_id),
+                        content=content,
+                    )
                 # Read attachments off the row so file-only turns (empty
                 # content + non-empty attachments) survive replay and so the
                 # chip metadata reaches the synthesized user_message event.

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -277,12 +277,17 @@ def persist_assistant_message(
     message_type: str = "assistant_message",
     interactions: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
+    content_is_reconciled: bool = False,
 ) -> Optional[TaskChatMessage]:
-    reconciled_content = reconcile_assistant_file_references(
-        db,
-        task_id=task_id,
-        user_id=user_id,
-        content=content,
+    reconciled_content = (
+        content
+        if content_is_reconciled
+        else reconcile_assistant_file_references(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            content=content,
+        )
     )
     transcript_content = build_assistant_transcript_content(
         reconciled_content, interactions
@@ -308,14 +313,19 @@ def persist_assistant_message_no_commit(
     message_type: str = "assistant_message",
     interactions: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
+    content_is_reconciled: bool = False,
 ) -> Optional[TaskChatMessage]:
     """Stage an assistant transcript row for an atomic caller-owned commit."""
 
-    reconciled_content = reconcile_assistant_file_references(
-        db,
-        task_id=task_id,
-        user_id=user_id,
-        content=content,
+    reconciled_content = (
+        content
+        if content_is_reconciled
+        else reconcile_assistant_file_references(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            content=content,
+        )
     )
     transcript_content = build_assistant_transcript_content(
         reconciled_content, interactions

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -14,6 +14,7 @@ from ...core.agent.transcript import (
     normalize_transcript_messages,
 )
 from ..models.chat_message import TaskChatMessage
+from .file_reference_output_service import reconcile_assistant_file_references
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +278,15 @@ def persist_assistant_message(
     interactions: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
-    transcript_content = build_assistant_transcript_content(content, interactions)
+    reconciled_content = reconcile_assistant_file_references(
+        db,
+        task_id=task_id,
+        user_id=user_id,
+        content=content,
+    )
+    transcript_content = build_assistant_transcript_content(
+        reconciled_content, interactions
+    )
     return _persist_message(
         db=db,
         task_id=task_id,
@@ -302,7 +311,15 @@ def persist_assistant_message_no_commit(
 ) -> Optional[TaskChatMessage]:
     """Stage an assistant transcript row for an atomic caller-owned commit."""
 
-    transcript_content = build_assistant_transcript_content(content, interactions)
+    reconciled_content = reconcile_assistant_file_references(
+        db,
+        task_id=task_id,
+        user_id=user_id,
+        content=content,
+    )
+    transcript_content = build_assistant_transcript_content(
+        reconciled_content, interactions
+    )
     normalized_content = transcript_content.strip()
     if not normalized_content:
         return None

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -21,24 +21,15 @@ _MARKDOWN_FILE_REFERENCE_RE = re.compile(
 )
 
 
-def reconcile_assistant_file_references(
+def load_assistant_file_reference_records(
     db: Session,
     *,
     task_id: int,
     user_id: int,
-    content: Any,
-) -> Any:
-    """Canonicalize valid links, repair unique filename matches, and unlink fakes.
+) -> list[UploadedFile]:
+    """Load the task/user file scope once for one or more reconciliations."""
 
-    Models occasionally copy a filename correctly while inventing the UUID in
-    ``file:<id>``. A broken UUID must never become a clickable preview. When the
-    markdown label uniquely identifies a file in the current task/user scope,
-    replace it with that record's canonical id; otherwise keep only plain text.
-    """
-    if not isinstance(content, str) or "file:" not in content:
-        return content
-
-    records = (
+    return (
         db.query(UploadedFile)
         .filter(
             UploadedFile.user_id == int(user_id),
@@ -46,6 +37,34 @@ def reconcile_assistant_file_references(
         )
         .all()
     )
+
+
+def reconcile_assistant_file_references(
+    db: Session,
+    *,
+    task_id: int,
+    user_id: int,
+    content: Any,
+    records: Sequence[UploadedFile] | None = None,
+) -> Any:
+    """Canonicalize valid links, repair unique filename matches, and unlink fakes.
+
+    Models occasionally copy a filename correctly while inventing the UUID in
+    ``file:<id>``. A broken UUID must never become a clickable preview. When the
+    markdown label uniquely identifies a file in the current task/user scope,
+    replace it with that record's canonical id; otherwise keep only plain text.
+    Filename repair is necessarily heuristic if an older same-named file is no
+    longer present, so every repair is logged as a warning for auditability.
+    """
+    if not isinstance(content, str) or "file:" not in content:
+        return content
+
+    if records is None:
+        records = load_assistant_file_reference_records(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+        )
     records_by_id = {str(record.file_id): record for record in records}
     records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
     task_records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
@@ -70,9 +89,9 @@ def reconcile_assistant_file_references(
                 candidates = records_by_filename.get(filename_key, [])
             if len(candidates) == 1:
                 record = candidates[0]
-                logger.info(
-                    "Repaired invalid assistant FileRef %s using unique filename %s "
-                    "for task %s",
+                logger.warning(
+                    "Repaired invalid assistant FileRef %s using heuristic unique "
+                    "filename %s for task %s",
                     referenced_id or target,
                     filename,
                     task_id,

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -1,0 +1,91 @@
+"""Validate and repair model-authored file links before they reach the UI."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from ...core.file_ref import build_file_id_ref, parse_file_id_ref
+from ..models.uploaded_file import UploadedFile
+
+logger = logging.getLogger(__name__)
+
+_MARKDOWN_FILE_REFERENCE_RE = re.compile(
+    r"(?P<image>!)?\[(?P<label>[^\]]*)\]\((?P<target>file:[^)\s]+)\)"
+)
+
+
+def reconcile_assistant_file_references(
+    db: Session,
+    *,
+    task_id: int,
+    user_id: int,
+    content: Any,
+) -> Any:
+    """Canonicalize valid links, repair unique filename matches, and unlink fakes.
+
+    Models occasionally copy a filename correctly while inventing the UUID in
+    ``file:<id>``. A broken UUID must never become a clickable preview. When the
+    markdown label uniquely identifies a file in the current task/user scope,
+    replace it with that record's canonical id; otherwise keep only plain text.
+    """
+    if not isinstance(content, str) or "file:" not in content:
+        return content
+
+    records = (
+        db.query(UploadedFile)
+        .filter(
+            UploadedFile.user_id == int(user_id),
+            or_(UploadedFile.task_id == int(task_id), UploadedFile.task_id.is_(None)),
+        )
+        .all()
+    )
+    records_by_id = {str(record.file_id): record for record in records}
+    records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
+    task_records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
+    for record in records:
+        filename_key = str(record.filename).casefold()
+        records_by_filename[filename_key].append(record)
+        if record.task_id is not None and int(record.task_id) == int(task_id):
+            task_records_by_filename[filename_key].append(record)
+
+    def replacement(match: re.Match[str]) -> str:
+        prefix = match.group("image") or ""
+        label = match.group("label")
+        target = match.group("target")
+        referenced_id = parse_file_id_ref(target)
+        record = records_by_id.get(referenced_id or "")
+
+        if record is None:
+            filename = Path(label.strip()).name
+            filename_key = filename.casefold()
+            candidates = task_records_by_filename.get(filename_key, [])
+            if not candidates:
+                candidates = records_by_filename.get(filename_key, [])
+            if len(candidates) == 1:
+                record = candidates[0]
+                logger.info(
+                    "Repaired invalid assistant FileRef %s using unique filename %s "
+                    "for task %s",
+                    referenced_id or target,
+                    filename,
+                    task_id,
+                )
+
+        if record is None:
+            logger.warning(
+                "Removed invalid assistant FileRef %s for task %s",
+                referenced_id or target,
+                task_id,
+            )
+            return label
+
+        return f"{prefix}[{label}]({build_file_id_ref(str(record.file_id))})"
+
+    return _MARKDOWN_FILE_REFERENCE_RE.sub(replacement, content)

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -105,6 +105,17 @@ def reconcile_assistant_file_references(
             )
             return label
 
-        return f"{prefix}[{label}]({build_file_id_ref(str(record.file_id))})"
+        try:
+            canonical_ref = build_file_id_ref(str(record.file_id))
+        except ValueError:
+            logger.warning(
+                "Removed assistant FileRef %s for task %s because stored file id %s "
+                "is invalid",
+                referenced_id or target,
+                task_id,
+                record.file_id,
+            )
+            return label
+        return f"{prefix}[{label}]({canonical_ref})"
 
     return _MARKDOWN_FILE_REFERENCE_RE.sub(replacement, content)

--- a/src/xagent/web/services/task_execution_context_service.py
+++ b/src/xagent/web/services/task_execution_context_service.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
+from ...core.file_ref import build_file_id_ref
 from ...skills.utils import create_skill_manager
 from ..models.task import TraceEvent
 
@@ -182,6 +183,7 @@ def summarize_execution_failure_event(data: Dict[str, Any]) -> Optional[str]:
 def _summarize_generic_result(result: Any, max_length: int = 240) -> Optional[str]:
     if result is None:
         return None
+    file_links = _collect_file_reference_links(result)
     compact_result = _compact_preview_value(result)
     if isinstance(compact_result, str):
         preview = compact_result.strip()
@@ -191,11 +193,69 @@ def _summarize_generic_result(result: Any, max_length: int = 240) -> Optional[st
         except Exception:
             preview = str(compact_result).strip()
 
+    file_summary = f"files: {', '.join(file_links)}" if file_links else ""
     if not preview:
-        return None
-    if len(preview) > max_length:
-        return preview[: max_length - 3] + "..."
-    return preview
+        return file_summary or None
+    if not file_summary:
+        if len(preview) > max_length:
+            return preview[: max_length - 3] + "..."
+        return preview
+
+    # FileRefs are durable execution state. Keep their canonical markdown links
+    # intact and spend only the remaining preview budget on verbose provider
+    # payloads (video URLs commonly appear before file_ref in tool results).
+    separator = "; result: "
+    remaining = max_length - len(file_summary) - len(separator)
+    if remaining <= 3:
+        return file_summary
+    if len(preview) > remaining:
+        preview = preview[: remaining - 3] + "..."
+    return file_summary + separator + preview
+
+
+_MARKDOWN_FILE_LINK_RE = re.compile(r"!?\[[^\]]*\]\((file:[^)\s]+)\)")
+
+
+def _collect_file_reference_links(value: Any, *, limit: int = 5) -> List[str]:
+    """Collect exact model-facing FileRef links from a nested tool result."""
+    links: List[str] = []
+    seen: set[str] = set()
+
+    def add(link: str) -> None:
+        normalized = link.strip()
+        if not normalized or normalized in seen or len(links) >= limit:
+            return
+        seen.add(normalized)
+        links.append(normalized)
+
+    def visit(item: Any, depth: int = 0) -> None:
+        if depth > 8 or len(links) >= limit:
+            return
+        if isinstance(item, dict):
+            file_id = str(item.get("file_id") or "").strip()
+            filename = str(item.get("filename") or item.get("name") or "").strip()
+            markdown_link = item.get("markdown_link")
+            if isinstance(markdown_link, str):
+                matches = _MARKDOWN_FILE_LINK_RE.findall(markdown_link)
+                if matches:
+                    add(markdown_link)
+            elif file_id and filename:
+                try:
+                    add(f"[{filename}]({build_file_id_ref(file_id)})")
+                except ValueError:
+                    pass
+
+            for key, nested in item.items():
+                if key in {"raw", "raw_response", "content", "video_url"}:
+                    continue
+                if isinstance(nested, (dict, list, tuple)):
+                    visit(nested, depth + 1)
+        elif isinstance(item, (list, tuple)):
+            for nested in item:
+                visit(nested, depth + 1)
+
+    visit(value)
+    return links
 
 
 def _compact_preview_value(value: Any, *, max_string_length: int = 160) -> Any:

--- a/tests/core/model/chat/basic/test_dashscope.py
+++ b/tests/core/model/chat/basic/test_dashscope.py
@@ -113,6 +113,32 @@ def test_dashscope_provider_reasoning_hook_disables_qwen_thinking(dashscope_llm)
     }
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    ["qwen3.7-plus", "qwen3.5-plus", "qwen3-vl-flash", "qwen-omni-turbo"],
+)
+def test_dashscope_native_video_capability_for_supported_families(model_name):
+    llm = DashScopeLLM(
+        model_name=model_name,
+        base_url=_DASHSCOPE_BASE_URL,
+        api_key="test-key",
+        abilities=["vision"],
+    )
+
+    assert llm.supports_native_video_input is True
+
+
+def test_dashscope_text_model_does_not_claim_native_video():
+    llm = DashScopeLLM(
+        model_name="qwen-plus",
+        base_url=_DASHSCOPE_BASE_URL,
+        api_key="test-key",
+        abilities=["vision"],
+    )
+
+    assert llm.supports_native_video_input is False
+
+
 def test_dashscope_provider_reasoning_hook_enables_qwen_thinking(dashscope_llm):
     assert dashscope_llm._prepare_provider_reasoning_extra_body(
         extra_body={"trace_id": "abc"},

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -576,6 +576,12 @@ class TestGeminiLLMSDK:
             }
         ]
 
+    def test_native_video_conversion_rejects_unsupported_remote_url(self) -> None:
+        llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+
+        with pytest.raises(ValueError, match="inline local video"):
+            llm.build_native_video_content("https://example.com/clip.mp4")
+
     @pytest.mark.asyncio
     async def test_supports_thinking_mode(self, llm: GeminiLLM) -> None:
         """Test that Gemini does not support thinking mode."""

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -540,11 +540,41 @@ class TestGeminiLLMSDK:
         vision_llm = GeminiLLM(model_name="gemini-pro-vision", api_key="test-key")
         assert "vision" in vision_llm.abilities
 
-        # Test non-vision model
+        # Gemini chat models are natively multimodal.
         chat_llm = GeminiLLM(model_name="gemini-1.5-pro", api_key="test-key")
-        assert "vision" not in chat_llm.abilities
+        assert "vision" in chat_llm.abilities
         assert "chat" in chat_llm.abilities
         assert "tool_calling" in chat_llm.abilities
+
+    def test_native_video_conversion_uses_inline_data_and_offsets(self) -> None:
+        llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+        content = llm.build_native_video_content(
+            "data:video/mp4;base64,ZmFrZV92aWRlbw==",
+            start_time=1.5,
+            end_time=4,
+        )
+
+        _, messages = llm._convert_messages_to_gemini_format(
+            [{"role": "user", "content": [content]}]
+        )
+
+        assert messages == [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "inline_data": {
+                            "mime_type": "video/mp4",
+                            "data": "ZmFrZV92aWRlbw==",
+                        },
+                        "video_metadata": {
+                            "start_offset": "1.5s",
+                            "end_offset": "4s",
+                        },
+                    }
+                ],
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_supports_thinking_mode(self, llm: GeminiLLM) -> None:

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -30,6 +30,28 @@ class TestZhipuLLM:
             llm._client = mock_zhipu_client
             return llm
 
+    @pytest.mark.parametrize("model_name", ["glm-4.5v", "glm-4.6v-flash"])
+    def test_native_video_capability(self, model_name):
+        llm = ZhipuLLM(
+            model_name=model_name,
+            api_key="test-key",
+            abilities=["vision"],
+        )
+
+        assert llm.supports_native_video_input is True
+
+    def test_native_video_content_uses_raw_base64(self):
+        llm = ZhipuLLM(
+            model_name="glm-4.6v",
+            api_key="test-key",
+            abilities=["vision"],
+        )
+
+        assert llm.build_native_video_content("data:video/mp4;base64,ZmFrZQ==") == {
+            "type": "video_url",
+            "video_url": {"url": "ZmFrZQ=="},
+        }
+
     @pytest.mark.asyncio
     async def test_normal_text_response(self, zhipu_llm, mock_zhipu_client):
         """Test normal text response handling."""

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -498,6 +498,26 @@ class TestVisionToolUnderstandMedia:
         mock_vision_model.vision_chat.assert_not_awaited()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(("start_time", "end_time"), [(4, 4), (10, 2)])
+    async def test_understand_video_rejects_non_increasing_time_range(
+        self,
+        vision_tool_without_workspace,
+        mock_vision_model,
+        start_time,
+        end_time,
+    ):
+        result = await vision_tool_without_workspace.understand_media(
+            "clip.mp4",
+            "What happens?",
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        assert result.success is False
+        assert "end_time must be greater than start_time" in result.error
+        mock_vision_model.vision_chat.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_understand_video_samples_timestamped_frames(
         self, vision_tool_without_workspace, mock_vision_model
     ):
@@ -678,11 +698,42 @@ class TestVisionToolUnderstandMedia:
         ]
         assert content[1]["type"] == "video_url"
 
+    @pytest.mark.asyncio
+    async def test_unsupported_native_video_url_does_not_fail_other_media(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        mock_vision_model.supports_native_video_input = True
+
+        def build_native_video_content(url, **_):
+            if url.startswith("https://"):
+                raise ValueError("unsupported remote video URL")
+            return {"type": "video_url", "video_url": {"url": url}}
+
+        mock_vision_model.build_native_video_content = Mock(
+            side_effect=build_native_video_content
+        )
+
+        result = await vision_tool_without_workspace.understand_media(
+            [
+                "data:video/mp4;base64,ZmFrZV92aWRlbw==",
+                "https://example.com/remote.mp4",
+            ],
+            "Summarize the available video",
+        )
+
+        assert result.success is True
+        assert result.videos_processed == 1
+        assert result.native_videos_processed == 1
+        assert any("unsupported remote video URL" in item for item in result.warnings)
+        assert any("upload the video" in item for item in result.warnings)
+        mock_vision_model.vision_chat.assert_awaited_once()
+
     def test_frame_budget_reserves_one_frame_for_every_video(
         self, vision_tool_without_workspace
     ):
         assert vision_tool_without_workspace.core._video_frame_budgets(
             image_count=2,
+            native_video_count=0,
             video_count=2,
             max_frames=8,
         ) == [4, 4]
@@ -717,7 +768,7 @@ class TestVisionToolUnderstandMedia:
         frame_budgets.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_native_failure_budgets_only_fallback_videos(self, mock_vision_model):
+    async def test_native_videos_consume_fallback_frame_budget(self, mock_vision_model):
         mock_vision_model.supports_native_video_input = True
         mock_vision_model.build_native_video_content = Mock(
             return_value={
@@ -733,6 +784,7 @@ class TestVisionToolUnderstandMedia:
                 "_convert_video_to_base64",
                 side_effect=[
                     "data:video/mp4;base64,ZmFrZS12aWRlbw==",
+                    "data:video/mp4;base64,ZmFrZS12aWRlbw==",
                     ValueError("cannot inline"),
                 ],
             ),
@@ -743,13 +795,13 @@ class TestVisionToolUnderstandMedia:
             ) as extract_frames,
         ):
             result = await tool.understand_media(
-                ["native.mp4", "fallback.mp4"],
+                ["native-1.mp4", "native-2.mp4", "fallback.mp4"],
                 "Compare the videos",
-                max_frames=8,
+                max_frames=10,
             )
 
         assert result.success is True
-        assert result.native_videos_processed == 1
+        assert result.native_videos_processed == 2
         assert result.frames_extracted == 1
         extract_frames.assert_called_once_with(
             "fallback.mp4",

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -524,7 +524,18 @@ class TestVisionToolUnderstandMedia:
         )
         tool = VisionTool(mock_vision_model)
 
-        with patch.object(tool.core, "_extract_video_frames") as extract_frames:
+        with (
+            patch.object(
+                tool.core,
+                "_convert_video_to_base64",
+                return_value="data:video/mp4;base64,ZmFrZS12aWRlbw==",
+            ) as convert_video,
+            patch(
+                "xagent.core.tools.core.vision_tool.asyncio.to_thread",
+                new=AsyncMock(return_value="data:video/mp4;base64,ZmFrZS12aWRlbw=="),
+            ) as to_thread,
+            patch.object(tool.core, "_extract_video_frames") as extract_frames,
+        ):
             result = await tool.understand_media(
                 str(video_path),
                 "What happens?",
@@ -537,6 +548,7 @@ class TestVisionToolUnderstandMedia:
         assert result.native_videos_processed == 1
         assert result.frames_extracted == 0
         extract_frames.assert_not_called()
+        to_thread.assert_awaited_once_with(convert_video, str(video_path))
 
         video_data = mock_vision_model.build_native_video_content.call_args.args[0]
         assert video_data.startswith("data:video/mp4;base64,")
@@ -644,6 +656,122 @@ class TestVisionToolUnderstandMedia:
             video_count=2,
             max_frames=8,
         ) == [4, 4]
+
+    @pytest.mark.asyncio
+    async def test_all_native_videos_skip_fallback_frame_budget(
+        self, mock_vision_model
+    ):
+        mock_vision_model.supports_native_video_input = True
+        mock_vision_model.build_native_video_content = Mock(
+            side_effect=lambda url, **_: {
+                "type": "video_url",
+                "video_url": {"url": url},
+            }
+        )
+        tool = VisionTool(mock_vision_model)
+        media = [f"clip-{index}.mp4" for index in range(10)]
+
+        with (
+            patch.object(
+                tool.core,
+                "_convert_video_to_base64",
+                return_value="data:video/mp4;base64,ZmFrZS12aWRlbw==",
+            ),
+            patch.object(tool.core, "_video_frame_budgets") as frame_budgets,
+        ):
+            result = await tool.understand_media(media, "Summarize all videos")
+
+        assert result.success is True
+        assert result.native_videos_processed == 10
+        assert result.frames_extracted == 0
+        frame_budgets.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_native_failure_budgets_only_fallback_videos(self, mock_vision_model):
+        mock_vision_model.supports_native_video_input = True
+        mock_vision_model.build_native_video_content = Mock(
+            return_value={
+                "type": "video_url",
+                "video_url": {"url": "provider-ready-video"},
+            }
+        )
+        tool = VisionTool(mock_vision_model)
+
+        with (
+            patch.object(
+                tool.core,
+                "_convert_video_to_base64",
+                side_effect=[
+                    "data:video/mp4;base64,ZmFrZS12aWRlbw==",
+                    ValueError("cannot inline"),
+                ],
+            ),
+            patch.object(
+                tool.core,
+                "_extract_video_frames",
+                return_value=[(1.0, "data:image/jpeg;base64,ZmFrZQ==")],
+            ) as extract_frames,
+        ):
+            result = await tool.understand_media(
+                ["native.mp4", "fallback.mp4"],
+                "Compare the videos",
+                max_frames=8,
+            )
+
+        assert result.success is True
+        assert result.native_videos_processed == 1
+        assert result.frames_extracted == 1
+        extract_frames.assert_called_once_with(
+            "fallback.mp4",
+            start_time=None,
+            end_time=None,
+            max_frames=8,
+        )
+
+    def test_probe_video_duration_requires_ffprobe(self, vision_tool_without_workspace):
+        with patch(
+            "xagent.core.tools.core.vision_tool.shutil.which", return_value=None
+        ):
+            with pytest.raises(RuntimeError, match="requires ffprobe/ffmpeg"):
+                vision_tool_without_workspace.core._probe_video_duration("clip.mp4")
+
+    def test_extract_video_frames_skips_empty_frame_and_uses_bucket_midpoints(
+        self, vision_tool_without_workspace, tmp_path
+    ):
+        video_path = tmp_path / "clip.mp4"
+        video_path.write_bytes(b"fake-video")
+        completed_frames = [Mock(stdout=b""), Mock(stdout=b"jpeg-frame")]
+
+        with (
+            patch(
+                "xagent.core.tools.core.vision_tool.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+            patch.object(
+                vision_tool_without_workspace.core,
+                "_probe_video_duration",
+                return_value=8.0,
+            ),
+            patch(
+                "xagent.core.tools.core.vision_tool.subprocess.run",
+                side_effect=completed_frames,
+            ) as run,
+        ):
+            frames = vision_tool_without_workspace.core._extract_video_frames(
+                str(video_path),
+                start_time=0.0,
+                end_time=8.0,
+                max_frames=2,
+            )
+
+        assert frames == [
+            (
+                6.0,
+                "data:image/jpeg;base64,"
+                + base64.b64encode(b"jpeg-frame").decode("ascii"),
+            )
+        ]
+        assert [call.args[0][4] for call in run.call_args_list] == ["2.000", "6.000"]
 
 
 class TestVisionToolDescribeImages:

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -27,6 +27,7 @@ def mock_vision_model():
 
     # Mock has_ability method
     model.has_ability = Mock(return_value=True)
+    model.supports_native_video_input = False
 
     return model
 
@@ -429,7 +430,7 @@ class TestVisionToolUnderstandImages:
         )
 
         assert result.success is False
-        assert "No valid images could be processed" in result.error
+        assert "No valid images or video frames could be processed" in result.error
 
     @pytest.mark.asyncio
     async def test_understand_no_model_available(self):
@@ -461,6 +462,188 @@ class TestVisionToolUnderstandImages:
 
         assert result.success is False
         assert "Model error" in result.error
+
+
+class TestVisionToolUnderstandMedia:
+    """Tests for the public image/video understanding entrypoint."""
+
+    @pytest.mark.asyncio
+    async def test_understand_video_samples_timestamped_frames(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        frames = [
+            (0.0, "data:image/jpeg;base64,ZmFrZV9mcmFtZV8x"),
+            (2.5, "data:image/jpeg;base64,ZmFrZV9mcmFtZV8y"),
+        ]
+        with patch.object(
+            vision_tool_without_workspace.core,
+            "_extract_video_frames",
+            return_value=frames,
+        ) as extract_frames:
+            result = await vision_tool_without_workspace.understand_media(
+                "clip.mp4",
+                "What changes over time?",
+                start_time=0,
+                end_time=3,
+                max_frames=2,
+            )
+
+        assert result.success is True
+        assert result.media_processed == 1
+        assert result.images_processed == 0
+        assert result.videos_processed == 1
+        assert result.frames_extracted == 2
+        extract_frames.assert_called_once_with(
+            "clip.mp4", start_time=0.0, end_time=3.0, max_frames=2
+        )
+
+        content = mock_vision_model.vision_chat.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        assert content[0] == {"type": "text", "text": "What changes over time?"}
+        assert content[1]["text"] == "Video clip.mp4, frame at 0.00 seconds:"
+        assert content[3]["text"] == "Video clip.mp4, frame at 2.50 seconds:"
+        image_items = [item for item in content if item["type"] == "image_url"]
+        assert [item["image_url"]["url"] for item in image_items] == [
+            frame_data for _, frame_data in frames
+        ]
+
+    @pytest.mark.asyncio
+    async def test_understand_video_uses_native_input_when_model_supports_it(
+        self, tmp_path, mock_vision_model
+    ):
+        video_path = tmp_path / "clip.mp4"
+        video_path.write_bytes(b"fake-video")
+        mock_vision_model.supports_native_video_input = True
+        mock_vision_model.supports_native_video_time_range = True
+        mock_vision_model.build_native_video_content = Mock(
+            return_value={
+                "type": "video_url",
+                "video_url": {"url": "provider-ready-video"},
+            }
+        )
+        tool = VisionTool(mock_vision_model)
+
+        with patch.object(tool.core, "_extract_video_frames") as extract_frames:
+            result = await tool.understand_media(
+                str(video_path),
+                "What happens?",
+                start_time=1,
+                end_time=4,
+            )
+
+        assert result.success is True
+        assert result.videos_processed == 1
+        assert result.native_videos_processed == 1
+        assert result.frames_extracted == 0
+        extract_frames.assert_not_called()
+
+        video_data = mock_vision_model.build_native_video_content.call_args.args[0]
+        assert video_data.startswith("data:video/mp4;base64,")
+        assert mock_vision_model.build_native_video_content.call_args.kwargs == {
+            "start_time": 1.0,
+            "end_time": 4.0,
+        }
+        content = mock_vision_model.vision_chat.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        assert content[1] == {
+            "type": "video_url",
+            "video_url": {"url": "provider-ready-video"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_time_range_falls_back_when_native_protocol_has_no_offsets(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        mock_vision_model.supports_native_video_input = True
+        mock_vision_model.supports_native_video_time_range = False
+        with patch.object(
+            vision_tool_without_workspace.core,
+            "_extract_video_frames",
+            return_value=[(2.0, "data:image/jpeg;base64,ZmFrZQ==")],
+        ) as extract_frames:
+            result = await vision_tool_without_workspace.understand_media(
+                "clip.mp4",
+                "What happens between one and three seconds?",
+                start_time=1,
+                end_time=3,
+                max_frames=1,
+            )
+
+        assert result.success is True
+        assert result.native_videos_processed == 0
+        assert result.frames_extracted == 1
+        extract_frames.assert_called_once_with(
+            "clip.mp4", start_time=1.0, end_time=3.0, max_frames=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_understand_mixed_media_uses_one_model_call(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        with patch.object(
+            vision_tool_without_workspace.core,
+            "_extract_video_frames",
+            return_value=[(1.0, "data:image/jpeg;base64,ZmFrZV9mcmFtZQ==")],
+        ):
+            result = await vision_tool_without_workspace.understand_media(
+                ["data:image/png;base64,ZmFrZV9pbWFnZQ==", "clip.mov"],
+                "Compare them",
+                max_frames=1,
+            )
+
+        assert result.success is True
+        assert result.media_processed == 2
+        assert result.images_processed == 1
+        assert result.videos_processed == 1
+        assert result.frames_extracted == 1
+        mock_vision_model.vision_chat.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_video_is_never_wrapped_directly_as_image_url(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        result = await vision_tool_without_workspace.understand_media(
+            "data:video/mp4;base64,ZmFrZV92aWRlbw==", "What happens?"
+        )
+
+        assert result.success is False
+        assert result.warnings
+        mock_vision_model.vision_chat.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_video_data_url_is_passed_without_frame_sampling(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        mock_vision_model.supports_native_video_input = True
+        mock_vision_model.build_native_video_content = Mock(
+            side_effect=lambda url, **_: {
+                "type": "video_url",
+                "video_url": {"url": url},
+            }
+        )
+
+        result = await vision_tool_without_workspace.understand_media(
+            "data:video/mp4;base64,ZmFrZV92aWRlbw==", "What happens?"
+        )
+
+        assert result.success is True
+        assert result.native_videos_processed == 1
+        assert result.frames_extracted == 0
+        content = mock_vision_model.vision_chat.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        assert content[1]["type"] == "video_url"
+
+    def test_frame_budget_reserves_one_frame_for_every_video(
+        self, vision_tool_without_workspace
+    ):
+        assert vision_tool_without_workspace.core._video_frame_budgets(
+            image_count=2,
+            video_count=2,
+            max_frames=8,
+        ) == [4, 4]
 
 
 class TestVisionToolDescribeImages:
@@ -731,12 +914,11 @@ class TestGetVisionTool:
         """Test get_vision_tool with model provided"""
         tools = get_vision_tool(vision_model=mock_vision_model)
 
-        assert len(tools) == 3
+        assert len(tools) == 2
 
         # Check tool names
         tool_names = [tool.metadata.name for tool in tools]
-        assert "understand_images" in tool_names
-        assert "describe_images" in tool_names
+        assert "understand_media" in tool_names
         assert "detect_objects" in tool_names
 
     def test_get_vision_tool_with_workspace(self, mock_vision_model, mock_workspace):
@@ -745,12 +927,11 @@ class TestGetVisionTool:
             vision_model=mock_vision_model, workspace=mock_workspace
         )
 
-        assert len(tools) == 3
+        assert len(tools) == 2
 
         # Check that tools were created (workspace binding is internal to VisionTool)
         tool_names = [tool.metadata.name for tool in tools]
-        assert "understand_images" in tool_names
-        assert "describe_images" in tool_names
+        assert "understand_media" in tool_names
         assert "detect_objects" in tool_names
 
     def test_get_vision_tool_without_model(self):
@@ -759,20 +940,19 @@ class TestGetVisionTool:
 
         # Test should handle both scenarios:
         # 1. No vision models available (returns empty list)
-        # 2. Vision models available in test environment (returns 3 tools)
+        # 2. Vision models available in test environment (returns 2 tools)
 
         if len(tools) == 0:
             # No vision models available scenario
             assert len(tools) == 0
-        elif len(tools) == 3:
+        elif len(tools) == 2:
             # Vision models available scenario
             tool_names = [tool.metadata.name for tool in tools]
-            assert "understand_images" in tool_names
-            assert "describe_images" in tool_names
+            assert "understand_media" in tool_names
             assert "detect_objects" in tool_names
         else:
             # Unexpected number of tools - this indicates a problem
-            pytest.fail(f"Expected 0 or 3 tools, got {len(tools)}")
+            pytest.fail(f"Expected 0 or 2 tools, got {len(tools)}")
 
 
 class TestGetDefaultVisionModel:
@@ -843,10 +1023,10 @@ class TestVisionToolIntegration:
             vision_model=mock_vision_model, workspace=mock_workspace
         )
 
-        # Find understand_images tool
+        # Find unified media understanding tool
         understand_tool = None
         for tool in tools:
-            if tool.metadata.name == "understand_images":
+            if tool.metadata.name == "understand_media":
                 understand_tool = tool
                 break
 
@@ -854,7 +1034,7 @@ class TestVisionToolIntegration:
 
         # Execute tool
         result = await understand_tool.run_json_async(
-            {"images": "existing_image.jpg", "question": "What is this image?"}
+            {"media": "existing_image.jpg", "question": "What is this image?"}
         )
 
         assert result["success"] is True
@@ -874,12 +1054,8 @@ class TestVisionToolIntegration:
         tools_dict = {tool.metadata.name: tool for tool in tools}
 
         # Execute all tools
-        understand_result = await tools_dict["understand_images"].run_json_async(
-            {"images": "existing_image.jpg", "question": "What is this?"}
-        )
-
-        describe_result = await tools_dict["describe_images"].run_json_async(
-            {"images": "existing_image.jpg", "question": "Describe this image"}
+        understand_result = await tools_dict["understand_media"].run_json_async(
+            {"media": "existing_image.jpg", "question": "What is this?"}
         )
 
         detect_result = await tools_dict["detect_objects"].run_json_async(
@@ -888,11 +1064,10 @@ class TestVisionToolIntegration:
 
         # All should succeed and use the same model
         assert understand_result["success"] is True
-        assert describe_result["success"] is True
         assert detect_result["success"] is True
 
         # Verify model was called for each tool
-        assert mock_vision_model.vision_chat.call_count == 3
+        assert mock_vision_model.vision_chat.call_count == 2
 
     def test_tool_metadata(self, mock_vision_model):
         """Test that tools have correct metadata"""
@@ -923,7 +1098,7 @@ class TestVisionToolErrorHandling:
         assert (
             result.success is False
             and result.error is not None
-            and "At least one image must be provided" in result.error
+            and "At least one image or video must be provided" in result.error
         )
 
     @pytest.mark.asyncio
@@ -934,7 +1109,7 @@ class TestVisionToolErrorHandling:
         assert (
             result.success is False
             and result.error is not None
-            and "At least one image must be provided" in result.error
+            and "At least one image or video must be provided" in result.error
         )
 
 

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -468,6 +468,36 @@ class TestVisionToolUnderstandMedia:
     """Tests for the public image/video understanding entrypoint."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field_name", "invalid_value"),
+        [
+            ("start_time", float("nan")),
+            ("start_time", float("inf")),
+            ("end_time", float("nan")),
+            ("end_time", float("inf")),
+        ],
+    )
+    async def test_understand_video_rejects_non_finite_time_ranges(
+        self,
+        vision_tool_without_workspace,
+        mock_vision_model,
+        field_name,
+        invalid_value,
+    ):
+        result = await vision_tool_without_workspace.understand_media(
+            "clip.mp4",
+            "What happens?",
+            **{field_name: invalid_value},
+        )
+
+        assert result.success is False
+        assert (
+            f"{field_name} must be a finite number greater than or equal to 0"
+            in result.error
+        )
+        mock_vision_model.vision_chat.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_understand_video_samples_timestamped_frames(
         self, vision_tool_without_workspace, mock_vision_model
     ):

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -561,6 +561,12 @@ async def test_pause_admin_on_other_users_task_runs_as_owner(db_session) -> None
         patch("xagent.web.api.websocket.manager", ws_manager),
     ):
         await handle_pause_task(MagicMock(), int(task.id), {"user": admin})
+        for _ in range(100):
+            if "task_owner_user_id" in captured:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("durable pause command was not dispatched in time")
 
     # Built and paused as the OWNER, not the admin actor.
     assert captured["task_owner_user_id"] == int(owner.id)

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -121,5 +123,34 @@ def test_reconcile_unlinks_unknown_or_ambiguous_file_reference():
 
         assert content == "missing.mp4 and report.mp4"
         assert "file:" not in content
+    finally:
+        db.close()
+
+
+def test_reconcile_reuses_prefetched_records_without_querying():
+    db, user, task = _create_context()
+    try:
+        record = _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        with patch.object(
+            db,
+            "query",
+            side_effect=AssertionError("prefetched reconciliation must not query"),
+        ):
+            content = reconcile_assistant_file_references(
+                db,
+                task_id=int(task.id),
+                user_id=int(user.id),
+                content="[generated_video.mp4](file:invented-id)",
+                records=[record],
+            )
+
+        assert content == "[generated_video.mp4](file:real-id)"
     finally:
         db.close()

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1,0 +1,125 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+from xagent.web.services.file_reference_output_service import (
+    reconcile_assistant_file_references,
+)
+
+
+def _create_context():
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    user = User(username="owner", password_hash="hashed", is_admin=False)
+    db.add(user)
+    db.flush()
+    task = Task(
+        user_id=int(user.id),
+        title="FileRef task",
+        description="Generate a video",
+        status=TaskStatus.COMPLETED,
+    )
+    db.add(task)
+    db.flush()
+    return db, user, task
+
+
+def _add_file(db, user, task, *, file_id: str, filename: str):
+    record = UploadedFile(
+        file_id=file_id,
+        user_id=int(user.id),
+        task_id=int(task.id) if task is not None else None,
+        filename=filename,
+        storage_path=f"/tmp/{file_id}/{filename}",
+        mime_type="video/mp4",
+        file_size=123,
+    )
+    db.add(record)
+    db.flush()
+    return record
+
+
+def test_reconcile_keeps_valid_file_reference():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[generated_video.mp4](file:real-id)",
+        )
+
+        assert content == "[generated_video.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_repairs_invented_id_from_unique_filename():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="c6553861-5bdd-4628-9b15-1310e34fe499",
+            filename="generated_video_253a6da9.mp4",
+        )
+        _add_file(
+            db,
+            user,
+            None,
+            file_id="older-unbound-id",
+            filename="generated_video_253a6da9.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=(
+                "下载：[generated_video_253a6da9.mp4]"
+                "(file:253a6da9-76e1-4b16-b26e-2eba2d8b0583)"
+            ),
+        )
+
+        assert content == (
+            "下载：[generated_video_253a6da9.mp4]"
+            "(file:c6553861-5bdd-4628-9b15-1310e34fe499)"
+        )
+    finally:
+        db.close()
+
+
+def test_reconcile_unlinks_unknown_or_ambiguous_file_reference():
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="first-id", filename="report.mp4")
+        _add_file(db, user, task, file_id="second-id", filename="report.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=(
+                "[missing.mp4](file:invented-id) and "
+                "[report.mp4](file:another-invented-id)"
+            ),
+        )
+
+        assert content == "missing.mp4 and report.mp4"
+        assert "file:" not in content
+    finally:
+        db.close()

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -127,6 +127,29 @@ def test_reconcile_unlinks_unknown_or_ambiguous_file_reference():
         db.close()
 
 
+def test_reconcile_unlinks_record_with_invalid_file_id():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="invalid/id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[generated_video.mp4](file:invented-id)",
+        )
+
+        assert content == "generated_video.mp4"
+    finally:
+        db.close()
+
+
 def test_reconcile_reuses_prefetched_records_without_querying():
     db, user, task = _create_context()
     try:

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -237,6 +237,48 @@ async def test_agent_outbound_handler_skips_hidden_messages(monkeypatch) -> None
     assert broadcast_calls == []
 
 
+@pytest.mark.asyncio
+async def test_agent_outbound_handler_repairs_completed_final_answer(
+    monkeypatch,
+) -> None:
+    broadcast_calls: list[tuple[dict[str, object], int]] = []
+
+    def fake_reconcile(task_id: int, content: str) -> str:
+        assert task_id == 365
+        assert content == "[video.mp4](file:invented-id)"
+        return "[video.mp4](file:real-id)"
+
+    async def fake_to_thread(func: object, /, *args: object):
+        return func(*args)
+
+    async def fake_broadcast(event: dict[str, object], task_id: int) -> None:
+        broadcast_calls.append((event, task_id))
+
+    monkeypatch.setattr(
+        "xagent.web.api.websocket._reconcile_streamed_final_answer",
+        fake_reconcile,
+    )
+    monkeypatch.setattr("xagent.web.api.websocket.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.broadcast_to_task", fake_broadcast
+    )
+
+    handler = make_agent_outbound_handler(365)
+    await handler(
+        {
+            "type": "final_answer_end",
+            "message_id": "final-answer-1",
+            "content": "[video.mp4](file:invented-id)",
+        }
+    )
+
+    assert len(broadcast_calls) == 1
+    event, task_id = broadcast_calls[0]
+    assert task_id == 365
+    assert event["type"] == "final_answer_end"
+    assert event["content"] == "[video.mp4](file:real-id)"
+
+
 def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
@@ -155,6 +157,31 @@ def test_persist_assistant_message_repairs_invented_file_id():
 
         assert message is not None
         assert message.content == "[generated_video.mp4](file:real-video-id)"
+    finally:
+        db_session.close()
+
+
+def test_persist_assistant_message_skips_duplicate_reconciliation():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        with patch(
+            "xagent.web.services.chat_history_service."
+            "reconcile_assistant_file_references",
+            side_effect=AssertionError("content was already reconciled"),
+        ):
+            message = persist_assistant_message(
+                db_session,
+                int(task.id),
+                int(task.user_id),
+                "Already canonical",
+                message_type="final_answer",
+                content_is_reconciled=True,
+            )
+
+        assert message is not None
+        assert message.content == "Already canonical"
     finally:
         db_session.close()
 

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -7,6 +7,7 @@ from xagent.core.agent.transcript import build_assistant_transcript_content
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.chat_history_service import (
     DELIVERY_FAILED,
@@ -123,6 +124,37 @@ def test_persist_assistant_message_formats_interactions_into_transcript():
         assert stored_message.role == "assistant"
         assert "Please answer the following questions:" in stored_message.content
         assert "Repository path: Enter the repository path" in stored_message.content
+    finally:
+        db_session.close()
+
+
+def test_persist_assistant_message_repairs_invented_file_id():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        db_session.add(
+            UploadedFile(
+                file_id="real-video-id",
+                user_id=int(task.user_id),
+                task_id=int(task.id),
+                filename="generated_video.mp4",
+                storage_path="/tmp/real-video-id/generated_video.mp4",
+                mime_type="video/mp4",
+                file_size=123,
+            )
+        )
+        db_session.commit()
+
+        message = persist_assistant_message(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "[generated_video.mp4](file:invented-video-id)",
+            message_type="final_answer",
+        )
+
+        assert message is not None
+        assert message.content == "[generated_video.mp4](file:real-video-id)"
     finally:
         db_session.close()
 

--- a/tests/web/test_task_execution_context_service.py
+++ b/tests/web/test_task_execution_context_service.py
@@ -131,6 +131,47 @@ def test_summarize_tool_event_compacts_nested_large_strings():
     assert "a" * 200 not in summary
 
 
+def test_summarize_tool_event_preserves_file_ref_before_long_video_payload():
+    file_id = "c6553861-5bdd-4628-9b15-1310e34fe499"
+    markdown_link = f"[generated_video_253a6da9.mp4](file:{file_id})"
+
+    summary = summarize_tool_event(
+        {
+            "tool_name": "generate_video",
+            "success": True,
+            "result": {
+                "success": True,
+                "video_url": "https://provider.example/video?signature=" + ("x" * 500),
+                "file_ref": {
+                    "file_id": file_id,
+                    "filename": "generated_video_253a6da9.mp4",
+                    "markdown_link": markdown_link,
+                },
+            },
+        }
+    )
+
+    assert summary is not None
+    assert summary.startswith("- Tool generate_video previously returned: files: ")
+    assert markdown_link in summary
+    assert file_id in summary
+
+
+def test_summarize_tool_event_builds_link_from_file_id_and_filename():
+    summary = summarize_tool_event(
+        {
+            "tool_name": "write_file",
+            "success": True,
+            "result": {
+                "file_refs": [{"file_id": "report-id", "filename": "report.pdf"}]
+            },
+        }
+    )
+
+    assert summary is not None
+    assert "[report.pdf](file:report-id)" in summary
+
+
 def test_summarize_execution_failure_event_includes_step_anchor():
     summary = summarize_execution_failure_event(
         {


### PR DESCRIPTION
## What changed

- replace separate public image understanding tools with one `understand_media` entry point for images, videos, and mixed media
- route supported Gemini, Qwen, and GLM models through native video inputs, while keeping timestamped frame extraction as the fallback
- preserve canonical FileRefs in compacted execution context and validate/repair assistant file links across persistence, live streams, and historical replay
- install ffmpeg in the backend runtime for provider-neutral frame extraction

## Why

Video files were treated as images or could not be inspected after generation, so agents could not validate temporal behavior. Separately, verbose tool results could push the canonical generated-file reference out of the compact execution summary, allowing the model to invent a plausible-looking but invalid file UUID. The file itself existed, but the final link could not be opened.

## Impact

Models with native video support retain motion, timing, and—where supported by the model—audio information. Other vision models continue to work through sampled frames without adding another public tool. Generated file links are now durable and task-scoped, and historical links can be repaired from a unique task filename.

## Validation

- 315 targeted model, vision-tool, FileRef, history, WebSocket, orchestrator, and task API tests
- focused WebSocket and media-understanding regression tests after import normalization
- all changed-file pre-commit hooks, including ruff, mypy, isort, codespell, and whitespace checks
- `git diff --check`
