### PR TITLE
feat(workforce): add runs history for workforce (#801)

### DIFF
--- a/frontend/src/app/workforces/[id]/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/page-client.tsx
@@ -2,8 +2,8 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import Link from "next/link"
-import { useParams } from "next/navigation"
-import { ArrowLeft, LayoutDashboard, MessageSquare } from "lucide-react"
+import { useParams, useRouter } from "next/navigation"
+import { ArrowLeft, History, LayoutDashboard, MessageSquare } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
 import type { Task } from "@/contexts/app-context-chat"
@@ -30,6 +30,7 @@ import {
     normalizeWorkerSortOrder,
     WorkforceCanvas,
     WorkforceConfigPanel,
+    WorkforceRunsList,
     WorkforceStatusBadge,
     type WorkerEditState,
 } from "@/components/workforce"
@@ -38,7 +39,7 @@ import { ResizableSplitLayout } from "@/components/layout/resizable-split-layout
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
 
-type ActiveView = "configure" | "canvas"
+type ActiveView = "configure" | "canvas" | "runs"
 
 interface LoadOptions {
     silent?: boolean
@@ -47,6 +48,7 @@ interface LoadOptions {
 export default function WorkforceDetailPage() {
     const { t } = useI18n()
     const params = useParams()
+    const router = useRouter()
     const { sendMessage, setTaskId, closeFilePreview, dispatch } = useApp()
     const id = Array.isArray(params.id) ? params.id[0] : params.id
 
@@ -337,6 +339,17 @@ export default function WorkforceDetailPage() {
                         <LayoutDashboard className="h-3.5 w-3.5 rotate-90" />
                         {t("workforces.canvas.title")}
                     </button>
+                    <button
+                        onClick={() => setActiveView("runs")}
+                        className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                            activeView === "runs"
+                                ? "bg-background text-foreground shadow-sm"
+                                : "text-muted-foreground hover:text-foreground"
+                        }`}
+                    >
+                        <History className="h-3.5 w-3.5" />
+                        {t("workforces.runs.title")}
+                    </button>
                 </div>
 
                 <div className="flex-1" />
@@ -381,9 +394,21 @@ export default function WorkforceDetailPage() {
                                     onRemoveWorker={handleRemoveWorker}
                                 />
                             </div>
-                        ) : (
+                        ) : activeView === "canvas" ? (
                             <div className="h-full">
                                 <WorkforceCanvas workforce={workforce} />
+                            </div>
+                        ) : (
+                            <div className="h-full overflow-y-auto p-4 sm:p-6">
+                                <div className="mx-auto max-w-3xl">
+                                    <h2 className="text-sm font-semibold">{t("workforces.runs.historyTitle")}</h2>
+                                    <p className="mt-1 text-xs text-muted-foreground">{t("workforces.runs.historyHint")}</p>
+                                    <WorkforceRunsList
+                                        className="mt-4"
+                                        workforceId={id ?? workforce.id}
+                                        onSelectRun={(run) => router.push(`/workforces/${id ?? workforce.id}/run?run=${run.id}`)}
+                                    />
+                                </div>
                             </div>
                         )
                     }

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -369,11 +369,14 @@ function WorkforceRunPageInner() {
     if (openedRunParamRef.current === runParam) return
     openedRunParamRef.current = runParam
     let active = true
+    let settled = false
     void (async () => {
       try {
         const run = await getWorkforceRun(id, runParam)
+        settled = true
         if (active) openRun(run)
       } catch (err) {
+        settled = true
         if (active) {
           // Allow retrying the same ?run= value after a failed load.
           openedRunParamRef.current = null
@@ -383,6 +386,11 @@ function WorkforceRunPageInner() {
     })()
     return () => {
       active = false
+      // If the fetch was discarded mid-flight (StrictMode double-invoke or a
+      // dependency change), release the ref so the next effect run retries.
+      if (!settled && openedRunParamRef.current === runParam) {
+        openedRunParamRef.current = null
+      }
     }
   }, [id, runParam, openRun, t, closeFilePreview, dispatch, setTaskId])
 

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -2,7 +2,7 @@
 
 import React, { Suspense, useCallback, useEffect, useRef, useState } from "react"
 import Link from "next/link"
-import { useParams, useSearchParams } from "next/navigation"
+import { useParams, useRouter, useSearchParams } from "next/navigation"
 import {
   ReactFlow,
   Background,
@@ -274,6 +274,7 @@ export default function WorkforceRunPage() {
 function WorkforceRunPageInner() {
   const { t } = useI18n()
   const params = useParams()
+  const router = useRouter()
   const searchParams = useSearchParams()
   const { sendMessage, setTaskId, closeFilePreview, dispatch, state } = useApp()
   const id = Array.isArray(params.id) ? params.id[0] : params.id
@@ -329,6 +330,10 @@ function WorkforceRunPageInner() {
     }
     setHistoryOpen(false)
     if (previewTaskIdRef.current === run.task_id) return
+    // Keep ?run= authoritative no matter which path opened the run, and mark
+    // it as opened so the deep-link effect doesn't refetch it.
+    openedRunParamRef.current = String(run.id)
+    router.replace(`/workforces/${id}/run?run=${run.id}`, { scroll: false })
     previewTaskIdRef.current = run.task_id
     setTaskStarted(true)
     closeFilePreview()

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -323,7 +323,10 @@ function WorkforceRunPageInner() {
   }, [])
 
   const openRun = useCallback((run: WorkforceRunHistoryItem) => {
-    if (!run.task_id) return
+    if (!run.task_id) {
+      toast.error(t("workforces.runs.taskDeleted"))
+      return
+    }
     setHistoryOpen(false)
     if (previewTaskIdRef.current === run.task_id) return
     previewTaskIdRef.current = run.task_id
@@ -340,10 +343,30 @@ function WorkforceRunPageInner() {
       updatedAt: run.completed_at ?? run.created_at ?? new Date().toISOString(),
     }
     dispatch({ type: "SET_CURRENT_TASK", payload: taskPayload })
-  }, [closeFilePreview, setTaskId, dispatch])
+  }, [closeFilePreview, setTaskId, dispatch, t])
 
   useEffect(() => {
-    if (!id || !runParam || openedRunParamRef.current === runParam) return
+    if (!id) return
+    if (!runParam) {
+      // Navigating back to the plain run page (e.g. browser back clearing
+      // ?run=) should return to the fresh "start a new run" state instead of
+      // staying stuck in the previously opened conversation.
+      if (openedRunParamRef.current !== null) {
+        openedRunParamRef.current = null
+        previewTaskIdRef.current = null
+        setTaskStarted(false)
+        closeFilePreview()
+        dispatch({ type: "CLEAR_MESSAGES" })
+        dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
+        dispatch({ type: "SET_STEPS", payload: [] })
+        dispatch({ type: "SET_DAG_EXECUTION", payload: null })
+        dispatch({ type: "SET_CURRENT_TASK", payload: null })
+        dispatch({ type: "SET_HISTORY_LOADING", payload: false })
+        setTaskId(null, { navigate: false })
+      }
+      return
+    }
+    if (openedRunParamRef.current === runParam) return
     openedRunParamRef.current = runParam
     void (async () => {
       try {
@@ -353,7 +376,7 @@ function WorkforceRunPageInner() {
         toast.error(err instanceof Error ? err.message : t("workforces.runs.loadError"))
       }
     })()
-  }, [id, runParam, openRun, t])
+  }, [id, runParam, openRun, t, closeFilePreview, dispatch, setTaskId])
 
   const handleSend = useCallback(async (
     content: string,

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -368,14 +368,22 @@ function WorkforceRunPageInner() {
     }
     if (openedRunParamRef.current === runParam) return
     openedRunParamRef.current = runParam
+    let active = true
     void (async () => {
       try {
         const run = await getWorkforceRun(id, runParam)
-        openRun(run)
+        if (active) openRun(run)
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : t("workforces.runs.loadError"))
+        if (active) {
+          // Allow retrying the same ?run= value after a failed load.
+          openedRunParamRef.current = null
+          toast.error(err instanceof Error ? err.message : t("workforces.runs.loadError"))
+        }
       }
     })()
+    return () => {
+      active = false
+    }
   }, [id, runParam, openRun, t, closeFilePreview, dispatch, setTaskId])
 
   const handleSend = useCallback(async (

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { Suspense, useCallback, useEffect, useRef, useState } from "react"
 import Link from "next/link"
-import { useParams } from "next/navigation"
+import { useParams, useSearchParams } from "next/navigation"
 import {
   ReactFlow,
   Background,
@@ -15,17 +15,22 @@ import {
   type Edge,
 } from "@xyflow/react"
 import "@xyflow/react/dist/style.css"
-import { ArrowLeft, Crown, GitBranch, Pencil, Users, X } from "lucide-react"
+import { ArrowLeft, Crown, GitBranch, History, Pencil, Users, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useI18n, type Translate } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
 import type { Task } from "@/contexts/app-context-chat"
-import { type TaskStatus } from "@/lib/task-status"
-import { getWorkforce, runWorkforce } from "@/lib/workforces-api"
-import { WorkforceStatusBadge } from "@/components/workforce"
+import { normalizeTaskStatus, type TaskStatus } from "@/lib/task-status"
+import { getWorkforce, getWorkforceRun, runWorkforce } from "@/lib/workforces-api"
+import { WorkforceRunsList, WorkforceStatusBadge } from "@/components/workforce"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { ResizableSplitLayout } from "@/components/layout/resizable-split-layout"
-import type { WorkforceDetail, WorkforceRunResponse } from "@/types/workforce"
+import type {
+  WorkforceDetail,
+  WorkforceRunHistoryItem,
+  WorkforceRunResponse,
+} from "@/types/workforce"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 
@@ -258,17 +263,30 @@ function WorkforceFlowPanel({ workforce, taskStatus, onClose }: WorkforceFlowPan
 // ─── Main page ─────────────────────────────────────────────────────────────────
 
 export default function WorkforceRunPage() {
+  // useSearchParams must be inside a Suspense boundary for static export.
+  return (
+    <Suspense fallback={null}>
+      <WorkforceRunPageInner />
+    </Suspense>
+  )
+}
+
+function WorkforceRunPageInner() {
   const { t } = useI18n()
   const params = useParams()
+  const searchParams = useSearchParams()
   const { sendMessage, setTaskId, closeFilePreview, dispatch, state } = useApp()
   const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const runParam = searchParams.get("run")
 
   const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [showFlow, setShowFlow] = useState(false)
   const [taskStarted, setTaskStarted] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
 
   const previewTaskIdRef = useRef<number | null>(null)
+  const openedRunParamRef = useRef<string | null>(null)
   const taskStatus = state.currentTask?.status ?? null
 
   useEffect(() => {
@@ -303,6 +321,39 @@ export default function WorkforceRunPage() {
       set(null, { navigate: false })
     }
   }, [])
+
+  const openRun = useCallback((run: WorkforceRunHistoryItem) => {
+    if (!run.task_id) return
+    setHistoryOpen(false)
+    if (previewTaskIdRef.current === run.task_id) return
+    previewTaskIdRef.current = run.task_id
+    setTaskStarted(true)
+    closeFilePreview()
+    setTaskId(run.task_id, { navigate: false })
+    const title = run.task_title || run.message || `Run #${run.id}`
+    const taskPayload: Task = {
+      id: String(run.task_id),
+      title,
+      description: run.message ?? "",
+      status: normalizeTaskStatus(run.status) ?? "completed",
+      createdAt: run.created_at ?? new Date().toISOString(),
+      updatedAt: run.completed_at ?? run.created_at ?? new Date().toISOString(),
+    }
+    dispatch({ type: "SET_CURRENT_TASK", payload: taskPayload })
+  }, [closeFilePreview, setTaskId, dispatch])
+
+  useEffect(() => {
+    if (!id || !runParam || openedRunParamRef.current === runParam) return
+    openedRunParamRef.current = runParam
+    void (async () => {
+      try {
+        const run = await getWorkforceRun(id, runParam)
+        openRun(run)
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : t("workforces.runs.loadError"))
+      }
+    })()
+  }, [id, runParam, openRun, t])
 
   const handleSend = useCallback(async (
     content: string,
@@ -378,6 +429,19 @@ export default function WorkforceRunPage() {
 
         <div className="flex-1" />
 
+        <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5">
+              <History className="h-3.5 w-3.5" />
+              {t("workforces.runs.title")}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="max-h-[70vh] w-96 overflow-y-auto p-3">
+            {historyOpen && id && (
+              <WorkforceRunsList workforceId={id} compact onSelectRun={openRun} />
+            )}
+          </PopoverContent>
+        </Popover>
         <Button
           variant={showFlow ? "secondary" : "outline"}
           size="sm"

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -4,7 +4,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const getWorkforceMock = vi.hoisted(() => vi.fn())
+const getWorkforceRunMock = vi.hoisted(() => vi.fn())
 const listAgentOptionsMock = vi.hoisted(() => vi.fn().mockResolvedValue([]))
+const listWorkforceRunsMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, size: 10, pages: 0 }),
+)
 const listWorkforcesMock = vi.hoisted(() => vi.fn())
 const runWorkforceMock = vi.hoisted(() => vi.fn())
 const addWorkforceAgentMock = vi.hoisted(() => vi.fn())
@@ -17,6 +21,7 @@ const updateWorkforceAgentMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const setTaskIdMock = vi.hoisted(() => vi.fn())
 const paramsMock = vi.hoisted(() => ({ id: "42" as string | string[] | undefined }))
+const searchParamsMock = vi.hoisted(() => new URLSearchParams())
 const translateMock = vi.hoisted(
   () => (key: string, vars?: Record<string, string | number>) => {
     if (!vars) return key
@@ -31,6 +36,7 @@ const translateMock = vi.hoisted(
 vi.mock("next/navigation", () => ({
   useParams: () => paramsMock,
   useRouter: () => ({ push: routerPushMock }),
+  useSearchParams: () => searchParamsMock,
 }))
 
 vi.mock("next/link", () => ({
@@ -75,7 +81,9 @@ vi.mock("@/lib/workforces-api", () => ({
   addWorkforceAgent: addWorkforceAgentMock,
   archiveWorkforce: archiveWorkforceMock,
   getWorkforce: getWorkforceMock,
+  getWorkforceRun: getWorkforceRunMock,
   listAgentOptions: listAgentOptionsMock,
+  listWorkforceRuns: listWorkforceRunsMock,
   listWorkforces: listWorkforcesMock,
   publishWorkforce: publishWorkforceMock,
   removeWorkforceAgent: removeWorkforceAgentMock,
@@ -202,7 +210,11 @@ const listResponse: WorkforceListResponse = {
 describe("workforce route entry points", () => {
   beforeEach(() => {
     getWorkforceMock.mockReset()
+    getWorkforceRunMock.mockReset()
     listAgentOptionsMock.mockReset().mockResolvedValue([])
+    listWorkforceRunsMock
+      .mockReset()
+      .mockResolvedValue({ items: [], total: 0, page: 1, size: 10, pages: 0 })
     listWorkforcesMock.mockReset()
     runWorkforceMock.mockReset()
     addWorkforceAgentMock.mockReset()
@@ -215,6 +227,7 @@ describe("workforce route entry points", () => {
     routerPushMock.mockReset()
     setTaskIdMock.mockReset()
     paramsMock.id = "42"
+    searchParamsMock.delete("run")
   })
 
   afterEach(() => {
@@ -332,6 +345,63 @@ describe("workforce route entry points", () => {
         message: "test message",
       })
     })
+  })
+
+  it("shows run history in the detail page runs tab and opens a run", async () => {
+    getWorkforceMock.mockResolvedValueOnce(workforceDetail)
+    listWorkforceRunsMock.mockResolvedValue({
+      items: [
+        {
+          id: 9,
+          task_id: 99,
+          status: "completed",
+          is_preview: false,
+          task_title: "Launch Workforce: draft plan",
+          message: "draft plan",
+          created_at: "2026-07-19T10:00:00Z",
+          completed_at: "2026-07-19T10:03:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+      pages: 1,
+    })
+
+    render(<WorkforceDetailPage />)
+
+    fireEvent.click(await screen.findByRole("button", { name: /workforces.runs.title/ }))
+
+    const runRow = await screen.findByText("Launch Workforce: draft plan")
+    expect(listWorkforceRunsMock).toHaveBeenCalledWith("42", { page: 1, size: 20 })
+
+    fireEvent.click(runRow)
+    expect(routerPushMock).toHaveBeenCalledWith("/workforces/42/run?run=9")
+  })
+
+  it("opens a past run on the run page via the run query param", async () => {
+    searchParamsMock.set("run", "9")
+    getWorkforceMock.mockResolvedValueOnce(workforceDetail)
+    getWorkforceRunMock.mockResolvedValueOnce({
+      id: 9,
+      task_id: 99,
+      status: "completed",
+      is_preview: false,
+      task_title: "Launch Workforce: draft plan",
+      message: "draft plan",
+      created_at: "2026-07-19T10:00:00Z",
+      completed_at: "2026-07-19T10:03:00Z",
+    })
+
+    render(<WorkforceRunPage />)
+
+    await waitFor(() => {
+      expect(getWorkforceRunMock).toHaveBeenCalledWith("42", "9")
+    })
+    await waitFor(() => {
+      expect(setTaskIdMock).toHaveBeenCalledWith(99, { navigate: false })
+    })
+    expect(await screen.findByTestId("task-conversation-panel")).toBeInTheDocument()
   })
 
   it("keeps the current manager visible when it is hidden from agent options", async () => {

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -19,6 +19,7 @@ const unpublishWorkforceMock = vi.hoisted(() => vi.fn())
 const updateWorkforceMock = vi.hoisted(() => vi.fn())
 const updateWorkforceAgentMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
+const routerReplaceMock = vi.hoisted(() => vi.fn())
 const setTaskIdMock = vi.hoisted(() => vi.fn())
 const paramsMock = vi.hoisted(() => ({ id: "42" as string | string[] | undefined }))
 const searchParamsMock = vi.hoisted(() => new URLSearchParams())
@@ -35,7 +36,7 @@ const translateMock = vi.hoisted(
 
 vi.mock("next/navigation", () => ({
   useParams: () => paramsMock,
-  useRouter: () => ({ push: routerPushMock }),
+  useRouter: () => ({ push: routerPushMock, replace: routerReplaceMock }),
   useSearchParams: () => searchParamsMock,
 }))
 
@@ -225,6 +226,7 @@ describe("workforce route entry points", () => {
     updateWorkforceMock.mockReset()
     updateWorkforceAgentMock.mockReset()
     routerPushMock.mockReset()
+    routerReplaceMock.mockReset()
     setTaskIdMock.mockReset()
     paramsMock.id = "42"
     searchParamsMock.delete("run")

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -403,6 +403,10 @@ describe("workforce route entry points", () => {
     await waitFor(() => {
       expect(setTaskIdMock).toHaveBeenCalledWith(99, { navigate: false })
     })
+    // openRun must keep ?run= authoritative regardless of the opening path.
+    expect(routerReplaceMock).toHaveBeenCalledWith("/workforces/42/run?run=9", {
+      scroll: false,
+    })
     expect(await screen.findByTestId("task-conversation-panel")).toBeInTheDocument()
   })
 

--- a/frontend/src/components/workforce/index.ts
+++ b/frontend/src/components/workforce/index.ts
@@ -5,6 +5,7 @@ export { WorkforceConfigPanel, buildWorkerEditState, normalizeWorkerSortOrder, w
 export type { WorkerEditState } from "./workforce-config-panel"
 export { WorkforceCreateView } from "./workforce-create-view"
 export { WorkforcePromptCreator } from "./workforce-prompt-creator"
+export { WorkforceRunsList } from "./workforce-runs-list"
 export { WorkforceStatusBadge } from "./workforce-status-badge"
 export { WorkforceWizard } from "./workforce-wizard"
 export { WorkersStep } from "./workers-step"

--- a/frontend/src/components/workforce/workforce-runs-list.tsx
+++ b/frontend/src/components/workforce/workforce-runs-list.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from "react"
 import { History, Loader2, RefreshCw } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { listWorkforceRuns } from "@/lib/workforces-api"
+import { normalizeTaskStatus } from "@/lib/task-status"
 import type { WorkforceRunHistoryItem, WorkforceRunHistoryResponse } from "@/types/workforce"
 import { formatTime } from "@/lib/time-utils"
 import { Button } from "@/components/ui/button"
@@ -14,23 +15,8 @@ const RUN_STATUS_CLASSES: Record<string, string> = {
   running: "bg-blue-100 text-blue-700",
   pending: "bg-amber-100 text-amber-700",
   paused: "bg-amber-100 text-amber-700",
+  waiting_for_user: "bg-amber-100 text-amber-700",
   failed: "bg-red-100 text-red-700",
-}
-
-const KNOWN_RUN_STATUSES = [
-  "pending",
-  "running",
-  "paused",
-  "completed",
-  "failed",
-  "waiting_for_user",
-] as const
-type KnownRunStatus = (typeof KNOWN_RUN_STATUSES)[number]
-
-function knownRunStatus(status: string): KnownRunStatus | null {
-  return (KNOWN_RUN_STATUSES as readonly string[]).includes(status)
-    ? (status as KnownRunStatus)
-    : null
 }
 
 function runDuration(run: WorkforceRunHistoryItem): string | null {
@@ -50,7 +36,6 @@ interface WorkforceRunsListProps {
   workforceId: number | string
   onSelectRun?: (run: WorkforceRunHistoryItem) => void
   compact?: boolean
-  pageSize?: number
   className?: string
 }
 
@@ -58,11 +43,10 @@ export function WorkforceRunsList({
   workforceId,
   onSelectRun,
   compact = false,
-  pageSize,
   className,
 }: WorkforceRunsListProps) {
   const { t } = useI18n()
-  const size = pageSize ?? (compact ? 10 : 20)
+  const size = compact ? 10 : 20
 
   const [data, setData] = useState<WorkforceRunHistoryResponse | null>(null)
   const [page, setPage] = useState(1)
@@ -154,7 +138,7 @@ export function WorkforceRunsList({
             run.task_title || run.message || t("workforces.runs.untitled", { id: run.id })
           const duration = runDuration(run)
           const clickable = Boolean(onSelectRun && run.task_id)
-          const statusKey = knownRunStatus(run.status)
+          const statusKey = normalizeTaskStatus(run.status)
           return (
             <li key={run.id}>
               <button

--- a/frontend/src/components/workforce/workforce-runs-list.tsx
+++ b/frontend/src/components/workforce/workforce-runs-list.tsx
@@ -1,0 +1,234 @@
+"use client"
+
+import React, { useCallback, useEffect, useState } from "react"
+import { History, Loader2, RefreshCw } from "lucide-react"
+import { useI18n } from "@/contexts/i18n-context"
+import { listWorkforceRuns } from "@/lib/workforces-api"
+import type { WorkforceRunHistoryItem, WorkforceRunHistoryResponse } from "@/types/workforce"
+import { formatTime } from "@/lib/time-utils"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const RUN_STATUS_CLASSES: Record<string, string> = {
+  completed: "bg-green-100 text-green-700",
+  running: "bg-blue-100 text-blue-700",
+  pending: "bg-amber-100 text-amber-700",
+  paused: "bg-amber-100 text-amber-700",
+  failed: "bg-red-100 text-red-700",
+}
+
+const KNOWN_RUN_STATUSES = [
+  "pending",
+  "running",
+  "paused",
+  "completed",
+  "failed",
+  "waiting_for_user",
+] as const
+type KnownRunStatus = (typeof KNOWN_RUN_STATUSES)[number]
+
+function knownRunStatus(status: string): KnownRunStatus | null {
+  return (KNOWN_RUN_STATUSES as readonly string[]).includes(status)
+    ? (status as KnownRunStatus)
+    : null
+}
+
+function runDuration(run: WorkforceRunHistoryItem): string | null {
+  if (!run.created_at || !run.completed_at) return null
+  const seconds = Math.round(
+    (new Date(run.completed_at).getTime() - new Date(run.created_at).getTime()) / 1000,
+  )
+  if (seconds < 0) return null
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+interface WorkforceRunsListProps {
+  workforceId: number | string
+  onSelectRun?: (run: WorkforceRunHistoryItem) => void
+  compact?: boolean
+  pageSize?: number
+  className?: string
+}
+
+export function WorkforceRunsList({
+  workforceId,
+  onSelectRun,
+  compact = false,
+  pageSize,
+  className,
+}: WorkforceRunsListProps) {
+  const { t } = useI18n()
+  const size = pageSize ?? (compact ? 10 : 20)
+
+  const [data, setData] = useState<WorkforceRunHistoryResponse | null>(null)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(
+    async (nextPage: number, options: { silent?: boolean } = {}) => {
+      try {
+        if (!options.silent) setLoading(true)
+        setError(null)
+        const response = await listWorkforceRuns(workforceId, { page: nextPage, size })
+        setData(response)
+        setPage(response.page)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("workforces.runs.loadError"))
+      } finally {
+        if (!options.silent) setLoading(false)
+      }
+    },
+    [workforceId, size, t],
+  )
+
+  useEffect(() => {
+    void load(1)
+  }, [load])
+
+  if (loading && !data) {
+    return (
+      <div className={cn("flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground", className)}>
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t("workforces.runs.loading")}
+      </div>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <div className={cn("flex flex-col items-center gap-3 py-10 text-sm text-red-500", className)}>
+        <span>{error}</span>
+        <Button variant="outline" size="sm" onClick={() => void load(page)}>
+          {t("workforces.runs.retry")}
+        </Button>
+      </div>
+    )
+  }
+
+  const items = data?.items ?? []
+
+  if (items.length === 0) {
+    return (
+      <div className={cn("flex flex-col items-center justify-center gap-2 py-10 text-center", className)}>
+        <History className="h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm font-medium text-foreground">{t("workforces.runs.empty")}</p>
+        <p className="max-w-xs text-xs text-muted-foreground">{t("workforces.runs.emptyHint")}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      {!compact && (
+        <div className="flex items-center justify-between pb-3">
+          <span className="text-xs text-muted-foreground">
+            {t("workforces.pagination.showing", {
+              start: (page - 1) * size + 1,
+              end: (page - 1) * size + items.length,
+              total: data?.total ?? items.length,
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground"
+            onClick={() => void load(page, { silent: true })}
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {t("workforces.runs.refresh")}
+          </Button>
+        </div>
+      )}
+
+      <ul className={cn("flex flex-col", compact ? "gap-0.5" : "gap-1.5")}>
+        {items.map((run) => {
+          const title =
+            run.task_title || run.message || t("workforces.runs.untitled", { id: run.id })
+          const duration = runDuration(run)
+          const clickable = Boolean(onSelectRun && run.task_id)
+          const statusKey = knownRunStatus(run.status)
+          return (
+            <li key={run.id}>
+              <button
+                type="button"
+                disabled={!clickable}
+                onClick={() => {
+                  if (clickable && onSelectRun) onSelectRun(run)
+                }}
+                className={cn(
+                  "flex w-full flex-col gap-1 rounded-lg border bg-card text-left transition-colors",
+                  compact ? "px-3 py-2" : "px-4 py-3",
+                  clickable
+                    ? "hover:border-primary/40 hover:bg-muted/50 cursor-pointer"
+                    : "opacity-70 cursor-default",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <span className={cn("truncate font-medium", compact ? "text-xs" : "text-sm")}>
+                    {title}
+                  </span>
+                  {run.is_preview && (
+                    <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {t("workforces.runs.previewBadge")}
+                    </span>
+                  )}
+                  <span
+                    className={cn(
+                      "ml-auto shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold",
+                      RUN_STATUS_CLASSES[run.status] ?? "bg-muted text-muted-foreground",
+                    )}
+                  >
+                    {statusKey ? t(`workforces.runs.status.${statusKey}`) : run.status}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                  {run.created_at && <span>{formatTime(run.created_at, "datetime")}</span>}
+                  {duration && (
+                    <>
+                      <span>·</span>
+                      <span>{duration}</span>
+                    </>
+                  )}
+                  {!run.task_id && (
+                    <>
+                      <span>·</span>
+                      <span>{t("workforces.runs.taskDeleted")}</span>
+                    </>
+                  )}
+                </div>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+
+      {(data?.pages ?? 1) > 1 && (
+        <div className="flex items-center justify-between pt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1 || loading}
+            onClick={() => void load(page - 1)}
+          >
+            {t("workforces.pagination.prev")}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {t("workforces.pagination.page", { page, pages: data?.pages ?? 1 })}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= (data?.pages ?? 1) || loading}
+            onClick={() => void load(page + 1)}
+          >
+            {t("workforces.pagination.next")}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/workforce/workforce-runs-list.tsx
+++ b/frontend/src/components/workforce/workforce-runs-list.tsx
@@ -35,9 +35,10 @@ function knownRunStatus(status: string): KnownRunStatus | null {
 
 function runDuration(run: WorkforceRunHistoryItem): string | null {
   if (!run.created_at || !run.completed_at) return null
-  const seconds = Math.round(
-    (new Date(run.completed_at).getTime() - new Date(run.created_at).getTime()) / 1000,
-  )
+  const start = new Date(run.created_at).getTime()
+  const end = new Date(run.completed_at).getTime()
+  if (Number.isNaN(start) || Number.isNaN(end)) return null
+  const seconds = Math.round((end - start) / 1000)
   if (seconds < 0) return null
   if (seconds < 60) return `${seconds}s`
   const minutes = Math.floor(seconds / 60)
@@ -86,6 +87,9 @@ export function WorkforceRunsList({
   )
 
   useEffect(() => {
+    // New workforce/size: drop the previous list so stale rows never flash.
+    // Pagination keeps the current list visible while the next page loads.
+    setData(null)
     void load(1)
   }, [load])
 

--- a/frontend/src/components/workforce/workforce-runs-list.tsx
+++ b/frontend/src/components/workforce/workforce-runs-list.tsx
@@ -167,7 +167,8 @@ export function WorkforceRunsList({
                   <span
                     className={cn(
                       "ml-auto shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold",
-                      RUN_STATUS_CLASSES[run.status] ?? "bg-muted text-muted-foreground",
+                      RUN_STATUS_CLASSES[statusKey ?? run.status] ??
+                        "bg-muted text-muted-foreground",
                     )}
                   >
                     {statusKey ? t(`workforces.runs.status.${statusKey}`) : run.status}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3898,6 +3898,28 @@ Build when you need.`,
       inactiveDisabled: "Publish this workforce before running it.",
       archivedDisabled: "Archived workforces cannot run."
     },
+    runs: {
+      title: "Runs",
+      historyTitle: "Run history",
+      historyHint: "Previous runs of this workforce. Click a run to reopen its conversation.",
+      loading: "Loading runs...",
+      loadError: "Failed to load runs",
+      retry: "Retry",
+      refresh: "Refresh",
+      empty: "No runs yet",
+      emptyHint: "Runs will appear here after you send this workforce a task.",
+      untitled: "Run #{id}",
+      previewBadge: "Preview",
+      taskDeleted: "Conversation unavailable",
+      status: {
+        pending: "Pending",
+        running: "Running",
+        paused: "Paused",
+        completed: "Completed",
+        failed: "Failed",
+        waiting_for_user: "Waiting for user",
+      }
+    },
     builder: {
       archivedReadOnly: "Archived workforces are read-only."
     },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3898,6 +3898,28 @@ const zh = {
       inactiveDisabled: "请先发布这个 Workforce 再运行。",
       archivedDisabled: "已归档的 Workforce 不能运行。"
     },
+    runs: {
+      title: "运行记录",
+      historyTitle: "历史运行",
+      historyHint: "这个 Workforce 的历史运行记录。点击某次运行可重新打开对应会话。",
+      loading: "正在加载运行记录...",
+      loadError: "加载运行记录失败",
+      retry: "重试",
+      refresh: "刷新",
+      empty: "还没有运行记录",
+      emptyHint: "向这个 Workforce 发送任务后，运行记录会显示在这里。",
+      untitled: "运行 #{id}",
+      previewBadge: "预览",
+      taskDeleted: "会话不可用",
+      status: {
+        pending: "等待中",
+        running: "运行中",
+        paused: "已暂停",
+        completed: "已完成",
+        failed: "失败",
+        waiting_for_user: "等待用户",
+      }
+    },
     builder: {
       archivedReadOnly: "已归档的 Workforce 只能查看。"
     },

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -231,13 +231,11 @@ export async function listWorkforceRuns(
   params?: {
     page?: number
     size?: number
-    includePreview?: boolean
   },
 ): Promise<WorkforceRunHistoryResponse> {
   const searchParams = new URLSearchParams()
   if (params?.page) searchParams.set("page", String(params.page))
   if (params?.size) searchParams.set("size", String(params.size))
-  if (params?.includePreview) searchParams.set("include_preview", "true")
 
   const suffix = searchParams.toString() ? `?${searchParams.toString()}` : ""
   const response = await apiRequest(

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -10,6 +10,8 @@ import type {
   WorkforceDetail,
   WorkforceListResponse,
   WorkforcePromptCreatePayload,
+  WorkforceRunHistoryItem,
+  WorkforceRunHistoryResponse,
   WorkforceRunPayload,
   WorkforceRunResponse,
   WorkforceUpdatePayload,
@@ -219,6 +221,44 @@ export async function runWorkforce(
   })
   if (!response.ok) {
     throw await parseApiError(response, "Failed to run workforce")
+  }
+  return response.json()
+}
+
+
+export async function listWorkforceRuns(
+  workforceId: number | string,
+  params?: {
+    page?: number
+    size?: number
+    includePreview?: boolean
+  },
+): Promise<WorkforceRunHistoryResponse> {
+  const searchParams = new URLSearchParams()
+  if (params?.page) searchParams.set("page", String(params.page))
+  if (params?.size) searchParams.set("size", String(params.size))
+  if (params?.includePreview) searchParams.set("include_preview", "true")
+
+  const suffix = searchParams.toString() ? `?${searchParams.toString()}` : ""
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/runs${suffix}`,
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforce runs")
+  }
+  return response.json()
+}
+
+
+export async function getWorkforceRun(
+  workforceId: number | string,
+  runId: number | string,
+): Promise<WorkforceRunHistoryItem> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/runs/${runId}`,
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforce run")
   }
   return response.json()
 }

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -41,6 +41,25 @@ export interface WorkforceRunListItem {
   created_at: string | null
 }
 
+export interface WorkforceRunHistoryItem {
+  id: number
+  task_id: number | null
+  status: string
+  is_preview: boolean
+  task_title: string | null
+  message: string | null
+  created_at: string | null
+  completed_at: string | null
+}
+
+export interface WorkforceRunHistoryResponse {
+  items: WorkforceRunHistoryItem[]
+  total: number
+  page: number
+  size: number
+  pages: number
+}
+
 export interface WorkforceListItem {
   id: number
   name: string

--- a/src/xagent/migrations/versions/20260720_add_workforce_run_is_preview.py
+++ b/src/xagent/migrations/versions/20260720_add_workforce_run_is_preview.py
@@ -1,0 +1,59 @@
+"""add is_preview flag to workforce_runs
+
+Revision ID: 20260720_add_workforce_run_is_preview
+Revises: 20260715_add_public_mcp_app_audits
+Create Date: 2026-07-20
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+revision: str = "20260720_add_workforce_run_is_preview"
+down_revision: Union[str, None] = "20260715_add_public_mcp_app_audits"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "workforce_runs"
+COLUMN = "is_preview"
+
+
+def _existing_columns(inspector: Inspector) -> list[str]:
+    return [col["name"] for col in inspector.get_columns(TABLE)]
+
+
+def upgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if TABLE not in inspector.get_table_names():
+        return
+
+    if COLUMN not in _existing_columns(inspector):
+        op.add_column(
+            TABLE,
+            sa.Column(
+                COLUMN,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if TABLE not in inspector.get_table_names():
+        return
+
+    if COLUMN in _existing_columns(inspector):
+        op.drop_column(TABLE, COLUMN)

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -789,15 +789,15 @@ async def list_workforce_runs(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict[str, Any]:
-    if page < 1 or size < 1 or size > 100:
-        raise HTTPException(status_code=400, detail="Invalid pagination parameters")
-
     workforce = ensure_workforce_access(
         db,
         user,
         _load_workforce(db, workforce_id),
         action="view",
     )
+    if page < 1 or size < 1 or size > 100:
+        raise HTTPException(status_code=400, detail="Invalid pagination parameters")
+
     query = db.query(WorkforceRun).filter(
         WorkforceRun.workforce_id == int(workforce.id)
     )

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -263,7 +263,10 @@ def _load_latest_runs_by_workforce(
             )
             .label("rank"),
         )
-        .filter(WorkforceRun.workforce_id.in_(workforce_ids))
+        .filter(
+            WorkforceRun.workforce_id.in_(workforce_ids),
+            WorkforceRun.is_preview.is_(False),
+        )
         .subquery()
     )
     latest_runs = (
@@ -754,6 +757,97 @@ async def create_workforce_run(
         "task_id": result.task.id,
         "status": result.workforce_run.status,
         "redirect_url": f"/task/{result.task.id}",
+    }
+
+
+_RUN_MESSAGE_PREVIEW_LIMIT = 200
+
+
+def _serialize_run_list_item(run: WorkforceRun) -> dict[str, Any]:
+    task = run.task
+    message = cast(str | None, task.description) if task is not None else None
+    if message and len(message) > _RUN_MESSAGE_PREVIEW_LIMIT:
+        message = message[:_RUN_MESSAGE_PREVIEW_LIMIT] + "..."
+    return {
+        "id": run.id,
+        "task_id": run.task_id,
+        "status": run.status,
+        "is_preview": bool(run.is_preview),
+        "task_title": task.title if task is not None else None,
+        "message": message,
+        "created_at": _serialize_datetime(run.created_at),
+        "completed_at": _serialize_datetime(run.completed_at),
+    }
+
+
+@router.get("/{workforce_id}/runs")
+async def list_workforce_runs(
+    workforce_id: int,
+    page: int = 1,
+    size: int = 20,
+    include_preview: bool = False,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    if page < 1 or size < 1 or size > 100:
+        raise HTTPException(status_code=400, detail="Invalid pagination parameters")
+
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="view",
+    )
+    query = db.query(WorkforceRun).filter(
+        WorkforceRun.workforce_id == int(workforce.id)
+    )
+    if not include_preview:
+        query = query.filter(WorkforceRun.is_preview.is_(False))
+
+    total = query.count()
+    runs = (
+        query.options(selectinload(WorkforceRun.task))
+        .order_by(WorkforceRun.created_at.desc(), WorkforceRun.id.desc())
+        .offset((page - 1) * size)
+        .limit(size)
+        .all()
+    )
+    return {
+        "items": [_serialize_run_list_item(run) for run in runs],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": (total + size - 1) // size,
+    }
+
+
+@router.get("/{workforce_id}/runs/{run_id}")
+async def get_workforce_run(
+    workforce_id: int,
+    run_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="view",
+    )
+    run = (
+        db.query(WorkforceRun)
+        .options(selectinload(WorkforceRun.task))
+        .filter(
+            WorkforceRun.id == run_id,
+            WorkforceRun.workforce_id == int(workforce.id),
+        )
+        .first()
+    )
+    if run is None:
+        raise HTTPException(status_code=404, detail="Workforce run not found")
+    return {
+        **_serialize_run_list_item(run),
+        "snapshot": run.snapshot,
     }
 
 

--- a/src/xagent/web/models/workforce.py
+++ b/src/xagent/web/models/workforce.py
@@ -116,6 +116,7 @@ class WorkforceRun(Base):  # type: ignore[no-any-unimported]
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     status = Column(String(20), nullable=False, default="pending", index=True)
+    is_preview = Column(Boolean, nullable=False, default=False, server_default="0")
     snapshot = Column(JSON, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -151,6 +151,7 @@ async def create_workforce_run(
             task_id=int(task.id),
             user_id=int(user.id),
             status="pending",
+            is_preview=is_preview,
             snapshot=snapshot,
         )
         db.add(workforce_run)

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -119,21 +119,47 @@ def _create_workforce_run(
     user_id: int,
     status: str,
     created_at: datetime,
+    is_preview: bool = False,
+    task_id: int | None = None,
+    completed_at: datetime | None = None,
 ) -> int:
     db = _direct_db_session()
     try:
         run = WorkforceRun(
             workforce_id=workforce_id,
-            task_id=None,
+            task_id=task_id,
             user_id=user_id,
             status=status,
+            is_preview=is_preview,
             snapshot={"workforce": {"id": workforce_id}},
             created_at=created_at,
+            completed_at=completed_at,
         )
         db.add(run)
         db.commit()
         db.refresh(run)
         return int(run.id)
+    finally:
+        db.close()
+
+
+def _create_task(user_id: int, *, title: str, description: str) -> int:
+    from xagent.web.models.task import Task, TaskStatus
+
+    db = _direct_db_session()
+    try:
+        task = Task(
+            user_id=user_id,
+            title=title,
+            description=description,
+            status=TaskStatus.COMPLETED,
+            source="internal",
+            is_visible=False,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return int(task.id)
     finally:
         db.close()
 
@@ -707,6 +733,154 @@ def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) 
         "is_preview": False,
         "is_visible": True,
     }
+
+
+def test_list_workforce_runs_orders_paginates_and_excludes_previews() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id()
+    workforce = _create_workforce(headers, name="Runs History Workforce")
+    workforce_id = int(workforce["id"])
+    now = datetime.now(timezone.utc)
+
+    task_id = _create_task(
+        owner_id,
+        title="Runs History Workforce: analyze",
+        description="analyze " + "x" * 300,
+    )
+    oldest_run_id = _create_workforce_run(
+        workforce_id=workforce_id,
+        user_id=owner_id,
+        status="completed",
+        created_at=now,
+        task_id=task_id,
+        completed_at=now + timedelta(minutes=1),
+    )
+    preview_run_id = _create_workforce_run(
+        workforce_id=workforce_id,
+        user_id=owner_id,
+        status="completed",
+        created_at=now + timedelta(minutes=5),
+        is_preview=True,
+    )
+    latest_run_id = _create_workforce_run(
+        workforce_id=workforce_id,
+        user_id=owner_id,
+        status="running",
+        created_at=now + timedelta(minutes=10),
+    )
+
+    response = client.get(f"/api/workforces/{workforce_id}/runs", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert payload["pages"] == 1
+    assert [item["id"] for item in payload["items"]] == [latest_run_id, oldest_run_id]
+
+    oldest_item = payload["items"][1]
+    assert oldest_item["task_id"] == task_id
+    assert oldest_item["status"] == "completed"
+    assert oldest_item["is_preview"] is False
+    assert oldest_item["task_title"] == "Runs History Workforce: analyze"
+    assert oldest_item["message"].endswith("...")
+    assert len(oldest_item["message"]) == 203
+    assert oldest_item["completed_at"] is not None
+
+    latest_item = payload["items"][0]
+    assert latest_item["task_id"] is None
+    assert latest_item["task_title"] is None
+    assert latest_item["message"] is None
+    assert latest_item["completed_at"] is None
+
+    with_previews = client.get(
+        f"/api/workforces/{workforce_id}/runs",
+        headers=headers,
+        params={"include_preview": "true"},
+    )
+    assert with_previews.status_code == 200
+    preview_payload = with_previews.json()
+    assert preview_payload["total"] == 3
+    assert [item["id"] for item in preview_payload["items"]] == [
+        latest_run_id,
+        preview_run_id,
+        oldest_run_id,
+    ]
+    assert preview_payload["items"][1]["is_preview"] is True
+
+    paged = client.get(
+        f"/api/workforces/{workforce_id}/runs",
+        headers=headers,
+        params={"page": 2, "size": 1},
+    )
+    assert paged.status_code == 200
+    paged_payload = paged.json()
+    assert paged_payload["total"] == 2
+    assert paged_payload["pages"] == 2
+    assert [item["id"] for item in paged_payload["items"]] == [oldest_run_id]
+
+    invalid = client.get(
+        f"/api/workforces/{workforce_id}/runs",
+        headers=headers,
+        params={"page": 0},
+    )
+    assert invalid.status_code == 400
+
+    # Preview runs are also excluded from the list endpoint's last_run.
+    list_response = client.get(
+        "/api/workforces",
+        headers=headers,
+        params={"search": "Runs History Workforce"},
+    )
+    assert list_response.status_code == 200
+    assert list_response.json()["items"][0]["last_run"]["id"] == latest_run_id
+
+
+def test_workforce_run_detail_and_access_control() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id()
+    workforce = _create_workforce(headers, name="Run Detail Workforce")
+    workforce_id = int(workforce["id"])
+    now = datetime.now(timezone.utc)
+    run_id = _create_workforce_run(
+        workforce_id=workforce_id,
+        user_id=owner_id,
+        status="completed",
+        created_at=now,
+    )
+
+    detail = client.get(
+        f"/api/workforces/{workforce_id}/runs/{run_id}", headers=headers
+    )
+    assert detail.status_code == 200
+    detail_payload = detail.json()
+    assert detail_payload["id"] == run_id
+    assert detail_payload["snapshot"] == {"workforce": {"id": workforce_id}}
+
+    missing = client.get(
+        f"/api/workforces/{workforce_id}/runs/{run_id + 999}", headers=headers
+    )
+    assert missing.status_code == 404
+
+    other_headers = _register_second_user()
+    other_workforce = _create_workforce(
+        other_headers,
+        name="Other Runs Workforce",
+        username="bob",
+    )
+    denied_list = client.get(
+        f"/api/workforces/{workforce_id}/runs", headers=other_headers
+    )
+    assert denied_list.status_code == 403
+    denied_detail = client.get(
+        f"/api/workforces/{workforce_id}/runs/{run_id}", headers=other_headers
+    )
+    assert denied_detail.status_code == 403
+
+    # A run id from another workforce is not addressable through this one.
+    cross_lookup = client.get(
+        f"/api/workforces/{other_workforce['id']}/runs/{run_id}",
+        headers=other_headers,
+    )
+    assert cross_lookup.status_code == 404
 
 
 def test_canvas_read_returns_nodes_edges_and_layout() -> None:

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -228,6 +228,7 @@ async def test_create_workforce_run_creates_task_run_and_starts_turn(
     assert task.connector_runtime_selected_refs == []
     assert workforce_run.task_id == task.id
     assert workforce_run.status == "running"
+    assert workforce_run.is_preview is False
     assert uploaded_file.task_id == task.id
     assert scheduled["task_id"] == task.id
     assert scheduled["payload"].transcript_message == "Coordinate a launch brief"
@@ -276,6 +277,7 @@ async def test_create_workforce_run_allows_draft_only_for_preview(
 
     assert result.task.is_visible is False
     assert result.workforce_run.status == "running"
+    assert result.workforce_run.is_preview is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #801

Workforce previously had no way to see previous runs — all workforce run tasks are created with `is_visible=false`, so once you left the run page the conversation was unreachable. This PR adds a full "Runs" history:

### Backend
- New migration: add `is_preview` boolean column to `workforce_runs` (default `false`); the flag was previously only used for validation and never persisted, so preview (builder test panel) runs could not be distinguished from real runs.
- `GET /api/workforces/{id}/runs` — paginated run history, ordered by `created_at` desc. Preview runs are excluded by default; `include_preview=true` opts them back in. Each item includes status, task title, a 200-char message preview, `created_at`/`completed_at`.
- `GET /api/workforces/{id}/runs/{run_id}` — run detail incl. snapshot.
- Both endpoints gated by `ensure_workforce_access(action="view")`. The workforce list's `last_run` now also ignores preview runs.

### Frontend
- New shared `WorkforceRunsList` component: status badges, duration, pagination, refresh, empty state, compact mode.
- Workforce detail page: third tab **Runs** (configure | canvas | runs); clicking a run opens `/workforces/{id}/run?run={runId}`.
- Run page: new **Runs** popover in the header for switching between past conversations in place; `?run=` deep link reopens a past run (conversation restores via the existing task history mechanism, and you can continue chatting in it).
- New `workforces.runs.*` i18n keys (en/zh).

### Tests
- API: run list ordering/pagination/preview filtering, detail + snapshot, cross-user 403/404, cross-workforce 404.
- Service: `is_preview` persisted for preview runs, `false` for normal runs.
- Frontend routes: runs tab renders history and navigates on click; `?run=` param loads the past run on the run page.

Note: 4 pre-existing failures in `workforces-routes.test.tsx` (worker sort order cases) also fail on `main` and are unrelated to this change.