### PR TITLE
feat: allow enabling triggers during agent creation (#928)

### DIFF
--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -134,6 +134,65 @@ interface TemplateRequirements {
   requiresKnowledgeBase: boolean
 }
 
+// One-time reveal of auto-generated webhook secrets. Rendered both inside the
+// creation success dialog and inline in the config form (retry path / while
+// the dialog is closed); only the inline instance is dismissible.
+function WebhookSecretsAlert({
+  secrets,
+  onDismiss,
+}: {
+  secrets: { name: string; secret: string }[]
+  onDismiss?: () => void
+}) {
+  const { t } = useI18n()
+  if (secrets.length === 0) return null
+  return (
+    <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle className="flex items-center justify-between gap-2">
+        {t("triggers.secret.title")}
+        {onDismiss && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={onDismiss}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </AlertTitle>
+      <AlertDescription>
+        <div className="mt-2 space-y-2">
+          {secrets.map((item) => (
+            <div key={`${item.name}:${item.secret}`} className="flex items-center gap-2">
+              <span className="max-w-[160px] shrink-0 truncate text-xs font-medium">{item.name}</span>
+              <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
+                {item.secret}
+              </code>
+              <Button
+                type="button"
+                size="icon"
+                variant="secondary"
+                className="h-7 w-7 shrink-0"
+                onClick={async () => {
+                  if (await copyToClipboard(item.secret)) {
+                    toast.success(t("common.copied"))
+                  }
+                }}
+                title={t("common.copy")}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
 export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const MAX_INSTRUCTIONS_LENGTH = 8192;
   const { state, setTaskId, sendMessage, dispatch, closeFilePreview } = useApp()
@@ -258,25 +317,51 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     void refreshTriggerSummary()
   }, [refreshTriggerSummary])
 
+  // While failed retries (or an unread secret) are on screen, dialog-close
+  // handlers skip router.replace to keep this instance mounted; this flag
+  // remembers that a navigation is owed once both lists drain.
+  const navPendingRef = useRef(false)
+  const reconcileDeferredNavigation = (
+    nextFailed: FailedStagedTrigger[],
+    nextSecrets: { name: string; secret: string }[],
+  ) => {
+    if (!navPendingRef.current) return
+    if (nextFailed.length > 0 || nextSecrets.length > 0) return
+    navPendingRef.current = false
+    if (createdAgent?.id) {
+      router.replace(`/build/${createdAgent.id}`)
+    }
+  }
+
   // Retry a staged trigger whose POST failed during agent creation. The agent
   // exists by now, so this goes straight through the live trigger API.
-  const retryFailedTrigger = async (index: number) => {
+  // Entries are keyed by their stable clientId — a positional index goes
+  // stale when another entry is discarded while a retry is in flight.
+  const retryFailedTrigger = async (clientId: number) => {
     if (!localAgentId) return
-    const entry = failedStagedTriggers[index]
+    const entry = failedStagedTriggers.find((item) => item.staged.clientId === clientId)
     if (!entry) return
     try {
       const created = await createAgentTrigger(localAgentId, stagedToCreatePayload(entry.staged))
-      setFailedStagedTriggers((prev) => prev.filter((_, i) => i !== index))
+      const nextFailed = failedStagedTriggers.filter(
+        (item) => item.staged.clientId !== clientId,
+      )
+      let nextSecrets = createdWebhookSecrets
       const secret = created.webhook_secret
       if (secret && !entry.staged.secret) {
-        setCreatedWebhookSecrets((prev) => [...prev, { name: entry.staged.name, secret }])
+        nextSecrets = [...createdWebhookSecrets, { name: entry.staged.name, secret }]
       }
+      setFailedStagedTriggers(nextFailed)
+      setCreatedWebhookSecrets(nextSecrets)
       void refreshTriggerSummary()
       toast.success(t("triggers.messages.created"))
+      reconcileDeferredNavigation(nextFailed, nextSecrets)
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
       setFailedStagedTriggers((prev) =>
-        prev.map((item, i) => (i === index ? { ...item, error: reason } : item)),
+        prev.map((item) =>
+          item.staged.clientId === clientId ? { ...item, error: reason } : item,
+        ),
       )
       toast.error(
         t("triggers.messages.stagedCreateFailed", { name: entry.staged.name, error: reason }),
@@ -284,8 +369,25 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     }
   }
 
-  const discardFailedTrigger = (index: number) => {
-    setFailedStagedTriggers((prev) => prev.filter((_, i) => i !== index))
+  // Discarding drops the entered config irreversibly, so it uses the same
+  // two-click confirm pattern as trigger deletion in the dialog.
+  const [discardConfirmClientId, setDiscardConfirmClientId] = useState<number | null>(null)
+  const discardFailedTrigger = (clientId: number) => {
+    if (discardConfirmClientId !== clientId) {
+      setDiscardConfirmClientId(clientId)
+      return
+    }
+    setDiscardConfirmClientId(null)
+    const nextFailed = failedStagedTriggers.filter(
+      (item) => item.staged.clientId !== clientId,
+    )
+    setFailedStagedTriggers(nextFailed)
+    reconcileDeferredNavigation(nextFailed, createdWebhookSecrets)
+  }
+
+  const dismissWebhookSecrets = () => {
+    setCreatedWebhookSecrets([])
+    reconcileDeferredNavigation(failedStagedTriggers, [])
   }
 
   // During creation the agent has no server-side triggers yet; the summary
@@ -1415,6 +1517,8 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         setShowSuccessDialog(false)
         if (failedStagedTriggers.length === 0) {
           router.replace(`/build/${createdAgent.id}`)
+        } else {
+          navPendingRef.current = true
         }
       } else {
         const error = await response.json()
@@ -1432,9 +1536,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     setShowSuccessDialog(false)
     // router.replace remounts the builder and would drop the failed-trigger
     // retry list. The URL was already pushState'd to /build/{id} at creation,
-    // so staying on this instance is safe while retries are pending.
-    if (createdAgent?.id && failedStagedTriggers.length === 0) {
+    // so staying on this instance is safe while retries are pending; the
+    // deferred navigation runs once the failed list drains.
+    if (!createdAgent?.id) return
+    if (failedStagedTriggers.length === 0) {
       router.replace(`/build/${createdAgent.id}`)
+    } else {
+      navPendingRef.current = true
     }
   }
 
@@ -2190,7 +2298,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             <AlertTitle>{t("triggers.staging.failedTitle")}</AlertTitle>
             <AlertDescription>
               <div className="mt-2 space-y-2">
-                {failedStagedTriggers.map((entry, index) => (
+                {failedStagedTriggers.map((entry) => (
                   <div key={entry.staged.clientId} className="flex flex-wrap items-center gap-2">
                     <span className="min-w-0 flex-1 truncate text-xs">
                       <span className="font-medium">{entry.staged.name}</span>
@@ -2201,18 +2309,24 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                       size="sm"
                       variant="secondary"
                       className="h-7 px-2 text-xs"
-                      onClick={() => void retryFailedTrigger(index)}
+                      onClick={() => void retryFailedTrigger(entry.staged.clientId)}
                     >
                       {t("triggers.actions.retry")}
                     </Button>
                     <Button
                       type="button"
                       size="sm"
-                      variant="ghost"
+                      variant={
+                        discardConfirmClientId === entry.staged.clientId
+                          ? "destructive"
+                          : "ghost"
+                      }
                       className="h-7 px-2 text-xs"
-                      onClick={() => discardFailedTrigger(index)}
+                      onClick={() => discardFailedTrigger(entry.staged.clientId)}
                     >
-                      {t("triggers.actions.discard")}
+                      {discardConfirmClientId === entry.staged.clientId
+                        ? t("triggers.actions.confirmDiscard")
+                        : t("triggers.actions.discard")}
                     </Button>
                   </div>
                 ))}
@@ -2222,50 +2336,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         )}
 
         {/* One-time reveal for webhook secrets generated outside the creation
-            success dialog (e.g. a retried staged trigger). Also a fallback
-            surface while that dialog is open. */}
-        {createdWebhookSecrets.length > 0 && (
-          <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle className="flex items-center justify-between gap-2">
-              {t("triggers.secret.title")}
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 shrink-0"
-                onClick={() => setCreatedWebhookSecrets([])}
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
-            </AlertTitle>
-            <AlertDescription>
-              <div className="mt-2 space-y-2">
-                {createdWebhookSecrets.map((item) => (
-                  <div key={`${item.name}:${item.secret}`} className="flex items-center gap-2">
-                    <span className="max-w-[160px] shrink-0 truncate text-xs font-medium">{item.name}</span>
-                    <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
-                      {item.secret}
-                    </code>
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="secondary"
-                      className="h-7 w-7 shrink-0"
-                      onClick={async () => {
-                        if (await copyToClipboard(item.secret)) {
-                          toast.success(t("common.copied"))
-                        }
-                      }}
-                      title={t("common.copy")}
-                    >
-                      <Copy className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </AlertDescription>
-          </Alert>
+            success dialog (e.g. a retried staged trigger). Hidden while the
+            dialog is open — it shows the same list itself. */}
+        {!showSuccessDialog && (
+          <WebhookSecretsAlert secrets={createdWebhookSecrets} onDismiss={dismissWebhookSecrets} />
         )}
 
         {effectiveTriggerSummary.some((trigger) => trigger.enabled) && (
@@ -2660,40 +2734,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             </DialogDescription>
           </DialogHeader>
           {/* One-time reveal of webhook secrets generated for staged triggers
-              (#928). Closing this dialog navigates away and remounts the
-              builder, so this is the only chance to copy them. */}
-          {createdWebhookSecrets.length > 0 && (
-            <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{t("triggers.secret.title")}</AlertTitle>
-              <AlertDescription>
-                <div className="mt-2 space-y-2">
-                  {createdWebhookSecrets.map((item) => (
-                    <div key={`${item.name}:${item.secret}`} className="flex items-center gap-2">
-                      <span className="max-w-[160px] shrink-0 truncate text-xs font-medium">{item.name}</span>
-                      <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
-                        {item.secret}
-                      </code>
-                      <Button
-                        type="button"
-                        size="icon"
-                        variant="secondary"
-                        className="h-7 w-7 shrink-0"
-                        onClick={async () => {
-                          if (await copyToClipboard(item.secret)) {
-                            toast.success(t("common.copied"))
-                          }
-                        }}
-                        title={t("common.copy")}
-                      >
-                        <Copy className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              </AlertDescription>
-            </Alert>
-          )}
+              (#928). Closing this dialog usually navigates away and remounts
+              the builder, so this is the moment to copy them. */}
+          <WebhookSecretsAlert secrets={createdWebhookSecrets} />
           <DialogFooter className="gap-2 sm:justify-end">
             <div className="flex w-full sm:w-auto gap-2 justify-end">
               <Button variant="outline" onClick={handleDialogClose}>

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -53,8 +53,10 @@ import { AgentFlowView } from "./agent-flow-view"
 import {
   AgentTrigger,
   AgentTriggerType,
+  FailedStagedTrigger,
   StagedTrigger,
   createAgentTrigger,
+  createStagedTriggers,
   listAgentTriggers,
   stagedToCreatePayload,
   stagedToPseudoTrigger,
@@ -185,10 +187,18 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   // Triggers configured before the agent exists (#928). Posted via the
   // trigger API right after the agent is created, then cleared.
   const [stagedTriggers, setStagedTriggers] = useState<StagedTrigger[]>([])
+  // Staged triggers whose POST failed after the agent was created. Their
+  // config is kept for retry/discard instead of being silently dropped.
+  const [failedStagedTriggers, setFailedStagedTriggers] = useState<FailedStagedTrigger[]>([])
   // Auto-generated webhook secrets from staged-trigger creation; shown once.
   const [createdWebhookSecrets, setCreatedWebhookSecrets] = useState<
     { name: string; secret: string }[]
   >([])
+  // Creation succeeded but ownership reconciliation opened the
+  // share-connectors dialog instead of the success dialog. The success dialog
+  // (which reveals generated webhook secrets) must still be shown once that
+  // flow resolves, whichever way it resolves.
+  const pendingCreationDialogRef = useRef(false)
   const [showAIAssistant, setShowAIAssistant] = useState(false)
   const [viewMode, setViewMode] = useState<"config" | "flow">("config")
   const [configSynced, setConfigSynced] = useState(false)
@@ -247,6 +257,36 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   useEffect(() => {
     void refreshTriggerSummary()
   }, [refreshTriggerSummary])
+
+  // Retry a staged trigger whose POST failed during agent creation. The agent
+  // exists by now, so this goes straight through the live trigger API.
+  const retryFailedTrigger = async (index: number) => {
+    if (!localAgentId) return
+    const entry = failedStagedTriggers[index]
+    if (!entry) return
+    try {
+      const created = await createAgentTrigger(localAgentId, stagedToCreatePayload(entry.staged))
+      setFailedStagedTriggers((prev) => prev.filter((_, i) => i !== index))
+      const secret = created.webhook_secret
+      if (secret && !entry.staged.secret) {
+        setCreatedWebhookSecrets((prev) => [...prev, { name: entry.staged.name, secret }])
+      }
+      void refreshTriggerSummary()
+      toast.success(t("triggers.messages.created"))
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      setFailedStagedTriggers((prev) =>
+        prev.map((item, i) => (i === index ? { ...item, error: reason } : item)),
+      )
+      toast.error(
+        t("triggers.messages.stagedCreateFailed", { name: entry.staged.name, error: reason }),
+      )
+    }
+  }
+
+  const discardFailedTrigger = (index: number) => {
+    setFailedStagedTriggers((prev) => prev.filter((_, i) => i !== index))
+  }
 
   // During creation the agent has no server-side triggers yet; the summary
   // sections and flow view render the staged ones instead (#928).
@@ -1116,6 +1156,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       const result = await reconcileOwnership(localAgentId, null)
       if (result) {
         setOriginalData((current: any) => ({ ...current, ...result }))
+        pendingCreationDialogRef.current = false
         setShowSuccessDialog(true)
       }
     } catch (error) {
@@ -1131,6 +1172,12 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     setUnsharedConnectors([])
     setUnsharedKnowledgeBases([])
     setOwnership("personal")
+    // If this share flow interrupted agent creation, the success dialog was
+    // deferred; show it now so generated webhook secrets are still revealed.
+    if (pendingCreationDialogRef.current) {
+      pendingCreationDialogRef.current = false
+      setShowSuccessDialog(true)
+    }
   }
 
   const handleCreate = async () => {
@@ -1240,31 +1287,21 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
           // Staged triggers (configured before the agent existed, #928) go
           // through the regular trigger API now that a real agent id exists.
-          // Failures don't roll back the agent; each one surfaces as a toast
-          // and the trigger can be re-added from the (now live) dialog.
+          // Failures don't roll back the agent; failed configs are kept in
+          // failedStagedTriggers for retry/discard instead of being dropped.
           if (stagedTriggers.length > 0) {
-            const results = await Promise.allSettled(
-              stagedTriggers.map((staged) =>
-                createAgentTrigger(newAgent.id, stagedToCreatePayload(staged)),
-              ),
-            )
-            const generatedSecrets: { name: string; secret: string }[] = []
-            results.forEach((result, index) => {
-              const staged = stagedTriggers[index]
-              if (result.status === "rejected") {
-                const reason =
-                  result.reason instanceof Error
-                    ? result.reason.message
-                    : String(result.reason)
-                toast.error(
-                  t("triggers.messages.stagedCreateFailed", { name: staged.name, error: reason }),
-                )
-              } else if (result.value.webhook_secret && !staged.secret) {
-                generatedSecrets.push({ name: staged.name, secret: result.value.webhook_secret })
-              }
+            const outcome = await createStagedTriggers(newAgent.id, stagedTriggers)
+            outcome.failed.forEach((entry) => {
+              toast.error(
+                t("triggers.messages.stagedCreateFailed", {
+                  name: entry.staged.name,
+                  error: entry.error,
+                }),
+              )
             })
             setStagedTriggers([])
-            setCreatedWebhookSecrets(generatedSecrets)
+            setFailedStagedTriggers(outcome.failed)
+            setCreatedWebhookSecrets(outcome.generatedSecrets)
             try {
               setTriggerSummary(await listAgentTriggers(newAgent.id))
             } catch (error) {
@@ -1277,9 +1314,12 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           setOriginalData({ ...newAgent, ...(ownershipResult ?? {}) })
           // Only confirm success once ownership resolved. If a promote was blocked
           // (the share-connectors dialog opened, ownershipResult is null), don't
-          // stack a "created" dialog on top of it.
+          // stack a "created" dialog on top of it — but remember to show it when
+          // that flow resolves, or generated webhook secrets would never surface.
           if (ownershipResult) {
             setShowSuccessDialog(true)
+          } else {
+            pendingCreationDialogRef.current = true
           }
           setLocalAgentId(newAgent.id.toString())
 
@@ -1373,7 +1413,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       if (response.ok) {
         toast.success(t("builds.editor.success.published"))
         setShowSuccessDialog(false)
-        router.replace(`/build/${createdAgent.id}`)
+        if (failedStagedTriggers.length === 0) {
+          router.replace(`/build/${createdAgent.id}`)
+        }
       } else {
         const error = await response.json()
         toast.error(error.detail || t("builds.editor.error.publishFailed"))
@@ -1388,7 +1430,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
   const handleDialogClose = () => {
     setShowSuccessDialog(false)
-    if (createdAgent?.id) {
+    // router.replace remounts the builder and would drop the failed-trigger
+    // retry list. The URL was already pushState'd to /build/{id} at creation,
+    // so staying on this instance is safe while retries are pending.
+    if (createdAgent?.id && failedStagedTriggers.length === 0) {
       router.replace(`/build/${createdAgent.id}`)
     }
   }
@@ -2138,6 +2183,90 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             </div>
           )}
         </div>
+
+        {failedStagedTriggers.length > 0 && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>{t("triggers.staging.failedTitle")}</AlertTitle>
+            <AlertDescription>
+              <div className="mt-2 space-y-2">
+                {failedStagedTriggers.map((entry, index) => (
+                  <div key={entry.staged.clientId} className="flex flex-wrap items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate text-xs">
+                      <span className="font-medium">{entry.staged.name}</span>
+                      {` — ${entry.error}`}
+                    </span>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => void retryFailedTrigger(index)}
+                    >
+                      {t("triggers.actions.retry")}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => discardFailedTrigger(index)}
+                    >
+                      {t("triggers.actions.discard")}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* One-time reveal for webhook secrets generated outside the creation
+            success dialog (e.g. a retried staged trigger). Also a fallback
+            surface while that dialog is open. */}
+        {createdWebhookSecrets.length > 0 && (
+          <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle className="flex items-center justify-between gap-2">
+              {t("triggers.secret.title")}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0"
+                onClick={() => setCreatedWebhookSecrets([])}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </AlertTitle>
+            <AlertDescription>
+              <div className="mt-2 space-y-2">
+                {createdWebhookSecrets.map((item) => (
+                  <div key={`${item.name}:${item.secret}`} className="flex items-center gap-2">
+                    <span className="max-w-[160px] shrink-0 truncate text-xs font-medium">{item.name}</span>
+                    <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
+                      {item.secret}
+                    </code>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="secondary"
+                      className="h-7 w-7 shrink-0"
+                      onClick={async () => {
+                        if (await copyToClipboard(item.secret)) {
+                          toast.success(t("common.copied"))
+                        }
+                      }}
+                      title={t("common.copy")}
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
 
         {effectiveTriggerSummary.some((trigger) => trigger.enabled) && (
           <div className="space-y-2">

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -11,7 +11,7 @@ import { Switch } from "@/components/ui/switch"
 import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { isBuiltinModel, hostnameFromUrl } from "@/lib/models"
-import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain, Webhook, CalendarClock, Mail, Eye, Workflow } from "lucide-react"
+import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain, Webhook, CalendarClock, Mail, Eye, Workflow, AlertCircle, Copy } from "lucide-react"
 import { ConnectMcpDialog } from "@/components/mcp/connect-mcp-dialog"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
@@ -50,7 +50,17 @@ import { BuildFilePreviewSheet } from "./build-file-preview-sheet"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { AgentTriggersDialog } from "./agent-triggers-dialog"
 import { AgentFlowView } from "./agent-flow-view"
-import { AgentTrigger, AgentTriggerType, listAgentTriggers } from "@/lib/agent-triggers-api"
+import {
+  AgentTrigger,
+  AgentTriggerType,
+  StagedTrigger,
+  createAgentTrigger,
+  listAgentTriggers,
+  stagedToCreatePayload,
+  stagedToPseudoTrigger,
+} from "@/lib/agent-triggers-api"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { copyToClipboard } from "@/lib/clipboard"
 import {
   sanitizeUnsharedConnectors,
   sanitizeUnsharedKnowledgeBases,
@@ -172,6 +182,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const [isTriggersDialogOpen, setIsTriggersDialogOpen] = useState(false)
   const [triggerDialogInitialType, setTriggerDialogInitialType] = useState<AgentTriggerType | null>(null)
   const [triggerSummary, setTriggerSummary] = useState<AgentTrigger[]>([])
+  // Triggers configured before the agent exists (#928). Posted via the
+  // trigger API right after the agent is created, then cleared.
+  const [stagedTriggers, setStagedTriggers] = useState<StagedTrigger[]>([])
+  // Auto-generated webhook secrets from staged-trigger creation; shown once.
+  const [createdWebhookSecrets, setCreatedWebhookSecrets] = useState<
+    { name: string; secret: string }[]
+  >([])
   const [showAIAssistant, setShowAIAssistant] = useState(false)
   const [viewMode, setViewMode] = useState<"config" | "flow">("config")
   const [configSynced, setConfigSynced] = useState(false)
@@ -231,13 +248,20 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     void refreshTriggerSummary()
   }, [refreshTriggerSummary])
 
+  // During creation the agent has no server-side triggers yet; the summary
+  // sections and flow view render the staged ones instead (#928).
+  const effectiveTriggerSummary = useMemo(
+    () => (localAgentId ? triggerSummary : stagedTriggers.map(stagedToPseudoTrigger)),
+    [localAgentId, triggerSummary, stagedTriggers],
+  )
+
   const triggerStats = useMemo(() => {
     const stats = {
       webhook: { total: 0, enabled: 0 },
       scheduled: { total: 0, enabled: 0 },
       gmail: { total: 0, enabled: 0 },
     }
-    triggerSummary.forEach((trigger) => {
+    effectiveTriggerSummary.forEach((trigger) => {
       if (trigger.type !== "webhook" && trigger.type !== "scheduled" && trigger.type !== "gmail") return
       stats[trigger.type].total += 1
       if (trigger.enabled) {
@@ -245,7 +269,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       }
     })
     return stats
-  }, [triggerSummary])
+  }, [effectiveTriggerSummary])
 
   const gmailConnection = useMemo(() => {
     const gmailApp = findMatchingMcpApp(officialApps, "gmail")
@@ -1213,6 +1237,41 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         } else {
           const newAgent = await response.json()
           setCreatedAgent(newAgent)
+
+          // Staged triggers (configured before the agent existed, #928) go
+          // through the regular trigger API now that a real agent id exists.
+          // Failures don't roll back the agent; each one surfaces as a toast
+          // and the trigger can be re-added from the (now live) dialog.
+          if (stagedTriggers.length > 0) {
+            const results = await Promise.allSettled(
+              stagedTriggers.map((staged) =>
+                createAgentTrigger(newAgent.id, stagedToCreatePayload(staged)),
+              ),
+            )
+            const generatedSecrets: { name: string; secret: string }[] = []
+            results.forEach((result, index) => {
+              const staged = stagedTriggers[index]
+              if (result.status === "rejected") {
+                const reason =
+                  result.reason instanceof Error
+                    ? result.reason.message
+                    : String(result.reason)
+                toast.error(
+                  t("triggers.messages.stagedCreateFailed", { name: staged.name, error: reason }),
+                )
+              } else if (result.value.webhook_secret && !staged.secret) {
+                generatedSecrets.push({ name: staged.name, secret: result.value.webhook_secret })
+              }
+            })
+            setStagedTriggers([])
+            setCreatedWebhookSecrets(generatedSecrets)
+            try {
+              setTriggerSummary(await listAgentTriggers(newAgent.id))
+            } catch (error) {
+              console.error("Failed to refresh trigger summary:", error)
+            }
+          }
+
           // Newly created agents are always personal; promote if the user chose Team.
           const ownershipResult = await reconcileOwnership(newAgent.id.toString(), newAgent.team_id)
           setOriginalData({ ...newAgent, ...(ownershipResult ?? {}) })
@@ -2080,7 +2139,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           )}
         </div>
 
-        {triggerSummary.some((trigger) => trigger.enabled) && (
+        {effectiveTriggerSummary.some((trigger) => trigger.enabled) && (
           <div className="space-y-2">
             <div className="flex items-center gap-1.5">
               <Label>{t("triggers.builder.title")}</Label>
@@ -2236,7 +2295,6 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
               setTriggerDialogInitialType(null)
               setIsTriggersDialogOpen(true)
             }}
-            disabled={!localAgentId}
             className="h-7 border-dashed border-primary/45 bg-primary/5 px-2 text-xs text-primary hover:border-primary hover:bg-primary/10"
           >
             <Zap className="mr-1 h-3.5 w-3.5" />
@@ -2472,6 +2530,41 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
               {t("builds.editor.success.createdDesc", { name: createdAgent?.name })}
             </DialogDescription>
           </DialogHeader>
+          {/* One-time reveal of webhook secrets generated for staged triggers
+              (#928). Closing this dialog navigates away and remounts the
+              builder, so this is the only chance to copy them. */}
+          {createdWebhookSecrets.length > 0 && (
+            <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{t("triggers.secret.title")}</AlertTitle>
+              <AlertDescription>
+                <div className="mt-2 space-y-2">
+                  {createdWebhookSecrets.map((item) => (
+                    <div key={`${item.name}:${item.secret}`} className="flex items-center gap-2">
+                      <span className="max-w-[160px] shrink-0 truncate text-xs font-medium">{item.name}</span>
+                      <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
+                        {item.secret}
+                      </code>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="secondary"
+                        className="h-7 w-7 shrink-0"
+                        onClick={async () => {
+                          if (await copyToClipboard(item.secret)) {
+                            toast.success(t("common.copied"))
+                          }
+                        }}
+                        title={t("common.copy")}
+                      >
+                        <Copy className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
           <DialogFooter className="gap-2 sm:justify-end">
             <div className="flex w-full sm:w-auto gap-2 justify-end">
               <Button variant="outline" onClick={handleDialogClose}>
@@ -2547,6 +2640,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
       <AgentTriggersDialog
         agentId={localAgentId ? Number(localAgentId) : null}
+        staged={localAgentId ? null : { triggers: stagedTriggers, onChange: setStagedTriggers }}
         agentName={name}
         open={isTriggersDialogOpen}
         onOpenChange={(dialogOpen) => {

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import React from "react"
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
@@ -41,6 +41,7 @@ vi.mock("@/lib/clipboard", () => ({
 }))
 
 import { AgentTriggersDialog } from "./agent-triggers-dialog"
+import type { StagedTrigger } from "@/lib/agent-triggers-api"
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -263,5 +264,116 @@ describe("AgentTriggersDialog", () => {
     fireEvent.click(await screen.findByText("triggers.cards.gmail.title"))
 
     expect(await screen.findByText("triggers.gmail.accountMissing")).toBeInTheDocument()
+  })
+})
+
+describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
+  function stagedWebhook(clientId: number, name: string): StagedTrigger {
+    return {
+      clientId,
+      type: "webhook",
+      name,
+      enabled: true,
+      config: {},
+      prompt_template: null,
+      secret: null,
+    }
+  }
+
+  function renderStaging(triggers: StagedTrigger[]) {
+    const onChange = vi.fn()
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        open
+        onOpenChange={vi.fn()}
+        staged={{ triggers, onChange }}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+    return onChange
+  }
+
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    apiRequestMock.mockResolvedValue(jsonResponse([]))
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("stages a default trigger when a type is toggled on", async () => {
+    const onChange = renderStaging([])
+
+    expect(await screen.findByText("triggers.staging.info")).toBeInTheDocument()
+
+    const [webhookSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(webhookSwitch)
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          clientId: -1,
+          type: "webhook",
+          enabled: true,
+          name: "triggers.defaults.webhookName",
+        }),
+      ])
+    })
+  })
+
+  it("appends a new staged trigger via Add instead of overwriting the selected one", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "First hook")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("First hook")
+
+    fireEvent.click(screen.getByRole("button", { name: /triggers.actions.addAnother/ }))
+
+    // Creation state: empty form and the create label, no leaked delete action.
+    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("")
+    expect(screen.getByRole("button", { name: "triggers.actions.enable" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "triggers.actions.delete" })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("triggers.form.name"), {
+      target: { value: "Second hook" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.enable" }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -1, name: "First hook" }),
+        expect.objectContaining({ clientId: -2, name: "Second hook", type: "webhook" }),
+      ])
+    })
+  })
+
+  it("lists staged triggers newest first and selects the primary one", async () => {
+    renderStaging([stagedWebhook(-1, "Old hook"), stagedWebhook(-2, "New hook")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+
+    // Newest staged trigger (-2) is the primary selection…
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("New hook")
+    // …and precedes the older one in the picker.
+    const newPill = screen.getByText("New hook")
+    const oldPill = screen.getByText("Old hook")
+    expect(
+      newPill.compareDocumentPosition(oldPill) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it("removes a staged trigger after delete confirmation", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "Doomed hook")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.delete" }))
+    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.confirmDelete" }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([])
+    })
   })
 })

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -376,4 +376,42 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
       expect(onChange).toHaveBeenCalledWith([])
     })
   })
+
+  it("updates the selected staged trigger in place on save", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "Old name")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("Old name")
+
+    fireEvent.change(screen.getByLabelText("triggers.form.name"), {
+      target: { value: "New name" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.save" }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -1, name: "New name", type: "webhook" }),
+      ])
+    })
+  })
+
+  it("disables every staged trigger of a type when its switch is toggled off", async () => {
+    const onChange = renderStaging([
+      stagedWebhook(-1, "Hook one"),
+      stagedWebhook(-2, "Hook two"),
+    ])
+
+    await screen.findByText("triggers.staging.info")
+    const [webhookSwitch] = screen.getAllByRole("switch")
+    expect(webhookSwitch).toHaveAttribute("aria-checked", "true")
+
+    fireEvent.click(webhookSwitch)
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -1, enabled: false }),
+        expect.objectContaining({ clientId: -2, enabled: false }),
+      ])
+    })
+  })
 })

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -220,6 +220,11 @@ export function AgentTriggersDialog({
   const isStaging = !isValidAgentId(agentId) && stagedTriggersProp !== null
   const canOperate = isValidAgentId(agentId) || isStaging
 
+  // Ref mirror so the dialog-open effect can pick a default selection without
+  // re-running whenever the staged list changes.
+  const stagedTriggersRef = useRef<StagedTrigger[] | null>(null)
+  stagedTriggersRef.current = stagedTriggersProp
+
   // Staged clientIds are stable negative numbers so they can serve as pseudo
   // AgentTrigger ids without ever colliding with a real server id.
   const nextStagedClientId = () =>
@@ -253,13 +258,13 @@ export function AgentTriggersDialog({
   }, [triggers])
 
   const activeTypeTriggers = activeType ? triggerGroups[activeType] : []
+  // A null selectedTriggerId means "creating a new trigger" (e.g. via the Add
+  // button), so it must NOT fall back to an existing trigger — that would make
+  // handleSubmit overwrite it. Every browse flow selects an id explicitly
+  // (openType, beginEdit, loadTriggers, the open effect).
   const selectedTrigger = useMemo(() => {
-    if (!activeType) return null
-    return (
-      activeTypeTriggers.find((trigger) => trigger.id === selectedTriggerId) ??
-      activeTypeTriggers[0] ??
-      null
-    )
+    if (!activeType || selectedTriggerId === null) return null
+    return activeTypeTriggers.find((trigger) => trigger.id === selectedTriggerId) ?? null
   }, [activeType, activeTypeTriggers, selectedTriggerId])
 
   const selectedWebhookUrl = webhookUrl(selectedTrigger)
@@ -320,9 +325,20 @@ export function AgentTriggersDialog({
     setRuns([])
     if (initialType) {
       setForm(emptyForm(initialType))
+      // Live mode gets its default selection from loadTriggers below; in
+      // staging mode it early-returns, so pick the primary staged trigger of
+      // the requested type here (selectedTrigger no longer falls back to the
+      // first trigger when nothing is selected).
+      if (isStaging) {
+        const typeStaged = (stagedTriggersRef.current ?? []).filter(
+          (item) => item.type === initialType,
+        )
+        const primary = typeStaged.find((item) => item.enabled) ?? typeStaged[0]
+        if (primary) setSelectedTriggerId(primary.clientId)
+      }
     }
     void loadTriggers(null)
-  }, [initialType, loadTriggers, open, setActiveType, setSelectedTriggerId])
+  }, [initialType, isStaging, loadTriggers, open, setActiveType, setSelectedTriggerId])
 
   useEffect(() => {
     if (!open) return

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -37,11 +37,13 @@ import {
   AgentTriggerRun,
   AgentTriggerType,
   GmailAccount,
+  StagedTrigger,
   createAgentTrigger,
   deleteAgentTrigger,
   listAgentTriggerRuns,
   listAgentTriggers,
   listGmailAccounts,
+  stagedToPseudoTrigger,
   testAgentTrigger,
   updateAgentTrigger,
 } from "@/lib/agent-triggers-api"
@@ -62,6 +64,11 @@ interface AgentTriggersDialogProps {
   initialType?: AgentTriggerType | null
   gmailConnection?: GmailConnectionState | null
   onConnectGmail?: () => void
+  // Creation flow (#928): when the agent does not exist yet the parent owns a
+  // list of staged triggers. All create/update/delete operations mutate that
+  // list instead of calling the API; the builder posts the staged triggers
+  // right after the agent is created.
+  staged?: { triggers: StagedTrigger[]; onChange: (next: StagedTrigger[]) => void } | null
 }
 
 interface TriggerFormState {
@@ -186,6 +193,7 @@ export function AgentTriggersDialog({
   initialType = null,
   gmailConnection = null,
   onConnectGmail,
+  staged = null,
 }: AgentTriggersDialogProps) {
   const { t } = useI18n()
   const router = useRouter()
@@ -207,6 +215,22 @@ export function AgentTriggersDialog({
   const [gmailAccountsLoading, setGmailAccountsLoading] = useState(false)
   const selectedTriggerIdRef = useRef<number | null>(null)
   const activeTypeRef = useRef<AgentTriggerType | null>(null)
+
+  const stagedTriggersProp = staged?.triggers ?? null
+  const isStaging = !isValidAgentId(agentId) && stagedTriggersProp !== null
+  const canOperate = isValidAgentId(agentId) || isStaging
+
+  // Staged clientIds are stable negative numbers so they can serve as pseudo
+  // AgentTrigger ids without ever colliding with a real server id.
+  const nextStagedClientId = () =>
+    (stagedTriggersProp ?? []).reduce((min, item) => Math.min(min, item.clientId), 0) - 1
+
+  // Staging mode: mirror the parent-owned staged triggers into the dialog's
+  // trigger list so grouping/selection/form logic works unchanged.
+  useEffect(() => {
+    if (!isStaging || !stagedTriggersProp) return
+    setTriggers(stagedTriggersProp.map(stagedToPseudoTrigger))
+  }, [isStaging, stagedTriggersProp])
 
   const setSelectedTriggerId = useCallback((id: number | null) => {
     selectedTriggerIdRef.current = id
@@ -448,11 +472,25 @@ export function AgentTriggersDialog({
   }
 
   const createDefaultTrigger = async (type: AgentTriggerType, enabled: boolean) => {
-    if (!isValidAgentId(agentId)) return null
     const config = defaultConfigForType(type)
     if (type === "gmail" && gmailAccounts?.length === 1) {
       config.oauth_account_id = gmailAccounts[0].id
     }
+    if (isStaging && staged) {
+      const stagedTrigger: StagedTrigger = {
+        clientId: nextStagedClientId(),
+        type,
+        name: defaultNameForType(type),
+        enabled,
+        config,
+        prompt_template: null,
+        secret: null,
+      }
+      staged.onChange([...staged.triggers, stagedTrigger])
+      notifyChanged()
+      return stagedToPseudoTrigger(stagedTrigger)
+    }
+    if (!isValidAgentId(agentId)) return null
     const saved = await createAgentTrigger(agentId, {
       type,
       name: defaultNameForType(type),
@@ -467,7 +505,7 @@ export function AgentTriggersDialog({
   }
 
   const handleTypeToggle = async (type: AgentTriggerType, checked: boolean) => {
-    if (!isValidAgentId(agentId)) return
+    if (!canOperate) return
     const typeTriggers = triggerGroups[type]
     const primary =
       typeTriggers.find((trigger) => trigger.enabled) ??
@@ -489,6 +527,35 @@ export function AgentTriggersDialog({
     }
     setBusyType(type)
     try {
+      if (isStaging && staged) {
+        if (checked) {
+          if (primary) {
+            staged.onChange(
+              staged.triggers.map((item) =>
+                item.clientId === primary.id ? { ...item, enabled: true } : item,
+              ),
+            )
+            setSelectedTriggerId(primary.id)
+          } else {
+            const created = await createDefaultTrigger(type, true)
+            if (created) {
+              setActiveType(type)
+              setSelectedTriggerId(created.id)
+              setForm(formFromTrigger(created))
+            }
+          }
+        } else {
+          staged.onChange(
+            staged.triggers.map((item) =>
+              item.type === type ? { ...item, enabled: false } : item,
+            ),
+          )
+        }
+        notifyChanged()
+        toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
+        return
+      }
+      if (!isValidAgentId(agentId)) return
       let preferredId: number | null = primary?.id ?? null
       if (checked) {
         if (primary) {
@@ -523,7 +590,7 @@ export function AgentTriggersDialog({
   }
 
   const handleSubmit = async () => {
-    if (!isValidAgentId(agentId)) return
+    if (!canOperate) return
     let payload
     try {
       payload = buildPayload()
@@ -532,6 +599,45 @@ export function AgentTriggersDialog({
       return
     }
 
+    if (isStaging && staged) {
+      if (selectedTrigger) {
+        staged.onChange(
+          staged.triggers.map((item) =>
+            item.clientId === selectedTrigger.id
+              ? {
+                  ...item,
+                  name: payload.name,
+                  enabled: payload.enabled,
+                  config: payload.config,
+                  prompt_template: payload.prompt_template,
+                  // Like the live edit flow, a blank secret keeps the current one.
+                  secret: payload.secret ?? item.secret,
+                }
+              : item,
+          ),
+        )
+      } else {
+        const clientId = nextStagedClientId()
+        staged.onChange([
+          ...staged.triggers,
+          {
+            clientId,
+            type: payload.type,
+            name: payload.name,
+            enabled: payload.enabled,
+            config: payload.config,
+            prompt_template: payload.prompt_template,
+            secret: payload.secret,
+          },
+        ])
+        setSelectedTriggerId(clientId)
+      }
+      notifyChanged()
+      toast.success(t("triggers.messages.staged"))
+      return
+    }
+
+    if (!isValidAgentId(agentId)) return
     setBusy(true)
     try {
       const saved = selectedTrigger
@@ -571,11 +677,21 @@ export function AgentTriggersDialog({
   }
 
   const handleDelete = async (trigger: AgentTrigger) => {
-    if (!isValidAgentId(agentId)) return
+    if (!canOperate) return
     if (deleteConfirmId !== trigger.id) {
       setDeleteConfirmId(trigger.id)
       return
     }
+    if (isStaging && staged) {
+      staged.onChange(staged.triggers.filter((item) => item.clientId !== trigger.id))
+      setSelectedTriggerId(null)
+      setRuns([])
+      setDeleteConfirmId(null)
+      notifyChanged()
+      toast.success(t("triggers.messages.deleted"))
+      return
+    }
+    if (!isValidAgentId(agentId)) return
     setBusy(true)
     try {
       await deleteAgentTrigger(agentId, trigger.id)
@@ -703,7 +819,7 @@ export function AgentTriggersDialog({
         <div className="flex items-center gap-3">
           <Switch
             checked={isEnabled}
-            disabled={busyType === type || !isValidAgentId(agentId)}
+            disabled={busyType === type || !canOperate}
             onCheckedChange={(checked) => void handleTypeToggle(type, checked)}
           />
           <button
@@ -724,7 +840,7 @@ export function AgentTriggersDialog({
       <Alert className="border-primary/20 bg-primary/5 text-primary">
         <Info className="h-4 w-4" />
         <AlertDescription className="text-sm text-foreground">
-          {t("triggers.overview.info")}
+          {t(isStaging ? "triggers.staging.info" : "triggers.overview.info")}
         </AlertDescription>
       </Alert>
 
@@ -846,7 +962,11 @@ export function AgentTriggersDialog({
                 type="password"
                 value={form.secret}
                 onChange={(event) => setFormValue("secret", event.target.value)}
-                placeholder={isNew ? t("triggers.form.secretPlaceholder") : t("triggers.form.secretEditPlaceholder")}
+                placeholder={
+                  isNew || isStaging
+                    ? t("triggers.form.secretPlaceholder")
+                    : t("triggers.form.secretEditPlaceholder")
+                }
               />
             </div>
           )}
@@ -992,7 +1112,16 @@ export function AgentTriggersDialog({
           </Alert>
         )}
 
-        {selectedTrigger?.type === "webhook" && (
+        {isStaging && activeType === "webhook" && (
+          <Alert className="border-primary/20 bg-primary/5">
+            <Info className="h-4 w-4" />
+            <AlertDescription className="text-sm text-foreground">
+              {t("triggers.staging.webhookPending")}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {!isStaging && selectedTrigger?.type === "webhook" && (
           <section className="space-y-3 rounded-lg border bg-muted/20 p-4">
             <div className="text-sm font-medium">{t("triggers.webhook.title")}</div>
             <div className="flex gap-2">
@@ -1013,17 +1142,17 @@ export function AgentTriggersDialog({
 
         <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-4">
           <div className="flex flex-wrap gap-2">
-            <Button onClick={handleSubmit} disabled={busy || !isValidAgentId(agentId)}>
+            <Button onClick={handleSubmit} disabled={busy || !canOperate}>
               {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {isNew ? t("triggers.actions.enable") : t("triggers.actions.save")}
             </Button>
-            {selectedTrigger && (
+            {!isStaging && selectedTrigger && (
               <Button variant="outline" onClick={handleTest} disabled={busy}>
                 <Play className="mr-2 h-4 w-4" />
                 {t("triggers.actions.test")}
               </Button>
             )}
-            {selectedTrigger?.type === "webhook" && (
+            {!isStaging && selectedTrigger?.type === "webhook" && (
               <Button variant="outline" onClick={handleRotateSecret} disabled={busy}>
                 <RotateCcw className="mr-2 h-4 w-4" />
                 {t("triggers.actions.rotateSecret")}
@@ -1045,7 +1174,7 @@ export function AgentTriggersDialog({
           )}
         </div>
 
-        {selectedTrigger && (
+        {!isStaging && selectedTrigger && (
           <section className="space-y-3 rounded-lg border p-4">
             <div className="flex items-center justify-between gap-3">
               <div>
@@ -1094,7 +1223,7 @@ export function AgentTriggersDialog({
           </section>
         )}
 
-        {selectedTrigger && (
+        {!isStaging && selectedTrigger && (
           <section className="space-y-3 rounded-lg border p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -177,7 +177,11 @@ function runStatusClass(status: string): string {
 }
 
 function newestFirst(a: AgentTrigger, b: AgentTrigger): number {
-  return b.id - a.id
+  // Compare by magnitude: real ids are positive and grow with creation order,
+  // staged pseudo ids are negative and shrink (-1, -2, …). Plain b - a would
+  // invert the order for staged triggers; the two id spaces never mix in one
+  // list.
+  return Math.abs(b.id) - Math.abs(a.id)
 }
 
 function isValidAgentId(agentId: number | null): agentId is number {

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -197,7 +197,7 @@ export function AgentTriggersDialog({
 }: AgentTriggersDialogProps) {
   const { t } = useI18n()
   const router = useRouter()
-  const [triggers, setTriggers] = useState<AgentTrigger[]>([])
+  const [liveTriggers, setLiveTriggers] = useState<AgentTrigger[]>([])
   const [activeType, setActiveTypeState] = useState<AgentTriggerType | null>(null)
   const [selectedTriggerId, setSelectedTriggerIdState] = useState<number | null>(null)
   const [runs, setRuns] = useState<AgentTriggerRun[]>([])
@@ -230,12 +230,18 @@ export function AgentTriggersDialog({
   const nextStagedClientId = () =>
     (stagedTriggersProp ?? []).reduce((min, item) => Math.min(min, item.clientId), 0) - 1
 
-  // Staging mode: mirror the parent-owned staged triggers into the dialog's
-  // trigger list so grouping/selection/form logic works unchanged.
-  useEffect(() => {
-    if (!isStaging || !stagedTriggersProp) return
-    setTriggers(stagedTriggersProp.map(stagedToPseudoTrigger))
-  }, [isStaging, stagedTriggersProp])
+  // Staging mode: derive the trigger list from the parent-owned staged
+  // triggers so grouping/selection/form logic works unchanged. Derivation (not
+  // a state mirror) keeps `triggers` in sync within the same render — a
+  // useEffect mirror lags one render behind, which briefly resolved
+  // selectedTrigger to null after a save and reset the form.
+  const triggers = useMemo(
+    () =>
+      isStaging && stagedTriggersProp
+        ? stagedTriggersProp.map(stagedToPseudoTrigger)
+        : liveTriggers,
+    [isStaging, stagedTriggersProp, liveTriggers],
+  )
 
   const setSelectedTriggerId = useCallback((id: number | null) => {
     selectedTriggerIdRef.current = id
@@ -280,7 +286,7 @@ export function AgentTriggersDialog({
     setLoading(true)
     try {
       const data = await listAgentTriggers(agentId)
-      setTriggers(data)
+      setLiveTriggers(data)
 
       const currentSelectedId = preferredTriggerId ?? selectedTriggerIdRef.current
       if (currentSelectedId && data.some((trigger) => trigger.id === currentSelectedId)) {
@@ -909,6 +915,16 @@ export function AgentTriggersDialog({
   const renderDetail = () => {
     if (!activeType) return null
     const isNew = !selectedTrigger
+    // Whether leaving the secret field blank keeps an existing secret: true
+    // for live triggers (the server holds one) and for staged triggers that
+    // stored a user-provided secret; a staged trigger without one gets a
+    // generated secret when the agent is created.
+    const blankSecretKeepsCurrent = isStaging
+      ? Boolean(
+          selectedTrigger &&
+            stagedTriggersProp?.find((item) => item.clientId === selectedTrigger.id)?.secret,
+        )
+      : !isNew
 
     return (
       <div className="space-y-5">
@@ -979,9 +995,9 @@ export function AgentTriggersDialog({
                 value={form.secret}
                 onChange={(event) => setFormValue("secret", event.target.value)}
                 placeholder={
-                  isNew || isStaging
-                    ? t("triggers.form.secretPlaceholder")
-                    : t("triggers.form.secretEditPlaceholder")
+                  blankSecretKeepsCurrent
+                    ? t("triggers.form.secretEditPlaceholder")
+                    : t("triggers.form.secretPlaceholder")
                 }
               />
             </div>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3545,10 +3545,13 @@ Build when you need.`,
     builder: {
       title: "Triggers",
       description: "Choose automatic entry points for this agent.",
-      saveFirst: "Save the agent before configuring triggers.",
       tooltip: "Triggers automatically start this agent when an external event or schedule fires.",
       open: "Triggers",
       configure: "Configure trigger"
+    },
+    staging: {
+      info: "Triggers configured here are saved with the draft and created automatically together with the agent.",
+      webhookPending: "The webhook URL and signing secret will be generated after the agent is created."
     },
     type: {
       webhook: "Webhook",
@@ -3653,6 +3656,8 @@ Build when you need.`,
       runsLoadFailed: "Failed to load trigger runs",
       created: "Trigger created",
       updated: "Trigger updated",
+      staged: "Trigger saved. It will be created together with the agent.",
+      stagedCreateFailed: "Failed to create trigger \"{name}\": {error}",
       enabled: "Trigger enabled",
       disabled: "Trigger disabled",
       deleted: "Trigger deleted",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3551,7 +3551,8 @@ Build when you need.`,
     },
     staging: {
       info: "Triggers configured here are saved with the draft and created automatically together with the agent.",
-      webhookPending: "The webhook URL and signing secret will be generated after the agent is created."
+      webhookPending: "The webhook URL and signing secret will be generated after the agent is created.",
+      failedTitle: "Some triggers could not be created. Their configuration is kept — retry or discard."
     },
     type: {
       webhook: "Webhook",
@@ -3607,7 +3608,9 @@ Build when you need.`,
       confirmDelete: "Confirm delete",
       rotateSecret: "Rotate secret",
       test: "Test trigger",
-      addAnother: "Add"
+      addAnother: "Add",
+      retry: "Retry",
+      discard: "Discard"
     },
     secret: {
       title: "Copy this secret now. It is shown only once."

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3610,7 +3610,8 @@ Build when you need.`,
       test: "Test trigger",
       addAnother: "Add",
       retry: "Retry",
-      discard: "Discard"
+      discard: "Discard",
+      confirmDiscard: "Confirm discard"
     },
     secret: {
       title: "Copy this secret now. It is shown only once."

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3610,7 +3610,8 @@ const zh = {
       test: "测试触发",
       addAnother: "新增",
       retry: "重试",
-      discard: "丢弃"
+      discard: "丢弃",
+      confirmDiscard: "确认丢弃"
     },
     secret: {
       title: "请立即复制此 secret，它只显示一次。"

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3545,10 +3545,13 @@ const zh = {
     builder: {
       title: "Triggers",
       description: "选择此 Agent 的自动触发入口。",
-      saveFirst: "保存 Agent 后即可配置 Triggers。",
       tooltip: "Triggers 会在外部事件或定时计划发生时自动启动此 Agent。",
       open: "Triggers",
       configure: "配置 Trigger"
+    },
+    staging: {
+      info: "此处配置的 Triggers 会随草稿一起保存，创建 Agent 时自动生效。",
+      webhookPending: "Webhook 地址和签名 secret 将在 Agent 创建后生成。"
     },
     type: {
       webhook: "Webhook",
@@ -3653,6 +3656,8 @@ const zh = {
       runsLoadFailed: "加载 Trigger 运行记录失败",
       created: "Trigger 已创建",
       updated: "Trigger 已更新",
+      staged: "Trigger 已暂存，创建 Agent 时自动生效。",
+      stagedCreateFailed: "Trigger「{name}」创建失败：{error}",
       enabled: "Trigger 已启用",
       disabled: "Trigger 已停用",
       deleted: "Trigger 已删除",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3551,7 +3551,8 @@ const zh = {
     },
     staging: {
       info: "此处配置的 Triggers 会随草稿一起保存，创建 Agent 时自动生效。",
-      webhookPending: "Webhook 地址和签名 secret 将在 Agent 创建后生成。"
+      webhookPending: "Webhook 地址和签名 secret 将在 Agent 创建后生成。",
+      failedTitle: "部分 Trigger 创建失败，配置已保留，可重试或丢弃。"
     },
     type: {
       webhook: "Webhook",
@@ -3607,7 +3608,9 @@ const zh = {
       confirmDelete: "确认删除",
       rotateSecret: "轮换 secret",
       test: "测试触发",
-      addAnother: "新增"
+      addAnother: "新增",
+      retry: "重试",
+      discard: "丢弃"
     },
     secret: {
       title: "请立即复制此 secret，它只显示一次。"

--- a/frontend/src/lib/agent-triggers-api.test.ts
+++ b/frontend/src/lib/agent-triggers-api.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/utils", () => ({
 import {
   StagedTrigger,
   createAgentTrigger,
+  createStagedTriggers,
   listAgentTriggerRuns,
   stagedToCreatePayload,
   stagedToPseudoTrigger,
@@ -160,5 +161,70 @@ describe("staged triggers (agent creation flow)", () => {
       secret: null,
     })
     expect("clientId" in payload).toBe(false)
+  })
+
+  const webhookNoSecret: StagedTrigger = {
+    clientId: -1,
+    type: "webhook",
+    name: "Generated hook",
+    enabled: true,
+    config: {},
+    prompt_template: null,
+    secret: null,
+  }
+  const webhookCustomSecret: StagedTrigger = {
+    clientId: -2,
+    type: "webhook",
+    name: "Custom hook",
+    enabled: true,
+    config: {},
+    prompt_template: null,
+    secret: "user-supplied",
+  }
+
+  function createdTrigger(id: number, overrides: Record<string, unknown> = {}) {
+    return jsonResponse({
+      id,
+      user_id: 1,
+      agent_id: 42,
+      type: "webhook",
+      name: "created",
+      enabled: true,
+      config: {},
+      prompt_template: null,
+      webhook_token: null,
+      next_run_at: null,
+      last_run_at: null,
+      last_error: null,
+      created_at: null,
+      updated_at: null,
+      ...overrides,
+    })
+  }
+
+  it("keeps failed staged triggers (config intact) instead of dropping them", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(createdTrigger(11, { webhook_secret: "gen-secret" }))
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: "Gmail account not found" }, { status: 404 }),
+      )
+
+    const outcome = await createStagedTriggers(42, [webhookNoSecret, staged])
+
+    expect(outcome.failed).toHaveLength(1)
+    expect(outcome.failed[0].staged).toBe(staged)
+    expect(outcome.failed[0].error).toBe("Gmail account not found")
+    expect(outcome.generatedSecrets).toEqual([
+      { name: "Generated hook", secret: "gen-secret" },
+    ])
+  })
+
+  it("does not report user-supplied webhook secrets as generated", async () => {
+    apiRequestMock.mockResolvedValue(createdTrigger(12, { webhook_secret: "echoed-back" }))
+
+    const outcome = await createStagedTriggers(42, [webhookCustomSecret])
+
+    expect(outcome.failed).toHaveLength(0)
+    expect(outcome.generatedSecrets).toEqual([])
   })
 })

--- a/frontend/src/lib/agent-triggers-api.test.ts
+++ b/frontend/src/lib/agent-triggers-api.test.ts
@@ -11,8 +11,11 @@ vi.mock("@/lib/utils", () => ({
 }))
 
 import {
+  StagedTrigger,
   createAgentTrigger,
   listAgentTriggerRuns,
+  stagedToCreatePayload,
+  stagedToPseudoTrigger,
   updateAgentTrigger,
 } from "./agent-triggers-api"
 
@@ -118,5 +121,44 @@ describe("agent trigger API client", () => {
     )
     expect(runs).toHaveLength(1)
     expect(runs[0].task_id).toBe(99)
+  })
+})
+
+describe("staged triggers (agent creation flow)", () => {
+  const staged: StagedTrigger = {
+    clientId: -3,
+    type: "scheduled",
+    name: "Daily report",
+    enabled: true,
+    config: { interval_seconds: 3600 },
+    prompt_template: "Run {{payload}}",
+    secret: null,
+  }
+
+  it("maps a staged trigger to a pseudo AgentTrigger keyed by its negative clientId", () => {
+    const pseudo = stagedToPseudoTrigger(staged)
+
+    expect(pseudo.id).toBe(-3)
+    expect(pseudo.type).toBe("scheduled")
+    expect(pseudo.name).toBe("Daily report")
+    expect(pseudo.enabled).toBe(true)
+    expect(pseudo.config).toEqual({ interval_seconds: 3600 })
+    expect(pseudo.prompt_template).toBe("Run {{payload}}")
+    expect(pseudo.webhook_token).toBeNull()
+    expect(pseudo.callback_id).toBeNull()
+  })
+
+  it("builds a create payload without leaking the client-side id", () => {
+    const payload = stagedToCreatePayload(staged)
+
+    expect(payload).toEqual({
+      type: "scheduled",
+      name: "Daily report",
+      enabled: true,
+      config: { interval_seconds: 3600 },
+      prompt_template: "Run {{payload}}",
+      secret: null,
+    })
+    expect("clientId" in payload).toBe(false)
   })
 })

--- a/frontend/src/lib/agent-triggers-api.ts
+++ b/frontend/src/lib/agent-triggers-api.ts
@@ -101,6 +101,45 @@ export function stagedToCreatePayload(
   }
 }
 
+export interface FailedStagedTrigger {
+  staged: StagedTrigger
+  error: string
+}
+
+export interface StagedTriggerCreateOutcome {
+  failed: FailedStagedTrigger[]
+  // Auto-generated webhook secrets (returned only once by the create API);
+  // omitted for triggers where the user supplied their own secret.
+  generatedSecrets: { name: string; secret: string }[]
+}
+
+// Post staged triggers against a freshly created agent. Failures never throw:
+// each failed trigger is returned with its config intact so the caller can
+// offer retry instead of discarding the user's input.
+export async function createStagedTriggers(
+  agentId: number | string,
+  staged: StagedTrigger[],
+): Promise<StagedTriggerCreateOutcome> {
+  const results = await Promise.allSettled(
+    staged.map((item) => createAgentTrigger(agentId, stagedToCreatePayload(item))),
+  )
+  const outcome: StagedTriggerCreateOutcome = { failed: [], generatedSecrets: [] }
+  results.forEach((result, index) => {
+    const item = staged[index]
+    if (result.status === "rejected") {
+      const error =
+        result.reason instanceof Error ? result.reason.message : String(result.reason)
+      outcome.failed.push({ staged: item, error })
+      return
+    }
+    const secret = result.value.webhook_secret
+    if (secret && !item.secret) {
+      outcome.generatedSecrets.push({ name: item.name, secret })
+    }
+  })
+  return outcome
+}
+
 export interface AgentTriggerTestPayload {
   payload: Record<string, unknown>
   source_event_id?: string | null

--- a/frontend/src/lib/agent-triggers-api.ts
+++ b/frontend/src/lib/agent-triggers-api.ts
@@ -53,6 +53,54 @@ export interface AgentTriggerPayload {
   rotate_secret?: boolean
 }
 
+// A trigger configured while the agent itself does not exist yet (issue #928).
+// Staged triggers live only in builder state; on agent creation each one is
+// posted through createAgentTrigger. clientId is a stable NEGATIVE number so
+// it can double as a pseudo AgentTrigger.id without ever colliding with (or
+// being mistaken for) a real server id.
+export interface StagedTrigger {
+  clientId: number
+  type: AgentTriggerType
+  name: string
+  enabled: boolean
+  config: Record<string, unknown>
+  prompt_template: string | null
+  secret: string | null
+}
+
+export function stagedToPseudoTrigger(staged: StagedTrigger): AgentTrigger {
+  return {
+    id: staged.clientId,
+    user_id: 0,
+    agent_id: 0,
+    type: staged.type,
+    name: staged.name,
+    enabled: staged.enabled,
+    config: staged.config,
+    prompt_template: staged.prompt_template,
+    webhook_token: null,
+    callback_id: null,
+    next_run_at: null,
+    last_run_at: null,
+    last_error: null,
+    created_at: null,
+    updated_at: null,
+  }
+}
+
+export function stagedToCreatePayload(
+  staged: StagedTrigger,
+): AgentTriggerPayload & { type: AgentTriggerType } {
+  return {
+    type: staged.type,
+    name: staged.name,
+    enabled: staged.enabled,
+    config: staged.config,
+    prompt_template: staged.prompt_template,
+    secret: staged.secret,
+  }
+}
+
 export interface AgentTriggerTestPayload {
   payload: Record<string, unknown>
   source_event_id?: string | null


### PR DESCRIPTION
Closes #928

## What

Allow users to enable and configure Triggers while initially creating an Agent. Previously the Triggers entry point was disabled until the agent had been saved once, because every trigger API route requires an existing `agent_id`.

## How

Frontend-only staging approach — no backend changes:

- **`agent-triggers-api.ts`**: new `StagedTrigger` type (stable negative `clientId` doubles as a pseudo `AgentTrigger.id`) plus `stagedToPseudoTrigger` / `stagedToCreatePayload` helpers.
- **`agent-triggers-dialog.tsx`**: new optional `staged` prop enters staging mode when the agent does not exist yet. Enable/save/delete operations mutate the builder-owned staged list instead of calling the API. Sections that need a real resource (test runs, rotate secret, webhook URL) are hidden while staging, with a hint that the webhook URL and signing secret are generated after creation. Edit-mode behavior is unchanged.
- **`agent-builder.tsx`**: the Triggers button is no longer gated on `localAgentId`; summary cards and the flow view render staged triggers live. After `POST /api/agents` succeeds, staged triggers are posted through the existing `POST /api/agents/{id}/triggers` endpoint via `Promise.allSettled` — per-trigger failures surface as toasts without rolling back the agent. Auto-generated webhook secrets are revealed one-time inside the creation success dialog (closing it navigates and remounts the builder, so it is the only reliable surface).
- **i18n**: new `triggers.staging.*` / `triggers.messages.staged*` keys (en/zh); removed the never-rendered `triggers.builder.saveFirst` key.

## Testing

- `tsc --noEmit` clean; eslint issue count identical to `main` (no new findings).
- New unit tests for the staged-trigger helpers (`agent-triggers-api.test.ts`), full frontend suite otherwise unchanged (6 pre-existing failures on `main` unrelated to this change).
- Manual end-to-end run against a local backend: staged Schedule + Webhook during creation, verified two `POST /api/agents/{id}/triggers` (200) right after agent creation, one-time secret reveal in the success dialog, and unchanged live dialog behavior in edit mode (webhook endpoint, test trigger, rotate secret).
