### PR TITLE
fix: harden agent execution reliability

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -791,6 +791,7 @@ class AutoPattern(AgentPattern):
         decision_tools = [self._decision_tool_schema()]
         retry_feedback: str | None = None
         attempt = 0
+        # This is a whole-loop budget, independent of the parse attempt budget.
         protocol_retries = 0
         while attempt < MAX_DECISION_PARSE_ATTEMPTS:
             messages = append_user_message_preserving_turns(

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from json_repair import loads as repair_json_loads
 
+from ....model.chat.exceptions import LLMToolProtocolError
 from ...context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
     RETRIEVED_MEMORIES_METADATA_KEY,
@@ -306,6 +307,19 @@ class _AutoChildRuntime:
         await self.parent.on_llm_end(
             context=context,
             response=response,
+            metadata=metadata,
+        )
+
+    async def on_llm_error(
+        self,
+        *,
+        context: Any,
+        error: Exception,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_llm_error(
+            context=context,
+            error=error,
             metadata=metadata,
         )
 
@@ -776,7 +790,9 @@ class AutoPattern(AgentPattern):
         )
         decision_tools = [self._decision_tool_schema()]
         retry_feedback: str | None = None
-        for attempt in range(MAX_DECISION_PARSE_ATTEMPTS):
+        attempt = 0
+        protocol_retries = 0
+        while attempt < MAX_DECISION_PARSE_ATTEMPTS:
             messages = append_user_message_preserving_turns(
                 base_messages,
                 content=decision_prompt,
@@ -792,8 +808,9 @@ class AutoPattern(AgentPattern):
                 "phase": "auto_decision",
                 **resolved_llm_metadata(call_llm),
             }
-            if attempt:
-                metadata["attempt"] = attempt + 1
+            total_retries = attempt + protocol_retries
+            if total_retries:
+                metadata["attempt"] = total_retries + 1
             await runtime.on_llm_start(
                 context=context,
                 messages=messages,
@@ -821,6 +838,41 @@ class AutoPattern(AgentPattern):
                     thinking={"type": "disabled", "enable": False},
                     on_chunk=answer_streamer.handle_chunk,
                 )
+            except LLMToolProtocolError as exc:
+                await answer_streamer.fail(
+                    f"invalid {exc.code} routing tool protocol, retrying"
+                )
+                await runtime.on_llm_error(
+                    context=context,
+                    error=exc,
+                    metadata={
+                        **metadata,
+                        "phase": exc.code,
+                        "protocol_code": exc.code,
+                    },
+                )
+                if protocol_retries >= 1:
+                    raise
+                protocol_retries += 1
+                retry_feedback = self._tool_protocol_retry_feedback(exc)
+                logger.warning(
+                    "AutoPattern routing received invalid %s tool protocol; "
+                    "retrying decision. execution_id=%s attempt=%s",
+                    exc.code,
+                    getattr(context, "execution_id", None),
+                    attempt + protocol_retries,
+                )
+                await runtime.checkpoint(
+                    "auto_decision_retry",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "attempt": attempt + protocol_retries,
+                        "error": str(exc),
+                        "protocol_code": exc.code,
+                    },
+                )
+                continue
             except Exception as exc:
                 await answer_streamer.fail(str(exc))
                 await runtime.on_llm_error(
@@ -833,7 +885,8 @@ class AutoPattern(AgentPattern):
             try:
                 decision = self._parse_decision(response, attempts=attempt + 1)
             except RequiredToolCallError:
-                if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
+                attempt += 1
+                if attempt >= MAX_DECISION_PARSE_ATTEMPTS:
                     raise
                 retry_feedback = self._required_tool_call_retry_feedback(
                     DECISION_TOOL_NAME
@@ -843,21 +896,22 @@ class AutoPattern(AgentPattern):
                     "retrying decision. execution_id=%s attempt=%s",
                     DECISION_TOOL_NAME,
                     getattr(context, "execution_id", None),
-                    attempt + 1,
+                    attempt,
                 )
                 await runtime.checkpoint(
                     "auto_decision_retry",
                     context=context,
                     pattern=self,
                     metadata={
-                        "attempt": attempt + 1,
+                        "attempt": attempt,
                         "failure_reason": REQUIRED_TOOL_CALL_FAILURE_REASON,
                         "required_tool_name": DECISION_TOOL_NAME,
                     },
                 )
                 continue
             except AutoDecisionArgumentsError as exc:
-                if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
+                attempt += 1
+                if attempt >= MAX_DECISION_PARSE_ATTEMPTS:
                     raise
                 retry_feedback = self._decision_retry_feedback(exc)
                 logger.warning(
@@ -871,7 +925,7 @@ class AutoPattern(AgentPattern):
                     context=context,
                     pattern=self,
                     metadata={
-                        "attempt": attempt + 1,
+                        "attempt": attempt,
                         "error": str(exc),
                     },
                 )
@@ -907,6 +961,26 @@ class AutoPattern(AgentPattern):
                 if argument_preview
                 else ""
             )
+        )
+
+    def _tool_protocol_retry_feedback(self, error: LLMToolProtocolError) -> str:
+        if error.code == "malformed_tool_arguments":
+            correction = (
+                "The provider rejected the previous routing tool call because "
+                "its arguments were malformed."
+            )
+        elif error.code == "unavailable_tool_call":
+            correction = (
+                "The provider rejected the previous response because it called "
+                "a tool that is unavailable during Auto routing."
+            )
+        else:
+            correction = "The provider rejected the previous routing tool call."
+        return (
+            f"{correction} Retry by calling exactly one currently available "
+            f"routing tool: {DECISION_TOOL_NAME}. Use the exact tool name and "
+            "one complete JSON object matching its schema. Do not answer in "
+            "natural language."
         )
 
     def _truncate_retry_preview(self, value: str, *, limit: int = 1200) -> str:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -225,6 +225,24 @@ class _DAGStepRuntime:
             },
         )
 
+    async def on_llm_error(
+        self,
+        *,
+        context: Any,
+        error: Exception,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_llm_error(
+            context=context,
+            error=error,
+            metadata={
+                "task_id": self.root_context.execution_id,
+                "step_id": self.step_id,
+                "dag_step_id": self.step_id,
+                **(metadata or {}),
+            },
+        )
+
     async def compact_context_if_needed(
         self,
         *,
@@ -1322,12 +1340,18 @@ class DAGPattern(AgentPattern):
             for message in getattr(context, "messages", [])
             if getattr(message, "role", None) in {"user", "assistant", "tool"}
         ]
+        authoritative_user_requests = [
+            {"role": message.role, "content": message.content}
+            for message in getattr(context, "messages", [])
+            if getattr(message, "role", None) == "user"
+        ]
         payload = {
             "output_language_policy": output_language_policy(
                 getattr(context, "metadata", {}).get(OUTPUT_LANGUAGE_METADATA_KEY)
                 if isinstance(getattr(context, "metadata", {}), dict)
                 else None
             ),
+            "authoritative_user_requests": authoritative_user_requests,
             "messages": latest_messages,
             "plan": self.plan.to_dict() if self.plan is not None else None,
             "step_results": self.step_results,
@@ -1339,7 +1363,14 @@ class DAGPattern(AgentPattern):
                 "role": "system",
                 "content": (
                     "Assess whether the completed DAG steps satisfy the user's "
-                    "overall request. Call the assessment tool exactly once. If "
+                    "overall request. The authoritative_user_requests field is "
+                    "the only source of required scope. The plan, step results, "
+                    "briefs, inferred formats, and candidate output are evidence "
+                    "of execution only; they cannot add deliverables, claims, "
+                    "formats, or acceptance criteria that the user did not ask "
+                    "for. Do not mark the goal incomplete solely because an "
+                    "intermediate step proposed extra work. Call the assessment "
+                    "tool exactly once. If "
                     "the goal is satisfied, choose status=completed and put the "
                     "final user-facing answer in answer. If anything material is "
                     "missing, choose status=incomplete, leave answer empty, and "

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -296,8 +296,12 @@ class LLMPlanGenerator(PlanGenerator):
                     "supporting context only and must not change the plan "
                     "language. "
                     f"{plan_language_rules()} "
-                    "Keep ids stable "
-                    "across replans when a completed step can be reused."
+                    "Keep ids stable across replans when a completed step can "
+                    "be reused. A replan response must be a complete, "
+                    "self-contained execution plan, not a delta: every "
+                    "dependency id must also appear in the returned steps. "
+                    "Include completed steps that new work depends on so their "
+                    "results can be reused."
                 ),
             },
             {"role": "user", "content": self._build_prompt(request)},
@@ -350,7 +354,19 @@ class LLMPlanGenerator(PlanGenerator):
                 )
                 continue
             self._apply_response_language(request.context, plan_arguments)
-            plan = coerce_execution_plan(plan_arguments)
+            try:
+                plan = coerce_execution_plan(plan_arguments)
+            except PlanValidationError as exc:
+                if attempt + 1 >= MAX_PLAN_TOOL_CALL_ATTEMPTS:
+                    raise
+                retry_feedback = self._invalid_plan_retry_feedback(exc)
+                logger.warning(
+                    "LLMPlanGenerator response contained an invalid DAG plan; "
+                    "retrying plan generation. execution_id=%s error=%s",
+                    request.execution_id,
+                    exc,
+                )
+                continue
             return self._filter_suggested_tools(
                 plan=plan,
                 available_tool_names=request.available_tool_names,
@@ -546,6 +562,16 @@ class LLMPlanGenerator(PlanGenerator):
                 if argument_preview
                 else ""
             )
+        )
+
+    def _invalid_plan_retry_feedback(self, error: PlanValidationError) -> str:
+        return (
+            f"The previous {self.PLAN_TOOL_NAME} call returned an invalid DAG "
+            f"plan: {error} Call {self.PLAN_TOOL_NAME} again exactly once with "
+            "a complete, self-contained plan. Every dependency id must be "
+            "present in the returned steps. On a replan, include any completed "
+            "steps that new work depends on and preserve their ids. Do not "
+            "return only the newly added steps."
         )
 
     def _extract_tool_arguments(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -41,6 +41,7 @@ from datetime import timezone
 from enum import Enum
 from typing import Any, cast
 
+from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ...context.enrichment import (
     enrich_context_with_memory,
@@ -451,6 +452,8 @@ class ReActPattern(AgentPattern):
                 metadata=llm_metadata,
             )
             answer_streamer: ReActFinalAnswerStreamer | None = None
+            protocol_retry_performed = False
+            response_already_traced = False
             try:
                 effective_tool_choice = (
                     "required"
@@ -484,31 +487,23 @@ class ReActPattern(AgentPattern):
                 if interrupted is not None:
                     return interrupted
                 raise
-            except Exception as exc:
+            except LLMToolProtocolError as exc:
+                unavailable_tool_call = exc.code == "unavailable_tool_call"
                 if answer_streamer is not None:
-                    await answer_streamer.fail(str(exc))
-                raise
-            self.repeated_tool_decision = None
-            self.last_response = response
-            normalized = self._normalize_llm_response(response)
-            requires_protocol_retry = self._response_requires_tool_protocol_retry(
-                normalized,
-                force_final_answer=force_final_answer_now,
-            )
-            end_metadata: dict[str, Any] = dict(llm_metadata)
-            if requires_protocol_retry:
-                end_metadata.update(
-                    success=False,
-                    phase="discarded_invalid_tool_protocol",
+                    await answer_streamer.fail(
+                        "unavailable tool call, restoring available tools"
+                        if unavailable_tool_call
+                        else f"invalid {exc.code} tool protocol, retrying"
+                    )
+                await runtime.on_llm_error(
+                    context=context,
+                    error=exc,
+                    metadata={
+                        **llm_metadata,
+                        "phase": exc.code,
+                        "protocol_code": exc.code,
+                    },
                 )
-            await runtime.on_llm_end(
-                context=context,
-                response=response,
-                metadata=end_metadata,
-            )
-            if requires_protocol_retry:
-                if answer_streamer is not None:
-                    await answer_streamer.fail("invalid tool protocol, retrying")
                 try:
                     (
                         response,
@@ -518,8 +513,11 @@ class ReActPattern(AgentPattern):
                         llm=call_llm,
                         runtime=runtime,
                         iteration=iteration,
-                        tool_schemas=tool_schemas,
-                        force_final_answer=force_final_answer_now,
+                        tool_schemas=base_tool_schemas,
+                        force_final_answer=(
+                            force_final_answer_now and not unavailable_tool_call
+                        ),
+                        recovery_reason=exc.code,
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -530,11 +528,99 @@ class ReActPattern(AgentPattern):
                     if interrupted is not None:
                         return interrupted
                     raise
+                if unavailable_tool_call:
+                    self.force_final_answer_next = False
+                    force_final_answer_now = False
+                protocol_retry_performed = True
+                response_already_traced = True
+            except Exception as exc:
+                if answer_streamer is not None:
+                    await answer_streamer.fail(str(exc))
+                raise
+            self.repeated_tool_decision = None
+            self.last_response = response
+            normalized = self._normalize_llm_response(response)
+            requires_protocol_retry = self._response_requires_tool_protocol_retry(
+                normalized,
+                force_final_answer=force_final_answer_now,
+                reject_mixed_control_calls=protocol_retry_performed,
+            )
+            end_metadata: dict[str, Any] = dict(llm_metadata)
+            if requires_protocol_retry:
+                end_metadata.update(
+                    success=False,
+                    phase="discarded_invalid_tool_protocol",
+                )
+            if not response_already_traced:
+                await runtime.on_llm_end(
+                    context=context,
+                    response=response,
+                    metadata=end_metadata,
+                )
+            if requires_protocol_retry:
+                if protocol_retry_performed:
+                    if answer_streamer is not None:
+                        await answer_streamer.fail(
+                            "invalid tool protocol after recovery"
+                        )
+                    await runtime.checkpoint(
+                        "invalid_tool_protocol",
+                        context=context,
+                        pattern=self,
+                        metadata={"iteration": iteration},
+                    )
+                    return PatternResult(
+                        success=False,
+                        error=(
+                            "The model returned an invalid tool protocol response "
+                            "after one repair attempt."
+                        ),
+                        metadata={
+                            "iterations": iteration + 1,
+                            "status": "invalid_tool_protocol",
+                        },
+                    ).to_dict()
+                if answer_streamer is not None:
+                    await answer_streamer.fail("invalid tool protocol, retrying")
+                recover_full_tool_set = self._requires_full_tool_set_recovery(
+                    normalized,
+                    force_final_answer=force_final_answer_now,
+                )
+                try:
+                    (
+                        response,
+                        answer_streamer,
+                    ) = await self._retry_tool_protocol_response(
+                        context=context,
+                        llm=call_llm,
+                        runtime=runtime,
+                        iteration=iteration,
+                        tool_schemas=base_tool_schemas,
+                        force_final_answer=(
+                            force_final_answer_now and not recover_full_tool_set
+                        ),
+                        recovery_reason=(
+                            "unavailable_tool_call" if recover_full_tool_set else None
+                        ),
+                    )
+                except LLMCallInterrupted:
+                    interrupted = await self._interrupt_if_requested(
+                        runtime=runtime,
+                        context=context,
+                        label="during_llm",
+                    )
+                    if interrupted is not None:
+                        return interrupted
+                    raise
+                if recover_full_tool_set:
+                    self.force_final_answer_next = False
+                    force_final_answer_now = False
                 self.last_response = response
                 normalized = self._normalize_llm_response(response)
                 if self._response_requires_tool_protocol_retry(
                     normalized,
                     force_final_answer=force_final_answer_now,
+                    reject_mixed_control_calls=recover_full_tool_set,
                 ):
                     if answer_streamer is not None:
                         await answer_streamer.fail("invalid tool protocol after retry")
@@ -723,6 +809,7 @@ class ReActPattern(AgentPattern):
         iteration: int,
         tool_schemas: list[dict[str, Any]],
         force_final_answer: bool,
+        recovery_reason: str | None = None,
     ) -> tuple[Any, ReActFinalAnswerStreamer]:
         tools = (
             [self._final_answer_tool_schema()] if force_final_answer else tool_schemas
@@ -733,24 +820,48 @@ class ReActPattern(AgentPattern):
             force_final_answer=force_final_answer,
             tool_names=self._schema_tool_names(tools),
         )
-        retry_instruction = (
-            "The previous response used an invalid tool protocol. Retry the same "
-            "turn using native structured tool calls only. Never place one tool "
-            "invocation or its arguments inside another tool's arguments. If work "
-            "remains, call the appropriate available work tool directly; call "
-            "final_answer only when the task is actually complete."
-        )
+        if recovery_reason == "unavailable_tool_call":
+            retry_instruction = (
+                "The previous response called a tool that was unavailable in the "
+                "narrowed tool schema. Re-decide this turn using the complete "
+                "current tool set listed above. Call only a tool present in that "
+                "set. If the requested work or artifact has not been successfully "
+                "produced, call the appropriate work tool; call final_answer only "
+                "when the task is actually complete and its required results exist."
+            )
+            retry_phase = "unavailable_tool_call_recovery"
+        elif recovery_reason == "malformed_tool_arguments":
+            retry_instruction = (
+                "The previous response returned malformed JSON arguments for a "
+                "tool call. Retry this turn by calling exactly one available tool "
+                "with one complete JSON object that matches its schema. Do not "
+                "truncate, concatenate, manually serialize, or wrap the arguments "
+                "in prose. If final_answer is the only available tool, put the "
+                "complete user-facing response in its answer field."
+            )
+            retry_phase = "malformed_tool_arguments_recovery"
+        else:
+            retry_instruction = (
+                "The previous response used an invalid tool protocol. Retry the same "
+                "turn using native structured tool calls only. Never place one tool "
+                "invocation or its arguments inside another tool's arguments. If "
+                "work remains, call the appropriate available work tool directly; "
+                "call final_answer only when the task is actually complete."
+            )
+            retry_phase = "tool_protocol_retry"
         messages[0] = {
             **messages[0],
             "content": f"{messages[0].get('content', '')}\n\n{retry_instruction}",
         }
         metadata = {
             "iteration": iteration,
-            "phase": "tool_protocol_retry",
+            "phase": retry_phase,
             **resolved_llm_metadata(llm),
         }
+        if recovery_reason:
+            metadata["recovery_reason"] = recovery_reason
         await runtime.checkpoint(
-            "tool_protocol_retry",
+            retry_phase,
             context=context,
             pattern=self,
             metadata=metadata,
@@ -785,6 +896,7 @@ class ReActPattern(AgentPattern):
         retry_is_invalid = self._response_requires_tool_protocol_retry(
             normalized,
             force_final_answer=force_final_answer,
+            reject_mixed_control_calls=(recovery_reason == "unavailable_tool_call"),
         )
         end_metadata = dict(metadata)
         if retry_is_invalid:
@@ -804,15 +916,46 @@ class ReActPattern(AgentPattern):
         normalized: dict[str, Any],
         *,
         force_final_answer: bool,
+        reject_mixed_control_calls: bool = False,
     ) -> bool:
         if get_tool_protocol_error(normalized.get("raw")) is not None:
             return True
-        for tool_call in normalized.get("tool_calls") or []:
+        tool_calls = normalized.get("tool_calls") or []
+        if (
+            reject_mixed_control_calls
+            and len(tool_calls) > 1
+            and any(
+                isinstance(tool_call, dict)
+                and tool_call.get("name") in self._control_tool_names()
+                for tool_call in tool_calls
+            )
+        ):
+            return True
+        for tool_call in tool_calls:
             if not isinstance(tool_call, dict):
                 continue
             if force_final_answer and tool_call.get("name") != "final_answer":
                 return True
         return False
+
+    def _requires_full_tool_set_recovery(
+        self,
+        normalized: dict[str, Any],
+        *,
+        force_final_answer: bool,
+    ) -> bool:
+        protocol_error = get_tool_protocol_error(normalized.get("raw"))
+        if (
+            isinstance(protocol_error, dict)
+            and protocol_error.get("code") == "unavailable_tool_call"
+        ):
+            return True
+        if not force_final_answer:
+            return False
+        return any(
+            isinstance(tool_call, dict) and tool_call.get("name") != "final_answer"
+            for tool_call in normalized.get("tool_calls") or []
+        )
 
     def _final_answer_tool_schema(self) -> dict[str, Any]:
         for schema in self._builtin_tool_schemas():

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -559,27 +559,13 @@ class ReActPattern(AgentPattern):
                 )
             if requires_protocol_retry:
                 if protocol_retry_performed:
-                    if answer_streamer is not None:
-                        await answer_streamer.fail(
-                            "invalid tool protocol after recovery"
-                        )
-                    await runtime.checkpoint(
-                        "invalid_tool_protocol",
+                    return await self._invalid_tool_protocol_result(
+                        runtime=runtime,
                         context=context,
-                        pattern=self,
-                        metadata={"iteration": iteration},
+                        iteration=iteration,
+                        answer_streamer=answer_streamer,
+                        stream_failure_message=("invalid tool protocol after recovery"),
                     )
-                    return PatternResult(
-                        success=False,
-                        error=(
-                            "The model returned an invalid tool protocol response "
-                            "after one repair attempt."
-                        ),
-                        metadata={
-                            "iterations": iteration + 1,
-                            "status": "invalid_tool_protocol",
-                        },
-                    ).to_dict()
                 if answer_streamer is not None:
                     await answer_streamer.fail("invalid tool protocol, retrying")
                 recover_full_tool_set = self._requires_full_tool_set_recovery(
@@ -622,25 +608,13 @@ class ReActPattern(AgentPattern):
                     force_final_answer=force_final_answer_now,
                     reject_mixed_control_calls=recover_full_tool_set,
                 ):
-                    if answer_streamer is not None:
-                        await answer_streamer.fail("invalid tool protocol after retry")
-                    await runtime.checkpoint(
-                        "invalid_tool_protocol",
+                    return await self._invalid_tool_protocol_result(
+                        runtime=runtime,
                         context=context,
-                        pattern=self,
-                        metadata={"iteration": iteration},
+                        iteration=iteration,
+                        answer_streamer=answer_streamer,
+                        stream_failure_message="invalid tool protocol after retry",
                     )
-                    return PatternResult(
-                        success=False,
-                        error=(
-                            "The model returned an invalid tool protocol response "
-                            "after one repair attempt."
-                        ),
-                        metadata={
-                            "iterations": iteration + 1,
-                            "status": "invalid_tool_protocol",
-                        },
-                    ).to_dict()
             if force_final_answer_now and not normalized.get("tool_calls"):
                 normalized["done"] = True
 
@@ -696,6 +670,35 @@ class ReActPattern(AgentPattern):
             success=False,
             error="ReActPattern reached max iterations without a final answer.",
             metadata={"iterations": self.max_iterations, "status": self.status},
+        ).to_dict()
+
+    async def _invalid_tool_protocol_result(
+        self,
+        *,
+        runtime: PatternRuntime,
+        context: Any,
+        iteration: int,
+        answer_streamer: ReActFinalAnswerStreamer | None,
+        stream_failure_message: str,
+    ) -> dict[str, Any]:
+        if answer_streamer is not None:
+            await answer_streamer.fail(stream_failure_message)
+        await runtime.checkpoint(
+            "invalid_tool_protocol",
+            context=context,
+            pattern=self,
+            metadata={"iteration": iteration},
+        )
+        return PatternResult(
+            success=False,
+            error=(
+                "The model returned an invalid tool protocol response "
+                "after one repair attempt."
+            ),
+            metadata={
+                "iterations": iteration + 1,
+                "status": "invalid_tool_protocol",
+            },
         ).to_dict()
 
     async def _finish_streamed_answer_if_final(

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -16,6 +16,7 @@ from ..agent.trace import (
     normalize_llm_trace_payload,
 )
 from ..model.chat.basic.base import BaseLLM
+from ..model.chat.exceptions import LLMToolProtocolError
 from ..model.chat.token_context import extract_cached_input_tokens
 from ..model.chat.tool_protocol import TOOL_PROTOCOL_ERROR_KEY
 from ..model.chat.types import ChunkType
@@ -1025,6 +1026,14 @@ class PatternRuntime:
         metadata: dict[str, Any] | None = None,
     ) -> None:
         event_metadata = metadata or {}
+        protocol_metadata: dict[str, Any] = {}
+        if isinstance(error, LLMToolProtocolError):
+            protocol_metadata = {
+                "protocol_provider": error.provider,
+                "protocol_code": error.code,
+            }
+            if error.details:
+                protocol_metadata["protocol_details"] = error.details
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.LLM),
             task_id=str(event_metadata.get("task_id") or self._task_id(context)),
@@ -1034,6 +1043,7 @@ class PatternRuntime:
                 "error": str(error),
                 "error_message": str(error),
                 "success": False,
+                **protocol_metadata,
                 **event_metadata,
             },
         )

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -9,10 +9,20 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
+from ..utils.security import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 
 DISPLAY_MESSAGE_KEY = "display_message"
 DISPLAY_USER_MESSAGE_KEY = "display_user_message"
+TRACE_HANDLER_ERROR_SUMMARY_LIMIT = 1024
+
+
+def _trace_handler_error_summary(error: Exception) -> str:
+    message = redact_sensitive_text(str(error))
+    if len(message) > TRACE_HANDLER_ERROR_SUMMARY_LIMIT:
+        message = f"{message[:TRACE_HANDLER_ERROR_SUMMARY_LIMIT]}…"
+    return f"{type(error).__name__}: {message}"
 
 
 def _display_message_from_metadata(metadata: Any) -> str | None:
@@ -985,10 +995,12 @@ class Tracer:
 
         if require_persisted:
             if handler_errors:
+                first_error = handler_errors[0]
                 raise RuntimeError(
                     f"{len(handler_errors)} trace handler(s) failed while "
-                    "persisting required trace event."
-                ) from handler_errors[0]
+                    "persisting required trace event. First failure: "
+                    f"{_trace_handler_error_summary(first_error)}"
+                ) from first_error
             if not self.handlers:
                 raise RuntimeError(
                     "No trace handlers are configured for required trace persistence."

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -9,7 +9,12 @@ FILE_REF_OUTPUT_INSTRUCTIONS = """## FILE REFERENCE OUTPUTS
 When mentioning a generated or uploaded file that has a file_id, render it as a Markdown file reference:
 - Files: [filename](file:file_id)
 - Images intended for inline display: ![filename](file:file_id)
-Do not mention only the filename when a file_id or markdown_link is available. Prefer an existing markdown_link value when one is present."""
+Do not mention only the filename when a file_id or markdown_link is available. Prefer an existing markdown_link value when one is present.
+
+File delivery integrity:
+- Never invent, guess, or construct a file_id or `file:` link. Use only a trusted FileRef supplied for an existing input/attachment, or the exact FileRef or markdown_link returned by a successful tool result. A link mentioned only in prior assistant prose is not provenance.
+- When the user requests a new file or file-based artifact, it is not delivered until a successful tool result returns its registered FileRef or markdown_link.
+- Do not call final_answer claiming that a file was created or delivered unless that result exists."""
 
 FILE_REF_MODEL_INSTRUCTIONS = f"""## FILE REFERENCES
 Files are referenced by FileRef objects. Treat file_id as the canonical file handle.

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -272,18 +272,24 @@ def _tool_call_violation(
                     name,
                     details=argument_details,
                 )
-            argument_details["repair_status"] = "repaired"
-            if isinstance(arguments, dict):
-                applied = _set_tool_call_arguments(
-                    tool_call,
-                    json.dumps(arguments, ensure_ascii=False, separators=(",", ":")),
+            if not isinstance(arguments, dict):
+                argument_details["repair_status"] = "failed_non_dict"
+                return _malformed_arguments_violation(
+                    name,
+                    message=f"DeepSeek returned non-object arguments for {name!r}.",
+                    details=argument_details,
                 )
-                if not applied:
-                    argument_details["repair_status"] = "repair_application_failed"
-                    return _malformed_arguments_violation(
-                        name,
-                        details=argument_details,
-                    )
+            argument_details["repair_status"] = "repaired"
+            applied = _set_tool_call_arguments(
+                tool_call,
+                json.dumps(arguments, ensure_ascii=False, separators=(",", ":")),
+            )
+            if not applied:
+                argument_details["repair_status"] = "repair_application_failed"
+                return _malformed_arguments_violation(
+                    name,
+                    details=argument_details,
+                )
     if not isinstance(arguments, dict):
         details = argument_details or _argument_diagnostics(arguments)
         details.setdefault("repair_status", "not_applicable")
@@ -362,27 +368,27 @@ def _is_structurally_complete_json_object(arguments: str) -> bool:
 
     pairs = {"}": "{", "]": "["}
     stack: list[str] = []
-    in_string = False
+    string_quote: str | None = None
     escaped = False
     for char in stripped:
-        if in_string:
+        if string_quote is not None:
             if escaped:
                 escaped = False
             elif char == "\\":
                 escaped = True
-            elif char == '"':
-                in_string = False
+            elif char == string_quote:
+                string_quote = None
             continue
 
-        if char == '"':
-            in_string = True
+        if char in {'"', "'"}:
+            string_quote = char
         elif char in "{[":
             stack.append(char)
         elif char in pairs:
             if not stack or stack.pop() != pairs[char]:
                 return False
 
-    return not in_string and not escaped and not stack
+    return string_quote is None and not escaped and not stack
 
 
 def _set_tool_call_arguments(tool_call: Any, arguments: str) -> bool:

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -31,6 +31,8 @@ def normalize_deepseek_response(
     *,
     tools: list[dict[str, Any]] | None,
 ) -> Any:
+    """Validate a response, repairing malformed tool arguments in place."""
+
     if not tools:
         return response
     violation = _response_violation(response, tools=tools)

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
 
+from json_repair import loads as repair_json_loads
+
 from ..tool_protocol import (
     ToolProtocolViolation,
     tool_protocol_error_response,
@@ -20,6 +22,8 @@ _SERIALIZED_TOOL_CALL_RE = re.compile(
 _PARTIAL_MARKER_TARGET = "dsmltool_calls"
 _PARTIAL_MARKER_SCAN_LIMIT = 64
 _MARKER_SEPARATOR_RE = re.compile(r"[\s|｜]")
+_ARGUMENTS_PREVIEW_LIMIT = 4096
+_ERROR_PREVIEW_LIMIT = 512
 
 
 def normalize_deepseek_response(
@@ -78,6 +82,11 @@ async def adapt_deepseek_stream(
             buffered_tool_chunk = chunk
             if violation is None:
                 violation = _streaming_tool_call_violation(chunk)
+            if violation is None:
+                violation = _complete_streaming_tool_call_violation(
+                    chunk,
+                    tools=tools,
+                )
             if violation is None:
                 safe_chunk, withheld_tool_tail = _safe_streaming_tool_chunk(chunk)
                 yield safe_chunk
@@ -176,6 +185,22 @@ def _streaming_tool_call_violation(
     return None
 
 
+def _complete_streaming_tool_call_violation(
+    chunk: StreamChunk,
+    *,
+    tools: list[dict[str, Any]] | None,
+) -> ToolProtocolViolation | None:
+    """Validate complete accumulated calls without rejecting partial chunks."""
+    for tool_call in chunk.tool_calls:
+        arguments = _function_payload(tool_call).get("arguments", {})
+        if not _arguments_are_ready_for_validation(arguments):
+            continue
+        violation = _tool_call_violation(tool_call, tools=tools)
+        if violation is not None:
+            return violation
+    return None
+
+
 def _safe_streaming_tool_chunk(
     chunk: StreamChunk,
 ) -> tuple[StreamChunk, bool]:
@@ -215,20 +240,57 @@ def _tool_call_violation(
         )
 
     arguments = function.get("arguments", {})
+    argument_details: dict[str, Any] | None = None
     if isinstance(arguments, str):
+        original_arguments = arguments
         try:
             arguments = json.loads(arguments)
-        except json.JSONDecodeError:
-            return ToolProtocolViolation(
-                provider=_PROVIDER,
-                code="malformed_tool_arguments",
-                message=f"DeepSeek returned malformed arguments for {name!r}.",
+        except json.JSONDecodeError as original_error:
+            argument_details = _argument_diagnostics(
+                original_arguments,
+                json_error=original_error,
             )
+            if not _is_structurally_complete_json_object(original_arguments):
+                argument_details["repair_status"] = "skipped_incomplete"
+                return _malformed_arguments_violation(
+                    name,
+                    details=argument_details,
+                )
+            try:
+                arguments = repair_json_loads(
+                    original_arguments,
+                    logging=False,
+                )
+            except Exception as repair_error:  # noqa: BLE001
+                argument_details.update(
+                    {
+                        "repair_status": "failed",
+                        "repair_error": _bounded_text(repair_error),
+                    }
+                )
+                return _malformed_arguments_violation(
+                    name,
+                    details=argument_details,
+                )
+            argument_details["repair_status"] = "repaired"
+            if isinstance(arguments, dict):
+                applied = _set_tool_call_arguments(
+                    tool_call,
+                    json.dumps(arguments, ensure_ascii=False, separators=(",", ":")),
+                )
+                if not applied:
+                    argument_details["repair_status"] = "repair_application_failed"
+                    return _malformed_arguments_violation(
+                        name,
+                        details=argument_details,
+                    )
     if not isinstance(arguments, dict):
-        return ToolProtocolViolation(
-            provider=_PROVIDER,
-            code="malformed_tool_arguments",
+        details = argument_details or _argument_diagnostics(arguments)
+        details.setdefault("repair_status", "not_applicable")
+        return _malformed_arguments_violation(
+            name,
             message=f"DeepSeek returned non-object arguments for {name!r}.",
+            details=details,
         )
 
     if _contains_serialized_tool_call(arguments):
@@ -236,6 +298,7 @@ def _tool_call_violation(
             provider=_PROVIDER,
             code="nested_serialized_tool_call",
             message=f"DeepSeek embedded serialized tool-call markup inside {name!r}.",
+            details=argument_details,
         )
 
     schemas = _tool_schema_by_name(tools)
@@ -247,6 +310,7 @@ def _tool_call_violation(
             provider=_PROVIDER,
             code="unavailable_tool_call",
             message=f"DeepSeek returned unavailable tool call {name!r}.",
+            details=argument_details,
         )
 
     parameters = schema.get("parameters")
@@ -262,8 +326,104 @@ def _tool_call_violation(
                     f"DeepSeek returned unexpected arguments for {name!r}: "
                     f"{', '.join(sorted(unexpected))}."
                 ),
+                details=argument_details,
             )
     return None
+
+
+def _malformed_arguments_violation(
+    name: str,
+    *,
+    message: str | None = None,
+    details: dict[str, Any],
+) -> ToolProtocolViolation:
+    return ToolProtocolViolation(
+        provider=_PROVIDER,
+        code="malformed_tool_arguments",
+        message=message or f"DeepSeek returned malformed arguments for {name!r}.",
+        details=details,
+    )
+
+
+def _arguments_are_ready_for_validation(arguments: Any) -> bool:
+    if not isinstance(arguments, str):
+        return True
+    try:
+        json.loads(arguments)
+    except json.JSONDecodeError:
+        return _is_structurally_complete_json_object(arguments)
+    return True
+
+
+def _is_structurally_complete_json_object(arguments: str) -> bool:
+    stripped = arguments.strip()
+    if not stripped.startswith("{") or not stripped.endswith("}"):
+        return False
+
+    pairs = {"}": "{", "]": "["}
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    for char in stripped:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char in "{[":
+            stack.append(char)
+        elif char in pairs:
+            if not stack or stack.pop() != pairs[char]:
+                return False
+
+    return not in_string and not escaped and not stack
+
+
+def _set_tool_call_arguments(tool_call: Any, arguments: str) -> bool:
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function")
+        if isinstance(function, dict):
+            function["arguments"] = arguments
+            return True
+        if "args" in tool_call:
+            tool_call["args"] = arguments
+            return True
+        tool_call["arguments"] = arguments
+        return True
+
+    function = getattr(tool_call, "function", None)
+    try:
+        setattr(function, "arguments", arguments)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _argument_diagnostics(
+    arguments: Any,
+    *,
+    json_error: json.JSONDecodeError | None = None,
+) -> dict[str, Any]:
+    original = arguments if isinstance(arguments, str) else repr(arguments)
+    preview = original[:_ARGUMENTS_PREVIEW_LIMIT]
+    details: dict[str, Any] = {
+        "original_arguments_preview": preview,
+        "original_arguments_length": len(original),
+        "original_arguments_truncated": len(original) > len(preview),
+    }
+    if json_error is not None:
+        details["json_error"] = _bounded_text(json_error)
+    return details
+
+
+def _bounded_text(value: Any) -> str:
+    return str(value)[:_ERROR_PREVIEW_LIMIT]
 
 
 def _contains_serialized_tool_call(value: Any) -> bool:

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from .....config import get_openrouter_official_providers_only
-from ..exceptions import LLMRetryableError
+from ..exceptions import LLMRetryableError, LLMToolProtocolError
 from ..timeout_config import TimeoutConfig
 from ..tool_protocol import TOOL_PROTOCOL_ERROR_KEY, get_tool_protocol_error
 from ..types import StreamChunk
@@ -103,8 +103,20 @@ def _deepseek_tool_protocol_retry_error(response: Any) -> LLMRetryableError | No
     if error is None:
         return None
     code = str(error.get("code") or "invalid_tool_protocol")
+    # Replaying the same narrowed schema cannot make the requested tool
+    # available. Surface this response to the agent pattern so it can restore
+    # the appropriate tool set and re-decide with explicit feedback.
+    if code == "unavailable_tool_call":
+        return None
     message = str(error.get("message") or "DeepSeek returned an invalid tool call.")
-    return LLMRetryableError(f"DeepSeek tool protocol error ({code}): {message}")
+    return LLMToolProtocolError(
+        provider="deepseek",
+        code=code,
+        message=message,
+        details=error.get("details")
+        if isinstance(error.get("details"), dict)
+        else None,
+    )
 
 
 class OpenRouterLLM(OpenAILLM):

--- a/src/xagent/core/model/chat/error.py
+++ b/src/xagent/core/model/chat/error.py
@@ -1,7 +1,7 @@
 import httpx
 import openai
 
-from .exceptions import LLMRetryableError
+from .exceptions import LLMRetryableError, LLMToolProtocolError
 
 try:
     from zai.core._errors import APIStatusError as ZaiAPIStatusError  # type: ignore
@@ -19,6 +19,15 @@ def retry_on(e: Exception) -> bool:
     )
 
     def _is_retryable(exc: BaseException) -> bool:
+        # These failures need a changed agent-level decision or repair prompt.
+        # Blindly replaying the identical provider request only burns the retry
+        # budget and hides the structured error from the execution pattern.
+        if isinstance(exc, LLMToolProtocolError):
+            return exc.code not in {
+                "malformed_tool_arguments",
+                "unavailable_tool_call",
+            }
+
         # Handle LLM-specific retryable errors
         # These are explicitly marked as retryable by the LLM implementation
         if isinstance(exc, LLMRetryableError):

--- a/src/xagent/core/model/chat/exceptions.py
+++ b/src/xagent/core/model/chat/exceptions.py
@@ -1,5 +1,7 @@
 """LLM-specific exceptions for retry logic."""
 
+from typing import Any
+
 
 class LLMRetryableError(RuntimeError):
     """Base exception for LLM errors that should trigger retry.
@@ -16,6 +18,34 @@ class LLMRetryableError(RuntimeError):
     """
 
     pass
+
+
+class LLMToolProtocolError(LLMRetryableError):
+    """Structured provider tool-protocol failure.
+
+    Most protocol failures can benefit from replaying the same request because
+    the model may emit a valid structured call on the next sample. Failures that
+    require changed agent context, including ``unavailable_tool_call`` and
+    ``malformed_tool_arguments``, are excluded by the retry filter so the agent
+    layer can retry with an explicit correction instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        code: str,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.provider = str(provider or "unknown")
+        self.code = str(code or "invalid_tool_protocol")
+        self.protocol_message = str(message or "Invalid tool protocol response.")
+        self.details = dict(details or {})
+        super().__init__(
+            f"{self.provider} tool protocol error ({self.code}): "
+            f"{self.protocol_message}"
+        )
 
 
 class LLMEmptyContentError(LLMRetryableError):

--- a/src/xagent/core/model/chat/tool_protocol.py
+++ b/src/xagent/core/model/chat/tool_protocol.py
@@ -11,9 +11,10 @@ class ToolProtocolViolation:
     provider: str
     code: str
     message: str
+    details: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {key: value for key, value in asdict(self).items() if value is not None}
 
 
 def tool_protocol_error_response(

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -264,6 +264,21 @@ Images are automatically saved to workspace.
                 "No image models with edit capabilities available"
             )
 
+    def _resolve_model_label(
+        self, image_model: Optional[BaseImageModel], model_id: Optional[str]
+    ) -> str:
+        """Best-effort identifier of the model that actually served the request."""
+        if model_id and model_id in self._image_models:
+            return model_id
+        if image_model is not None:
+            for known_id, model in self._image_models.items():
+                if model is image_model:
+                    return known_id
+            model_name = getattr(image_model, "model_name", None)
+            if model_name:
+                return str(model_name)
+        return "default"
+
     def _get_model(self, model_id: Optional[str] = None) -> Optional[BaseImageModel]:
         """Get image model with generate capability by ID or default model."""
         if model_id and model_id in self._image_models:
@@ -549,9 +564,7 @@ Images are automatically saved to workspace.
             result = await image_model.generate_image(**generate_params)
 
             # Determine the actual model used
-            actual_model_id = (
-                model_id if model_id and model_id in self._image_models else "default"
-            )
+            actual_model_id = self._resolve_model_label(image_model, model_id)
 
             image_url = result.get("image_url")
             image_path = None
@@ -600,8 +613,8 @@ Images are automatically saved to workspace.
         except Exception as e:
             logger.error(f"Image generation failed: {e}")
             # Determine the actual model used for error reporting
-            actual_model_id = (
-                model_id if model_id and model_id in self._image_models else "default"
+            actual_model_id = self._resolve_model_label(
+                self._get_model(model_id), model_id
             )
             return {
                 "success": False,
@@ -687,7 +700,7 @@ Images are automatically saved to workspace.
             result = await image_model.edit_image(**edit_params)
 
             # Determine the actual model used
-            actual_model_id = model_id if model_id else "default_edit_model"
+            actual_model_id = self._resolve_model_label(image_model, model_id)
 
             edited_image_url = result.get("image_url")
             image_path = None
@@ -739,7 +752,9 @@ Images are automatically saved to workspace.
         except Exception as e:
             logger.error(f"Image editing failed: {e}")
             # Determine the actual model used for error reporting
-            actual_model_id = model_id if model_id else "default_edit_model"
+            actual_model_id = self._resolve_model_label(
+                self._get_edit_model(model_id), model_id
+            )
             return {
                 "success": False,
                 "error": str(e),

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -14,6 +14,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
 from ...config import get_checkpoint_encoding_v2_enabled
@@ -1214,6 +1216,44 @@ def _remember_blob_candidate(
     candidates[blob_hash] = BlobCandidate(data=data, payload_bytes=payload_bytes)
 
 
+def _insert_blob_rows_on_conflict_do_nothing(
+    db: Session,
+    *,
+    model: Any,
+    values: list[dict[str, Any]],
+    index_elements: list[str],
+) -> bool:
+    """Atomically insert deduplicated blobs on supported databases.
+
+    Query-then-insert is unsafe when parallel DAG steps checkpoint the same
+    context: every transaction can observe a missing hash and then race on the
+    unique constraint. SQLite and PostgreSQL both support conflict-safe inserts;
+    executing them immediately also makes SQLite writers wait in the configured
+    busy timeout instead of accumulating duplicate pending ORM rows.
+
+    Returns ``False`` for an unknown dialect so callers can retain the existing
+    compatibility fallback.
+    """
+    if not values:
+        return True
+
+    bind = db.get_bind()
+    dialect = bind.dialect.name if bind is not None else ""
+    statement: Any
+    if dialect == "sqlite":
+        statement = sqlite_insert(model)
+    elif dialect == "postgresql":
+        statement = postgresql_insert(model)
+    else:
+        return False
+
+    db.execute(
+        statement.on_conflict_do_nothing(index_elements=index_elements),
+        values,
+    )
+    return True
+
+
 def _pending_message_hashes(
     db: Session,
     *,
@@ -1257,6 +1297,31 @@ def _upsert_message_blobs(
         blobs_by_hash=blobs_by_hash,
     )
     hashes_to_query = sorted(set(blobs_by_hash) - pending_hashes)
+    candidates_to_insert = {
+        message_hash: blobs_by_hash[message_hash] for message_hash in hashes_to_query
+    }
+    if _insert_blob_rows_on_conflict_do_nothing(
+        db,
+        model=TraceMessageBlob,
+        values=[
+            {
+                "task_id": task_id,
+                "execution_id": execution_id,
+                "message_hash": message_hash,
+                "message_data": copy.deepcopy(candidate.data),
+                "message_bytes": candidate.payload_bytes,
+            }
+            for message_hash, candidate in candidates_to_insert.items()
+        ],
+        index_elements=["task_id", "message_hash"],
+    ):
+        _validate_message_blobs(
+            db,
+            task_id=task_id,
+            blobs_by_hash=candidates_to_insert,
+        )
+        return
+
     existing_hashes: set[str] = set()
     chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
     for hashes_chunk in chunks(hashes_to_query, chunk_size):
@@ -1289,6 +1354,44 @@ def _upsert_message_blobs(
                 message_data=copy.deepcopy(candidate.data),
                 message_bytes=candidate.payload_bytes,
             )
+        )
+
+
+def _validate_message_blobs(
+    db: Session,
+    *,
+    task_id: int,
+    blobs_by_hash: dict[str, BlobCandidate],
+) -> None:
+    if not blobs_by_hash:
+        return
+
+    found: set[str] = set()
+    chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
+    for hashes_chunk in chunks(sorted(blobs_by_hash), chunk_size):
+        rows = (
+            db.query(TraceMessageBlob.message_hash, TraceMessageBlob.message_bytes)
+            .filter(
+                TraceMessageBlob.task_id == task_id,
+                TraceMessageBlob.message_hash.in_(hashes_chunk),
+            )
+            .all()
+        )
+        for message_hash, message_bytes in rows:
+            message_hash = str(message_hash)
+            candidate = blobs_by_hash[message_hash]
+            if message_bytes != candidate.payload_bytes:
+                raise ValueError(
+                    f"trace message blob hash collision for task {task_id}: "
+                    f"{message_hash}"
+                )
+            found.add(message_hash)
+
+    missing = set(blobs_by_hash) - found
+    if missing:
+        raise RuntimeError(
+            f"trace message blob upsert did not persist {len(missing)} row(s) "
+            f"for task {task_id}."
         )
 
 
@@ -1336,6 +1439,32 @@ def _upsert_checkpoint_blobs(
         blobs_by_ref=blobs_by_ref,
     )
     refs_to_query = sorted(set(blobs_by_ref) - pending_refs)
+    candidates_to_insert = {
+        blob_ref: blobs_by_ref[blob_ref] for blob_ref in refs_to_query
+    }
+    if _insert_blob_rows_on_conflict_do_nothing(
+        db,
+        model=TraceCheckpointBlob,
+        values=[
+            {
+                "task_id": task_id,
+                "execution_id": execution_id,
+                "blob_kind": blob_kind,
+                "blob_hash": blob_hash,
+                "blob_data": copy.deepcopy(candidate.data),
+                "blob_bytes": candidate.payload_bytes,
+            }
+            for (blob_kind, blob_hash), candidate in candidates_to_insert.items()
+        ],
+        index_elements=["task_id", "blob_kind", "blob_hash"],
+    ):
+        _validate_checkpoint_blobs(
+            db,
+            task_id=task_id,
+            blobs_by_ref=candidates_to_insert,
+        )
+        return
+
     existing_refs: set[tuple[str, str]] = set()
     if refs_to_query:
         refs_by_kind: dict[str, set[str]] = {}
@@ -1383,4 +1512,52 @@ def _upsert_checkpoint_blobs(
                 blob_data=copy.deepcopy(candidate.data),
                 blob_bytes=candidate.payload_bytes,
             )
+        )
+
+
+def _validate_checkpoint_blobs(
+    db: Session,
+    *,
+    task_id: int,
+    blobs_by_ref: dict[tuple[str, str], BlobCandidate],
+) -> None:
+    if not blobs_by_ref:
+        return
+
+    found: set[tuple[str, str]] = set()
+    refs_by_kind: dict[str, set[str]] = {}
+    for kind, blob_hash in blobs_by_ref:
+        refs_by_kind.setdefault(kind, set()).add(blob_hash)
+
+    for kind, blob_hashes in refs_by_kind.items():
+        chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=2)
+        for hash_chunk in chunks(sorted(blob_hashes), chunk_size):
+            rows = (
+                db.query(
+                    TraceCheckpointBlob.blob_kind,
+                    TraceCheckpointBlob.blob_hash,
+                    TraceCheckpointBlob.blob_bytes,
+                )
+                .filter(
+                    TraceCheckpointBlob.task_id == task_id,
+                    TraceCheckpointBlob.blob_kind == kind,
+                    TraceCheckpointBlob.blob_hash.in_(hash_chunk),
+                )
+                .all()
+            )
+            for blob_kind, blob_hash, blob_bytes in rows:
+                blob_ref = (str(blob_kind), str(blob_hash))
+                candidate = blobs_by_ref[blob_ref]
+                if blob_bytes != candidate.payload_bytes:
+                    raise ValueError(
+                        f"trace checkpoint blob hash collision for task {task_id}: "
+                        f"{blob_ref[0]} {blob_ref[1]}"
+                    )
+                found.add(blob_ref)
+
+    missing = set(blobs_by_ref) - found
+    if missing:
+        raise RuntimeError(
+            f"trace checkpoint blob upsert did not persist {len(missing)} row(s) "
+            f"for task {task_id}."
         )

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ from xagent.core.agent import (
     ReActPattern,
 )
 from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRuntime
+from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
@@ -66,6 +68,15 @@ class FakeLLM:
         if not self.responses and has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
             return default_completion_assessment_response(kwargs)
         return self.responses.pop(0)
+
+
+class RaisingFakeLLM(FakeLLM):
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 class StreamingDecisionLLM:
@@ -253,6 +264,45 @@ def test_auto_child_runtime_forwards_clear_interrupt() -> None:
 
     assert parent_runtime._interrupt_requested is False
     assert parent_runtime.interrupt_reason is None
+
+
+@pytest.mark.asyncio
+async def test_auto_child_runtime_forwards_llm_errors() -> None:
+    parent_runtime = RecordingRuntime()
+    context = ExecutionContext(execution_id="auto-child-llm-error")
+    child_runtime = _AutoChildRuntime(
+        parent=parent_runtime,
+        auto_pattern=AutoPattern(),
+        root_context=context,
+    )
+
+    await child_runtime.on_llm_error(
+        context=context,
+        error=RuntimeError("provider failed"),
+        metadata={"phase": "dag_step"},
+    )
+
+    assert parent_runtime.hooks == [
+        (
+            "llm_error",
+            {
+                "error": "provider failed",
+                "metadata": {"phase": "dag_step"},
+            },
+        )
+    ]
+
+
+def test_auto_child_runtime_covers_pattern_runtime_async_interface() -> None:
+    missing = [
+        name
+        for name, method in inspect.getmembers(PatternRuntime)
+        if not name.startswith("_")
+        and inspect.iscoroutinefunction(method)
+        and not hasattr(_AutoChildRuntime, name)
+    ]
+
+    assert missing == []
 
 
 def decision_tool_response(
@@ -1425,6 +1475,53 @@ async def test_auto_pattern_final_answer_redecision_refreshes_enrichment() -> No
     )
     assert "memory for replacement question" in resumed_system_context
     assert "memory for first question" not in resumed_system_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "protocol_code",
+    ["malformed_tool_arguments", "unavailable_tool_call"],
+)
+async def test_auto_pattern_retries_provider_routing_protocol_errors(
+    protocol_code: str,
+) -> None:
+    llm = RaisingFakeLLM(
+        [
+            LLMToolProtocolError(
+                provider="deepseek",
+                code=protocol_code,
+                message="invalid routing tool call",
+            ),
+            decision_tool_response(
+                "final_answer",
+                "Recovered after protocol error.",
+                answer="Recovered routing answer.",
+            ),
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext(execution_id="auto-protocol-retry")
+    context.add_user_message("Answer from the current context")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "Recovered routing answer."
+    assert len(llm.calls) == 2
+    retry_message = llm.calls[1]["messages"][-1]["content"]
+    assert protocol_code.split("_", 1)[0] in retry_message
+    assert "one complete JSON object" in retry_message
+    assert DECISION_TOOL_NAME in retry_message
+    llm_error_hooks = [
+        payload for name, payload in runtime.hooks if name == "llm_error"
+    ]
+    assert llm_error_hooks[-1]["metadata"]["protocol_code"] == protocol_code
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_checkpoint.py
+++ b/tests/core/agent/test_checkpoint.py
@@ -6,11 +6,13 @@ import pytest
 
 from xagent.core.agent import Agent, AgentRunner
 from xagent.core.agent.checkpoint import (
+    CHECKPOINT_EVENT_TYPE,
     CHECKPOINT_TYPE,
     LEGACY_CHECKPOINT_TYPES,
     CheckpointPersistenceError,
     TraceCheckpointStore,
 )
+from xagent.core.agent.trace import TraceEvent, TraceHandler, Tracer
 
 
 class PersistentTraceBackend:
@@ -92,6 +94,11 @@ class LegacyCheckpointBackend:
         }
 
 
+class FailingTraceHandler(TraceHandler):
+    async def handle_event(self, _: TraceEvent) -> None:
+        raise ValueError("checkpoint write failed: secret=supersecret")
+
+
 class FakeLLM:
     async def chat(self, **_: Any) -> str:
         return "done"
@@ -131,6 +138,24 @@ async def test_trace_checkpoint_store_persists_full_snapshot_event() -> None:
     assert backend.events[0]["data"]["checkpoint_type"] == CHECKPOINT_TYPE
     assert backend.events[0]["data"]["snapshot"] == payload
     assert loaded == payload
+
+
+@pytest.mark.asyncio
+async def test_required_trace_error_preserves_redacted_handler_cause() -> None:
+    tracer = Tracer()
+    tracer.add_handler(FailingTraceHandler())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await tracer.trace_event(
+            CHECKPOINT_EVENT_TYPE,
+            task_id="trace-cause",
+            require_persisted=True,
+        )
+
+    message = str(exc_info.value)
+    assert "First failure: ValueError: checkpoint write failed" in message
+    assert "supersecret" not in message
+    assert isinstance(exc_info.value.__cause__, ValueError)
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -22,6 +22,7 @@ from xagent.core.agent import (
     PlanValidationError,
 )
 from xagent.core.agent.pattern.base import RequiredToolCallError
+from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
 )
@@ -457,6 +458,55 @@ def test_plan_step_serializes_termination_condition() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dag_step_runtime_forwards_llm_error_with_step_metadata() -> None:
+    class ErrorRecordingRuntime(PatternRuntime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.llm_errors: list[dict[str, Any]] = []
+
+        async def on_llm_error(
+            self,
+            *,
+            context: Any,
+            error: Exception,
+            metadata: dict[str, Any] | None = None,
+        ) -> None:
+            self.llm_errors.append(
+                {"context": context, "error": error, "metadata": metadata}
+            )
+
+    parent = ErrorRecordingRuntime()
+    root_context = ExecutionContext(execution_id="dag-root")
+    child_context = ExecutionContext(execution_id="dag-root:creative")
+    runtime = _DAGStepRuntime(
+        parent=parent,
+        dag_pattern=DAGPattern(lambda **_: build_plan()),
+        root_context=root_context,
+        step_id="creative",
+    )
+    error = RuntimeError("provider rejected tool call")
+
+    await runtime.on_llm_error(
+        context=child_context,
+        error=error,
+        metadata={"phase": "unavailable_tool_call"},
+    )
+
+    assert parent.llm_errors == [
+        {
+            "context": child_context,
+            "error": error,
+            "metadata": {
+                "task_id": "dag-root",
+                "step_id": "creative",
+                "dag_step_id": "creative",
+                "phase": "unavailable_tool_call",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dag_pattern_interrupt_before_plan_skips_plan_generation() -> None:
     plan_calls: list[dict[str, Any]] = []
 
@@ -691,6 +741,32 @@ async def test_dag_completion_assessment_replans_when_goal_incomplete() -> None:
     assert generator.requests[1].replan is True
     assert generator.requests[1].completion_feedback == "Add a second step."
     assert generator.requests[1].completed_step_results == {"first": "first done"}
+
+
+def test_dag_completion_assessment_keeps_user_request_as_scope_authority() -> None:
+    pattern = DAGPattern(
+        lambda **_: build_plan(PlanStep(id="create", task="Create two images"))
+    )
+    pattern.plan = build_plan(PlanStep(id="create", task="Create two images"))
+    pattern.step_results = {
+        "create": (
+            "Created the requested square and story images. An intermediate "
+            "brief also proposed landscape and leaderboard variants."
+        )
+    }
+    context = ExecutionContext(execution_id="dag-user-scope")
+    context.add_user_message("Create two reports.")
+
+    messages = pattern._completion_assessment_messages(context)
+
+    system_prompt = messages[0]["content"]
+    payload = json.loads(messages[1]["content"])
+    assert payload["authoritative_user_requests"] == [
+        {"role": "user", "content": "Create two reports."}
+    ]
+    assert "the only source of required scope" in system_prompt
+    assert "cannot add deliverables" in system_prompt
+    assert "intermediate step proposed extra work" in system_prompt
 
 
 class ReplanningPlanGenerator(PlanGenerator):
@@ -1813,6 +1889,76 @@ async def test_llm_plan_generator_retries_invalid_tool_arguments() -> None:
     assert "invalid JSON" in retry_message
     assert "not json at all" in retry_message
     assert "one complete valid JSON object" in retry_message
+
+
+@pytest.mark.asyncio
+async def test_llm_plan_generator_retries_invalid_replan_dependencies() -> None:
+    generator = LLMPlanGenerator()
+    context = ExecutionContext(execution_id="dag-llm-invalid-replan")
+    context.add_user_message("Create two reports.")
+    completed_step = PlanStep(id="2", task="Generate key visual")
+    llm = SequenceLLM(
+        [
+            plan_tool_response(
+                [
+                    {
+                        "id": "6",
+                        "task": "Create an extra banner",
+                        "dependencies": ["2"],
+                        "termination_condition": (
+                            "Stop after final_answer reports the banner."
+                        ),
+                        "completion_evidence": "The banner was returned.",
+                        "tool_names": [],
+                    }
+                ]
+            ),
+            plan_tool_response(
+                [
+                    {
+                        "id": "2",
+                        "task": "Generate key visual",
+                        "dependencies": [],
+                        "termination_condition": (
+                            "Stop after final_answer reports the key visual."
+                        ),
+                        "completion_evidence": "The key visual was returned.",
+                        "tool_names": [],
+                    },
+                    {
+                        "id": "6",
+                        "task": "Create an extra banner",
+                        "dependencies": ["2"],
+                        "termination_condition": (
+                            "Stop after final_answer reports the banner."
+                        ),
+                        "completion_evidence": "The banner was returned.",
+                        "tool_names": [],
+                    },
+                ]
+            ),
+        ]
+    )
+
+    plan = await generator.generate_plan(
+        request=PlanGenerationRequest(
+            context=context,
+            execution_id="dag-llm-invalid-replan",
+            replan=True,
+            completed_step_results={"2": "key visual file"},
+            previous_plan=ExecutionPlan(steps=[completed_step]),
+            completion_feedback="Add a banner using step 2.",
+            available_tool_names=[],
+        ),
+        llm=llm,
+    )
+
+    assert [step.id for step in plan.steps] == ["2", "6"]
+    assert llm.calls == 2
+    retry_message = llm.seen_messages[1][-1]["content"]
+    assert "depends on unknown step 2" in retry_message
+    assert "complete, self-contained plan" in retry_message
+    assert "Do not return only the newly added steps" in retry_message
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -19,6 +19,7 @@ from xagent.core.agent import (
     ToolCallRecord,
 )
 from xagent.core.model.chat.basic.router import RouterLLM
+from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.tool_protocol import (
     ToolProtocolViolation,
     tool_protocol_error_response,
@@ -476,6 +477,111 @@ class StreamingInvalidToolProtocolFinalAnswerLLM:
                     }
                 ],
             )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class StreamingUnavailableToolRecoveryLLM:
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("unavailable-tool recovery path should stay streaming")
+
+    async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        call_index = len(self.stream_calls) - 1
+        if call_index == 0:
+            tool_name = "calculator"
+            arguments = '{"expression":"2+2"}'
+            tool_call_id = "call_first_work"
+        elif call_index == 1:
+            raise LLMToolProtocolError(
+                provider="deepseek",
+                code="unavailable_tool_call",
+                message="DeepSeek returned unavailable tool call 'calculator'.",
+            )
+        elif call_index == 2:
+            tool_name = "calculator"
+            arguments = '{"expression":"3+3"}'
+            tool_call_id = "call_recovered_work"
+        else:
+            tool_name = "final_answer"
+            arguments = json.dumps(
+                {
+                    "response_language": "English",
+                    "answer": "The results are 4 and 6.",
+                }
+            )
+            tool_call_id = "call_final"
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "id": tool_call_id,
+                    "function": {
+                        "name": tool_name,
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class StreamingMalformedFinalAnswerRecoveryLLM:
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("malformed-tool recovery path should stay streaming")
+
+    async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        call_index = len(self.stream_calls) - 1
+        if call_index == 0:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "call_transcribe",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            )
+            yield StreamChunk(type=ChunkType.END)
+            return
+        if call_index == 1:
+            raise LLMToolProtocolError(
+                provider="deepseek",
+                code="malformed_tool_arguments",
+                message="DeepSeek returned malformed arguments for 'final_answer'.",
+                details={
+                    "original_arguments_preview": '{"answer":',
+                    "original_arguments_length": 10,
+                    "repair_status": "skipped_incomplete",
+                },
+            )
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "id": "call_final_repaired",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": json.dumps(
+                            {
+                                "response_language": "Simplified Chinese",
+                                "answer": "音频主要讲运动如何缓解精神疲劳。",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    },
+                }
+            ],
+        )
         yield StreamChunk(type=ChunkType.END)
 
 
@@ -969,6 +1075,86 @@ async def test_react_pattern_streams_only_final_answer_after_tool_call() -> None
     ]
 
 
+@pytest.mark.asyncio
+async def test_react_recovers_unavailable_forced_final_with_full_tool_set() -> None:
+    llm = StreamingUnavailableToolRecoveryLLM()
+    pattern = ReActPattern(max_iterations=4, finalize_after_tool_result=True)
+    tool = FakeTool()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2 and 3+3")
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(execution_id="task-1", tracer=tracer)
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "The results are 4 and 6."
+    assert tool.calls == [{"expression": "2+2"}, {"expression": "3+3"}]
+    assert len(llm.stream_calls) == 4
+    assert [schema["function"]["name"] for schema in llm.stream_calls[1]["tools"]] == [
+        "final_answer"
+    ]
+    recovery_tool_names = [
+        schema["function"]["name"] for schema in llm.stream_calls[2]["tools"]
+    ]
+    assert "calculator" in recovery_tool_names
+    assert "final_answer" in recovery_tool_names
+    assert (
+        "Re-decide this turn using the complete current tool set"
+        in llm.stream_calls[2]["messages"][0]["content"]
+    )
+    recovery_starts = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_start_llm"
+        and event["data"].get("phase") == "unavailable_tool_call_recovery"
+    ]
+    assert len(recovery_starts) == 1
+
+
+@pytest.mark.asyncio
+async def test_react_repairs_malformed_forced_final_answer_arguments() -> None:
+    llm = StreamingMalformedFinalAnswerRecoveryLLM()
+    pattern = ReActPattern(max_iterations=3, finalize_after_tool_result=True)
+    tool = FakeTool()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="780")
+    context.add_user_message("这个音频讲了什么？")
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(execution_id="780", tracer=tracer)
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "音频主要讲运动如何缓解精神疲劳。"
+    assert tool.calls == [{"expression": "2+2"}]
+    assert len(llm.stream_calls) == 3
+    assert [schema["function"]["name"] for schema in llm.stream_calls[2]["tools"]] == [
+        "final_answer"
+    ]
+    retry_prompt = llm.stream_calls[2]["messages"][0]["content"]
+    assert "malformed JSON arguments" in retry_prompt
+    assert "one complete JSON object" in retry_prompt
+    recovery_starts = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_start_llm"
+        and event["data"].get("phase") == "malformed_tool_arguments_recovery"
+    ]
+    assert len(recovery_starts) == 1
+    protocol_errors = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_error_llm"
+        and event["data"].get("protocol_code") == "malformed_tool_arguments"
+    ]
+    assert len(protocol_errors) == 1
+    assert protocol_errors[0]["data"]["protocol_details"] == {
+        "original_arguments_preview": '{"answer":',
+        "original_arguments_length": 10,
+        "repair_status": "skipped_incomplete",
+    }
+
+
 @pytest.mark.parametrize("structured_work_tool", [False, True])
 @pytest.mark.asyncio
 async def test_react_retries_invalid_forced_final_as_final_answer_tool(
@@ -1000,12 +1186,18 @@ async def test_react_retries_invalid_forced_final_as_final_answer_tool(
     ]
     assert llm.stream_calls[1]["tool_choice"] == "required"
     retry_tools = llm.stream_calls[2]["tools"]
-    assert [tool["function"]["name"] for tool in retry_tools] == ["final_answer"]
+    retry_tool_names = [tool["function"]["name"] for tool in retry_tools]
+    if structured_work_tool:
+        assert "calculator" in retry_tool_names
+        assert "final_answer" in retry_tool_names
+    else:
+        assert retry_tool_names == ["final_answer"]
     assert llm.stream_calls[2]["tool_choice"] == "required"
-    assert (
-        "calling the final_answer control tool exactly once"
-        in (llm.stream_calls[2]["messages"][0]["content"])
-    )
+    retry_prompt = llm.stream_calls[2]["messages"][0]["content"]
+    if structured_work_tool:
+        assert "complete current tool set" in retry_prompt
+    else:
+        assert "calling the final_answer control tool exactly once" in retry_prompt
     outbound_text = "".join(
         str(event.get("delta", "")) + str(event.get("content", ""))
         for event in outbound.events
@@ -1179,7 +1371,7 @@ async def test_react_reuses_resolved_route_for_tool_protocol_retry() -> None:
         event
         for event in tracer.events
         if event["event_type"] == "action_start_llm"
-        and event["data"].get("phase") == "tool_protocol_retry"
+        and event["data"].get("phase") == "unavailable_tool_call_recovery"
     ]
     assert len(retry_starts) == 1
     assert retry_starts[0]["data"]["selected_model"] == "test/model-2"

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -237,6 +237,92 @@ def test_deepseek_codec_repairs_complete_malformed_tool_arguments() -> None:
     }
 
 
+def test_deepseek_codec_repairs_brace_inside_single_quoted_string() -> None:
+    response = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "id": "call_write",
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "arguments": (
+                        "{'file_path':'artifact.txt','content':'Use {value',}"
+                    ),
+                },
+            }
+        ],
+    }
+
+    normalized = normalize_deepseek_response(
+        response,
+        tools=[WRITE_FILE_TOOL],
+    )
+
+    assert normalized is response
+    repaired = json.loads(response["tool_calls"][0]["function"]["arguments"])
+    assert repaired == {
+        "file_path": "artifact.txt",
+        "content": "Use {value",
+    }
+
+
+def test_deepseek_codec_marks_non_object_repair_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.deepseek_tool_protocol.repair_json_loads",
+        lambda *_args, **_kwargs: [],
+    )
+    normalized = normalize_deepseek_response(
+        {
+            "type": "tool_call",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "write_file",
+                        "arguments": "{broken}",
+                    }
+                }
+            ],
+        },
+        tools=[WRITE_FILE_TOOL],
+    )
+
+    error = get_tool_protocol_error(normalized)
+    assert error is not None
+    assert error["code"] == "malformed_tool_arguments"
+    assert error["details"]["repair_status"] == "failed_non_dict"
+
+
+def test_deepseek_codec_accepts_empty_object_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.deepseek_tool_protocol.repair_json_loads",
+        lambda *_args, **_kwargs: {},
+    )
+    response = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "ping",
+                    "arguments": "{broken}",
+                }
+            }
+        ],
+    }
+
+    normalized = normalize_deepseek_response(
+        response,
+        tools=[_tool_schema("ping", {}, additional_properties=False)],
+    )
+
+    assert normalized is response
+    assert response["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
 def test_deepseek_codec_keeps_original_arguments_when_repair_is_unsafe() -> None:
     original_arguments = '{"file_path":'
 

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -207,6 +207,92 @@ def test_deepseek_codec_keeps_valid_tool_call() -> None:
     assert normalize_deepseek_response(response, tools=[WRITE_FILE_TOOL]) is response
 
 
+def test_deepseek_codec_repairs_complete_malformed_tool_arguments() -> None:
+    response = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "id": "call_final",
+                "type": "function",
+                "function": {
+                    "name": "final_answer",
+                    "arguments": (
+                        "{'response_language': 'English', 'answer': 'Done.',}"
+                    ),
+                },
+            }
+        ],
+    }
+
+    normalized = normalize_deepseek_response(
+        response,
+        tools=[FINAL_ANSWER_TOOL],
+    )
+
+    assert normalized is response
+    repaired = json.loads(response["tool_calls"][0]["function"]["arguments"])
+    assert repaired == {
+        "response_language": "English",
+        "answer": "Done.",
+    }
+
+
+def test_deepseek_codec_keeps_original_arguments_when_repair_is_unsafe() -> None:
+    original_arguments = '{"file_path":'
+
+    normalized = normalize_deepseek_response(
+        {
+            "type": "tool_call",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "write_file",
+                        "arguments": original_arguments,
+                    }
+                }
+            ],
+        },
+        tools=[WRITE_FILE_TOOL],
+    )
+
+    error = get_tool_protocol_error(normalized)
+    assert error is not None
+    assert error["code"] == "malformed_tool_arguments"
+    assert error["details"] == {
+        "original_arguments_preview": original_arguments,
+        "original_arguments_length": len(original_arguments),
+        "original_arguments_truncated": False,
+        "json_error": "Expecting value: line 1 column 14 (char 13)",
+        "repair_status": "skipped_incomplete",
+    }
+
+
+def test_deepseek_codec_bounds_original_argument_diagnostics() -> None:
+    original_arguments = '{"answer":"' + ("x" * 5000)
+
+    normalized = normalize_deepseek_response(
+        {
+            "type": "tool_call",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": original_arguments,
+                    }
+                }
+            ],
+        },
+        tools=[FINAL_ANSWER_TOOL],
+    )
+
+    error = get_tool_protocol_error(normalized)
+    assert error is not None
+    details = error["details"]
+    assert details["original_arguments_length"] == len(original_arguments)
+    assert len(details["original_arguments_preview"]) == 4096
+    assert details["original_arguments_truncated"] is True
+
+
 def test_deepseek_codec_is_inactive_without_requested_tools() -> None:
     response = {
         "type": "text",
@@ -364,6 +450,82 @@ async def test_deepseek_stream_forwards_accumulated_valid_tool_calls() -> None:
     assert tool_chunks[-1].tool_calls[0]["function"]["arguments"] == (
         '{"file_path":"podcast.md","content":"script"}'
     )
+
+
+@pytest.mark.asyncio
+async def test_deepseek_stream_repairs_complete_malformed_tool_arguments() -> None:
+    async def source() -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_final",
+                    "type": "function",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": (
+                            "{'response_language': 'English', 'answer': 'Done.',}"
+                        ),
+                    },
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+
+    chunks = [
+        chunk
+        async for chunk in adapt_deepseek_stream(
+            source(),
+            tools=[FINAL_ANSWER_TOOL],
+        )
+    ]
+
+    assert not any(chunk.is_protocol_error() for chunk in chunks)
+    tool_chunks = [chunk for chunk in chunks if chunk.is_tool_call()]
+    assert len(tool_chunks) == 1
+    repaired = json.loads(tool_chunks[0].tool_calls[0]["function"]["arguments"])
+    assert repaired == {
+        "response_language": "English",
+        "answer": "Done.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deepseek_stream_records_truncated_original_arguments() -> None:
+    original_arguments = '{"response_language":"English","answer":'
+
+    async def source() -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_final",
+                    "type": "function",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": original_arguments,
+                    },
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+
+    chunks = [
+        chunk
+        async for chunk in adapt_deepseek_stream(
+            source(),
+            tools=[FINAL_ANSWER_TOOL],
+        )
+    ]
+
+    protocol_errors = [chunk for chunk in chunks if chunk.is_protocol_error()]
+    assert len(protocol_errors) == 1
+    details = protocol_errors[0].protocol_error["details"]
+    assert details["original_arguments_preview"] == original_arguments
+    assert details["original_arguments_length"] == len(original_arguments)
+    assert details["repair_status"] == "skipped_incomplete"
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -10,7 +10,14 @@ from xagent.core.model.chat.basic import openrouter as openrouter_module
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
 from xagent.core.model.chat.error import retry_on
-from xagent.core.model.chat.exceptions import LLMRetryableError
+from xagent.core.model.chat.exceptions import (
+    LLMRetryableError,
+    LLMToolProtocolError,
+)
+from xagent.core.model.chat.tool_protocol import (
+    TOOL_PROTOCOL_ERROR_KEY,
+    get_tool_protocol_error,
+)
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 from xagent.core.retry.strategy import FixedDelay
 from xagent.core.retry.wrapper import create_retry_wrapper
@@ -202,6 +209,162 @@ async def test_openrouter_deepseek_protocol_error_uses_shared_stream_retry(mocke
         and chunk.tool_calls[0]["function"]["name"] == "select_execution_pattern"
         for chunk in chunks
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_does_not_replay_unavailable_tool_call(mocker):
+    unavailable_tool_call = SimpleNamespace(
+        id="call_unavailable",
+        type="function",
+        function=SimpleNamespace(
+            name="calculator",
+            arguments='{"expression":"2+2"}',
+        ),
+    )
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[unavailable_tool_call],
+                    reasoning_content=None,
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-deepseek-unavailable-tool"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    inner = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+    llm = create_retry_wrapper(
+        inner,
+        BaseLLM,  # type: ignore[type-abstract]
+        retry_methods={"chat"},
+        strategy=FixedDelay(delay_ms=0),
+        max_retries=10,
+        retry_on=retry_on,
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Finish this task"}],
+        tools=_single_tool_schema(),
+        tool_choice="required",
+    )
+
+    protocol_error = get_tool_protocol_error(result)
+    assert protocol_error is not None
+    assert protocol_error["code"] == "unavailable_tool_call"
+    assert mock_client.chat.completions.create.await_count == 1
+
+
+def test_retry_filter_defers_unavailable_tool_call_to_agent_pattern() -> None:
+    error = LLMToolProtocolError(
+        provider="deepseek",
+        code="unavailable_tool_call",
+        message="DeepSeek returned an unavailable tool call.",
+    )
+
+    assert retry_on(error) is False
+
+
+def test_retry_filter_defers_malformed_tool_arguments_to_agent_pattern() -> None:
+    error = LLMToolProtocolError(
+        provider="deepseek",
+        code="malformed_tool_arguments",
+        message="DeepSeek returned malformed arguments for 'final_answer'.",
+    )
+
+    assert retry_on(error) is False
+
+
+def test_deepseek_protocol_error_preserves_argument_diagnostics() -> None:
+    details = {
+        "original_arguments_preview": '{"answer":',
+        "original_arguments_length": 10,
+        "repair_status": "skipped_incomplete",
+    }
+
+    error = openrouter_module._deepseek_tool_protocol_retry_error(
+        {
+            TOOL_PROTOCOL_ERROR_KEY: {
+                "provider": "deepseek",
+                "code": "malformed_tool_arguments",
+                "message": "Malformed arguments.",
+                "details": details,
+            }
+        }
+    )
+
+    assert isinstance(error, LLMToolProtocolError)
+    assert error.details == details
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_defers_unavailable_tool_call_without_replay(mocker):
+    attempts = 0
+
+    async def unavailable_stream():
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_unavailable",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                }
+            ],
+        )
+        yield StreamChunk(type=ChunkType.END, finish_reason="tool_calls")
+
+    def fake_stream(**kwargs):
+        nonlocal attempts
+        del kwargs
+        attempts += 1
+        return unavailable_stream()
+
+    inner = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+    mocker.patch.object(
+        inner,
+        "_stream_chat_with_prefix_retry",
+        side_effect=fake_stream,
+    )
+    llm = create_retry_wrapper(
+        inner,
+        BaseLLM,  # type: ignore[type-abstract]
+        retry_methods={"stream_chat"},
+        strategy=FixedDelay(delay_ms=0),
+        max_retries=10,
+        retry_on=retry_on,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Finish this task"}],
+            tools=_single_tool_schema(),
+            tool_choice="required",
+        )
+    ]
+
+    assert attempts == 1
+    protocol_errors = [chunk for chunk in chunks if chunk.is_protocol_error()]
+    assert len(protocol_errors) == 1
+    assert protocol_errors[0].protocol_error["code"] == "unavailable_tool_call"
 
 
 def _deepseek_function_prefix_error() -> openai.BadRequestError:

--- a/tests/core/tools/core/test_image_tool_core.py
+++ b/tests/core/tools/core/test_image_tool_core.py
@@ -154,7 +154,7 @@ class TestImageGenerationToolCore:
 
         assert result["success"] is True
         assert result["image_path"] is not None
-        assert result["model_used"] == "default"
+        assert result["model_used"] == "model1"
         assert result["usage"] == {"input_tokens": 10, "output_tokens": 20}
         assert result["request_id"] == "req1"
         assert result["saved_to_workspace"] is True
@@ -250,7 +250,7 @@ class TestImageGenerationToolCore:
         )
 
         assert result["success"] is True
-        assert result["model_used"] == "default_edit_model"
+        assert result["model_used"] == "model1"
         mock_image_models["model1"].generate_image.assert_not_called()
         mock_image_models["model1"].edit_image.assert_called_once_with(
             prompt="Keep the same cabin composition, but make it a night scene",
@@ -530,7 +530,7 @@ class TestImageGenerationToolCore:
 
         assert result["success"] is True
         assert result["image_path"] is not None
-        assert result["model_used"] == "default_edit_model"
+        assert result["model_used"] == "model1"
         assert result["usage"] == {"input_tokens": 15, "output_tokens": 25}
         assert result["request_id"] == "edit_req1"
         assert result["saved_to_workspace"] is True
@@ -585,7 +585,7 @@ class TestImageGenerationToolCore:
 
         assert result["success"] is False
         assert result["error"] == "Edit model error"
-        assert result["model_used"] == "default_edit_model"
+        assert result["model_used"] == "model1"
 
     @pytest.mark.asyncio
     @patch("aiohttp.ClientSession.get")

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -128,7 +128,7 @@ class TestImageGenerationTool:
 
         assert result["success"] is True
         assert result["image_path"] is not None
-        assert result["model_used"] == "default"
+        assert result["model_used"] == "model1"
         assert result["usage"] == {"input_tokens": 10, "output_tokens": 20}
         assert result["request_id"] == "req1"
         assert result["saved_to_workspace"] is True
@@ -226,7 +226,7 @@ class TestImageGenerationTool:
         )
 
         assert result["success"] is True
-        assert result["model_used"] == "default"
+        assert result["model_used"] == "model1"
 
         # Should fall back to first available model
         mock_image_models["model1"].generate_image.assert_called_once()
@@ -353,7 +353,7 @@ class TestImageGenerationTool:
         assert result["success"] is False
         assert result["error"] == "Model error"
         assert result["image_path"] is None
-        assert result["model_used"] == "default"
+        assert result["model_used"] == "model1"
 
     def test_list_available_models(self, image_tool, mock_image_models):
         """Test listing available models"""
@@ -570,7 +570,7 @@ class TestImageGenerationTool:
 
         assert result["success"] is True
         assert result["image_path"] is not None
-        assert result["model_used"] == "default_edit_model"
+        assert result["model_used"] == "model1"
         assert result["usage"] == {"input_tokens": 15, "output_tokens": 25}
         assert result["request_id"] == "edit_req1"
         assert result["saved_to_workspace"] is True

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import copy
 import sqlite3
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Barrier
 from typing import Any
 
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import NullPool, StaticPool
 
 from scripts.convert_trace_checkpoint_messages import convert_trace_checkpoint_messages
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
@@ -21,6 +24,7 @@ from xagent.core.agent.trace import (
     TraceScope,
 )
 from xagent.core.tools.adapters.vibe.connector_runtime import REDACTED_RUNTIME_SECRET
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.api.trace_handlers import DatabaseTraceHandler
 from xagent.web.models.database import Base
 from xagent.web.models.task import (
@@ -783,6 +787,72 @@ def test_database_trace_handler_shares_blobs_across_checkpoints() -> None:
         assert db.query(TraceCheckpointBlob).count() == 2
     finally:
         db.close()
+
+
+def test_database_trace_handler_dedupes_concurrent_checkpoint_blobs(
+    tmp_path: Path,
+) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'concurrent-checkpoints.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    messages = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"message-{index}-" + ("x" * 2000),
+        }
+        for index in range(24)
+    ]
+    checkpoint = _checkpoint_data_with_large_fields(
+        str(task_id),
+        messages,
+        tool_ledger={"tool-1": {"result": "r" * 4000}},
+        metadata={"memory": "m" * 4000},
+    )
+    checkpoint["snapshot"]["context"]["system_prompt"] = "system" * 1000
+    start = Barrier(4)
+
+    def save_checkpoint(worker: int) -> None:
+        event = TraceEvent(
+            CHECKPOINT_EVENT_TYPE,
+            task_id=str(task_id),
+            data={**copy.deepcopy(checkpoint), "worker": worker},
+            require_persisted=True,
+        )
+        worker_db = SessionLocal()
+        try:
+            start.wait(timeout=5)
+            DatabaseTraceHandler(task_id)._save_trace_event(worker_db, event)
+        finally:
+            worker_db.close()
+
+    try:
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(save_checkpoint, worker) for worker in range(4)]
+            for future in futures:
+                future.result(timeout=15)
+
+        db = SessionLocal()
+        try:
+            assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 4
+            assert db.query(TraceMessageBlob).filter_by(task_id=task_id).count() == 24
+            assert db.query(TraceCheckpointBlob).filter_by(task_id=task_id).count() == 3
+        finally:
+            db.close()
+    finally:
+        engine.dispose()
 
 
 def test_database_trace_handler_reads_old_inline_checkpoint(


### PR DESCRIPTION
## Summary

- recover malformed and unavailable provider tool calls in Auto and ReAct with one bounded, schema-aware retry
- safely repair structurally complete DeepSeek JSON arguments while preserving bounded original diagnostics for tracing
- forward child Auto and DAG-step LLM errors with the correct execution metadata
- make DAG replanning/completion checks respect valid dependencies and the user's authoritative requested scope
- require trusted tool-result provenance before claiming delivery of a generated file
- make checkpoint blob persistence idempotent under concurrent DAG writes
- report the image model that actually served generation and edit requests

## Why

Provider protocol failures and parallel execution races were terminating otherwise recoverable tasks or hiding the original failure details. In other cases, narrowed tool schemas, invalid replans, or unverified file references could produce a failed run or an incorrect completion claim.

These are general agent-runtime reliability fixes and do not contain the static visual design skill, ad-creative art direction, logo handling, or brand-asset workflow.

## Relationship to #942

This PR extracts the non-ad-creative reliability work from #942. The #942 branch has been left unchanged and will be rebased onto main after this PR merges.

## Validation

- 332 focused tests passed across Auto, DAG, ReAct, DeepSeek/OpenRouter protocol handling, image model reporting, checkpoint persistence, and trace storage
- commit hooks passed, including Ruff, formatting, mypy, isort, and codespell
- git diff --check upstream/main...HEAD
