### PR TITLE
fix(migrations): merge parallel 2026-07-20/21 alembic heads

### DIFF
--- a/src/xagent/migrations/versions/20260721_merge_migration_heads.py
+++ b/src/xagent/migrations/versions/20260721_merge_migration_heads.py
@@ -1,0 +1,32 @@
+"""merge parallel 2026-07-20/21 migration heads
+
+Three migrations merged in parallel PRs (#933, #939 and the docs/slides/
+hubspot seed) all branched off 20260715_add_public_mcp_app_audits, leaving
+alembic with three heads and making every ``alembic upgrade`` (and
+``init_db``) fail with "Multiple heads are present". This no-op merge
+revision joins them back into a single head.
+
+Revision ID: 20260721_merge_migration_heads
+Revises: 20260720_add_workforce_run_is_preview, 20260720_seed_docs_slides_hubspot, 20260721_drop_workforce_manager_instr
+Create Date: 2026-07-21
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "20260721_merge_migration_heads"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260720_add_workforce_run_is_preview",
+    "20260720_seed_docs_slides_hubspot",
+    "20260721_drop_workforce_manager_instr",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

`main` currently has **three alembic heads**: `20260720_add_workforce_run_is_preview` (#933), `20260720_seed_docs_slides_hubspot`, and `20260721_drop_workforce_manager_instr` (#939) all declare `down_revision = "20260715_add_public_mcp_app_audits"` — they were developed in parallel and merged without rebasing onto each other.

As a result, every `alembic upgrade` fails with:

```
alembic.util.exc.CommandError: Multiple heads are present; please specify a single target revision
```

This breaks fresh DB bootstrap (`init_db`) and, downstream, every test that lays out a database via the `_test_db` fixture — e.g. `tests/web/api/v1/test_management.py` currently errors at setup on `main`.

## Fix

Add a no-op merge revision `20260721_merge_migration_heads` whose `down_revision` is the tuple of the three heads, converging the graph back to a single head. No schema changes.

## Verification

- `alembic heads` now reports the single merged head.
- `pytest tests/web/api/v1/test_management.py` goes from setup errors to fully green.
