### PR TITLE
fix(kb): parse staged background uploads instead of the unpublished canonical path

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -334,6 +334,14 @@ class ParseDocumentRequest(BaseModel):
     collection: str = Field(..., description="Collection name for data isolation")
     doc_id: str = Field(..., description="Document ID to parse")
     parse_method: ParseMethod = Field(..., description="Parsing method to use")
+    source_path_override: Optional[str] = Field(
+        None,
+        description=(
+            "Physical file path to parse instead of the document row's persisted "
+            "source_path. Used by staged ingestion so parsing reads the staged "
+            "upload while durable metadata keeps the canonical path."
+        ),
+    )
     params: Optional[Dict[str, Any]] = Field(
         None, description="Optional parameters for parsing"
     )

--- a/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
@@ -277,6 +277,7 @@ class KBLegacyStepCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         progress_callback: Optional[Any] = None,
+        source_path_override: Optional[str] = None,
     ) -> Dict[str, Any]:
         from ..parse.parse_document import _parse_document_impl
 
@@ -295,6 +296,7 @@ class KBLegacyStepCompatibilityFacade:
                     user_id=user_id,
                     is_admin=is_admin,
                     progress_callback=progress_callback,
+                    source_path_override=source_path_override,
                     handle=handle,
                 )
             self._record_parse_side_effect(

--- a/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
@@ -52,6 +52,7 @@ def parse_document(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     progress_callback: Optional[Any] = None,
+    source_path_override: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Parse a document using the specified method."""
     return _get_legacy_step_compatibility_facade().parse_document(
@@ -62,6 +63,7 @@ def parse_document(
         user_id=user_id,
         is_admin=is_admin,
         progress_callback=progress_callback,
+        source_path_override=source_path_override,
     )
 
 
@@ -73,6 +75,7 @@ def _parse_document_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     progress_callback: Optional[Any] = None,
+    source_path_override: Optional[str] = None,
     *,
     handle: "LanceDBCollectionHandle",
 ) -> Dict[str, Any]:
@@ -98,6 +101,7 @@ def _parse_document_impl(
         collection=collection,
         doc_id=doc_id,
         parse_method=parse_method,
+        source_path_override=source_path_override,
         params=params,
         user_id=user_id,
         is_admin=is_admin,
@@ -149,7 +153,7 @@ async def _parse_document_internal(
     if not document:
         raise DocumentNotFoundError(f"Document not found: {doc_id}")
 
-    source_path = document["source_path"]
+    source_path = request.source_path_override or document["source_path"]
     file_type = document["file_type"]
     logger.info("Found document: %s", source_path)
 

--- a/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
@@ -248,7 +248,10 @@ async def _parse_document_internal(
         # Start with parser metadata, then override with authoritative values
         enriched_metadata = {
             **paragraph.metadata,
-            "source": source_path,
+            # Persist the canonical path from the document row, not the physical
+            # path actually read (which for staged ingestion is a transient file
+            # removed after publish). Durable metadata must keep the canonical path.
+            "source": document["source_path"],
             "file_type": file_type,  # Use file_type from database (without dot)
             "parse_method": str(parse_method),
             "parser": f"local:{parse_method}@v1.0.0",

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -841,6 +841,10 @@ def _process_document_impl(
                     user_id=user_id,
                     is_admin=is_admin,
                     progress_callback=parse_tracker,
+                    # Parse the physical input actually supplied to this run, not
+                    # the canonical path persisted in document metadata (which for
+                    # staged uploads is not published until ingestion succeeds).
+                    source_path_override=source_path,
                 )
         parse_model = (
             parse_response

--- a/tests/core/tools/core/RAG_tools/parse/test_parse_document.py
+++ b/tests/core/tools/core/RAG_tools/parse/test_parse_document.py
@@ -224,6 +224,82 @@ class TestParseDocumentCore:
                 is_admin=True,
             )
 
+    def test_staged_parse_uses_physical_path_when_canonical_absent(
+        self,
+        tmp_path,
+        temp_lancedb_dir: str,
+        test_collection: str,
+        test_doc_id: str,
+    ) -> None:
+        """Regression for GH #931: staged ingestion must parse the physical staged
+        file while durable metadata keeps the canonical path, even though that
+        canonical file is not published until after ingestion succeeds.
+        """
+        staged = tmp_path / "staged.txt"
+        staged.write_text("staged marker content", encoding="utf-8")
+        canonical = tmp_path / "canonical" / "doc.txt"
+        assert not canonical.exists()
+
+        register_document(
+            collection=test_collection,
+            source_path=str(staged),
+            metadata_source_path=str(canonical),
+            doc_id=test_doc_id,
+            user_id=1,
+        )
+
+        out = parse_document(
+            collection=test_collection,
+            doc_id=test_doc_id,
+            parse_method=ParseMethod.DEEPDOC,
+            user_id=1,
+            is_admin=True,
+            source_path_override=str(staged),
+        )
+
+        # Parse succeeded reading the staged file; canonical never had to exist.
+        assert out["written"] is True
+        assert not canonical.exists()
+        joined = " ".join(p["text"] for p in out["paragraphs"])
+        assert "staged marker content" in joined
+
+    def test_staged_parse_reads_new_staged_bytes_over_existing_canonical(
+        self,
+        tmp_path,
+        temp_lancedb_dir: str,
+        test_collection: str,
+        test_doc_id: str,
+    ) -> None:
+        """Updating an existing target must parse the new staged bytes, not the
+        previous canonical file contents (GH #931 second consequence)."""
+        canonical = tmp_path / "canonical" / "doc.txt"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("old canonical content", encoding="utf-8")
+        staged = tmp_path / "staged.txt"
+        staged.write_text("new staged content", encoding="utf-8")
+
+        register_document(
+            collection=test_collection,
+            source_path=str(staged),
+            metadata_source_path=str(canonical),
+            doc_id=test_doc_id,
+            user_id=1,
+        )
+
+        out = parse_document(
+            collection=test_collection,
+            doc_id=test_doc_id,
+            parse_method=ParseMethod.DEEPDOC,
+            user_id=1,
+            is_admin=True,
+            source_path_override=str(staged),
+        )
+
+        assert out["written"] is True
+        joined = " ".join(p["text"] for p in out["paragraphs"])
+        assert "new staged content" in joined
+        assert "old canonical content" not in joined
+
 
 class TestParseDocumentFallback:
     """Test three-tier fallback logic for parse_document internal functions."""

--- a/tests/core/tools/core/RAG_tools/parse/test_parse_document.py
+++ b/tests/core/tools/core/RAG_tools/parse/test_parse_document.py
@@ -263,6 +263,20 @@ class TestParseDocumentCore:
         joined = " ".join(p["text"] for p in out["paragraphs"])
         assert "staged marker content" in joined
 
+        # Durable metadata keeps the canonical path (acceptance criterion #2):
+        # both the document row and paragraph metadata store the canonical path,
+        # not the transient staged path that gets removed after publish.
+        from xagent.core.tools.core.RAG_tools.parse.parse_document import (
+            _get_document_from_db,
+        )
+
+        document = _get_document_from_db(
+            collection=test_collection, doc_id=test_doc_id, user_id=1, is_admin=True
+        )
+        assert document is not None
+        assert document["source_path"] == str(canonical)
+        assert out["paragraphs"][0]["metadata"]["source"] == str(canonical)
+
     def test_staged_parse_reads_new_staged_bytes_over_existing_canonical(
         self,
         tmp_path,
@@ -299,6 +313,17 @@ class TestParseDocumentCore:
         joined = " ".join(p["text"] for p in out["paragraphs"])
         assert "new staged content" in joined
         assert "old canonical content" not in joined
+
+        # Durable metadata still stores the canonical path (acceptance criterion #2).
+        from xagent.core.tools.core.RAG_tools.parse.parse_document import (
+            _get_document_from_db,
+        )
+
+        document = _get_document_from_db(
+            collection=test_collection, doc_id=test_doc_id, user_id=1, is_admin=True
+        )
+        assert document is not None
+        assert document["source_path"] == str(canonical)
 
 
 class TestParseDocumentFallback:

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -720,6 +720,43 @@ def test_process_document_passes_file_id_to_register_document(
     assert captured_kwargs["file_id"] == "file-123"
 
 
+def test_process_document_parses_physical_source_not_metadata_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parsing must read the physical source_path, not the canonical metadata path.
+
+    Staged uploads pass the staged file as ``source_path`` and the not-yet-published
+    canonical path as ``metadata_source_path``. The parse step must be handed the
+    physical staged path so it never depends on a file published only after success.
+    """
+    _patch_pipeline_dependencies(monkeypatch)
+    captured_kwargs: Dict[str, object] = {}
+
+    def _capture_parse_document(**kwargs: object) -> dict:
+        captured_kwargs.update(kwargs)
+        return ParseDocumentResponse(
+            doc_id="doc-1",
+            parse_hash="hash-1",
+            paragraphs=[ParsedParagraph(text="para", metadata={})],
+            written=True,
+        ).model_dump()
+
+    monkeypatch.setattr(document_ingestion, "parse_document", _capture_parse_document)
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/staging/.background-ingest/abc/doc.pdf",
+        config=IngestionConfig(),
+        metadata_source_path="/uploads/user_1/kb/doc.pdf",
+    )
+
+    assert result.status == "success"
+    assert (
+        captured_kwargs["source_path_override"]
+        == "/staging/.background-ingest/abc/doc.pdf"
+    )
+
+
 def test_process_document_skips_embedding_when_no_pending(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -380,6 +380,125 @@ def test_kb_document_job_reads_staged_file_and_publishes_canonical(
         db.close()
 
 
+class _StubEmbeddingAdapter:
+    """Deterministic embedding adapter so the real pipeline avoids external APIs."""
+
+    def encode(self, text, dimension=None, instruct=None):
+        if isinstance(text, str):
+            return [float(len(text)), 0.0]
+        return [[float(len(item)), float(i)] for i, item in enumerate(text)]
+
+    def get_dimension(self) -> int:
+        return 2
+
+    @property
+    def abilities(self):
+        return ["embedding"]
+
+
+def test_kb_document_job_full_worker_path_new_target_end_to_end(tmp_path, monkeypatch):
+    """Real register->parse->publish->cleanup without mocking run_document_ingestion.
+
+    Proves GH #931 end-to-end: a new staged target is parsed from the staged file
+    (canonical absent until publish), and the persisted document row, content hash,
+    chunks, embeddings, and published file all represent the same staged bytes.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+    monkeypatch.setenv("LANCEDB_DIR", str((tmp_path / "lancedb").resolve()))
+
+    from xagent.core.model.model import EmbeddingModelConfig
+    from xagent.core.storage.manager import initialize_storage_manager
+    from xagent.core.tools.core.RAG_tools.parse.parse_document import (
+        _get_document_from_db,
+    )
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+    from xagent.core.tools.core.RAG_tools.utils.hash_utils import compute_file_hash
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
+
+    storage_root = tmp_path / "storage"
+    uploads_dir = storage_root / "uploads"
+    uploads_dir.mkdir(parents=True)
+    initialize_storage_manager(str(storage_root), str(uploads_dir))
+
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
+    stub_config = EmbeddingModelConfig(
+        id="embedding-default",
+        model_name="stub",
+        model_provider="stub",
+        dimension=2,
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "_resolve_embedding_adapter",
+        lambda _cfg: (stub_config, _StubEmbeddingAdapter()),
+    )
+    # Collection init resolves the adapter through its own imported reference.
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_embedding_adapter",
+        lambda *args, **kwargs: (stub_config, _StubEmbeddingAdapter()),
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "kb-full-worker.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="kb-full-worker-test")
+        staged_file = tmp_path / "stage" / "doc.txt"
+        target_file = tmp_path / "canonical" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("staged end to end content", encoding="utf-8")
+        assert not target_file.exists()
+        file_id = "55555555-5555-4555-8555-555555555555"
+        ingestion_config = IngestionConfig(embedding_model_id="embedding-default")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_DOCUMENT,
+            payload={
+                "collection": "kb",
+                "source_path": str(staged_file),
+                "target_path": str(target_file),
+                "file_id": file_id,
+                "filename": "doc.txt",
+                "mime_type": "text/plain",
+                "file_size": staged_file.stat().st_size,
+                "user_id": int(user.id),
+                "is_admin": True,
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "collection_existed_before": False,
+            },
+        )
+
+        result = handle_kb_ingest_document(db, job)
+
+        # Ingestion succeeded end-to-end on the real pipeline.
+        assert result["status"] == "success"
+        assert result["chunk_count"] > 0
+        assert result["embedding_count"] > 0
+        assert result["vector_count"] > 0
+        assert result["file_id"] == file_id
+
+        # Canonical file published with staged bytes; staged input cleaned up.
+        assert target_file.read_text(encoding="utf-8") == "staged end to end content"
+        assert not staged_file.exists()
+
+        # Durable metadata is canonical and its hash matches the published bytes.
+        document = _get_document_from_db(
+            collection="kb",
+            doc_id=result["doc_id"],
+            user_id=int(user.id),
+            is_admin=True,
+        )
+        assert document is not None
+        assert document["source_path"] == str(target_file)
+        assert document["content_hash"] == compute_file_hash(str(target_file))
+    finally:
+        db.close()
+
+
 def test_kb_document_job_supersedes_older_generation_for_same_target(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Background staged document ingestion promised to parse the staged upload while
persisting the future canonical path as metadata, but the pipeline conflated the
two paths and parsed the canonical one — which is only published *after*
ingestion succeeds. New targets therefore failed deterministically at
`parse_document` with `File not found`.

Root cause: physical parse input and durable metadata path shared a single
`source_path` column on the document row. `register_document` persisted the
canonical path, and `parse_document` re-derived its physical input from that
persisted value, so it opened a file that cannot exist until parsing succeeds.

Fix: carry the physical parse path explicitly into the parse step via a new
optional `source_path_override`. Durable metadata still stores only the canonical
path. When the override is absent, parsing falls back to the persisted path, so
all other callers (re-parse, etc.) are unaffected.

This also closes the existing-target correctness risk: parsing now reads the new
staged bytes instead of the previous canonical file, keeping the persisted file,
content hash, chunks, and embeddings representing the same content.

Closes #931

## Changes

- `core/schemas.py` — add optional `source_path_override` to `ParseDocumentRequest`.
- `parse/parse_document.py` — parse `request.source_path_override or document["source_path"]`; thread the new arg through the public and impl signatures.
- `kb/legacy_step_compatibility.py` — forward `source_path_override` in the parse facade.
- `pipelines/document_ingestion.py` — pass the physical `source_path` as `source_path_override` to the parse step.

## Tests

- `test_document_ingestion.py` — pipeline forwards the physical `source_path` (not the canonical metadata path) to parsing.
- `test_parse_document.py` — real register→parse regressions (no `run_document_ingestion` mock):
  - staged file parses successfully while the canonical target remains absent;
  - updating an existing target parses the new staged bytes, not the old canonical contents.

All three fail on the current implementation.

## Verification

- `pytest` parse + pipeline + KB compatibility + background-jobs suites — pass.
- `ruff check` and `mypy` on changed source — clean.

## Out of scope

Concurrent-generation isolation / RAG-output redesign (#559) is a separate
concern and is intentionally not addressed here.
