### PR TITLE
fix(triggers): exclude workforce-generated manager agents from trigger ownership resolution

### DIFF
--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -22,7 +22,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     ConnectorRuntimeError,
 )
 from ...core.utils.encryption import decrypt_value, encrypt_value
-from ..models.agent import Agent
+from ..models.agent import Agent, AgentOrigin
 from ..models.background_job import BackgroundJob, BackgroundJobType
 from ..models.task import Task, TaskStatus
 from ..models.trigger import AgentTrigger, TriggerRun, TriggerRunStatus, TriggerType
@@ -424,10 +424,14 @@ def _unregister_trigger_binding(
 
 
 def get_owned_agent(db: Session, *, user_id: int, agent_id: int) -> Agent | None:
+    # Workforce-generated manager agents are private implementation details;
+    # they must not be addressable through trigger management, matching the
+    # exclusion every other external channel (share/widget/api-keys) applies.
     return (
         db.query(Agent)
         .filter(
             Agent.id == agent_id,
+            Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
             owned_agent_clause(user_id, get_agent_team_scope(db, user_id)),
         )
         .first()

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -13,7 +13,7 @@ from xagent.core.tools.adapters.vibe.config import (
     RequiredMCPUnavailableError,
 )
 from xagent.core.utils.encryption import decrypt_value
-from xagent.web.models.agent import Agent
+from xagent.web.models.agent import Agent, AgentOrigin
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.task import Task, TaskConnectorRuntimeContext, TaskStatus
@@ -231,6 +231,37 @@ def test_webhook_trigger_crud_returns_secret_once() -> None:
     assert patched.status_code == 200, patched.text
     assert patched.json()["name"] == "Renamed webhook"
     assert patched.json()["webhook_secret"]
+
+
+def test_trigger_routes_reject_workforce_manager_agent() -> None:
+    # Workforce-generated manager agents are private implementation details
+    # and must not be addressable through trigger management, matching the
+    # exclusion applied by the share/widget/api-key channels.
+    headers = _admin_headers()
+    agent_id = _create_agent(headers, name="Workforce Manager Agent")
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.origin = AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+        db.commit()
+    finally:
+        db.close()
+
+    listed = client.get(f"/api/agents/{agent_id}/triggers", headers=headers)
+    assert listed.status_code == 404
+
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "webhook",
+            "name": "Inbound webhook",
+            "prompt_template": "payload={{payload}}",
+            "config": {"source": "crm"},
+        },
+    )
+    assert created.status_code == 404
 
 
 def test_trigger_config_validation_dispatches_through_provider() -> None:

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -240,17 +240,10 @@ def test_trigger_routes_reject_workforce_manager_agent() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers, name="Workforce Manager Agent")
 
-    db = _direct_db_session()
-    try:
-        agent = db.query(Agent).filter(Agent.id == agent_id).one()
-        agent.origin = AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
-        db.commit()
-    finally:
-        db.close()
-
-    listed = client.get(f"/api/agents/{agent_id}/triggers", headers=headers)
-    assert listed.status_code == 404
-
+    # Create a trigger while the agent is still a normal one, so the
+    # trigger-scoped routes below traverse ``get_owned_trigger``'s internal
+    # ``get_owned_agent`` guard rather than short-circuiting on a missing
+    # trigger row.
     created = client.post(
         f"/api/agents/{agent_id}/triggers",
         headers=headers,
@@ -261,7 +254,51 @@ def test_trigger_routes_reject_workforce_manager_agent() -> None:
             "config": {"source": "crm"},
         },
     )
-    assert created.status_code == 404
+    assert created.status_code == 200, created.text
+    trigger_id = int(created.json()["id"])
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.origin = AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+        db.commit()
+    finally:
+        db.close()
+
+    # Routes resolving the agent directly through ``get_owned_agent``.
+    listed = client.get(f"/api/agents/{agent_id}/triggers", headers=headers)
+    assert listed.status_code == 404
+
+    recreated = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "webhook",
+            "name": "Another webhook",
+            "prompt_template": "payload={{payload}}",
+            "config": {"source": "crm"},
+        },
+    )
+    assert recreated.status_code == 404
+
+    # Trigger-scoped routes gate through ``get_owned_trigger``, which relies
+    # on its internal ``get_owned_agent`` call for the same exclusion.
+    updated = client.patch(
+        f"/api/agents/{agent_id}/triggers/{trigger_id}",
+        headers=headers,
+        json={"name": "Renamed"},
+    )
+    assert updated.status_code == 404
+
+    runs = client.get(
+        f"/api/agents/{agent_id}/triggers/{trigger_id}/runs", headers=headers
+    )
+    assert runs.status_code == 404
+
+    deleted = client.delete(
+        f"/api/agents/{agent_id}/triggers/{trigger_id}", headers=headers
+    )
+    assert deleted.status_code == 404
 
 
 def test_trigger_config_validation_dispatches_through_provider() -> None:


### PR DESCRIPTION
## What

Add the workforce-generated manager agent exclusion to `get_owned_agent` in `src/xagent/web/services/triggers.py`, which resolves agent ownership for all trigger management operations (CRUD, listing, runs, test-fire).

## Why

Manager agents are private implementation details of a workforce. Every other externally-reachable channel already excludes them — `api/share.py`, `api/widget.py`, `api/v1/deps.py`, and `services/api_keys.py` (`_owned_agents_query`) — but trigger management did not, so triggers could be attached to a workforce manager agent. A trigger firing on a manager agent would build a plain `Task` without `workforce_run_id`, silently losing all worker delegation.

The fix applies the same SQL-level `Agent.origin != WORKFORCE_GENERATED_MANAGER` filter used by `AgentApiKeyService._owned_agents_query`, so all trigger routes now return 404 for manager agents.

## Testing

- New regression test `test_trigger_routes_reject_workforce_manager_agent` (list + create both 404).
- Full trigger suites pass: `test_agent_triggers.py`, `test_gmail_auto_triggers.py`, `test_trigger_payload_retention.py`, `test_trigger_rate_limits.py`, `test_trigger_audit.py`, `test_trigger_provider_pipeline.py`, `test_trigger_dispatcher_gmail_gate.py` (68 passed, 1 skipped requiring Postgres).
- `ruff format --check`, `ruff check`, `mypy` clean on changed files.

Closes #945. Part of #805.
