### PR TITLE
fix(runtime): isolate synchronous database work from async task execution

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -95,7 +95,12 @@ class AgentService:
         self._tool_policy_signature: Any | None = None
         if self._tools_initialized and self.tool_config:
             try:
-                self._tool_policy_signature = self._current_tool_policy_signature()
+                has_async_policy_refresh = callable(
+                    getattr(self.tool_config, "refresh_runtime_policy", None)
+                )
+                self._tool_policy_signature = self._current_tool_policy_signature(
+                    refresh_policy=not has_async_policy_refresh
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to capture initial tool policy signature for "
@@ -639,11 +644,27 @@ class AgentService:
                 ):
                     self.tool_config._workspace_config["task_id"] = self.id
 
-                policy_signature = self._current_tool_policy_signature()
+                refresh_runtime_policy = getattr(
+                    self.tool_config, "refresh_runtime_policy", None
+                )
+                if callable(refresh_runtime_policy):
+                    await refresh_runtime_policy()
+                    policy_signature = self._current_tool_policy_signature(
+                        refresh_policy=False
+                    )
+                else:
+                    policy_signature = self._current_tool_policy_signature()
                 if (
                     self._tools_initialized
                     and policy_signature == self._tool_policy_signature
                 ):
+                    release_factory_runtime = getattr(
+                        self.tool_config,
+                        "release_prepared_factory_runtime",
+                        None,
+                    )
+                    if callable(release_factory_runtime):
+                        release_factory_runtime()
                     return
 
                 # Rebuild the tool list so disabled tools disappear from reused agents.
@@ -675,7 +696,11 @@ class AgentService:
                     f"Tool initialization failed for AgentService '{self.name}': {exc}"
                 ) from exc
 
-    def _current_tool_policy_signature(self) -> tuple[Any, ...]:
+    def _current_tool_policy_signature(
+        self,
+        *,
+        refresh_policy: bool = True,
+    ) -> tuple[Any, ...]:
         if not self.tool_config:
             return ()
 
@@ -686,14 +711,14 @@ class AgentService:
         refresh_overrides = getattr(
             self.tool_config, "refresh_user_tool_overrides", None
         )
-        if callable(refresh_overrides):
+        if refresh_policy and callable(refresh_overrides):
             # Re-read the hook-backed policy before comparing signatures.
             refresh_overrides()
 
         refresh_allowlist = getattr(
             self.tool_config, "refresh_user_tool_allowlist", None
         )
-        if callable(refresh_allowlist):
+        if refresh_policy and callable(refresh_allowlist):
             # The CA allowlist is resolved from the active execution scope, so
             # it can change between turns even when the config is reused.
             refresh_allowlist()

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -3,6 +3,7 @@ Agent Tool - Convert published agents into callable tools
 """
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 from uuid import uuid4
@@ -237,6 +238,123 @@ def _string_override(overrides: Mapping[str, Any], *keys: str) -> Optional[str]:
         if isinstance(value, str) and value.strip():
             return value
     return None
+
+
+@dataclass(frozen=True)
+class PublishedAgentToolQueryPolicy:
+    """Detached, normalized policy for published-agent enumeration."""
+
+    injected_agent_ids: tuple[int, ...] | None
+    call_stack: tuple[int, ...]
+    excluded_agent_ids: tuple[int, ...]
+    include_draft: bool
+    draft_agent_ids: tuple[int, ...]
+    enable_global_agent_tools: bool
+    allow_cross_user_agent_ids: bool
+
+    @property
+    def query_required(self) -> bool:
+        if self.injected_agent_ids is not None:
+            return bool(self.injected_agent_ids)
+        return self.enable_global_agent_tools
+
+
+@dataclass(frozen=True)
+class PublishedAgentToolRecord:
+    """ORM-free fields needed to construct one published-agent tool."""
+
+    id: int
+    name: str
+    description: str | None
+    instructions: str | None
+    status: str
+
+
+def _resolve_published_agent_tool_policy(
+    *,
+    excluded_agent_id: Optional[int],
+    include_draft: bool,
+    draft_agent_ids_to_include: Optional[list[int]],
+    allowed_agent_ids: Optional[list[int]],
+    agent_tool_overrides: Optional[Mapping[Any, Any]],
+    enable_global_agent_tools: bool,
+    allow_cross_user_agent_ids: bool,
+    agent_call_stack: Optional[list[int]],
+) -> tuple[PublishedAgentToolQueryPolicy, dict[int, dict[str, Any]]]:
+    normalized_overrides = _normalize_agent_tool_overrides(agent_tool_overrides)
+    normalized_injected_agent_ids = _normalize_agent_ids(allowed_agent_ids)
+    normalized_call_stack = _normalize_agent_ids(agent_call_stack) or []
+    excluded_agent_ids = set(normalized_call_stack)
+
+    if excluded_agent_id is not None:
+        try:
+            excluded_agent_ids.add(int(excluded_agent_id))
+        except (TypeError, ValueError):
+            pass
+
+    if (
+        normalized_injected_agent_ids is None
+        and not enable_global_agent_tools
+        and normalized_overrides
+    ):
+        normalized_injected_agent_ids = list(normalized_overrides.keys())
+
+    if normalized_injected_agent_ids is not None:
+        normalized_injected_agent_ids = [
+            agent_id
+            for agent_id in normalized_injected_agent_ids
+            if agent_id not in excluded_agent_ids
+        ]
+
+    normalized_draft_agent_ids = _normalize_agent_ids(draft_agent_ids_to_include) or []
+    normalized_draft_agent_ids = [
+        agent_id
+        for agent_id in normalized_draft_agent_ids
+        if agent_id not in excluded_agent_ids
+    ]
+
+    return (
+        PublishedAgentToolQueryPolicy(
+            injected_agent_ids=(
+                tuple(normalized_injected_agent_ids)
+                if normalized_injected_agent_ids is not None
+                else None
+            ),
+            call_stack=tuple(normalized_call_stack),
+            excluded_agent_ids=tuple(sorted(excluded_agent_ids)),
+            include_draft=include_draft,
+            draft_agent_ids=tuple(normalized_draft_agent_ids),
+            enable_global_agent_tools=enable_global_agent_tools,
+            allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+        ),
+        normalized_overrides,
+    )
+
+
+def build_published_agent_tool_query_policy(
+    *,
+    excluded_agent_id: Optional[int] = None,
+    include_draft: bool = False,
+    draft_agent_ids_to_include: Optional[list[int]] = None,
+    allowed_agent_ids: Optional[list[int]] = None,
+    agent_tool_overrides: Optional[Mapping[Any, Any]] = None,
+    enable_global_agent_tools: bool = True,
+    allow_cross_user_agent_ids: bool = False,
+    agent_call_stack: Optional[list[int]] = None,
+) -> PublishedAgentToolQueryPolicy:
+    """Normalize construction inputs into an immutable worker-safe policy."""
+
+    policy, _ = _resolve_published_agent_tool_policy(
+        excluded_agent_id=excluded_agent_id,
+        include_draft=include_draft,
+        draft_agent_ids_to_include=draft_agent_ids_to_include,
+        allowed_agent_ids=allowed_agent_ids,
+        agent_tool_overrides=agent_tool_overrides,
+        enable_global_agent_tools=enable_global_agent_tools,
+        allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+        agent_call_stack=agent_call_stack,
+    )
+    return policy
 
 
 async def _missing_knowledge_bases_for_user(
@@ -1997,6 +2115,205 @@ class AgentTool(AbstractBaseTool):
             return AgentToolResult(response=error_msg).model_dump(exclude_none=True)
 
 
+def load_published_agent_tool_records(
+    db: Any,
+    *,
+    user_id: int,
+    policy: PublishedAgentToolQueryPolicy,
+) -> list[PublishedAgentToolRecord]:
+    """Load detached construction rows using the caller-owned DB session."""
+    from .....web.models.agent import Agent, AgentStatus
+
+    if not policy.query_required:
+        return []
+
+    normalized_injected_agent_ids = (
+        list(policy.injected_agent_ids)
+        if policy.injected_agent_ids is not None
+        else None
+    )
+    if normalized_injected_agent_ids is not None:
+        query = db.query(Agent).filter(
+            Agent.status.in_(["published"]),  # type: ignore[attr-defined]
+        )
+        query = _apply_agent_visibility_filters(
+            query,
+            Agent,
+            user_id=user_id,
+            allowed_agent_ids=normalized_injected_agent_ids,
+            allow_cross_user_agent_ids=policy.allow_cross_user_agent_ids,
+            db=db,
+        )
+        if query is None:
+            return []
+    elif policy.include_draft:
+        query = db.query(Agent).filter(
+            Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
+        )
+        query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id, db=db)
+    else:
+        query = db.query(Agent).filter(Agent.status == "published")
+        query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id, db=db)
+
+    if policy.excluded_agent_ids:
+        query = query.filter(Agent.id.notin_(policy.excluded_agent_ids))
+
+    agents = query.all()
+
+    if policy.draft_agent_ids:
+        draft_agents = _apply_owned_agent_tool_filters(
+            db.query(Agent).filter(
+                Agent.id.in_(policy.draft_agent_ids),
+                Agent.status == "draft",
+            ),
+            Agent,
+            user_id=user_id,
+            db=db,
+        ).all()
+        existing_ids = {agent.id for agent in agents}
+        for draft_agent in draft_agents:
+            if draft_agent.id not in existing_ids:
+                agents.append(draft_agent)
+
+    if normalized_injected_agent_ids is not None:
+        agent_types = "selected PUBLISHED"
+    else:
+        agent_types = "PUBLISHED and DRAFT" if policy.include_draft else "PUBLISHED"
+    logger.info(
+        "Found %s %s agents (excluded: %s)",
+        len(agents),
+        agent_types,
+        list(policy.excluded_agent_ids),
+    )
+
+    records: list[PublishedAgentToolRecord] = []
+    for agent in agents:
+        status = agent.status
+        records.append(
+            PublishedAgentToolRecord(
+                id=int(agent.id),
+                name=str(agent.name),
+                description=agent.description,
+                instructions=agent.instructions,
+                status=(
+                    status.value if isinstance(status, AgentStatus) else str(status)
+                ),
+            )
+        )
+    return records
+
+
+def build_published_agent_tools_from_records(
+    records: list[PublishedAgentToolRecord],
+    *,
+    session_factory: Any,
+    user_id: int,
+    task_id: Optional[str] = None,
+    workspace_base_dir: Optional[str] = None,
+    excluded_agent_id: Optional[int] = None,
+    include_draft: bool = False,
+    draft_agent_ids_to_include: Optional[list[int]] = None,
+    allowed_agent_ids: Optional[list[int]] = None,
+    agent_tool_overrides: Optional[Mapping[Any, Any]] = None,
+    enable_global_agent_tools: bool = True,
+    allow_cross_user_agent_ids: bool = False,
+    parent_task_id: Optional[str] = None,
+    parent_tracer: Optional[Any] = None,
+    agent_call_stack: Optional[list[int]] = None,
+    execution_scope: Optional[Any] = None,
+) -> list[AbstractBaseTool]:
+    """Construct AgentTool instances from ORM-free worker results."""
+    if workspace_base_dir is None:
+        workspace_base_dir = str(get_uploads_dir())
+
+    policy, normalized_overrides = _resolve_published_agent_tool_policy(
+        excluded_agent_id=excluded_agent_id,
+        include_draft=include_draft,
+        draft_agent_ids_to_include=draft_agent_ids_to_include,
+        allowed_agent_ids=allowed_agent_ids,
+        agent_tool_overrides=agent_tool_overrides,
+        enable_global_agent_tools=enable_global_agent_tools,
+        allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+        agent_call_stack=agent_call_stack,
+    )
+    normalized_injected_agent_ids = (
+        list(policy.injected_agent_ids)
+        if policy.injected_agent_ids is not None
+        else None
+    )
+    normalized_call_stack = list(policy.call_stack)
+    tools: list[AbstractBaseTool] = []
+
+    for agent in records:
+        override = normalized_overrides.get(agent.id, {})
+        description = agent.description or f"Call {agent.name} agent"
+        if agent.instructions:
+            instructions_preview = agent.instructions[:200]
+            if len(agent.instructions) > 200:
+                instructions_preview += "..."
+            description += f". Instructions: {instructions_preview}"
+
+        if agent.status == "draft":
+            description = f"[DRAFT] {description}"
+
+        tool_name = _string_override(override, "tool_name")
+        tool_description = _string_override(override, "description", "tool_description")
+        extra_system_prompt = _string_override(override, "extra_system_prompt")
+        delegation_allowed_agent_ids = (
+            _normalize_agent_ids(override.get("allowed_agent_ids"))
+            if "allowed_agent_ids" in override
+            else None
+        )
+        delegation_agent_tool_overrides = _normalize_agent_tool_overrides(
+            override.get("agent_tool_overrides")
+        )
+        delegation_enable_global_agent_tools = _truthy_bool(
+            override.get("enable_global_agent_tools"), True
+        )
+        delegation_allow_cross_user_agent_ids = _truthy_bool(
+            override.get("allow_cross_user_agent_ids"), False
+        )
+        runtime_metadata = {
+            key: override[key]
+            for key in (
+                "workforce_run_id",
+                "workforce_id",
+                "workforce_name",
+                "worker_member_id",
+                "worker_alias",
+            )
+            if key in override
+        }
+
+        tool = AgentTool(
+            agent_id=agent.id,
+            agent_name=agent.name,
+            agent_description=tool_description or description,
+            session_factory=session_factory,
+            user_id=user_id,
+            task_id=task_id,
+            workspace_base_dir=workspace_base_dir,
+            tool_name=tool_name,
+            tool_description=tool_description,
+            extra_system_prompt=extra_system_prompt,
+            parent_task_id=parent_task_id,
+            parent_tracer=parent_tracer,
+            agent_call_stack=normalized_call_stack,
+            delegation_allowed_agent_ids=delegation_allowed_agent_ids,
+            agent_tool_overrides=delegation_agent_tool_overrides,
+            enable_global_agent_tools=delegation_enable_global_agent_tools,
+            delegation_allow_cross_user_agent_ids=delegation_allow_cross_user_agent_ids,
+            target_allowed_agent_ids=normalized_injected_agent_ids,
+            target_allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+            runtime_metadata=runtime_metadata,
+            execution_scope=execution_scope,
+        )
+        tools.append(tool)
+        logger.debug("Created agent tool: %s", tool.name)
+
+    return tools
+
+
 def get_published_agents_tools(
     session_factory: Any,
     user_id: int,
@@ -2036,194 +2353,48 @@ def get_published_agents_tools(
     Returns:
         List of AgentTool instances
     """
-    from .....config import get_uploads_dir
-    from .....web.models.agent import Agent, AgentStatus
     from .db_session import tool_session_scope
 
-    if workspace_base_dir is None:
-        workspace_base_dir = str(get_uploads_dir())
-
-    tools: list[AbstractBaseTool] = []
-    normalized_overrides = _normalize_agent_tool_overrides(agent_tool_overrides)
-    normalized_injected_agent_ids = _normalize_agent_ids(allowed_agent_ids)
-    normalized_call_stack = _normalize_agent_ids(agent_call_stack) or []
-    excluded_agent_ids = set(normalized_call_stack)
-
-    if excluded_agent_id is not None:
-        try:
-            excluded_agent_ids.add(int(excluded_agent_id))
-        except (TypeError, ValueError):
-            pass
-
-    if (
-        normalized_injected_agent_ids is None
-        and not enable_global_agent_tools
-        and normalized_overrides
-    ):
-        normalized_injected_agent_ids = list(normalized_overrides.keys())
-
-    if normalized_injected_agent_ids is not None:
-        normalized_injected_agent_ids = [
-            agent_id
-            for agent_id in normalized_injected_agent_ids
-            if agent_id not in excluded_agent_ids
-        ]
-
     try:
+        policy = build_published_agent_tool_query_policy(
+            excluded_agent_id=excluded_agent_id,
+            include_draft=include_draft,
+            draft_agent_ids_to_include=draft_agent_ids_to_include,
+            allowed_agent_ids=allowed_agent_ids,
+            agent_tool_overrides=agent_tool_overrides,
+            enable_global_agent_tools=enable_global_agent_tools,
+            allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+            agent_call_stack=agent_call_stack,
+        )
         with tool_session_scope(session_factory) as db:
-            if normalized_injected_agent_ids is not None:
-                if not normalized_injected_agent_ids:
-                    return []
-                query = db.query(Agent).filter(
-                    Agent.status.in_(["published"]),  # type: ignore[attr-defined]
-                )
-                query = _apply_agent_visibility_filters(
-                    query,
-                    Agent,
-                    user_id=user_id,
-                    allowed_agent_ids=normalized_injected_agent_ids,
-                    allow_cross_user_agent_ids=allow_cross_user_agent_ids,
-                    db=db,
-                )
-                if query is None:
-                    return []
-            elif not enable_global_agent_tools:
-                return []
-            elif include_draft:
-                # Include both PUBLISHED and DRAFT agents
-                query = db.query(Agent).filter(
-                    Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
-                )
-                query = _apply_owned_agent_tool_filters(
-                    query, Agent, user_id=user_id, db=db
-                )
-            else:
-                # Only PUBLISHED agents
-                query = db.query(Agent).filter(
-                    Agent.status == "published",
-                )
-                query = _apply_owned_agent_tool_filters(
-                    query, Agent, user_id=user_id, db=db
-                )
-
-            # Exclude the active delegation stack to prevent recursive self-calls.
-            if excluded_agent_ids:
-                query = query.filter(Agent.id.notin_(sorted(excluded_agent_ids)))
-
-            agents = query.all()
-
-            # If specific DRAFT agents should be included, add them
-            if draft_agent_ids_to_include:
-                normalized_draft_agent_ids = _normalize_agent_ids(
-                    draft_agent_ids_to_include
-                )
-                normalized_draft_agent_ids = [
-                    agent_id
-                    for agent_id in (normalized_draft_agent_ids or [])
-                    if agent_id not in excluded_agent_ids
-                ]
-                # Skip the query entirely when nothing survives the exclusion
-                # filter, so we never issue an empty ``IN ()`` predicate.
-                if normalized_draft_agent_ids:
-                    draft_agents = _apply_owned_agent_tool_filters(
-                        db.query(Agent).filter(
-                            Agent.id.in_(normalized_draft_agent_ids),
-                            Agent.status == "draft",
-                        ),
-                        Agent,
-                        user_id=user_id,
-                        db=db,
-                    ).all()
-                    # Merge without duplicates
-                    existing_ids = {agent.id for agent in agents}
-                    for draft_agent in draft_agents:
-                        if draft_agent.id not in existing_ids:
-                            agents.append(draft_agent)
-
-            if normalized_injected_agent_ids is not None:
-                agent_types = "selected PUBLISHED"
-            else:
-                agent_types = "PUBLISHED and DRAFT" if include_draft else "PUBLISHED"
-            logger.info(
-                f"Found {len(agents)} {agent_types} agents (excluded: {sorted(excluded_agent_ids)})"
+            records = load_published_agent_tool_records(
+                db,
+                user_id=user_id,
+                policy=policy,
             )
 
-            for agent in agents:
-                override = normalized_overrides.get(int(agent.id or 0), {})
-                # Build description
-                description = agent.description or f"Call {agent.name} agent"
-                if agent.instructions:
-                    # Add brief instructions to description
-                    instructions_preview = agent.instructions[:200]
-                    if len(agent.instructions) > 200:
-                        instructions_preview += "..."
-                    description += f". Instructions: {instructions_preview}"
-
-                # Add status indicator for draft agents
-                if agent.status == AgentStatus.DRAFT:
-                    description = f"[DRAFT] {description}"
-
-                tool_name = _string_override(override, "tool_name")
-                tool_description = _string_override(
-                    override, "description", "tool_description"
-                )
-                extra_system_prompt = _string_override(override, "extra_system_prompt")
-                delegation_allowed_agent_ids = (
-                    _normalize_agent_ids(override.get("allowed_agent_ids"))
-                    if "allowed_agent_ids" in override
-                    else None
-                )
-                delegation_agent_tool_overrides = _normalize_agent_tool_overrides(
-                    override.get("agent_tool_overrides")
-                )
-                delegation_enable_global_agent_tools = _truthy_bool(
-                    override.get("enable_global_agent_tools"), True
-                )
-                delegation_allow_cross_user_agent_ids = _truthy_bool(
-                    override.get("allow_cross_user_agent_ids"), False
-                )
-                runtime_metadata = {
-                    key: override[key]
-                    for key in (
-                        "workforce_run_id",
-                        "workforce_id",
-                        "workforce_name",
-                        "worker_member_id",
-                        "worker_alias",
-                    )
-                    if key in override
-                }
-
-                tool = AgentTool(
-                    agent_id=agent.id,
-                    agent_name=agent.name,
-                    agent_description=tool_description or description,
-                    session_factory=session_factory,
-                    user_id=user_id,
-                    task_id=task_id,
-                    workspace_base_dir=workspace_base_dir,
-                    tool_name=tool_name,
-                    tool_description=tool_description,
-                    extra_system_prompt=extra_system_prompt,
-                    parent_task_id=parent_task_id,
-                    parent_tracer=parent_tracer,
-                    agent_call_stack=normalized_call_stack,
-                    delegation_allowed_agent_ids=delegation_allowed_agent_ids,
-                    agent_tool_overrides=delegation_agent_tool_overrides,
-                    enable_global_agent_tools=delegation_enable_global_agent_tools,
-                    delegation_allow_cross_user_agent_ids=delegation_allow_cross_user_agent_ids,
-                    target_allowed_agent_ids=normalized_injected_agent_ids,
-                    target_allow_cross_user_agent_ids=allow_cross_user_agent_ids,
-                    runtime_metadata=runtime_metadata,
-                    execution_scope=execution_scope,
-                )
-                tools.append(tool)
-                logger.debug(f"Created agent tool: {tool.name}")
+        return build_published_agent_tools_from_records(
+            records,
+            session_factory=session_factory,
+            user_id=user_id,
+            task_id=task_id,
+            workspace_base_dir=workspace_base_dir,
+            excluded_agent_id=excluded_agent_id,
+            include_draft=include_draft,
+            draft_agent_ids_to_include=draft_agent_ids_to_include,
+            allowed_agent_ids=allowed_agent_ids,
+            agent_tool_overrides=agent_tool_overrides,
+            enable_global_agent_tools=enable_global_agent_tools,
+            allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+            parent_task_id=parent_task_id,
+            parent_tracer=parent_tracer,
+            agent_call_stack=agent_call_stack,
+            execution_scope=execution_scope,
+        )
 
     except Exception as e:
         logger.error(f"Failed to load agents as tools: {e}", exc_info=True)
-
-    return tools
+        return []
 
 
 # Register tool creator for auto-discovery
@@ -2263,8 +2434,7 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             return []
 
         excluded_agent_id = config.get_excluded_agent_id() if config else None
-
-        return get_published_agents_tools(
+        construction_kwargs: dict[str, Any] = dict(
             session_factory=session_factory,
             user_id=user_id,
             task_id=config.get_task_id(),
@@ -2282,6 +2452,15 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             if hasattr(config, "get_execution_scope")
             else None,
         )
+        records_getter = getattr(config, "get_published_agent_tool_records", None)
+        records = records_getter() if callable(records_getter) else None
+        if isinstance(records, (list, tuple)):
+            return build_published_agent_tools_from_records(
+                list(records),
+                **construction_kwargs,
+            )
+
+        return get_published_agents_tools(**construction_kwargs)
     except Exception as e:
         logger.warning(f"Failed to create agent tools: {e}")
         return []

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -331,6 +331,10 @@ class BaseToolConfig(ABC):
         """Get per-agent tool metadata/runtime overrides for delegation."""
         return {}
 
+    def get_published_agent_tool_records(self) -> Optional[List[Any]]:
+        """Return detached published-agent construction rows when prefetched."""
+        return None
+
     def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
         """Get remote A2A agent tool configurations.
 

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -283,6 +283,26 @@ class ToolFactory:
     async def create_all_tools(
         config: BaseToolConfig, apply_user_override_filter: bool = True
     ) -> List[Tool]:
+        """Create tools within the config's optional prepared-runtime boundary."""
+        prepare_factory_runtime = getattr(type(config), "prepare_factory_runtime", None)
+        release_factory_runtime = getattr(
+            type(config), "release_prepared_factory_runtime", None
+        )
+        if callable(prepare_factory_runtime):
+            await prepare_factory_runtime(config)
+        try:
+            return await ToolFactory._create_all_tools_prepared(
+                config,
+                apply_user_override_filter=apply_user_override_filter,
+            )
+        finally:
+            if callable(release_factory_runtime):
+                release_factory_runtime(config)
+
+    @staticmethod
+    async def _create_all_tools_prepared(
+        config: BaseToolConfig, apply_user_override_filter: bool = True
+    ) -> List[Tool]:
         """
         Create all tools based on configuration.
 

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -1,5 +1,6 @@
 """Core document search functionality for RAG pipelines."""
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -37,8 +38,11 @@ async def _list_visible_collections(
     collections_by_name = {
         collection.name: collection for collection in result.collections
     }
+    team_refs = await asyncio.to_thread(
+        visible_team_knowledge_bases, None, int(user_id)
+    )
     refs_by_owner: dict[int, list] = {}
-    for ref in visible_team_knowledge_bases(None, int(user_id)):
+    for ref in team_refs:
         refs_by_owner.setdefault(ref.storage_user_id, []).append(ref)
     for storage_user_id, refs in refs_by_owner.items():
         owner_result = await list_collections(user_id=storage_user_id, is_admin=False)

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from copy import deepcopy
+from dataclasses import dataclass, replace
 from datetime import datetime
 from time import monotonic
-from typing import Any, Mapping, Tuple
+from types import MappingProxyType
+from typing import Any, Mapping
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import String, and_, cast, false, func, or_
+from sqlalchemy import String, and_, cast, false, or_
 from sqlalchemy.orm import Session
 
-from ..models.agent import Agent
-from ..models.agent_api_key import AgentApiKey
+from ...core.execution_scope import resolve_execution_scope
+from ..models.agent import Agent, AgentStatus
 from ..models.database import get_db, get_session_local
 from ..models.task import Task, TaskStatus
 from ..services.a2a_protocol import (
@@ -33,6 +37,12 @@ from ..services.a2a_protocol import (
     task_state,
     task_to_a2a,
 )
+from ..services.api_keys import AgentApiIdentity
+from ..services.db_runtime import (
+    drain_async_task_cancellation_safe,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
+)
 from ..services.task_command_transport import (
     COMMAND_COMPLETED,
     COMMAND_FAILED,
@@ -47,17 +57,28 @@ from ..services.task_execution_controller import (
     apply_task_control_transition,
     task_execution_controller,
 )
+from ..services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    acquire_task_lease_no_commit,
+    release_task_lease_no_commit,
+    run_task_lease_heartbeat,
+    stop_task_lease_heartbeat,
+)
 from ..services.task_orchestrator import (
+    TaskCreationSpec,
     TaskTurnError,
     TaskTurnNotFoundError,
     TaskTurnOrchestrator,
     TaskTurnPayload,
     TurnKind,
 )
+from ..services.task_setup_snapshot import load_task_setup_snapshot_sync
 from .v1.deps import get_agent_from_api_key, record_key_usage
 from .v1.errors import V1ApiError
 
 router = APIRouter(prefix="/api/a2a", tags=["a2a"])
+logger = logging.getLogger(__name__)
 _bearer = HTTPBearer(auto_error=False)
 _TERMINAL_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
 _STREAM_END_STATUSES = _TERMINAL_STATUSES | {
@@ -80,14 +101,70 @@ _A2A_TASK_STATUS_MAP: dict[str, tuple[TaskStatus, ...]] = {
 }
 
 
+@dataclass(frozen=True)
+class _A2ATaskSnapshot:
+    """Session-independent fields consumed by A2A response/poll helpers."""
+
+    id: int
+    status: TaskStatus
+    updated_at: datetime | None
+    output: str | None
+    error_message: str | None
+    agent_config: Mapping[str, Any]
+    run_id: str | None
+
+
+@dataclass(frozen=True)
+class _A2ATurnPreparation:
+    task: _A2ATaskSnapshot
+    waiting_for_user: bool
+
+
+@dataclass(frozen=True)
+class _A2ACancelPreparation:
+    """Detached command identity produced by the cancel DB transaction."""
+
+    command_db_id: int
+    command_identity: str
+
+
+def _request_identity(
+    path_agent_id: int,
+    identity: AgentApiIdentity,
+) -> AgentApiIdentity:
+    _require_bound_agent(path_agent_id, identity)
+    return identity
+
+
+def _task_snapshot(task: Task) -> _A2ATaskSnapshot:
+    raw_status = task.status
+    status = (
+        raw_status if isinstance(raw_status, TaskStatus) else TaskStatus(raw_status)
+    )
+    raw_config: Mapping[str, Any] = (
+        task.agent_config if isinstance(task.agent_config, Mapping) else {}
+    )
+    raw_updated_at = getattr(task, "updated_at", None)
+    return _A2ATaskSnapshot(
+        id=int(task.id),
+        status=status,
+        updated_at=(raw_updated_at if isinstance(raw_updated_at, datetime) else None),
+        output=str(task.output) if task.output is not None else None,
+        error_message=(
+            str(task.error_message) if task.error_message is not None else None
+        ),
+        agent_config=MappingProxyType(deepcopy(dict(raw_config))),
+        run_id=str(task.run_id) if task.run_id is not None else None,
+    )
+
+
 async def _get_a2a_agent_from_api_key(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
-    db: Session = Depends(get_db),
-) -> Tuple[Agent, AgentApiKey]:
+) -> AgentApiIdentity:
     _validate_a2a_version(request)
     try:
-        return await get_agent_from_api_key(credentials, db)
+        return await get_agent_from_api_key(credentials)
     except V1ApiError as exc:
         raise a2a_error(
             "invalid_api_key",
@@ -104,11 +181,19 @@ def _resolve_published_agent(db: Session, agent_id: int) -> Agent:
 
 
 def _resolve_a2a_task(db: Session, task_id: int, agent: Agent) -> Task:
+    return _resolve_a2a_task_for_agent_id(db, task_id, int(agent.id))
+
+
+def _resolve_a2a_task_for_agent_id(
+    db: Session,
+    task_id: int,
+    agent_id: int,
+) -> Task:
     task = (
         db.query(Task)
         .filter(
             Task.id == task_id,
-            Task.agent_id == int(agent.id),
+            Task.agent_id == agent_id,
             Task.source == "a2a",
         )
         .first()
@@ -123,8 +208,11 @@ def _task_run_id(task: Task) -> str | None:
     return str(run_id) if run_id is not None else None
 
 
-def _require_bound_agent(path_agent_id: int, agent: Agent) -> None:
-    if int(agent.id) != int(path_agent_id) or not is_published_agent(agent):
+def _require_bound_agent(path_agent_id: int, identity: AgentApiIdentity) -> None:
+    if (
+        identity.agent_id != int(path_agent_id)
+        or identity.status != AgentStatus.PUBLISHED.value
+    ):
         raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
 
 
@@ -134,6 +222,7 @@ def _schedule_waiting_a2a_resume(
     agent_service: Any,
     task_owner_user_id: int,
     run_id: str | None,
+    resolved_execution_scope: Any,
 ) -> None:
     from .websocket import background_task_manager, execute_resume_background
 
@@ -149,6 +238,7 @@ def _schedule_waiting_a2a_resume(
                 task_owner_user_id=task_owner_user_id,
                 expected_run_id=run_id,
                 previous_task=previous_task,
+                resolved_execution_scope=resolved_execution_scope,
             )
         )
         background_task_manager.register_reserved_resume(task_id, bg_task)
@@ -159,114 +249,309 @@ def _schedule_waiting_a2a_resume(
         raise
 
 
-def _restore_waiting_resume_claim(db: Session, task_id: int) -> None:
-    db.rollback()
-    (
-        db.query(Task)
-        .filter(
-            Task.id == task_id,
-            Task.status == TaskStatus.RUNNING,
-            Task.runner_id.is_(None),
+def _restore_waiting_resume_claim(
+    task_id: int,
+    agent_id: int,
+    lease: TaskLease,
+) -> bool:
+    """Release exactly one failed A2A resume claim back to WAITING."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        claimed = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "a2a",
+                Task.status == TaskStatus.RUNNING,
+                Task.runner_id == lease.runner_id,
+                Task.run_id == lease.run_id,
+            )
+            .with_for_update()
+            .first()
         )
-        .update(
-            {
-                Task.status: TaskStatus.WAITING_FOR_USER,
-                Task.control_state: TaskControlState.WAITING_FOR_USER.value,
-                Task.state_version: func.coalesce(Task.state_version, 0) + 1,
-            },
-            synchronize_session=False,
+        if claimed is None:
+            db.rollback()
+            return False
+        released = release_task_lease_no_commit(
+            db,
+            lease,
+            status=TaskStatus.WAITING_FOR_USER,
         )
-    )
-    db.commit()
-    db.expire_all()
+        if not released:
+            db.rollback()
+            return False
+        db.commit()
+        return True
+
+
+def _claim_waiting_a2a_resume(task_id: int, agent_id: int) -> TaskLease:
+    """Atomically claim one WAITING task with a fenced, expiring lease."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "a2a",
+            )
+            .with_for_update()
+            .first()
+        )
+        if task is None:
+            raise a2a_error("task_not_found", "Task not found.", status_code=404)
+        if task.status != TaskStatus.WAITING_FOR_USER:
+            raise a2a_error(
+                "unsupported_operation",
+                "Task is currently running and cannot accept a new message.",
+                status_code=400,
+                details={"taskId": task_id},
+            )
+        lease = acquire_task_lease_no_commit(
+            db,
+            task_id,
+            expected_run_id=_task_run_id(task),
+        )
+        if lease is None:
+            db.rollback()
+            raise a2a_error(
+                "unsupported_operation",
+                "Task is currently running and cannot accept a new message.",
+                status_code=400,
+                details={"taskId": task_id},
+            )
+        db.commit()
+        return lease
+
+
+def _finalize_waiting_a2a_resume(
+    *,
+    task_id: int,
+    agent_id: int,
+    text: str,
+    posted: bool,
+    lease: TaskLease,
+) -> _A2ATaskSnapshot:
+    """Persist the checkpoint result without reusing the request Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "a2a",
+                Task.status == TaskStatus.RUNNING,
+                Task.runner_id == lease.runner_id,
+                Task.run_id == lease.run_id,
+            )
+            .with_for_update()
+            .first()
+        )
+        if task is None:
+            raise RuntimeError(
+                f"Task {task_id} A2A resume claim is no longer owned by this run"
+            )
+        if not posted:
+            # A WAITING_FOR_USER checkpoint should normally be durable. If it is
+            # unavailable, retain the previous restart-safe behavior by starting a
+            # new turn from transcript history instead of leaving the task stuck.
+            released = release_task_lease_no_commit(
+                db,
+                lease,
+                status=TaskStatus.PAUSED,
+            )
+            if not released:
+                db.rollback()
+                raise RuntimeError(
+                    f"Task {task_id} A2A resume lease changed before fallback"
+                )
+        else:
+            setattr(task, "input", text)
+            setattr(task, "output", None)
+            setattr(task, "error_message", None)
+        db.commit()
+        db.refresh(task)
+        return _task_snapshot(task)
 
 
 async def _resume_waiting_a2a_task(
     *,
-    db: Session,
-    agent: Agent,
-    task: Task,
+    task_id: int,
+    agent_id: int,
+    task_owner_user_id: int,
     text: str,
     message_id: str,
-) -> bool:
-    task_id = int(task.id)
-    claimed = (
-        db.query(Task)
-        .filter(
-            Task.id == task_id,
-            Task.agent_id == int(agent.id),
-            Task.source == "a2a",
-            Task.status == TaskStatus.WAITING_FOR_USER,
-        )
-        .update(
-            {
-                Task.status: TaskStatus.RUNNING,
-                Task.runner_id: None,
-                Task.lease_expires_at: None,
-                Task.last_heartbeat_at: None,
-                Task.control_state: TaskControlState.RESUME_REQUESTED.value,
-                Task.state_version: func.coalesce(Task.state_version, 0) + 1,
-            },
-            synchronize_session=False,
-        )
+) -> tuple[bool, _A2ATaskSnapshot]:
+    scope = await run_db_io_cancellation_safe(lambda: resolve_execution_scope(task_id))
+    setup_snapshot = await run_db_io_cancellation_safe(
+        lambda: load_task_setup_snapshot_sync(task_id, task_owner_user_id)
     )
-    db.commit()
-    if claimed != 1:
-        db.expire_all()
-        raise a2a_error(
-            "unsupported_operation",
-            "Task is currently running and cannot accept a new message.",
-            status_code=400,
-            details={"taskId": task_id},
-        )
-    db.refresh(task)
+    if setup_snapshot is None:
+        raise a2a_error("task_not_found", "Task not found.", status_code=404)
 
-    try:
-        from .chat import get_agent_manager
+    from .chat import get_agent_manager
 
-        agent_service = await get_agent_manager().get_agent_for_task(
-            task_id,
-            db,
-            task_owner_user_id=int(agent.user_id),
-        )
-        posted = await agent_service.post_user_message(
-            str(task_id),
-            execution_message=text,
-            display_message=text,
-            turn_id=f"a2a:{task_id}:{message_id}",
-            request_interrupt=False,
-            reason="A2A input-required response",
-        )
-    except Exception:
-        _restore_waiting_resume_claim(db, task_id)
-        raise
-
-    if not posted:
-        # A WAITING_FOR_USER checkpoint should normally be durable. If it is
-        # unavailable, retain the previous restart-safe behavior by starting a
-        # new turn from transcript history instead of leaving the task stuck.
-        apply_task_control_transition(
-            task,
-            TaskControlState.PAUSED,
-            status=TaskStatus.PAUSED,
-            expected_run_id=_task_run_id(task),
-        )
-        db.commit()
-        db.refresh(task)
-        return False
-
-    setattr(task, "input", text)
-    setattr(task, "output", None)
-    setattr(task, "error_message", None)
-    db.commit()
-    db.refresh(task)
-    _schedule_waiting_a2a_resume(
-        task_id=task_id,
-        agent_service=agent_service,
-        task_owner_user_id=int(agent.user_id),
-        run_id=_task_run_id(task),
+    agent_service = await get_agent_manager().get_agent_for_task(
+        task_id,
+        None,
+        user=setup_snapshot.runtime_user,
+        task_setup_snapshot=setup_snapshot,
+        task_owner_user_id=task_owner_user_id,
+        resolved_execution_scope=scope,
     )
-    return True
+
+    async def claim_finalize_and_schedule() -> tuple[bool, _A2ATaskSnapshot]:
+        lease = await run_db_io_cancellation_safe(
+            lambda: _claim_waiting_a2a_resume(task_id, agent_id)
+        )
+        heartbeat_stop_event = asyncio.Event()
+        heartbeat_task: asyncio.Task[TaskLeaseHeartbeatOutcome] | None = (
+            asyncio.create_task(run_task_lease_heartbeat(lease, heartbeat_stop_event))
+        )
+
+        async def stop_claim_heartbeat() -> TaskLeaseHeartbeatOutcome:
+            nonlocal heartbeat_task
+            task = heartbeat_task
+            if task is None:
+                return TaskLeaseHeartbeatOutcome()
+            outcome = await stop_task_lease_heartbeat(task, heartbeat_stop_event)
+            heartbeat_task = None
+            return outcome
+
+        def raise_if_heartbeat_unhealthy(
+            outcome: TaskLeaseHeartbeatOutcome,
+            *,
+            component: str,
+        ) -> None:
+            if not outcome.requires_ttl_recovery:
+                return
+            logger.error(
+                "task_id=%s component=%s A2A resume lease heartbeat is "
+                "unhealthy; retaining the exact claim for TTL recovery "
+                "(lost=%s, pool_timeout=%s)",
+                task_id,
+                component,
+                outcome.lease_lost,
+                outcome.pool_timeout is not None,
+            )
+            if outcome.pool_timeout is not None:
+                raise outcome.pool_timeout
+            raise RuntimeError(
+                f"Task {task_id} A2A resume lease heartbeat lost ownership"
+            )
+
+        async def restore_after(error: BaseException, component: str) -> None:
+            if is_database_pool_timeout(error):
+                logger.error(
+                    "task_id=%s component=%s database pool checkout timed out; "
+                    "retaining A2A resume lease for TTL recovery: %s",
+                    task_id,
+                    component,
+                    error,
+                    exc_info=True,
+                )
+                return
+            await run_db_io_cancellation_safe(
+                lambda: _restore_waiting_resume_claim(
+                    task_id,
+                    agent_id,
+                    lease,
+                )
+            )
+
+        try:
+            # Let the heartbeat coroutine enter its wait before yielding to the
+            # external checkpoint post. The lease must remain renewable for the
+            # whole await; otherwise a second runner can take over the same run
+            # while this runner still injects the user message.
+            await asyncio.sleep(0)
+            if heartbeat_task is not None and heartbeat_task.done():
+                raise_if_heartbeat_unhealthy(
+                    heartbeat_task.result(),
+                    component="a2a-resume-heartbeat",
+                )
+            try:
+                posted = await agent_service.post_user_message(
+                    str(task_id),
+                    execution_message=text,
+                    display_message=text,
+                    turn_id=f"a2a:{task_id}:{message_id}",
+                    request_interrupt=False,
+                    reason="A2A input-required response",
+                )
+            except BaseException as exc:
+                heartbeat_outcome = await stop_claim_heartbeat()
+                if heartbeat_outcome.requires_ttl_recovery:
+                    raise_if_heartbeat_unhealthy(
+                        heartbeat_outcome,
+                        component="a2a-resume-heartbeat",
+                    )
+                await restore_after(exc, "a2a-resume-post")
+                raise
+
+            heartbeat_outcome = await stop_claim_heartbeat()
+            raise_if_heartbeat_unhealthy(
+                heartbeat_outcome,
+                component="a2a-resume-heartbeat",
+            )
+
+            try:
+                finalized = await run_db_io_cancellation_safe(
+                    lambda: _finalize_waiting_a2a_resume(
+                        task_id=task_id,
+                        agent_id=agent_id,
+                        text=text,
+                        posted=posted,
+                        lease=lease,
+                    )
+                )
+            except BaseException as exc:
+                await restore_after(exc, "a2a-resume-finalize")
+                raise
+
+            if not posted:
+                return False, finalized
+
+            try:
+                _schedule_waiting_a2a_resume(
+                    task_id=task_id,
+                    agent_service=agent_service,
+                    task_owner_user_id=task_owner_user_id,
+                    run_id=lease.run_id,
+                    resolved_execution_scope=scope,
+                )
+            except BaseException as exc:
+                await restore_after(exc, "a2a-resume-schedule")
+                raise
+            return True, finalized
+        finally:
+            if heartbeat_task is not None:
+                try:
+                    outcome = await stop_claim_heartbeat()
+                    if outcome.requires_ttl_recovery:
+                        logger.error(
+                            "task_id=%s component=a2a-resume-heartbeat "
+                            "cleanup retained the exact claim for TTL recovery "
+                            "(lost=%s, pool_timeout=%s)",
+                            task_id,
+                            outcome.lease_lost,
+                            outcome.pool_timeout is not None,
+                        )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "Failed to stop A2A resume claim heartbeat for task %s",
+                        task_id,
+                    )
+
+    workflow = asyncio.create_task(claim_finalize_and_schedule())
+    return await drain_async_task_cancellation_safe(workflow)
 
 
 def _validate_a2a_version(request: Request) -> None:
@@ -344,17 +629,19 @@ def _validate_send_configuration(body: Mapping[str, Any]) -> bool:
 
 async def _start_a2a_turn(
     *,
-    db: Session,
-    agent: Agent,
+    agent_id: int,
+    task_owner_user_id: int,
+    execution_mode: str | None,
     text: str,
     message_id: str,
     context_id: str | None,
     task_id: int | None,
-) -> Task:
-    async def start_unserialized() -> Task:
+) -> _A2ATaskSnapshot:
+    async def start_unserialized() -> _A2ATaskSnapshot:
         return await _start_a2a_turn_unserialized(
-            db=db,
-            agent=agent,
+            agent_id=agent_id,
+            task_owner_user_id=task_owner_user_id,
+            execution_mode=execution_mode,
             text=text,
             message_id=message_id,
             context_id=context_id,
@@ -369,35 +656,143 @@ async def _start_a2a_turn(
 
 async def _start_a2a_turn_unserialized(
     *,
-    db: Session,
-    agent: Agent,
+    agent_id: int,
+    task_owner_user_id: int,
+    execution_mode: str | None,
     text: str,
     message_id: str,
     context_id: str | None,
     task_id: int | None,
-) -> Task:
-    created_task = task_id is None
-    normalized_waiting_task = False
+) -> _A2ATaskSnapshot:
+    payload = TaskTurnPayload(transcript_message=text)
     if task_id is None:
-        context_id = context_id or new_context_id()
-        task = Task(
-            user_id=int(agent.user_id),
-            title=(text[:50] or "A2A task"),
-            description=text,
-            status=TaskStatus.PENDING,
-            agent_id=int(agent.id),
-            input=text,
-            source="a2a",
-            is_visible=False,
-            execution_mode=agent.execution_mode,
-            agent_config={"a2a_context_id": context_id},
+        resolved_context_id = context_id or new_context_id()
+        try:
+            started = await TaskTurnOrchestrator.create_and_begin_turn(
+                creation=TaskCreationSpec(
+                    task_owner_user_id=task_owner_user_id,
+                    title=(text[:50] or "A2A task"),
+                    description=text,
+                    agent_id=agent_id,
+                    execution_mode=execution_mode,
+                    source="a2a",
+                    is_visible=False,
+                    agent_config={"a2a_context_id": resolved_context_id},
+                ),
+                payload=payload,
+                actor_user_id=task_owner_user_id,
+            )
+        except TaskTurnNotFoundError as exc:
+            raise a2a_error(
+                "task_not_found", "Task not found.", status_code=404
+            ) from exc
+        except TaskTurnError as exc:
+            raise a2a_error(
+                "unsupported_operation",
+                "Task is currently running and cannot accept a new message.",
+                status_code=400,
+            ) from exc
+        return _A2ATaskSnapshot(
+            id=started.task_id,
+            status=started.status,
+            updated_at=started.updated_at,
+            output=None,
+            error_message=None,
+            agent_config=MappingProxyType({"a2a_context_id": resolved_context_id}),
+            run_id=started.run_id or None,
         )
-        db.add(task)
-        db.commit()
-        db.refresh(task)
-        kind = TurnKind.CREATE
-    else:
-        task = _resolve_a2a_task(db, task_id, agent)
+
+    prepared = await run_db_io_cancellation_safe(
+        lambda: _prepare_existing_a2a_turn(
+            agent_id=agent_id,
+            context_id=context_id,
+            task_id=task_id,
+        )
+    )
+    task = prepared.task
+    normalized_waiting_task = False
+    if prepared.waiting_for_user:
+        # Resume the trace-backed checkpoint so DAG/React step state is
+        # preserved across workers and restarts. Only a missing checkpoint
+        # falls back to the durable APPEND/replan path.
+        resumed, task = await _resume_waiting_a2a_task(
+            task_id=task.id,
+            agent_id=agent_id,
+            task_owner_user_id=task_owner_user_id,
+            text=text,
+            message_id=message_id,
+        )
+        if resumed:
+            return task
+        normalized_waiting_task = True
+
+    try:
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=task.id,
+            task_owner_user_id=task_owner_user_id,
+            actor_user_id=task_owner_user_id,
+            payload=payload,
+            kind=TurnKind.APPEND,
+            force_fresh=False,
+        )
+    except TaskTurnNotFoundError as exc:
+        await run_db_io_cancellation_safe(
+            lambda: _recover_failed_turn_start(
+                task.id,
+                restore_waiting=normalized_waiting_task,
+            )
+        )
+        raise a2a_error("task_not_found", "Task not found.", status_code=404) from exc
+    except TaskTurnError as exc:
+        await run_db_io_cancellation_safe(
+            lambda: _recover_failed_turn_start(
+                task.id,
+                restore_waiting=normalized_waiting_task,
+            )
+        )
+        raise a2a_error(
+            "unsupported_operation",
+            "Task is currently running and cannot accept a new message.",
+            status_code=400,
+            details={"taskId": task.id},
+        ) from exc
+    except Exception as exc:
+        if not is_database_pool_timeout(exc):
+            await run_db_io_cancellation_safe(
+                lambda: _recover_failed_turn_start(
+                    task.id,
+                    restore_waiting=normalized_waiting_task,
+                )
+            )
+        else:
+            logger.error(
+                "task_id=%s component=a2a-turn-start database pool checkout "
+                "timed out; skipping immediate recovery checkout",
+                task.id,
+            )
+        raise
+
+    return replace(
+        task,
+        status=started.status,
+        updated_at=started.updated_at,
+        output=None,
+        error_message=None,
+        run_id=started.run_id or None,
+    )
+
+
+def _prepare_existing_a2a_turn(
+    *,
+    agent_id: int,
+    context_id: str | None,
+    task_id: int,
+) -> _A2ATurnPreparation:
+    """Validate an existing A2A turn using one worker-owned Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _resolve_a2a_task_for_agent_id(db, task_id, agent_id)
         if task.status in _TERMINAL_STATUSES:
             raise a2a_error(
                 "unsupported_operation",
@@ -413,97 +808,38 @@ async def _start_a2a_turn_unserialized(
                 status_code=400,
                 details={"taskId": task.id, "contextId": context_id},
             )
-        context_id = stored_context_id
         agent_config: dict[str, Any] = (
-            dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+            dict(task.agent_config) if isinstance(task.agent_config, Mapping) else {}
         )
         if not agent_config.get("a2a_context_id"):
-            agent_config["a2a_context_id"] = context_id
+            agent_config["a2a_context_id"] = stored_context_id
             setattr(task, "agent_config", agent_config)
             db.commit()
             db.refresh(task)
-        if task.status == TaskStatus.WAITING_FOR_USER:
-            # Resume the trace-backed checkpoint so DAG/React step state is
-            # preserved across workers and restarts. Only a missing checkpoint
-            # falls back to the durable APPEND/replan path.
-            if await _resume_waiting_a2a_task(
-                db=db,
-                agent=agent,
-                task=task,
-                text=text,
-                message_id=message_id,
-            ):
-                return task
-            normalized_waiting_task = True
-        kind = TurnKind.APPEND
-
-    payload = TaskTurnPayload(transcript_message=text)
-    try:
-        await TaskTurnOrchestrator.begin_turn(
-            task_id=int(task.id),
-            task_owner_user_id=int(agent.user_id),
-            actor_user_id=int(agent.user_id),
-            payload=payload,
-            kind=kind,
-            force_fresh=False,
+        return _A2ATurnPreparation(
+            task=_task_snapshot(task),
+            waiting_for_user=task.status == TaskStatus.WAITING_FOR_USER,
         )
-    except TaskTurnNotFoundError as exc:
-        _recover_failed_turn_start(
-            db,
-            int(task.id),
-            created_task=created_task,
-            restore_waiting=normalized_waiting_task,
-        )
-        raise a2a_error("task_not_found", "Task not found.", status_code=404) from exc
-    except TaskTurnError as exc:
-        _recover_failed_turn_start(
-            db,
-            int(task.id),
-            created_task=created_task,
-            restore_waiting=normalized_waiting_task,
-        )
-        raise a2a_error(
-            "unsupported_operation",
-            "Task is currently running and cannot accept a new message.",
-            status_code=400,
-            details={"taskId": task.id},
-        ) from exc
-    except Exception:
-        _recover_failed_turn_start(
-            db,
-            int(task.id),
-            created_task=created_task,
-            restore_waiting=normalized_waiting_task,
-        )
-        raise
-
-    db.expire_all()
-    return _resolve_a2a_task(db, int(task.id), agent)
 
 
 def _recover_failed_turn_start(
-    db: Session,
     task_id: int,
     *,
-    created_task: bool,
     restore_waiting: bool,
 ) -> None:
-    db.expire_all()
-    task = db.query(Task).filter(Task.id == task_id).first()
-    if task is None:
-        return
-    if created_task and task.status == TaskStatus.PENDING:
-        db.delete(task)
-        db.commit()
-        return
-    if restore_waiting and task.status == TaskStatus.PAUSED:
-        apply_task_control_transition(
-            task,
-            TaskControlState.WAITING_FOR_USER,
-            status=TaskStatus.WAITING_FOR_USER,
-            expected_run_id=_task_run_id(task),
-        )
-        db.commit()
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            return
+        if restore_waiting and task.status == TaskStatus.PAUSED:
+            apply_task_control_transition(
+                task,
+                TaskControlState.WAITING_FOR_USER,
+                status=TaskStatus.WAITING_FOR_USER,
+                expected_run_id=_task_run_id(task),
+            )
+            db.commit()
 
 
 async def _json_body(request: Request) -> Mapping[str, Any]:
@@ -545,12 +881,14 @@ def _message_id(message: Mapping[str, Any]) -> str:
     )
 
 
-def _fetch_fresh_a2a_task(agent_id: int, task_id: int) -> Task | None:
+def _fetch_fresh_a2a_task_sync(
+    agent_id: int,
+    task_id: int,
+) -> _A2ATaskSnapshot | None:
     session_local = get_session_local()
-    local_db = session_local()
-    try:
-        fresh = (
-            local_db.query(Task)
+    with session_local() as db:
+        task = (
+            db.query(Task)
             .filter(
                 Task.id == task_id,
                 Task.agent_id == agent_id,
@@ -558,15 +896,23 @@ def _fetch_fresh_a2a_task(agent_id: int, task_id: int) -> Task | None:
             )
             .first()
         )
-        if fresh is not None:
-            local_db.expunge(fresh)
-        return fresh
-    finally:
-        local_db.close()
+        return _task_snapshot(task) if task is not None else None
 
 
-def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
-    started_task_id = int(task.id)
+async def _fetch_fresh_a2a_task(
+    agent_id: int,
+    task_id: int,
+) -> _A2ATaskSnapshot | None:
+    return await run_db_io_cancellation_safe(
+        lambda: _fetch_fresh_a2a_task_sync(agent_id, task_id)
+    )
+
+
+def _task_stream_response(
+    agent_id: int,
+    task: _A2ATaskSnapshot,
+) -> StreamingResponse:
+    started_task_id = task.id
 
     async def _events() -> Any:
         deadline = monotonic() + A2A_STREAM_MAX_DURATION_SECONDS
@@ -584,7 +930,7 @@ def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
             if remaining <= 0:
                 return
             await asyncio.sleep(min(0.5, remaining))
-            fresh = _fetch_fresh_a2a_task(int(agent.id), started_task_id)
+            fresh = await _fetch_fresh_a2a_task(agent_id, started_task_id)
             if fresh is None:
                 return
             fresh_output = str(fresh.output or "")
@@ -630,7 +976,10 @@ def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
     )
 
 
-async def _wait_for_task(agent: Agent, task: Task) -> Task:
+async def _wait_for_task(
+    agent_id: int,
+    task: _A2ATaskSnapshot,
+) -> _A2ATaskSnapshot:
     if task.status in _STREAM_END_STATUSES:
         return task
     task_id = int(task.id)
@@ -641,7 +990,7 @@ async def _wait_for_task(agent: Agent, task: Task) -> Task:
         if remaining <= 0:
             return fresh
         await asyncio.sleep(min(0.25, remaining))
-        fetched = _fetch_fresh_a2a_task(int(agent.id), task_id)
+        fetched = await _fetch_fresh_a2a_task(agent_id, task_id)
         if fetched is None:
             raise a2a_error("task_not_found", "Task not found.", status_code=404)
         fresh = fetched
@@ -676,11 +1025,9 @@ async def get_agent_card_well_known(
 async def send_message(
     agent_id: int,
     request: Request,
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
 ) -> Any:
-    agent, key = authed
-    _require_bound_agent(agent_id, agent)
+    identity = _request_identity(agent_id, authed)
     body = await _json_body(request)
     return_immediately = _validate_send_configuration(body)
     message = _message_payload(body)
@@ -689,16 +1036,17 @@ async def send_message(
     context_id = message_context_id(message, body)
     task_id = message_task_id(message, body)
     task = await _start_a2a_turn(
-        db=db,
-        agent=agent,
+        agent_id=identity.agent_id,
+        task_owner_user_id=identity.user_id,
+        execution_mode=identity.execution_mode,
         text=text,
         message_id=message_id,
         context_id=context_id,
         task_id=task_id,
     )
-    record_key_usage(str(key.key_prefix))
+    await record_key_usage(identity.key_prefix)
     if not return_immediately:
-        task = await _wait_for_task(agent, task)
+        task = await _wait_for_task(identity.agent_id, task)
     return a2a_json_response({"task": task_to_a2a(task)})
 
 
@@ -706,11 +1054,9 @@ async def send_message(
 async def stream_message(
     agent_id: int,
     request: Request,
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
 ) -> StreamingResponse:
-    agent, key = authed
-    _require_bound_agent(agent_id, agent)
+    identity = _request_identity(agent_id, authed)
     body = await _json_body(request)
     _validate_send_configuration(body)
     message = _message_payload(body)
@@ -719,27 +1065,29 @@ async def stream_message(
     context_id = message_context_id(message, body)
     task_id = message_task_id(message, body)
     task = await _start_a2a_turn(
-        db=db,
-        agent=agent,
+        agent_id=identity.agent_id,
+        task_owner_user_id=identity.user_id,
+        execution_mode=identity.execution_mode,
         text=text,
         message_id=message_id,
         context_id=context_id,
         task_id=task_id,
     )
-    record_key_usage(str(key.key_prefix))
-    return _task_stream_response(agent, task)
+    await record_key_usage(identity.key_prefix)
+    return _task_stream_response(identity.agent_id, task)
 
 
 @router.get("/agents/{agent_id}/tasks/{task_id}")
 async def get_task(
     agent_id: int,
     task_id: int,
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
 ) -> Any:
-    agent, _key = authed
-    _require_bound_agent(agent_id, agent)
-    task = _resolve_a2a_task(db, task_id, agent)
+    _require_bound_agent(agent_id, authed)
+    resolved_agent_id = authed.agent_id
+    task = await _fetch_fresh_a2a_task(resolved_agent_id, task_id)
+    if task is None:
+        raise a2a_error("task_not_found", "Task not found.", status_code=404)
     return a2a_json_response(task_to_a2a(task))
 
 
@@ -759,13 +1107,12 @@ async def list_tasks(
             "this is backed by Task.updated_at."
         ),
     ),
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
     db: Session = Depends(get_db),
 ) -> Any:
-    agent, _key = authed
-    _require_bound_agent(agent_id, agent)
+    _require_bound_agent(agent_id, authed)
     query = db.query(Task).filter(
-        Task.agent_id == int(agent.id),
+        Task.agent_id == authed.agent_id,
         Task.source == "a2a",
     )
     if context_id is not None:
@@ -829,12 +1176,13 @@ async def list_tasks(
 async def subscribe_task(
     agent_id: int,
     task_id: int,
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
 ) -> StreamingResponse:
-    agent, _key = authed
-    _require_bound_agent(agent_id, agent)
-    task = _resolve_a2a_task(db, task_id, agent)
+    _require_bound_agent(agent_id, authed)
+    resolved_agent_id = authed.agent_id
+    task = await _fetch_fresh_a2a_task(resolved_agent_id, task_id)
+    if task is None:
+        raise a2a_error("task_not_found", "Task not found.", status_code=404)
     if task.status in _TERMINAL_STATUSES:
         raise a2a_error(
             "unsupported_operation",
@@ -842,45 +1190,25 @@ async def subscribe_task(
             status_code=400,
             details={"taskId": task.id},
         )
-    return _task_stream_response(agent, task)
+    return _task_stream_response(resolved_agent_id, task)
 
 
 @router.post("/agents/{agent_id}/tasks/{task_id}:cancel")
 async def cancel_task(
     agent_id: int,
     task_id: int,
-    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(_get_a2a_agent_from_api_key),
 ) -> Any:
-    agent, _key = authed
-    _require_bound_agent(agent_id, agent)
-    task = _resolve_a2a_task(db, task_id, agent)
-    command_identity = f"cancel:{task_id}:{task.run_id or task.state_version}"
-    enqueued = enqueue_task_command(
-        db,
-        task_id=task_id,
-        actor_user_id=int(agent.user_id),
-        command_id=command_identity,
-        kind=TaskCommandKind.CANCEL,
-        payload={"agent_id": int(agent.id)},
+    _require_bound_agent(agent_id, authed)
+    resolved_agent_id = authed.agent_id
+    actor_user_id = authed.user_id
+    prepared = await run_db_io_cancellation_safe(
+        lambda: _prepare_a2a_cancel_command_sync(
+            task_id=task_id,
+            agent_id=resolved_agent_id,
+            actor_user_id=actor_user_id,
+        )
     )
-    if not enqueued.payload_matches:
-        raise a2a_error(
-            "invalid_request",
-            "Cancel command identity conflicts with a different request.",
-            status_code=409,
-        )
-    if enqueued.status == COMMAND_FAILED:
-        retry_failed_task_command(
-            db,
-            enqueued.command_id,
-            target_run_id=_task_run_id(task),
-            target_runner_id=(
-                str(task.runner_id)
-                if task.status == TaskStatus.RUNNING and task.runner_id is not None
-                else None
-            ),
-        )
 
     from .websocket import execute_durable_task_command
 
@@ -889,26 +1217,28 @@ async def cancel_task(
     # completes it; polling here preserves the synchronous A2A cancel contract.
     await dispatch_one_task_command(
         execute_durable_task_command,
-        command_db_id=enqueued.command_id,
+        command_db_id=prepared.command_db_id,
     )
     deadline = monotonic() + 10.0
     while True:
-        stored = await asyncio.to_thread(load_task_command, enqueued.command_id)
+        stored = await run_db_io_cancellation_safe(
+            lambda: load_task_command(prepared.command_db_id)
+        )
         if stored is not None and stored.status == COMMAND_COMPLETED:
-            db.expire_all()
-            return a2a_json_response(task_to_a2a(_resolve_a2a_task(db, task_id, agent)))
+            task = await _fetch_fresh_a2a_task(resolved_agent_id, task_id)
+            if task is None:
+                raise a2a_error("task_not_found", "Task not found.", status_code=404)
+            return a2a_json_response(task_to_a2a(task))
         if stored is not None and stored.status == COMMAND_FAILED:
-            rejection_reason = (
-                stored.result.get("rejection_reason")
-                if isinstance(stored.result, dict)
-                else None
-            )
-            if rejection_reason == "stale_run":
+            if stored.rejection_reason == "stale_run":
                 raise a2a_error(
                     "invalid_request",
                     "Task run changed before cancellation was applied; retry the request.",
                     status_code=409,
-                    details={"taskId": task_id, "commandId": command_identity},
+                    details={
+                        "taskId": task_id,
+                        "commandId": prepared.command_identity,
+                    },
                 )
             raise a2a_error(
                 "internal_error",
@@ -920,54 +1250,123 @@ async def cancel_task(
                 "temporarily_unavailable",
                 "Task cancellation was accepted but is still being applied.",
                 status_code=503,
-                details={"taskId": task_id, "commandId": command_identity},
+                details={
+                    "taskId": task_id,
+                    "commandId": prepared.command_identity,
+                },
             )
         await asyncio.sleep(0.05)
+
+
+def _prepare_a2a_cancel_command_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    actor_user_id: int,
+) -> _A2ACancelPreparation:
+    """Validate and persist one cancel command in a worker-owned Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _resolve_a2a_task_for_agent_id(db, task_id, agent_id)
+        command_identity = f"cancel:{task_id}:{task.run_id or task.state_version}"
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=actor_user_id,
+            command_id=command_identity,
+            kind=TaskCommandKind.CANCEL,
+            payload={"agent_id": agent_id},
+        )
+        if not enqueued.payload_matches:
+            raise a2a_error(
+                "invalid_request",
+                "Cancel command identity conflicts with a different request.",
+                status_code=409,
+            )
+        if enqueued.status == COMMAND_FAILED:
+            retry_failed_task_command(
+                db,
+                enqueued.command_id,
+                target_run_id=_task_run_id(task),
+                target_runner_id=(
+                    str(task.runner_id)
+                    if task.status == TaskStatus.RUNNING and task.runner_id is not None
+                    else None
+                ),
+            )
+        return _A2ACancelPreparation(
+            command_db_id=enqueued.command_id,
+            command_identity=command_identity,
+        )
 
 
 async def _cancel_task_unserialized(
     *,
     task_id: int,
-    agent: Agent,
-    db: Session,
+    agent_id: int,
 ) -> Any:
-    task = _resolve_a2a_task(db, task_id, agent)
-    agent_config: dict[str, Any] = (
-        dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+    prepared = await run_db_io_cancellation_safe(
+        lambda: _prepare_a2a_cancel_sync(task_id, agent_id)
     )
-    if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
-        return a2a_json_response(task_to_a2a(task))
-    if task.status in _TERMINAL_STATUSES:
-        raise a2a_error(
-            "task_not_cancelable",
-            "Task is not in a cancelable state.",
-            status_code=400,
-            details={"taskId": task.id},
-        )
+    if prepared is not None:
+        return a2a_json_response(prepared)
 
     from .websocket import background_task_manager
 
-    await background_task_manager.cancel_task(int(task.id))
-    db.expire(task)
-    db.refresh(task)
-    agent_config = (
-        dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+    await background_task_manager.cancel_task(task_id)
+    finalized = await run_db_io_cancellation_safe(
+        lambda: _finalize_a2a_cancel_sync(task_id, agent_id)
     )
-    if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
-        return a2a_json_response(task_to_a2a(task))
-    if task.status in _TERMINAL_STATUSES:
-        return a2a_json_response(task_to_a2a(task))
-    agent_config["a2a_state"] = "TASK_STATE_CANCELED"
-    setattr(task, "agent_config", agent_config)
-    apply_task_control_transition(
-        task,
-        TaskControlState.FAILED,
-        status=TaskStatus.FAILED,
-        expected_run_id=_task_run_id(task),
-        expected_state_version=int(task.state_version or 0),
-    )
-    setattr(task, "output", None)
-    setattr(task, "error_message", "Task canceled by A2A client.")
-    db.commit()
-    db.refresh(task)
-    return a2a_json_response(task_to_a2a(task))
+    return a2a_json_response(finalized)
+
+
+def _prepare_a2a_cancel_sync(
+    task_id: int,
+    agent_id: int,
+) -> dict[str, Any] | None:
+    """Validate cancellation in a short worker-owned database session."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _resolve_a2a_task_for_agent_id(db, task_id, agent_id)
+        agent_config: dict[str, Any] = (
+            dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+        )
+        if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+            return task_to_a2a(task)
+        if task.status in _TERMINAL_STATUSES:
+            raise a2a_error(
+                "task_not_cancelable",
+                "Task is not in a cancelable state.",
+                status_code=400,
+                details={"taskId": task.id},
+            )
+        return None
+
+
+def _finalize_a2a_cancel_sync(task_id: int, agent_id: int) -> dict[str, Any]:
+    """Apply cancellation to the fresh task row after runtime shutdown."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _resolve_a2a_task_for_agent_id(db, task_id, agent_id)
+        agent_config: dict[str, Any] = (
+            dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+        )
+        if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+            return task_to_a2a(task)
+        if task.status in _TERMINAL_STATUSES:
+            return task_to_a2a(task)
+        agent_config["a2a_state"] = "TASK_STATE_CANCELED"
+        setattr(task, "agent_config", agent_config)
+        apply_task_control_transition(
+            task,
+            TaskControlState.FAILED,
+            status=TaskStatus.FAILED,
+            expected_run_id=_task_run_id(task),
+            expected_state_version=int(task.state_version or 0),
+        )
+        setattr(task, "output", None)
+        setattr(task, "error_message", "Task canceled by A2A client.")
+        db.commit()
+        db.refresh(task)
+        return task_to_a2a(task)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3835,7 +3835,7 @@ async def delete_task(
 
         from .websocket import background_task_manager, manager
 
-        connections = manager.active_connections.pop(task_id, [])
+        connections = manager.detach_task_connections(task_id)
 
         async def _cleanup_runtime_state() -> None:
             await background_task_manager.cancel_task(task_id, timeout_seconds=0.05)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -6,7 +6,7 @@ import os
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, cast
+from typing import Any, Dict, List, Mapping, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import func, or_
@@ -64,6 +64,11 @@ from ..services.connector_runtime import (
     bind_connector_runtime_selection_snapshot,
     prepare_connector_runtime_selection_snapshot,
 )
+from ..services.db_runtime import (
+    drain_async_task_cancellation_safe,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
+)
 from ..services.hot_path_cache import (
     cache_get,
     cache_set,
@@ -78,19 +83,23 @@ from ..services.managed_file_ref import ensure_uploaded_file_local_path
 from ..services.model_service import _get_visible_user_ids
 from ..services.task_execution_context_service import (
     load_task_execution_recovery_state,
+    materialize_task_execution_recovery_state,
 )
 from ..services.task_lease_service import (
-    acquire_task_lease,
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    acquire_task_lease_cancellation_safe,
+    acquire_task_lease_isolated,
     mark_task_paused_if_stale,
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
 from ..services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskOwnerMismatchError,
     TaskSetupSnapshot,
     load_task_setup_snapshot_sync,
 )
-from ..services.trace_message_storage import decode_trace_events_data
 from ..services.workforce_runtime import (
     WorkforceTaskRuntime,
     release_task_lease_with_workforce_sync,
@@ -107,6 +116,13 @@ logger = logging.getLogger(__name__)
 # Depth of the per-task recently-evicted scope-fingerprint memory used for
 # resolver-flap detection; catches scope cycles up to this period.
 _EVICTED_FINGERPRINT_MEMORY = 4
+
+
+class _ResolvedExecutionScopeNotProvided:
+    """Sentinel separating an omitted scope from an explicitly unscoped turn."""
+
+
+_RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED = _ResolvedExecutionScopeNotProvided()
 
 # Create router
 chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
@@ -249,7 +265,7 @@ class AgentServiceMemoryPolicy:
 
 def resolve_agent_service_memory_policy(
     *,
-    task: Optional[Task] = None,
+    task: Optional[Any] = None,
     agent_config: Optional[Mapping[str, Any]] = None,
 ) -> AgentServiceMemoryPolicy:
     """Resolve the memory store and enablement for an AgentService runtime."""
@@ -495,9 +511,9 @@ def _int_id_or_none(value: Any) -> Optional[int]:
 
 
 async def create_default_tools(
-    db: Session,
+    db: Optional[Session],
     request: Any = None,
-    user: Optional[User] = None,
+    user: Optional[Union[User, RuntimeUserFields]] = None,
     task_id: Optional[str] = None,
     workspace_owner_id: Optional[int] = None,
     allowed_collections: Optional[List[str]] = None,
@@ -536,6 +552,12 @@ async def create_default_tools(
     # Create a WebToolConfig to properly initialize tools
     from ..tools.config import WebToolConfig
 
+    db_factory = None
+    if db is None:
+        from ..models.database import get_session_local
+
+        db_factory = get_session_local()
+
     owner_id = (
         int(workspace_owner_id) if workspace_owner_id is not None else int(user.id)
     )
@@ -548,6 +570,7 @@ async def create_default_tools(
     tool_config = WebToolConfig(
         db=db,
         request=request,
+        db_factory=db_factory,
         user=user,
         llm=llm,
         user_id=int(user.id),
@@ -588,6 +611,11 @@ async def create_default_tools(
         mcp_load_summary_trace_task_id=mcp_load_summary_trace_task_id,
     )
 
+    # The application policy hooks are synchronous and may query the database
+    # (for example SaaS team tool settings). Resolve them through a worker-owned
+    # short Session before ToolFactory calls the synchronous config getters.
+    await tool_config.refresh_runtime_policy()
+
     # Store excluded_agent_id in tool_config for agent tool filtering
     if excluded_agent_id:
         tool_config._excluded_agent_id = excluded_agent_id
@@ -605,8 +633,70 @@ async def create_default_tools(
     return tools, tool_config
 
 
+def _selected_file_ids_from_agent_config(
+    agent_config: Any,
+) -> list[str]:
+    if not isinstance(agent_config, dict):
+        return []
+    raw_file_ids = agent_config.get("selected_file_ids")
+    if not isinstance(raw_file_ids, list):
+        return []
+    return [
+        str(file_id)
+        for file_id in raw_file_ids
+        if isinstance(file_id, str) and file_id.strip()
+    ]
+
+
+def _register_selected_task_files_isolated(
+    workspace: Any,
+    *,
+    task_id: int,
+    task_owner_id: int,
+    selected_file_ids: list[str],
+) -> None:
+    """Bind and register selected files inside one worker-owned Session."""
+    if not selected_file_ids:
+        return
+
+    from ..models.database import get_session_local
+    from ..models.uploaded_file import UploadedFile
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as file_db:
+        for selected_file_id in selected_file_ids:
+            uploaded_file = (
+                file_db.query(UploadedFile)
+                .filter(
+                    UploadedFile.file_id == selected_file_id,
+                    UploadedFile.user_id == task_owner_id,
+                    or_(
+                        UploadedFile.task_id == task_id,
+                        UploadedFile.task_id.is_(None),
+                    ),
+                )
+                .first()
+            )
+            if uploaded_file is None:
+                continue
+
+            source_path = ensure_uploaded_file_local_path(uploaded_file)
+            if not source_path.exists() or not source_path.is_file():
+                continue
+
+            if uploaded_file.task_id is None:
+                setattr(uploaded_file, "task_id", task_id)
+
+            workspace.register_file(
+                str(source_path.resolve()),
+                file_id=selected_file_id,
+                db_session=file_db,
+            )
+        file_db.commit()
+
+
 async def update_task_title_from_agent(
-    agent_service: AgentService, task_id: int, db: Session
+    agent_service: AgentService, task_id: int
 ) -> bool:
     """Update task title with generated task_name from agent service.
 
@@ -617,8 +707,6 @@ async def update_task_title_from_agent(
     Args:
         agent_service: The agent service that executed the task
         task_id: The task ID to update
-        db: Database session
-
     Returns:
         True if title was updated, False otherwise
     """
@@ -635,32 +723,99 @@ async def update_task_title_from_agent(
             logger.debug(f"No task_name in task info for task {task_id}")
             return False
 
-        # Update database (web layer responsibility)
-        from ..models.task import Task as TaskModel
-
-        task_record = db.query(TaskModel).filter(TaskModel.id == task_id).first()
-        if not task_record:
-            logger.warning(f"No task record found for task_id={task_id}")
-            return False
-
-        # Only update if title is different
-        if task_record.title != task_name:
-            old_title = task_record.title
-            task_record.title = task_name
-            db.commit()
-            logger.info(
-                f"Updated task {task_id} title from '{old_title}' to '{task_name}'"
-            )
-            return True
-        else:
-            logger.debug(f"Task title already matches: '{task_record.title}'")
-            return False
+        # Title persistence owns a short Session on a worker. A saturated
+        # QueuePool must not block the asyncio loop after the agent finishes.
+        return await run_db_io_cancellation_safe(
+            lambda: _update_task_title_isolated(task_id, str(task_name))
+        )
 
     except Exception as e:
         logger.error(
             f"Failed to update task title for task {task_id}: {e}", exc_info=True
         )
         return False
+
+
+def _update_task_title_isolated(task_id: int, task_name: str) -> bool:
+    """Persist a generated title using a worker-owned short Session."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as title_db:
+        task_record = title_db.query(Task).filter(Task.id == task_id).first()
+        if task_record is None:
+            logger.warning("No task record found for task_id=%s", task_id)
+            return False
+        if task_record.title == task_name:
+            logger.debug("Task title already matches: '%s'", task_record.title)
+            return False
+        old_title = str(task_record.title)
+        setattr(task_record, "title", task_name)
+        title_db.commit()
+        logger.info(
+            "Updated task %s title from '%s' to '%s'",
+            task_id,
+            old_title,
+            task_name,
+        )
+        return True
+
+
+def _check_task_run_gate_isolated(
+    task_id: int,
+) -> str | dict[str, Any] | None:
+    """Run the existing start gate in a worker-owned short Session."""
+    from ..models.database import get_session_local
+    from ..services.quota_hooks import check_run_gate
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as gate_db:
+        gate_task = gate_db.query(Task).filter(Task.id == task_id).first()
+        if gate_task is None:
+            logger.warning("Quota gate: task %s not found; allowing run", task_id)
+            return None
+        gate_reason = check_run_gate(gate_db, getattr(gate_task, "user_id", None))
+        if isinstance(gate_reason, Mapping):
+            # Do not return an application-owned Mapping that may retain ORM
+            # state from the worker Session.
+            return dict(gate_reason)
+        return str(gate_reason) if gate_reason is not None else None
+
+
+def _sync_task_workforce_running_isolated(task_id: int) -> bool:
+    """Project RUNNING to WorkforceRun in a worker-owned transaction."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as workforce_db:
+        task = workforce_db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            return False
+        changed = sync_workforce_run_status(
+            workforce_db,
+            task,
+            TaskStatus.RUNNING,
+        )
+        if changed:
+            workforce_db.commit()
+        return changed
+
+
+def _release_managed_task_lease_isolated(
+    lease: TaskLease,
+    *,
+    status: TaskStatus,
+) -> bool:
+    """Release a manager-owned lease without reusing the caller Session."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as lease_db:
+        return release_task_lease_with_workforce_sync(
+            lease_db,
+            lease,
+            status=status,
+        )
 
 
 class AgentServiceManager:
@@ -1269,47 +1424,54 @@ class AgentServiceManager:
         self,
         *,
         task_id: int,
-        task: Task,
-        db: Session,
-        user: User,
+        task: Any,
+        db: Optional[Session],
+        user: Union[User, RuntimeUserFields],
         agent_config: Optional[dict],
         task_llm: Optional[BaseLLM],
         task_vision_llm: Optional[BaseLLM],
         parent_tracer: Optional[Any] = None,
         scope: Optional[ExecutionScope] = None,
+        task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
     ) -> tuple[list[Any], Any]:
         """Build the tool set configured for a web task."""
-        workforce_runtime = resolve_workforce_task_runtime(db, task)
-        excluded_agent_id = None
-        current_agent = _load_agent_for_task_runtime(db, task, workforce_runtime)
-        if current_agent and _is_published_agent(current_agent):
-            excluded_agent_id = int(current_agent.id)
-            logger.info(
-                f"Task {task_id} is associated with published agent "
-                f"{current_agent.id} ({current_agent.name}), will exclude from "
-                "agent tools"
-            )
-        elif agent_config and agent_config.get("preview_agent_id"):
-            preview_user_id = int(task.user_id)
-            current_agent = (
-                db.query(Agent)
-                .filter(
-                    Agent.id == agent_config["preview_agent_id"],
-                    owned_agent_clause(
-                        preview_user_id, get_agent_team_scope(db, preview_user_id)
-                    ),
-                )
-                .first()
-            )
-            if current_agent and current_agent.status == AgentStatus.PUBLISHED:
+        if task_setup_snapshot is not None:
+            workforce_runtime = task_setup_snapshot.workforce_runtime
+            excluded_agent_id = task_setup_snapshot.excluded_agent_id
+        else:
+            if db is None:
+                raise ValueError("Database session or task snapshot is required")
+            workforce_runtime = resolve_workforce_task_runtime(db, task)
+            excluded_agent_id = None
+            current_agent = _load_agent_for_task_runtime(db, task, workforce_runtime)
+            if current_agent and _is_published_agent(current_agent):
                 excluded_agent_id = int(current_agent.id)
                 logger.info(
-                    f"Preview task {task_id} is for published agent "
+                    f"Task {task_id} is associated with published agent "
                     f"{current_agent.id} ({current_agent.name}), will exclude from "
                     "agent tools"
                 )
+            elif agent_config and agent_config.get("preview_agent_id"):
+                preview_user_id = int(task.user_id)
+                current_agent = (
+                    db.query(Agent)
+                    .filter(
+                        Agent.id == agent_config["preview_agent_id"],
+                        owned_agent_clause(
+                            preview_user_id,
+                            get_agent_team_scope(db, preview_user_id),
+                        ),
+                    )
+                    .first()
+                )
+                if current_agent and current_agent.status == AgentStatus.PUBLISHED:
+                    excluded_agent_id = int(current_agent.id)
+                    logger.info(
+                        f"Preview task {task_id} is for published agent "
+                        f"{current_agent.id} ({current_agent.name}), will exclude from "
+                        "agent tools"
+                    )
 
-        workforce_runtime = resolve_workforce_task_runtime(db, task)
         tool_selection_spec = _build_tool_selection_spec_for_task(
             agent_config, workforce_runtime, task_id=task_id
         )
@@ -1337,7 +1499,8 @@ class AgentServiceManager:
         # Sandbox startup is container/network work that can take seconds;
         # don't hold this session's read transaction (and its pool slot)
         # across it (issue #889).
-        release_db_connection_if_clean(db)
+        if db is not None:
+            release_db_connection_if_clean(db)
         sandbox = await self._get_or_create_task_sandbox(
             task_id=task_id,
             workspace_owner_id=workspace_owner_id,
@@ -1388,10 +1551,13 @@ class AgentServiceManager:
         self,
         task_id: int,
         db: Optional[Session] = None,
-        user: Optional[User] = None,
+        user: Optional[Union[User, RuntimeUserFields]] = None,
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
+        resolved_execution_scope: Union[
+            ExecutionScope, None, _ResolvedExecutionScopeNotProvided
+        ] = _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED,
     ) -> AgentService:
         lock = self._agent_build_locks.get(task_id)
         if lock is None:
@@ -1405,16 +1571,20 @@ class AgentServiceManager:
                 task_setup_snapshot=task_setup_snapshot,
                 task_owner_user_id=task_owner_user_id,
                 connector_runtime_turn_id=connector_runtime_turn_id,
+                resolved_execution_scope=resolved_execution_scope,
             )
 
     async def _get_agent_for_task_unlocked(
         self,
         task_id: int,
         db: Optional[Session] = None,
-        user: Optional[User] = None,
+        user: Optional[Union[User, RuntimeUserFields]] = None,
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
+        resolved_execution_scope: Union[
+            ExecutionScope, None, _ResolvedExecutionScopeNotProvided
+        ] = _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED,
     ) -> AgentService:
         """Get or create AgentService instance for specific task.
 
@@ -1433,6 +1603,12 @@ class AgentServiceManager:
         When omitted it falls back to the snapshot owner, then the task row's
         owner, then ``user.id``.
         """
+        # Track whether this invocation already tried the worker-owned snapshot
+        # boundary. Active-task reconstruction and normal creation must share
+        # that single read instead of probing history on the event loop and
+        # then checking out another connection for the full snapshot.
+        task_setup_snapshot_load_attempted = task_setup_snapshot is not None
+
         # Resolve the runtime identity (OWNER). Everything below — snapshot
         # load, model resolution, tool config, UserContext — runs as this
         # identity, never the acting principal. Precedence: explicit owner →
@@ -1453,29 +1629,41 @@ class AgentServiceManager:
                 runtime_user_id = None
         if runtime_user_id is None and user is not None and user.id is not None:
             runtime_user_id = int(user.id)
-        # The User object the runtime needs (tool overrides / tracer). Reuse the
-        # passed ``user`` when it already IS the owner; otherwise load the owner.
-        runtime_user: Optional[User] = user
-        if (
+        # Runtime identity for tool policy. Reuse a passed owner; otherwise use
+        # the snapshot's primitive identity, with a DB fallback only on legacy
+        # paths that did not supply a snapshot.
+        runtime_user: Optional[Union[User, RuntimeUserFields]] = user
+        if task_setup_snapshot is not None and (
+            user is None
+            or user.id is None
+            or (runtime_user_id is not None and int(user.id) != runtime_user_id)
+        ):
+            snapshot_user = task_setup_snapshot.runtime_user
+            if (
+                snapshot_user is not None
+                and runtime_user_id is not None
+                and snapshot_user.id == runtime_user_id
+            ):
+                runtime_user = snapshot_user
+            else:
+                runtime_user = None
+        elif (
             runtime_user_id is not None
             and db is not None
             and (user is None or user.id is None or int(user.id) != runtime_user_id)
         ):
             runtime_user = db.query(User).filter(User.id == runtime_user_id).first()
 
-        # One turn resolves once: an activated turn (the orchestrated
-        # execute/resume paths) already resolved this task's scope and
-        # carries it in the contextvar, so prefer that over a fresh
-        # loader/resolver round-trip. A None contextvar is ambiguous —
-        # "explicitly unscoped turn" and "not inside an activated turn"
-        # (pause/resume handlers, channels) look the same — so None falls
-        # back to resolving per call, at the same place the owner is
-        # resolved. Correctness is identical either way: the resolver is
-        # idempotent per task and every activation site wraps operations
-        # on the task it activated for.
-        scope = get_execution_scope()
-        if scope is None:
-            scope = resolve_execution_scope(task_id)
+        # One turn resolves once. Orchestrated execute/resume callers pass the
+        # resolved value explicitly, including ``None`` for an intentionally
+        # unscoped turn. Legacy callers omit it and retain the contextvar-first
+        # fallback used by channels and direct WS paths.
+        if resolved_execution_scope is _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED:
+            scope = get_execution_scope()
+            if scope is None:
+                scope = resolve_execution_scope(task_id)
+        else:
+            scope = cast(Optional[ExecutionScope], resolved_execution_scope)
         fingerprint = scope_fingerprint(scope)
 
         # Owner invariant: evict a cached AgentService built for a different
@@ -1553,15 +1741,17 @@ class AgentServiceManager:
 
         if task_id not in self._agents:
             # Check if task exists in database
-            task_exists = False
+            task_exists = task_setup_snapshot is not None
             # ``task`` is widened to ``Task | _TaskFields | None`` because
             # the LLM-config block below rebinds it from an ORM ``Task``
             # to a frozen ``_TaskFields`` once the snapshot lands.
             # Downstream consumers only read primitive attributes
             # (``user_id``, ``agent_id``, ``agent_config``, ``status``)
             # which both types expose identically.
-            task: Any = None
-            if db is not None:
+            task: Any = (
+                task_setup_snapshot.task if task_setup_snapshot is not None else None
+            )
+            if task_setup_snapshot is None and db is not None:
                 try:
                     task = db.query(Task).filter(Task.id == task_id).first()
                     task_exists = task is not None
@@ -1599,43 +1789,61 @@ class AgentServiceManager:
                     TaskStatus.PAUSED,
                     TaskStatus.WAITING_FOR_USER,
                 ]
-                # Brand-new SDK task pre-check: ``begin_turn`` flips the
-                # task to RUNNING before this code runs, but a freshly
-                # created task has no trace events or DAG plan to
-                # recover -- ``_reconstruct_agent_from_history`` would
-                # run two queries, find nothing, and log a misleading
-                # "Failed to reconstruct" warning. Short-circuit the
-                # wasted path here. ``PAUSED`` / ``WAITING_FOR_USER``
-                # always have prior state by definition; only gate on
-                # ``RUNNING``.
-                if (
-                    should_reconstruct
-                    and task is not None
-                    and task.status == TaskStatus.RUNNING
-                    and db is not None
-                    and not self._has_reconstructable_history(task_id, db)
-                ):
-                    logger.info(
-                        f"Task {task_id} is RUNNING but has no reconstructable "
-                        "history (no trace events, no DAG plan); skipping "
-                        "reconstruct and going to normal creation."
-                    )
-                    should_reconstruct = False
-                # Task exists in database, try to reconstruct from history only for active executions
-                if db is not None and should_reconstruct:
+                if should_reconstruct:
                     try:
-                        await self._reconstruct_agent_from_history(
-                            task_id, db, scope=scope
-                        )
-                        self._load_persisted_conversation_history(task_id, db)
-                        await self._load_persisted_execution_context(task_id, db)
-                        self._agent_owner_ids[task_id] = runtime_user_id
-                        self._agent_scope_fingerprints[task_id] = fingerprint
-                        self._sync_connector_runtime_turn(
-                            task_id, connector_runtime_turn_id
-                        )
-                        return self._agents[task_id]
-                    except HTTPException:
+                        if task_setup_snapshot is None:
+                            task_setup_snapshot_load_attempted = True
+                            task_setup_snapshot = await run_db_io_cancellation_safe(
+                                lambda: load_task_setup_snapshot_sync(
+                                    task_id,
+                                    runtime_user_id,
+                                )
+                            )
+                            if task_setup_snapshot is not None:
+                                task = task_setup_snapshot.task
+                            else:
+                                logger.info(
+                                    "Task %s disappeared before reconstruction "
+                                    "snapshot loading; skipping reconstruction",
+                                    task_id,
+                                )
+                                should_reconstruct = False
+
+                        # Brand-new SDK task pre-check: ``begin_turn`` flips
+                        # the task to RUNNING before this code runs, but a
+                        # freshly-created task has no history to recover. The
+                        # worker snapshot already owns both history probes, so
+                        # reuse its detached boolean here instead of querying
+                        # the request Session on the event loop.
+                        if (
+                            should_reconstruct
+                            and task is not None
+                            and task.status == TaskStatus.RUNNING
+                            and task_setup_snapshot is not None
+                            and not task_setup_snapshot.has_reconstructable_history
+                        ):
+                            logger.info(
+                                f"Task {task_id} is RUNNING but has no "
+                                "reconstructable history (no trace events, no "
+                                "DAG plan); skipping reconstruct and going to "
+                                "normal creation."
+                            )
+                            should_reconstruct = False
+
+                        if should_reconstruct:
+                            await self._reconstruct_agent_from_history(
+                                task_id,
+                                db,
+                                scope=scope,
+                                task_setup_snapshot=task_setup_snapshot,
+                            )
+                            self._agent_owner_ids[task_id] = runtime_user_id
+                            self._agent_scope_fingerprints[task_id] = fingerprint
+                            self._sync_connector_runtime_turn(
+                                task_id, connector_runtime_turn_id
+                            )
+                            return self._agents[task_id]
+                    except (HTTPException, TaskOwnerMismatchError):
                         raise
                     except RequiredMCPUnavailableError:
                         self._agents.pop(task_id, None)
@@ -1659,7 +1867,7 @@ class AgentServiceManager:
                         # Continue with normal agent creation
 
             # Create tracer with all necessary handlers
-            tracer = create_task_tracer(task_id, runtime_user)
+            tracer = create_task_tracer(task_id, user_id=runtime_user_id)
 
             # Load the contiguous synchronous DB block (Task row,
             # per-task LLM resolution, optional Agent Builder lookup
@@ -1675,9 +1883,6 @@ class AgentServiceManager:
             excluded_agent_id: Optional[int] = None
             snapshot: Optional[TaskSetupSnapshot] = None
             try:
-                if db is None:
-                    raise ValueError("Database session is required")
-
                 if task_setup_snapshot is not None:
                     # Caller already loaded the snapshot off-loop
                     # (typically ``_schedule_bg._runner``). Reuse it
@@ -1696,11 +1901,13 @@ class AgentServiceManager:
                             int(task_setup_snapshot.task.user_id),
                         )
                     snapshot = task_setup_snapshot
-                else:
-                    snapshot = await asyncio.to_thread(
-                        load_task_setup_snapshot_sync,
-                        task_id,
-                        runtime_user_id,
+                elif not task_setup_snapshot_load_attempted:
+                    task_setup_snapshot_load_attempted = True
+                    snapshot = await run_db_io_cancellation_safe(
+                        lambda: load_task_setup_snapshot_sync(
+                            task_id,
+                            runtime_user_id,
+                        )
                     )
 
                 if snapshot is not None:
@@ -1818,9 +2025,9 @@ class AgentServiceManager:
                         "Task owner / runtime user is required for agent creation"
                     )
 
-                if not db:
+                if snapshot is None and db is None:
                     raise ValueError(
-                        "Database connection is required for agent creation"
+                        "Task snapshot or database session is required for agent creation"
                     )
 
                 # ``excluded_agent_id`` for the legacy task-agent
@@ -1849,6 +2056,7 @@ class AgentServiceManager:
                 # (either task has an agent_id OR has inline preview).
                 if (
                     excluded_agent_id is None
+                    and snapshot is None
                     and agent_config
                     and agent_config.get("preview_agent_id")
                 ):
@@ -1859,6 +2067,7 @@ class AgentServiceManager:
                             f"Task {task_id} missing while resolving preview agent"
                         )
                     preview_user_id = int(task.user_id)
+                    assert db is not None
                     current_agent = (
                         db.query(Agent)
                         .filter(
@@ -1877,7 +2086,11 @@ class AgentServiceManager:
                         )
 
                 workforce_runtime = (
-                    resolve_workforce_task_runtime(db, task) if task else None
+                    snapshot.workforce_runtime
+                    if snapshot is not None
+                    else resolve_workforce_task_runtime(db, task)
+                    if db is not None and task is not None
+                    else None
                 )
                 workspace_owner_id = (
                     int(task.user_id)
@@ -1911,7 +2124,8 @@ class AgentServiceManager:
                 # Sandbox startup is container/network work that can take
                 # seconds; don't hold this session's read transaction (and
                 # its pool slot) across it (issue #889).
-                release_db_connection_if_clean(db)
+                if db is not None:
+                    release_db_connection_if_clean(db)
                 sandbox = await self._get_or_create_task_sandbox(
                     task_id=task_id,
                     workspace_owner_id=workspace_owner_id,
@@ -2032,56 +2246,20 @@ class AgentServiceManager:
                         system_prompt=system_prompt,  # Pass agent builder instructions
                     )
 
-                    selected_file_ids: list[str] = []
-                    if task and isinstance(task.agent_config, dict):
-                        raw_selected_file_ids = task.agent_config.get(
-                            "selected_file_ids"
-                        )
-                        if isinstance(raw_selected_file_ids, list):
-                            selected_file_ids = [
-                                str(item)
-                                for item in raw_selected_file_ids
-                                if isinstance(item, str) and item.strip()
-                            ]
+                    selected_file_ids = _selected_file_ids_from_agent_config(
+                        task.agent_config if task is not None else None
+                    )
 
                     workspace = self._agents[task_id].workspace
                     if selected_file_ids and workspace is not None:
-                        from ..models.uploaded_file import UploadedFile
-
-                        for selected_file_id in selected_file_ids:
-                            task_owner_id = (
-                                int(task.user_id) if task else int(runtime_user.id)
+                        await run_db_io_cancellation_safe(
+                            lambda: _register_selected_task_files_isolated(
+                                workspace,
+                                task_id=task_id,
+                                task_owner_id=int(runtime_user.id),
+                                selected_file_ids=selected_file_ids,
                             )
-                            uploaded_file = (
-                                db.query(UploadedFile)
-                                .filter(
-                                    UploadedFile.file_id == selected_file_id,
-                                    UploadedFile.user_id == task_owner_id,
-                                    or_(
-                                        UploadedFile.task_id == int(task_id),
-                                        UploadedFile.task_id.is_(None),
-                                    ),
-                                )
-                                .first()
-                            )
-                            if uploaded_file is None:
-                                continue
-
-                            source_path = ensure_uploaded_file_local_path(uploaded_file)
-                            if not source_path.exists() or not source_path.is_file():
-                                continue
-
-                            if uploaded_file.task_id is None:
-                                uploaded_file.task_id = int(task_id)
-                                db.flush()
-
-                            # Use the source file directly (user's upload directory) instead of copying
-                            # This avoids duplicate files across the system.
-                            # Resolve to an absolute path so Workspace.register_file
-                            # doesn't try to interpret it as workspace-relative.
-                            workspace.register_file(
-                                str(source_path.resolve()), file_id=selected_file_id
-                            )
+                        )
 
                 pattern_info = (
                     f"with DAG pattern and workspace using {llm_info}"
@@ -2092,7 +2270,21 @@ class AgentServiceManager:
                     f"Created new AgentService for task {task_id} {pattern_info}"
                 )
 
-                if task_exists and db is not None:
+                if task_exists and snapshot is not None:
+                    agent_service = self._agents[task_id]
+                    agent_service.set_conversation_history(
+                        [dict(message) for message in snapshot.conversation_history]
+                    )
+                    recovery_state = await materialize_task_execution_recovery_state(
+                        snapshot.execution_recovery
+                    )
+                    agent_service.set_execution_context_messages(
+                        recovery_state.get("messages", [])
+                    )
+                    agent_service.set_recovered_skill_context(
+                        recovery_state.get("skill_context")
+                    )
+                elif task_exists and db is not None:
                     self._load_persisted_conversation_history(task_id, db)
                     await self._load_persisted_execution_context(task_id, db)
 
@@ -2195,11 +2387,15 @@ class AgentServiceManager:
         db_session: Optional[Any] = None,
         *,
         manage_task_lease: bool = True,
+        task_lease: TaskLease | None = None,
     ) -> Dict[str, Any]:
         """
         Execute task with automatic token tracking.
 
-        This method wraps the agent's execute_task with token tracking if db_session is provided.
+        This method wraps the agent's execute_task with token tracking when a
+        ``tracking_task_id`` (or ``task_id`` fallback) is provided. Database
+        work owns isolated short Sessions; ``db_session`` remains only for
+        backward-compatible callers and is never used for runtime I/O.
 
         Args:
             agent_service: The AgentService instance to use
@@ -2214,6 +2410,8 @@ class AgentServiceManager:
                 ``running_elsewhere`` or release the row before
                 ``execute_task_background`` / ``finish_turn`` land the terminal
                 snapshot, leaving tasks stuck RUNNING for SDK clients.
+            task_lease: Lease owned by an outer orchestrator. Its run id fences
+                tracker writes when this method does not manage the lease.
 
         Returns:
             Execution result dictionary
@@ -2226,29 +2424,15 @@ class AgentServiceManager:
         lease_heartbeat_task = None
         result: Dict[str, Any] | None = None
         sandbox_task_key = None
-        # Reused below for the workforce-status sync so we don't re-query the row.
-        gate_task = None
 
         # Quota gate: refuse to start a run when the team is out of monthly
         # quota. Fails open if the check itself errors, so quota infra problems
-        # never block execution.
-        if db_session and tracker_task_id:
+        # never block execution. The hook may query the application database;
+        # keep that QueuePool wait off the asyncio event loop.
+        if tracker_task_id:
             try:
-                from ..services.quota_hooks import check_run_gate
-
-                gate_task = (
-                    db_session.query(Task)
-                    .filter(Task.id == int(tracker_task_id))
-                    .first()
-                )
-                if gate_task is None:
-                    # Fail open (a delete-race can legitimately leave no row),
-                    # but surface it rather than silently allowing the run.
-                    logger.warning(
-                        "Quota gate: task %s not found; allowing run", tracker_task_id
-                    )
-                gate_reason = check_run_gate(
-                    db_session, getattr(gate_task, "user_id", None)
+                gate_reason = await run_db_io_cancellation_safe(
+                    lambda: _check_task_run_gate_isolated(int(tracker_task_id))
                 )
                 if gate_reason:
                     # The gate returns either a plain message or a structured
@@ -2281,13 +2465,19 @@ class AgentServiceManager:
             except Exception:
                 logger.warning("Quota gate check failed open", exc_info=True)
 
-        if manage_task_lease and db_session and tracker_task_id:
+        if manage_task_lease and tracker_task_id:
             from ..services.task_execution_controller import (
                 task_execution_controller,
             )
 
             async with task_execution_controller.command(int(tracker_task_id)):
-                lease = acquire_task_lease(db_session, int(tracker_task_id))
+                lease = await acquire_task_lease_cancellation_safe(
+                    lambda: acquire_task_lease_isolated(int(tracker_task_id)),
+                    lambda acquired: _release_managed_task_lease_isolated(
+                        acquired,
+                        status=TaskStatus.FAILED,
+                    ),
+                )
             if lease is None:
                 return {
                     "success": False,
@@ -2299,21 +2489,11 @@ class AgentServiceManager:
                 run_task_lease_heartbeat(lease, lease_stop_event)
             )
 
-        if db_session and tracker_task_id:
+        if tracker_task_id:
             try:
-                # Reuse the row already fetched for the quota gate; only re-query
-                # if the gate path didn't run or errored before assigning it.
-                task_for_sync = gate_task
-                if task_for_sync is None:
-                    task_for_sync = (
-                        db_session.query(Task)
-                        .filter(Task.id == int(tracker_task_id))
-                        .first()
-                    )
-                if task_for_sync is not None and sync_workforce_run_status(
-                    db_session, task_for_sync, TaskStatus.RUNNING
-                ):
-                    db_session.commit()
+                await run_db_io_cancellation_safe(
+                    lambda: _sync_task_workforce_running_isolated(int(tracker_task_id))
+                )
             except Exception:
                 logger.debug(
                     "Failed to sync workforce run status after lease acquisition",
@@ -2322,9 +2502,15 @@ class AgentServiceManager:
             try:
                 from ..tracking.task_tracker import TaskTracker
 
+                tracking_lease = lease or task_lease
                 tracker = TaskTracker(
                     task_id=int(tracker_task_id),
-                    db_session=db_session,
+                    expected_run_id=(
+                        tracking_lease.run_id if tracking_lease is not None else None
+                    ),
+                    expected_runner_id=(
+                        tracking_lease.runner_id if tracking_lease is not None else None
+                    ),
                 )
                 await tracker.start_tracking()
                 # Enforce quota mid-run: the pattern loop polls this every step
@@ -2384,43 +2570,95 @@ class AgentServiceManager:
             logger.info("=== Task executed successfully, updating title if needed ===")
 
             # Update task title with generated task_name (clean architecture: Core provides API, Web handles DB)
-            if db_session and task_id and result and result.get("success"):
-                await update_task_title_from_agent(
-                    agent_service, int(task_id), db_session
-                )
+            if task_id and result and result.get("success"):
+                await update_task_title_from_agent(agent_service, int(task_id))
 
             return result
         finally:
-            await stop_task_lease_heartbeat(lease_heartbeat_task, lease_stop_event)
-            if manage_task_lease and db_session and lease:
-                if result is None:
-                    final_status = TaskStatus.FAILED
-                else:
-                    status = str(result.get("status") or "")
-                    if status == "waiting_for_user":
-                        final_status = TaskStatus.WAITING_FOR_USER
-                    elif status == "interrupted":
-                        final_status = TaskStatus.PAUSED
-                    elif result.get("success", False):
-                        final_status = TaskStatus.COMPLETED
-                    else:
-                        final_status = TaskStatus.FAILED
-                release_task_lease_with_workforce_sync(
-                    db_session, lease, status=final_status
+
+            async def finalize_execution_resources() -> None:
+                tracker_pool_timeout: Exception | None = None
+                heartbeat_pool_timeout: BaseException | None = None
+                heartbeat_lost = False
+                # Persist usage before stopping/releasing the lease. Otherwise a
+                # replacement run can acquire ownership and then receive a late
+                # usage write from this completed run.
+                if tracker:
+                    # Drop the mid-run quota checker before metering so a reused
+                    # agent_service can't keep calling this finished run's tracker.
+                    agent_service.set_interrupt_checker(None)
+                    try:
+                        await tracker.complete_tracking()
+                        logger.info(
+                            f"Completed token tracking for task {tracker_task_id}"
+                        )
+                    except Exception as e:
+                        if is_database_pool_timeout(e):
+                            tracker_pool_timeout = e
+                            logger.error(
+                                "task_id=%s component=tracker database pool "
+                                "checkout timed out; retaining lease for TTL "
+                                "recovery: %s",
+                                tracker_task_id,
+                                e,
+                                exc_info=True,
+                            )
+                        else:
+                            logger.error(
+                                "Failed to complete token tracking for task %s: %s",
+                                tracker_task_id,
+                                e,
+                            )
+
+                heartbeat_outcome = await stop_task_lease_heartbeat(
+                    lease_heartbeat_task,
+                    lease_stop_event,
                 )
-            # Complete tracking if it was started
-            if tracker:
-                # Drop the mid-run quota checker before metering so a reused
-                # agent_service can't keep calling this finished run's tracker.
-                agent_service.set_interrupt_checker(None)
-                try:
-                    await tracker.complete_tracking()
-                    logger.info(f"Completed token tracking for task {tracker_task_id}")
-                except Exception as e:
-                    logger.error(
-                        f"Failed to complete token tracking for task {tracker_task_id}: {e}"
+                if isinstance(heartbeat_outcome, TaskLeaseHeartbeatOutcome):
+                    heartbeat_pool_timeout = heartbeat_outcome.pool_timeout
+                    heartbeat_lost = heartbeat_outcome.lease_lost
+                    if heartbeat_outcome.requires_ttl_recovery:
+                        logger.error(
+                            "task_id=%s component=lease-heartbeat unhealthy "
+                            "at shutdown; retaining lease for TTL recovery "
+                            "(lost=%s, pool_timeout=%s)",
+                            tracker_task_id,
+                            heartbeat_lost,
+                            heartbeat_pool_timeout is not None,
+                        )
+                if (
+                    manage_task_lease
+                    and lease
+                    and tracker_pool_timeout is None
+                    and heartbeat_pool_timeout is None
+                    and not heartbeat_lost
+                ):
+                    if result is None:
+                        final_status = TaskStatus.FAILED
+                    else:
+                        status = str(result.get("status") or "")
+                        if status == "waiting_for_user":
+                            final_status = TaskStatus.WAITING_FOR_USER
+                        elif status == "interrupted":
+                            final_status = TaskStatus.PAUSED
+                        elif result.get("success", False):
+                            final_status = TaskStatus.COMPLETED
+                        else:
+                            final_status = TaskStatus.FAILED
+                    await run_db_io_cancellation_safe(
+                        lambda: _release_managed_task_lease_isolated(
+                            lease,
+                            status=final_status,
+                        )
                     )
-            await self._release_sandbox_task(sandbox_task_key)
+                await self._release_sandbox_task(sandbox_task_key)
+                if tracker_pool_timeout is not None:
+                    raise tracker_pool_timeout
+                if heartbeat_pool_timeout is not None:
+                    raise heartbeat_pool_timeout
+
+            cleanup_task = asyncio.create_task(finalize_execution_resources())
+            await drain_async_task_cancellation_safe(cleanup_task)
 
     def _cleanup_workspace_directory(
         self, task_id: int, user_id: Optional[int] = None
@@ -2480,252 +2718,152 @@ class AgentServiceManager:
                 f"No workspace directory found for task {task_id} (user {user_id})"
             )
 
-    def _has_reconstructable_history(self, task_id: int, db: Session) -> bool:
-        """Cheap pre-check: does the task have prior state that
-        ``_reconstruct_agent_from_history`` could actually recover?
-
-        Reconstruct depends on either:
-
-        * trace events from prior tool / LLM runs (``TraceEvent`` rows
-          for the task with ``build_id IS NULL`` -- VIBE phase only,
-          matches the same filter ``_reconstruct_agent_from_history``
-          uses)
-        * a ``DAGExecution.current_plan`` blob for the task
-
-        A brand-new SDK task whose status was just flipped to RUNNING
-        by ``begin_turn`` has neither -- ``_reconstruct_agent_from_history``
-        would run the same two queries, return empty, log a warning,
-        and fall through to normal creation. The check here saves the
-        wasted-work cost plus the noisy ``Failed to reconstruct agent
-        from history`` log line that misleads post-incident triage
-        into thinking something actually failed.
-
-        ``PAUSED`` / ``WAITING_FOR_USER`` tasks always have prior state
-        by definition; the caller in ``get_agent_for_task`` should only
-        gate on this check for ``RUNNING`` status.
-
-        Two ``.first()`` queries: trace short-circuits the plan check
-        when present (typical case for any agent that has run a step).
-        """
-        from ..models.task import DAGExecution, TraceEvent
-
-        has_trace = (
-            db.query(TraceEvent)
-            .filter(
-                TraceEvent.task_id == task_id,
-                TraceEvent.build_id.is_(None),
-            )
-            .first()
-            is not None
-        )
-        if has_trace:
-            return True
-        has_plan = (
-            db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
-            is not None
-        )
-        return has_plan
-
     async def _reconstruct_agent_from_history(
         self,
         task_id: int,
-        db: Session,
+        db: Optional[Session],
         scope: Optional[ExecutionScope] = None,
+        task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
     ) -> None:
-        """Reconstruct agent from historical data"""
+        """Reconstruct from the detached task-runtime snapshot.
+
+        Legacy callers may omit the snapshot; that fallback loads the same
+        snapshot through a worker-owned short Session before any runtime work.
+        """
         try:
-            # Get task user information from database
-            task = db.query(Task).filter(Task.id == task_id).first()
-            user_id = task.user_id if task else None
-
-            # Get tracer events from database
-            tracer_events = []
-            plan_state = None
-
-            # Query trace events
-            from ..models.task import DAGExecution, TraceEvent
-
-            # Get tracer events (only VIBE phase, exclude BUILD phase)
-            trace_events = (
-                db.query(TraceEvent)
-                .filter(
-                    TraceEvent.task_id == task_id,
-                    TraceEvent.build_id.is_(None),  # ← Only get VIBE events
+            snapshot = task_setup_snapshot
+            if snapshot is None:
+                snapshot = await run_db_io_cancellation_safe(
+                    lambda: load_task_setup_snapshot_sync(task_id, None)
                 )
-                .all()
-            )
-            decoded_event_data = decode_trace_events_data(
-                db,
-                task_id=task_id,
-                data_items=[event.data for event in trace_events],
-                strict=False,
-            )
-            for event, event_data in zip(trace_events, decoded_event_data):
-                tracer_events.append(
-                    {
-                        "id": event.event_id,
-                        "event_type": event.event_type,
-                        "task_id": str(event.task_id),
-                        "step_id": event.step_id,
-                        "timestamp": event.timestamp.timestamp()
-                        if event.timestamp
-                        else None,
-                        "data": event_data,
-                        "parent_id": event.parent_event_id,
-                    }
+            if snapshot is None:
+                raise ValueError(
+                    f"Task {task_id} not found during agent reconstruction"
                 )
 
-            # Get DAG execution data
-            dag_execution = (
-                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            tracer_events = [
+                dict(event) for event in snapshot.reconstruction.tracer_events
+            ]
+            plan_state = (
+                dict(snapshot.reconstruction.plan_state)
+                if snapshot.reconstruction.plan_state is not None
+                else None
             )
-            if dag_execution and dag_execution.current_plan:
-                plan_state = (
-                    dict(dag_execution.current_plan)
-                    if dag_execution.current_plan
-                    else None
-                )
-
-            if tracer_events or plan_state:
-                # Create a minimal agent first
-                tracer = create_task_tracer(
+            if not tracer_events and plan_state is None:
+                logger.info(
+                    "No historical data found for task %s, will create new agent",
                     task_id,
-                    user_id=int(user_id) if user_id is not None else None,
                 )
-
-                # Get LLM configuration from task database record
-                try:
-                    task = db.query(Task).filter(Task.id == task_id).first()
-                    if task:
-                        user = (
-                            db.query(User).filter(User.id == task.user_id).first()
-                            if task.user_id
-                            else None
-                        )
-                        if user is None:
-                            raise ValueError(
-                                "User context is required for agent reconstruction"
-                            )
-
-                        runtime_config = self._resolve_task_runtime_config(
-                            task_id=task_id,
-                            task=task,
-                            db=db,
-                            user=user,
-                        )
-                        agent_config = runtime_config["agent_config"]
-                        task_llm = runtime_config["task_llm"]
-                        task_fast_llm = runtime_config["task_fast_llm"]
-                        task_vision_llm = runtime_config["task_vision_llm"]
-                        task_compact_llm = runtime_config["task_compact_llm"]
-                        task_pattern = runtime_config["task_pattern"]
-
-                        tools_list, tool_config = await self._build_tools_for_task(
-                            task_id=task_id,
-                            task=task,
-                            db=db,
-                            user=user,
-                            agent_config=agent_config,
-                            task_llm=task_llm,
-                            task_vision_llm=task_vision_llm,
-                            parent_tracer=tracer,
-                            scope=scope,
-                        )
-                    else:
-                        raise ValueError(
-                            f"Task {task_id} not found in database during agent reconstruction"
-                        )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to rebuild runtime configuration for task {task_id}: {e}"
-                    )
-                    raise
-
-                # Build allowed external directories
-                allowed_external_dirs = _build_allowed_external_dirs(
-                    int(user_id) if user_id is not None else None,
-                    scope=scope,
-                )
-                scope_segments = scope.workspace_segments if scope is not None else ()
-
-                # Create agent with basic configuration
-                if user_id is not None:
-                    with UserContext(int(user_id)):
-                        from .agents import enhance_system_prompt_with_kb
-
-                        system_prompt = (
-                            agent_config.get("instructions") if agent_config else None
-                        )
-                        kb_list = (
-                            agent_config.get("knowledge_bases")
-                            if agent_config
-                            else None
-                        )
-                        system_prompt = enhance_system_prompt_with_kb(
-                            system_prompt, kb_list
-                        )
-                        system_prompt = _build_workforce_system_prompt(
-                            system_prompt,
-                            resolve_workforce_task_runtime(db, task),
-                        )
-                        memory_similarity_threshold = None
-                        if (
-                            agent_config
-                            and "memory_similarity_threshold" in agent_config
-                        ):
-                            memory_similarity_threshold = agent_config[
-                                "memory_similarity_threshold"
-                            ]
-                        memory_policy = resolve_agent_service_memory_policy(
-                            task=task,
-                            agent_config=agent_config,
-                        )
-                        self._agents[task_id] = AgentService(
-                            name=f"reconstructed_agent_task_{task_id}",
-                            id=f"web_task_{task_id}",  # Use task ID only for workspace
-                            llm=task_llm,
-                            fast_llm=task_fast_llm,
-                            vision_llm=task_vision_llm,
-                            compact_llm=task_compact_llm,
-                            tools=tools_list,
-                            tool_config=tool_config,
-                            memory=memory_policy.memory,
-                            pattern=task_pattern,
-                            tracer=tracer,
-                            system_prompt=system_prompt,
-                            enable_workspace=True,
-                            workspace_base_dir=str(
-                                scoped_user_root(
-                                    get_uploads_dir(), int(user_id), scope_segments
-                                )
-                            ),  # Use user- (and scope-) isolated base directory
-                            allowed_external_dirs=allowed_external_dirs,
-                            scope_segments=scope_segments,
-                            task_id=str(task_id),
-                            memory_similarity_threshold=memory_similarity_threshold,
-                            memory_enabled=memory_policy.memory_enabled,
-                        )
-                else:
-                    raise ValueError(
-                        "User context is required for agent reconstruction"
-                    )
-
-                await self._agents[task_id].reconstruct_from_history(
-                    str(task_id), tracer_events, plan_state
-                )
-                self._load_persisted_conversation_history(task_id, db)
-                await self._load_persisted_execution_context(task_id, db)
-
-                logger.info(
-                    f"Successfully reconstructed agent for task {task_id} from history"
-                )
-            else:
-                logger.info(
-                    f"No historical data found for task {task_id}, will create new agent"
-                )
-                # Don't create agent here, let the normal flow handle it
-                # Raise an exception to indicate reconstruction is not possible
                 raise ValueError(f"No historical data found for task {task_id}")
+
+            task = snapshot.task
+            user = snapshot.runtime_user
+            user_id = int(task.user_id)
+            if user is None:
+                raise ValueError("User context is required for agent reconstruction")
+
+            task_llm = snapshot.task_llm
+            if task_llm is None:
+                task_llm = self._pick_default_llm_with_warning(
+                    self._default_llm,
+                    task_id=task_id,
+                    has_agent_builder_config=snapshot.agent is not None,
+                    agent_id=task.agent_id,
+                    saved_model_ids=(snapshot.agent_config or {}).get(
+                        "saved_model_ids"
+                    ),
+                    saved_model_descriptors=(snapshot.agent_config or {}).get(
+                        "saved_model_descriptors"
+                    ),
+                    user_id=user_id,
+                )
+
+            tracer = create_task_tracer(task_id, user_id=user_id)
+            tools_list, tool_config = await self._build_tools_for_task(
+                task_id=task_id,
+                task=task,
+                db=db,
+                user=user,
+                agent_config=snapshot.agent_config,
+                task_llm=task_llm,
+                task_vision_llm=snapshot.task_vision_llm,
+                parent_tracer=tracer,
+                scope=scope,
+                task_setup_snapshot=snapshot,
+            )
+
+            from .agents import enhance_system_prompt_with_kb
+
+            agent_config = snapshot.agent_config
+            system_prompt = agent_config.get("instructions") if agent_config else None
+            kb_list = agent_config.get("knowledge_bases") if agent_config else None
+            system_prompt = enhance_system_prompt_with_kb(system_prompt, kb_list)
+            system_prompt = _build_workforce_system_prompt(
+                system_prompt,
+                snapshot.workforce_runtime,
+            )
+            memory_similarity_threshold = (
+                agent_config.get("memory_similarity_threshold")
+                if agent_config
+                else None
+            )
+            memory_policy = resolve_agent_service_memory_policy(
+                task=task,
+                agent_config=agent_config,
+            )
+            allowed_external_dirs = _build_allowed_external_dirs(
+                user_id,
+                scope=scope,
+            )
+            scope_segments = scope.workspace_segments if scope is not None else ()
+
+            with UserContext(user_id):
+                self._agents[task_id] = AgentService(
+                    name=f"reconstructed_agent_task_{task_id}",
+                    id=f"web_task_{task_id}",
+                    llm=task_llm,
+                    fast_llm=snapshot.task_fast_llm,
+                    vision_llm=snapshot.task_vision_llm,
+                    compact_llm=snapshot.task_compact_llm,
+                    tools=tools_list,
+                    tool_config=tool_config,
+                    memory=memory_policy.memory,
+                    pattern=snapshot.task_pattern,
+                    tracer=tracer,
+                    system_prompt=system_prompt,
+                    enable_workspace=True,
+                    workspace_base_dir=str(
+                        scoped_user_root(get_uploads_dir(), user_id, scope_segments)
+                    ),
+                    allowed_external_dirs=allowed_external_dirs,
+                    scope_segments=scope_segments,
+                    task_id=str(task_id),
+                    memory_similarity_threshold=memory_similarity_threshold,
+                    memory_enabled=memory_policy.memory_enabled,
+                )
+
+            agent_service = self._agents[task_id]
+            await agent_service.reconstruct_from_history(
+                str(task_id),
+                tracer_events,
+                plan_state,
+            )
+            agent_service.set_conversation_history(
+                [dict(message) for message in snapshot.conversation_history]
+            )
+            recovery_state = await materialize_task_execution_recovery_state(
+                snapshot.execution_recovery
+            )
+            agent_service.set_execution_context_messages(
+                recovery_state.get("messages", [])
+            )
+            agent_service.set_recovered_skill_context(
+                recovery_state.get("skill_context")
+            )
+            logger.info(
+                "Successfully reconstructed agent for task %s from history",
+                task_id,
+            )
 
         except Exception as e:
             logger.error(

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional, Tuple, cast
@@ -25,6 +26,7 @@ from ...config import (
     get_uploads_dir,
 )
 from ...core.file_storage import get_user_file_storage
+from ...core.file_storage.keys import build_upload_storage_key
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.workspace import scoped_user_root
@@ -40,6 +42,11 @@ from ..models.database import get_db
 from ..models.task import Task
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
+from ..services import uploaded_file_store as uploaded_file_store_service
+from ..services.db_runtime import (
+    await_task_settlement,
+    drain_async_task_cancellation_safe,
+)
 from ..services.kb_file_service import aggregate_uploaded_file_statuses
 from ..services.managed_file_ref import (
     FILE_INTEGRITY_REUPLOAD_MESSAGE,
@@ -49,7 +56,11 @@ from ..services.managed_file_ref import (
     ManagedFileRef,
     guess_media_type,
 )
-from ..services.uploaded_file_store import UploadedFileStore, delete_pptx_pdf_cache
+from ..services.uploaded_file_store import (
+    PreparedUploadedFile,
+    UploadedFileStore,
+    delete_pptx_pdf_cache,
+)
 from .legacy_file import (
     infer_user_id_from_legacy_path,
     is_valid_uuid,
@@ -178,15 +189,22 @@ def _accel_redirect_response(
     )
 
 
-async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path) -> int:
-    """Persist an uploaded file while enforcing the configured size limit."""
+def _delete_local_path_sync(target_path: Path) -> None:
+    try:
+        target_path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to clean up local upload: %s", target_path)
+
+
+def _copy_upload_to_local_path_sync(source: Any, target_path: Path) -> int:
+    """Copy an upload stream to local storage in one worker thread."""
     total_size = 0
     read_buffer_size = 1024 * 1024  # 1MB chunks keep memory bounded for large files.
 
     try:
         with open(target_path, "wb") as buffer:
             while True:
-                chunk = await uploaded.read(read_buffer_size)
+                chunk = source.read(read_buffer_size)
                 if not chunk:
                     break
                 total_size += len(chunk)
@@ -198,15 +216,274 @@ async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path)
                         ),
                     )
                 buffer.write(chunk)
-    except Exception:
-        try:
-            if target_path.exists():
-                target_path.unlink()
-        except OSError:
-            pass
+    except BaseException:
+        _delete_local_path_sync(target_path)
         raise
 
     return total_size
+
+
+async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path) -> int:
+    """Persist an upload off-loop while enforcing the configured size limit."""
+    copy_task = asyncio.create_task(
+        asyncio.to_thread(
+            _copy_upload_to_local_path_sync,
+            uploaded.file,
+            target_path,
+        )
+    )
+    file_size, cancellation = await await_task_settlement(copy_task)
+    if cancellation is not None:
+        cleanup_task = asyncio.create_task(
+            asyncio.to_thread(_delete_local_path_sync, target_path)
+        )
+        await await_task_settlement(cleanup_task)
+        raise cancellation
+    return file_size
+
+
+def _resolve_v1_upload_path_sync(
+    *,
+    filename: str,
+    folder: str | None,
+    owner_user_id: int,
+) -> Path:
+    """Resolve and reserve a unique local v1 upload path off the event loop."""
+    return _build_unique_file_path(
+        get_upload_path(
+            filename,
+            None,
+            folder,
+            owner_user_id,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class _StagedV1Upload:
+    file_id: str
+    owner_user_id: int
+    filename: str
+    mime_type: str | None
+    local_path: Path
+    storage_key: str
+
+
+@dataclass(frozen=True)
+class _PreparedV1Upload:
+    file: PreparedUploadedFile
+    content_preview: str
+
+
+def _upload_content_preview(local_path: Path, filename: str) -> str:
+    file_extension = Path(filename).suffix.lower()
+    if file_extension == ".pptx":
+        try:
+            preview_content = _pptx_text_preview(local_path)
+        except Exception:
+            return ""
+    elif file_extension == ".ppt" or file_extension in BINARY_EXTENSIONS:
+        return ""
+    else:
+        try:
+            preview_content = read_file(str(local_path))
+        except Exception:
+            return ""
+
+    if isinstance(preview_content, str) and len(preview_content) > 500:
+        return preview_content[:500] + "..."
+    return preview_content if isinstance(preview_content, str) else ""
+
+
+def _prepare_v1_uploads_sync(
+    staged_files: tuple[_StagedV1Upload, ...],
+) -> tuple[_PreparedV1Upload, ...]:
+    prepared: list[_PreparedV1Upload] = []
+    try:
+        for staged in staged_files:
+            file_metadata = (
+                uploaded_file_store_service.prepare_uploaded_file_from_local_path(
+                    local_path=staged.local_path,
+                    user_id=staged.owner_user_id,
+                    filename=staged.filename,
+                    file_id=staged.file_id,
+                    task_id=None,
+                    mime_type=staged.mime_type,
+                    storage_key=staged.storage_key,
+                )
+            )
+            prepared.append(
+                _PreparedV1Upload(
+                    file=file_metadata,
+                    content_preview=_upload_content_preview(
+                        staged.local_path, staged.filename
+                    ),
+                )
+            )
+    except BaseException:
+        uploaded_file_store_service.delete_durable_upload_keys(
+            [(item.owner_user_id, item.storage_key) for item in staged_files]
+        )
+        raise
+    return tuple(prepared)
+
+
+def _delete_local_uploads(staged_files: tuple[_StagedV1Upload, ...]) -> None:
+    for item in staged_files:
+        _delete_local_path_sync(item.local_path)
+
+
+def _format_stored_uploads(
+    *,
+    prepared_files: tuple[_PreparedV1Upload, ...],
+    task_type: str,
+    single_file_mode: bool,
+) -> Dict[str, Any]:
+    uploaded_files = [
+        {
+            "file_id": item.file.file_id,
+            "filename": item.file.filename,
+            "file_size": item.file.file_size,
+            "mime_type": item.file.mime_type,
+            "content_preview": item.content_preview,
+        }
+        for item in prepared_files
+    ]
+    if single_file_mode:
+        first_file = uploaded_files[0]
+        return {
+            "success": True,
+            "file_id": first_file["file_id"],
+            "filename": first_file["filename"],
+            "file_size": first_file["file_size"],
+            "mime_type": first_file["mime_type"],
+            "task_type": task_type,
+            "content_preview": first_file["content_preview"],
+            "message": f"Successfully uploaded {first_file['filename']}",
+        }
+    return {
+        "success": True,
+        "files": uploaded_files,
+        "total_files": len(uploaded_files),
+        "task_type": task_type,
+        "message": f"Successfully uploaded {len(uploaded_files)} files",
+    }
+
+
+async def _store_v1_uploaded_files_workflow(
+    *,
+    upload_items: list[UploadFile],
+    task_type: str,
+    folder: str | None,
+    owner_user_id: int,
+    single_file_mode: bool,
+) -> Dict[str, Any]:
+    staged_files: list[_StagedV1Upload] = []
+    prepared_files: tuple[_PreparedV1Upload, ...] = ()
+    persisted = False
+    try:
+        for uploaded in upload_items:
+            if not uploaded.filename or not uploaded.filename.strip():
+                raise HTTPException(status_code=422, detail="No filename provided")
+            if not is_allowed_file(uploaded.filename, task_type):
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        f"File type {Path(uploaded.filename).suffix.lower()} "
+                        f"not supported for task type {task_type}"
+                    ),
+                )
+            try:
+                path_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        _resolve_v1_upload_path_sync,
+                        filename=uploaded.filename,
+                        folder=folder,
+                        owner_user_id=owner_user_id,
+                    )
+                )
+                local_path, cancellation = await await_task_settlement(path_task)
+                if cancellation is not None:
+                    raise cancellation
+            except ValueError as exc:
+                logger.warning("Invalid folder name rejected: %r - %s", folder, exc)
+                raise HTTPException(
+                    status_code=422, detail=f"Invalid folder name: {exc}"
+                ) from exc
+
+            await _write_upload_with_size_limit(uploaded, local_path)
+            file_id = str(uuid4())
+            staged_files.append(
+                _StagedV1Upload(
+                    file_id=file_id,
+                    owner_user_id=owner_user_id,
+                    filename=Path(uploaded.filename).name,
+                    mime_type=uploaded.content_type,
+                    local_path=local_path,
+                    storage_key=build_upload_storage_key(
+                        owner_user_id, file_id, Path(uploaded.filename).name
+                    ),
+                )
+            )
+
+        staged_batch = tuple(staged_files)
+        preparation_task = asyncio.create_task(
+            asyncio.to_thread(_prepare_v1_uploads_sync, staged_batch)
+        )
+        prepared_files, cancellation = await await_task_settlement(preparation_task)
+        if cancellation is not None:
+            raise cancellation
+
+        metadata = tuple(item.file for item in prepared_files)
+        persistence_task = asyncio.create_task(
+            asyncio.to_thread(
+                uploaded_file_store_service.persist_prepared_uploaded_files,
+                metadata,
+            )
+        )
+        _, cancellation = await await_task_settlement(persistence_task)
+        persisted = True
+        if cancellation is not None:
+            raise cancellation
+
+        return _format_stored_uploads(
+            prepared_files=prepared_files,
+            task_type=task_type,
+            single_file_mode=single_file_mode,
+        )
+    except DurableStorageOperationError as exc:
+        logger.warning("Durable storage unavailable during upload: %s", exc)
+        raise _durable_storage_unavailable() from exc
+    finally:
+        if not persisted:
+            prepared_metadata = tuple(item.file for item in prepared_files)
+            if prepared_metadata:
+                await asyncio.to_thread(
+                    uploaded_file_store_service.delete_prepared_uploaded_files_durable,
+                    prepared_metadata,
+                )
+            await asyncio.to_thread(_delete_local_uploads, tuple(staged_files))
+
+
+async def store_v1_uploaded_files(
+    *,
+    upload_items: list[UploadFile],
+    task_type: str,
+    folder: str | None,
+    owner_user_id: int,
+    single_file_mode: bool,
+) -> Dict[str, Any]:
+    """Store unbound SDK uploads without carrying ORM state across async work."""
+    workflow = asyncio.create_task(
+        _store_v1_uploaded_files_workflow(
+            upload_items=upload_items,
+            task_type=task_type,
+            folder=folder,
+            owner_user_id=owner_user_id,
+            single_file_mode=single_file_mode,
+        )
+    )
+    return await drain_async_task_cancellation_safe(workflow)
 
 
 async def store_uploaded_files(
@@ -262,33 +539,9 @@ async def store_uploaded_files(
             setattr(file_record, "file_size", file_size)
             db.flush()
 
-            content_preview = ""
-            file_extension = Path(uploaded.filename).suffix.lower()
-            if file_extension == ".pptx":
-                try:
-                    preview_content = await asyncio.to_thread(
-                        _pptx_text_preview, target_path
-                    )
-                    content_preview = (
-                        preview_content[:500] + "..."
-                        if len(preview_content) > 500
-                        else preview_content
-                    )
-                except Exception:
-                    content_preview = ""
-            elif file_extension == ".ppt":
-                content_preview = ""
-            elif file_extension not in BINARY_EXTENSIONS:
-                try:
-                    preview_content = read_file(str(target_path))
-                    content_preview = (
-                        preview_content[:500] + "..."
-                        if isinstance(preview_content, str)
-                        and len(preview_content) > 500
-                        else preview_content
-                    )
-                except Exception:
-                    content_preview = ""
+            content_preview = await asyncio.to_thread(
+                _upload_content_preview, target_path, uploaded.filename
+            )
 
             uploaded_files.append(
                 {

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -551,7 +551,7 @@ async def public_chat_websocket_endpoint(
         else:
             logger.error("Public chat WebSocket error: %s", exc)
     finally:
-        manager.disconnect(websocket, task_id)
+        manager.disconnect(websocket)
 
 
 async def share_chat_websocket_endpoint(
@@ -605,4 +605,4 @@ async def share_chat_websocket_endpoint(
         else:
             logger.error("Share chat WebSocket error: %s", exc)
     finally:
-        manager.disconnect(websocket, task_id)
+        manager.disconnect(websocket)

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -1,14 +1,9 @@
 """SDK management endpoints for user-owned agents."""
 
-from typing import Tuple
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
-from sqlalchemy.orm import Session
 
-from ...models.agent import Agent
-from ...models.database import get_db
-from ...models.user import User
-from ...models.user_api_key import UserApiKey
 from ...schemas.agent_api_key import APIKeyGenerateResponse
 from ...schemas.v1 import (
     RuntimeKeyResponse,
@@ -19,13 +14,16 @@ from ...schemas.v1 import (
     V1AgentTemplateCreateRequest,
 )
 from ...services.agent_management import (
-    AgentManagementService,
     DuplicateAgentNameError,
     InvalidAgentModelConfigError,
     InvalidKnowledgeBaseError,
     TemplateNotFoundError,
+    create_agent_from_template_worker_owned,
+    create_agent_worker_owned,
+    list_agents_for_user_worker_owned,
+    rotate_agent_runtime_key_worker_owned,
 )
-from ...services.api_keys import KeyRotationConflict
+from ...services.api_keys import KeyRotationConflict, PersonalApiIdentity
 from .deps import get_user_from_personal_key
 from .errors import V1ApiError, V1ErrorCode
 
@@ -40,37 +38,29 @@ def _runtime_key_response(api_key: APIKeyGenerateResponse) -> RuntimeKeyResponse
     )
 
 
-def _agent_response(service: AgentManagementService, agent: Agent) -> V1AgentResponse:
-    return V1AgentResponse.model_validate(service.store.agent_to_response_dict(agent))
+def _agent_response(agent: dict[str, Any]) -> V1AgentResponse:
+    return V1AgentResponse.model_validate(agent)
 
 
 @router.get("", response_model=list[V1AgentSummary])
 async def list_agents(
-    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
-    db: Session = Depends(get_db),
+    authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> list[V1AgentSummary]:
-    user, _key = authed
-    service = AgentManagementService(db)
-    return [
-        V1AgentSummary.model_validate(item)
-        for item in service.list_agents_for_user(int(user.id))
-    ]
+    items = await list_agents_for_user_worker_owned(user_id=authed.user_id)
+    return [V1AgentSummary.model_validate(item) for item in items]
 
 
 @router.post("", response_model=V1AgentCreateResponse)
 async def create_agent(
     request: V1AgentCreateRequest,
-    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
-    db: Session = Depends(get_db),
+    authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> V1AgentCreateResponse:
-    user, _key = authed
-    service = AgentManagementService(db)
     try:
         # Atomic: KB validation + agent row + optional first runtime key,
         # all behind the single async create entry point.
-        agent, api_key = await service.create_agent(
-            user_id=int(user.id),
-            is_admin=bool(user.is_admin),
+        result = await create_agent_worker_owned(
+            user_id=authed.user_id,
+            is_admin=authed.is_admin,
             name=request.name,
             description=request.description,
             instructions=request.instructions,
@@ -100,8 +90,8 @@ async def create_agent(
         )
 
     return V1AgentCreateResponse(
-        agent=_agent_response(service, agent),
-        api_key=_runtime_key_response(api_key) if api_key else None,
+        agent=_agent_response(result.agent),
+        api_key=_runtime_key_response(result.api_key) if result.api_key else None,
     )
 
 
@@ -109,18 +99,16 @@ async def create_agent(
 async def create_agent_from_template(
     request: V1AgentTemplateCreateRequest,
     fastapi_request: Request,
-    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
-    db: Session = Depends(get_db),
+    authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> V1AgentCreateResponse:
-    user, _key = authed
     template_manager = getattr(fastapi_request.app.state, "template_manager", None)
-    service = AgentManagementService(db, template_manager=template_manager)
     try:
         # Atomic: template-derived agent + optional first runtime key
         # commit together, same boundary as the plain create path.
-        agent, api_key = await service.create_agent_from_template(
-            user_id=int(user.id),
-            is_admin=bool(user.is_admin),
+        result = await create_agent_from_template_worker_owned(
+            template_manager=template_manager,
+            user_id=authed.user_id,
+            is_admin=authed.is_admin,
             template_id=request.template_id,
             name=request.name,
             description=request.description,
@@ -153,22 +141,19 @@ async def create_agent_from_template(
         )
 
     return V1AgentCreateResponse(
-        agent=_agent_response(service, agent),
-        api_key=_runtime_key_response(api_key) if api_key else None,
+        agent=_agent_response(result.agent),
+        api_key=_runtime_key_response(result.api_key) if result.api_key else None,
     )
 
 
 @router.post("/{agent_id}/api-key", response_model=RuntimeKeyResponse)
 async def rotate_agent_runtime_key(
     agent_id: int,
-    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
-    db: Session = Depends(get_db),
+    authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> RuntimeKeyResponse:
-    user, _key = authed
-    service = AgentManagementService(db)
     try:
-        api_key = service.generate_agent_runtime_key(
-            user_id=int(user.id), agent_id=agent_id
+        api_key = await rotate_agent_runtime_key_worker_owned(
+            user_id=authed.user_id, agent_id=agent_id
         )
     except KeyRotationConflict:
         raise V1ApiError(

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -1,250 +1,68 @@
-"""Auth dependency for ``/v1/*`` endpoints.
+"""Authentication dependencies for ``/v1/*`` and authenticated A2A routes.
 
-``get_agent_from_api_key`` resolves the ``Authorization: Bearer
-xag_<prefix>_<secret>`` header to the bound :class:`Agent` row,
-returning ``(Agent, AgentApiKey)`` on success and raising
-:class:`V1ApiError` ``invalid_api_key`` (HTTP 401) on every failure
-path.
-
-Failure paths intentionally share the same response code and burn the
-same ~100ms of bcrypt work (via :func:`verify_dummy`) regardless of
-which check failed:
-
-  - Missing / malformed header
-  - Prefix not in DB
-  - Secret doesn't match the stored bcrypt hash
-  - Bound agent row missing (orphan key, shouldn't happen but defended)
-
-Without this symmetry, an attacker could enumerate live prefixes by
-timing the response (slow = bcrypt ran = prefix exists; fast = index
-miss = prefix doesn't exist). See SDK design doc §7 (key format and
-auth flow) and §10 (security considerations).
+Synchronous SQLAlchemy pool waits, queries, and bcrypt checks run as one
+cancellation-safe worker operation. The worker owns its Session from creation
+through close, closes it before bcrypt begins, and returns only immutable
+detached identity values.
 """
-
-import logging
-from datetime import datetime, timezone
-from typing import Tuple
 
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import case
-from sqlalchemy.orm import Session, joinedload
 
-from ....core.utils.api_key import (
-    ApiKeyKind,
-    parse_api_key,
-    verify_api_key,
-    verify_dummy,
+from ...services.api_keys import (
+    AgentApiIdentity,
+    InvalidApiKeyError,
+    PersonalApiIdentity,
+    authenticate_agent_api_key,
+    authenticate_personal_api_key,
+    record_agent_api_key_usage,
 )
-from ...models.agent import Agent, is_workforce_generated_manager_agent
-from ...models.agent_api_key import AgentApiKey
-from ...models.database import get_db, get_session_local
-from ...models.user import User
-from ...models.user_api_key import UserApiKey
-from ...utils.db_timezone import normalize_datetime_from_db
+from ...services.db_runtime import run_db_io_cancellation_safe
 from .errors import V1ApiError, V1ErrorCode
 
-# ``auto_error=False`` so we can raise our own V1ApiError envelope
-# instead of FastAPI's default 403 ``{"detail": "Not authenticated"}``
-# when the header is missing -- the SDK contract is one error shape.
+# ``auto_error=False`` lets every failure use the stable v1 error envelope.
 _bearer = HTTPBearer(auto_error=False)
+
+
+def _raw_credentials(
+    credentials: HTTPAuthorizationCredentials | None,
+) -> str | None:
+    return credentials.credentials if credentials is not None else None
 
 
 async def get_agent_from_api_key(
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
-    db: Session = Depends(get_db),
-) -> Tuple[Agent, AgentApiKey]:
-    """Resolve an SDK API key to ``(Agent, AgentApiKey)``.
+) -> AgentApiIdentity:
+    """Resolve an agent runtime key to a detached identity snapshot."""
 
-    All failure paths spend ~100ms of bcrypt work and return the same
-    ``invalid_api_key`` code, so an attacker cannot enumerate live
-    prefixes by either error code or response timing.
-
-    Returns:
-        Tuple ``(agent, key_row)`` where ``agent`` is the bound Agent
-        ORM row and ``key_row`` is the matching active AgentApiKey row.
-        Use the key_row for downstream operations that need to know
-        which prefix was presented (e.g. ``/v1/me``).
-
-    Raises:
-        V1ApiError(INVALID_API_KEY, 401): on any auth failure -- one
-            opaque code so caller cannot distinguish *which* check
-            failed.
-    """
-    # Missing header. Still burn bcrypt time so a curl-with-no-header
-    # response can't be timed apart from a curl-with-bad-secret one.
-    if credentials is None:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    raw = credentials.credentials
-
-    # Format check. parse_api_key returns None for anything not shaped
-    # like ``xag_<6 alnum>_<32 alnum>``.
-    parsed = parse_api_key(raw)
-    if parsed is None:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    if parsed.kind != ApiKeyKind.AGENT:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    prefix = parsed.prefix
-
-    # Index lookup is O(1) on ix_agent_api_keys_key_prefix; revoked (and,
-    # below, paused) rows are excluded by the filter, not by any DB
-    # constraint -- an agent can hold multiple simultaneously-active
-    # keys, so uniqueness is no longer enforced at the schema level.
-    # ``joinedload`` pulls the bound Agent row in the same SELECT so we
-    # don't pay a second round-trip on the success path (the relationship
-    # defaults to lazy='select', which would otherwise emit a separate
-    # query when we access ``key_row.agent`` below).
-    key_row = (
-        db.query(AgentApiKey)
-        .options(joinedload(AgentApiKey.agent))
-        .filter(
-            AgentApiKey.key_prefix == prefix,
-            AgentApiKey.revoked_at.is_(None),
-            # A paused key is treated identically to a missing/revoked one
-            # -- same opaque 401, same verify_dummy timing -- so a caller
-            # can't distinguish "paused" from "never existed" below.
-            AgentApiKey.paused_at.is_(None),
-        )
-        .first()
-    )
-
-    # Prefix missing, revoked, or paused. verify_dummy to keep timing
-    # indistinguishable from the "secret wrong" branch below.
-    if key_row is None:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    # Real bcrypt check on the full key. Constant time within the cost
-    # factor; ``verify_api_key`` returns False (not raise) on malformed
-    # hash inputs.
-    if not verify_api_key(raw, key_row.key_hash):  # type: ignore[arg-type]
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    # Bound agent. Should always exist (CASCADE on agents -> api_keys),
-    # but defend against an out-of-band DELETE that somehow leaves a
-    # dangling key row. The relationship was eagerly loaded above, so
-    # this is a memory access, not another query. Treat as
-    # invalid_api_key rather than 404 so the client retries with a
-    # fresh key instead of investigating an imaginary agent.
-    agent = key_row.agent
-    if agent is None or is_workforce_generated_manager_agent(agent):
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    return agent, key_row
-
-
-def record_key_usage(key_prefix: str) -> None:
-    """Best-effort usage tracking for the API Keys page's stat cards.
-
-    Deliberately NOT called from :func:`get_agent_from_api_key` itself --
-    that dependency backs every ``/v1/chat/tasks/*`` route including the
-    read-only status/steps polling endpoints SDK clients hit repeatedly,
-    and recording a write there would (a) put a DB write+commit on the
-    busiest possible request path and (b) conflate polling with real
-    invocations in the "calls this month" stat. Callers should invoke
-    this only from endpoints that represent an actual SDK-visible call
-    (e.g. creating a task or appending a message), not from polling GETs.
-
-    Runs on its own DB session -- deliberately isolated from the
-    request-scoped ``db`` session used for auth -- and issues a single
-    atomic UPDATE (month rollover included via ``case()``) rather than a
-    Python-side read-modify-write. This avoids three problems a shared
-    session would have: committing here would prematurely flush/commit
-    whatever the caller's endpoint later stages on the same session;
-    rolling back on failure would poison that session for the rest of
-    the request; and incrementing ``usage_month_calls`` in Python is
-    subject to lost updates under concurrent calls with the same key.
-    Never allowed to fail the request -- errors are logged and
-    swallowed, not raised.
-    """
-    now = datetime.now(timezone.utc)
-    current_month = now.strftime("%Y-%m")
-    session_local = get_session_local()
-    local_db = session_local()
+    raw = _raw_credentials(credentials)
     try:
-        local_db.query(AgentApiKey).filter(
-            AgentApiKey.key_prefix == key_prefix,
-            # Belt-and-suspenders: today both call sites are gated by
-            # get_agent_from_api_key, which already excludes revoked/paused
-            # keys before the endpoint body runs. Repeating the guard here
-            # means a future caller that forgets that gate can't silently
-            # bump usage on a dead key.
-            AgentApiKey.revoked_at.is_(None),
-            AgentApiKey.paused_at.is_(None),
-        ).update(
-            {
-                AgentApiKey.last_used_at: now,
-                AgentApiKey.usage_month: current_month,
-                AgentApiKey.usage_month_calls: case(
-                    (
-                        AgentApiKey.usage_month == current_month,
-                        AgentApiKey.usage_month_calls + 1,
-                    ),
-                    else_=1,
-                ),
-            },
-            synchronize_session=False,
+        return await run_db_io_cancellation_safe(
+            lambda: authenticate_agent_api_key(raw)
         )
-        local_db.commit()
-    except Exception:
-        local_db.rollback()
-        logging.getLogger(__name__).warning(
-            "Failed to record API key usage for key_prefix=%s", key_prefix
-        )
-    finally:
-        local_db.close()
+    except InvalidApiKeyError as exc:
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401) from exc
 
 
 async def get_user_from_personal_key(
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
-    db: Session = Depends(get_db),
-) -> Tuple[User, UserApiKey]:
-    """Resolve a personal management API key to ``(User, UserApiKey)``."""
-    if credentials is None:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+) -> PersonalApiIdentity:
+    """Resolve a personal management key to a detached identity snapshot."""
 
-    raw = credentials.credentials
-    parsed = parse_api_key(raw)
-    if parsed is None or parsed.kind != ApiKeyKind.PERSONAL:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
-
-    key_row = (
-        db.query(UserApiKey)
-        .options(joinedload(UserApiKey.user))
-        .filter(
-            UserApiKey.key_prefix == parsed.prefix,
-            UserApiKey.revoked_at.is_(None),
+    raw = _raw_credentials(credentials)
+    try:
+        return await run_db_io_cancellation_safe(
+            lambda: authenticate_personal_api_key(raw)
         )
-        .first()
-    )
-    if key_row is None:
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+    except InvalidApiKeyError as exc:
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401) from exc
 
-    now = datetime.now(timezone.utc)
-    expires_at = key_row.expires_at
-    # ``DateTime(timezone=True)`` reads back naive on SQLite; normalize
-    # to aware UTC before comparing so an expired key yields 401, not a
-    # 500 from comparing naive vs aware datetimes.
-    if (
-        expires_at is not None and normalize_datetime_from_db(expires_at) <= now  # type: ignore[arg-type]
-    ):
-        verify_dummy()
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 
-    if not verify_api_key(raw, key_row.key_hash):  # type: ignore[arg-type]
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+async def record_key_usage(key_prefix: str) -> None:
+    """Best-effort usage tracking without blocking the event loop.
 
-    user = key_row.user
-    if user is None:
-        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+    This remains an explicit endpoint action rather than part of auth so
+    read-only status polling is not counted as an invocation.
+    """
 
-    return user, key_row
+    await run_db_io_cancellation_safe(lambda: record_agent_api_key_usage(key_prefix))

--- a/src/xagent/web/api/v1/me.py
+++ b/src/xagent/web/api/v1/me.py
@@ -1,12 +1,9 @@
 """GET /v1/me -- personal management key identity probe."""
 
-from typing import Tuple
-
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from ...models.user import User
-from ...models.user_api_key import UserApiKey
+from ...services.api_keys import PersonalApiIdentity
 from .deps import get_user_from_personal_key
 
 router = APIRouter()
@@ -32,14 +29,13 @@ class MeResponse(BaseModel):
 
 @router.get("/me", response_model=MeResponse)
 async def get_me(
-    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> MeResponse:
     """Probe the user identity bound to the caller's personal key."""
-    user, key = authed
     return MeResponse(
         principal_type="user",
-        user_id=int(user.id),
-        username=str(user.username),
-        email=str(user.email) if user.email is not None else None,
-        key_prefix=key.key_prefix,
+        user_id=authed.user_id,
+        username=authed.username,
+        email=authed.email,
+        key_prefix=authed.key_prefix,
     )

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -14,20 +14,15 @@ persist messages, schedule bg, sync output) is delegated to
 by the WebSocket UI path so both transports share one state machine.
 """
 
+import asyncio
 import logging
-from typing import Any, NoReturn, Optional, Tuple, cast
+from typing import Any, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
-from sqlalchemy import func
-from sqlalchemy.orm import Session
 
 from ....core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from ...config import is_allowed_file
-from ...models.agent import Agent
-from ...models.agent_api_key import AgentApiKey
-from ...models.database import get_db
-from ...models.task import Task, TaskStatus, TraceEvent
-from ...models.user import User
+from ...models.task import TaskStatus
 from ...schemas.v1 import (
     AppendMessageRequest,
     AppendMessageResponse,
@@ -39,20 +34,19 @@ from ...schemas.v1 import (
     UploadedFileInfo,
     UploadFilesResponse,
 )
+from ...services.api_keys import AgentApiIdentity
 from ...services.connector_runtime import (
-    bind_create_connector_runtime_plan,
-    persist_create_connector_runtime_context,
     pop_ephemeral_runtime_values,
-    prepare_append_connector_runtime,
-    prepare_create_connector_runtime,
     store_ephemeral_runtime_values,
+)
+from ...services.db_runtime import (
+    drain_async_task_cancellation_safe,
+    run_db_io_cancellation_safe,
 )
 from ...services.file_turn import (
     append_uploaded_files_context,
-    bind_turn_files,
     build_uploaded_files_context,
     normalize_attachments_for_persistence,
-    resolve_turn_file_infos,
 )
 from ...services.hot_path_cache import (
     cache_get,
@@ -63,9 +57,18 @@ from ...services.hot_path_cache import (
     task_steps_key,
 )
 from ...services.managed_file_ref import DurableStorageOperationError
-from ...services.task_execution_controller import (
-    TaskControlState,
-    apply_task_control_transition,
+from ...services.sdk_task_service import (
+    SdkAgentMismatchError,
+    SdkTaskNotFoundError,
+    SdkTurnFilesMissingError,
+    bind_sdk_turn_files_sync,
+    load_sdk_task_snapshot_sync,
+    load_sdk_task_steps_snapshot_sync,
+    load_sdk_task_steps_version_sync,
+    mark_pending_sdk_task_failed_sync,
+    prepare_append_sdk_task_sync,
+    prepare_create_sdk_task_sync,
+    resolve_sdk_upload_owner_sync,
 )
 from ...services.task_orchestrator import (
     TaskTurnError,
@@ -82,6 +85,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE = "Connector runtime setup failed."
+_TASK_TURN_START_FAILED_MESSAGE = "Task turn start failed."
 
 
 @router.post("/chat/files", response_model=UploadFilesResponse)
@@ -95,8 +99,7 @@ async def upload_task_files(
             "the uploaded files."
         ),
     ),
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(get_agent_from_api_key),
 ) -> UploadFilesResponse:
     """Store files for later attachment to a task turn.
 
@@ -112,21 +115,24 @@ async def upload_task_files(
     owns the upload. This keeps historical tasks usable after agent ownership
     changes without transferring file ownership during append.
     """
-    from ..files import store_uploaded_files
+    from ..files import store_v1_uploaded_files
 
-    agent, _key = authed
-    upload_owner_user_id = int(agent.user_id)
-    if task_id is not None:
-        task = _resolve_task_or_404(task_id, agent, db)
-        upload_owner_user_id = int(task.user_id)
-
-    owner = db.query(User).filter(User.id == upload_owner_user_id).first()
-    if owner is None:
+    try:
+        upload_owner_user_id = await run_db_io_cancellation_safe(
+            lambda: resolve_sdk_upload_owner_sync(
+                task_id=task_id,
+                authenticated_agent_id=authed.agent_id,
+                default_user_id=authed.user_id,
+            )
+        )
+    except SdkTaskNotFoundError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404) from exc
+    if upload_owner_user_id is None:
         raise V1ApiError(V1ErrorCode.INTERNAL_ERROR, 500)
 
-    # Reject unsupported types up front with a clean v1 400. ``store_uploaded_files``
-    # would otherwise raise a bare HTTPException (a 500 for unsupported type) that
-    # bypasses the v1 error envelope and leaks the internal ``task_type`` wording.
+    # Reject unsupported types up front with a clean v1 400. The storage
+    # workflow otherwise raises a bare HTTPException that would bypass the v1
+    # envelope and leak its internal ``task_type`` wording.
     for uploaded in files:
         if not is_allowed_file(uploaded.filename or "", "general"):
             raise V1ApiError(
@@ -136,20 +142,16 @@ async def upload_task_files(
             )
 
     try:
-        result = await store_uploaded_files(
+        result = await store_v1_uploaded_files(
             upload_items=list(files),
             task_type="general",
-            task_id=None,
             folder=None,
-            user=owner,
-            db=db,
+            owner_user_id=upload_owner_user_id,
             single_file_mode=False,
         )
     except HTTPException as exc:
-        # ``store_uploaded_files`` is shared with the JWT upload route and raises
-        # bare HTTPExceptions; translate to the v1 envelope so SDK clients keep a
-        # stable {"error": {"code": ...}} shape. 503 (durable storage) stays 503 so
-        # callers can retry; 413 (too large) stays 413; other client errors -> 400.
+        # Translate storage-layer HTTPExceptions to the stable v1 envelope.
+        # 503 remains retryable; 413 remains 413; other client errors become 400.
         if exc.status_code == 503:
             raise V1ApiError(
                 V1ErrorCode.INTERNAL_ERROR,
@@ -176,47 +178,9 @@ async def upload_task_files(
     )
 
 
-def _resolve_turn_files_or_400(
-    *,
-    file_ids: list[str],
-    owner_user_id: int,
-    db: Session,
-    task_id: Optional[int] = None,
-) -> list[dict[str, Any]]:
-    """Resolve every ``file_id`` up front (all-or-nothing) WITHOUT binding.
-
-    Called before the task is committed (create) or the turn is claimed
-    (append), so a bad/unowned/already-bound id fails with 400 before any
-    task row is created or mutated -- no orphan task, no binding stuck to a
-    turn that later 409s. Actual binding happens via :func:`bind_turn_files`
-    only after the turn is committed to running.
-    """
-    if not file_ids:
-        return []
-    try:
-        file_infos, missing = resolve_turn_file_infos(
-            file_ids=file_ids,
-            owner_user_id=owner_user_id,
-            db=db,
-            task_id=task_id,
-        )
-    except DurableStorageOperationError as exc:
-        # Transient storage fault, not a client error -- 503 so SDK can retry.
-        raise V1ApiError(
-            V1ErrorCode.INTERNAL_ERROR,
-            503,
-            message="File storage is temporarily unavailable.",
-        ) from exc
-    if missing:
-        raise V1ApiError(
-            V1ErrorCode.INVALID_INPUT,
-            400,
-            message="These file ids are not accessible: " + ", ".join(missing),
-        )
-    return file_infos
-
-
-def _turn_payload(content: str, file_infos: list[dict[str, Any]]) -> TaskTurnPayload:
+def _turn_payload(
+    content: str, file_infos: list[dict[str, Any]] | tuple[dict[str, Any], ...]
+) -> TaskTurnPayload:
     """Build a :class:`TaskTurnPayload`, file-enriching the execution channel.
 
     Consolidates the payload construction shared by create and append so the
@@ -224,11 +188,14 @@ def _turn_payload(content: str, file_infos: list[dict[str, Any]]) -> TaskTurnPay
     """
     if not file_infos:
         return TaskTurnPayload(transcript_message=content)
-    context = build_uploaded_files_context(file_infos)
+    normalized_file_infos = list(file_infos)
+    context = build_uploaded_files_context(normalized_file_infos)
     return TaskTurnPayload(
         transcript_message=content,
         execution_message=append_uploaded_files_context(content, context),
-        attachments=normalize_attachments_for_persistence(file_infos) or None,
+        attachments=(
+            normalize_attachments_for_persistence(normalized_file_infos) or None
+        ),
     )
 
 
@@ -245,45 +212,11 @@ def _raise_v1_connector_runtime_error(exc: ConnectorRuntimeError) -> NoReturn:
     ) from exc
 
 
-def _rollback_runtime_setup_mark_failure(db: Session, task_id: int) -> None:
-    try:
-        db.rollback()
-    except Exception:
-        logger.warning(
-            "Failed to roll back task %s session after connector runtime setup error",
-            task_id,
-            exc_info=True,
-        )
-
-
-def _mark_task_failed_after_runtime_setup_error(db: Session, task_id: int) -> None:
-    """Best-effort terminal mark after pre-schedule runtime setup fails."""
-
-    try:
-        db.rollback()
-        task = db.query(Task).filter(Task.id == task_id).first()
-        if task is not None:
-            orm_task = cast(Any, task)
-            apply_task_control_transition(
-                task,
-                TaskControlState.FAILED,
-                status=TaskStatus.FAILED,
-            )
-            orm_task.error_message = _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE
-            db.commit()
-    except Exception:
-        _rollback_runtime_setup_mark_failure(db, task_id)
-        logger.warning(
-            "Failed to mark task %s failed after connector runtime setup error",
-            task_id,
-            exc_info=True,
-        )
-
-
-def _store_connector_runtime_values_or_fail(
+async def _store_connector_runtime_values_or_fail(
     *,
-    db: Session,
     task_id: int,
+    agent_id: int,
+    owner_user_id: int,
     turn_id: str,
     values_by_ref: dict,
     mark_task_failed: bool,
@@ -293,7 +226,14 @@ def _store_connector_runtime_values_or_fail(
     except Exception as exc:
         pop_ephemeral_runtime_values(turn_id)
         if mark_task_failed:
-            _mark_task_failed_after_runtime_setup_error(db, task_id)
+            await run_db_io_cancellation_safe(
+                lambda: mark_pending_sdk_task_failed_sync(
+                    task_id,
+                    _CONNECTOR_RUNTIME_SETUP_FAILED_MESSAGE,
+                    expected_agent_id=agent_id,
+                    expected_owner_user_id=owner_user_id,
+                )
+            )
         logger.warning(
             "Connector runtime setup failed for task %s turn %s",
             task_id,
@@ -313,8 +253,7 @@ def _store_connector_runtime_values_or_fail(
 )
 async def create_chat_task(
     request: CreateTaskRequest,
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(get_agent_from_api_key),
 ) -> CreateTaskResponse:
     """Create a new SDK-driven task and kick off its first turn.
 
@@ -340,10 +279,9 @@ async def create_chat_task(
         request: Validated :class:`CreateTaskRequest`. ``message.content``
             is guaranteed non-empty by Pydantic; ``agent_id`` is the
             target agent the SDK caller wants to invoke.
-        authed: ``(Agent, AgentApiKey)`` tuple resolved by the auth
-            dependency. The agent here is the *key-bound* agent, the
-            single source of truth for what this caller may touch.
-        db: SQLAlchemy session.
+        authed: Detached key-bound agent identity resolved by the auth
+            dependency; the single source of truth for what this caller
+            may touch.
 
     Returns:
         :class:`CreateTaskResponse` with the new ``task_id``,
@@ -362,136 +300,105 @@ async def create_chat_task(
             ``{"error": {"code": "internal_error", ...}}`` and the raw
             exception message stays out of the response.
     """
-    agent, _key = authed
-    task_source = "sdk"
-    task_owner_user_id = int(agent.user_id)
-    actor_user_id = int(agent.user_id)
-
     # Server-side agent_id consistency check. The key already binds an
     # agent; ``body.agent_id`` is required by the SDK contract for
     # forward-compat (and Python/TS SDK symmetry), but the bound
     # agent is the only authority. Mismatch is a 404 -- never a 403
     # -- so the existence of agent_id=N elsewhere in the system isn't
     # observable to this caller.
-    if request.agent_id != agent.id:
+    if request.agent_id != authed.agent_id:
         raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
 
-    # Validate any attached file ids BEFORE creating the task, so a bad id
-    # fails with 400 without leaving an orphan PENDING task behind. Binding
-    # happens after the turn is claimed (below).
-    file_infos = _resolve_turn_files_or_400(
-        file_ids=request.message.files or [],
-        owner_user_id=task_owner_user_id,
-        db=db,
-        task_id=None,
-    )
-
-    # title is what the web UI shows in its task list. Truncate to
-    # 50 chars (matches the WS handler convention) so very long
-    # user inputs don't fill the sidebar with a one-line wall of
-    # text. The full message is preserved in ``description`` /
-    # ``input`` / ``task_chat_messages``.
-    title = request.message.content[:50] or "SDK task"
-
-    # Create the Task row with SDK-specific fields populated.
-    # ``source='sdk'`` lets adoption metrics queries split SDK traffic
-    # from web/widget; ``is_visible=False`` keeps SDK/REST runs out of
-    # Web UI discovery surfaces while preserving exact task-id access
-    # for SDK polling and audit views; ``input`` records this turn's
-    # user message so GET endpoint can return it without going through
-    # task_chat_messages.
-    task = Task(
-        user_id=task_owner_user_id,
-        title=title,
-        description=request.message.content,
-        status=TaskStatus.PENDING,
-        agent_id=agent.id,
-        input=request.message.content,
-        source=task_source,
-        is_visible=False,
-    )
+    operation = asyncio.create_task(_create_chat_task_workflow(request, authed))
     try:
-        runtime_plan = prepare_create_connector_runtime(
-            db=db,
-            agent=agent,
-            task_source=task_source,
-            connector_user_id=task_owner_user_id,
-            payload_items=request.connector_runtime_context,
-        )
-        bind_create_connector_runtime_plan(task=task, plan=runtime_plan)
+        return await drain_async_task_cancellation_safe(operation)
+    except SdkTurnFilesMissingError as exc:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            message="These file ids are not accessible: " + ", ".join(exc.missing),
+        ) from exc
+    except DurableStorageOperationError as exc:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            503,
+            message="File storage is temporarily unavailable.",
+        ) from exc
     except ConnectorRuntimeError as exc:
         _raise_v1_connector_runtime_error(exc)
+    except TaskTurnNotFoundError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404) from exc
+    except TaskTurnError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409) from exc
 
-    db.add(task)
-    db.flush()
-    persist_create_connector_runtime_context(
-        db=db, task_id=int(task.id), plan=runtime_plan
+
+async def _create_chat_task_workflow(
+    request: CreateTaskRequest,
+    authed: AgentApiIdentity,
+) -> CreateTaskResponse:
+    """Own a create from first durable write through turn scheduling.
+
+    The route drains this child on caller cancellation.  That prevents a
+    committed PENDING task from being abandoned between worker preparation and
+    ``begin_turn``.
+    """
+
+    prepared = await run_db_io_cancellation_safe(
+        lambda: prepare_create_sdk_task_sync(
+            agent_id=authed.agent_id,
+            task_owner_user_id=authed.user_id,
+            actor_user_id=authed.user_id,
+            tool_categories=authed.tool_categories,
+            content=request.message.content,
+            file_ids=tuple(request.message.files or ()),
+            connector_runtime_context=tuple(
+                item.model_dump() for item in (request.connector_runtime_context or ())
+            ),
+        )
     )
-    db.commit()
-    db.refresh(task)
-
-    # Orchestrator's begin_turn handles the full new-turn transition:
-    # bg-inflight guard, atomic status flip + transcript persist in one
-    # commit, and bg coroutine scheduling under a lease lifecycle.
-    # A brand-new task shouldn't ever hit busy -- but we map it
-    # anyway for defense.
-    payload = _turn_payload(request.message.content, file_infos)
-    _store_connector_runtime_values_or_fail(
-        db=db,
-        task_id=int(task.id),
+    payload = _turn_payload(request.message.content, prepared.file_infos)
+    await _store_connector_runtime_values_or_fail(
+        task_id=prepared.task_id,
+        agent_id=prepared.agent_id,
+        owner_user_id=prepared.task_owner_user_id,
         turn_id=payload.turn_id,
-        values_by_ref=runtime_plan.ephemeral_by_ref,
+        values_by_ref=prepared.ephemeral_by_ref,
         mark_task_failed=True,
     )
     try:
         started = await TaskTurnOrchestrator.begin_turn(
-            task_id=int(task.id),
-            task_owner_user_id=task_owner_user_id,
-            # SDK key resolves to the agent owner; actor == owner here.
-            actor_user_id=actor_user_id,
+            task_id=prepared.task_id,
+            task_owner_user_id=prepared.task_owner_user_id,
+            actor_user_id=prepared.actor_user_id,
             payload=payload,
             kind=TurnKind.CREATE,
             force_fresh=False,
         )
-    except TaskTurnNotFoundError:
+    except (Exception, asyncio.CancelledError):
         pop_ephemeral_runtime_values(payload.turn_id)
-        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
-    except TaskTurnError:
-        pop_ephemeral_runtime_values(payload.turn_id)
-        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
-    except Exception:
-        pop_ephemeral_runtime_values(payload.turn_id)
+        await run_db_io_cancellation_safe(
+            lambda: mark_pending_sdk_task_failed_sync(
+                prepared.task_id,
+                _TASK_TURN_START_FAILED_MESSAGE,
+                expected_agent_id=prepared.agent_id,
+                expected_owner_user_id=prepared.task_owner_user_id,
+            )
+        )
         raise
 
-    # Bind files only after the turn is committed to running. This bind can
-    # race the background runner (begin_turn schedules it via create_task and
-    # may await further steps before returning here), but that's harmless: the
-    # runner's file query tolerates a NULL task_id (task_id == this OR IS NULL,
-    # owned by the user), so the just-uploaded files are readable whether or
-    # not this bind has landed. The bind is for durable task<->file association.
-    bind_turn_files(
-        file_ids=[info["file_id"] for info in file_infos],
-        task_id=int(task.id),
-        owner_user_id=task_owner_user_id,
-        db=db,
+    await run_db_io_cancellation_safe(
+        lambda: bind_sdk_turn_files_sync(
+            file_ids=tuple(info["file_id"] for info in prepared.file_infos),
+            task_id=prepared.task_id,
+            owner_user_id=prepared.task_owner_user_id,
+        )
     )
-
-    # Record usage here (not in the shared auth dependency) so read-only
-    # status/steps polling below doesn't count as a "call". Runtime validation
-    # and turn claim have already accepted this as a real task invocation.
-    record_key_usage(str(_key.key_prefix))
-
-    # ``status`` comes from the orchestrator's committed-row snapshot
-    # (``started.status`` == RUNNING), NOT the caller's ``task`` object --
-    # ``begin_turn`` now commits on an isolated worker-thread session and
-    # never refreshes this request's ORM row, so ``task.status`` is still
-    # the stale PENDING. ``created_at`` is set at task creation and isn't
-    # touched by the turn, so the in-memory value is correct.
+    await record_key_usage(authed.key_prefix)
     return CreateTaskResponse(
-        task_id=int(task.id),
-        agent_id=int(agent.id),
+        task_id=prepared.task_id,
+        agent_id=prepared.agent_id,
         status=started.status.value,
-        created_at=task.created_at,
+        created_at=prepared.created_at,
         run_id=started.run_id,
         state_version=started.state_version,
         control_state=started.control_state,
@@ -506,55 +413,6 @@ async def create_chat_task(
 _TERMINAL_STATUSES = (TaskStatus.COMPLETED, TaskStatus.FAILED)
 
 
-def _resolve_task_or_404(task_id: int, agent: Agent, db: Session) -> Task:
-    """Resolve a task_id against the calling agent's ownership AND
-    SDK-source scope.
-
-    Returns the :class:`Task` row when the task:
-
-      1. Exists.
-      2. Belongs to ``agent``.
-      3. Was created by the SDK (``source == "sdk"``).
-
-    Any other case — missing row, row belongs to a different agent,
-    or row was created by the Web UI / internal paths — raises
-    :class:`V1ApiError` with ``task_not_found`` (404 not 403, so the
-    existence of tasks under other agents / other surfaces isn't
-    observable through error code).
-
-    The ``source == "sdk"`` filter exists because an SDK API key
-    binds to an agent, not to a particular product surface. Without
-    it, an SDK client could read or append to any task the Web UI
-    created under the same agent (the user's own historical Web UI
-    chats, for example). Whether that's intentional is a product
-    decision, but the safe default for a public SDK is to scope
-    lookups to tasks the SDK itself created — ``POST /v1/chat/tasks``
-    writes ``source="sdk"`` so this is well-defined.
-
-    Args:
-        task_id: Path parameter from the route.
-        agent: The key-bound agent resolved by
-            ``get_agent_from_api_key``.
-        db: SQLAlchemy session.
-
-    Raises:
-        V1ApiError(TASK_NOT_FOUND, 404): task missing, not owned by
-            the calling agent, or not created by the SDK.
-    """
-    task = (
-        db.query(Task)
-        .filter(
-            Task.id == task_id,
-            Task.agent_id == agent.id,
-            Task.source == "sdk",
-        )
-        .first()
-    )
-    if task is None:
-        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
-    return task
-
-
 @router.post(
     "/chat/tasks/{task_id}/messages",
     status_code=202,
@@ -563,8 +421,7 @@ def _resolve_task_or_404(task_id: int, agent: Agent, db: Session) -> Task:
 async def append_message_to_task(
     task_id: int,
     request: AppendMessageRequest,
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(get_agent_from_api_key),
 ) -> AppendMessageResponse:
     """Append the next user message to an existing task and kick off its next turn.
 
@@ -589,8 +446,7 @@ async def append_message_to_task(
         task_id: Path parameter; the target task's primary key.
         request: Validated :class:`AppendMessageRequest`. ``message.content``
             is guaranteed non-empty by Pydantic.
-        authed: ``(Agent, AgentApiKey)`` from the auth dependency.
-        db: SQLAlchemy session.
+        authed: Detached key-bound agent identity from the auth dependency.
 
     Returns:
         :class:`AppendMessageResponse` with the task identity and an
@@ -603,100 +459,87 @@ async def append_message_to_task(
         V1ApiError 409: ``task_busy`` -- task currently RUNNING.
         500: any other unexpected error (V1 envelope via global handler).
     """
-    agent, _key = authed
-
-    # Resolve task first so cross-agent leak protection (404 instead
-    # of 403 for "not yours") fires before any body-level checks.
-    task = _resolve_task_or_404(task_id, agent, db)
-    task_owner_user_id = int(task.user_id)
-    actor_user_id = int(agent.user_id)
-
-    # body.agent_id mismatch is also a 404 -- but agent_not_found,
-    # not task_not_found, because that's the field the caller got
-    # wrong. Choosing AGENT_NOT_FOUND keeps it consistent with the
-    # POST /v1/chat/tasks behavior for the same condition.
-    if request.agent_id != agent.id:
-        raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
-
+    operation = asyncio.create_task(
+        _append_message_to_task_workflow(task_id, request, authed)
+    )
     try:
-        runtime_plan = prepare_append_connector_runtime(
-            db=db,
-            agent=agent,
-            task=task,
-            connector_user_id=task_owner_user_id,
-            payload_items=request.connector_runtime_context,
-        )
+        return await drain_async_task_cancellation_safe(operation)
+    except SdkTaskNotFoundError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404) from exc
+    except SdkAgentMismatchError as exc:
+        raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404) from exc
+    except SdkTurnFilesMissingError as exc:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            message="These file ids are not accessible: " + ", ".join(exc.missing),
+        ) from exc
+    except DurableStorageOperationError as exc:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            503,
+            message="File storage is temporarily unavailable.",
+        ) from exc
     except ConnectorRuntimeError as exc:
         _raise_v1_connector_runtime_error(exc)
+    except TaskTurnNotFoundError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404) from exc
+    except TaskTurnError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409) from exc
 
-    # Validate attached file ids before claiming the turn: an unresolvable id
-    # is a 400 that must not mutate anything, and files must not be bound to a
-    # turn that then 409s (task busy). ``task_id`` is passed so files already
-    # bound to this task re-resolve idempotently. Binding runs after the claim.
-    file_infos = _resolve_turn_files_or_400(
-        file_ids=request.message.files or [],
-        owner_user_id=task_owner_user_id,
-        db=db,
-        task_id=int(task.id),
+
+async def _append_message_to_task_workflow(
+    task_id: int,
+    request: AppendMessageRequest,
+    authed: AgentApiIdentity,
+) -> AppendMessageResponse:
+    """Own append preparation and claim through caller cancellation."""
+
+    prepared = await run_db_io_cancellation_safe(
+        lambda: prepare_append_sdk_task_sync(
+            task_id=task_id,
+            authenticated_agent_id=authed.agent_id,
+            actor_user_id=authed.user_id,
+            requested_agent_id=request.agent_id,
+            file_ids=tuple(request.message.files or ()),
+            connector_runtime_context=tuple(
+                item.model_dump() for item in (request.connector_runtime_context or ())
+            ),
+        )
     )
-
-    # Orchestrator does the atomic claim (status must be terminal --
-    # COMPLETED or FAILED -- to be appendable, so PENDING/RUNNING both
-    # 409), persists the new user message, and schedules the bg turn
-    # with a single-flight guard against concurrent kickoffs.
-    payload = _turn_payload(request.message.content, file_infos)
-    _store_connector_runtime_values_or_fail(
-        db=db,
-        task_id=int(task.id),
+    payload = _turn_payload(request.message.content, prepared.file_infos)
+    await _store_connector_runtime_values_or_fail(
+        task_id=task_id,
+        agent_id=prepared.agent_id,
+        owner_user_id=prepared.task_owner_user_id,
         turn_id=payload.turn_id,
-        values_by_ref=runtime_plan.ephemeral_by_ref,
+        values_by_ref=prepared.ephemeral_by_ref,
         mark_task_failed=False,
     )
     try:
         started = await TaskTurnOrchestrator.begin_turn(
-            task_id=int(task.id),
-            task_owner_user_id=task_owner_user_id,
-            # The key-bound agent authorizes access; the persisted task owner
-            # remains the runtime identity when those identities have drifted.
-            actor_user_id=actor_user_id,
+            task_id=task_id,
+            task_owner_user_id=prepared.task_owner_user_id,
+            actor_user_id=prepared.actor_user_id,
             payload=payload,
             kind=TurnKind.APPEND,
             force_fresh=False,
         )
-    except TaskTurnNotFoundError:
-        pop_ephemeral_runtime_values(payload.turn_id)
-        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
-    except TaskTurnError:
-        pop_ephemeral_runtime_values(payload.turn_id)
-        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
-    except Exception:
+    except (Exception, asyncio.CancelledError):
         pop_ephemeral_runtime_values(payload.turn_id)
         raise
 
-    # Bind files only after the turn is claimed -- a 409 above leaves them
-    # unbound and reusable. The bind can race the background runner, but the
-    # runner's file query tolerates a NULL task_id (see create_chat_task), so
-    # visibility doesn't depend on this commit landing first.
-    bind_turn_files(
-        file_ids=[info["file_id"] for info in file_infos],
-        task_id=int(task.id),
-        owner_user_id=task_owner_user_id,
-        db=db,
+    await run_db_io_cancellation_safe(
+        lambda: bind_sdk_turn_files_sync(
+            file_ids=tuple(info["file_id"] for info in prepared.file_infos),
+            task_id=task_id,
+            owner_user_id=prepared.task_owner_user_id,
+        )
     )
-
-    # See the matching comment in create_chat_task: recorded here, not in
-    # the shared auth dependency, so status polling elsewhere never counts.
-    record_key_usage(str(_key.key_prefix))
-
-    # ``status`` / ``accepted_at`` come from the orchestrator's committed-row
-    # snapshot (``started``), not a post-call ``db.refresh(task)``. The
-    # refresh was itself a blocking SELECT on the event loop; ``begin_turn``
-    # already SELECTed ``updated_at`` (set by ``onupdate=func.now()`` on the
-    # atomic UPDATE) inside its off-loop transaction, so SDK clients still see
-    # a value matching what GET /v1/chat/tasks/{id} would return.
+    await record_key_usage(authed.key_prefix)
     return AppendMessageResponse(
-        task_id=int(task.id),
-        agent_id=int(agent.id),
+        task_id=task_id,
+        agent_id=prepared.agent_id,
         status=started.status.value,
         accepted_at=started.updated_at,
         run_id=started.run_id,
@@ -708,8 +551,7 @@ async def append_message_to_task(
 @router.get("/chat/tasks/{task_id}", response_model=TaskInfoResponse)
 async def get_chat_task(
     task_id: int,
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(get_agent_from_api_key),
 ) -> TaskInfoResponse:
     """Return a snapshot of one task's current state.
 
@@ -720,8 +562,7 @@ async def get_chat_task(
 
     Args:
         task_id: Path parameter; the target task's primary key.
-        authed: ``(Agent, AgentApiKey)`` tuple.
-        db: SQLAlchemy session.
+        authed: Detached key-bound agent identity.
 
     Returns:
         :class:`TaskInfoResponse` with ``task_id``, ``agent_id``,
@@ -733,8 +574,11 @@ async def get_chat_task(
         V1ApiError 401: missing / invalid / revoked key.
         V1ApiError 404: task missing or not owned by the calling agent.
     """
-    agent, _key = authed
-    task = _resolve_task_or_404(task_id, agent, db)
+    task = await run_db_io_cancellation_safe(
+        lambda: load_sdk_task_snapshot_sync(task_id, authed.agent_id)
+    )
+    if task is None:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
 
     # completed_at is derived from updated_at when the task is in a
     # terminal state. Pre-terminal states return None so SDK clients
@@ -748,8 +592,8 @@ async def get_chat_task(
         return TaskInfoResponse.model_validate(cached["response"])
 
     response = TaskInfoResponse(
-        task_id=int(task.id),
-        agent_id=int(task.agent_id),
+        task_id=task.task_id,
+        agent_id=task.agent_id,
         status=task.status.value,
         run_id=task.run_id,
         state_version=int(task.state_version or 0),
@@ -774,8 +618,7 @@ async def get_chat_task(
 @router.get("/chat/tasks/{task_id}/steps", response_model=StepsResponse)
 async def get_chat_task_steps(
     task_id: int,
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
-    db: Session = Depends(get_db),
+    authed: AgentApiIdentity = Depends(get_agent_from_api_key),
 ) -> StepsResponse:
     """Return the public-timeline steps for a task.
 
@@ -793,9 +636,8 @@ async def get_chat_task_steps(
 
     Args:
         task_id: Path parameter; the target task's primary key.
-        authed: ``(Agent, AgentApiKey)`` tuple resolved by the auth
-            dependency. The agent here is the key-bound agent.
-        db: SQLAlchemy session.
+        authed: Detached key-bound agent identity resolved by the auth
+            dependency.
 
     Returns:
         :class:`StepsResponse` with ``task_id``, ``agent_id``, and the
@@ -807,51 +649,36 @@ async def get_chat_task_steps(
         V1ApiError 401: missing / invalid / revoked key.
         V1ApiError 404: task missing or not owned by the calling agent.
     """
-    agent, _key = authed
-    task = _resolve_task_or_404(task_id, agent, db)
-
-    max_event_id = (
-        db.query(func.max(TraceEvent.id))
-        .filter(
-            TraceEvent.task_id == task_id,
-            TraceEvent.build_id.is_(None),
-        )
-        .scalar()
-        or 0
+    version = await run_db_io_cancellation_safe(
+        lambda: load_sdk_task_steps_version_sync(task_id, authed.agent_id)
     )
+    if version is None:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
     cache_key = task_steps_key(task_id)
     cached = cache_get(cache_key)
-    if isinstance(cached, dict) and cached.get("max_event_id") == int(max_event_id):
+    if isinstance(cached, dict) and cached.get("max_event_id") == version.max_event_id:
         return StepsResponse.model_validate(cached["response"])
 
-    # Ordered ASC by ``id`` -- the trace_events PK is monotonically
-    # increasing per write, so ordering by it gives us the same
-    # temporal ordering as ``timestamp`` but without depending on
-    # clock-skew within a single task's write fan-out.
-    events = (
-        db.query(TraceEvent)
-        .filter(
-            TraceEvent.task_id == task_id,
-            TraceEvent.build_id.is_(None),
-        )
-        .order_by(TraceEvent.id.asc())
-        .all()
+    snapshot = await run_db_io_cancellation_safe(
+        lambda: load_sdk_task_steps_snapshot_sync(task_id, authed.agent_id)
     )
+    if snapshot is None:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
 
     # Pure mapping -- testable in isolation via
     # tests/web/api/v1/test_steps_mapping.py without spinning up a
     # FastAPI app or DB session.
-    public_steps_data = map_trace_events_to_public_steps(events)
+    public_steps_data = map_trace_events_to_public_steps(list(snapshot.events))
 
     response = StepsResponse(
-        task_id=int(task.id),
-        agent_id=int(task.agent_id),
+        task_id=snapshot.task_id,
+        agent_id=snapshot.agent_id,
         steps=[PublicStep(**step) for step in public_steps_data],
     )
     cache_set(
         cache_key,
         {
-            "max_event_id": int(max_event_id),
+            "max_event_id": snapshot.max_event_id,
             "response": response.model_dump(mode="json"),
         },
         ttl_seconds=task_cache_ttl_seconds(),

--- a/src/xagent/web/api/v1/templates.py
+++ b/src/xagent/web/api/v1/templates.py
@@ -1,12 +1,11 @@
 """SDK management endpoints for built-in templates."""
 
-from typing import Any, Tuple
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
-from ...models.user import User
-from ...models.user_api_key import UserApiKey
 from ...schemas.v1 import V1TemplateDetail, V1TemplateSummary
+from ...services.api_keys import PersonalApiIdentity
 from .deps import get_user_from_personal_key
 from .errors import V1ApiError, V1ErrorCode
 
@@ -49,7 +48,7 @@ def _template_summary(template: dict[str, Any]) -> V1TemplateSummary:
 @router.get("", response_model=list[V1TemplateSummary])
 async def list_templates(
     request: Request,
-    _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    _authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> list[V1TemplateSummary]:
     template_manager = _get_template_manager(request)
     templates = await template_manager.list_templates()
@@ -60,7 +59,7 @@ async def list_templates(
 async def get_template(
     template_id: str,
     request: Request,
-    _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    _authed: PersonalApiIdentity = Depends(get_user_from_personal_key),
 ) -> V1TemplateDetail:
     template_manager = _get_template_manager(request)
     template = await template_manager.get_template(template_id)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -24,6 +24,7 @@ from typing import (
 )
 from urllib.parse import unquote
 
+from anyio import BrokenResourceError, ClosedResourceError
 from fastapi import (
     APIRouter,
     Depends,
@@ -3233,6 +3234,8 @@ class ConnectionManager:
     def __init__(self) -> None:
         # task_id -> List[WebSocket]
         self.active_connections: Dict[int, List[WebSocket]] = {}
+        # WebSocket -> current task_id
+        self._connection_task_ids: Dict[WebSocket, int] = {}
 
     async def connect(self, websocket: WebSocket, task_id: int) -> None:
         await websocket.accept()
@@ -3240,12 +3243,16 @@ class ConnectionManager:
 
     def register_connection(self, websocket: WebSocket, task_id: int) -> None:
         """Register an already-accepted websocket for task broadcasts."""
+        current_task_id = self._connection_task_ids.get(websocket)
+        if current_task_id is not None and current_task_id != task_id:
+            self._remove_from_task(websocket, current_task_id)
         if task_id not in self.active_connections:
             self.active_connections[task_id] = []
         if websocket not in self.active_connections[task_id]:
             self.active_connections[task_id].append(websocket)
+        self._connection_task_ids[websocket] = task_id
 
-    def disconnect(self, websocket: WebSocket, task_id: int) -> None:
+    def _remove_from_task(self, websocket: WebSocket, task_id: int) -> None:
         if task_id in self.active_connections:
             try:
                 self.active_connections[task_id].remove(websocket)
@@ -3254,21 +3261,31 @@ class ConnectionManager:
             except ValueError:
                 pass
 
-    def move_connection(
-        self, websocket: WebSocket, old_task_id: int, new_task_id: int
-    ) -> None:
-        """Move a WebSocket connection from one task_id to another"""
-        if old_task_id in self.active_connections:
-            try:
-                self.active_connections[old_task_id].remove(websocket)
-                if not self.active_connections[old_task_id]:
-                    del self.active_connections[old_task_id]
-            except ValueError:
-                pass
+    def disconnect(self, websocket: WebSocket) -> None:
+        task_id = self._connection_task_ids.pop(websocket, None)
+        if task_id is not None:
+            self._remove_from_task(websocket, task_id)
 
-        if new_task_id not in self.active_connections:
-            self.active_connections[new_task_id] = []
-        self.active_connections[new_task_id].append(websocket)
+    def detach_task_connections(self, task_id: int) -> List[WebSocket]:
+        """Remove and return every connection currently owned by a task."""
+        connections = self.active_connections.pop(task_id, [])
+        for connection in connections:
+            if self._connection_task_ids.get(connection) == task_id:
+                del self._connection_task_ids[connection]
+        return connections
+
+    def connections_for_task(self, task_id: int) -> List[WebSocket]:
+        """Return a stable snapshot of a task's current connections."""
+        return self.active_connections.get(task_id, []).copy()
+
+    def is_connection_registered(self, websocket: WebSocket, task_id: int) -> bool:
+        """Return whether a connection is still owned by the given task."""
+        return self._connection_task_ids.get(websocket) == task_id
+
+    def move_connection(self, websocket: WebSocket, new_task_id: int) -> None:
+        """Move a WebSocket connection from one task_id to another"""
+        old_task_id = self._connection_task_ids.get(websocket)
+        self.register_connection(websocket, new_task_id)
         logger.info(
             f"Moved WebSocket connection from task {old_task_id} to {new_task_id}"
         )
@@ -3278,25 +3295,33 @@ class ConnectionManager:
         await websocket.send_text(json.dumps(versioned_message))
 
     async def broadcast_to_task(self, message: dict, task_id: int) -> None:
-        if task_id in self.active_connections:
+        if self.connections_for_task(task_id):
             versioned_message = await _with_current_task_control_state(
                 message,
                 fallback_task_id=task_id,
             )
-            for connection in self.active_connections[task_id].copy():
+            for connection in self.connections_for_task(task_id):
+                if not self.is_connection_registered(connection, task_id):
+                    continue
                 try:
                     await connection.send_text(json.dumps(versioned_message))
-                except (ConnectionError, WebSocketDisconnect, RuntimeError) as e:
+                except (
+                    BrokenResourceError,
+                    ClosedResourceError,
+                    ConnectionError,
+                    WebSocketDisconnect,
+                    RuntimeError,
+                ) as e:
                     # Network connection error, remove disconnected connection
                     logger.warning(f"Connection error for task {task_id}: {e}")
-                    self.disconnect(connection, task_id)
+                    self.disconnect(connection)
                 except Exception as e:
                     # Other errors should not be silently handled, log and re-raise
                     logger.error(
                         f"Unexpected error broadcasting to task {task_id}: {e}"
                     )
                     # Remove disconnected connection but preserve error propagation
-                    self.disconnect(connection, task_id)
+                    self.disconnect(connection)
                     raise
 
 
@@ -3967,7 +3992,7 @@ async def _handle_chat_message_unserialized(
                         )
 
                         # Move WebSocket connection to new task_id
-                        manager.move_connection(websocket, old_task_id, task_id)
+                        manager.move_connection(websocket, task_id)
 
                         # Send task ID update event to notify frontend
                         await manager.send_personal_message(
@@ -5701,16 +5726,16 @@ async def websocket_chat_endpoint(
                 )
 
     except WebSocketDisconnect:
-        manager.disconnect(websocket, task_id)
+        pass
     except (ConnectionError, RuntimeError) as e:
         # Connection error
         logger.error(f"Connection error in WebSocket: {e}")
-        manager.disconnect(websocket, task_id)
     except Exception as e:
         # Other errors, re-raise
         logger.error(f"Unexpected error in WebSocket: {e}")
-        manager.disconnect(websocket, task_id)
         raise
+    finally:
+        manager.disconnect(websocket)
 
 
 async def handle_intervention(
@@ -6247,7 +6272,7 @@ async def _execute_durable_task_command(
     still broadcast normally.
     """
 
-    connections = manager.active_connections.get(command.task_id, [])
+    connections = manager.connections_for_task(command.task_id)
     websocket: Any = connections[0] if connections else _DiscardingCommandWebSocket()
     message_data = dict(command.payload)
     message_data.update(
@@ -6936,12 +6961,7 @@ async def websocket_build_preview_endpoint(
                         )
                     )
             elif message_type == "clear_context":
-                preview_task_id = getattr(websocket.state, "preview_task_id", None)
-                if (
-                    isinstance(preview_task_id, (int, str))
-                    and str(preview_task_id).isdigit()
-                ):
-                    manager.disconnect(websocket, int(preview_task_id))
+                manager.disconnect(websocket)
                 websocket.state.preview_task_id = None
                 await websocket.send_text(
                     json.dumps(
@@ -6963,14 +6983,13 @@ async def websocket_build_preview_endpoint(
                 )
 
     except WebSocketDisconnect:
-        preview_task_id = getattr(websocket.state, "preview_task_id", None)
-        if isinstance(preview_task_id, (int, str)) and str(preview_task_id).isdigit():
-            manager.disconnect(websocket, int(preview_task_id))
         logger.info(f"Build preview WebSocket disconnected for user {user.id}")
     except (ConnectionError, RuntimeError) as e:
         logger.error(f"Connection error in build preview WebSocket: {e}")
     except Exception as e:
         logger.error(f"Unexpected error in build preview WebSocket: {e}")
+    finally:
+        manager.disconnect(websocket)
 
 
 async def handle_build_preview_execution(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7,9 +7,21 @@ import re
 import shutil
 import uuid
 from contextlib import closing
+from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 from urllib.parse import unquote
 
 from fastapi import (
@@ -21,7 +33,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import RedirectResponse
-from sqlalchemy import func, or_
+from sqlalchemy import case, func, or_, update
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -31,11 +43,18 @@ from ...config import (
 )
 from ...core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from ...core.agent.trace import TraceEvent, TraceHandler, trace_user_message
-from ...core.execution_scope import resolve_execution_scope, turn_execution_scope
+from ...core.execution_scope import (
+    ExecutionScope,
+    ExecutionScopeContext,
+    resolve_execution_scope,
+)
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
 from ..models.chat_message import TaskChatMessage
-from ..models.database import get_db, get_session_local
+from ..models.database import (
+    get_db,
+    get_session_local,
+)
 from ..models.task import Task, TaskStatus
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
@@ -55,6 +74,11 @@ from ..services.chat_history_service import (
     inspect_user_message_delivery,
     mark_user_message_delivery,
     mark_user_message_delivery_sync,
+)
+from ..services.db_runtime import (
+    drain_async_task_cancellation_safe,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
 )
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
@@ -102,24 +126,26 @@ from ..services.task_command_transport import (
 )
 from ..services.task_execution_controller import (
     StaleTaskRunError,
+    TaskControlSnapshot,
     TaskControlState,
     apply_task_control_transition,
+    control_state_for_status,
     task_control_snapshot,
     task_execution_controller,
 )
 from ..services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
     acquire_task_lease,
+    acquire_task_lease_cancellation_safe,
+    acquire_task_lease_no_commit,
     mark_task_paused_if_stale,
+    release_task_lease_no_commit,
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
 from ..services.uploaded_file_store import UploadedFileStore
-from ..services.workforce_runtime import (
-    mark_workforce_task_status,
-    release_current_runner_task_lease_with_workforce_sync,
-    release_task_lease_with_workforce_sync,
-    sync_workforce_run_status,
-)
+from ..services.workforce_runtime import sync_workforce_run_status
 from ..tracing import create_ephemeral_tracer
 from ..user_isolated_memory import UserContext
 from ..utils.db_timezone import safe_timestamp_to_unix
@@ -134,6 +160,13 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_EVENT_TYPE_NAME = str(CHECKPOINT_EVENT_TYPE)
 
 _pause_accepted_task_ids: set[int] = set()
+
+
+class _ResolvedExecutionScopeNotProvided:
+    """Sentinel separating an omitted scope from an explicitly unscoped turn."""
+
+
+_RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED = _ResolvedExecutionScopeNotProvided()
 
 
 def _mark_task_pause_accepted(task_id: int) -> None:
@@ -223,59 +256,104 @@ async def _send_message_delivery(
     await manager.send_personal_message(payload, websocket)
 
 
+@overload
 def _terminal_task_error_payload(
     task_id: int,
     message: str,
     *,
     event_type: str = "agent_error",
     expected_run_id: str | None = None,
-) -> dict[str, Any]:
+    only_if_running: Literal[False] = False,
+) -> dict[str, Any]: ...
+
+
+@overload
+def _terminal_task_error_payload(
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "agent_error",
+    expected_run_id: str | None = None,
+    only_if_running: Literal[True],
+) -> dict[str, Any] | None: ...
+
+
+def _terminal_task_error_payload(
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "agent_error",
+    expected_run_id: str | None = None,
+    only_if_running: bool = False,
+) -> dict[str, Any] | None:
     SessionLocal = get_session_local()
     db = SessionLocal()
     try:
-        current_task = db.query(Task).filter(Task.id == task_id).first()
-        if (
-            current_task is not None
-            and expected_run_id is not None
-            and current_task.run_id != expected_run_id
-        ):
-            logger.info(
-                "Ignoring late terminal error for task %s run %s; current run is %s",
-                task_id,
-                expected_run_id,
-                current_task.run_id,
-            )
-            return _task_error_payload(db, task_id, message, event_type=event_type)
-        released = release_current_runner_task_lease_with_workforce_sync(
-            db,
-            task_id,
-            status=TaskStatus.FAILED,
-            expected_run_id=expected_run_id,
-        )
-        task = db.query(Task).filter(Task.id == task_id).first()
-        if task is not None:
-            if not released:
-                orm_task = cast(Any, task)
-                orm_task.runner_id = None
-                orm_task.lease_expires_at = None
-                orm_task.last_heartbeat_at = datetime.now(timezone.utc)
-            mark_workforce_task_status(
-                db,
-                task,
-                TaskStatus.FAILED,
+        failed_control_state = TaskControlState.FAILED.value
+        current_version = func.coalesce(Task.state_version, 0)
+        statement = (
+            update(Task)
+            .where(Task.id == task_id)
+            # This legacy helper has no concrete TaskLease. It may only settle
+            # an ownerless row; a RUNNING row with any owner belongs to the
+            # lease-aware orchestrator and must be left untouched.
+            .where(Task.runner_id.is_(None))
+            .values(
+                status=TaskStatus.FAILED,
+                lease_expires_at=None,
+                last_heartbeat_at=datetime.now(timezone.utc),
+                control_state=failed_control_state,
+                state_version=case(
+                    (
+                        or_(
+                            Task.status != TaskStatus.FAILED,
+                            Task.control_state != failed_control_state,
+                        ),
+                        current_version + 1,
+                    ),
+                    else_=current_version,
+                ),
                 error_message=message,
             )
-            db.commit()
+        )
+        if expected_run_id is not None:
+            statement = statement.where(Task.run_id == expected_run_id)
+        if only_if_running:
+            statement = statement.where(Task.status == TaskStatus.RUNNING)
+
+        result = db.execute(statement.execution_options(synchronize_session=False))
+        if int(getattr(result, "rowcount", 0) or 0) != 1:
+            db.rollback()
+            current_payload = _task_error_payload(
+                db,
+                task_id,
+                message,
+                event_type=event_type,
+            )
+            logger.info(
+                "Ignoring unfenced terminal error for task %s run %s; "
+                "current status is %s",
+                task_id,
+                expected_run_id,
+                (current_payload.get("task") or {}).get("status"),
+            )
+            return None if only_if_running else current_payload
+
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is not None:
+            sync_workforce_run_status(db, task, TaskStatus.FAILED)
             # Persist the error as an assistant message so failures that
             # happen before agent execution starts (no trace events, e.g.
             # sandbox capacity rejection) survive a history reload instead
             # of degrading to a generic "Unknown error" bubble.
             task_user_id = getattr(task, "user_id", None)
             if task_user_id is not None:
-                from ..services.chat_history_service import persist_assistant_message
+                from ..services.chat_history_service import (
+                    persist_assistant_message_no_commit,
+                )
 
                 try:
-                    persist_assistant_message(
+                    persist_assistant_message_no_commit(
                         db,
                         task_id=task_id,
                         user_id=int(task_user_id),
@@ -287,6 +365,7 @@ def _terminal_task_error_payload(
                         "Failed to persist terminal error chat message",
                         exc_info=True,
                     )
+            db.commit()
         return _task_error_payload(
             db,
             task_id,
@@ -306,6 +385,39 @@ def _terminal_task_error_payload(
         }
     finally:
         db.close()
+
+
+def _read_task_error_payload_isolated(
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "agent_error",
+) -> dict[str, Any]:
+    """Read a task error payload in a short Session owned by this worker."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        try:
+            return _task_error_payload(db, task_id, message, event_type=event_type)
+        except Exception:
+            db.rollback()
+            logger.warning("Failed to read terminal task error payload", exc_info=True)
+            return {"type": event_type, "message": message}
+
+
+async def _read_task_error_payload_offloop(
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "agent_error",
+) -> dict[str, Any]:
+    """Keep a potentially blocked pool checkout off the asyncio event loop."""
+    return await run_db_io_cancellation_safe(
+        lambda: _read_task_error_payload_isolated(
+            task_id,
+            message,
+            event_type=event_type,
+        )
+    )
 
 
 def _resolve_task_llm_ids(
@@ -1049,12 +1161,17 @@ def _normalize_file_outputs(
     task_id: int,
     task_user_id: int,
     file_outputs: Any,
+    *,
+    resolved_scope_segments: tuple[str, ...] | None = None,
+    commit_changes: bool = True,
 ) -> tuple[list[Dict[str, Any]], Dict[str, str]]:
     from ..models.uploaded_file import UploadedFile
 
     if isinstance(file_outputs, str):
         file_outputs = [file_outputs] if file_outputs.strip() else []
     if not isinstance(file_outputs, list):
+        return [], {}
+    if not file_outputs:
         return [], {}
 
     normalized_outputs: list[Dict[str, Any]] = []
@@ -1063,7 +1180,11 @@ def _normalize_file_outputs(
     # Resolved once per normalization pass: per-storage-key resolution would
     # re-query the snapshot loader / resolver once per output file (N+1 with
     # the output-file count — workforce runs can emit dozens).
-    scope_segments = _scope_segments_for_task(task_id)
+    scope_segments = (
+        _scope_segments_for_task(task_id)
+        if resolved_scope_segments is None
+        else resolved_scope_segments
+    )
 
     def add_normalized_output(
         file_record: UploadedFile,
@@ -1283,7 +1404,10 @@ def _normalize_file_outputs(
             )
 
     if changed:
-        db.commit()
+        if commit_changes:
+            db.commit()
+        else:
+            db.flush()
 
     return normalized_outputs, path_to_file_id
 
@@ -1295,6 +1419,8 @@ def _normalize_task_file_outputs(
     *,
     task_id: Optional[int] = None,
     task_user_id: Optional[int] = None,
+    resolved_scope_segments: tuple[str, ...] | None = None,
+    commit_changes: bool = True,
 ) -> tuple[list[Dict[str, Any]], Dict[str, str]]:
     """Resolve and persist ``file_outputs`` produced by an agent run.
 
@@ -1324,6 +1450,8 @@ def _normalize_task_file_outputs(
         task_id=resolved_task_id,
         task_user_id=resolved_user_id,
         file_outputs=file_outputs,
+        resolved_scope_segments=resolved_scope_segments,
+        commit_changes=commit_changes,
     )
 
 
@@ -1357,6 +1485,246 @@ def _task_control_state_value(task: Any) -> str | None:
     return str(control_state) if control_state is not None else None
 
 
+@dataclass(frozen=True)
+class _TaskExecutionFinalization:
+    normalized_outputs: list[dict[str, Any]]
+    ai_response: Any
+    chat_response: Any
+    waiting_for_control: bool
+    terminal_state_committed: bool
+    final_control_snapshot: TaskControlSnapshot | None
+    final_task_status: str
+    broadcast_meta: dict[str, Any]
+    late_result: bool = False
+
+
+def _finalize_task_execution_result_isolated(
+    *,
+    task_id: int,
+    task_user_id: int | None,
+    pre_run_status: TaskStatus,
+    result: dict[str, Any],
+    expected_run_id: str | None,
+    task_lease: TaskLease | None,
+    resolved_scope_segments: tuple[str, ...],
+) -> _TaskExecutionFinalization:
+    """Persist one task result in a worker-owned, ownership-fenced session."""
+    from ..services.chat_history_service import persist_assistant_message_no_commit
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as finalize_db:
+        default_response = "Task completed" if result.get("success", False) else ""
+        chat_response = result.get("chat_response")
+        if isinstance(chat_response, dict):
+            ai_response = chat_response.get("message") or result.get(
+                "output", default_response
+            )
+        else:
+            ai_response = result.get("output", default_response)
+
+        task_query = finalize_db.query(Task).filter(Task.id == task_id)
+        if task_lease is not None:
+            if task_lease.run_id is None:
+                logger.warning(
+                    "Task %s result has an unfenced lease; refusing finalization",
+                    task_id,
+                )
+                task_updated = None
+                late_result = True
+            else:
+                task_updated = (
+                    task_query.filter(
+                        Task.runner_id == task_lease.runner_id,
+                        Task.run_id == task_lease.run_id,
+                    )
+                    .with_for_update()
+                    .first()
+                )
+                late_result = task_updated is None
+        else:
+            # Legacy callers have no concrete owner identity and may only
+            # finalize an ownerless task row.
+            task_query = task_query.filter(Task.runner_id.is_(None))
+            if expected_run_id is not None:
+                task_query = task_query.filter(Task.run_id == expected_run_id)
+            task_updated = task_query.with_for_update().first()
+            late_result = task_updated is None
+
+        if late_result:
+            finalize_db.rollback()
+            logger.info(
+                "Ignoring late task result for task %s run %s; ownership changed",
+                task_id,
+                expected_run_id,
+            )
+            return _TaskExecutionFinalization(
+                normalized_outputs=[],
+                ai_response=ai_response,
+                chat_response=chat_response,
+                waiting_for_control=False,
+                terminal_state_committed=False,
+                final_control_snapshot=None,
+                final_task_status=pre_run_status.value,
+                broadcast_meta={},
+                late_result=True,
+            )
+
+        normalized_outputs, path_to_file_id = _normalize_task_file_outputs(
+            finalize_db,
+            task_updated,
+            result.get("file_outputs", []),
+            resolved_scope_segments=resolved_scope_segments,
+            commit_changes=False,
+        )
+        ai_response = _rewrite_file_links_to_file_id(ai_response, path_to_file_id)
+        if task_user_id is not None:
+            ai_response = reconcile_assistant_file_references(
+                finalize_db,
+                task_id=task_id,
+                user_id=task_user_id,
+                content=ai_response,
+            )
+            if isinstance(chat_response, dict) and chat_response.get("message"):
+                chat_response = {**chat_response, "message": ai_response}
+
+        waiting_for_control = False
+        terminal_state_committed = False
+        final_control_snapshot: TaskControlSnapshot | None = None
+        final_task_status = pre_run_status.value
+
+        if task_updated is not None:
+            task_agent_config: dict[str, Any] = (
+                task_updated.agent_config
+                if isinstance(task_updated.agent_config, dict)
+                else {}
+            )
+            if task_agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+                waiting_for_control = True
+                terminal_state_committed = True
+                logger.info(
+                    "Task %s was canceled while execution was in flight; "
+                    "ignoring the late result",
+                    task_id,
+                )
+            elif result.get("status") == "waiting_for_user":
+                next_control_state = (
+                    TaskControlState.RESUME_REQUESTED
+                    if task_updated.control_state
+                    == TaskControlState.RESUME_REQUESTED.value
+                    else TaskControlState.WAITING_FOR_USER
+                )
+                final_control_snapshot = apply_task_control_transition(
+                    task_updated,
+                    next_control_state,
+                    status=TaskStatus.WAITING_FOR_USER,
+                    expected_run_id=expected_run_id,
+                )
+                sync_workforce_run_status(
+                    finalize_db,
+                    task_updated,
+                    task_updated.status,
+                )
+                finalize_db.commit()
+                terminal_state_committed = True
+                waiting_for_control = True
+            elif result.get("status") == "interrupted":
+                next_control_state = (
+                    TaskControlState.RESUME_REQUESTED
+                    if task_updated.control_state
+                    == TaskControlState.RESUME_REQUESTED.value
+                    else TaskControlState.PAUSED
+                )
+                final_control_snapshot = apply_task_control_transition(
+                    task_updated,
+                    next_control_state,
+                    status=TaskStatus.PAUSED,
+                    expected_run_id=expected_run_id,
+                )
+                sync_workforce_run_status(
+                    finalize_db,
+                    task_updated,
+                    task_updated.status,
+                )
+                finalize_db.commit()
+                terminal_state_committed = True
+                waiting_for_control = True
+            elif task_updated.status not in {
+                TaskStatus.PAUSED,
+                TaskStatus.WAITING_FOR_USER,
+            }:
+                final_status = (
+                    TaskStatus.COMPLETED
+                    if result.get("success", False)
+                    else TaskStatus.FAILED
+                )
+                final_control_snapshot = apply_task_control_transition(
+                    task_updated,
+                    TaskControlState.COMPLETED
+                    if final_status == TaskStatus.COMPLETED
+                    else TaskControlState.FAILED,
+                    status=final_status,
+                    expected_run_id=expected_run_id,
+                )
+                sync_workforce_run_status(
+                    finalize_db,
+                    task_updated,
+                    task_updated.status,
+                )
+            else:
+                waiting_for_control = True
+                terminal_state_committed = True
+
+            final_task_status = task_updated.status.value
+            if not waiting_for_control:
+                if task_user_id is None:
+                    raise ValueError(
+                        f"Task {task_id}: cannot persist assistant message "
+                        "without a resolved user_id"
+                    )
+                persist_assistant_message_no_commit(
+                    finalize_db,
+                    task_id=task_id,
+                    user_id=task_user_id,
+                    content=str(ai_response),
+                    message_type="chat_response"
+                    if isinstance(chat_response, dict)
+                    else "final_answer",
+                    interactions=chat_response.get("interactions")
+                    if isinstance(chat_response, dict)
+                    else None,
+                    content_is_reconciled=True,
+                )
+                finalize_db.commit()
+                terminal_state_committed = True
+
+            broadcast_meta = {
+                "id": int(task_updated.id),
+                "title": task_updated.title,
+                "description": task_updated.description,
+                "execution_mode": getattr(task_updated, "execution_mode", None),
+                "updated_at": task_updated.updated_at,
+            }
+        else:
+            broadcast_meta = {
+                "id": task_id,
+                "title": None,
+                "description": None,
+                "execution_mode": None,
+                "updated_at": None,
+            }
+
+        return _TaskExecutionFinalization(
+            normalized_outputs=normalized_outputs,
+            ai_response=ai_response,
+            chat_response=chat_response,
+            waiting_for_control=waiting_for_control,
+            terminal_state_committed=terminal_state_committed,
+            final_control_snapshot=final_control_snapshot,
+            final_task_status=final_task_status,
+            broadcast_meta=broadcast_meta,
+        )
+
+
 async def execute_task_background(
     task_id: int,
     user_message: str,
@@ -1367,53 +1735,52 @@ async def execute_task_background(
     llm_user_message: Optional[str] = None,
     task_setup_snapshot: Optional["TaskSetupSnapshot"] = None,
     expected_run_id: str | None = None,
+    task_lease: TaskLease | None = None,
+    resolved_execution_scope: Union[
+        ExecutionScope, None, _ResolvedExecutionScopeNotProvided
+    ] = _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED,
 ) -> None:
-    """Execute task in background without blocking WebSocket message loop.
+    """Execute one task without checking out a DB connection on the event loop.
 
-    ``task_setup_snapshot`` is the off-loop snapshot loaded by
-    ``_schedule_bg._runner``. When provided, the Task SELECT is
-    skipped (saves a synchronous DB read measured at 3.33s on the
-    main event loop under contention, issue #427) and downstream
-    consumers pull task fields from the snapshot. The User SELECT is
-    kept because ``get_user_tool_overrides`` is a hook
-    (``Callable[[Session, Any], dict]``, ``services/tool_credentials.py``)
-    that may read arbitrary ORM fields off the user object;
-    constructing a primitive shim there would be a quiet BC break.
-
-    WS callers (and any caller that has not yet adopted the snapshot
-    plumbing) pass ``None`` and the legacy Task SELECT runs as
-    before.
+    Setup and finalization use worker-owned short Sessions. The long-running
+    agent await receives only detached runtime state and primitive identifiers.
     """
-    from ..models.database import get_db
-    from ..models.task import Task, TaskStatus
-    from ..models.user import User
-    from ..services.chat_history_service import (
-        load_task_transcript,
-        persist_assistant_message,
-    )
     from ..services.task_execution_context_service import (
-        load_task_execution_recovery_state,
+        materialize_task_execution_recovery_state,
     )
+    from ..services.task_setup_snapshot import load_task_setup_snapshot_sync
 
     # Wait for previous background task to complete
     await background_task_manager.wait_for_previous(task_id)
 
-    db_gen = get_db()
+    terminal_state_committed = False
     try:
-        db = next(db_gen)
+        if resolved_execution_scope is _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED:
+            execution_scope = await run_db_io_cancellation_safe(
+                lambda: resolve_execution_scope(task_id)
+            )
+        else:
+            execution_scope = cast(
+                Optional[ExecutionScope],
+                resolved_execution_scope,
+            )
+
+        snapshot = task_setup_snapshot
+        if snapshot is None:
+            snapshot = await run_db_io_cancellation_safe(
+                lambda: load_task_setup_snapshot_sync(
+                    task_id,
+                    task_owner_user_id,
+                    before_message_id=before_message_id,
+                )
+            )
+        if snapshot is None:
+            raise ValueError(f"Task {task_id} not found")
+
         context_dict = context if isinstance(context, dict) else {}
         logger.info(f"Background task execution started for task {task_id}")
-
-        task_user_id: Optional[int]
-        if task_setup_snapshot is not None:
-            # Snapshot path: skip the Task SELECT.
-            task_user_id = task_setup_snapshot.task.user_id
-            task = None
-        else:
-            task = db.query(Task).filter(Task.id == task_id).first()
-            if task is None:
-                raise ValueError(f"Task {task_id} not found")
-            task_user_id = _task_user_id(task)
+        task_user_id = snapshot.task.user_id
+        user = snapshot.runtime_user
 
         # The task OWNER (from snapshot / DB) is the runtime identity. A passed
         # ``task_owner_user_id`` must equal it -- it may never override the
@@ -1431,52 +1798,43 @@ async def execute_task_background(
                 f"{task_owner_user_id} does not match task {task_id} owner "
                 f"{task_user_id}; refusing to run as the wrong user"
             )
-        effective_user_id = (
-            task_user_id if task_user_id is not None else task_owner_user_id
-        )
-        user = (
-            db.query(User).filter(User.id == effective_user_id).first()
-            if effective_user_id is not None
-            else None
-        )
+        effective_user_id = task_user_id
 
-        # The execution scope resolves per turn alongside the acting user, so
-        # a resumed/restarted task re-derives the same scope from the resolver.
-        with UserContext(effective_user_id), turn_execution_scope(task_id):
+        with UserContext(effective_user_id), ExecutionScopeContext(execution_scope):
             # Get agent service. ``effective_user_id`` is the task owner
             # (authoritative above); pass it as the runtime identity so the
             # agent's models / tools resolve as the owner, not any acting admin.
             agent_service = await agent_manager.get_agent_for_task(
                 task_id,
-                db,
+                None,
                 user=user,
-                task_setup_snapshot=task_setup_snapshot,
+                task_setup_snapshot=snapshot,
                 task_owner_user_id=effective_user_id,
                 connector_runtime_turn_id=context_dict.get("turn_id")
                 if isinstance(context_dict.get("turn_id"), str)
                 else None,
+                resolved_execution_scope=execution_scope,
             )
             if hasattr(agent_service, "set_outbound_message_handler"):
                 agent_service.set_outbound_message_handler(
                     make_agent_outbound_handler(task_id)
                 )
-            if before_message_id is not None:
-                conversation_history = load_task_transcript(
-                    db,
-                    task_id,
-                    before_message_id=before_message_id,
-                )
-                agent_service.set_conversation_history(conversation_history)
-            recovery_state = await load_task_execution_recovery_state(db, task_id)
+            agent_service.set_conversation_history(
+                [dict(message) for message in snapshot.conversation_history]
+            )
+            recovery_state = await materialize_task_execution_recovery_state(
+                snapshot.execution_recovery
+            )
             execution_context_messages = recovery_state.get("messages", [])
             agent_service.set_execution_context_messages(execution_context_messages)
             agent_service.set_recovered_skill_context(
                 recovery_state.get("skill_context")
             )
-            _register_uploaded_files_for_agent(
-                agent_service,
-                context_dict.get("file_info", []),
-                db,
+            await run_db_io_cancellation_safe(
+                lambda: _register_uploaded_files_for_agent_isolated(
+                    agent_service,
+                    context_dict.get("file_info", []),
+                )
             )
 
             # Execute the next turn under the same task/thread id.
@@ -1488,291 +1846,47 @@ async def execute_task_background(
                 context=context,
                 task_id=actual_task_id,
                 tracking_task_id=str(task_id),
-                db_session=db,
+                db_session=None,
                 manage_task_lease=False,
+                task_lease=task_lease,
             )
 
-        normalized_outputs, path_to_file_id = _normalize_task_file_outputs(
-            db,
-            task,
-            result.get("file_outputs", []),
-            task_id=int(task_id) if task is None else None,
-            task_user_id=task_user_id if task is None else None,
+        finalize_run_id = (
+            task_lease.run_id if task_lease is not None else expected_run_id
         )
+        finalized = await run_db_io_cancellation_safe(
+            lambda: _finalize_task_execution_result_isolated(
+                task_id=task_id,
+                task_user_id=effective_user_id,
+                pre_run_status=cast(TaskStatus, snapshot.task.status),
+                result=result,
+                expected_run_id=finalize_run_id,
+                task_lease=task_lease,
+                resolved_scope_segments=(
+                    execution_scope.workspace_segments
+                    if execution_scope is not None
+                    else ()
+                ),
+            )
+        )
+        if finalized.late_result:
+            return
+
+        normalized_outputs = finalized.normalized_outputs
         if normalized_outputs:
             result["file_outputs"] = normalized_outputs
-
-        # Get AI response. A failed turn has no assistant reply, so it must not
-        # inherit the "Task completed" success sentinel: the frontend reads
-        # `output` as the failure reason, so the sentinel would render (and
-        # persist) a misleading "Task completed" bubble on a failed task. Fall
-        # back to the sentinel only when the turn actually succeeded.
-        default_response = "Task completed" if result.get("success", False) else ""
-        chat_response = result.get("chat_response")
-        if isinstance(chat_response, dict):
-            ai_response = chat_response.get("message") or result.get(
-                "output", default_response
-            )
-        else:
-            ai_response = result.get("output", default_response)
-
-        # Rewrite file links to file_id
-        ai_response = _rewrite_file_links_to_file_id(
-            ai_response,
-            path_to_file_id,
-        )
-        if effective_user_id is not None:
-            ai_response = reconcile_assistant_file_references(
-                db,
-                task_id=int(task_id),
-                user_id=int(effective_user_id),
-                content=ai_response,
-            )
-            if isinstance(chat_response, dict) and chat_response.get("message"):
-                chat_response = {**chat_response, "message": ai_response}
-
-        # Task execution result is logged by ConsoleTraceHandler, no need for duplicate logs
-
-        db_new_gen = get_db()
-        final_control_snapshot = None
-        try:
-            db_new = next(db_new_gen)
-            waiting_for_control = False
-            # ``task`` is ``None`` on the snapshot path; pull the
-            # pre-run status from the snapshot in that case. The
-            # ``task_updated`` query just below normally overwrites
-            # this with the post-run value, but we still need a
-            # sensible default for the rare case where the row went
-            # missing between snapshot load and finalize.
-            if task is not None:
-                final_task_status = task.status.value
-            elif task_setup_snapshot is not None:
-                final_task_status = task_setup_snapshot.task.status.value
-            else:
-                final_task_status = TaskStatus.PENDING.value
-            task_updated = db_new.query(Task).filter(Task.id == task_id).first()
-            if task_updated:
-                if (
-                    expected_run_id is not None
-                    and task_updated.run_id != expected_run_id
-                ):
-                    logger.info(
-                        "Ignoring late task result for task %s run %s; "
-                        "current run is %s",
-                        task_id,
-                        expected_run_id,
-                        task_updated.run_id,
-                    )
-                    return
-                # Caller is responsible for the lease lifecycle (acquire +
-                # release); this function only writes ``status``. The
-                # orchestrator's ``_schedule_bg`` wraps the call in
-                # acquire/release; chat.py and WS continuation paths
-                # acquire and release the lease directly themselves.
-                #
-                # Previously this branch called
-                # ``release_current_runner_task_lease(status=...)``, which
-                # bundled status update with lease release in one UPDATE
-                # filtered on ``runner_id == get_runner_id()``. That hid a
-                # bug for callers that never acquired the lease: the
-                # filter didn't match, so status was silently never
-                # written either (a quiet "stuck RUNNING" outcome).
-                task_agent_config: dict[str, Any] = (
-                    task_updated.agent_config
-                    if isinstance(task_updated.agent_config, dict)
-                    else {}
-                )
-                # A2A cancellation is durable even when the cancelled coroutine
-                # ignores cancellation and produces a result after the timeout.
-                if task_agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
-                    waiting_for_control = True
-                    logger.info(
-                        "Task %s was canceled while execution was in flight; "
-                        "ignoring the late result",
-                        task_id,
-                    )
-                elif result.get("status") == "waiting_for_user":
-                    next_control_state = (
-                        TaskControlState.RESUME_REQUESTED
-                        if task_updated.control_state
-                        == TaskControlState.RESUME_REQUESTED.value
-                        else TaskControlState.WAITING_FOR_USER
-                    )
-                    final_control_snapshot = apply_task_control_transition(
-                        task_updated,
-                        next_control_state,
-                        status=TaskStatus.WAITING_FOR_USER,
-                        expected_run_id=expected_run_id,
-                    )
-                    sync_workforce_run_status(db_new, task_updated, task_updated.status)
-                    db_new.commit()
-                    waiting_for_control = True
-                    logger.info(
-                        f"Updated task {task_id} status to WAITING_FOR_USER for v2 control state"
-                    )
-                elif result.get("status") == "interrupted":
-                    next_control_state = (
-                        TaskControlState.RESUME_REQUESTED
-                        if task_updated.control_state
-                        == TaskControlState.RESUME_REQUESTED.value
-                        else TaskControlState.PAUSED
-                    )
-                    final_control_snapshot = apply_task_control_transition(
-                        task_updated,
-                        next_control_state,
-                        status=TaskStatus.PAUSED,
-                        expected_run_id=expected_run_id,
-                    )
-                    sync_workforce_run_status(db_new, task_updated, task_updated.status)
-                    db_new.commit()
-                    waiting_for_control = True
-                    logger.info(
-                        f"Updated task {task_id} status to PAUSED for v2 interrupt state"
-                    )
-                elif task_updated.status not in {
-                    TaskStatus.PAUSED,
-                    TaskStatus.WAITING_FOR_USER,
-                }:
-                    final_control_state = (
-                        TaskControlState.COMPLETED
-                        if result.get("success", False)
-                        else TaskControlState.FAILED
-                    )
-                    final_status = (
-                        TaskStatus.COMPLETED
-                        if result.get("success", False)
-                        else TaskStatus.FAILED
-                    )
-                    final_control_snapshot = apply_task_control_transition(
-                        task_updated,
-                        final_control_state,
-                        status=final_status,
-                        expected_run_id=expected_run_id,
-                    )
-                    sync_workforce_run_status(db_new, task_updated, task_updated.status)
-                    # Do NOT commit the terminal status here. Leave it
-                    # pending so the assistant-message persistence below
-                    # commits it atomically: the task is marked terminal
-                    # only once the turn is durably complete. If that write
-                    # fails, the status stays RUNNING and the outer except
-                    # surfaces a real failure -- instead of leaving a
-                    # COMPLETED row with no assistant message. Control
-                    # statuses (PAUSED / WAITING_FOR_USER) above commit
-                    # themselves; they have no assistant message to persist.
-                    logger.info(
-                        f"Task {task_id} marked {task_updated.status.value} "
-                        "(pending commit with assistant message)"
-                    )
-                else:
-                    waiting_for_control = True
-                    logger.info(
-                        f"Task {task_id} is paused, not updating status to {result.get('success')}"
-                    )
-                final_task_status = task_updated.status.value
-
-                if not waiting_for_control:
-                    # ``persist_assistant_message`` requires a real
-                    # user_id (FK into ``users.id``). Prefer
-                    # ``effective_user_id`` -- it already folded the
-                    # function-parameter ``user_id`` and the
-                    # snapshot/legacy ``task_user_id`` together earlier.
-                    # If both were None we cannot persist; fail loudly
-                    # rather than writing an orphan row with user_id=0.
-                    if effective_user_id is None:
-                        raise ValueError(
-                            f"Task {task_id}: cannot persist assistant "
-                            "message without a resolved user_id "
-                            "(both function param and task.user_id were None)"
-                        )
-                    persist_assistant_message(
-                        db_new,
-                        task_id=task_id,
-                        user_id=int(effective_user_id),
-                        content=str(ai_response),
-                        message_type="chat_response"
-                        if isinstance(chat_response, dict)
-                        else "final_answer",
-                        interactions=chat_response.get("interactions")
-                        if isinstance(chat_response, dict)
-                        else None,
-                        content_is_reconciled=True,
-                    )
-                    # Commit the pending terminal status. ``persist_assistant_message``
-                    # commits internally when it writes a row, but it
-                    # early-returns WITHOUT committing when the assistant
-                    # content is empty (a valid empty-reply turn). This
-                    # explicit commit lands the terminal status in that
-                    # case too, so an empty successful turn stays COMPLETED
-                    # rather than being left RUNNING (and later flipped to
-                    # FAILED by finish_turn). If persistence raised, control
-                    # never reaches here -- the status stays uncommitted and
-                    # the outer except surfaces a real failure.
-                    db_new.commit()
-
-            # Materialize broadcast metadata into primitives BEFORE the
-            # ``finally`` block closes ``db_new``. ``task_updated`` is
-            # bound to that session; accessing its attributes after
-            # close raises ``DetachedInstanceError``. Title /
-            # description / execution_mode / updated_at don't change
-            # during a turn, so this snapshot is consistent with what
-            # the legacy code emitted.
-            if task_updated is not None:
-                broadcast_meta = {
-                    "id": int(task_updated.id),
-                    "title": task_updated.title,
-                    "description": task_updated.description,
-                    "execution_mode": getattr(task_updated, "execution_mode", None),
-                    "updated_at": task_updated.updated_at,
-                }
-            else:
-                # Task row deleted between turn start and finalize.
-                # Broadcasts below will emit nulls for title /
-                # description; log here so the gap is visible in
-                # incident triage instead of having to reconstruct it
-                # from the silent-null payload.
-                logger.warning(
-                    "Task %s row missing at finalize; broadcasting partial "
-                    "task metadata (title/description/execution_mode null)",
-                    task_id,
-                )
-                broadcast_meta = {
-                    "id": task_id,
-                    "title": None,
-                    "description": None,
-                    "execution_mode": None,
-                    "updated_at": None,
-                }
-
-            # Snapshot agent metadata before the request-scoped ORM
-            # session closes. Snapshot callers intentionally set
-            # ``task=None``, so we fall back to the off-loop snapshot.
-            if task is not None:
-                broadcast_agent_meta = {
-                    "agent_id": task.agent_id,
-                    "agent_name": task.agent.name if task.agent else None,
-                    "agent_logo_url": task.agent.logo_url if task.agent else None,
-                }
-            elif task_setup_snapshot is not None:
-                broadcast_agent_meta = {
-                    "agent_id": task_setup_snapshot.task.agent_id,
-                    "agent_name": (
-                        task_setup_snapshot.agent.name
-                        if task_setup_snapshot.agent is not None
-                        else None
-                    ),
-                    "agent_logo_url": None,
-                }
-            else:
-                broadcast_agent_meta = {
-                    "agent_id": None,
-                    "agent_name": None,
-                    "agent_logo_url": None,
-                }
-        finally:
-            try:
-                next(db_new_gen)
-            except StopIteration:
-                pass
+        ai_response = finalized.ai_response
+        chat_response = finalized.chat_response
+        waiting_for_control = finalized.waiting_for_control
+        terminal_state_committed = finalized.terminal_state_committed
+        final_control_snapshot = finalized.final_control_snapshot
+        final_task_status = finalized.final_task_status
+        broadcast_meta = finalized.broadcast_meta
+        broadcast_agent_meta = {
+            "agent_id": snapshot.task.agent_id,
+            "agent_name": snapshot.agent.name if snapshot.agent is not None else None,
+            "agent_logo_url": None,
+        }
 
         # Note: trace_task_completion is handled by the agent execution logic (e.g., dag_plan_execute.py)
 
@@ -1844,17 +1958,72 @@ async def execute_task_background(
         # execution failure. Otherwise a failed post-completion broadcast
         # would rewrite an already-COMPLETED task as FAILED and store the
         # broadcast error as the task's failure cause.
-        status_db = get_session_local()()
-        try:
-            current = status_db.query(Task).filter(Task.id == task_id).first()
-            still_running = current is not None and (
-                current.status == TaskStatus.RUNNING
-                and (expected_run_id is None or current.run_id == expected_run_id)
-            )
-        finally:
-            status_db.close()
+        if task_lease is not None:
+            if terminal_state_committed:
+                logger.warning(
+                    "Background task %s post-terminal step failed; "
+                    "task state left unchanged: %s",
+                    task_id,
+                    e,
+                    exc_info=True,
+                )
+                return
 
-        if not still_running:
+            if is_database_pool_timeout(e):
+                # The orchestrator owns the concrete lease and will retain it
+                # for TTL recovery. Broadcasting FAILED here would contradict
+                # the durable RUNNING + fenced-lease state.
+                logger.error(
+                    "task_id=%s component=execution database pool checkout "
+                    "timed out; retaining exact lease for TTL recovery without "
+                    "broadcasting task_error: %s",
+                    task_id,
+                    e,
+                    exc_info=True,
+                )
+                raise
+
+            logger.error(
+                "Background task %s execution failed: %s",
+                task_id,
+                e,
+                exc_info=True,
+            )
+            try:
+                await manager.broadcast_to_task(
+                    {
+                        "type": "task_error",
+                        "message": str(e),
+                        "task_id": task_id,
+                        "task": {
+                            "id": task_id,
+                            "status": TaskStatus.FAILED.value,
+                        },
+                        "error": str(e),
+                        "timestamp": datetime.now(timezone.utc).timestamp(),
+                    },
+                    task_id,
+                )
+            except Exception as broadcast_error:
+                logger.error("Failed to send error notification: %s", broadcast_error)
+            # The concrete run/runner lease belongs to the orchestrator. Let
+            # its single worker-owned settlement transaction persist failure
+            # and release the lease; doing DB work here would add another pool
+            # wait and could race a replacement run.
+            raise
+
+        error_message = str(e)
+        terminal_payload = await run_db_io_cancellation_safe(
+            lambda: _terminal_task_error_payload(
+                task_id,
+                error_message,
+                event_type="task_error",
+                expected_run_id=expected_run_id,
+                only_if_running=True,
+            )
+        )
+
+        if terminal_payload is None:
             # Terminal state already committed; the exception came from a
             # best-effort post-completion step. Observe it without touching
             # the row or emitting a contradictory task_error. ``finish_turn``
@@ -1874,12 +2043,7 @@ async def execute_task_background(
                 message = str(e)
                 await manager.broadcast_to_task(
                     {
-                        **_terminal_task_error_payload(
-                            task_id,
-                            message,
-                            event_type="task_error",
-                            expected_run_id=expected_run_id,
-                        ),
+                        **terminal_payload,
                         "task_id": task_id,
                         "error": message,
                         "timestamp": datetime.now(timezone.utc).timestamp(),
@@ -1895,10 +2059,6 @@ async def execute_task_background(
         # Clean up background task record
         _clear_task_pause_accepted(task_id)
         background_task_manager.cleanup_task(task_id)
-        try:
-            next(db_gen)
-        except StopIteration:
-            pass
 
 
 def _latest_result_user_turn_id(result: Dict[str, Any]) -> str | None:
@@ -1933,6 +2093,184 @@ def _latest_result_user_turn_id(result: Dict[str, Any]) -> str | None:
     return None
 
 
+def _acquire_resume_task_lease(
+    task_id: int,
+    task_owner_user_id: int | None,
+    expected_run_id: str | None,
+) -> TaskLease | None:
+    """Validate and claim a resume lease in one worker transaction."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if (
+            task is not None
+            and task_owner_user_id is not None
+            and int(task.user_id) != task_owner_user_id
+        ):
+            raise ValueError(
+                f"execute_resume_background: passed task_owner_user_id "
+                f"{task_owner_user_id} does not match task {task_id} "
+                f"owner {int(task.user_id)}; refusing to resume as the "
+                "wrong user"
+            )
+        lease = acquire_task_lease_no_commit(
+            db,
+            task_id,
+            expected_run_id=expected_run_id,
+        )
+        if lease is None:
+            db.commit()
+            return None
+        if task is not None:
+            sync_workforce_run_status(db, task, TaskStatus.RUNNING)
+        db.commit()
+        return lease
+
+
+def _finalize_resumed_task(
+    task_id: int,
+    *,
+    status: str,
+    success: bool,
+    output: str,
+    task_owner_user_id: int | None,
+    result: Dict[str, Any],
+    task_lease: TaskLease,
+    resolved_scope_segments: tuple[str, ...],
+) -> dict[str, Any]:
+    """Persist one fenced resumed result in a single worker transaction."""
+    from ..models.agent import Agent
+    from ..services.chat_history_service import persist_assistant_message_no_commit
+
+    finalized: dict[str, Any] = {
+        "task_title": None,
+        "task_description": None,
+        "task_execution_mode": None,
+        "task_agent_id": None,
+        "agent_name": None,
+        "agent_logo_url": None,
+        "final_status": TaskStatus.RUNNING.value,
+        "lease_released": False,
+        "control_event_state": {},
+        "normalized_outputs": [],
+        "output": output,
+        "late_result": False,
+    }
+    if task_lease.run_id is None:
+        finalized["late_result"] = True
+        return finalized
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.runner_id == task_lease.runner_id,
+                Task.run_id == task_lease.run_id,
+            )
+            .with_for_update()
+            .first()
+        )
+        if task is None:
+            finalized["late_result"] = True
+            return finalized
+
+        normalized_outputs, path_to_file_id = _normalize_task_file_outputs(
+            db,
+            task,
+            result.get("file_outputs", []),
+            resolved_scope_segments=resolved_scope_segments,
+            commit_changes=False,
+        )
+        if normalized_outputs:
+            output = _rewrite_file_links_to_file_id(output, path_to_file_id)
+        if task_owner_user_id is not None:
+            output = reconcile_assistant_file_references(
+                db,
+                task_id=task_id,
+                user_id=task_owner_user_id,
+                content=output,
+            )
+        finalized["normalized_outputs"] = normalized_outputs
+        finalized["output"] = output
+
+        finalized["task_title"] = cast(Any, task.title)
+        finalized["task_description"] = cast(Any, task.description)
+        finalized["task_execution_mode"] = cast(Any, task.execution_mode)
+        finalized["task_agent_id"] = cast(Any, task.agent_id)
+        if task.agent_id is not None:
+            agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+            if agent is not None:
+                finalized["agent_name"] = cast(Any, agent.name)
+                finalized["agent_logo_url"] = cast(Any, agent.logo_url)
+
+        if status == "waiting_for_user":
+            final_task_status = TaskStatus.WAITING_FOR_USER
+        elif status == "interrupted":
+            final_task_status = TaskStatus.PAUSED
+        elif success:
+            final_task_status = TaskStatus.COMPLETED
+        else:
+            final_task_status = TaskStatus.FAILED
+
+        control_snapshot = apply_task_control_transition(
+            task,
+            {
+                TaskStatus.WAITING_FOR_USER: TaskControlState.WAITING_FOR_USER,
+                TaskStatus.PAUSED: TaskControlState.PAUSED,
+                TaskStatus.COMPLETED: TaskControlState.COMPLETED,
+                TaskStatus.FAILED: TaskControlState.FAILED,
+            }[final_task_status],
+            status=final_task_status,
+            expected_run_id=task_lease.run_id,
+        )
+
+        if success and output.strip() and task_owner_user_id is not None:
+            persist_assistant_message_no_commit(
+                db,
+                task_id=task_id,
+                user_id=task_owner_user_id,
+                content=output,
+                message_type="final_answer",
+                turn_id=_latest_result_user_turn_id(result),
+                content_is_reconciled=True,
+            )
+            orm_task = cast(Any, task)
+            orm_task.output = output
+            orm_task.error_message = None
+        elif final_task_status == TaskStatus.FAILED:
+            orm_task = cast(Any, task)
+            orm_task.output = None
+            orm_task.error_message = output or "Task execution failed."
+
+        sync_workforce_run_status(db, task, final_task_status)
+        lease_released = release_task_lease_no_commit(
+            db,
+            task_lease,
+            status=final_task_status,
+        )
+        if not lease_released:
+            db.rollback()
+            finalized["late_result"] = True
+            return finalized
+        db.commit()
+        finalized["lease_released"] = True
+        finalized["final_status"] = final_task_status.value
+        finalized["control_event_state"] = control_snapshot.as_dict()
+        return finalized
+
+
+def _settle_resumed_task_lease(
+    lease: TaskLease,
+    *,
+    error_message: str | None,
+) -> bool:
+    """Delegate resume cleanup to the shared run/runner-fenced lifecycle."""
+    from ..services.task_orchestrator import settle_task_lease_isolated
+
+    return settle_task_lease_isolated(lease, error_message=error_message)
+
+
 async def execute_resume_background(
     task_id: int,
     agent_service: Any,
@@ -1944,26 +2282,25 @@ async def execute_resume_background(
     delivery_websocket: WebSocket | None = None,
     delivery_client_message_id: str | None = None,
     expected_run_id: str | None = None,
+    resolved_execution_scope: Union[
+        ExecutionScope, None, _ResolvedExecutionScopeNotProvided
+    ] = _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
     ``task_owner_user_id`` is the task OWNER's id -- the runtime identity the
     resume executes as (``UserContext``), not the acting principal.
     """
-    from ..models.agent import Agent
-    from ..models.database import get_db
-    from ..models.task import Task, TaskStatus
-
     lease_stop_event = None
     lease_heartbeat_task = None
-    lease = None
+    lease: TaskLease | None = None
     lease_released = False
+    settlement_error: str | None = None
+    defer_db_cleanup_to_ttl_recovery = False
     result: Dict[str, Any] | None = None
     # Token tracking + mid-run quota gate for the resumed segment (resume had
     # neither before, so a resumed run escaped mid-run enforcement entirely).
     resume_tracker = None
-    resume_tracker_db = None
-    resume_tracker_db_gen = None
     normalized_outputs: list[Dict[str, str]] = []
     output = ""
     success = False
@@ -1975,7 +2312,7 @@ async def execute_resume_background(
     agent_name: str | None = None
     agent_logo_url: str | None = None
     delivery_was_dispatched = delivery_already_dispatched
-    final_control_snapshot = None
+    control_event_state: dict[str, Any] = {}
 
     async def notify_deferred_delivery(
         accepted: bool,
@@ -2003,6 +2340,34 @@ async def execute_resume_background(
                 exc_info=True,
             )
 
+    async def mark_deferred_delivery_failed() -> bool:
+        """Persist a failed delivery without amplifying pool exhaustion."""
+        nonlocal defer_db_cleanup_to_ttl_recovery
+        if delivery_turn_id is None or delivery_was_dispatched:
+            return True
+        try:
+            await run_db_io_cancellation_safe(
+                lambda: mark_user_message_delivery_sync(
+                    task_id,
+                    delivery_turn_id,
+                    DELIVERY_FAILED,
+                )
+            )
+            return True
+        except Exception as delivery_error:
+            if not is_database_pool_timeout(delivery_error):
+                raise
+            defer_db_cleanup_to_ttl_recovery = lease is not None and not lease_released
+            logger.error(
+                "task_id=%s component=resume-delivery database pool checkout "
+                "timed out; skipping immediate settlement and retaining lease "
+                "for TTL recovery: %s",
+                task_id,
+                delivery_error,
+                exc_info=True,
+            )
+            return False
+
     try:
         if previous_task is not None and not previous_task.done():
             try:
@@ -2017,51 +2382,38 @@ async def execute_resume_background(
             raise RuntimeError(f"Task {task_id} resume has no asyncio task")
         background_task_manager.promote_resume_task(task_id, current_task)
 
-        db_gen = get_db()
-        db_lease = next(db_gen)
-        try:
-            lease = acquire_task_lease(
-                db_lease,
-                task_id,
-                expected_run_id=expected_run_id,
+        if resolved_execution_scope is _RESOLVED_EXECUTION_SCOPE_NOT_PROVIDED:
+            execution_scope = await run_db_io_cancellation_safe(
+                lambda: resolve_execution_scope(task_id)
             )
-            if lease is not None:
-                task_for_sync = db_lease.query(Task).filter(Task.id == task_id).first()
-                # Same owner guard as ``execute_task_background``: the resume
-                # runs under ``UserContext(task_owner_user_id)`` below, so a
-                # passed owner that disagrees with the task row would resume as
-                # the wrong user. All callers pass the owner; a mismatch is a
-                # programming error -- fail loudly rather than run as the wrong
-                # identity.
-                if (
-                    task_for_sync is not None
-                    and task_owner_user_id is not None
-                    and int(task_for_sync.user_id) != task_owner_user_id
-                ):
-                    raise ValueError(
-                        f"execute_resume_background: passed task_owner_user_id "
-                        f"{task_owner_user_id} does not match task {task_id} "
-                        f"owner {int(task_for_sync.user_id)}; refusing to resume "
-                        "as the wrong user"
-                    )
-                if task_for_sync is not None and sync_workforce_run_status(
-                    db_lease, task_for_sync, TaskStatus.RUNNING
-                ):
-                    db_lease.commit()
-                elif task_for_sync is not None:
-                    db_lease.commit()
-        finally:
-            db_lease.close()
+        else:
+            execution_scope = cast(
+                Optional[ExecutionScope],
+                resolved_execution_scope,
+            )
+
+        lease = await acquire_task_lease_cancellation_safe(
+            lambda: _acquire_resume_task_lease(
+                task_id,
+                task_owner_user_id,
+                expected_run_id,
+            ),
+            lambda acquired: _settle_resumed_task_lease(
+                acquired,
+                error_message="resume cancelled during lease acquisition",
+            ),
+        )
         if lease is None:
             logger.info(
                 "Task %s resume skipped; another runner owns the lease", task_id
             )
             if delivery_turn_id is not None and not delivery_was_dispatched:
-                await asyncio.to_thread(
-                    mark_user_message_delivery_sync,
-                    task_id,
-                    delivery_turn_id,
-                    DELIVERY_FAILED,
+                await run_db_io_cancellation_safe(
+                    lambda: mark_user_message_delivery_sync(
+                        task_id,
+                        delivery_turn_id,
+                        DELIVERY_FAILED,
+                    )
                 )
                 await notify_deferred_delivery(
                     False,
@@ -2106,11 +2458,12 @@ async def execute_resume_background(
                 )
             delivery_was_dispatched = True
             if delivery_turn_id is not None:
-                await asyncio.to_thread(
-                    mark_user_message_delivery_sync,
-                    task_id,
-                    delivery_turn_id,
-                    DELIVERY_DISPATCHED,
+                await run_db_io_cancellation_safe(
+                    lambda: mark_user_message_delivery_sync(
+                        task_id,
+                        delivery_turn_id,
+                        DELIVERY_DISPATCHED,
+                    )
                 )
             await notify_deferred_delivery(True)
 
@@ -2131,10 +2484,10 @@ async def execute_resume_background(
         try:
             from ..tracking.task_tracker import TaskTracker
 
-            resume_tracker_db_gen = get_db()
-            resume_tracker_db = next(resume_tracker_db_gen)
             resume_tracker = TaskTracker(
-                task_id=int(task_id), db_session=resume_tracker_db
+                task_id=int(task_id),
+                expected_run_id=lease.run_id,
+                expected_runner_id=lease.runner_id,
             )
             await resume_tracker.start_tracking()
             agent_service.set_interrupt_checker(
@@ -2147,7 +2500,7 @@ async def execute_resume_background(
             )
             resume_tracker = None
 
-        with UserContext(task_owner_user_id), turn_execution_scope(task_id):
+        with UserContext(task_owner_user_id), ExecutionScopeContext(execution_scope):
             result = await agent_service.resume_execution_by_id(str(task_id))
 
         if result is None:
@@ -2175,115 +2528,90 @@ async def execute_resume_background(
         success = bool(result.get("success", False))
         output = str(result.get("output") or result.get("error") or "")
 
-        if task_owner_user_id is not None:
-            db_gen = get_db()
-            db_normalize = next(db_gen)
-            try:
-                task_for_normalize = (
-                    db_normalize.query(Task).filter(Task.id == task_id).first()
-                )
-                if task_for_normalize is not None:
-                    normalized_outputs, path_to_file_id = _normalize_task_file_outputs(
-                        db_normalize,
-                        task_for_normalize,
-                        result.get("file_outputs", []),
-                    )
-                    if normalized_outputs:
-                        result["file_outputs"] = normalized_outputs
-                        output = _rewrite_file_links_to_file_id(output, path_to_file_id)
-                    output = reconcile_assistant_file_references(
-                        db_normalize,
-                        task_id=int(task_id),
-                        user_id=int(task_owner_user_id),
-                        content=output,
-                    )
-            finally:
-                db_normalize.close()
+        # Final usage belongs to this exact run. Persist it while the run still
+        # owns the lease, then stop heartbeat before the atomic result/lease
+        # finalizer. If the usage checkout itself times out, its exception is
+        # handled below and the lease is deliberately retained for TTL recovery
+        # instead of performing a second checkout against the exhausted pool.
+        if resume_tracker is not None:
+            tracker_to_complete = resume_tracker
+            resume_tracker = None
+            agent_service.set_interrupt_checker(None)
+            await tracker_to_complete.complete_tracking()
 
-        db_gen = get_db()
-        db_new = next(db_gen)
-        try:
-            task_updated = db_new.query(Task).filter(Task.id == task_id).first()
-            if task_updated:
-                task_title = cast(Any, task_updated.title)
-                task_description = cast(Any, task_updated.description)
-                task_execution_mode = cast(Any, task_updated.execution_mode)
-                task_agent_id = cast(Any, task_updated.agent_id)
-                if task_updated.agent_id is not None:
-                    agent = (
-                        db_new.query(Agent)
-                        .filter(Agent.id == task_updated.agent_id)
-                        .first()
-                    )
-                    if agent is not None:
-                        agent_name = cast(Any, agent.name)
-                        agent_logo_url = cast(Any, agent.logo_url)
-                if status == "waiting_for_user":
-                    final_task_status = TaskStatus.WAITING_FOR_USER
-                elif status == "interrupted":
-                    final_task_status = TaskStatus.PAUSED
-                elif success:
-                    final_task_status = TaskStatus.COMPLETED
-                else:
-                    final_task_status = TaskStatus.FAILED
+        heartbeat_outcome = await stop_task_lease_heartbeat(
+            lease_heartbeat_task, lease_stop_event
+        )
+        lease_heartbeat_task = None
+        lease_stop_event = None
+        if (
+            isinstance(heartbeat_outcome, TaskLeaseHeartbeatOutcome)
+            and heartbeat_outcome.requires_ttl_recovery
+        ):
+            defer_db_cleanup_to_ttl_recovery = True
+            logger.error(
+                "task_id=%s component=resume-heartbeat unhealthy before "
+                "finalization; retaining lease for TTL recovery (lost=%s, "
+                "pool_timeout=%s)",
+                task_id,
+                heartbeat_outcome.lease_lost,
+                heartbeat_outcome.pool_timeout is not None,
+            )
+            if heartbeat_outcome.pool_timeout is not None:
+                raise heartbeat_outcome.pool_timeout
+            # A replacement owner already holds the task. Do not persist or
+            # broadcast this stale runner's result.
+            return
 
-                final_control_snapshot = apply_task_control_transition(
-                    task_updated,
-                    {
-                        TaskStatus.WAITING_FOR_USER: TaskControlState.WAITING_FOR_USER,
-                        TaskStatus.PAUSED: TaskControlState.PAUSED,
-                        TaskStatus.COMPLETED: TaskControlState.COMPLETED,
-                        TaskStatus.FAILED: TaskControlState.FAILED,
-                    }[final_task_status],
-                    status=final_task_status,
-                    expected_run_id=expected_run_id,
-                )
-
-                if success and output.strip() and task_owner_user_id is not None:
-                    from ..services.chat_history_service import (
-                        persist_assistant_message_no_commit,
-                    )
-
-                    persist_assistant_message_no_commit(
-                        db_new,
-                        task_id=task_id,
-                        user_id=int(task_owner_user_id),
-                        content=output,
-                        message_type="final_answer",
-                        turn_id=_latest_result_user_turn_id(result),
-                        content_is_reconciled=True,
-                    )
-                    orm_task_updated = cast(Any, task_updated)
-                    orm_task_updated.output = output
-                    orm_task_updated.error_message = None
-                elif final_task_status == TaskStatus.FAILED:
-                    orm_task_updated = cast(Any, task_updated)
-                    orm_task_updated.output = None
-                    orm_task_updated.error_message = output or "Task execution failed."
-                lease_released = release_current_runner_task_lease_with_workforce_sync(
-                    db_new,
-                    task_id,
-                    status=final_task_status,
-                    expected_run_id=expected_run_id,
-                )
-                db_new.refresh(task_updated)
-                final_status = task_updated.status.value
-        finally:
-            db_new.close()
+        finalized = await run_db_io_cancellation_safe(
+            lambda: _finalize_resumed_task(
+                task_id,
+                status=status,
+                success=success,
+                output=output,
+                task_owner_user_id=task_owner_user_id,
+                result=result,
+                task_lease=lease,
+                resolved_scope_segments=(
+                    execution_scope.workspace_segments
+                    if execution_scope is not None
+                    else ()
+                ),
+            )
+        )
+        if finalized["late_result"]:
+            logger.info(
+                "Ignoring late resume result for task %s run %s; ownership changed",
+                task_id,
+                lease.run_id,
+            )
+            # Ownership was already checked inside the fenced finalizer. There
+            # is no lease from this run left to settle, and another checkout
+            # would only race the replacement run.
+            lease_released = True
+            return
+        normalized_outputs = finalized["normalized_outputs"]
+        output = finalized["output"]
+        if normalized_outputs:
+            result["file_outputs"] = normalized_outputs
+        task_title = finalized["task_title"]
+        task_description = finalized["task_description"]
+        task_execution_mode = finalized["task_execution_mode"]
+        task_agent_id = finalized["task_agent_id"]
+        agent_name = finalized["agent_name"]
+        agent_logo_url = finalized["agent_logo_url"]
+        final_status = finalized["final_status"]
+        lease_released = bool(finalized["lease_released"])
+        control_event_state = finalized["control_event_state"]
 
         if delivery_turn_id is not None:
-            await asyncio.to_thread(
-                mark_user_message_delivery_sync,
-                task_id,
-                delivery_turn_id,
-                DELIVERY_COMPLETED,
+            await run_db_io_cancellation_safe(
+                lambda: mark_user_message_delivery_sync(
+                    task_id,
+                    delivery_turn_id,
+                    DELIVERY_COMPLETED,
+                )
             )
-
-        control_event_state = (
-            final_control_snapshot.as_dict()
-            if final_control_snapshot is not None
-            else {}
-        )
 
         if status in {"interrupted", "waiting_for_user"}:
             await manager.broadcast_to_task(
@@ -2330,56 +2658,76 @@ async def execute_resume_background(
             task_id,
         )
     except asyncio.CancelledError:
+        settlement_error = "resume execution cancelled"
         logger.info(f"V2 resume background task {task_id} cancelled")
         if delivery_turn_id is not None and not delivery_was_dispatched:
-            await asyncio.to_thread(
-                mark_user_message_delivery_sync,
-                task_id,
-                delivery_turn_id,
-                DELIVERY_FAILED,
-            )
-            await notify_deferred_delivery(
-                False,
-                "The deferred message was cancelled. Please retry.",
-                retry_with_new_id=True,
-            )
+            if await mark_deferred_delivery_failed():
+                await notify_deferred_delivery(
+                    False,
+                    "The deferred message was cancelled. Please retry.",
+                    retry_with_new_id=True,
+                )
         raise
     except Exception as e:
-        logger.error(f"V2 resume background task {task_id} failed: {e}", exc_info=True)
         error_message = str(e)
-        if delivery_turn_id is not None and not delivery_was_dispatched:
-            await asyncio.to_thread(
-                mark_user_message_delivery_sync,
+        if is_database_pool_timeout(e):
+            # The failed operation already waited on an exhausted checkout.
+            # Any delivery/status/settlement write here would immediately
+            # request another connection. Keep the exact lease fenced until
+            # TTL recovery and leave a pending delivery reclaimable.
+            defer_db_cleanup_to_ttl_recovery = lease is not None and not lease_released
+            recovery_action = (
+                "retaining lease for TTL recovery"
+                if defer_db_cleanup_to_ttl_recovery
+                else "leaving durable state for retry"
+            )
+            logger.error(
+                "task_id=%s component=resume database pool checkout timed out; "
+                "skipping immediate DB cleanup and %s: %s",
                 task_id,
-                delivery_turn_id,
-                DELIVERY_FAILED,
+                recovery_action,
+                e,
+                exc_info=True,
             )
-            await notify_deferred_delivery(
-                False,
-                error_message,
-                retry_with_new_id=True,
-            )
-        current_snapshot = (
-            await task_execution_controller.snapshot(task_id)
-            if expected_run_id is not None
-            else None
-        )
-        if current_snapshot is not None and current_snapshot.run_id != expected_run_id:
-            logger.info(
-                "Suppressing late resume error for task %s run %s; current run is %s",
-                task_id,
-                expected_run_id,
-                current_snapshot.run_id,
-            )
+            # The durable state remains RUNNING under the exact lease (or is
+            # otherwise left reclaimable when no lease was acquired). Do not
+            # emit the generic FAILED/task_error payload below.
             return
+        else:
+            logger.error(
+                "V2 resume background task %s failed: %s",
+                task_id,
+                e,
+                exc_info=True,
+            )
+            settlement_error = error_message
+            if delivery_turn_id is not None and not delivery_was_dispatched:
+                if await mark_deferred_delivery_failed():
+                    await notify_deferred_delivery(
+                        False,
+                        error_message,
+                        retry_with_new_id=True,
+                    )
+            current_snapshot = None
+            if not defer_db_cleanup_to_ttl_recovery and expected_run_id is not None:
+                current_snapshot = await task_execution_controller.snapshot(task_id)
+            if (
+                current_snapshot is not None
+                and current_snapshot.run_id != expected_run_id
+            ):
+                logger.info(
+                    "Suppressing late resume error for task %s run %s; "
+                    "current run is %s",
+                    task_id,
+                    expected_run_id,
+                    current_snapshot.run_id,
+                )
+                return
         await manager.broadcast_to_task(
             {
-                **_terminal_task_error_payload(
-                    task_id,
-                    error_message,
-                    event_type="task_error",
-                    expected_run_id=expected_run_id,
-                ),
+                "type": "task_error",
+                "message": error_message,
+                "task": {"id": task_id, "status": TaskStatus.FAILED.value},
                 "task_id": task_id,
                 "error": error_message,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
@@ -2387,31 +2735,96 @@ async def execute_resume_background(
             task_id,
         )
     finally:
-        # Finalize the resumed segment's tracking: drop the checker, meter the
-        # partial usage, and close the tracker's dedicated session. Best-effort.
-        if resume_tracker is not None:
-            agent_service.set_interrupt_checker(None)
+
+        async def finalize_resume_resources() -> None:
+            nonlocal defer_db_cleanup_to_ttl_recovery
+
             try:
-                await resume_tracker.complete_tracking()
-            except Exception as e:  # noqa: BLE001
-                logger.warning(
-                    f"execute_resume_background: token tracking completion "
-                    f"failed for task {task_id}: {e}"
-                )
-        if resume_tracker_db is not None:
-            resume_tracker_db.close()
-        await stop_task_lease_heartbeat(lease_heartbeat_task, lease_stop_event)
-        if lease is not None and not lease_released:
-            db_gen = get_db()
-            db_cleanup = next(db_gen)
-            try:
-                release_task_lease_with_workforce_sync(
-                    db_cleanup, lease, status=TaskStatus.FAILED
-                )
+                # Finalize any tracker that did not reach the normal completion
+                # point, then release any unfinished lease through worker-owned
+                # short Sessions.
+                if resume_tracker is not None:
+                    agent_service.set_interrupt_checker(None)
+                    try:
+                        if defer_db_cleanup_to_ttl_recovery:
+                            # Do not initiate a final usage checkout immediately
+                            # after a pool timeout. Stop/drain only the periodic
+                            # loop.
+                            await resume_tracker.stop_periodic_updates()
+                        else:
+                            await resume_tracker.complete_tracking()
+                    except Exception as e:  # noqa: BLE001
+                        if is_database_pool_timeout(e):
+                            defer_db_cleanup_to_ttl_recovery = (
+                                lease is not None and not lease_released
+                            )
+                            logger.error(
+                                "task_id=%s component=resume-tracker database "
+                                "pool checkout timed out; retaining lease for "
+                                "TTL recovery: %s",
+                                task_id,
+                                e,
+                                exc_info=True,
+                            )
+                        else:
+                            logger.warning(
+                                "execute_resume_background: token tracking "
+                                "completion failed for task %s: %s",
+                                task_id,
+                                e,
+                            )
+                if lease_heartbeat_task is not None or lease_stop_event is not None:
+                    try:
+                        heartbeat_outcome = await stop_task_lease_heartbeat(
+                            lease_heartbeat_task,
+                            lease_stop_event,
+                        )
+                        if (
+                            isinstance(heartbeat_outcome, TaskLeaseHeartbeatOutcome)
+                            and heartbeat_outcome.requires_ttl_recovery
+                        ):
+                            defer_db_cleanup_to_ttl_recovery = (
+                                lease is not None and not lease_released
+                            )
+                            logger.error(
+                                "task_id=%s component=resume-heartbeat unhealthy "
+                                "during cleanup; retaining lease for TTL "
+                                "recovery (lost=%s, pool_timeout=%s)",
+                                task_id,
+                                heartbeat_outcome.lease_lost,
+                                heartbeat_outcome.pool_timeout is not None,
+                            )
+                    except Exception:
+                        logger.warning(
+                            "resume heartbeat shutdown failed for task %s",
+                            task_id,
+                            exc_info=True,
+                        )
+                if (
+                    lease is not None
+                    and not lease_released
+                    and not defer_db_cleanup_to_ttl_recovery
+                ):
+                    try:
+                        await run_db_io_cancellation_safe(
+                            lambda: _settle_resumed_task_lease(
+                                lease,
+                                error_message=settlement_error,
+                            )
+                        )
+                    except Exception:
+                        logger.error(
+                            "resume lease settlement failed for task %s; "
+                            "retaining lease for TTL recovery",
+                            task_id,
+                            exc_info=True,
+                        )
             finally:
-                db_cleanup.close()
-        _clear_task_pause_accepted(task_id)
-        background_task_manager.cleanup_task(task_id)
+                _clear_task_pause_accepted(task_id)
+                background_task_manager.cleanup_task(task_id)
+
+        cleanup_task = asyncio.create_task(finalize_resume_resources())
+        await drain_async_task_cancellation_safe(cleanup_task)
 
 
 # Background task manager: ensures only one active background execution per task
@@ -2440,7 +2853,7 @@ class BackgroundTaskManager:
                     f"Waiting for previous background task {task_id} to complete..."
                 )
                 try:
-                    await old_task
+                    await asyncio.shield(old_task)
                     logger.info(f"Previous background task {task_id} completed")
                 except Exception as e:
                     logger.warning(
@@ -2891,7 +3304,7 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
-async def handle_file_upload_for_task(
+def _handle_file_upload_for_task_sync(
     task_id: int,
     files: list,
     db: Session,
@@ -2944,6 +3357,121 @@ async def handle_file_upload_for_task(
     except Exception as e:
         logger.error(f"Error handling file upload for task {task_id}: {e}")
         raise
+
+
+async def handle_file_upload_for_task(
+    task_id: int,
+    files: list,
+    db: Session,
+    user: Optional[User] = None,
+    task_owner_id: Optional[int] = None,
+) -> dict:
+    """Compatibility wrapper for callers that use the historical async API."""
+
+    return _handle_file_upload_for_task_sync(
+        task_id,
+        files,
+        db,
+        user,
+        task_owner_id,
+    )
+
+
+@dataclass(frozen=True)
+class _UserMessageDeliverySnapshot:
+    """Primitive delivery result safe to carry outside its DB Session."""
+
+    claimed: bool
+    payload_matches: bool
+    failed: bool
+    pending: bool
+
+
+def _snapshot_user_message_delivery(
+    claim: UserMessageDeliveryClaim,
+) -> _UserMessageDeliverySnapshot:
+    return _UserMessageDeliverySnapshot(
+        claimed=bool(claim.claimed),
+        payload_matches=bool(claim.payload_matches),
+        failed=bool(claim.failed),
+        pending=bool(claim.pending),
+    )
+
+
+def _claim_user_message_delivery_isolated(
+    *,
+    task_id: int,
+    task_owner_user_id: int,
+    content: str,
+    attachments: list[dict[str, Any]] | None,
+    turn_id: str,
+) -> _UserMessageDeliverySnapshot:
+    """Claim a live-control message in one worker-owned short Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        claim = claim_user_message_delivery(
+            db,
+            task_id=task_id,
+            user_id=task_owner_user_id,
+            content=content,
+            attachments=attachments,
+            turn_id=turn_id,
+        )
+        return _snapshot_user_message_delivery(claim)
+
+
+@dataclass(frozen=True)
+class _ContinuationResumeResult:
+    lease_acquired: bool
+    task_event: dict[str, Any] | None = None
+
+
+def _resume_continuation_isolated(task_id: int) -> _ContinuationResumeResult:
+    """Resume a legacy continuation without retaining its Session for IO."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None or acquire_task_lease(db, task_id) is None:
+            return _ContinuationResumeResult(lease_acquired=False)
+        db.refresh(task)
+        if sync_workforce_run_status(db, task, task.status):
+            db.commit()
+
+        (
+            model_id,
+            small_fast_model_id,
+            visual_model_id,
+            compact_model_id,
+        ) = _resolve_task_llm_ids(task, db)
+        event = create_stream_event(
+            "task_info",
+            task_id,
+            {
+                "id": task.id,
+                "title": task.title,
+                "description": task.description,
+                "status": task.status.value,
+                "model_id": model_id,
+                "small_fast_model_id": small_fast_model_id,
+                "visual_model_id": visual_model_id,
+                "compact_model_id": compact_model_id,
+                "model_name": task.model_name,
+                "small_fast_model_name": task.small_fast_model_name,
+                "visual_model_name": task.visual_model_name,
+                "compact_model_name": task.compact_model_name,
+                "execution_mode": task.execution_mode,
+                "created_at": (
+                    safe_timestamp_to_unix(task.created_at) if task.created_at else None
+                ),
+                "updated_at": (
+                    safe_timestamp_to_unix(task.updated_at) if task.updated_at else None
+                ),
+            },
+            task.created_at if task.created_at else None,
+        )
+        return _ContinuationResumeResult(lease_acquired=True, task_event=event)
 
 
 def _register_uploaded_files_for_agent(
@@ -3011,6 +3539,17 @@ def _register_uploaded_files_for_agent(
             registration_path,
             workspace_link_path,
         )
+
+
+def _register_uploaded_files_for_agent_isolated(
+    agent_service: Any,
+    file_info_list: List[Dict[str, Any]],
+) -> None:
+    """Register staged uploads with a worker-owned short Session."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        _register_uploaded_files_for_agent(agent_service, file_info_list, db)
+        db.commit()
 
 
 async def get_authenticated_user(
@@ -3220,7 +3759,9 @@ async def _handle_chat_message_unserialized(
     delivery_finished = False
     delivery_dispatched = False
     delivery_claimed = False
-    recovered_delivery: UserMessageDeliveryClaim | None = None
+    delivery_failure_persist_attempted = False
+    delivery_failure_pool_timeout = False
+    recovered_delivery: _UserMessageDeliverySnapshot | None = None
 
     async def finish_delivery(
         accepted: bool,
@@ -3245,25 +3786,47 @@ async def _handle_chat_message_unserialized(
             retry_with_new_id=retry_with_new_id,
         )
 
-    async def finish_delivery_failure(message: str) -> None:
+    async def finish_delivery_failure(message: str) -> bool:
         """Reject pre-dispatch failures; never confuse persistence with delivery."""
 
+        nonlocal delivery_failure_persist_attempted, delivery_failure_pool_timeout
         if delivery_finished:
-            return
-        if delivery_claimed and not delivery_dispatched:
-            await asyncio.to_thread(
-                mark_user_message_delivery_sync,
-                task_id,
-                turn_id,
-                DELIVERY_FAILED,
-            )
+            return not delivery_failure_pool_timeout
+        if (
+            delivery_claimed
+            and not delivery_dispatched
+            and not delivery_failure_persist_attempted
+        ):
+            # Set before awaiting the worker. If its checkout times out and the
+            # exception reaches another handler layer, that layer must not
+            # issue the same write again against the exhausted pool.
+            delivery_failure_persist_attempted = True
+            try:
+                await asyncio.to_thread(
+                    mark_user_message_delivery_sync,
+                    task_id,
+                    turn_id,
+                    DELIVERY_FAILED,
+                )
+            except Exception as delivery_error:
+                if not is_database_pool_timeout(delivery_error):
+                    raise
+                delivery_failure_pool_timeout = True
+                logger.error(
+                    "task_id=%s component=live-control-delivery database pool "
+                    "checkout timed out; not retrying failure persistence: %s",
+                    task_id,
+                    delivery_error,
+                    exc_info=True,
+                )
         await finish_delivery(
             delivery_dispatched,
             None if delivery_dispatched else message,
         )
+        return not delivery_failure_pool_timeout
 
     async def finish_existing_delivery(
-        claim: UserMessageDeliveryClaim,
+        claim: Union[UserMessageDeliveryClaim, _UserMessageDeliverySnapshot],
     ) -> None:
         if not claim.payload_matches:
             await finish_delivery(
@@ -3498,7 +4061,7 @@ async def _handle_chat_message_unserialized(
                 uploaded_files_context = ""
                 if files:
                     # Process file upload
-                    upload_result = await handle_file_upload_for_task(
+                    upload_result = _handle_file_upload_for_task_sync(
                         task_id,
                         files,
                         db,
@@ -3611,10 +4174,11 @@ async def _handle_chat_message_unserialized(
                             # The command claim is the exclusive replay lease,
                             # so it may safely adopt a PENDING transcript row
                             # left by a worker that died mid-application.
-                            recovered_delivery = UserMessageDeliveryClaim(
-                                message=existing_delivery.message,
+                            recovered_delivery = _UserMessageDeliverySnapshot(
                                 claimed=True,
                                 payload_matches=True,
+                                failed=False,
+                                pending=True,
                             )
                             delivery_claimed = True
                             if (
@@ -3631,10 +4195,15 @@ async def _handle_chat_message_unserialized(
                                     status=DELIVERY_DISPATCHED,
                                 )
                                 delivery_dispatched = True
+                                db.close()
                                 await finish_delivery(True)
                                 return
                         else:
-                            await finish_existing_delivery(existing_delivery)
+                            existing_delivery_snapshot = (
+                                _snapshot_user_message_delivery(existing_delivery)
+                            )
+                            db.close()
+                            await finish_existing_delivery(existing_delivery_snapshot)
                             return
 
                 # DAG plan-execute will automatically send user_message trace event
@@ -3666,11 +4235,39 @@ async def _handle_chat_message_unserialized(
                 supports_live_control = False
                 has_continuation = False
                 if task_uses_live_control:
+                    task_owner_user_id = int(task.user_id)
+                    task_status = cast(TaskStatus, task.status)
+                    task_run_id = _task_run_id(task)
+                    actor_user_id = int(user.id)
+                    actor_is_admin = bool(user.is_admin)
+                    # No request Session or ORM row may survive into agent
+                    # construction. The setup loader owns its worker Session
+                    # and returns only frozen application-layer values.
+                    db.close()
+                    resolved_execution_scope = await run_db_io_cancellation_safe(
+                        lambda: resolve_execution_scope(task_id)
+                    )
+                    from ..services.task_setup_snapshot import (
+                        load_task_setup_snapshot_sync,
+                    )
+
+                    task_setup_snapshot = await run_db_io_cancellation_safe(
+                        lambda: load_task_setup_snapshot_sync(
+                            task_id,
+                            task_owner_user_id,
+                            actor_user_id=actor_user_id,
+                            actor_is_admin=actor_is_admin,
+                        )
+                    )
+                    if task_setup_snapshot is None:
+                        raise ValueError(f"Task {task_id} is no longer available")
                     agent_service = await get_agent_manager().get_agent_for_task(
                         task_id,
-                        db,
-                        user=user,
-                        task_owner_user_id=int(task.user_id),
+                        None,
+                        user=task_setup_snapshot.runtime_user,
+                        task_setup_snapshot=task_setup_snapshot,
+                        task_owner_user_id=task_owner_user_id,
+                        resolved_execution_scope=resolved_execution_scope,
                     )
                     if hasattr(agent_service, "set_outbound_message_handler"):
                         agent_service.set_outbound_message_handler(
@@ -3697,14 +4294,18 @@ async def _handle_chat_message_unserialized(
                     logger.info(f"Using continuation for running task {task_id}")
                     assert dag_pattern is not None  # for mypy type checking
 
-                    delivery_claim = recovered_delivery or claim_user_message_delivery(
-                        db,
-                        task_id=task_id,
-                        user_id=int(task.user_id),
-                        content=display_user_message,
-                        attachments=persisted_attachments or None,
-                        turn_id=turn_id,
-                    )
+                    if recovered_delivery is not None:
+                        delivery_claim = recovered_delivery
+                    else:
+                        delivery_claim = await run_db_io_cancellation_safe(
+                            lambda: _claim_user_message_delivery_isolated(
+                                task_id=task_id,
+                                task_owner_user_id=task_owner_user_id,
+                                content=display_user_message,
+                                attachments=persisted_attachments or None,
+                                turn_id=turn_id,
+                            )
+                        )
                     recovered_delivery = None
                     if not delivery_claim.claimed:
                         await finish_existing_delivery(delivery_claim)
@@ -3739,11 +4340,12 @@ async def _handle_chat_message_unserialized(
                         )
 
                     dag_pattern.request_continuation(user_message_for_llm, context)
-                    mark_user_message_delivery(
-                        db,
-                        task_id=task_id,
-                        turn_id=turn_id,
-                        status=DELIVERY_DISPATCHED,
+                    await run_db_io_cancellation_safe(
+                        lambda: mark_user_message_delivery_sync(
+                            task_id,
+                            turn_id,
+                            DELIVERY_DISPATCHED,
+                        )
                     )
                     # The existing DAG worker owns terminal execution and has
                     # no per-continuation completion callback. For this path,
@@ -3752,8 +4354,14 @@ async def _handle_chat_message_unserialized(
                     delivery_dispatched = True
 
                     # If previously PAUSED/WAITING_FOR_USER, update status to RUNNING
-                    if task.status in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
-                        if acquire_task_lease(db, task_id) is None:
+                    if task_status in {
+                        TaskStatus.PAUSED,
+                        TaskStatus.WAITING_FOR_USER,
+                    }:
+                        continuation_resume = await run_db_io_cancellation_safe(
+                            lambda: _resume_continuation_isolated(task_id)
+                        )
+                        if not continuation_resume.lease_acquired:
                             await manager.send_personal_message(
                                 {
                                     "type": "error",
@@ -3765,45 +4373,10 @@ async def _handle_chat_message_unserialized(
                             )
                             await finish_delivery(True)
                             return
-                        db.refresh(task)
-                        if sync_workforce_run_status(db, task, task.status):
-                            db.commit()
-
-                        (
-                            model_id,
-                            small_fast_model_id,
-                            visual_model_id,
-                            compact_model_id,
-                        ) = _resolve_task_llm_ids(task, db)
-
-                        # Send task status update event
-                        task_event = create_stream_event(
-                            "task_info",
-                            task_id,
-                            {
-                                "id": task.id,
-                                "title": task.title,
-                                "description": task.description,
-                                "status": task.status.value,
-                                "model_id": model_id,
-                                "small_fast_model_id": small_fast_model_id,
-                                "visual_model_id": visual_model_id,
-                                "compact_model_id": compact_model_id,
-                                "model_name": task.model_name,
-                                "small_fast_model_name": task.small_fast_model_name,
-                                "visual_model_name": task.visual_model_name,
-                                "compact_model_name": task.compact_model_name,
-                                "execution_mode": task.execution_mode,
-                                "created_at": safe_timestamp_to_unix(task.created_at)
-                                if task.created_at
-                                else None,
-                                "updated_at": safe_timestamp_to_unix(task.updated_at)
-                                if task.updated_at
-                                else None,
-                            },
-                            task.created_at if task.created_at else None,
+                        assert continuation_resume.task_event is not None
+                        await manager.broadcast_to_task(
+                            continuation_resume.task_event, task_id
                         )
-                        await manager.broadcast_to_task(task_event, task_id)
                         logger.info(f"Task {task_id} status updated to RUNNING")
 
                     # Continuation will be handled by old task, return directly
@@ -3835,17 +4408,18 @@ async def _handle_chat_message_unserialized(
                     # keeps its own immediate trace.
                     bg_task: asyncio.Task[None] | None = None
                     try:
-                        delivery_claim = (
-                            recovered_delivery
-                            or claim_user_message_delivery(
-                                db,
-                                task_id=task_id,
-                                user_id=int(task.user_id),
-                                content=display_user_message,
-                                attachments=persisted_attachments or None,
-                                turn_id=turn_id,
+                        if recovered_delivery is not None:
+                            delivery_claim = recovered_delivery
+                        else:
+                            delivery_claim = await run_db_io_cancellation_safe(
+                                lambda: _claim_user_message_delivery_isolated(
+                                    task_id=task_id,
+                                    task_owner_user_id=task_owner_user_id,
+                                    content=display_user_message,
+                                    attachments=persisted_attachments or None,
+                                    turn_id=turn_id,
+                                )
                             )
-                        )
                         recovered_delivery = None
                         if not delivery_claim.claimed:
                             background_task_manager.release_resume_reservation(task_id)
@@ -3859,7 +4433,7 @@ async def _handle_chat_message_unserialized(
                             display_message=display_user_message,
                             files=display_file_refs,
                             turn_id=turn_id,
-                            request_interrupt=task.status == TaskStatus.RUNNING,
+                            request_interrupt=task_status == TaskStatus.RUNNING,
                             reason="new websocket user message",
                         )
                         if not posted:
@@ -3869,11 +4443,12 @@ async def _handle_chat_message_unserialized(
                                 task_id,
                             )
                         else:
-                            mark_user_message_delivery(
-                                db,
-                                task_id=task_id,
-                                turn_id=turn_id,
-                                status=DELIVERY_DISPATCHED,
+                            await run_db_io_cancellation_safe(
+                                lambda: mark_user_message_delivery_sync(
+                                    task_id,
+                                    turn_id,
+                                    DELIVERY_DISPATCHED,
+                                )
                             )
                         # ``post_user_message`` has already durably injected the
                         # turn when it returns True. Preserve that fact even if
@@ -3884,7 +4459,7 @@ async def _handle_chat_message_unserialized(
                         await task_execution_controller.transition(
                             task_id,
                             TaskControlState.RESUME_REQUESTED,
-                            expected_run_id=_task_run_id(task),
+                            expected_run_id=task_run_id,
                         )
 
                         previous_task = background_task_manager.running_tasks.get(
@@ -3894,9 +4469,10 @@ async def _handle_chat_message_unserialized(
                             execute_resume_background(
                                 task_id=task_id,
                                 agent_service=agent_service,
-                                task_owner_user_id=int(task.user_id),
-                                expected_run_id=_task_run_id(task),
+                                task_owner_user_id=task_owner_user_id,
+                                expected_run_id=task_run_id,
                                 previous_task=previous_task,
+                                resolved_execution_scope=resolved_execution_scope,
                                 pending_user_message=(
                                     None
                                     if posted
@@ -4137,17 +4713,25 @@ async def _handle_chat_message_unserialized(
                         )
                         return
 
+                    turn_task_id = int(task.id)
+                    turn_owner_user_id = int(task.user_id)
+                    turn_actor_user_id = int(user.id)
+                    # All response/context fields needed above are now detached
+                    # primitives. Return the request's read transaction before
+                    # the orchestrator worker opens its claim Session; otherwise
+                    # a one-slot pool deterministically becomes a nested checkout.
+                    db.close()
                     try:
                         await TaskTurnOrchestrator.begin_turn(
-                            task_id=int(task.id),
+                            task_id=turn_task_id,
                             # Owner, not the acting principal: ``task`` was
                             # already authorized above (admin bypass / owner
                             # check), and the turn must run as the task owner,
                             # not an admin acting on someone else's task.
-                            task_owner_user_id=int(task.user_id),
+                            task_owner_user_id=turn_owner_user_id,
                             # The acting principal (the admin when acting on
                             # another user's task) -- audit/logging only.
-                            actor_user_id=int(user.id),
+                            actor_user_id=turn_actor_user_id,
                             payload=payload,
                             kind=turn_kind,
                             force_fresh=turn_force_fresh,
@@ -4163,14 +4747,14 @@ async def _handle_chat_message_unserialized(
                             "begin_turn: task %s not found / not owned at claim",
                             task_id,
                         )
+                        error_payload = await _read_task_error_payload_offloop(
+                            task_id,
+                            "Task is no longer available.",
+                            event_type="agent_error",
+                        )
                         await manager.broadcast_to_task(
                             {
-                                **_task_error_payload(
-                                    db,
-                                    task_id,
-                                    "Task is no longer available.",
-                                    event_type="agent_error",
-                                ),
+                                **error_payload,
                                 "timestamp": datetime.now(timezone.utc).timestamp(),
                             },
                             task_id,
@@ -4187,18 +4771,18 @@ async def _handle_chat_message_unserialized(
                             f"Refused to schedule bg for task {task_id}: "
                             f"{busy_err.reason}"
                         )
+                        error_payload = await _read_task_error_payload_offloop(
+                            task_id,
+                            (
+                                "Task is currently busy; please wait for "
+                                "the previous turn to finish before sending "
+                                "another message."
+                            ),
+                            event_type="agent_error",
+                        )
                         await manager.broadcast_to_task(
                             {
-                                **_task_error_payload(
-                                    db,
-                                    task_id,
-                                    (
-                                        "Task is currently busy; please wait for "
-                                        "the previous turn to finish before sending "
-                                        "another message."
-                                    ),
-                                    event_type="agent_error",
-                                ),
+                                **error_payload,
                                 "timestamp": datetime.now(timezone.utc).timestamp(),
                             },
                             task_id,
@@ -4216,12 +4800,17 @@ async def _handle_chat_message_unserialized(
             # Data validation and format error
             message = f"Data validation error: {str(e)}"
             logger.error(f"Data validation error in agent execution: {e}")
-            await finish_delivery_failure(message)
+            if not await finish_delivery_failure(message):
+                return
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
+                error_payload = await _read_task_error_payload_offloop(
+                    authorized_task_id,
+                    message,
+                )
                 await manager.broadcast_to_task(
                     {
-                        **_terminal_task_error_payload(authorized_task_id, message),
+                        **error_payload,
                         "timestamp": timestamp,
                     },
                     authorized_task_id,
@@ -4239,12 +4828,17 @@ async def _handle_chat_message_unserialized(
             # Runtime error
             message = f"Runtime error: {str(e)}"
             logger.error(f"Runtime error in agent execution: {e}")
-            await finish_delivery_failure(message)
+            if not await finish_delivery_failure(message):
+                return
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
+                error_payload = await _read_task_error_payload_offloop(
+                    authorized_task_id,
+                    message,
+                )
                 await manager.broadcast_to_task(
                     {
-                        **_terminal_task_error_payload(authorized_task_id, message),
+                        **error_payload,
                         "timestamp": timestamp,
                     },
                     authorized_task_id,
@@ -4282,17 +4876,113 @@ async def _handle_chat_message_unserialized(
         raise
 
 
+@dataclass(frozen=True)
+class _LegacyExecuteTaskRequest:
+    """Detached input needed before scheduling an existing task execution."""
+
+    task_id: int
+    task_owner_user_id: int
+    task_source: str | None
+    task_description: str
+    task_context: dict[str, Any]
+    task_info: dict[str, Any]
+    created_at: datetime | None
+
+
+def _load_legacy_execute_task_request_sync(
+    task_id: int,
+    *,
+    actor_user_id: int,
+    actor_is_admin: bool,
+) -> _LegacyExecuteTaskRequest | None:
+    """Authorize and detach legacy execution metadata in one short Session."""
+    from ..models.agent import Agent
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task_query = db.query(Task).filter(Task.id == task_id)
+        if not actor_is_admin:
+            task_query = task_query.filter(Task.user_id == actor_user_id)
+        task = task_query.first()
+        if task is None:
+            return None
+
+        (
+            model_id,
+            small_fast_model_id,
+            visual_model_id,
+            compact_model_id,
+        ) = _resolve_task_llm_ids(task, db)
+        agent_name: str | None = None
+        agent_logo_url: str | None = None
+        if task.agent_id is not None:
+            agent_fields = (
+                db.query(Agent.name, Agent.logo_url)
+                .filter(Agent.id == task.agent_id)
+                .first()
+            )
+            if agent_fields is not None:
+                agent_name = str(agent_fields[0])
+                agent_logo_url = (
+                    str(agent_fields[1]) if agent_fields[1] is not None else None
+                )
+
+        task_context: dict[str, Any] = {}
+        if task.execution_mode:
+            task_context["execution_mode"] = str(task.execution_mode)
+        if task.process_description:
+            task_context["process_description"] = str(task.process_description)
+        if task.examples:
+            task_context["examples"] = deepcopy(task.examples)
+
+        created_at = cast(datetime | None, task.created_at)
+        return _LegacyExecuteTaskRequest(
+            task_id=int(task.id),
+            task_owner_user_id=int(task.user_id),
+            task_source=str(task.source) if task.source is not None else None,
+            task_description=str(task.description),
+            task_context=task_context,
+            task_info={
+                "id": int(task.id),
+                "title": task.title,
+                "description": task.description,
+                "status": task.status.value,
+                "model_id": model_id,
+                "small_fast_model_id": small_fast_model_id,
+                "visual_model_id": visual_model_id,
+                "compact_model_id": compact_model_id,
+                "model_name": task.model_name,
+                "small_fast_model_name": task.small_fast_model_name,
+                "visual_model_name": task.visual_model_name,
+                "compact_model_name": task.compact_model_name,
+                "execution_mode": task.execution_mode,
+                "agent_id": task.agent_id,
+                "agent_name": agent_name,
+                "agent_logo_url": agent_logo_url,
+                "created_at": safe_timestamp_to_unix(task.created_at)
+                if task.created_at
+                else None,
+                "updated_at": safe_timestamp_to_unix(task.updated_at)
+                if task.updated_at
+                else None,
+            },
+            created_at=created_at,
+        )
+
+
 async def handle_execute_task(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
-    """Handle task execution request"""
+    """Handle the legacy execution command without retaining a DB Session."""
     try:
         user = message_data.get("user")
         authorized_task_id: int | None = None
         if not user:
             raise ValueError("User authentication required for task execution")
+        actor_user_id = int(user.id)
+        actor_is_admin = bool(user.is_admin)
 
-        # Send execution start confirmation
+        # Preserve the legacy protocol acknowledgement before task lookup.
         await manager.send_personal_message(
             {
                 "type": "execution_started",
@@ -4302,182 +4992,46 @@ async def handle_execute_task(
             websocket,
         )
 
-        # Get database session
-        from ..models.database import get_db
-        from ..models.task import Task, TaskStatus
-        from ..services.task_execution_context_service import (
-            load_task_execution_recovery_state,
+        request = await run_db_io_cancellation_safe(
+            lambda: _load_legacy_execute_task_request_sync(
+                task_id,
+                actor_user_id=actor_user_id,
+                actor_is_admin=actor_is_admin,
+            )
         )
-        from .chat import get_agent_manager
+        if request is None:
+            raise Exception(f"Task {task_id} not found or access denied")
+        authorized_task_id = request.task_id
 
-        db_gen = get_db()
-        db: Session = next(db_gen)
-
-        try:
-            # Get task - admin can access any task
-            if user.is_admin:
-                task = db.query(Task).filter(Task.id == task_id).first()
-            else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
-            if not task:
-                raise Exception(f"Task {task_id} not found or access denied")
-            authorized_task_id = int(task.id)
-
-            (
-                model_id,
-                small_fast_model_id,
-                visual_model_id,
-                compact_model_id,
-            ) = _resolve_task_llm_ids(task, db)
-
-            # Send task info event to update frontend state
-            task_event = create_stream_event(
+        await manager.broadcast_to_task(
+            create_stream_event(
                 "task_info",
-                task_id,
-                {
-                    "id": task.id,
-                    "title": task.title,
-                    "description": task.description,
-                    "status": task.status.value,
-                    "model_id": model_id,
-                    "small_fast_model_id": small_fast_model_id,
-                    "visual_model_id": visual_model_id,
-                    "compact_model_id": compact_model_id,
-                    "model_name": task.model_name,
-                    "small_fast_model_name": task.small_fast_model_name,
-                    "visual_model_name": task.visual_model_name,
-                    "compact_model_name": task.compact_model_name,
-                    "execution_mode": task.execution_mode,
-                    "agent_id": task.agent_id,
-                    "agent_name": task.agent.name if task.agent else None,
-                    "agent_logo_url": task.agent.logo_url if task.agent else None,
-                    "created_at": safe_timestamp_to_unix(task.created_at)
-                    if task.created_at
-                    else None,
-                    "updated_at": safe_timestamp_to_unix(task.updated_at)
-                    if task.updated_at
-                    else None,
-                },
-                task.created_at if task.created_at else None,
-            )
-            await manager.broadcast_to_task(task_event, task_id)
+                request.task_id,
+                request.task_info,
+                request.created_at,
+            ),
+            request.task_id,
+        )
 
-            # DAG plan-execute will automatically send user_message trace event
+        from ..services.task_orchestrator import (
+            TaskTurnOrchestrator,
+            TaskTurnPayload,
+        )
 
-            # DAG plan-execute also sends trace events, but may not forward in real-time
-
-            # Get agent and execute task
-            from .chat import get_agent_manager
-
-            agent_manager = get_agent_manager()
-            agent_service = await agent_manager.get_agent_for_task(
-                task_id, db, user=user, task_owner_user_id=int(task.user_id)
-            )
-            if hasattr(agent_service, "set_outbound_message_handler"):
-                agent_service.set_outbound_message_handler(
-                    make_agent_outbound_handler(task_id)
-                )
-            recovery_state = await load_task_execution_recovery_state(db, task_id)
-            agent_service.set_execution_context_messages(
-                recovery_state.get("messages", [])
-            )
-            agent_service.set_recovered_skill_context(
-                recovery_state.get("skill_context")
-            )
-
-            # Set up user context as the task OWNER (runtime identity), not the
-            # acting principal -- an admin executing another user's task must
-            # run with the owner's identity. ``task`` is already loaded and
-            # authorized above.
-            with UserContext(int(task.user_id)), turn_execution_scope(task_id):
-                # Build context with vibe mode information if available
-                task_context = {}
-                if hasattr(task, "execution_mode") and task.execution_mode:
-                    task_context["execution_mode"] = task.execution_mode
-                if hasattr(task, "process_description") and task.process_description:
-                    task_context["process_description"] = task.process_description
-                if hasattr(task, "examples") and task.examples:
-                    task_context["examples"] = task.examples
-
-                # Execute task with automatic token tracking
-                result = await agent_manager.execute_task(
-                    agent_service=agent_service,
-                    task=str(task.description),
-                    context=task_context,
-                    task_id=str(task_id),
-                    db_session=db,
-                )
-
-                # Update task status
-                if result.get("success", False):
-                    release_current_runner_task_lease_with_workforce_sync(
-                        db, task_id, status=TaskStatus.COMPLETED
-                    )
-                else:
-                    release_current_runner_task_lease_with_workforce_sync(
-                        db, task_id, status=TaskStatus.FAILED
-                    )
-                db.refresh(task)
-
-                # Send task completion event (don't duplicate result as trace system already sent)
-
-            # Workspace cleanup now only happens on task deletion, so users can view result files
-
-            # Note: trace_task_completion is handled by handle_chat_message to avoid duplicates
-
-            # Extract file output info
-            file_outputs, path_to_file_id = _normalize_task_file_outputs(
-                db,
-                task,
-                result.get("file_outputs", []),
-            )
-            result["output"] = _rewrite_file_links_to_file_id(
-                result.get("output", ""),
-                path_to_file_id,
-            )
-            result["output"] = reconcile_assistant_file_references(
-                db,
-                task_id=int(task_id),
-                user_id=int(task.user_id),
-                content=result["output"],
-            )
-
-            # Send task completion event (don't duplicate result as trace system already sent)
-            await manager.broadcast_to_task(
-                {
-                    "type": "task_completed",
-                    "task": {
-                        "id": task.id,
-                        "title": task.title,
-                        "status": task.status.value,
-                        "description": task.description,
-                    },
-                    "success": result.get("success", False),
-                    "run_id": _task_run_id(task),
-                    "state_version": int(task.state_version or 0),
-                    "control_state": _task_control_state_value(task) or "idle",
-                    "status": task.status.value,
-                    "result": result.get("output", ""),
-                    "output": result.get("output", ""),
-                    # Same coded-reason forwarding as the primary completion
-                    # broadcast, so a coded failure on this path (e.g. a mid-run
-                    # quota interrupt) still reaches the app-layer dialog.
-                    "error_code": result.get("error_code"),
-                    "error_details": result.get("error_details"),
-                    "chat_response": result.get("chat_response"),
-                    "metadata": result.get("metadata", {}),
-                    "file_outputs": file_outputs,  # Add file output info
-                    "timestamp": datetime.now(timezone.utc).timestamp(),
-                },
-                task_id,
-            )
-
-        finally:
-            db.close()
+        background_task = await TaskTurnOrchestrator.schedule_existing_task_execution(
+            task_id=request.task_id,
+            task_owner_user_id=request.task_owner_user_id,
+            task_source=request.task_source,
+            payload=TaskTurnPayload(
+                transcript_message=request.task_description,
+                execution_message=request.task_description,
+            ),
+            context=request.task_context,
+            actor_user_id=actor_user_id,
+        )
+        # The legacy command did not return until execution finished. Keep that
+        # ordering while the scheduled coroutine owns all runtime DB work.
+        await background_task
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation and format error
@@ -4485,9 +5039,13 @@ async def handle_execute_task(
         logger.error(f"Data validation error in task execution: {e}")
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
+            error_payload = await _read_task_error_payload_offloop(
+                authorized_task_id,
+                message,
+            )
             await manager.broadcast_to_task(
                 {
-                    **_terminal_task_error_payload(authorized_task_id, message),
+                    **error_payload,
                     "timestamp": timestamp,
                 },
                 authorized_task_id,
@@ -4507,9 +5065,13 @@ async def handle_execute_task(
         logger.error(f"Runtime error in task execution: {e}")
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
+            error_payload = await _read_task_error_payload_offloop(
+                authorized_task_id,
+                message,
+            )
             await manager.broadcast_to_task(
                 {
-                    **_terminal_task_error_payload(authorized_task_id, message),
+                    **error_payload,
                     "timestamp": timestamp,
                 },
                 authorized_task_id,
@@ -5235,11 +5797,55 @@ async def handle_pause_task(
     )
 
 
+def _apply_pause_requested_isolated(
+    task_id: int,
+    *,
+    expected_run_id: str | None,
+) -> bool:
+    """Persist PAUSE_REQUESTED for the exact RUNNING run in a short Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        values: dict[str, Any] = {
+            "control_state": TaskControlState.PAUSE_REQUESTED.value,
+            "state_version": func.coalesce(Task.state_version, 0) + 1,
+        }
+        if expected_run_id is None:
+            # Preserve ``apply_task_control_transition`` semantics for legacy
+            # RUNNING rows that predate run ids.
+            values["run_id"] = str(uuid.uuid4())
+
+        statement = update(Task).where(
+            Task.id == task_id,
+            Task.status == TaskStatus.RUNNING,
+        )
+        statement = (
+            statement.where(Task.run_id.is_(None))
+            if expected_run_id is None
+            else statement.where(Task.run_id == expected_run_id)
+        )
+        result = db.execute(
+            statement.values(**values).execution_options(synchronize_session=False)
+        )
+        if int(getattr(result, "rowcount", 0) or 0) == 1:
+            db.commit()
+            return True
+
+        current = db.query(Task.run_id, Task.status).filter(Task.id == task_id).first()
+        if current is not None:
+            current_run_id = str(current[0]) if current[0] is not None else None
+            if current_run_id != expected_run_id:
+                raise StaleTaskRunError(
+                    f"task {task_id} run changed from {expected_run_id} "
+                    f"to {current_run_id}"
+                )
+        return False
+
+
 async def _handle_pause_task_unserialized(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
     """Handle task pause request"""
-    db: Session | None = None
     try:
         logger.info(f"🔘 handle_pause_task called for task {task_id}")
         user = message_data.get("user")
@@ -5249,38 +5855,39 @@ async def _handle_pause_task_unserialized(
 
         logger.info(f"User {user.id} authenticated for pause")
 
-        # Get database session
-        from ..models.database import get_db
+        from ..services.task_setup_snapshot import load_task_setup_snapshot_sync
+        from .chat import get_agent_manager
 
-        db_gen = get_db()
-        db = next(db_gen)
-
-        # Authorize the task BEFORE building any runtime: an admin may pause any
-        # task; a non-admin only their own. Loading the task here also gives us
-        # the OWNER, so the agent runtime runs as the owner, not the actor.
-        from ..models.task import Task as _PauseTask
-
-        if user.is_admin:
-            task = db.query(_PauseTask).filter(_PauseTask.id == task_id).first()
-        else:
-            task = (
-                db.query(_PauseTask)
-                .filter(_PauseTask.id == task_id, _PauseTask.user_id == int(user.id))
-                .first()
+        task_setup_snapshot = await run_db_io_cancellation_safe(
+            lambda: load_task_setup_snapshot_sync(
+                task_id,
+                None,
+                actor_user_id=int(user.id),
+                actor_is_admin=bool(user.is_admin),
             )
-        if task is None:
+        )
+        if task_setup_snapshot is None:
             logger.warning(
                 "pause: task %s not found or not owned by user %s", task_id, user.id
             )
             raise ValueError(f"Access denied: task {task_id} is not available")
-        task_owner_user_id = int(task.user_id)
+
+        task_fields = task_setup_snapshot.task
+        task_owner_user_id = int(task_fields.user_id)
+        expected_run_id = task_fields.run_id
+        execution_scope = await run_db_io_cancellation_safe(
+            lambda: resolve_execution_scope(task_id)
+        )
 
         # Get agent service (as the task owner)
-        from .chat import get_agent_manager
-
         logger.info(f"Getting agent service for task {task_id}")
         agent_service = await get_agent_manager().get_agent_for_task(
-            task_id, db, user=user, task_owner_user_id=task_owner_user_id
+            task_id,
+            None,
+            user=task_setup_snapshot.runtime_user,
+            task_setup_snapshot=task_setup_snapshot,
+            task_owner_user_id=task_owner_user_id,
+            resolved_execution_scope=execution_scope,
         )
         logger.info(f"Agent service obtained: {type(agent_service).__name__}")
 
@@ -5292,37 +5899,36 @@ async def _handle_pause_task_unserialized(
                 message_data["_durable_command_error"] = (
                     "No live execution found to pause"
                 )
+                error_payload = await _read_task_error_payload_offloop(
+                    task_id,
+                    "No live execution found to pause",
+                )
                 await manager.send_personal_message(
-                    _task_error_payload(
-                        db,
-                        task_id,
-                        "No live execution found to pause",
-                    ),
+                    error_payload,
                     websocket,
                 )
                 logger.warning(f"No live execution found to pause for task {task_id}")
                 return
             logger.info("Agent pause_execution completed")
-            db.refresh(task)
-            if task.status != TaskStatus.RUNNING:
+            pause_applied = await run_db_io_cancellation_safe(
+                lambda: _apply_pause_requested_isolated(
+                    task_id,
+                    expected_run_id=expected_run_id,
+                )
+            )
+            if not pause_applied:
                 message_data["_durable_command_error"] = (
                     "Task finished before the pause request was applied"
                 )
+                error_payload = await _read_task_error_payload_offloop(
+                    task_id,
+                    "Task finished before the pause request was applied",
+                )
                 await manager.send_personal_message(
-                    _task_error_payload(
-                        db,
-                        task_id,
-                        "Task finished before the pause request was applied",
-                    ),
+                    error_payload,
                     websocket,
                 )
                 return
-            apply_task_control_transition(
-                task,
-                TaskControlState.PAUSE_REQUESTED,
-                expected_run_id=_task_run_id(task),
-            )
-            db.commit()
             _mark_task_pause_accepted(task_id)
 
             # This confirms only that the control request was accepted. The
@@ -5344,12 +5950,12 @@ async def _handle_pause_task_unserialized(
             message_data["_durable_command_error"] = (
                 "Current agent does not support pause functionality"
             )
+            error_payload = await _read_task_error_payload_offloop(
+                task_id,
+                "Current agent does not support pause functionality",
+            )
             await manager.send_personal_message(
-                _task_error_payload(
-                    db,
-                    task_id,
-                    "Current agent does not support pause functionality",
-                ),
+                error_payload,
                 websocket,
             )
             logger.warning(
@@ -5374,9 +5980,6 @@ async def _handle_pause_task_unserialized(
         # Other errors, re-raise
         logger.error(f"Unexpected error pausing task {task_id}: {e}")
         raise
-    finally:
-        if db is not None:
-            db.close()
 
 
 async def handle_resume_task(
@@ -5430,46 +6033,23 @@ async def _handle_resume_task_unserialized(
         if not user:
             raise ValueError("User authentication required for task resume")
 
-        # Get database session
-        from ..models.database import get_db
+        from ..services.task_setup_snapshot import load_task_setup_snapshot_sync
+        from .chat import get_agent_manager
 
-        db_gen = get_db()
-        db = next(db_gen)
-
-        from ..models.task import Task
-
-        task: Any | None = None
-        agent_service: Any = None
-        try:
-            # Authorize BEFORE building any runtime: an admin may resume any
-            # task, a non-admin only their own. Loading the task here also
-            # yields the OWNER, so the agent runs as the owner (not the actor)
-            # and nothing is built / cached for an unauthorized request.
-            if user.is_admin:
-                task = db.query(Task).filter(Task.id == task_id).first()
-            else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == int(user.id))
-                    .first()
-                )
-            if task is None:
-                logger.warning(
-                    f"Task {task_id} not found or access denied for user {user.id}"
-                )
-            else:
-                from .chat import get_agent_manager
-
-                agent_service = await get_agent_manager().get_agent_for_task(
-                    task_id,
-                    db,
-                    user=user,
-                    task_owner_user_id=int(task.user_id),
-                )
-        finally:
-            db.close()
-
-        if task is None:
+        task_setup_snapshot = await run_db_io_cancellation_safe(
+            lambda: load_task_setup_snapshot_sync(
+                task_id,
+                None,
+                actor_user_id=int(user.id),
+                actor_is_admin=bool(user.is_admin),
+            )
+        )
+        if task_setup_snapshot is None:
+            logger.warning(
+                "Task %s not found or access denied for user %s",
+                task_id,
+                user.id,
+            )
             message_data["_durable_command_error"] = "Task not found or access denied"
             await manager.send_personal_message(
                 {"type": "error", "message": "Task not found or access denied"},
@@ -5477,9 +6057,35 @@ async def _handle_resume_task_unserialized(
             )
             return
 
-        resume_control_state = task_control_snapshot(task).as_dict()
+        task_fields = task_setup_snapshot.task
+        task_owner_user_id = int(task_fields.user_id)
+        task_status = cast(TaskStatus, task_fields.status)
+        resolved_execution_scope = await run_db_io_cancellation_safe(
+            lambda: resolve_execution_scope(task_id)
+        )
+        raw_control_state = task_fields.control_state
+        try:
+            control_state = TaskControlState(str(raw_control_state))
+        except ValueError:
+            control_state = control_state_for_status(task_status)
+        resume_control_state = TaskControlSnapshot(
+            task_id=task_id,
+            run_id=task_fields.run_id,
+            state_version=task_fields.state_version,
+            control_state=control_state,
+            status=task_status,
+        ).as_dict()
+
+        agent_service = await get_agent_manager().get_agent_for_task(
+            task_id,
+            None,
+            user=task_setup_snapshot.runtime_user,
+            task_setup_snapshot=task_setup_snapshot,
+            task_owner_user_id=task_owner_user_id,
+            resolved_execution_scope=resolved_execution_scope,
+        )
         if getattr(agent_service, "supports_live_control", lambda: False)():
-            if task.status not in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
+            if task_status not in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
                 message_data["_durable_command_error"] = (
                     "Task is not paused and cannot be resumed."
                 )
@@ -5508,16 +6114,17 @@ async def _handle_resume_task_unserialized(
                 resume_snapshot = await task_execution_controller.transition(
                     task_id,
                     TaskControlState.RESUME_REQUESTED,
-                    expected_run_id=_task_run_id(task),
+                    expected_run_id=task_fields.run_id,
                 )
                 previous_task = background_task_manager.running_tasks.get(task_id)
                 bg_task = asyncio.create_task(
                     execute_resume_background(
                         task_id=task_id,
                         agent_service=agent_service,
-                        task_owner_user_id=int(task.user_id),
+                        task_owner_user_id=task_owner_user_id,
                         expected_run_id=resume_snapshot.run_id,
                         previous_task=previous_task,
+                        resolved_execution_scope=resolved_execution_scope,
                     )
                 )
                 background_task_manager.register_reserved_resume(task_id, bg_task)
@@ -5546,7 +6153,7 @@ async def _handle_resume_task_unserialized(
             resume_snapshot = await task_execution_controller.transition(
                 task_id,
                 TaskControlState.RESUME_REQUESTED,
-                expected_run_id=_task_run_id(task),
+                expected_run_id=task_fields.run_id,
             )
             await agent_service.resume_execution()
             await task_execution_controller.transition(
@@ -5610,16 +6217,23 @@ class _DiscardingCommandWebSocket:
         return None
 
 
-def _load_command_actor(actor_user_id: int | None) -> User:
+@dataclass(frozen=True)
+class _CommandActor:
+    id: int
+    is_admin: bool
+
+
+def _load_command_actor(actor_user_id: int | None) -> _CommandActor:
     if actor_user_id is None:
         raise ValueError("Task command has no actor")
     SessionLocal = get_session_local()
     with SessionLocal() as db:
-        user = db.query(User).filter(User.id == actor_user_id).first()
-        if user is None:
+        user_row = (
+            db.query(User.id, User.is_admin).filter(User.id == actor_user_id).first()
+        )
+        if user_row is None:
             raise ValueError(f"Task command actor {actor_user_id} no longer exists")
-        db.expunge(user)
-        return user
+        return _CommandActor(id=int(user_row[0]), is_admin=bool(user_row[1]))
 
 
 async def _execute_durable_task_command(
@@ -5644,11 +6258,13 @@ async def _execute_durable_task_command(
         }
     )
     if command.kind != TaskCommandKind.CANCEL:
-        user = await asyncio.to_thread(_load_command_actor, command.actor_user_id)
+        user = await run_db_io_cancellation_safe(
+            lambda: _load_command_actor(command.actor_user_id)
+        )
         message_data.update({"user": user, "user_id": int(user.id)})
     if command.kind != TaskCommandKind.MESSAGE and command.target_run_id is not None:
-        current_run_id = await asyncio.to_thread(
-            _load_command_task_run_id, command.task_id
+        current_run_id = await run_db_io_cancellation_safe(
+            lambda: _load_command_task_run_id(command.task_id)
         )
         if current_run_id != command.target_run_id:
             raise TaskCommandRejected(
@@ -5660,9 +6276,8 @@ async def _execute_durable_task_command(
         TaskCommandKind.PAUSE,
         TaskCommandKind.RESUME,
         TaskCommandKind.CANCEL,
-    } and await asyncio.to_thread(
-        task_has_live_foreign_runner,
-        command.task_id,
+    } and await run_db_io_cancellation_safe(
+        lambda: task_has_live_foreign_runner(command.task_id)
     ):
         raise TaskCommandDeferred(
             f"{command.kind.value.title()} command {command.command_id} is waiting "
@@ -5673,10 +6288,11 @@ async def _execute_durable_task_command(
         await _handle_chat_message_unserialized(
             websocket, command.task_id, message_data
         )
-        delivery_status = await asyncio.to_thread(
-            _load_command_message_delivery_status,
-            command.task_id,
-            command.command_id,
+        delivery_status = await run_db_io_cancellation_safe(
+            lambda: _load_command_message_delivery_status(
+                command.task_id,
+                command.command_id,
+            )
         )
         if delivery_status == DELIVERY_PENDING:
             raise TaskCommandDeferred(
@@ -5691,7 +6307,6 @@ async def _execute_durable_task_command(
     elif command.kind == TaskCommandKind.RESUME:
         await _handle_resume_task_unserialized(websocket, command.task_id, message_data)
     elif command.kind == TaskCommandKind.CANCEL:
-        from ..models.agent import Agent
         from .a2a import _cancel_task_unserialized
 
         agent_id_value = message_data.get("agent_id")
@@ -5703,19 +6318,13 @@ async def _execute_durable_task_command(
             raise ValueError(
                 f"Agent ID {agent_id_value!r} is invalid in cancel command payload"
             ) from exc
-        SessionLocal = get_session_local()
-        with SessionLocal() as db:
-            agent = db.query(Agent).filter(Agent.id == agent_id).first()
-            if agent is None:
-                raise ValueError(f"Agent {agent_id} not found for cancel command")
-            try:
-                await _cancel_task_unserialized(
-                    task_id=command.task_id,
-                    agent=agent,
-                    db=db,
-                )
-            except StaleTaskRunError as exc:
-                raise TaskCommandRejected(str(exc), reason="stale_run") from exc
+        try:
+            await _cancel_task_unserialized(
+                task_id=command.task_id,
+                agent_id=agent_id,
+            )
+        except StaleTaskRunError as exc:
+            raise TaskCommandRejected(str(exc), reason="stale_run") from exc
     else:  # pragma: no cover - enum construction rejects this earlier
         raise ValueError(f"Unsupported task command kind: {command.kind}")
     durable_error = message_data.get("_durable_command_error")

--- a/src/xagent/web/services/a2a_protocol.py
+++ b/src/xagent/web/services/a2a_protocol.py
@@ -310,9 +310,9 @@ def message_task_id(message: Mapping[str, Any], body: Mapping[str, Any]) -> int 
     )
 
 
-def task_context_id(task: Task) -> str:
-    agent_config: dict[str, Any] = (
-        task.agent_config if isinstance(task.agent_config, dict) else {}
+def task_context_id(task: Any) -> str:
+    agent_config: Mapping[str, Any] = (
+        task.agent_config if isinstance(task.agent_config, Mapping) else {}
     )
     context_id = agent_config.get("a2a_context_id")
     if isinstance(context_id, str) and context_id:
@@ -320,7 +320,7 @@ def task_context_id(task: Task) -> str:
     return str(task.id)
 
 
-def task_to_a2a(task: Task, *, include_artifacts: bool = True) -> dict[str, Any]:
+def task_to_a2a(task: Any, *, include_artifacts: bool = True) -> dict[str, Any]:
     result: dict[str, Any] = {
         "id": str(task.id),
         "contextId": task_context_id(task),
@@ -344,11 +344,11 @@ def task_to_a2a(task: Task, *, include_artifacts: bool = True) -> dict[str, Any]
 
 
 def task_state(task_or_status: Task | Any) -> str:
-    task = task_or_status if isinstance(task_or_status, Task) else None
+    task = task_or_status if hasattr(task_or_status, "status") else None
     status = task.status if task is not None else task_or_status
     if task is not None:
-        agent_config: dict[str, Any] = (
-            task.agent_config if isinstance(task.agent_config, dict) else {}
+        agent_config: Mapping[str, Any] = (
+            task.agent_config if isinstance(task.agent_config, Mapping) else {}
         )
         override = agent_config.get("a2a_state")
         if override in {
@@ -375,11 +375,11 @@ def task_state(task_or_status: Task | Any) -> str:
     return "TASK_STATE_UNSPECIFIED"
 
 
-def sse_task_snapshot(task: Task) -> str:
+def sse_task_snapshot(task: Any) -> str:
     return _sse_event({"task": task_to_a2a(task)})
 
 
-def sse_task_update(task: Task) -> str:
+def sse_task_update(task: Any) -> str:
     return _sse_event(
         {
             "statusUpdate": {
@@ -392,7 +392,7 @@ def sse_task_update(task: Task) -> str:
 
 
 def sse_task_artifacts(
-    task: Task,
+    task: Any,
     *,
     text: str | None = None,
     append: bool = False,
@@ -418,7 +418,7 @@ def sse_task_artifacts(
     )
 
 
-def _agent_message(content: str, task: Task) -> dict[str, Any]:
+def _agent_message(content: str, task: Any) -> dict[str, Any]:
     return {
         "messageId": f"task-{task.id}-status",
         "contextId": task_context_id(task),

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -2,22 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Callable, NamedTuple, TypeVar, cast
 
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...templates.manager import TemplateManager
 from ..models.agent import Agent
+from ..models.agent_api_key import AgentApiKey
+from ..models.database import get_session_local
 from ..models.model import Model as DBModel
 from ..schemas.agent_api_key import APIKeyGenerateResponse
 from ..services.agent_store import AgentStore, invalidate_agent_cache
 from .api_keys import AgentApiKeyService, KeyRotationConflict
+from .db_runtime import (
+    run_db_io_cancellation_safe,
+    run_one_shot_secret_db_io_cancellation_safe,
+)
 
 # Agent-builder tool category that gates knowledge-base access. A KB
 # selection is only valid when this category is also enabled.
 KNOWLEDGE_TOOL_CATEGORY = "knowledge"
+_T = TypeVar("_T")
 
 
 class DuplicateAgentNameError(ValueError):
@@ -34,6 +42,105 @@ class InvalidAgentModelConfigError(ValueError):
 
 class InvalidKnowledgeBaseError(ValueError):
     """Raised when KB selection fails the knowledge-tool or visibility rule."""
+
+
+class ManagedAgentCreateResult(NamedTuple):
+    """Detached result returned across the database worker boundary."""
+
+    agent: dict[str, Any]
+    api_key: APIKeyGenerateResponse | None
+
+
+class _UndeliveredRuntimeKeyReceipt(NamedTuple):
+    """Detached identity for compensating one undelivered runtime key."""
+
+    agent_id: int
+    key_prefix: str
+
+
+async def validate_agent_knowledge_bases(
+    *,
+    knowledge_bases: list[str] | None,
+    tool_categories: list[str] | None,
+    user_id: int,
+    is_admin: bool,
+) -> None:
+    """Enforce the agent knowledge-base selection invariant."""
+    if not knowledge_bases:
+        return
+    if KNOWLEDGE_TOOL_CATEGORY not in (tool_categories or []):
+        raise InvalidKnowledgeBaseError(
+            "Knowledge bases are selected but the Knowledge tool "
+            "category is not enabled."
+        )
+    missing = await find_missing_knowledge_bases(
+        knowledge_bases, user_id=user_id, is_admin=is_admin
+    )
+    if missing:
+        raise InvalidKnowledgeBaseError(
+            "Knowledge base(s) not found or not visible to this user: "
+            + ", ".join(missing)
+        )
+
+
+async def _resolve_template_agent_fields(
+    *,
+    template_manager: TemplateManager | None,
+    template_id: str,
+    name: str | None,
+    description: str | None,
+    instructions: str | None,
+    execution_mode: str | None,
+    models: dict[str, Any] | None,
+    knowledge_bases: list[str] | None,
+    skills: list[str] | None,
+    tool_categories: list[str] | None,
+    suggested_prompts: list[str] | None,
+) -> dict[str, Any]:
+    """Resolve template defaults without opening a database Session."""
+    if template_manager is None:
+        raise TemplateNotFoundError(template_id)
+
+    template = await template_manager.get_template(template_id)
+    if template is None:
+        raise TemplateNotFoundError(template_id)
+
+    agent_config = template.get("agent_config") or {}
+    final_description = description
+    if final_description is None:
+        descriptions = template.get("descriptions") or {}
+        if isinstance(descriptions, dict):
+            final_description = descriptions.get("en") or ""
+        elif isinstance(descriptions, str):
+            final_description = descriptions
+
+    return {
+        "name": name or template.get("name") or template_id,
+        "description": final_description,
+        "instructions": (
+            instructions
+            if instructions is not None
+            else agent_config.get("instructions")
+        ),
+        "execution_mode": execution_mode or agent_config.get("execution_mode"),
+        "models": models if models is not None else agent_config.get("models"),
+        "knowledge_bases": (
+            knowledge_bases
+            if knowledge_bases is not None
+            else agent_config.get("knowledge_bases") or []
+        ),
+        "skills": skills if skills is not None else agent_config.get("skills") or [],
+        "tool_categories": (
+            tool_categories
+            if tool_categories is not None
+            else agent_config.get("tool_categories") or []
+        ),
+        "suggested_prompts": (
+            suggested_prompts
+            if suggested_prompts is not None
+            else agent_config.get("suggested_prompts") or []
+        ),
+    }
 
 
 class AgentManagementService:
@@ -67,21 +174,12 @@ class AgentManagementService:
         :meth:`create_agent` entry point rather than the sync transaction
         executor.
         """
-        if not knowledge_bases:
-            return
-        if KNOWLEDGE_TOOL_CATEGORY not in (tool_categories or []):
-            raise InvalidKnowledgeBaseError(
-                "Knowledge bases are selected but the Knowledge tool "
-                "category is not enabled."
-            )
-        missing = await find_missing_knowledge_bases(
-            knowledge_bases, user_id=user_id, is_admin=is_admin
+        await validate_agent_knowledge_bases(
+            knowledge_bases=knowledge_bases,
+            tool_categories=tool_categories,
+            user_id=user_id,
+            is_admin=is_admin,
         )
-        if missing:
-            raise InvalidKnowledgeBaseError(
-                "Knowledge base(s) not found or not visible to this user: "
-                + ", ".join(missing)
-            )
 
     async def create_agent(
         self,
@@ -99,10 +197,11 @@ class AgentManagementService:
         suggested_prompts: list[str] | None = None,
         generate_runtime_key: bool = True,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
-        """Sole external create entry point: validate KBs (async) then
-        run the transactional create. Every public create path
-        (``POST /v1/agents`` and ``POST /v1/agents/from-template``) goes
-        through here, so the KB invariant has a single enforcement point.
+        """Session-bound create entry point used by legacy web routes.
+
+        Worker-owned ``/v1`` routes share the same module-level KB validator
+        and transactional executor without carrying this service's Session
+        across the validation await.
         """
         await self.validate_knowledge_bases(
             knowledge_bases=knowledge_bases,
@@ -141,9 +240,8 @@ class AgentManagementService:
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
         """Create an agent and (optionally) its first runtime key in a
         single transaction. Internal transaction executor: assumes
-        knowledge-base inputs were already validated by the async
-        :meth:`create_agent` entry point; this method only validates
-        models and owns the commit boundary.
+        knowledge-base inputs were already validated by an async entry point;
+        this method only validates models and owns the commit boundary.
 
         Committing the agent and its first key separately would leave a
         persisted agent behind if the key step fails, so a client retry
@@ -184,29 +282,31 @@ class AgentManagementService:
         # here (agent has no unique constraint), so the conflict-to-409
         # translation wraps key staging + commit together. See the
         # contract note in the docstring above.
-        staged_key = None
+        key_resp: APIKeyGenerateResponse | None = None
         try:
             if generate_runtime_key:
-                staged_key = self.key_service.stage_rotated_key(int(agent.id))
+                new_row, full_key = self.key_service.stage_rotated_key(int(agent.id))
+                key_resp = APIKeyGenerateResponse(
+                    full_key=full_key,
+                    key_prefix=new_row.key_prefix,
+                    created_at=new_row.created_at,
+                )
+
+            # Build the complete response view while the current transaction
+            # still owns its connection, then detach the agent before commit.
+            # ``Session.commit()`` expires attached ORM rows by default; a
+            # later refresh or attribute load would otherwise require a new
+            # pool checkout after the durable agent/key write had succeeded.
+            self.store.agent_to_response_dict(agent)
+            agent_id = int(agent.id)
+            team_id = cast("int | None", agent.team_id)
+            self.db.expunge(agent)
             self.db.commit()  # single transaction boundary for both writes
         except IntegrityError as exc:
             self.db.rollback()
             raise KeyRotationConflict(str(exc)) from exc
 
-        self.db.refresh(agent)
-        invalidate_agent_cache(
-            user_id, int(agent.id), cast("int | None", agent.team_id)
-        )
-
-        key_resp: APIKeyGenerateResponse | None = None
-        if staged_key is not None:
-            new_row, full_key = staged_key
-            self.db.refresh(new_row)
-            key_resp = APIKeyGenerateResponse(
-                full_key=full_key,
-                key_prefix=new_row.key_prefix,
-                created_at=new_row.created_at,
-            )
+        invalidate_agent_cache(user_id, agent_id, team_id)
         return agent, key_resp
 
     async def create_agent_from_template(
@@ -230,52 +330,24 @@ class AgentManagementService:
         :meth:`create_agent`, so KB validation and the single commit
         boundary are shared with the plain create path.
         """
-        if self.template_manager is None:
-            raise TemplateNotFoundError(template_id)
-
-        template = await self.template_manager.get_template(template_id)
-        if template is None:
-            raise TemplateNotFoundError(template_id)
-
-        agent_config = template.get("agent_config") or {}
-        final_name = name or template.get("name") or template_id
-        final_description = description
-        if final_description is None:
-            descriptions = template.get("descriptions") or {}
-            if isinstance(descriptions, dict):
-                final_description = descriptions.get("en") or ""
-            elif isinstance(descriptions, str):
-                final_description = descriptions
-
+        fields = await _resolve_template_agent_fields(
+            template_manager=self.template_manager,
+            template_id=template_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+        )
         return await self.create_agent(
             user_id=user_id,
             is_admin=is_admin,
             generate_runtime_key=generate_runtime_key,
-            name=final_name,
-            description=final_description,
-            instructions=(
-                instructions
-                if instructions is not None
-                else agent_config.get("instructions")
-            ),
-            execution_mode=execution_mode or agent_config.get("execution_mode"),
-            models=models if models is not None else agent_config.get("models"),
-            knowledge_bases=(
-                knowledge_bases
-                if knowledge_bases is not None
-                else agent_config.get("knowledge_bases") or []
-            ),
-            skills=skills if skills is not None else agent_config.get("skills") or [],
-            tool_categories=(
-                tool_categories
-                if tool_categories is not None
-                else agent_config.get("tool_categories") or []
-            ),
-            suggested_prompts=(
-                suggested_prompts
-                if suggested_prompts is not None
-                else agent_config.get("suggested_prompts") or []
-            ),
+            **fields,
         )
 
     def generate_agent_runtime_key(
@@ -314,3 +386,188 @@ class AgentManagementService:
                 raise InvalidAgentModelConfigError(slot)
             normalized[slot] = model_id
         return normalized
+
+
+def _with_worker_owned_agent_service(
+    operation: Callable[[AgentManagementService], _T],
+) -> _T:
+    """Run one synchronous operation inside a short-lived Session.
+
+    This helper is called only from ``run_db_io_cancellation_safe`` workers.
+    Keeping Session construction here makes the ownership boundary explicit:
+    no Session or ORM object crosses back to the event-loop thread.
+    """
+    with get_session_local()() as db:
+        return operation(AgentManagementService(db))
+
+
+def _compensate_undelivered_runtime_key_sync(
+    receipt: _UndeliveredRuntimeKeyReceipt | None,
+) -> None:
+    """Revoke only the runtime key whose one-shot secret was not returned.
+
+    The durable agent and every sibling key remain untouched. This keeps create
+    cancellation consistent with ``generate_runtime_key=False`` and prevents a
+    late compensator from deleting concurrent agent updates, triggers, or a
+    successfully delivered later rotation. Retrying rotation is the explicit
+    recovery contract for the cancelled caller.
+    """
+    if receipt is None:
+        return
+    session_local = get_session_local()
+    with session_local() as db:
+        try:
+            db.query(AgentApiKey).filter(
+                AgentApiKey.agent_id == receipt.agent_id,
+                AgentApiKey.key_prefix == receipt.key_prefix,
+                AgentApiKey.revoked_at.is_(None),
+            ).update(
+                {AgentApiKey.revoked_at: func.now()},
+                synchronize_session=False,
+            )
+            db.commit()
+        except BaseException:
+            db.rollback()
+            raise
+
+
+async def list_agents_for_user_worker_owned(*, user_id: int) -> list[dict[str, Any]]:
+    """List agents without running synchronous SQL on the event loop."""
+    return await run_db_io_cancellation_safe(
+        lambda: _with_worker_owned_agent_service(
+            lambda service: service.list_agents_for_user(user_id)
+        )
+    )
+
+
+async def create_agent_worker_owned(
+    *,
+    user_id: int,
+    is_admin: bool,
+    name: str,
+    description: str | None,
+    instructions: str | None,
+    execution_mode: str | None = "balanced",
+    models: dict[str, Any] | None = None,
+    knowledge_bases: list[str] | None = None,
+    skills: list[str] | None = None,
+    tool_categories: list[str] | None = None,
+    suggested_prompts: list[str] | None = None,
+    generate_runtime_key: bool = True,
+) -> ManagedAgentCreateResult:
+    """Validate async inputs, then atomically create in a DB worker."""
+    await validate_agent_knowledge_bases(
+        knowledge_bases=knowledge_bases,
+        tool_categories=tool_categories,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+    def create_and_detach(
+        service: AgentManagementService,
+    ) -> ManagedAgentCreateResult:
+        agent, api_key = service.create_agent_with_optional_key(
+            user_id=user_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
+        return ManagedAgentCreateResult(
+            agent=service.store.agent_to_response_dict(agent),
+            api_key=api_key,
+        )
+
+    if generate_runtime_key:
+
+        def create_one_shot_secret_and_detach(
+            service: AgentManagementService,
+        ) -> tuple[ManagedAgentCreateResult, _UndeliveredRuntimeKeyReceipt]:
+            result = create_and_detach(service)
+            if result.api_key is None:
+                raise RuntimeError("Runtime key generation did not return a key")
+            return result, _UndeliveredRuntimeKeyReceipt(
+                agent_id=int(result.agent["id"]),
+                key_prefix=result.api_key.key_prefix,
+            )
+
+        return await run_one_shot_secret_db_io_cancellation_safe(
+            lambda: _with_worker_owned_agent_service(create_one_shot_secret_and_detach),
+            _compensate_undelivered_runtime_key_sync,
+        )
+
+    return await run_db_io_cancellation_safe(
+        lambda: _with_worker_owned_agent_service(create_and_detach)
+    )
+
+
+async def create_agent_from_template_worker_owned(
+    *,
+    template_manager: TemplateManager | None,
+    user_id: int,
+    is_admin: bool,
+    template_id: str,
+    name: str | None = None,
+    description: str | None = None,
+    instructions: str | None = None,
+    execution_mode: str | None = None,
+    models: dict[str, Any] | None = None,
+    knowledge_bases: list[str] | None = None,
+    skills: list[str] | None = None,
+    tool_categories: list[str] | None = None,
+    suggested_prompts: list[str] | None = None,
+    generate_runtime_key: bool = True,
+) -> ManagedAgentCreateResult:
+    """Resolve template I/O before opening the worker-owned Session."""
+    fields = await _resolve_template_agent_fields(
+        template_manager=template_manager,
+        template_id=template_id,
+        name=name,
+        description=description,
+        instructions=instructions,
+        execution_mode=execution_mode,
+        models=models,
+        knowledge_bases=knowledge_bases,
+        skills=skills,
+        tool_categories=tool_categories,
+        suggested_prompts=suggested_prompts,
+    )
+    return await create_agent_worker_owned(
+        user_id=user_id,
+        is_admin=is_admin,
+        generate_runtime_key=generate_runtime_key,
+        **fields,
+    )
+
+
+async def rotate_agent_runtime_key_worker_owned(
+    *, user_id: int, agent_id: int
+) -> APIKeyGenerateResponse | None:
+    """Rotate an agent key in a short-lived Session on a DB worker."""
+
+    def rotate_and_detach(
+        service: AgentManagementService,
+    ) -> tuple[APIKeyGenerateResponse | None, _UndeliveredRuntimeKeyReceipt | None]:
+        response = service.generate_agent_runtime_key(
+            user_id=user_id, agent_id=agent_id
+        )
+        receipt = (
+            _UndeliveredRuntimeKeyReceipt(
+                agent_id=agent_id,
+                key_prefix=response.key_prefix,
+            )
+            if response is not None
+            else None
+        )
+        return response, receipt
+
+    return await run_one_shot_secret_db_io_cancellation_safe(
+        lambda: _with_worker_owned_agent_service(rotate_and_detach),
+        _compensate_undelivered_runtime_key_sync,
+    )

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, NoReturn, cast
 
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
-from ...core.utils.api_key import ApiKeyKind, generate_api_key
+from ...core.utils.api_key import (
+    ApiKeyKind,
+    generate_api_key,
+    parse_api_key,
+    verify_api_key,
+    verify_dummy,
+)
 from ..models.agent import Agent, AgentOrigin
 from ..models.agent_api_key import AgentApiKey
+from ..models.database import get_session_local
+from ..models.user import User
 from ..models.user_api_key import UserApiKey
 from ..schemas.agent_api_key import (
     AgentApiKeyListItem,
@@ -26,9 +35,280 @@ from ..schemas.user_api_key import (
     PersonalAPIKeyMetadata,
     PersonalAPIKeyRevokeResponse,
 )
+from ..utils.db_timezone import normalize_datetime_from_db
 from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentApiIdentity:
+    """Detached identity authorized by an agent runtime API key."""
+
+    agent_id: int
+    user_id: int
+    execution_mode: str | None
+    tool_categories: tuple[str, ...] | None
+    status: str
+    origin: str
+    key_prefix: str
+
+
+@dataclass(frozen=True)
+class PersonalApiIdentity:
+    """Detached identity authorized by a personal management API key."""
+
+    user_id: int
+    is_admin: bool
+    username: str
+    email: str | None
+    key_prefix: str
+
+
+class InvalidApiKeyError(RuntimeError):
+    """Raised for every expected API-key authentication failure."""
+
+
+@dataclass(frozen=True)
+class _AgentAuthCandidate:
+    key_hash: str
+    key_prefix: str
+    agent_id: int | None
+    user_id: int | None
+    execution_mode: str | None
+    tool_categories: tuple[str, ...] | None
+    status: str | None
+    origin: str | None
+
+
+@dataclass(frozen=True)
+class _PersonalAuthCandidate:
+    key_hash: str
+    key_prefix: str
+    expires_at: datetime | None
+    user_id: int | None
+    is_admin: bool | None
+    username: str | None
+    email: str | None
+
+
+def _invalid_api_key() -> NoReturn:
+    raise InvalidApiKeyError("invalid_api_key")
+
+
+def authenticate_agent_api_key(raw: str | None) -> AgentApiIdentity:
+    """Authenticate one agent key inside a worker-owned Session boundary.
+
+    The database candidate is copied to primitives and the Session is closed
+    before either real or dummy bcrypt work begins. No ORM state leaves this
+    function.
+    """
+
+    if raw is None:
+        verify_dummy()
+        _invalid_api_key()
+
+    parsed = parse_api_key(raw)
+    if parsed is None or parsed.kind != ApiKeyKind.AGENT:
+        verify_dummy()
+        _invalid_api_key()
+
+    session_local = get_session_local()
+    with session_local() as db:
+        row = (
+            db.query(
+                AgentApiKey.key_hash,
+                AgentApiKey.key_prefix,
+                Agent.id.label("agent_id"),
+                Agent.user_id.label("user_id"),
+                Agent.execution_mode,
+                Agent.tool_categories,
+                cast(Any, Agent.status),
+                Agent.origin,
+            )
+            .outerjoin(Agent, Agent.id == AgentApiKey.agent_id)
+            .filter(
+                AgentApiKey.key_prefix == parsed.prefix,
+                AgentApiKey.revoked_at.is_(None),
+                AgentApiKey.paused_at.is_(None),
+            )
+            .first()
+        )
+        candidate = None
+        if row is not None:
+            raw_categories = row.tool_categories
+            status = getattr(row.status, "value", row.status)
+            origin = getattr(row.origin, "value", row.origin)
+            candidate = _AgentAuthCandidate(
+                key_hash=str(row.key_hash),
+                key_prefix=str(row.key_prefix),
+                agent_id=(int(row.agent_id) if row.agent_id is not None else None),
+                user_id=(int(row.user_id) if row.user_id is not None else None),
+                execution_mode=(
+                    str(row.execution_mode) if row.execution_mode is not None else None
+                ),
+                tool_categories=(
+                    tuple(cast(list[str], raw_categories))
+                    if isinstance(raw_categories, list)
+                    else None
+                ),
+                status=str(status) if status is not None else None,
+                origin=str(origin) if origin is not None else None,
+            )
+
+    if candidate is None:
+        verify_dummy()
+        _invalid_api_key()
+
+    if not verify_api_key(raw, candidate.key_hash):
+        _invalid_api_key()
+
+    if (
+        candidate.agent_id is None
+        or candidate.user_id is None
+        or candidate.status is None
+        or candidate.origin is None
+        or candidate.origin == AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+    ):
+        _invalid_api_key()
+
+    return AgentApiIdentity(
+        agent_id=candidate.agent_id,
+        user_id=candidate.user_id,
+        execution_mode=candidate.execution_mode,
+        tool_categories=candidate.tool_categories,
+        status=candidate.status,
+        origin=candidate.origin,
+        key_prefix=candidate.key_prefix,
+    )
+
+
+def authenticate_personal_api_key(raw: str | None) -> PersonalApiIdentity:
+    """Authenticate one personal key without leaking a Session or ORM row."""
+
+    if raw is None:
+        verify_dummy()
+        _invalid_api_key()
+
+    parsed = parse_api_key(raw)
+    if parsed is None or parsed.kind != ApiKeyKind.PERSONAL:
+        verify_dummy()
+        _invalid_api_key()
+
+    session_local = get_session_local()
+    with session_local() as db:
+        row = (
+            db.query(
+                UserApiKey.key_hash,
+                UserApiKey.key_prefix,
+                UserApiKey.expires_at,
+                User.id.label("user_id"),
+                User.is_admin,
+                User.username,
+                User.email,
+            )
+            .outerjoin(User, User.id == UserApiKey.user_id)
+            .filter(
+                cast(Any, UserApiKey.key_prefix) == parsed.prefix,
+                UserApiKey.revoked_at.is_(None),
+            )
+            .first()
+        )
+        candidate = None
+        if row is not None:
+            candidate = _PersonalAuthCandidate(
+                key_hash=str(row.key_hash),
+                key_prefix=str(row.key_prefix),
+                expires_at=row.expires_at,
+                user_id=(int(row.user_id) if row.user_id is not None else None),
+                is_admin=(bool(row.is_admin) if row.is_admin is not None else None),
+                username=(str(row.username) if row.username is not None else None),
+                email=str(row.email) if row.email is not None else None,
+            )
+
+    if candidate is None:
+        verify_dummy()
+        _invalid_api_key()
+
+    expires_at = candidate.expires_at
+    if expires_at is not None and normalize_datetime_from_db(
+        expires_at
+    ) <= datetime.now(timezone.utc):
+        verify_dummy()
+        _invalid_api_key()
+
+    if not verify_api_key(raw, candidate.key_hash):
+        _invalid_api_key()
+
+    if (
+        candidate.user_id is None
+        or candidate.is_admin is None
+        or candidate.username is None
+    ):
+        _invalid_api_key()
+
+    return PersonalApiIdentity(
+        user_id=candidate.user_id,
+        is_admin=candidate.is_admin,
+        username=candidate.username,
+        email=candidate.email,
+        key_prefix=candidate.key_prefix,
+    )
+
+
+def record_agent_api_key_usage(key_prefix: str) -> None:
+    """Best-effort atomic usage tracking in a worker-owned Session."""
+
+    now = datetime.now(timezone.utc)
+    current_month = now.strftime("%Y-%m")
+    session_local = get_session_local()
+    db: Session | None = None
+    try:
+        db = session_local()
+        db.query(AgentApiKey).filter(
+            AgentApiKey.key_prefix == key_prefix,
+            AgentApiKey.revoked_at.is_(None),
+            AgentApiKey.paused_at.is_(None),
+        ).update(
+            {
+                AgentApiKey.last_used_at: now,
+                AgentApiKey.usage_month: current_month,
+                AgentApiKey.usage_month_calls: case(
+                    (
+                        AgentApiKey.usage_month == current_month,
+                        AgentApiKey.usage_month_calls + 1,
+                    ),
+                    else_=1,
+                ),
+            },
+            synchronize_session=False,
+        )
+        db.commit()
+    except Exception:
+        if db is not None:
+            try:
+                db.rollback()
+            except Exception:
+                logger.warning(
+                    "Failed to roll back API key usage for key_prefix=%s",
+                    key_prefix,
+                    exc_info=True,
+                )
+        logger.warning(
+            "Failed to record API key usage for key_prefix=%s",
+            key_prefix,
+            exc_info=True,
+        )
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close API key usage session for key_prefix=%s",
+                    key_prefix,
+                    exc_info=True,
+                )
 
 
 class KeyRotationConflict(RuntimeError):
@@ -63,9 +343,11 @@ class AgentApiKeyService:
         (create-agent-with-key) stage this plus other writes and commit
         once at the outer boundary.
 
-        Returns the staged ORM row and the one-shot plaintext key. The
-        row's ``created_at`` is only populated after the caller commits
-        and refreshes.
+        Returns the staged ORM row and the one-shot plaintext key. Server
+        defaults needed by the response are refreshed before return, while
+        this transaction still owns its checked-out connection. Callers can
+        therefore build the detached one-shot response before committing and
+        must not refresh the expired row after commit.
         """
         now = datetime.now(timezone.utc)
         # Bulk-revoke rather than ``.filter(...).first()``: an agent can now
@@ -94,6 +376,10 @@ class AgentApiKeyService:
         )
         self.db.add(new_row)
         self.db.flush()
+        # ``created_at`` is database-owned. Load it while the transaction's
+        # connection is still checked out so a successful commit never needs
+        # a second pool checkout merely to construct the one-shot response.
+        self.db.refresh(new_row)
         logger.info(
             "Staged runtime API key for agent %s (prefix=%s, revoked=%d)",
             agent_id,
@@ -119,17 +405,17 @@ class AgentApiKeyService:
         """
         try:
             new_row, full_key = self.stage_rotated_key(agent_id)
+            response = APIKeyGenerateResponse(
+                full_key=full_key,
+                key_prefix=new_row.key_prefix,
+                created_at=new_row.created_at,
+            )
             self.db.commit()
         except IntegrityError as exc:
             self.db.rollback()
             raise KeyRotationConflict(str(exc)) from exc
 
-        self.db.refresh(new_row)
-        return APIKeyGenerateResponse(
-            full_key=full_key,
-            key_prefix=new_row.key_prefix,
-            created_at=new_row.created_at,
-        )
+        return response
 
     def get_metadata(self, agent_id: int) -> APIKeyMetadataResponse | None:
         # An agent can now have more than one active key (via the

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -316,7 +316,7 @@ def load_connector_runtime_view(
 def prepare_create_connector_runtime(
     *,
     db: Session,
-    agent: Agent,
+    tool_categories: Collection[str] | None,
     task_source: str | None,
     connector_user_id: int,
     payload_items: Iterable[Any] | None,
@@ -325,12 +325,13 @@ def prepare_create_connector_runtime(
 ) -> ConnectorRuntimeCreatePlan:
     """Prepare runtime values for a task identity chosen by the caller.
 
-    ``agent`` supplies tool-selection policy. ``connector_user_id`` supplies
-    connector visibility and must be the same owner later persisted on Task.
+    ``tool_categories`` is the detached tool-selection policy copied from the
+    authenticated agent. ``connector_user_id`` supplies connector visibility
+    and must be the same owner later persisted on Task.
     """
 
     visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
-    selected_refs = _plan_selected_refs(agent, visible)
+    selected_refs = _plan_selected_refs(tool_categories, visible)
     payload_by_ref = _parse_payload_items(payload_items)
     if not allow_ephemeral:
         _reject_ephemeral_payload_values(payload_by_ref)
@@ -392,7 +393,9 @@ def prepare_connector_runtime_selection_snapshot(
     if agent is None or connector_user_id is None:
         return ()
     visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
-    return _plan_selected_refs(agent, visible)
+    raw_categories = agent.tool_categories
+    tool_categories = raw_categories if isinstance(raw_categories, list) else None
+    return _plan_selected_refs(tool_categories, visible)
 
 
 def bind_connector_runtime_selection_snapshot(
@@ -452,7 +455,6 @@ def persist_create_connector_runtime_context(
 def prepare_append_connector_runtime(
     *,
     db: Session,
-    agent: Agent,
     task: Task,
     connector_user_id: int,
     payload_items: Iterable[Any] | None,
@@ -599,12 +601,13 @@ def _load_visible_runtime_connectors(
 
 
 def _plan_selected_refs(
-    agent: Agent, visible: dict[ConnectorRef, Any]
+    tool_categories: Collection[str] | None,
+    visible: dict[ConnectorRef, Any],
 ) -> tuple[ConnectorRef, ...]:
-    tool_categories = (
-        list(agent.tool_categories) if isinstance(agent.tool_categories, list) else None
+    normalized_categories = (
+        list(tool_categories) if tool_categories is not None else None
     )
-    spec = ToolSelectionSpec.from_raw(tool_categories=tool_categories)
+    spec = ToolSelectionSpec.from_raw(tool_categories=normalized_categories)
     selected: list[ConnectorRef] = []
     scoped_mcp_servers = spec.scoped_mcp_servers()
     for ref, connector in visible.items():

--- a/src/xagent/web/services/db_runtime.py
+++ b/src/xagent/web/services/db_runtime.py
@@ -1,0 +1,108 @@
+"""Async boundaries for synchronous database work."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, TypeVar
+
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+_T = TypeVar("_T")
+_ReceiptT = TypeVar("_ReceiptT")
+
+
+def is_database_pool_timeout(error: BaseException) -> bool:
+    """Return whether an exception chain represents pool checkout exhaustion."""
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, SQLAlchemyTimeoutError):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+async def await_task_settlement(
+    task: asyncio.Task[_T],
+) -> tuple[_T, asyncio.CancelledError | None]:
+    """Wait for ``task`` to settle while recording caller cancellation.
+
+    The returned cancellation lets resource owners inspect a late result and
+    perform compensation before cancellation is propagated. The task's own
+    cancellation and errors still propagate immediately when the caller was
+    not cancelled.
+    """
+    cancellation: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            current = asyncio.current_task()
+            caller_is_cancelling = current is not None and current.cancelling() > 0
+            if not caller_is_cancelling:
+                raise
+            if cancellation is None:
+                cancellation = exc
+            if not task.done():
+                continue
+            try:
+                result = task.result()
+            except BaseException as task_error:
+                raise cancellation from task_error
+        except BaseException as task_error:
+            if cancellation is not None:
+                raise cancellation from task_error
+            raise
+        return result, cancellation
+
+
+async def run_db_io_cancellation_safe(operation: Callable[[], _T]) -> _T:
+    """Run blocking database work without abandoning it on cancellation.
+
+    ``operation`` must create, use, and close its own SQLAlchemy Session in the
+    worker thread and return only detached data. If the awaiting coroutine is
+    cancelled after the worker starts, the worker is drained before that
+    cancellation is propagated so a late transaction cannot race cleanup.
+    """
+    worker = asyncio.get_running_loop().create_task(asyncio.to_thread(operation))
+    result, cancellation = await await_task_settlement(worker)
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
+async def run_one_shot_secret_db_io_cancellation_safe(
+    operation: Callable[[], tuple[_T, _ReceiptT]],
+    compensate_undelivered: Callable[[_ReceiptT], None],
+) -> _T:
+    """Run a one-shot-secret write and compensate if its result is cancelled.
+
+    The operation owns its worker Session and returns both its detached public
+    result and a detached receipt for the durable secret it committed. If the
+    caller is cancelled after that commit, the secret cannot be safely
+    delivered, so a second worker-owned transaction compensates it before the
+    original cancellation is propagated. Compensation failures remain attached
+    to that cancellation instead of being silently swallowed.
+    """
+    worker = asyncio.get_running_loop().create_task(asyncio.to_thread(operation))
+    (result, receipt), cancellation = await await_task_settlement(worker)
+    if cancellation is None:
+        return result
+
+    compensation_worker = asyncio.get_running_loop().create_task(
+        asyncio.to_thread(compensate_undelivered, receipt)
+    )
+    try:
+        await await_task_settlement(compensation_worker)
+    except BaseException as compensation_error:
+        raise cancellation from compensation_error
+    raise cancellation
+
+
+async def drain_async_task_cancellation_safe(task: asyncio.Task[_T]) -> _T:
+    """Drain an owned asynchronous task before propagating cancellation."""
+    result, cancellation = await await_task_settlement(task)
+    if cancellation is not None:
+        raise cancellation
+    return result

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -36,6 +37,30 @@ from ..models.uploaded_file import UploadedFile
 from .managed_file_ref import ensure_uploaded_file_local_path
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TurnFileLocator:
+    """Detached fields required to materialize one uploaded file."""
+
+    file_id: str
+    user_id: int
+    task_id: Optional[int]
+    filename: str
+    file_size: int
+    mime_type: Optional[str]
+    storage_path: str
+    storage_key: Optional[str]
+    storage_status: str
+    checksum: Optional[str]
+
+
+@dataclass(frozen=True)
+class TurnFileLookup:
+    """One request-order lookup, including unresolved file ids."""
+
+    requested_id: str
+    locator: Optional[TurnFileLocator]
 
 
 def normalize_filename(filename: str) -> str:
@@ -109,6 +134,23 @@ def resolve_turn_file_infos(
         lists ids that did not resolve (bad id, wrong owner, bound to another
         task, or missing bytes) so callers can decide strict-vs-lenient.
     """
+    lookups = load_turn_file_lookups(
+        file_ids=file_ids,
+        owner_user_id=owner_user_id,
+        db=db,
+        task_id=task_id,
+    )
+    return materialize_turn_file_lookups(lookups)
+
+
+def load_turn_file_lookups(
+    *,
+    file_ids: List[str],
+    owner_user_id: int,
+    db: Session,
+    task_id: Optional[int] = None,
+) -> tuple[TurnFileLookup, ...]:
+    """Load request-order file locator snapshots without durable I/O."""
     if task_id is not None:
         bind_filter: Any = or_(
             UploadedFile.task_id == task_id, UploadedFile.task_id.is_(None)
@@ -116,13 +158,12 @@ def resolve_turn_file_infos(
     else:
         bind_filter = UploadedFile.task_id.is_(None)
 
-    file_infos: List[Dict[str, Any]] = []
-    missing: List[str] = []
+    lookups: list[TurnFileLookup] = []
     seen: set[str] = set()
     for raw_file_id in file_ids:
         file_id = str(raw_file_id or "").strip()
         if not file_id:
-            missing.append(str(raw_file_id))
+            lookups.append(TurnFileLookup(requested_id=str(raw_file_id), locator=None))
             continue
         # Dedup at the source so a repeated file_id doesn't produce duplicate
         # UPLOADED FILES lines / attachment chips downstream.
@@ -140,23 +181,67 @@ def resolve_turn_file_infos(
             .first()
         )
         if record is None:
-            missing.append(file_id)
+            lookups.append(TurnFileLookup(requested_id=file_id, locator=None))
             continue
 
-        source_path = ensure_uploaded_file_local_path(record)
+        lookups.append(
+            TurnFileLookup(
+                requested_id=file_id,
+                locator=TurnFileLocator(
+                    file_id=str(record.file_id),
+                    user_id=int(record.user_id),
+                    task_id=(
+                        int(record.task_id) if record.task_id is not None else None
+                    ),
+                    filename=str(record.filename),
+                    file_size=int(record.file_size),
+                    mime_type=(
+                        str(record.mime_type) if record.mime_type is not None else None
+                    ),
+                    storage_path=str(record.storage_path),
+                    storage_key=(
+                        str(record.storage_key)
+                        if record.storage_key is not None
+                        else None
+                    ),
+                    storage_status=str(record.storage_status),
+                    checksum=(
+                        str(record.checksum) if record.checksum is not None else None
+                    ),
+                ),
+            )
+        )
+    return tuple(lookups)
+
+
+def materialize_turn_file_lookups(
+    lookups: tuple[TurnFileLookup, ...],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Materialize detached locators after their query Session is closed."""
+    file_infos: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    for lookup in lookups:
+        locator = lookup.locator
+        if locator is None:
+            missing.append(lookup.requested_id)
+            continue
+
+        source_path = ensure_uploaded_file_local_path(locator)
         if not source_path.exists():
-            logger.warning("Physical file not found for %s: %s", file_id, source_path)
-            missing.append(file_id)
+            logger.warning(
+                "Physical file not found for %s: %s", locator.file_id, source_path
+            )
+            missing.append(locator.file_id)
             continue
 
-        original_name = Path(record.filename).name
+        original_name = Path(locator.filename).name
         file_infos.append(
             {
-                "file_id": record.file_id,
+                "file_id": locator.file_id,
                 "name": normalize_filename(original_name),
                 "original_name": original_name,
-                "size": record.file_size,
-                "type": record.mime_type,
+                "size": locator.file_size,
+                "type": locator.mime_type,
                 "path": str(source_path),
                 "workspace_path": None,
             }

--- a/src/xagent/web/services/managed_task_lease.py
+++ b/src/xagent/web/services/managed_task_lease.py
@@ -9,8 +9,10 @@ from dataclasses import dataclass, field
 from sqlalchemy.orm import Session
 
 from ..models.task import Task, TaskStatus
+from .db_runtime import run_db_io_cancellation_safe
 from .task_lease_service import (
     TaskLease,
+    TaskLeaseHeartbeatOutcome,
     acquire_task_lease,
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
@@ -44,16 +46,30 @@ class ManagedTaskLease:
 
     lease: TaskLease
     stop_event: asyncio.Event
-    heartbeat_task: asyncio.Task[None]
+    heartbeat_task: asyncio.Task[TaskLeaseHeartbeatOutcome]
     _closed: bool = field(default=False, init=False)
 
     async def close(self) -> bool:
         if self._closed:
             return False
         self._closed = True
-        await stop_task_lease_heartbeat(self.heartbeat_task, self.stop_event)
+        heartbeat_outcome = await stop_task_lease_heartbeat(
+            self.heartbeat_task, self.stop_event
+        )
+        if heartbeat_outcome.requires_ttl_recovery:
+            logger.error(
+                "Task %s managed lease heartbeat unhealthy at shutdown; "
+                "retaining run %s for TTL recovery (lost=%s, pool_timeout=%s)",
+                self.lease.task_id,
+                self.lease.run_id,
+                heartbeat_outcome.lease_lost,
+                heartbeat_outcome.pool_timeout is not None,
+            )
+            return False
         try:
-            return await asyncio.to_thread(_release_managed_task_lease_sync, self.lease)
+            return await run_db_io_cancellation_safe(
+                lambda: _release_managed_task_lease_sync(self.lease)
+            )
         except Exception:
             logger.error(
                 "Failed to release managed task lease for task %s run %s",

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -7,7 +7,8 @@ across the xagent system with multi-tenant support.
 
 import json
 import logging
-from typing import Any, Dict, Optional, cast
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional, cast
 
 from sqlalchemy.orm import Session
 
@@ -22,6 +23,23 @@ from ...core.model.image.xinference import XinferenceImageModel
 from ...core.model.video.base import BaseVideoModel
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _default_model_session(db: Session | None) -> Iterator[Session]:
+    """Yield a caller-owned Session or deterministically close a local one."""
+    if db is not None:
+        yield db
+        return
+
+    from ..models.database import get_session_local
+
+    owned_db = get_session_local()()
+    try:
+        yield owned_db
+    finally:
+        owned_db.close()
+
 
 # ---------------------------------------------------------------------------
 # Hook infrastructure for dynamic model sharing
@@ -117,7 +135,11 @@ def _is_model_visible_to_user(
         return False
 
 
-def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
+def get_default_vision_model(
+    user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
+) -> Optional[BaseLLM]:
     """
     Get the default vision model for a specific user.
 
@@ -129,48 +151,49 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
     """
     try:
         # Try to get from database (requires web context)
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         # This won't work in non-web contexts, so we'll fallback to environment
         try:
-            # Try to get a database session (this might fail in CLI contexts)
-            db = next(get_db())
-
-            # If user_id is provided, get user-specific default
-            if user_id:
-                vision_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                    .filter(
-                        UserDefaultModel.user_id == user_id,
-                        UserDefaultModel.config_type == "visual",
-                        DBModel.is_active,
+            with _default_model_session(db) as model_db:
+                # If user_id is provided, get user-specific default
+                if user_id:
+                    vision_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "visual",
+                            DBModel.is_active,
+                        )
+                        .first()
                     )
-                    .first()
+
+                    if vision_default and vision_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, vision_default.model.id, user_id
+                        ):
+                            return _create_llm_instance(vision_default.model)
+
+                # Fallback to visible users' shared defaults
+                admin_vision_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .filter(
+                        UserDefaultModel.config_type == "visual",
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
+                    )
+                    .limit(1)
+                    .all()
                 )
 
-                if vision_default and vision_default.model:
-                    if _is_model_visible_to_user(db, vision_default.model.id, user_id):
-                        return _create_llm_instance(vision_default.model)
-
-            # Fallback to visible users' shared defaults
-            admin_vision_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(
-                    UserDefaultModel.config_type == "visual",
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if admin_vision_defaults:
-                return _create_llm_instance(admin_vision_defaults[0].model)
+                if admin_vision_defaults:
+                    return _create_llm_instance(admin_vision_defaults[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get vision model from database: {e}")
@@ -652,6 +675,8 @@ def get_models_by_category(category: str, db: Session) -> list:
 
 def get_default_image_generate_model(
     user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
 ) -> Optional[BaseImageModel]:
     """
     Get the default image generation model for a specific user.
@@ -666,66 +691,72 @@ def get_default_image_generate_model(
         from sqlalchemy import String, cast
 
         from ...core.model.image.adapter import get_image_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
         try:
-            db = next(get_db())
+            with _default_model_session(db) as model_db:
+                # If user_id is provided, get user-specific default
+                if user_id:
+                    image_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "image",
+                            DBModel.is_active,
+                            cast(DBModel.abilities, String).contains('"generate"'),
+                        )
+                        .first()
+                    )
 
-            # If user_id is provided, get user-specific default
-            if user_id:
-                image_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                    if image_default and image_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, image_default.model.id, user_id
+                        ):
+                            try:
+                                instance = get_image_model_instance(image_default.model)
+                                setattr(
+                                    instance,
+                                    "model_id",
+                                    str(image_default.model.model_id),
+                                )
+                                return instance
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to create image model instance: {e}"
+                                )
+
+                # Fallback to visible users' shared defaults
+                admin_image_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
-                        UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "image",
-                        DBModel.is_active,
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
                         cast(DBModel.abilities, String).contains('"generate"'),
                     )
-                    .first()
+                    .limit(1)
+                    .all()
                 )
 
-                if image_default and image_default.model:
-                    if _is_model_visible_to_user(db, image_default.model.id, user_id):
-                        try:
-                            instance = get_image_model_instance(image_default.model)
-                            setattr(
-                                instance, "model_id", str(image_default.model.model_id)
-                            )
-                            return instance
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to create image model instance: {e}"
-                            )
-
-            # Fallback to visible users' shared defaults
-            admin_image_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "image",
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                    cast(DBModel.abilities, String).contains('"generate"'),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if admin_image_defaults:
-                try:
-                    instance = get_image_model_instance(admin_image_defaults[0].model)
-                    setattr(
-                        instance,
-                        "model_id",
-                        str(admin_image_defaults[0].model.model_id),
-                    )
-                    return instance
-                except Exception as e:
-                    logger.warning(f"Failed to create image model instance: {e}")
+                if admin_image_defaults:
+                    try:
+                        instance = get_image_model_instance(
+                            admin_image_defaults[0].model
+                        )
+                        setattr(
+                            instance,
+                            "model_id",
+                            str(admin_image_defaults[0].model.model_id),
+                        )
+                        return instance
+                    except Exception as e:
+                        logger.warning(f"Failed to create image model instance: {e}")
 
         except Exception as e:
             logger.warning(
@@ -741,6 +772,8 @@ def get_default_image_generate_model(
 
 def get_default_image_edit_model(
     user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
 ) -> Optional[BaseImageModel]:
     """
     Get the default image editing model for a specific user.
@@ -753,63 +786,69 @@ def get_default_image_edit_model(
     """
     try:
         from ...core.model.image.adapter import get_image_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
         try:
-            db = next(get_db())
+            with _default_model_session(db) as model_db:
+                # If user_id is provided, get user-specific default
+                if user_id:
+                    image_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "image_edit",
+                            DBModel.is_active,
+                        )
+                        .first()
+                    )
 
-            # If user_id is provided, get user-specific default
-            if user_id:
-                image_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                    if image_default and image_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, image_default.model.id, user_id
+                        ):
+                            try:
+                                instance = get_image_model_instance(image_default.model)
+                                setattr(
+                                    instance,
+                                    "model_id",
+                                    str(image_default.model.model_id),
+                                )
+                                return instance
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to create image model instance: {e}"
+                                )
+
+                # Fallback to visible users' shared defaults
+                admin_image_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                     .filter(
-                        UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "image_edit",
-                        DBModel.is_active,
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
                     )
-                    .first()
+                    .limit(1)
+                    .all()
                 )
 
-                if image_default and image_default.model:
-                    if _is_model_visible_to_user(db, image_default.model.id, user_id):
-                        try:
-                            instance = get_image_model_instance(image_default.model)
-                            setattr(
-                                instance, "model_id", str(image_default.model.model_id)
-                            )
-                            return instance
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to create image model instance: {e}"
-                            )
-
-            # Fallback to visible users' shared defaults
-            admin_image_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(
-                    UserDefaultModel.config_type == "image_edit",
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if admin_image_defaults:
-                try:
-                    instance = get_image_model_instance(admin_image_defaults[0].model)
-                    setattr(
-                        instance,
-                        "model_id",
-                        str(admin_image_defaults[0].model.model_id),
-                    )
-                    return instance
-                except Exception as e:
-                    logger.warning(f"Failed to create image model instance: {e}")
+                if admin_image_defaults:
+                    try:
+                        instance = get_image_model_instance(
+                            admin_image_defaults[0].model
+                        )
+                        setattr(
+                            instance,
+                            "model_id",
+                            str(admin_image_defaults[0].model.model_id),
+                        )
+                        return instance
+                    except Exception as e:
+                        logger.warning(f"Failed to create image model instance: {e}")
 
         except Exception as e:
             logger.warning(
@@ -825,6 +864,8 @@ def get_default_image_edit_model(
 
 def get_default_video_model(
     user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
 ) -> Optional[BaseVideoModel]:
     """
     Get the default video generation model for a specific user.
@@ -839,67 +880,73 @@ def get_default_video_model(
         from sqlalchemy import String, cast
 
         from ...core.model.video.adapter import get_video_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
         try:
-            db = next(get_db())
+            with _default_model_session(db) as model_db:
+                if user_id:
+                    video_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "video",
+                            DBModel.category == "video",
+                            DBModel.is_active,
+                            cast(DBModel.abilities, String).contains('"generate"'),
+                        )
+                        .first()
+                    )
 
-            if user_id:
-                video_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                    if video_default and video_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, video_default.model.id, user_id
+                        ):
+                            try:
+                                instance = get_video_model_instance(video_default.model)
+                                setattr(
+                                    instance,
+                                    "model_id",
+                                    str(video_default.model.model_id),
+                                )
+                                return instance
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to create video model instance: {e}"
+                                )
+
+                shared_video_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
-                        UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "video",
                         DBModel.category == "video",
                         DBModel.is_active,
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
                         cast(DBModel.abilities, String).contains('"generate"'),
                     )
-                    .first()
+                    .limit(1)
+                    .all()
                 )
 
-                if video_default and video_default.model:
-                    if _is_model_visible_to_user(db, video_default.model.id, user_id):
-                        try:
-                            instance = get_video_model_instance(video_default.model)
-                            setattr(
-                                instance, "model_id", str(video_default.model.model_id)
-                            )
-                            return instance
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to create video model instance: {e}"
-                            )
-
-            shared_video_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "video",
-                    DBModel.category == "video",
-                    DBModel.is_active,
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                    cast(DBModel.abilities, String).contains('"generate"'),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if shared_video_defaults:
-                try:
-                    instance = get_video_model_instance(shared_video_defaults[0].model)
-                    setattr(
-                        instance,
-                        "model_id",
-                        str(shared_video_defaults[0].model.model_id),
-                    )
-                    return instance
-                except Exception as e:
-                    logger.warning(f"Failed to create video model instance: {e}")
+                if shared_video_defaults:
+                    try:
+                        instance = get_video_model_instance(
+                            shared_video_defaults[0].model
+                        )
+                        setattr(
+                            instance,
+                            "model_id",
+                            str(shared_video_defaults[0].model.model_id),
+                        )
+                        return instance
+                    except Exception as e:
+                        logger.warning(f"Failed to create video model instance: {e}")
 
         except Exception as e:
             logger.warning(f"Failed to get default video model from database: {e}")
@@ -1217,7 +1264,11 @@ def get_music_models(db: Session, user_id: Optional[int] = None) -> Dict[str, An
     return models
 
 
-def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
+def get_default_asr_model(
+    user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
+) -> Optional[Any]:
     """
     Get the default ASR model for a specific user.
 
@@ -1229,52 +1280,56 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
     """
     try:
         from ...core.model.asr.adapter import get_asr_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
         try:
-            db = next(get_db())
-
-            # If user_id is provided, get user-specific default
-            if user_id:
-                asr_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                    .filter(
-                        UserDefaultModel.user_id == user_id,
-                        UserDefaultModel.config_type == "asr",
-                        DBModel.is_active,
+            with _default_model_session(db) as model_db:
+                # If user_id is provided, get user-specific default
+                if user_id:
+                    asr_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "asr",
+                            DBModel.is_active,
+                        )
+                        .first()
                     )
-                    .first()
+
+                    if asr_default and asr_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, asr_default.model.id, user_id
+                        ):
+                            try:
+                                return get_asr_model_instance(asr_default.model)
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to create ASR model instance: {e}"
+                                )
+
+                # Visible users' shared defaults
+                admin_asr_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .filter(
+                        UserDefaultModel.config_type == "asr",
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
+                    )
+                    .limit(1)
+                    .all()
                 )
 
-                if asr_default and asr_default.model:
-                    if _is_model_visible_to_user(db, asr_default.model.id, user_id):
-                        try:
-                            return get_asr_model_instance(asr_default.model)
-                        except Exception as e:
-                            logger.warning(f"Failed to create ASR model instance: {e}")
-
-            # Visible users' shared defaults
-            admin_asr_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "asr",
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if admin_asr_defaults:
-                try:
-                    return get_asr_model_instance(admin_asr_defaults[0].model)
-                except Exception as e:
-                    logger.warning(f"Failed to create ASR model instance: {e}")
+                if admin_asr_defaults:
+                    try:
+                        return get_asr_model_instance(admin_asr_defaults[0].model)
+                    except Exception as e:
+                        logger.warning(f"Failed to create ASR model instance: {e}")
 
         except Exception as e:
             logger.warning(f"Database query failed for ASR model: {e}")
@@ -1285,7 +1340,11 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
     return None
 
 
-def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
+def get_default_tts_model(
+    user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
+) -> Optional[Any]:
     """
     Get the default TTS model for a specific user.
 
@@ -1297,52 +1356,56 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
     """
     try:
         from ...core.model.tts.adapter import get_tts_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
         try:
-            db = next(get_db())
-
-            # If user_id is provided, get user-specific default
-            if user_id:
-                tts_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                    .filter(
-                        UserDefaultModel.user_id == user_id,
-                        UserDefaultModel.config_type == "tts",
-                        DBModel.is_active,
+            with _default_model_session(db) as model_db:
+                # If user_id is provided, get user-specific default
+                if user_id:
+                    tts_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "tts",
+                            DBModel.is_active,
+                        )
+                        .first()
                     )
-                    .first()
+
+                    if tts_default and tts_default.model:
+                        if _is_model_visible_to_user(
+                            model_db, tts_default.model.id, user_id
+                        ):
+                            try:
+                                return get_tts_model_instance(tts_default.model)
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to create TTS model instance: {e}"
+                                )
+
+                # Visible users' shared defaults
+                admin_tts_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .filter(
+                        UserDefaultModel.config_type == "tts",
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
+                    )
+                    .limit(1)
+                    .all()
                 )
 
-                if tts_default and tts_default.model:
-                    if _is_model_visible_to_user(db, tts_default.model.id, user_id):
-                        try:
-                            return get_tts_model_instance(tts_default.model)
-                        except Exception as e:
-                            logger.warning(f"Failed to create TTS model instance: {e}")
-
-            # Visible users' shared defaults
-            admin_tts_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "tts",
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if admin_tts_defaults:
-                try:
-                    return get_tts_model_instance(admin_tts_defaults[0].model)
-                except Exception as e:
-                    logger.warning(f"Failed to create TTS model instance: {e}")
+                if admin_tts_defaults:
+                    try:
+                        return get_tts_model_instance(admin_tts_defaults[0].model)
+                    except Exception as e:
+                        logger.warning(f"Failed to create TTS model instance: {e}")
 
         except Exception as e:
             logger.warning(f"Database query failed for TTS model: {e}")
@@ -1353,119 +1416,127 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
     return None
 
 
-def get_default_sound_effect_model(user_id: Optional[int] = None) -> Optional[Any]:
+def get_default_sound_effect_model(
+    user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
+) -> Optional[Any]:
     """Get the user or shared default sound effect model."""
     try:
         from sqlalchemy import String
         from sqlalchemy import cast as sa_cast
 
         from ...core.model.sound_effect import get_sound_effect_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
-        db_gen = get_db()
         try:
-            db = next(db_gen)
-            if user_id:
-                user_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            with _default_model_session(db) as model_db:
+                if user_id:
+                    user_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "sound_effect",
+                            DBModel.category == "sound_effect",
+                            DBModel.is_active,
+                            sa_cast(DBModel.abilities, String).contains('"generate"'),
+                        )
+                        .first()
+                    )
+                    if (
+                        user_default
+                        and user_default.model
+                        and _is_model_visible_to_user(
+                            model_db, user_default.model.id, user_id
+                        )
+                    ):
+                        return get_sound_effect_model_instance(user_default.model)
+
+                shared_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
-                        UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "sound_effect",
                         DBModel.category == "sound_effect",
-                        DBModel.is_active,
                         sa_cast(DBModel.abilities, String).contains('"generate"'),
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
                     )
-                    .first()
+                    .limit(1)
+                    .all()
                 )
-                if (
-                    user_default
-                    and user_default.model
-                    and _is_model_visible_to_user(db, user_default.model.id, user_id)
-                ):
-                    return get_sound_effect_model_instance(user_default.model)
-
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "sound_effect",
-                    DBModel.category == "sound_effect",
-                    sa_cast(DBModel.abilities, String).contains('"generate"'),
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-            if shared_defaults:
-                return get_sound_effect_model_instance(shared_defaults[0].model)
+                if shared_defaults:
+                    return get_sound_effect_model_instance(shared_defaults[0].model)
         except Exception as exc:
             logger.warning("Database query failed for sound effect model: %s", exc)
-        finally:
-            db_gen.close()
     except Exception as exc:
         logger.error("Failed to get default sound effect model: %s", exc)
     return None
 
 
-def get_default_music_model(user_id: Optional[int] = None) -> Optional[Any]:
+def get_default_music_model(
+    user_id: Optional[int] = None,
+    *,
+    db: Session | None = None,
+) -> Optional[Any]:
     """Get the user or shared default music model."""
     try:
         from sqlalchemy import String
         from sqlalchemy import cast as sa_cast
 
         from ...core.model.music import get_music_model_instance
-        from ..models.database import get_db
         from ..models.model import Model as DBModel
         from ..models.user import UserDefaultModel, UserModel
 
-        db_gen = get_db()
         try:
-            db = next(db_gen)
-            if user_id:
-                user_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            with _default_model_session(db) as model_db:
+                if user_id:
+                    user_default = (
+                        model_db.query(UserDefaultModel)
+                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                        .filter(
+                            UserDefaultModel.user_id == user_id,
+                            UserDefaultModel.config_type == "music",
+                            DBModel.category == "music",
+                            DBModel.is_active,
+                            sa_cast(DBModel.abilities, String).contains('"generate"'),
+                        )
+                        .first()
+                    )
+                    if (
+                        user_default
+                        and user_default.model
+                        and _is_model_visible_to_user(
+                            model_db, user_default.model.id, user_id
+                        )
+                    ):
+                        return get_music_model_instance(user_default.model)
+
+                shared_defaults = (
+                    model_db.query(UserDefaultModel)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
-                        UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "music",
                         DBModel.category == "music",
-                        DBModel.is_active,
                         sa_cast(DBModel.abilities, String).contains('"generate"'),
+                        UserModel.is_shared.is_(True),
+                        UserDefaultModel.user_id.in_(
+                            _get_visible_user_ids(model_db, user_id)
+                        ),
                     )
-                    .first()
+                    .limit(1)
+                    .all()
                 )
-                if (
-                    user_default
-                    and user_default.model
-                    and _is_model_visible_to_user(db, user_default.model.id, user_id)
-                ):
-                    return get_music_model_instance(user_default.model)
-
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "music",
-                    DBModel.category == "music",
-                    sa_cast(DBModel.abilities, String).contains('"generate"'),
-                    UserModel.is_shared.is_(True),
-                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-                )
-                .limit(1)
-                .all()
-            )
-            if shared_defaults:
-                return get_music_model_instance(shared_defaults[0].model)
+                if shared_defaults:
+                    return get_music_model_instance(shared_defaults[0].model)
         except Exception as exc:
             logger.warning("Database query failed for music model: %s", exc)
-        finally:
-            db_gen.close()
     except Exception as exc:
         logger.error("Failed to get default music model: %s", exc)
     return None

--- a/src/xagent/web/services/sdk_task_service.py
+++ b/src/xagent/web/services/sdk_task_service.py
@@ -1,0 +1,536 @@
+"""Worker-owned persistence boundary for SDK task routes.
+
+The public ``/v1/chat/tasks`` handlers are async orchestration code.  Every
+synchronous SQLAlchemy operation owned by those handlers lives here, opens and
+closes its own Session in the worker thread, and returns detached snapshots.
+No ORM object or Session crosses back into the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Collection, Iterable, Sequence
+
+from sqlalchemy import func
+
+from ..models.database import get_session_local
+from ..models.task import Task, TaskStatus, TraceEvent
+from ..models.user import User
+from .connector_runtime import (
+    bind_create_connector_runtime_plan,
+    persist_create_connector_runtime_context,
+    prepare_append_connector_runtime,
+    prepare_create_connector_runtime,
+)
+from .file_turn import (
+    bind_turn_files,
+    load_turn_file_lookups,
+    materialize_turn_file_lookups,
+)
+from .hot_path_cache import invalidate_task_cache
+from .task_execution_controller import (
+    TaskControlState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SdkTaskNotFoundError(RuntimeError):
+    """The API key cannot address the requested SDK task."""
+
+
+class SdkAgentMismatchError(RuntimeError):
+    """The request body agent does not match the authenticated agent."""
+
+
+class SdkTurnFilesMissingError(RuntimeError):
+    """One or more requested files are unavailable to this task owner."""
+
+    def __init__(self, missing: Sequence[str]) -> None:
+        self.missing = tuple(missing)
+        super().__init__(", ".join(self.missing))
+
+
+def resolve_sdk_upload_owner_sync(
+    *,
+    task_id: int | None,
+    authenticated_agent_id: int,
+    default_user_id: int,
+) -> int | None:
+    """Resolve an SDK upload owner in a short worker-owned Session.
+
+    Task-aware uploads deliberately use the task's persisted owner rather
+    than the agent's current owner.  The task lookup is scoped by both the
+    authenticated agent and ``source='sdk'`` so inaccessible tasks remain
+    indistinguishable from missing tasks.  ``None`` means the resolved owner
+    row no longer exists and lets the API preserve its internal-error mapping.
+    """
+
+    session_local = get_session_local()
+    with session_local() as db:
+        owner_user_id = default_user_id
+        if task_id is not None:
+            owner_user_id = (
+                db.query(Task.user_id)
+                .filter(
+                    Task.id == task_id,
+                    Task.agent_id == authenticated_agent_id,
+                    Task.source == "sdk",
+                )
+                .scalar()
+            )
+            if owner_user_id is None:
+                raise SdkTaskNotFoundError(task_id)
+
+        existing_user_id = (
+            db.query(User.id).filter(User.id == int(owner_user_id)).scalar()
+        )
+        return int(existing_user_id) if existing_user_id is not None else None
+
+
+@dataclass(frozen=True)
+class SdkCreateTaskPrepared:
+    task_id: int
+    agent_id: int
+    task_owner_user_id: int
+    actor_user_id: int
+    created_at: datetime
+    file_infos: tuple[dict[str, Any], ...]
+    ephemeral_by_ref: dict[Any, dict[str, dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SdkAppendTaskPrepared:
+    task_id: int
+    agent_id: int
+    task_owner_user_id: int
+    actor_user_id: int
+    file_infos: tuple[dict[str, Any], ...]
+    ephemeral_by_ref: dict[Any, dict[str, dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SdkTaskSnapshot:
+    task_id: int
+    agent_id: int
+    status: TaskStatus
+    run_id: str | None
+    state_version: int
+    control_state: str
+    input: str | None
+    output: str | None
+    error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SdkTaskStepsVersion:
+    task_id: int
+    agent_id: int
+    max_event_id: int
+
+
+@dataclass(frozen=True)
+class TraceEventSnapshot:
+    id: int
+    task_id: int
+    event_id: str
+    event_type: str
+    timestamp: datetime
+    step_id: str | None
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SdkTaskStepsSnapshot:
+    task_id: int
+    agent_id: int
+    max_event_id: int
+    events: tuple[TraceEventSnapshot, ...]
+
+
+def _task_status(value: Any) -> TaskStatus:
+    if isinstance(value, TaskStatus):
+        return value
+    return TaskStatus(str(value))
+
+
+def _materialize_files_for_create(
+    *,
+    file_ids: Sequence[str],
+    owner_user_id: int,
+) -> tuple[dict[str, Any], ...]:
+    """Query file metadata, close the Session, then perform durable I/O."""
+
+    if not file_ids:
+        return ()
+    session_local = get_session_local()
+    with session_local() as db:
+        lookups = load_turn_file_lookups(
+            file_ids=list(file_ids),
+            owner_user_id=owner_user_id,
+            db=db,
+            task_id=None,
+        )
+    file_infos, missing = materialize_turn_file_lookups(lookups)
+    if missing:
+        raise SdkTurnFilesMissingError(missing)
+    return tuple(deepcopy(file_infos))
+
+
+def prepare_create_sdk_task_sync(
+    *,
+    agent_id: int,
+    task_owner_user_id: int,
+    actor_user_id: int,
+    tool_categories: Collection[str] | None,
+    content: str,
+    file_ids: Sequence[str],
+    connector_runtime_context: Iterable[Any] | None,
+) -> SdkCreateTaskPrepared:
+    """Validate and commit a new PENDING SDK task in worker-owned Sessions.
+
+    File lookup/materialization intentionally precedes connector validation,
+    matching the public route's established error precedence.  The Task and
+    connector context share one transaction whose commit is the last database
+    operation, so an exception return cannot hide a committed PENDING row.
+    """
+
+    file_infos = _materialize_files_for_create(
+        file_ids=file_ids,
+        owner_user_id=task_owner_user_id,
+    )
+    task_source = "sdk"
+    session_local = get_session_local()
+    with session_local() as db:
+        task = Task(
+            user_id=task_owner_user_id,
+            title=content[:50] or "SDK task",
+            description=content,
+            status=TaskStatus.PENDING,
+            agent_id=agent_id,
+            input=content,
+            source=task_source,
+            is_visible=False,
+        )
+        try:
+            runtime_plan = prepare_create_connector_runtime(
+                db=db,
+                tool_categories=tool_categories,
+                task_source=task_source,
+                connector_user_id=task_owner_user_id,
+                payload_items=connector_runtime_context,
+            )
+            bind_create_connector_runtime_plan(task=task, plan=runtime_plan)
+            db.add(task)
+            db.flush()
+            task_id = int(task.id)
+            persist_create_connector_runtime_context(
+                db=db,
+                task_id=task_id,
+                plan=runtime_plan,
+            )
+            created_at = db.query(Task.created_at).filter(Task.id == task_id).scalar()
+            if not isinstance(created_at, datetime):
+                raise RuntimeError("New SDK task has no creation timestamp")
+            prepared = SdkCreateTaskPrepared(
+                task_id=task_id,
+                agent_id=agent_id,
+                task_owner_user_id=task_owner_user_id,
+                actor_user_id=actor_user_id,
+                created_at=created_at,
+                file_infos=file_infos,
+                ephemeral_by_ref=deepcopy(runtime_plan.ephemeral_by_ref),
+            )
+            db.commit()
+        except BaseException:
+            db.rollback()
+            raise
+
+    return prepared
+
+
+def prepare_append_sdk_task_sync(
+    *,
+    task_id: int,
+    authenticated_agent_id: int,
+    actor_user_id: int,
+    requested_agent_id: int,
+    file_ids: Sequence[str],
+    connector_runtime_context: Iterable[Any] | None,
+) -> SdkAppendTaskPrepared:
+    """Authorize and snapshot an append without retaining its Session.
+
+    Error order is part of the SDK contract: task scope, body agent, connector
+    context, then files.  Durable file materialization happens only after the
+    query Session has closed.
+    """
+
+    session_local = get_session_local()
+    with session_local() as db:
+        task = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == authenticated_agent_id,
+                Task.source == "sdk",
+            )
+            .first()
+        )
+        if task is None:
+            raise SdkTaskNotFoundError(task_id)
+        if requested_agent_id != authenticated_agent_id:
+            raise SdkAgentMismatchError(requested_agent_id)
+
+        task_owner_user_id = int(task.user_id)
+        runtime_plan = prepare_append_connector_runtime(
+            db=db,
+            task=task,
+            connector_user_id=task_owner_user_id,
+            payload_items=connector_runtime_context,
+        )
+        lookups = load_turn_file_lookups(
+            file_ids=list(file_ids),
+            owner_user_id=task_owner_user_id,
+            db=db,
+            task_id=task_id,
+        )
+
+    file_infos, missing = materialize_turn_file_lookups(lookups)
+    if missing:
+        raise SdkTurnFilesMissingError(missing)
+    return SdkAppendTaskPrepared(
+        task_id=task_id,
+        agent_id=authenticated_agent_id,
+        task_owner_user_id=task_owner_user_id,
+        actor_user_id=actor_user_id,
+        file_infos=tuple(deepcopy(file_infos)),
+        ephemeral_by_ref=deepcopy(runtime_plan.ephemeral_by_ref),
+    )
+
+
+def bind_sdk_turn_files_sync(
+    *,
+    file_ids: Sequence[str],
+    task_id: int,
+    owner_user_id: int,
+) -> None:
+    """Bind already-validated files in a short worker-owned transaction."""
+
+    if not file_ids:
+        return
+    session_local = get_session_local()
+    with session_local() as db:
+        bind_turn_files(
+            file_ids=list(file_ids),
+            task_id=task_id,
+            owner_user_id=owner_user_id,
+            db=db,
+        )
+
+
+def mark_pending_sdk_task_failed_sync(
+    task_id: int,
+    error_message: str,
+    *,
+    expected_agent_id: int,
+    expected_owner_user_id: int,
+) -> bool:
+    """Best-effort compensation for a committed create that cannot start.
+
+    The eligibility predicate and FAILED transition are one SQL statement.
+    If the orchestrator claims the task first, the ``status=PENDING`` guard
+    makes this update a no-op so RUNNING remains authoritative.
+    """
+
+    session_local = get_session_local()
+    try:
+        with session_local() as db:
+            updated = (
+                db.query(Task)
+                .filter(
+                    Task.id == task_id,
+                    Task.agent_id == expected_agent_id,
+                    Task.user_id == expected_owner_user_id,
+                    Task.source == "sdk",
+                    Task.status == TaskStatus.PENDING,
+                )
+                .update(
+                    {
+                        Task.status: TaskStatus.FAILED,
+                        Task.control_state: TaskControlState.FAILED.value,
+                        Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+                        Task.error_message: error_message,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            db.commit()
+            if int(updated or 0) != 1:
+                return False
+    except Exception:
+        logger.warning(
+            "Failed to mark pending SDK task %s as failed",
+            task_id,
+            exc_info=True,
+        )
+        return False
+    try:
+        invalidate_task_cache(task_id)
+    except Exception:
+        logger.warning(
+            "Failed to invalidate cache for compensated SDK task %s",
+            task_id,
+            exc_info=True,
+        )
+    return True
+
+
+def load_sdk_task_snapshot_sync(
+    task_id: int,
+    authenticated_agent_id: int,
+) -> SdkTaskSnapshot | None:
+    """Return a detached scalar snapshot for SDK task polling."""
+
+    session_local = get_session_local()
+    with session_local() as db:
+        row = (
+            db.query(
+                Task.id,
+                Task.agent_id,
+                Task.status,
+                Task.run_id,
+                Task.state_version,
+                Task.control_state,
+                Task.input,
+                Task.output,
+                Task.error_message,
+                Task.created_at,
+                Task.updated_at,
+            )
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == authenticated_agent_id,
+                Task.source == "sdk",
+            )
+            .first()
+        )
+        if row is None:
+            return None
+        if not isinstance(row.created_at, datetime) or not isinstance(
+            row.updated_at, datetime
+        ):
+            raise RuntimeError(f"SDK task {task_id} has invalid timestamps")
+        return SdkTaskSnapshot(
+            task_id=int(row.id),
+            agent_id=int(row.agent_id),
+            status=_task_status(row.status),
+            run_id=str(row.run_id) if row.run_id is not None else None,
+            state_version=int(row.state_version or 0),
+            control_state=str(row.control_state or "idle"),
+            input=str(row.input) if row.input is not None else None,
+            output=str(row.output) if row.output is not None else None,
+            error_message=(
+                str(row.error_message) if row.error_message is not None else None
+            ),
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+
+def load_sdk_task_steps_version_sync(
+    task_id: int,
+    authenticated_agent_id: int,
+) -> SdkTaskStepsVersion | None:
+    """Authorize a task and return the cache version for its public trace."""
+
+    session_local = get_session_local()
+    with session_local() as db:
+        task_row = (
+            db.query(Task.id, Task.agent_id)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == authenticated_agent_id,
+                Task.source == "sdk",
+            )
+            .first()
+        )
+        if task_row is None:
+            return None
+        max_event_id = (
+            db.query(func.max(TraceEvent.id))
+            .filter(
+                TraceEvent.task_id == task_id,
+                TraceEvent.build_id.is_(None),
+            )
+            .scalar()
+            or 0
+        )
+        return SdkTaskStepsVersion(
+            task_id=int(task_row.id),
+            agent_id=int(task_row.agent_id),
+            max_event_id=int(max_event_id),
+        )
+
+
+def load_sdk_task_steps_snapshot_sync(
+    task_id: int,
+    authenticated_agent_id: int,
+) -> SdkTaskStepsSnapshot | None:
+    """Return detached, ordered trace snapshots for the public step mapper."""
+
+    session_local = get_session_local()
+    with session_local() as db:
+        task_row = (
+            db.query(Task.id, Task.agent_id)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == authenticated_agent_id,
+                Task.source == "sdk",
+            )
+            .first()
+        )
+        if task_row is None:
+            return None
+        rows = (
+            db.query(
+                TraceEvent.id,
+                TraceEvent.task_id,
+                TraceEvent.event_id,
+                TraceEvent.event_type,
+                TraceEvent.timestamp,
+                TraceEvent.step_id,
+                TraceEvent.data,
+            )
+            .filter(
+                TraceEvent.task_id == task_id,
+                TraceEvent.build_id.is_(None),
+            )
+            .order_by(TraceEvent.id.asc())
+            .all()
+        )
+        resolved_task_id = int(task_row.id)
+        resolved_agent_id = int(task_row.agent_id)
+
+    events = tuple(
+        TraceEventSnapshot(
+            id=int(row.id),
+            task_id=int(row.task_id),
+            event_id=str(row.event_id),
+            event_type=str(row.event_type),
+            timestamp=row.timestamp,
+            step_id=str(row.step_id) if row.step_id is not None else None,
+            data=deepcopy(row.data) if isinstance(row.data, dict) else {},
+        )
+        for row in rows
+    )
+    return SdkTaskStepsSnapshot(
+        task_id=resolved_task_id,
+        agent_id=resolved_agent_id,
+        max_event_id=events[-1].id if events else 0,
+        events=events,
+    )

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -26,6 +26,7 @@ from ...config import (
 )
 from ..models.task import Task, TaskStatus
 from ..models.task_command import TaskExecutionCommand
+from .db_runtime import is_database_pool_timeout, run_db_io_cancellation_safe
 from .task_lease_service import get_runner_id
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,31 @@ class ClaimedTaskCommand:
     attempt_count: int
     failure_count: int = 0
     defer_count: int = 0
+
+
+@dataclass(frozen=True)
+class TaskCommandStateSnapshot:
+    """Immutable command state safe to return across a worker boundary."""
+
+    command_db_id: int
+    status: str
+    error: str | None
+    rejection_reason: str | None
+    attempt_count: int
+    failure_count: int
+    defer_count: int
+
+
+@dataclass(frozen=True)
+class TaskCommandClaimHeartbeatOutcome:
+    """Last confirmed health of a processing-command claim."""
+
+    claim_lost: bool = False
+    pool_timeout: BaseException | None = None
+
+    @property
+    def requires_ttl_recovery(self) -> bool:
+        return self.claim_lost or self.pool_timeout is not None
 
 
 def _utc_now() -> datetime:
@@ -334,6 +360,24 @@ def claim_task_command(
     )
 
 
+def _claim_task_command_isolated(
+    *,
+    runner_id: str,
+    command_db_id: int | None,
+) -> ClaimedTaskCommand | None:
+    """Claim in a worker-owned short session and return a detached snapshot."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        return claim_task_command(
+            db,
+            runner_id=runner_id,
+            command_db_id=command_db_id,
+        )
+
+
 def renew_task_command_claim(
     command_db_id: int,
     runner_id: str,
@@ -371,22 +415,26 @@ async def _claim_heartbeat(
     runner_id: str,
     attempt_count: int,
     stop_event: asyncio.Event,
-) -> None:
+) -> TaskCommandClaimHeartbeatOutcome:
     interval = get_task_lease_heartbeat_seconds()
+    pool_timeout: BaseException | None = None
     while not stop_event.is_set():
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval)
-            return
+            return TaskCommandClaimHeartbeatOutcome(pool_timeout=pool_timeout)
         except asyncio.TimeoutError:
             pass
         try:
-            renewed = await asyncio.to_thread(
-                renew_task_command_claim,
-                command_db_id,
-                runner_id,
-                expected_attempt_count=attempt_count,
+            renewed = await run_db_io_cancellation_safe(
+                lambda: renew_task_command_claim(
+                    command_db_id,
+                    runner_id,
+                    expected_attempt_count=attempt_count,
+                )
             )
         except Exception as exc:  # noqa: BLE001
+            if is_database_pool_timeout(exc):
+                pool_timeout = exc
             logger.warning(
                 "Failed to renew task command claim %s: %s",
                 command_db_id,
@@ -394,8 +442,10 @@ async def _claim_heartbeat(
                 exc_info=True,
             )
             continue
+        pool_timeout = None
         if not renewed:
-            return
+            return TaskCommandClaimHeartbeatOutcome(claim_lost=True)
+    return TaskCommandClaimHeartbeatOutcome(pool_timeout=pool_timeout)
 
 
 def finish_task_command(
@@ -648,6 +698,7 @@ def task_has_live_foreign_runner(
 
 
 CommandExecutor = Callable[[ClaimedTaskCommand], Awaitable[dict[str, Any] | None]]
+CommandDisposition = Callable[[], bool]
 _dispatcher_wakeup: asyncio.Event | None = None
 _dispatcher_task: asyncio.Task[Any] | None = None
 _dispatcher_loop: asyncio.AbstractEventLoop | None = None
@@ -661,21 +712,56 @@ def notify_task_command_dispatcher() -> None:
         loop.call_soon_threadsafe(wakeup.set)
 
 
+async def _persist_task_command_disposition(
+    command: ClaimedTaskCommand,
+    *,
+    disposition: str,
+    operation: CommandDisposition,
+) -> bool:
+    """Persist one final state without retrying an exhausted pool checkout."""
+
+    try:
+        persisted = await run_db_io_cancellation_safe(operation)
+    except Exception as exc:  # noqa: BLE001
+        if not is_database_pool_timeout(exc):
+            raise
+        # The command is still fenced by claimed_by + attempt_count. Avoid an
+        # immediate second checkout; expiry is the durable recovery boundary.
+        logger.error(
+            "task_id=%s component=task-command-disposition disposition=%s "
+            "database pool checkout timed out; retaining command claim for "
+            "expiry (command_id=%s, kind=%s, attempt=%s): %s",
+            command.task_id,
+            disposition,
+            command.command_id,
+            command.kind.value,
+            command.attempt_count,
+            exc,
+            exc_info=True,
+        )
+        return False
+    if not persisted:
+        logger.warning(
+            "Lost claim while persisting task command %s disposition=%s attempt=%s",
+            command.id,
+            disposition,
+            command.attempt_count,
+        )
+    return persisted
+
+
 async def dispatch_one_task_command(
     executor: CommandExecutor,
     *,
     command_db_id: int | None = None,
 ) -> bool:
-    from ..models.database import get_session_local
-
     runner_id = get_runner_id()
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        command = claim_task_command(
-            db,
+    command = await run_db_io_cancellation_safe(
+        lambda: _claim_task_command_isolated(
             runner_id=runner_id,
             command_db_id=command_db_id,
         )
+    )
     if command is None:
         return False
 
@@ -683,6 +769,9 @@ async def dispatch_one_task_command(
     heartbeat = asyncio.get_running_loop().create_task(
         _claim_heartbeat(command.id, runner_id, command.attempt_count, stop_event)
     )
+    disposition_name: str | None = None
+    disposition_operation: CommandDisposition | None = None
+    heartbeat_outcome = TaskCommandClaimHeartbeatOutcome()
     try:
         result = await executor(command)
     except asyncio.CancelledError:
@@ -690,55 +779,107 @@ async def dispatch_one_task_command(
         # after the claim expires, which avoids concurrent replay on shutdown.
         raise
     except TaskCommandDeferred as exc:
-        await asyncio.to_thread(
-            defer_task_command,
-            command.id,
-            runner_id,
-            str(exc),
-            expected_attempt_count=command.attempt_count,
-        )
+        reason = str(exc)
+
+        def persist_deferral() -> bool:
+            return defer_task_command(
+                command.id,
+                runner_id,
+                reason,
+                expected_attempt_count=command.attempt_count,
+            )
+
+        disposition_name = "defer_task_command"
+        disposition_operation = persist_deferral
     except TaskCommandRejected as exc:
-        await asyncio.to_thread(
-            fail_task_command,
-            command.id,
-            runner_id,
-            str(exc),
-            force_terminal=True,
-            expected_attempt_count=command.attempt_count,
-            result=(
-                {"rejection_reason": exc.reason} if exc.reason is not None else None
-            ),
+        error = str(exc)
+        rejection_result = (
+            {"rejection_reason": exc.reason} if exc.reason is not None else None
         )
+
+        def persist_rejection() -> bool:
+            return fail_task_command(
+                command.id,
+                runner_id,
+                error,
+                force_terminal=True,
+                expected_attempt_count=command.attempt_count,
+                result=rejection_result,
+            )
+
+        disposition_name = "fail_task_command"
+        disposition_operation = persist_rejection
     except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "Task command %s (%s) failed on attempt %s",
+        if is_database_pool_timeout(exc):
+            # The handler already waited for an exhausted checkout. Persisting
+            # command failure here would immediately request a second
+            # connection. Keep the fenced processing claim intact; another
+            # dispatcher may reclaim it only after claim expiry.
+            logger.error(
+                "task_id=%s component=task-command-handler database pool "
+                "checkout timed out; retaining command claim for expiry "
+                "(command_id=%s, kind=%s, attempt=%s): %s",
+                command.task_id,
+                command.command_id,
+                command.kind.value,
+                command.attempt_count,
+                exc,
+                exc_info=True,
+            )
+        else:
+            logger.exception(
+                "Task command %s (%s) failed on attempt %s",
+                command.command_id,
+                command.kind.value,
+                command.attempt_count,
+            )
+            error = str(exc)
+
+            def persist_failure() -> bool:
+                return fail_task_command(
+                    command.id,
+                    runner_id,
+                    error,
+                    expected_attempt_count=command.attempt_count,
+                )
+
+            disposition_name = "fail_task_command"
+            disposition_operation = persist_failure
+    else:
+
+        def persist_completion() -> bool:
+            return finish_task_command(
+                command.id,
+                runner_id,
+                result=result,
+                expected_attempt_count=command.attempt_count,
+            )
+
+        disposition_name = "finish_task_command"
+        disposition_operation = persist_completion
+    finally:
+        stop_event.set()
+        heartbeat_outcome = await heartbeat
+
+    if heartbeat_outcome.requires_ttl_recovery:
+        logger.error(
+            "task_id=%s component=task-command-heartbeat claim is unresolved; "
+            "retaining command claim for expiry (command_id=%s, kind=%s, "
+            "attempt=%s, claim_lost=%s, pool_timeout=%s)",
+            command.task_id,
             command.command_id,
             command.kind.value,
             command.attempt_count,
+            heartbeat_outcome.claim_lost,
+            heartbeat_outcome.pool_timeout,
         )
-        await asyncio.to_thread(
-            fail_task_command,
-            command.id,
-            runner_id,
-            str(exc),
-            expected_attempt_count=command.attempt_count,
+        return True
+    if disposition_name is not None and disposition_operation is not None:
+        await _persist_task_command_disposition(
+            command,
+            disposition=disposition_name,
+            operation=disposition_operation,
         )
-    else:
-        if not await asyncio.to_thread(
-            finish_task_command,
-            command.id,
-            runner_id,
-            result=result,
-            expected_attempt_count=command.attempt_count,
-        ):
-            logger.warning("Lost claim while completing task command %s", command.id)
-    finally:
-        stop_event.set()
-        heartbeat.cancel()
-        try:
-            await heartbeat
-        except asyncio.CancelledError:
-            pass
     return True
 
 
@@ -790,7 +931,22 @@ async def _run_task_command_dispatcher_worker(executor: CommandExecutor) -> None
         # claim remains set, so an empty claim cannot erase that wakeup and
         # sleep while work is waiting.
         wakeup.clear()
-        processed = await dispatch_one_task_command(executor)
+        try:
+            processed = await dispatch_one_task_command(executor)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "component=task-command-dispatcher command dispatch failed; "
+                "worker continuing: %s",
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+            try:
+                await asyncio.wait_for(wakeup.wait(), timeout=DISPATCHER_IDLE_SECONDS)
+            except asyncio.TimeoutError:
+                pass
+            continue
         if processed:
             continue
         try:
@@ -846,18 +1002,36 @@ async def stop_task_command_dispatcher() -> None:
             pass
 
 
-def load_task_command(command_db_id: int) -> TaskExecutionCommand | None:
+def load_task_command(command_db_id: int) -> TaskCommandStateSnapshot | None:
     from ..models.database import get_session_local
 
     SessionLocal = get_session_local()
     with SessionLocal() as db:
-        command = (
-            db.query(TaskExecutionCommand)
+        row = (
+            db.query(
+                TaskExecutionCommand.id,
+                TaskExecutionCommand.status,
+                TaskExecutionCommand.error,
+                TaskExecutionCommand.result,
+                TaskExecutionCommand.attempt_count,
+                TaskExecutionCommand.failure_count,
+                TaskExecutionCommand.defer_count,
+            )
             .filter(TaskExecutionCommand.id == command_db_id)
             .first()
         )
-        if command is not None:
-            # Make the session boundary explicit. Callers only read scalar
-            # command state and must never depend on a live/lazy session.
-            db.expunge(command)
-        return command
+        if row is None:
+            return None
+        result = row.result if isinstance(row.result, dict) else {}
+        rejection_reason = result.get("rejection_reason")
+        return TaskCommandStateSnapshot(
+            command_db_id=int(row.id),
+            status=str(row.status),
+            error=str(row.error) if row.error is not None else None,
+            rejection_reason=(
+                rejection_reason if isinstance(rejection_reason, str) else None
+            ),
+            attempt_count=int(row.attempt_count or 0),
+            failure_count=int(row.failure_count or 0),
+            defer_count=int(row.defer_count or 0),
+        )

--- a/src/xagent/web/services/task_execution_context_service.py
+++ b/src/xagent/web/services/task_execution_context_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
@@ -13,19 +14,69 @@ from ...skills.utils import create_skill_manager
 from ..models.task import TraceEvent
 
 
+@dataclass(frozen=True)
+class TaskExecutionRecoverySnapshot:
+    """Detached DB portion of cross-round execution recovery.
+
+    Skill content is intentionally absent: loading it is async filesystem/plugin
+    work. The worker-side DB boundary only returns the selected skill name; the
+    event loop materializes that name after the snapshot Session is closed.
+    """
+
+    messages: tuple[Dict[str, str], ...] = ()
+    selected_skill_name: Optional[str] = None
+
+
+def load_task_execution_recovery_snapshot_sync(
+    db: Session,
+    task_id: int,
+    *,
+    max_tool_events: int = 8,
+) -> TaskExecutionRecoverySnapshot:
+    """Read the database-backed recovery inputs into detached primitives."""
+    return TaskExecutionRecoverySnapshot(
+        messages=tuple(
+            load_task_execution_context_messages(
+                db,
+                task_id,
+                max_tool_events=max_tool_events,
+            )
+        ),
+        selected_skill_name=load_task_recovered_skill_name(db, task_id),
+    )
+
+
+async def materialize_task_execution_recovery_state(
+    snapshot: TaskExecutionRecoverySnapshot,
+) -> Dict[str, Any]:
+    """Finish async skill loading after the DB snapshot has been detached."""
+    skill_context = None
+    if snapshot.selected_skill_name:
+        skill_context = await _load_skill_context_by_name(snapshot.selected_skill_name)
+    return {
+        "messages": [dict(message) for message in snapshot.messages],
+        "skill_context": skill_context,
+    }
+
+
 async def load_task_execution_recovery_state(
     db: Session,
     task_id: int,
     *,
     max_tool_events: int = 8,
 ) -> Dict[str, Any]:
-    """Load reusable execution recovery state for a task."""
-    return {
-        "messages": load_task_execution_context_messages(
-            db, task_id, max_tool_events=max_tool_events
-        ),
-        "skill_context": await load_task_recovered_skill_context(db, task_id),
-    }
+    """Load reusable execution recovery state for a task.
+
+    Compatibility wrapper for callers that still own a Session. Task-runtime
+    code should read :class:`TaskExecutionRecoverySnapshot` in its worker-owned
+    setup snapshot, then call :func:`materialize_task_execution_recovery_state`.
+    """
+    snapshot = load_task_execution_recovery_snapshot_sync(
+        db,
+        task_id,
+        max_tool_events=max_tool_events,
+    )
+    return await materialize_task_execution_recovery_state(snapshot)
 
 
 def load_task_execution_context_messages(
@@ -79,6 +130,15 @@ def load_task_execution_context_messages(
 
 async def load_task_recovered_skill_context(db: Session, task_id: int) -> Optional[str]:
     """Load the latest selected skill context for a task, if any."""
+    skill_name = load_task_recovered_skill_name(db, task_id)
+    if not skill_name:
+        return None
+
+    return await _load_skill_context_by_name(skill_name)
+
+
+def load_task_recovered_skill_name(db: Session, task_id: int) -> Optional[str]:
+    """Return the latest selected skill name without performing async I/O."""
     trace_event = (
         db.query(TraceEvent)
         .filter(
@@ -96,8 +156,7 @@ async def load_task_recovered_skill_context(db: Session, task_id: int) -> Option
     skill_name = str(trace_event.data.get("skill_name") or "").strip()
     if not selected or not skill_name:
         return None
-
-    return await _load_skill_context_by_name(skill_name)
+    return skill_name
 
 
 _BINARY_MAGIC_PREFIXES = (

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -7,10 +7,10 @@ import logging
 import os
 import socket
 import uuid
-from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from enum import Enum
+from typing import Any, Callable, cast
 
 from sqlalchemy import case, func, or_, update
 from sqlalchemy.orm import Session
@@ -20,8 +20,12 @@ from ...config import (
     get_task_lease_ttl_seconds,
 )
 from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
-from ..models.database import get_db
 from ..models.task import Task, TaskStatus, TraceEvent
+from .db_runtime import (
+    await_task_settlement,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
+)
 from .task_execution_controller import control_state_for_status
 
 logger = logging.getLogger(__name__)
@@ -38,6 +42,63 @@ class TaskLease:
     task_id: int
     runner_id: str
     run_id: str | None = None
+
+
+@dataclass(frozen=True)
+class TaskLeaseHeartbeatOutcome:
+    """Lease state observed when a heartbeat loop stops.
+
+    A pool timeout is retained only until a later successful refresh proves
+    that ownership is healthy again. Callers use an unresolved timeout (or a
+    definite ownership loss) to avoid an immediate settlement checkout.
+    """
+
+    lease_lost: bool = False
+    pool_timeout: BaseException | None = None
+
+    @property
+    def requires_ttl_recovery(self) -> bool:
+        return self.lease_lost or self.pool_timeout is not None
+
+
+class TaskLeaseRefreshState(str, Enum):
+    """Result of refreshing one exact task-run lease."""
+
+    REFRESHED = "refreshed"
+    SETTLEMENT_READY = "settlement_ready"
+    LOST = "lost"
+
+
+async def acquire_task_lease_cancellation_safe(
+    acquire: Callable[[], TaskLease | None],
+    cleanup: Callable[[TaskLease], Any],
+) -> TaskLease | None:
+    """Acquire a lease and clean up a late result before propagating cancel.
+
+    The acquisition callback and cleanup callback each execute in their own
+    worker thread. When cancellation arrives during acquisition, the acquire
+    worker is drained first; if it committed and returned a lease, cleanup is
+    then drained as well. Only after both operations settle is cancellation
+    delivered to the caller.
+    """
+    worker = asyncio.get_running_loop().create_task(asyncio.to_thread(acquire))
+    lease, cancellation = await await_task_settlement(worker)
+    if cancellation is None:
+        return lease
+
+    if lease is not None:
+        try:
+            await run_db_io_cancellation_safe(lambda: cleanup(lease))
+        except asyncio.CancelledError:
+            # A repeated caller cancellation was recorded and propagated only
+            # after cleanup settled. Preserve the original cancellation below.
+            pass
+        except Exception:
+            logger.exception(
+                "Failed to clean up task %s lease after cancelled acquisition",
+                lease.task_id,
+            )
+    raise cancellation
 
 
 def get_runner_id() -> str:
@@ -90,6 +151,38 @@ def acquire_task_lease(
     transports so another worker cannot rotate the run between a status check
     and lease acquisition.
     """
+    lease = acquire_task_lease_no_commit(
+        db,
+        task_id,
+        runner_id=runner_id,
+        expected_run_id=expected_run_id,
+        new_run=new_run,
+    )
+    db.commit()
+    if lease is None:
+        logger.info(
+            "Task %s lease acquisition denied for runner %s",
+            task_id,
+            runner_id or get_runner_id(),
+        )
+        return None
+    logger.info(
+        "Task %s lease acquired by runner %s",
+        task_id,
+        lease.runner_id,
+    )
+    return lease
+
+
+def acquire_task_lease_no_commit(
+    db: Session,
+    task_id: int,
+    *,
+    runner_id: str | None = None,
+    expected_run_id: str | None = None,
+    new_run: bool = False,
+) -> TaskLease | None:
+    """Stage one atomic lease claim; the caller owns commit/rollback."""
     runner = runner_id or get_runner_id()
     now = utc_now()
     expires_at = _expires_at(now)
@@ -138,18 +231,12 @@ def acquire_task_lease(
         stmt = stmt.where(Task.status != TaskStatus.RUNNING)
     if expected_run_id is not None:
         stmt = stmt.where(Task.run_id == expected_run_id)
-    result = db.execute(stmt.execution_options(synchronize_session=False))
-    db.commit()
-    if _rowcount(result) != 1:
-        logger.info("Task %s lease acquisition denied for runner %s", task_id, runner)
-        return None
-    stored_run_id = db.query(Task.run_id).filter(Task.id == task_id).scalar()
-    logger.info(
-        "Task %s lease acquired by runner %s until %s",
-        task_id,
-        runner,
-        expires_at.isoformat(),
+    result = db.execute(
+        stmt.returning(Task.run_id).execution_options(synchronize_session=False)
     )
+    stored_run_id = result.scalar_one_or_none()
+    if stored_run_id is None:
+        return None
     return TaskLease(
         task_id=task_id,
         runner_id=runner,
@@ -189,8 +276,14 @@ def acquire_task_lease_isolated(
         db.close()
 
 
-def refresh_task_lease(db: Session, lease: TaskLease) -> bool:
-    """Refresh a live task lease owned by this runner."""
+def refresh_task_lease(db: Session, lease: TaskLease) -> TaskLeaseRefreshState:
+    """Refresh one exact lease or classify why it no longer needs refresh.
+
+    A task finalizer commits its terminal status before post-result broadcasts
+    complete, while the scheduler still owns and later releases the lease.  A
+    heartbeat in that window must distinguish the same terminal run from a
+    lease that another runner or run actually replaced.
+    """
     now = utc_now()
     expires_at = _expires_at(now)
     stmt = (
@@ -203,8 +296,30 @@ def refresh_task_lease(db: Session, lease: TaskLease) -> bool:
     if lease.run_id is not None:
         stmt = stmt.where(Task.run_id == lease.run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
+    if _rowcount(result) == 1:
+        db.commit()
+        return TaskLeaseRefreshState.REFRESHED
+
+    owned_query = db.query(Task.status).filter(
+        Task.id == lease.task_id,
+        Task.runner_id == lease.runner_id,
+    )
+    if lease.run_id is not None:
+        owned_query = owned_query.filter(Task.run_id == lease.run_id)
+    owned_status = owned_query.scalar()
     db.commit()
-    return _rowcount(result) == 1
+    if owned_status is not None and owned_status != TaskStatus.RUNNING:
+        return TaskLeaseRefreshState.SETTLEMENT_READY
+    return TaskLeaseRefreshState.LOST
+
+
+def refresh_task_lease_isolated(lease: TaskLease) -> TaskLeaseRefreshState:
+    """Refresh ``lease`` in a short-lived session owned by this thread."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        return refresh_task_lease(db, lease)
 
 
 def release_task_lease(
@@ -214,6 +329,22 @@ def release_task_lease(
     status: TaskStatus,
 ) -> bool:
     """Release a task lease and set its final visible status."""
+    released = release_task_lease_no_commit(db, lease, status=status)
+    if lease is None:
+        return False
+    db.commit()
+    return released
+
+
+def release_task_lease_no_commit(
+    db: Session,
+    lease: TaskLease | None,
+    *,
+    status: TaskStatus,
+) -> bool:
+    """Stage release of one exact lease; the caller owns commit/rollback."""
+    if status == TaskStatus.RUNNING:
+        raise ValueError("Cannot release a task lease with RUNNING status")
     if lease is None:
         return False
     control_state = control_state_for_status(status).value
@@ -240,7 +371,44 @@ def release_task_lease(
     if lease.run_id is not None:
         stmt = stmt.where(Task.run_id == lease.run_id)
     result = db.execute(stmt.execution_options(synchronize_session=False))
-    db.commit()
+    return _rowcount(result) == 1
+
+
+def fail_and_release_task_lease_no_commit(
+    db: Session,
+    lease: TaskLease,
+    *,
+    error_message: str,
+) -> bool:
+    """Atomically fail and release the exact live lease without committing.
+
+    The caller owns the transaction so related lifecycle projections can be
+    synchronized before one final commit. A lease without a run id is not a
+    sufficient ownership fence and is therefore never allowed to mutate the
+    task row.
+    """
+    if lease.run_id is None:
+        return False
+
+    failed_control_state = control_state_for_status(TaskStatus.FAILED).value
+    stmt = (
+        update(Task)
+        .where(Task.id == lease.task_id)
+        .where(Task.runner_id == lease.runner_id)
+        .where(Task.run_id == lease.run_id)
+        .where(Task.status == TaskStatus.RUNNING)
+        .values(
+            status=TaskStatus.FAILED,
+            runner_id=None,
+            lease_expires_at=None,
+            last_heartbeat_at=utc_now(),
+            control_state=failed_control_state,
+            state_version=func.coalesce(Task.state_version, 0) + 1,
+            error_message=error_message,
+            output=None,
+        )
+    )
+    result = db.execute(stmt.execution_options(synchronize_session=False))
     return _rowcount(result) == 1
 
 
@@ -253,6 +421,8 @@ def release_current_runner_task_lease(
     expected_run_id: str | None = None,
 ) -> bool:
     """Release the current runner's lease for a task."""
+    if status == TaskStatus.RUNNING:
+        raise ValueError("Cannot release a task lease with RUNNING status")
     runner = runner_id or get_runner_id()
     control_state = control_state_for_status(status).value
     current_version = func.coalesce(Task.state_version, 0)
@@ -325,9 +495,10 @@ def mark_task_paused_if_stale(db: Session, task: Task) -> bool:
 async def run_task_lease_heartbeat(
     lease: TaskLease,
     stop_event: asyncio.Event,
-) -> None:
+) -> TaskLeaseHeartbeatOutcome:
     """Keep a task lease alive until the execution finishes."""
     interval = get_task_lease_heartbeat_seconds()
+    unresolved_pool_timeout: BaseException | None = None
     while not stop_event.is_set():
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval)
@@ -335,34 +506,59 @@ async def run_task_lease_heartbeat(
         except asyncio.TimeoutError:
             pass
 
-        db_gen = get_db()
-        db = next(db_gen)
         try:
-            if not refresh_task_lease(db, lease):
+            refresh_state = await run_db_io_cancellation_safe(
+                lambda: refresh_task_lease_isolated(lease)
+            )
+            if refresh_state == TaskLeaseRefreshState.SETTLEMENT_READY:
+                logger.debug(
+                    "Task %s lease heartbeat observed owned terminal state; "
+                    "handing lease to settlement",
+                    lease.task_id,
+                )
+                return TaskLeaseHeartbeatOutcome()
+            if refresh_state == TaskLeaseRefreshState.LOST:
                 logger.warning(
                     "Task %s lease heartbeat lost for runner %s",
                     lease.task_id,
                     lease.runner_id,
                 )
-                return
+                return TaskLeaseHeartbeatOutcome(lease_lost=True)
+            unresolved_pool_timeout = None
         except Exception as e:
+            if is_database_pool_timeout(e):
+                unresolved_pool_timeout = e
             logger.warning(
                 "Task %s lease heartbeat failed for runner %s: %s",
                 lease.task_id,
                 lease.runner_id,
                 e,
             )
-        finally:
-            db.close()
+    return TaskLeaseHeartbeatOutcome(pool_timeout=unresolved_pool_timeout)
 
 
 async def stop_task_lease_heartbeat(
     task: asyncio.Task[Any] | None,
     stop_event: asyncio.Event | None,
-) -> None:
+) -> TaskLeaseHeartbeatOutcome:
     if stop_event is not None:
         stop_event.set()
-    if task is not None:
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
+    if task is None:
+        return TaskLeaseHeartbeatOutcome()
+
+    try:
+        outcome, cancellation = await await_task_settlement(task)
+    except asyncio.CancelledError:
+        current = asyncio.current_task()
+        if current is not None and current.cancelling() > 0:
+            raise
+        # The heartbeat task itself had already been cancelled. Its worker I/O
+        # is cancellation-safe, so there is nothing left to drain here.
+        return TaskLeaseHeartbeatOutcome()
+    if cancellation is not None:
+        raise cancellation
+    if isinstance(outcome, TaskLeaseHeartbeatOutcome):
+        return outcome
+    # Compatibility with externally supplied/mocked heartbeat tasks that
+    # predate the structured result.
+    return TaskLeaseHeartbeatOutcome()

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -49,13 +49,21 @@ import enum
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 from uuid import uuid4
 
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
+from ...core.execution_scope import resolve_execution_scope
+from ...core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 from ..models.task import Task, TaskStatus
 from .chat_history_service import mark_user_message_delivery_sync
+from .db_runtime import (
+    drain_async_task_cancellation_safe,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
+)
 from .hot_path_cache import invalidate_task_cache
 from .task_execution_controller import (
     TaskControlState,
@@ -63,12 +71,17 @@ from .task_execution_controller import (
     task_execution_controller,
 )
 from .task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    acquire_task_lease_cancellation_safe,
     acquire_task_lease_isolated,
+    fail_and_release_task_lease_no_commit,
     get_runner_id,
+    release_task_lease,
     run_task_lease_heartbeat,
+    stop_task_lease_heartbeat,
 )
 from .task_setup_snapshot import load_task_setup_snapshot_sync
-from .workforce_runtime import release_current_runner_task_lease_with_workforce_sync
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +133,20 @@ class TaskTurnPayload:
     @property
     def for_agent(self) -> str:
         return self.execution_message or self.transcript_message
+
+
+@dataclass(frozen=True)
+class TaskCreationSpec:
+    """Detached fields for a task created and claimed in one transaction."""
+
+    task_owner_user_id: int
+    title: str
+    description: str | None
+    agent_id: int | None
+    execution_mode: str | None
+    source: str
+    is_visible: bool
+    agent_config: Mapping[str, Any]
 
 
 class TurnKind(str, enum.Enum):
@@ -209,6 +236,89 @@ class TaskTurnOrchestrator:
     State lives in the database and in the global
     ``background_task_manager``.
     """
+
+    @staticmethod
+    async def schedule_existing_task_execution(
+        *,
+        task_id: int,
+        task_owner_user_id: int,
+        task_source: Optional[str],
+        payload: TaskTurnPayload,
+        context: Optional[Dict[str, Any]] = None,
+        actor_user_id: Optional[int] = None,
+    ) -> "asyncio.Task[None]":
+        """Schedule the legacy ``execute_task`` command without a caller Session.
+
+        Unlike :meth:`begin_turn`, this compatibility entry does not persist a
+        new user message or reset terminal fields.  The legacy WebSocket command
+        executes the description already stored on ``Task``; changing it into a
+        new chat turn would duplicate that text in conversation history.
+
+        The shared scheduler still owns the runtime invariants: one local
+        in-flight coroutine, an exact task lease, worker-owned setup snapshot,
+        one off-loop execution-scope resolution, heartbeat, and fenced
+        settlement.  Cross-worker duplicates are rejected by lease acquisition.
+        """
+        async with task_execution_controller.command(task_id):
+            _refuse_if_bg_inflight(task_id)
+            background_task = _schedule_bg(
+                task_id=task_id,
+                task_owner_user_id=task_owner_user_id,
+                task_source=task_source,
+                payload=payload,
+                force_fresh=False,
+                context=context,
+            )
+
+        logger.info(
+            "existing task execution scheduled: task=%s owner=%s actor=%s",
+            task_id,
+            task_owner_user_id,
+            actor_user_id if actor_user_id is not None else task_owner_user_id,
+        )
+        return background_task
+
+    @staticmethod
+    async def create_and_begin_turn(
+        *,
+        creation: TaskCreationSpec,
+        payload: TaskTurnPayload,
+        context: Optional[Dict[str, Any]] = None,
+        actor_user_id: Optional[int] = None,
+    ) -> TurnStarted:
+        """Insert, claim, persist, and schedule a brand-new task lifecycle.
+
+        The task row and first transcript message commit together as RUNNING in
+        one worker-owned transaction. A failed checkout therefore leaves no
+        ownerless PENDING row, while a successful commit immediately enters the
+        same post-claim scheduling and compensation owner as ``begin_turn``.
+        """
+
+        async def create_claim_and_schedule() -> TurnStarted:
+            task_id, claimed = await asyncio.to_thread(
+                _create_turn_atomic_sync,
+                creation,
+                payload=payload,
+            )
+            background_task = await _schedule_committed_turn(
+                task_id=task_id,
+                task_owner_user_id=creation.task_owner_user_id,
+                payload=payload,
+                claimed=claimed,
+                force_fresh=False,
+                context=context,
+            )
+            return _turn_started_snapshot(
+                task_id=task_id,
+                task_owner_user_id=creation.task_owner_user_id,
+                actor_user_id=actor_user_id,
+                kind=TurnKind.CREATE,
+                claimed=claimed,
+                background_task=background_task,
+            )
+
+        operation = asyncio.create_task(create_claim_and_schedule())
+        return await drain_async_task_cancellation_safe(operation)
 
     @staticmethod
     async def begin_turn(
@@ -362,79 +472,30 @@ class TaskTurnOrchestrator:
             # Off-loop atomic claim + persist + commit. Only raises pre-commit
             # (busy / not-found), so a normal exception here means nothing was
             # committed; reaching the schedule means the row is RUNNING.
-            res = await asyncio.to_thread(
+            claimed = await asyncio.to_thread(
                 _begin_turn_atomic_sync,
                 task_id,
                 task_owner_user_id,
                 payload=payload,
                 kind=kind,
             )
-            try:
-                handle = _schedule_bg(
-                    task_id=task_id,
-                    task_owner_user_id=task_owner_user_id,
-                    task_source=res.task_source,
-                    run_id=res.run_id,
-                    payload=payload,
-                    force_fresh=force_fresh,
-                    context=context,
-                    before_message_id=res.before_message_id,
-                )
-            except BaseException:
-                # Schedule failed after the claim committed -> force FAILED so
-                # the row isn't left RUNNING. Off-loop, so the error path also
-                # keeps the goal of no synchronous DB on the event loop.
-                await asyncio.to_thread(
-                    _mark_task_failed_if_running,
-                    task_id,
-                    "turn scheduling failed after claim commit",
-                    res.run_id,
-                )
-                try:
-                    await asyncio.to_thread(
-                        mark_user_message_delivery_sync,
-                        task_id,
-                        payload.turn_id,
-                        "failed",
-                    )
-                except Exception:
-                    logger.exception(
-                        "Could not mark failed delivery for task=%s turn=%s",
-                        task_id,
-                        payload.turn_id,
-                    )
-                raise
-            await asyncio.to_thread(
-                mark_user_message_delivery_sync,
-                task_id,
-                payload.turn_id,
-                "dispatched",
+            handle = await _schedule_committed_turn(
+                task_id=task_id,
+                task_owner_user_id=task_owner_user_id,
+                payload=payload,
+                claimed=claimed,
+                force_fresh=force_fresh,
+                context=context,
             )
-            return res, handle
+            return claimed, handle
 
         claimed, bg_task = await asyncio.shield(_claim_and_schedule())
-
-        # Audit who initiated the committed turn. The runtime always runs as
-        # the owner; this only records the acting principal (an admin when
-        # acting on another user's task) and is intentionally not used for any
-        # runtime resolution.
-        logger.info(
-            "turn started: task=%s kind=%s owner=%s actor=%s",
-            task_id,
-            kind,
-            task_owner_user_id,
-            actor_user_id if actor_user_id is not None else task_owner_user_id,
-        )
-
-        return TurnStarted(
+        return _turn_started_snapshot(
             task_id=task_id,
-            status=claimed.status,
-            updated_at=claimed.updated_at,
-            before_message_id=claimed.before_message_id,
-            task_source=claimed.task_source,
-            run_id=claimed.run_id,
-            state_version=claimed.state_version,
-            control_state=claimed.control_state,
+            task_owner_user_id=task_owner_user_id,
+            actor_user_id=actor_user_id,
+            kind=kind,
+            claimed=claimed,
             background_task=bg_task,
         )
 
@@ -455,6 +516,251 @@ class _ClaimedTurn:
     run_id: str = ""
     state_version: int = 0
     control_state: str = TaskControlState.RUNNING.value
+
+
+async def _schedule_committed_turn(
+    *,
+    task_id: int,
+    task_owner_user_id: int,
+    payload: TaskTurnPayload,
+    claimed: _ClaimedTurn,
+    force_fresh: bool,
+    context: Optional[Dict[str, Any]],
+) -> "asyncio.Task[None]":
+    """Own scheduling and compensation after a turn claim has committed."""
+
+    try:
+        _refuse_if_bg_inflight(task_id)
+        handle = _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=task_owner_user_id,
+            task_source=claimed.task_source,
+            run_id=claimed.run_id,
+            payload=payload,
+            force_fresh=force_fresh,
+            context=context,
+            before_message_id=claimed.before_message_id,
+        )
+    except BaseException as schedule_error:
+        # Schedule failed after the claim committed -> force FAILED so the row
+        # is not left RUNNING. The terminal write remains off-loop.
+        try:
+            await asyncio.to_thread(
+                _mark_task_failed_if_running,
+                task_id,
+                "turn scheduling failed after claim commit",
+                claimed.run_id,
+            )
+        except Exception as terminal_error:
+            if not is_database_pool_timeout(terminal_error):
+                raise
+            # This checkout already waited for the exhausted pool. Do not
+            # immediately attempt the delivery update below; its committed
+            # PENDING marker remains reclaimable.
+            logger.error(
+                "task_id=%s component=turn-schedule-terminal database pool "
+                "checkout timed out; skipping delivery update: %s",
+                task_id,
+                terminal_error,
+                exc_info=True,
+            )
+            raise schedule_error from terminal_error
+        try:
+            await asyncio.to_thread(
+                mark_user_message_delivery_sync,
+                task_id,
+                payload.turn_id,
+                "failed",
+            )
+        except Exception:
+            logger.exception(
+                "Could not mark failed delivery for task=%s turn=%s",
+                task_id,
+                payload.turn_id,
+            )
+        raise
+
+    try:
+        await asyncio.to_thread(
+            mark_user_message_delivery_sync,
+            task_id,
+            payload.turn_id,
+            "dispatched",
+        )
+    except Exception as delivery_error:
+        if not is_database_pool_timeout(delivery_error):
+            raise
+        # Claim commit + background scheduling already succeeded. A transient
+        # delivery-state checkout must not turn that success into an API error
+        # or trigger another immediate checkout.
+        logger.error(
+            "task_id=%s component=turn-delivery database pool checkout timed "
+            "out after scheduling; leaving delivery pending for durable "
+            "recovery: %s",
+            task_id,
+            delivery_error,
+            exc_info=True,
+        )
+    return handle
+
+
+def _turn_started_snapshot(
+    *,
+    task_id: int,
+    task_owner_user_id: int,
+    actor_user_id: int | None,
+    kind: TurnKind,
+    claimed: _ClaimedTurn,
+    background_task: "asyncio.Task[None]",
+) -> TurnStarted:
+    """Build the detached turn result and emit its owner/actor audit record."""
+
+    logger.info(
+        "turn started: task=%s kind=%s owner=%s actor=%s",
+        task_id,
+        kind,
+        task_owner_user_id,
+        actor_user_id if actor_user_id is not None else task_owner_user_id,
+    )
+    return TurnStarted(
+        task_id=task_id,
+        status=claimed.status,
+        updated_at=claimed.updated_at,
+        before_message_id=claimed.before_message_id,
+        task_source=claimed.task_source,
+        run_id=claimed.run_id,
+        state_version=claimed.state_version,
+        control_state=claimed.control_state,
+        background_task=background_task,
+    )
+
+
+def _turn_claim_values(
+    payload: TaskTurnPayload,
+    *,
+    run_id: str,
+    state_version: Any,
+) -> dict[str, Any]:
+    """Return the shared persisted state for a newly owned task turn."""
+
+    return {
+        "status": TaskStatus.RUNNING,
+        "input": payload.transcript_message,
+        "output": None,
+        "error_message": None,
+        "runner_id": None,
+        "lease_expires_at": None,
+        "last_heartbeat_at": None,
+        "run_id": run_id,
+        "state_version": state_version,
+        "control_state": TaskControlState.RUNNING.value,
+    }
+
+
+def _persist_claimed_turn_no_commit(
+    db: Session,
+    *,
+    task_id: int,
+    task_owner_user_id: int,
+    payload: TaskTurnPayload,
+) -> _ClaimedTurn:
+    """Persist the first message and snapshot one already-claimed turn."""
+
+    from .chat_history_service import DELIVERY_PENDING, persist_user_message_no_commit
+
+    persisted_message = persist_user_message_no_commit(
+        db=db,
+        task_id=task_id,
+        user_id=task_owner_user_id,
+        content=payload.transcript_message,
+        attachments=payload.attachments,
+        turn_id=payload.turn_id,
+        delivery_status=DELIVERY_PENDING,
+    )
+    if persisted_message is not None:
+        db.flush()
+        before_message_id: Optional[int] = int(persisted_message.id)
+    else:
+        before_message_id = None
+
+    status, updated_at, source, stored_run_id, state_version, control_state = (
+        db.query(
+            Task.status,
+            Task.updated_at,
+            Task.source,
+            Task.run_id,
+            Task.state_version,
+            Task.control_state,
+        )
+        .filter(Task.id == task_id)
+        .one()
+    )
+    return _ClaimedTurn(
+        status=status,
+        updated_at=updated_at,
+        before_message_id=before_message_id,
+        task_source=source,
+        run_id=str(stored_run_id) if stored_run_id is not None else "",
+        state_version=int(state_version),
+        control_state=str(control_state),
+    )
+
+
+def _invalidate_claim_cache(task_id: int) -> None:
+    """Keep cache invalidation best-effort after a committed turn claim."""
+
+    try:
+        invalidate_task_cache(task_id)
+    except Exception:
+        logger.warning(
+            "invalidate_task_cache failed for task %s (non-fatal)",
+            task_id,
+            exc_info=True,
+        )
+
+
+def _create_turn_atomic_sync(
+    creation: TaskCreationSpec,
+    *,
+    payload: TaskTurnPayload,
+) -> tuple[int, _ClaimedTurn]:
+    """Insert RUNNING task + first message in one worker-owned transaction."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    run_id = str(uuid4())
+    try:
+        task = Task(
+            user_id=creation.task_owner_user_id,
+            title=creation.title,
+            description=creation.description,
+            agent_id=creation.agent_id,
+            execution_mode=creation.execution_mode,
+            source=creation.source,
+            is_visible=creation.is_visible,
+            agent_config=dict(creation.agent_config),
+            **_turn_claim_values(payload, run_id=run_id, state_version=1),
+        )
+        db.add(task)
+        db.flush()
+        task_id = int(task.id)
+        claimed = _persist_claimed_turn_no_commit(
+            db,
+            task_id=task_id,
+            task_owner_user_id=creation.task_owner_user_id,
+            payload=payload,
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+    _invalidate_claim_cache(task_id)
+    return task_id, claimed
 
 
 def _begin_turn_atomic_sync(
@@ -488,7 +794,6 @@ def _begin_turn_atomic_sync(
     RUNNING, and any exception means it is not.
     """
     from ..models.database import get_session_local
-    from .chat_history_service import DELIVERY_PENDING, persist_user_message_no_commit
 
     if kind == TurnKind.CREATE:
         status_filter = Task.status == TaskStatus.PENDING
@@ -499,6 +804,11 @@ def _begin_turn_atomic_sync(
     db = SessionLocal()
     run_id = str(uuid4())
     try:
+        claim_values = _turn_claim_values(
+            payload,
+            run_id=run_id,
+            state_version=func.coalesce(Task.state_version, 0) + 1,
+        )
         claimed = (
             db.query(Task)
             .filter(
@@ -507,25 +817,7 @@ def _begin_turn_atomic_sync(
                 status_filter,
             )
             .update(
-                {
-                    Task.status: TaskStatus.RUNNING,
-                    Task.input: payload.transcript_message,
-                    Task.output: None,
-                    Task.error_message: None,
-                    # A new turn owns the lifecycle from this claim forward.
-                    # Stale runner_id / lease columns left by a crashed worker
-                    # or a release that failed to clear would otherwise make
-                    # acquire_task_lease deny this worker even though no live
-                    # runner is executing -- leaving the SDK row stuck RUNNING
-                    # (GET /v1/chat/tasks/{id} never reaches completed; append
-                    # returns task_busy). Reset here atomically with the claim.
-                    Task.runner_id: None,
-                    Task.lease_expires_at: None,
-                    Task.last_heartbeat_at: None,
-                    Task.run_id: run_id,
-                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
-                    Task.control_state: TaskControlState.RUNNING.value,
-                },
+                {getattr(Task, key): value for key, value in claim_values.items()},
                 synchronize_session=False,
             )
         )
@@ -540,38 +832,12 @@ def _begin_turn_atomic_sync(
                 raise TaskTurnNotFoundError(task_id)
             raise TaskTurnError("busy")
 
-        persisted_message = persist_user_message_no_commit(
-            db=db,
+        result = _persist_claimed_turn_no_commit(
+            db,
             task_id=task_id,
-            user_id=task_owner_user_id,
-            content=payload.transcript_message,
-            attachments=payload.attachments,
-            turn_id=payload.turn_id,
-            delivery_status=DELIVERY_PENDING,
+            task_owner_user_id=task_owner_user_id,
+            payload=payload,
         )
-        if persisted_message is not None:
-            db.flush()
-            before_message_id: Optional[int] = int(persisted_message.id)
-        else:
-            before_message_id = None
-
-        # Snapshot the committed row's columns BEFORE commit (read-your-writes
-        # in the same transaction). Keeps commit as the last fallible DB op,
-        # so there is no post-commit window where the row is RUNNING but this
-        # helper still raises.
-        status, updated_at, source, stored_run_id, state_version, control_state = (
-            db.query(
-                Task.status,
-                Task.updated_at,
-                Task.source,
-                Task.run_id,
-                Task.state_version,
-                Task.control_state,
-            )
-            .filter(Task.id == task_id)
-            .one()
-        )
-
         db.commit()
     except (TaskTurnError, TaskTurnNotFoundError):
         raise
@@ -581,26 +847,8 @@ def _begin_turn_atomic_sync(
     finally:
         db.close()
 
-    # Best-effort: a stale cache entry self-heals on the next write / TTL,
-    # and must never strand a committed RUNNING task by raising here.
-    try:
-        invalidate_task_cache(task_id)
-    except Exception:
-        logger.warning(
-            "invalidate_task_cache failed for task %s (non-fatal)",
-            task_id,
-            exc_info=True,
-        )
-
-    return _ClaimedTurn(
-        status=status,
-        updated_at=updated_at,
-        before_message_id=before_message_id,
-        task_source=source,
-        run_id=str(stored_run_id) if stored_run_id is not None else "",
-        state_version=int(state_version),
-        control_state=str(control_state),
-    )
+    _invalidate_claim_cache(task_id)
+    return result
 
 
 def _refuse_if_bg_inflight(task_id: int) -> None:
@@ -644,24 +892,7 @@ def _mark_task_failed_if_running(
     error_message: str,
     expected_run_id: str | None = None,
 ) -> None:
-    """Setup/run-error sentinel for ``_schedule_bg._runner``.
-
-    ``acquire_task_lease_isolated`` sets ``task.status = RUNNING`` as
-    part of taking the lease. If a later step in ``_runner`` raises
-    (snapshot load, ``execute_task_background``) and no downstream
-    handler moves the task to a terminal status, the release block
-    would see ``status=RUNNING`` and write it back -- leaving the row
-    visible as running but with no active worker (zombie state). This
-    helper closes that window: ``_runner`` calls it from an outer
-    ``except`` so the task is forced to ``FAILED`` before release.
-
-    Guarded by ``status == RUNNING`` -- never overwrites a terminal /
-    control status (``PAUSED`` / ``WAITING_FOR_USER`` / ``FAILED`` /
-    ``COMPLETED``) that ``execute_task_background`` may have set
-    inside its own inner ``try/except``. Opens / commits / closes
-    its own session so the caller doesn't have to thread a session
-    through the exception path.
-    """
+    """Fail a committed claim if scheduling fails before a lease is acquired."""
     from ..models.database import get_session_local
 
     SessionLocal = get_session_local()
@@ -681,23 +912,87 @@ def _mark_task_failed_if_running(
             )
             task.error_message = error_message  # type: ignore[assignment]
             db.commit()
-    except Exception as e:
-        # Defensive: do not let this helper raise out of the ``except``
-        # path that's already handling an error. Log loudly so the
-        # zombie state, if it survives, is traceable.
+    except Exception as error:
         logger.error(
-            "Failed to mark task %s as FAILED during setup/run error: %s",
+            "Failed to mark task %s as FAILED after scheduling error: %s",
             task_id,
-            e,
+            error,
             exc_info=True,
         )
+        raise
+
+
+def settle_task_lease_isolated(
+    lease: TaskLease,
+    *,
+    error_message: str | None = None,
+) -> bool:
+    """Settle exactly one run/runner lease in one worker-owned Session.
+
+    A genuine execution error is failed and released by one conditional UPDATE
+    and one commit. Related workforce/trigger projections and the durable error
+    transcript are staged in that same transaction. If the row is already
+    terminal (for example a completion broadcast failed), ``finish_turn``
+    reconciles and releases it without rewriting the outcome.
+
+    On checkout or commit failure the transaction is rolled back and the lease
+    is intentionally retained for TTL recovery; this function never creates an
+    ownerless RUNNING task.
+    """
+    from ..models.database import get_session_local
+    from .chat_history_service import persist_assistant_message_no_commit
+    from .workforce_runtime import sync_workforce_run_status
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as settle_db:
+        try:
+            if error_message is not None:
+                failed = fail_and_release_task_lease_no_commit(
+                    settle_db,
+                    lease,
+                    error_message=error_message,
+                )
+                if failed:
+                    task = settle_db.query(Task).filter(Task.id == lease.task_id).one()
+                    sync_workforce_run_status(settle_db, task, TaskStatus.FAILED)
+                    _sync_trigger_run_status(settle_db, task, TaskStatus.FAILED)
+                    if task.user_id is not None:
+                        persist_assistant_message_no_commit(
+                            settle_db,
+                            task_id=lease.task_id,
+                            user_id=int(task.user_id),
+                            content=error_message,
+                            message_type="chat_response",
+                        )
+                    settle_db.commit()
+                    invalidate_task_cache(lease.task_id)
+                    return True
+
+                # The task may already have committed a terminal/control state.
+                # Clear the failed conditional UPDATE transaction before the
+                # fenced terminal reconciliation below.
+                settle_db.rollback()
+
+            return finish_turn(
+                settle_db,
+                lease.task_id,
+                task_lease=lease,
+            )
+        except Exception:
+            settle_db.rollback()
+            raise
 
 
 # ===== finish_turn / _schedule_bg (new lifecycle API) =====
 
 
-def finish_turn(bg_db: Any, task_id: int) -> None:
-    """Symmetric terminal-field writer with lease ownership guard.
+def finish_turn(
+    bg_db: Any,
+    task_id: int,
+    *,
+    task_lease: TaskLease | None = None,
+) -> bool:
+    """Reconcile terminal fields and, when supplied, release one exact lease.
 
     Called from ``_schedule_bg._runner`` after ``execute_task_background``
     returns. Two key properties:
@@ -709,15 +1004,10 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         stale ``output``). SDK consumers reading ``/v1/chat/tasks/{id}``
         therefore never see a contradictory snapshot like
         ``status='failed' + output='prior successful answer'``.
-      - lease ownership guard: the RUNNING-fallback branch refuses to
-        flip the row to FAILED while another worker still holds a live
-        lease, so a slow scheduler in this process can't overwrite the
-        in-flight execution result of a different process.
-
-    Uses :func:`get_runner_id` internally rather than accepting
-    runner_id as a parameter so the comparison always reads the
-    canonical process runner id and a separately-captured
-    ``lease.runner_id`` can't drift from it.
+      - lease ownership guard: orchestrated callers provide the concrete
+        ``TaskLease``. Every read and final write is then fenced by both
+        ``runner_id`` and ``run_id``; an old coroutine cannot touch a newer
+        run claimed by the same process-global runner id.
 
     Branches:
 
@@ -737,10 +1027,44 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
 
     bg_db.expire_all()
 
-    fresh = bg_db.query(Task).filter(Task.id == task_id).first()
+    query = bg_db.query(Task).filter(Task.id == task_id)
+    if task_lease is not None:
+        # A runner id alone is not a sufficient fence: two sequential runs in
+        # one process share it. Production acquisitions always return run_id;
+        # refuse to mutate when a caller cannot identify the concrete run.
+        if task_lease.run_id is None:
+            logger.warning(
+                "finish_turn: refusing unfenced lease settlement for task %s",
+                task_id,
+            )
+            return False
+        query = query.filter(
+            Task.runner_id == task_lease.runner_id,
+            Task.run_id == task_lease.run_id,
+        )
+        # PostgreSQL locks the exact owned row until release_task_lease commits;
+        # SQLite serializes the write transaction. This prevents an ORM flush
+        # from racing a replacement owner between the read and fenced release.
+        query = query.with_for_update()
+
+    fresh = query.first()
     if fresh is None:
-        logger.warning("finish_turn: task %s vanished after bg run", task_id)
-        return
+        logger.info(
+            "finish_turn: task %s missing or no longer owned by this lease",
+            task_id,
+        )
+        return False
+
+    def commit_terminal(status: TaskStatus, *, changed: bool = True) -> bool:
+        if task_lease is not None:
+            released = release_task_lease(bg_db, task_lease, status=status)
+            if released:
+                invalidate_task_cache(task_id)
+            return released
+        if changed:
+            bg_db.commit()
+            invalidate_task_cache(task_id)
+        return changed
 
     status = fresh.status
 
@@ -759,13 +1083,13 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             fresh.error_message = None
             sync_workforce_run_status(bg_db, fresh, TaskStatus.COMPLETED)
             _sync_trigger_run_status(bg_db, fresh, TaskStatus.COMPLETED)
-            bg_db.commit()
-            invalidate_task_cache(task_id)
+            committed = commit_terminal(TaskStatus.COMPLETED)
             logger.info(
                 "finish_turn: task %s output written (%d chars)",
                 task_id,
                 len(latest_assistant.content),
             )
+            return committed
         else:
             logger.warning(
                 "finish_turn: task %s completed but no assistant message found",
@@ -775,10 +1099,10 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             trigger_run_changed = _sync_trigger_run_status(
                 bg_db, fresh, TaskStatus.COMPLETED
             )
-            if run_changed or trigger_run_changed:
-                bg_db.commit()
-                invalidate_task_cache(task_id)
-        return
+            return commit_terminal(
+                TaskStatus.COMPLETED,
+                changed=run_changed or trigger_run_changed,
+            )
 
     if status == TaskStatus.FAILED:
         changed = False
@@ -795,13 +1119,13 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         run_changed = sync_workforce_run_status(bg_db, fresh, TaskStatus.FAILED)
         trigger_run_changed = _sync_trigger_run_status(bg_db, fresh, TaskStatus.FAILED)
         if changed or run_changed or trigger_run_changed:
-            bg_db.commit()
-            invalidate_task_cache(task_id)
+            committed = commit_terminal(TaskStatus.FAILED)
             logger.info(
                 "finish_turn: task %s marked failed (cleared stale output)",
                 task_id,
             )
-        return
+            return committed
+        return commit_terminal(TaskStatus.FAILED, changed=False)
 
     if status == TaskStatus.RUNNING:
         # Lease ownership guard: a live lease held by another worker
@@ -814,7 +1138,8 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         if expires_at is not None and expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
         live_other_owner = (
-            fresh.runner_id is not None
+            task_lease is None
+            and fresh.runner_id is not None
             and fresh.runner_id != get_runner_id()
             and expires_at is not None
             and expires_at > datetime.now(timezone.utc)
@@ -827,7 +1152,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
                 fresh.runner_id,
                 fresh.lease_expires_at,
             )
-            return
+            return False
         # Genuinely stuck: our bg coroutine returned, no live lease elsewhere.
         apply_task_control_transition(
             fresh,
@@ -838,25 +1163,19 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         fresh.output = None  # latest-turn snapshot invariant
         sync_workforce_run_status(bg_db, fresh, TaskStatus.FAILED)
         _sync_trigger_run_status(bg_db, fresh, TaskStatus.FAILED)
-        bg_db.commit()
-        invalidate_task_cache(task_id)
+        committed = commit_terminal(TaskStatus.FAILED)
         logger.warning(
             "finish_turn: task %s bg coroutine returned with status=RUNNING; "
             "flipping to FAILED",
             task_id,
         )
-        return
+        return committed
 
-    # PAUSED / WAITING_FOR_USER / other: leave alone.
-
-
-def finish_turn_isolated(task_id: int) -> None:
-    """Run finish_turn with a short-lived session owned by this thread."""
-    from ..models.database import get_session_local
-
-    SessionLocal = get_session_local()
-    with SessionLocal() as finalize_db:
-        finish_turn(finalize_db, task_id)
+    # PAUSED / WAITING_FOR_USER / other: preserve the control status while
+    # releasing this exact run's lease. Legacy callers still leave it alone.
+    if task_lease is not None:
+        return commit_terminal(status)
+    return False
 
 
 def _sync_trigger_run_status(bg_db: Any, task: Task, status: TaskStatus) -> bool:
@@ -922,11 +1241,13 @@ def _schedule_bg(
         skipping at the entry means we never even attempt local work
         on a task another worker is executing.
       - heartbeat alongside the run.
-      - release in ``finally`` as the single owner of the release
-        call, regardless of whether ``execute_task_background``
-        returned normally or raised. ``execute_task_background`` only
-        writes ``task.status`` and never touches the lease columns;
-        the scheduler is responsible for the whole lease lifecycle.
+      - release in ``finally`` as the single owner of the release call when
+        execution returns normally or raises a non-pool error.
+        ``execute_task_background`` only writes ``task.status`` and never
+        touches the lease columns; the scheduler is responsible for the whole
+        lease lifecycle. A SQLAlchemy pool checkout timeout is the deliberate
+        exception: heartbeat stops, the exact lease remains intact, and TTL
+        recovery reconciles it without an immediate second checkout.
 
     Takes primitives only (``task_id`` / ``task_owner_user_id`` /
     ``task_source``); the
@@ -936,31 +1257,26 @@ def _schedule_bg(
     from ..api.websocket import background_task_manager, execute_task_background
 
     async def _runner() -> None:
-        # ``bg_db`` is opened lazily inside the post-run finalize block
-        # only. We no longer keep a SessionLocal open across the entire
-        # agent run -- that previously held an idle connection-pool
-        # slot for tens of seconds to minutes (long-running agents)
-        # without doing any work. The lease acquire / heartbeat /
-        # snapshot load all open their own short-lived sessions, and
-        # ``finish_turn`` + release run inside a single ``with`` block
-        # below.
-        from ..models.database import get_session_local
-
-        lease = None
+        lease: TaskLease | None = None
+        stop_event: asyncio.Event | None = None
+        hb_task: asyncio.Task[TaskLeaseHeartbeatOutcome] | None = None
+        settlement_error: str | None = None
+        defer_settlement_to_ttl_recovery = False
+        cleanup_cancellation: asyncio.CancelledError | None = None
         try:
-            # Running-elsewhere short-circuit: acquire lease before
-            # doing anything else. If another worker owns it, skip
-            # execution entirely so finish_turn never touches the row.
-            #
-            # The acquire is a conditional UPDATE + commit that
-            # measured 3.75s of synchronous DB write on the main
-            # event loop (issue #427). ``acquire_task_lease_isolated``
-            # wraps the existing helper with its own SessionLocal so
-            # the work runs on a worker thread.
-            lease = await asyncio.to_thread(
-                acquire_task_lease_isolated,
-                task_id,
-                expected_run_id=run_id,
+            # A cancellation can land after the worker commits but before the
+            # await returns. Drain that worker and settle any late lease before
+            # propagating cancellation, otherwise the task remains RUNNING
+            # with no coroutine that knows it owns the lease.
+            lease = await acquire_task_lease_cancellation_safe(
+                lambda: acquire_task_lease_isolated(
+                    task_id,
+                    expected_run_id=run_id,
+                ),
+                lambda acquired: settle_task_lease_isolated(
+                    acquired,
+                    error_message="task execution cancelled during lease acquisition",
+                ),
             )
             if lease is None:
                 logger.info(
@@ -982,137 +1298,123 @@ def _schedule_bg(
             stop_event = asyncio.Event()
             hb_task = asyncio.create_task(run_task_lease_heartbeat(lease, stop_event))
             try:
-                # Outer ``try/except`` is the lease-acquire-to-terminal
-                # safety net: ``acquire_task_lease_isolated`` already
-                # set ``status=RUNNING`` for this row, so any unhandled
-                # exception from snapshot load / execute_task_background
-                # would leave the task in a zombie state (visible as
-                # running, no active worker) once the release block
-                # below clears ``runner_id``. ``_mark_task_failed_if_running``
-                # closes the window. We swallow the exception so
-                # ``finish_turn`` + lease release still run cleanly with
-                # the now-terminal status.
-                try:
-                    # Load the synchronous DB block on a worker thread
-                    # so the main loop stays responsive. The loader
-                    # opens / closes its own SessionLocal (no ORM
-                    # leak), and the snapshot is passed straight
-                    # through to execute_task_background →
-                    # get_agent_for_task. That turns the previous
-                    # chain of three redundant Task queries into a
-                    # single off-loop read.
-                    snapshot = await asyncio.to_thread(
-                        load_task_setup_snapshot_sync, task_id, task_owner_user_id
-                    )
-                    if snapshot is None:
-                        logger.warning(
-                            "bg task %s aborted: task vanished before snapshot load",
-                            task_id,
-                        )
-                        _mark_task_failed_if_running(
-                            task_id,
-                            "task vanished before snapshot load",
-                            run_id,
-                        )
-                        return
-
-                    await execute_task_background(
-                        task_id=task_id,
-                        user_message=payload.transcript_message,
-                        context=_execution_context_with_turn_id(
-                            context, payload.turn_id
-                        ),
-                        agent_manager=_get_agent_manager(),
-                        task_owner_user_id=task_owner_user_id,
+                # Snapshot and scope resolution each own a short Session in a
+                # worker. Drain either worker if cancellation arrives so final
+                # settlement never races an abandoned pool checkout.
+                snapshot = await run_db_io_cancellation_safe(
+                    lambda: load_task_setup_snapshot_sync(
+                        task_id,
+                        task_owner_user_id,
                         before_message_id=before_message_id,
-                        llm_user_message=payload.execution_message,
-                        task_setup_snapshot=snapshot,
-                        expected_run_id=run_id,
                     )
-                except Exception as setup_or_run_err:
+                )
+                if snapshot is None:
+                    raise RuntimeError("task vanished before snapshot load")
+
+                scope = await run_db_io_cancellation_safe(
+                    lambda: resolve_execution_scope(task_id)
+                )
+                await execute_task_background(
+                    task_id=task_id,
+                    user_message=payload.transcript_message,
+                    context=_execution_context_with_turn_id(context, payload.turn_id),
+                    agent_manager=_get_agent_manager(),
+                    task_owner_user_id=task_owner_user_id,
+                    before_message_id=before_message_id,
+                    llm_user_message=payload.execution_message,
+                    task_setup_snapshot=snapshot,
+                    expected_run_id=run_id,
+                    task_lease=lease,
+                    resolved_execution_scope=scope,
+                )
+            except asyncio.CancelledError:
+                settlement_error = "task execution cancelled"
+                raise
+            except Exception as setup_or_run_err:
+                if is_database_pool_timeout(setup_or_run_err):
+                    # The failed setup/run checkout already waited for the
+                    # exhausted pool. An immediate settlement would perform a
+                    # second checkout against the same exhausted pool. Keep
+                    # the exact run/runner lease intact and let its TTL recovery
+                    # path reconcile the task once capacity returns.
+                    defer_settlement_to_ttl_recovery = True
+                    logger.error(
+                        "task_id=%s component=setup/run database pool checkout "
+                        "timed out; skipping immediate settlement and retaining "
+                        "lease for TTL recovery: %s",
+                        task_id,
+                        setup_or_run_err,
+                        exc_info=True,
+                    )
+                else:
+                    if isinstance(setup_or_run_err, RequiredMCPUnavailableError):
+                        # This exception's string contract is deliberately
+                        # public-safe. Preserve it exactly in the durable task
+                        # and TriggerRun projections; adding the exception type
+                        # would replace the user-facing failure contract even
+                        # though the fenced settlement remains the sole owner of
+                        # the terminal write.
+                        settlement_error = str(setup_or_run_err)
+                    else:
+                        settlement_error = (
+                            "setup/run error: "
+                            f"{type(setup_or_run_err).__name__}: {setup_or_run_err}"
+                        )
                     logger.error(
                         "bg task %s setup/run failed: %s",
                         task_id,
                         setup_or_run_err,
                         exc_info=True,
                     )
-                    _mark_task_failed_if_running(
-                        task_id,
-                        f"setup/run error: "
-                        f"{type(setup_or_run_err).__name__}: {setup_or_run_err}",
-                        run_id,
-                    )
-                    # Do not re-raise: ``finish_turn`` + release below
-                    # must run so the lease is freed and the row is
-                    # not stuck mid-lifecycle.
-
-                # Short-lived finalize session. ``finish_turn`` only
-                # reads / updates the task row once, but the DB work can
-                # still block the event loop under load; run it in a
-                # worker-thread session.
-                try:
-                    await asyncio.to_thread(finish_turn_isolated, task_id)
-                except Exception as e:
-                    logger.error(
-                        "finish_turn failed for task %s: %s",
-                        task_id,
-                        e,
-                        exc_info=True,
-                    )
-            finally:
-                stop_event.set()
-                try:
-                    await hb_task
-                except Exception:
-                    pass
         finally:
             if lease is not None:
-                # Single owner of release. Open a fresh short-lived
-                # session for both the status read and the release UPDATE
-                # so we don't hold a connection across the agent run.
-                # Defensive: if the read raises (DB connectivity issue),
-                # default to FAILED so the lease still gets released
-                # instead of stuck-until-TTL.
-                SessionLocal = get_session_local()
-                with SessionLocal() as release_db:
-                    final_status: TaskStatus = TaskStatus.FAILED
+                try:
+                    heartbeat_outcome = await stop_task_lease_heartbeat(
+                        hb_task, stop_event
+                    )
+                    if (
+                        isinstance(heartbeat_outcome, TaskLeaseHeartbeatOutcome)
+                        and heartbeat_outcome.requires_ttl_recovery
+                    ):
+                        defer_settlement_to_ttl_recovery = True
+                        logger.error(
+                            "task_id=%s component=lease-heartbeat unhealthy "
+                            "at shutdown; skipping immediate settlement and "
+                            "retaining lease for TTL recovery (lost=%s, "
+                            "pool_timeout=%s)",
+                            task_id,
+                            heartbeat_outcome.lease_lost,
+                            heartbeat_outcome.pool_timeout is not None,
+                        )
+                except asyncio.CancelledError as exc:
+                    cleanup_cancellation = exc
+                except Exception:
+                    logger.warning(
+                        "task %s heartbeat shutdown failed",
+                        task_id,
+                        exc_info=True,
+                    )
+
+                if not defer_settlement_to_ttl_recovery:
                     try:
-                        fresh = (
-                            release_db.query(Task).filter(Task.id == task_id).first()
+                        await run_db_io_cancellation_safe(
+                            lambda: settle_task_lease_isolated(
+                                lease,
+                                error_message=settlement_error,
+                            )
                         )
-                        if fresh is not None:
-                            final_status = fresh.status
-                    except Exception as query_err:
-                        logger.warning(
-                            "task %s status read failed during lease release "
-                            "(%s); rolling session back and defaulting to FAILED",
+                    except asyncio.CancelledError as exc:
+                        cleanup_cancellation = cleanup_cancellation or exc
+                    except Exception as settle_err:
+                        # Preserve the concrete lease on failure. Its TTL is the
+                        # recovery path; clearing it here would create an ownerless
+                        # RUNNING row and permit an overlapping execution.
+                        logger.error(
+                            "task %s lease settlement failed: %s; "
+                            "retaining lease for TTL recovery",
                             task_id,
-                            query_err,
-                        )
-                        try:
-                            release_db.rollback()
-                        except Exception:
-                            pass
-                    # Use the workforce-aware release helper: it wraps
-                    # ``release_current_runner_task_lease`` (signature
-                    # unchanged) and additionally syncs the workforce
-                    # run status when the released task belongs to one.
-                    # Both PR #461 (short-open/short-close release_db
-                    # pattern) and PR #528 (workforce sync) compose
-                    # cleanly here -- decorator-style, no perf regression.
-                    try:
-                        release_current_runner_task_lease_with_workforce_sync(
-                            release_db,
-                            task_id,
-                            status=final_status,
-                            expected_run_id=run_id,
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "lease release failed for task %s: %s; "
-                            "TTL expiry will reclaim it",
-                            task_id,
-                            e,
+                            settle_err,
+                            exc_info=True,
                         )
             turn_id = getattr(payload, "turn_id", None)
             try:
@@ -1127,6 +1429,8 @@ def _schedule_bg(
                     turn_id,
                     exc_info=True,
                 )
+            if cleanup_cancellation is not None:
+                raise cleanup_cancellation
 
     bg_task = asyncio.create_task(_runner())
     background_task_manager.register_task(task_id, bg_task)

--- a/src/xagent/web/services/task_setup_snapshot.py
+++ b/src/xagent/web/services/task_setup_snapshot.py
@@ -20,31 +20,31 @@ Background:
     reference past the close would hit ``DetachedInstanceError`` on
     its next attribute access.
 
-Out of scope (first cut, by design):
-    * ``UploadedFile`` selected-files loop -- contains writes
-      (``UploadedFile.task_id`` assignment + ``db.flush()``), so it
-      stays on the main loop with the request session.
-    * ``_load_persisted_conversation_history`` /
-      ``_load_persisted_execution_context`` -- already separate async
-      helpers; can be migrated in a follow-up.
-    * ToolFactory inner DB I/O -- tool subclasses hold ``self._db``;
-      threading the factory requires a session-factory refactor of
-      every tool subclass first.
+Out of scope:
+    * ``UploadedFile`` selected-files binding -- contains writes and is
+      therefore handled by its own worker-owned Session during agent
+      bootstrap instead of being folded into this read-only snapshot.
     * MCP server configs -- async + OAuth refresh path.
 """
 
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from sqlalchemy.orm import Session
 
 from ...core.model.chat.basic.base import BaseLLM
 from ..models.database import get_session_local
-from ..models.task import Task
+from ..models.task import DAGExecution, Task, TraceEvent
+from ..models.user import User
 from .llm_utils import AgentRuntimeFields
+from .task_execution_context_service import (
+    TaskExecutionRecoverySnapshot,
+    load_task_execution_recovery_snapshot_sync,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,28 @@ class _TaskFields:
     execution_mode: Optional[str]
     agent_type: Optional[str]
     source: str | None = None
+    run_id: str | None = None
+    state_version: int = 0
+    control_state: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeUserFields:
+    """Primitive runtime identity required while an agent is constructed."""
+
+    id: int
+    is_admin: bool
+
+
+@dataclass(frozen=True)
+class TaskReconstructionSnapshot:
+    """Detached historical state consumed by agent reconstruction."""
+
+    tracer_events: tuple[dict[str, Any], ...] = ()
+    plan_state: Optional[dict[str, Any]] = None
+    # Preserve the legacy retry pre-check: any runtime TraceEvent or
+    # DAGExecution row attempts reconstruction, even when current_plan is empty.
+    has_history: bool = False
 
 
 @dataclass(frozen=True)
@@ -77,6 +99,8 @@ class TaskSetupSnapshot:
     """
 
     task: _TaskFields
+    runtime_user: Optional[RuntimeUserFields]
+    has_reconstructable_history: bool
     task_pattern: str
     # Final resolved LLMs after the agent-builder override (if any).
     task_llm: Optional[BaseLLM]
@@ -91,6 +115,12 @@ class TaskSetupSnapshot:
     agent: Optional[AgentRuntimeFields]
     agent_config: Optional[dict]
     excluded_agent_id: Optional[int]
+    conversation_history: tuple[dict[str, str], ...] = ()
+    execution_recovery: TaskExecutionRecoverySnapshot = TaskExecutionRecoverySnapshot()
+    reconstruction: TaskReconstructionSnapshot = TaskReconstructionSnapshot()
+    # Resolved by ``resolve_task_runtime_config_core`` using this same Session.
+    # Kept as the service-layer frozen dataclass; no ORM row is retained.
+    workforce_runtime: Any = None
 
 
 # NOTE: All LLM resolution + agent-builder merge + execution-mode →
@@ -102,9 +132,8 @@ class TaskSetupSnapshot:
 #      ``_TaskFields`` so nothing escapes the loader's session
 #      (``Agent`` primitives are already provided by the core as an
 #      ``AgentRuntimeFields`` instance).
-# The main-loop reconstruct path (``_resolve_task_runtime_config`` in
-# chat.py) calls the same core directly, since it doesn't need the
-# primitive wrapping and runs inside the request session's lifetime.
+# Reconstruction and normal creation both consume this detached snapshot;
+# neither path re-resolves runtime configuration from a request Session.
 
 
 class TaskOwnerMismatchError(Exception):
@@ -123,9 +152,93 @@ class TaskOwnerMismatchError(Exception):
         self.actual = actual
 
 
+def load_task_reconstruction_snapshot_sync(
+    session: Session,
+    task_id: int,
+) -> TaskReconstructionSnapshot:
+    """Load and decode reconstruction rows before the worker Session closes."""
+    from .trace_message_storage import decode_trace_events_data
+
+    trace_rows = (
+        session.query(TraceEvent)
+        .filter(
+            TraceEvent.task_id == task_id,
+            TraceEvent.build_id.is_(None),
+        )
+        .all()
+    )
+    decoded_data = decode_trace_events_data(
+        session,
+        task_id=task_id,
+        data_items=[row.data for row in trace_rows],
+        strict=False,
+    )
+    tracer_events = tuple(
+        {
+            "id": str(row.event_id),
+            "event_type": str(row.event_type),
+            "task_id": str(row.task_id),
+            "step_id": str(row.step_id) if row.step_id is not None else None,
+            "timestamp": row.timestamp.timestamp() if row.timestamp else None,
+            "data": deepcopy(data),
+            "parent_id": (
+                str(row.parent_event_id) if row.parent_event_id is not None else None
+            ),
+        }
+        for row, data in zip(trace_rows, decoded_data)
+    )
+
+    dag_row = (
+        session.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+    )
+    plan_state = (
+        deepcopy(cast(dict[str, Any], dag_row.current_plan))
+        if dag_row is not None and dag_row.current_plan
+        else None
+    )
+    return TaskReconstructionSnapshot(
+        tracer_events=tracer_events,
+        plan_state=plan_state,
+        has_history=bool(trace_rows) or dag_row is not None,
+    )
+
+
+def _resolve_inline_preview_excluded_agent_id(
+    session: Session,
+    task_row: Task,
+    agent_config: Optional[dict],
+) -> Optional[int]:
+    """Resolve the published preview agent with the legacy owner/team rule."""
+    if not agent_config or not agent_config.get("preview_agent_id"):
+        return None
+
+    from ..models.agent import Agent, AgentStatus
+    from .agent_team_scope import get_agent_team_scope, owned_agent_clause
+
+    owner_user_id = int(task_row.user_id)
+    preview_agent = (
+        session.query(Agent)
+        .filter(
+            Agent.id == agent_config["preview_agent_id"],
+            owned_agent_clause(
+                owner_user_id,
+                get_agent_team_scope(session, owner_user_id),
+            ),
+        )
+        .first()
+    )
+    if preview_agent is None or preview_agent.status != AgentStatus.PUBLISHED:
+        return None
+    return int(preview_agent.id)
+
+
 def load_task_setup_snapshot_sync(
     task_id: int,
     task_owner_user_id: Optional[int],
+    *,
+    before_message_id: Optional[int] = None,
+    actor_user_id: Optional[int] = None,
+    actor_is_admin: bool = False,
 ) -> Optional[TaskSetupSnapshot]:
     """Open a dedicated ``SessionLocal``, read every synchronous field
     ``get_agent_for_task`` needs for normal (non-reconstruct) creation,
@@ -150,13 +263,30 @@ def load_task_setup_snapshot_sync(
     session_factory = get_session_local()
     session: Session = session_factory()
     try:
-        task_row = session.query(Task).filter(Task.id == task_id).first()
+        task_query = session.query(Task).filter(Task.id == task_id)
+        if actor_user_id is not None and not actor_is_admin:
+            task_query = task_query.filter(Task.user_id == actor_user_id)
+        task_row = task_query.first()
         if task_row is None:
             return None
 
         owner_user_id = int(task_row.user_id)
         if task_owner_user_id is not None and owner_user_id != task_owner_user_id:
             raise TaskOwnerMismatchError(task_id, task_owner_user_id, owner_user_id)
+
+        runtime_user_row = (
+            session.query(User.id, User.is_admin)
+            .filter(User.id == owner_user_id)
+            .first()
+        )
+        runtime_user = (
+            RuntimeUserFields(
+                id=int(runtime_user_row[0]),
+                is_admin=bool(runtime_user_row[1]),
+            )
+            if runtime_user_row is not None
+            else None
+        )
 
         task_fields = _TaskFields(
             id=int(task_row.id),
@@ -181,6 +311,13 @@ def load_task_setup_snapshot_sync(
             agent_type=(
                 str(task_row.agent_type) if task_row.agent_type is not None else None
             ),
+            run_id=str(task_row.run_id) if task_row.run_id is not None else None,
+            state_version=int(task_row.state_version or 0),
+            control_state=(
+                str(task_row.control_state)
+                if task_row.control_state is not None
+                else None
+            ),
         )
 
         # Runtime resolution always uses the row's OWNER, never the passed
@@ -189,11 +326,35 @@ def load_task_setup_snapshot_sync(
             task_row, session, user_id=owner_user_id
         )
         task_llm, task_fast_llm, task_vision_llm, task_compact_llm = core.llms
+        excluded_agent_id = core.excluded_agent_id
+        if excluded_agent_id is None:
+            excluded_agent_id = _resolve_inline_preview_excluded_agent_id(
+                session,
+                task_row,
+                core.agent_config,
+            )
+
+        from .chat_history_service import load_task_transcript
+
+        conversation_history = tuple(
+            load_task_transcript(
+                session,
+                task_id,
+                before_message_id=before_message_id,
+            )
+        )
+        execution_recovery = load_task_execution_recovery_snapshot_sync(
+            session,
+            task_id,
+        )
+        reconstruction = load_task_reconstruction_snapshot_sync(session, task_id)
 
         # ``core.agent_fields`` is already an ``AgentRuntimeFields``
         # frozen dataclass; pass it through directly.
         return TaskSetupSnapshot(
             task=task_fields,
+            runtime_user=runtime_user,
+            has_reconstructable_history=reconstruction.has_history,
             task_pattern=core.task_pattern,
             task_llm=task_llm,
             task_fast_llm=task_fast_llm,
@@ -201,7 +362,11 @@ def load_task_setup_snapshot_sync(
             task_compact_llm=task_compact_llm,
             agent=core.agent_fields,
             agent_config=core.agent_config,
-            excluded_agent_id=core.excluded_agent_id,
+            excluded_agent_id=excluded_agent_id,
+            conversation_history=conversation_history,
+            execution_recovery=execution_recovery,
+            reconstruction=reconstruction,
+            workforce_runtime=deepcopy(core.workforce),
         )
     finally:
         session.close()

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -58,6 +58,14 @@ def get_user_tool_allowlist(db: Session, user: Any) -> list[str] | None:
     return None
 
 
+def has_user_tool_policy_hooks() -> bool:
+    """Return whether an application registered either runtime policy hook."""
+    return (
+        _get_user_tool_overrides_hook is not None
+        or _get_user_tool_allowlist_hook is not None
+    )
+
+
 TOOL_CREDENTIAL_SPECS: dict[str, dict[str, ToolFieldSpec]] = {
     "exa_web_search": {
         "api_key": {

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -788,7 +788,9 @@ def _attach_task_to_trigger_run(
     task_owner_user_id = int(trigger.user_id)
     runtime_plan = prepare_create_connector_runtime(
         db=db,
-        agent=agent,
+        tool_categories=(
+            agent.tool_categories if isinstance(agent.tool_categories, list) else None
+        ),
         task_source=task_source,
         connector_user_id=task_owner_user_id,
         payload_items=_trigger_connector_runtime_payload(trigger.config),

--- a/src/xagent/web/services/uploaded_file_store.py
+++ b/src/xagent/web/services/uploaded_file_store.py
@@ -2,17 +2,140 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
 from ...config import get_storage_root
+from ...core.file_storage import get_user_file_storage
+from ..models.database import get_session_local
 from ..models.uploaded_file import UploadedFile
 from .managed_file_ref import ManagedFileRef, guess_media_type
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedUploadedFile:
+    """Detached durable-upload metadata ready for one database transaction."""
+
+    file_id: str
+    user_id: int
+    task_id: int | None
+    filename: str
+    storage_path: str
+    storage_backend: str | None
+    storage_key: str
+    storage_uri: str | None
+    checksum: str
+    etag: str | None
+    mime_type: str | None
+    file_size: int
+    storage_status: str
+
+
+def prepare_uploaded_file_from_local_path(
+    *,
+    local_path: Path,
+    user_id: int,
+    filename: str,
+    file_id: str,
+    task_id: int | None,
+    mime_type: str | None,
+    storage_key: str | None = None,
+) -> PreparedUploadedFile:
+    """Write one local upload to durable storage without opening a DB session."""
+    record = create_unbound_uploaded_file_from_local_path(
+        local_path=local_path,
+        user_id=user_id,
+        filename=filename,
+        file_id=file_id,
+        task_id=task_id,
+        mime_type=mime_type,
+        storage_key=storage_key,
+    )
+    storage_key = getattr(record, "storage_key", None)
+    checksum = getattr(record, "checksum", None)
+    if not storage_key or not checksum:
+        raise RuntimeError("Durable upload metadata is incomplete")
+    return PreparedUploadedFile(
+        file_id=str(record.file_id),
+        user_id=int(record.user_id),
+        task_id=(None if record.task_id is None else int(record.task_id)),
+        filename=str(record.filename),
+        storage_path=str(record.storage_path),
+        storage_backend=(
+            None
+            if getattr(record, "storage_backend", None) is None
+            else str(record.storage_backend)
+        ),
+        storage_key=str(storage_key),
+        storage_uri=(
+            None
+            if getattr(record, "storage_uri", None) is None
+            else str(record.storage_uri)
+        ),
+        checksum=str(checksum),
+        etag=(None if getattr(record, "etag", None) is None else str(record.etag)),
+        mime_type=(
+            None
+            if getattr(record, "mime_type", None) is None
+            else str(record.mime_type)
+        ),
+        file_size=int(record.file_size),
+        storage_status=str(record.storage_status),
+    )
+
+
+def persist_prepared_uploaded_files(
+    files: Sequence[PreparedUploadedFile],
+) -> tuple[PreparedUploadedFile, ...]:
+    """Persist a prepared batch using a short, worker-owned transaction."""
+    session_factory = get_session_local()
+    with session_factory() as db:
+        try:
+            for item in files:
+                db.add(
+                    UploadedFile(
+                        file_id=item.file_id,
+                        user_id=item.user_id,
+                        task_id=item.task_id,
+                        filename=item.filename,
+                        storage_path=item.storage_path,
+                        storage_backend=item.storage_backend,
+                        storage_key=item.storage_key,
+                        storage_uri=item.storage_uri,
+                        checksum=item.checksum,
+                        etag=item.etag,
+                        mime_type=item.mime_type,
+                        file_size=item.file_size,
+                        storage_status=item.storage_status,
+                    )
+                )
+            db.commit()
+        except BaseException:
+            db.rollback()
+            raise
+    return tuple(files)
+
+
+def delete_prepared_uploaded_files_durable(
+    files: Sequence[PreparedUploadedFile],
+) -> None:
+    """Compensate durable objects for a batch that was not persisted."""
+    delete_durable_upload_keys([(item.user_id, item.storage_key) for item in files])
+
+
+def delete_durable_upload_keys(keys: Sequence[tuple[int, str]]) -> None:
+    """Delete known durable upload keys during transaction compensation."""
+    for user_id, storage_key in keys:
+        try:
+            get_user_file_storage(user_id).delete(storage_key)
+        except Exception:
+            logger.warning("Failed to clean up durable upload: %s", storage_key)
 
 
 def delete_pptx_pdf_cache(file_id: str) -> None:

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from xagent.web.models.database import release_db_connection_if_clean
 from xagent.web.models.task import ExecutionMode, Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -176,13 +177,20 @@ async def create_workforce_run(
     db.refresh(task)
     db.refresh(workforce_run)
     task_id = int(task.id)
+    task_owner_user_id = int(user.id)
+
+    # ``begin_turn`` owns a separate worker-thread Session. End the clean
+    # post-refresh request transaction first so its checkout cannot starve the
+    # orchestrator's atomic claim when the pool has only one free slot.
+    if not release_db_connection_if_clean(db):
+        raise RuntimeError("request DB transaction is not clean at turn boundary")
 
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=task_id,
-            task_owner_user_id=int(user.id),
+            task_owner_user_id=task_owner_user_id,
             # Workforce runs as the requesting user; actor == owner here.
-            actor_user_id=int(user.id),
+            actor_user_id=task_owner_user_id,
             payload=TaskTurnPayload(transcript_message=normalized_message),
             kind=TurnKind.CREATE,
             force_fresh=False,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -38,9 +38,11 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     runtime_bindings_from_config,
 )
 from ..services.tool_credentials import (
+    TOOL_CREDENTIAL_SPECS,
     get_sql_connection_map,
     get_user_tool_allowlist,
     get_user_tool_overrides,
+    has_user_tool_policy_hooks,
     resolve_tool_credential,
 )
 
@@ -197,6 +199,71 @@ class _OAuthLaunchConfigInvalid(Exception):
     def __init__(self, *, field: str) -> None:
         super().__init__(field)
         self.field = field
+
+
+@dataclass(frozen=True)
+class _ToolFactoryRuntimeLoadPlan:
+    """Detached inputs describing the synchronous factory reads to prefetch."""
+
+    user_id: int | None
+    task_id: str | None
+    connector_runtime_turn_id: str | None
+    load_policy: bool
+    load_basic: bool
+    load_sql: bool
+    load_custom_api: bool
+    load_vision: bool
+    load_image: bool
+    load_video: bool
+    load_audio: bool
+    published_agent_policy: Any | None
+
+    @property
+    def requires_direct_db(self) -> bool:
+        return any(
+            (
+                self.load_policy,
+                self.load_basic,
+                self.load_sql,
+                self.load_custom_api,
+                self.load_vision,
+                self.load_image,
+                self.load_video,
+                self.load_audio,
+                (
+                    self.published_agent_policy is not None
+                    and self.published_agent_policy.query_required
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _ToolFactoryRuntimeSnapshot:
+    """Worker-produced values consumed synchronously by tool creators."""
+
+    plan: _ToolFactoryRuntimeLoadPlan
+    tool_credentials: dict[tuple[str, str], str | None] = field(default_factory=dict)
+    sql_connections: dict[str, str] = field(default_factory=dict)
+    failed_inputs: frozenset[str] = frozenset()
+    custom_api_configs: list[dict[str, Any]] = field(default_factory=list)
+    tool_overrides: dict[str, Any] = field(default_factory=dict)
+    tool_allowlist: list[str] | None = None
+    vision_model: Any | None = None
+    image_models: dict[str, Any] = field(default_factory=dict)
+    image_generate_model: Any | None = None
+    image_edit_model: Any | None = None
+    video_models: dict[str, Any] = field(default_factory=dict)
+    video_model: Any | None = None
+    asr_models: dict[str, Any] = field(default_factory=dict)
+    asr_model: Any | None = None
+    tts_models: dict[str, Any] = field(default_factory=dict)
+    tts_model: Any | None = None
+    sound_effect_models: dict[str, Any] = field(default_factory=dict)
+    sound_effect_model: Any | None = None
+    music_models: dict[str, Any] = field(default_factory=dict)
+    music_model: Any | None = None
+    published_agent_records: list[Any] = field(default_factory=list)
 
 
 def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
@@ -443,6 +510,389 @@ async def refresh_oauth_token_if_needed(
     return False
 
 
+def _parse_custom_api_task_id(task_id: str | None) -> int | None:
+    if not isinstance(task_id, str) or not task_id:
+        return None
+    if task_id.startswith("web_task_"):
+        task_id = task_id.removeprefix("web_task_")
+    try:
+        return int(task_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_custom_api_runtime_view_sync(
+    db: Any,
+    *,
+    task_id: str | None,
+    connector_runtime_turn_id: str | None,
+    user_id: int | None,
+) -> dict[str, Any]:
+    numeric_task_id = _parse_custom_api_task_id(task_id)
+    if numeric_task_id is None or user_id is None:
+        return {}
+    try:
+        from ..services.connector_runtime import load_connector_runtime_view
+
+        return load_connector_runtime_view(
+            db=db,
+            task_id=numeric_task_id,
+            turn_id=connector_runtime_turn_id,
+            user_id=user_id,
+        )
+    except ConnectorRuntimeError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve connector runtime view for task %s",
+            task_id,
+            exc_info=True,
+        )
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector runtime context is unavailable.",
+            details={"reason": "runtime_view_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
+def _load_custom_api_factory_inputs(
+    db: Any,
+    *,
+    user_id: int | None,
+    task_id: str | None,
+    connector_runtime_turn_id: str | None,
+) -> list[dict[str, Any]]:
+    if user_id is None:
+        return []
+
+    from ..models.custom_api import UserCustomApi
+
+    user_apis = (
+        db.query(UserCustomApi)
+        .filter(
+            UserCustomApi.user_id == user_id,
+            UserCustomApi.is_active,
+        )
+        .all()
+    )
+    if not user_apis:
+        return []
+
+    runtime_view = _load_custom_api_runtime_view_sync(
+        db,
+        task_id=task_id,
+        connector_runtime_turn_id=connector_runtime_turn_id,
+        user_id=user_id,
+    )
+    configs: list[dict[str, Any]] = []
+    for user_api in user_apis:
+        api = user_api.custom_api
+        if api is None:
+            continue
+        runtime_values = runtime_view.get(f"custom_api:{int(api.id)}")
+        configs.append(
+            _custom_api_config_from_model(
+                api,
+                dict(runtime_values) if isinstance(runtime_values, dict) else None,
+            )
+        )
+    return configs
+
+
+def _custom_api_config_from_model(
+    api: Any,
+    connector_runtime: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "id": int(api.id),
+        "name": api.name,
+        "description": api.description or "",
+        "url": api.url,
+        "method": api.method or "GET",
+        "headers": api.headers or {},
+        "body": api.body,
+        "env": api.env or {},
+        "runtime_input_schema": getattr(api, "runtime_input_schema", None),
+        "runtime_bindings": getattr(api, "runtime_bindings", None),
+        "allow_delegated_authorization": bool(
+            getattr(api, "allow_delegated_authorization", False)
+        ),
+        "connector_runtime": connector_runtime,
+    }
+
+
+def _load_tool_factory_runtime_snapshot(
+    session_factory: Any,
+    plan: _ToolFactoryRuntimeLoadPlan,
+) -> _ToolFactoryRuntimeSnapshot:
+    """Load factory-only DB inputs using worker-owned sessions.
+
+    This function accepts only a session factory plus detached scalar policy. It
+    never receives the caller's ``WebToolConfig``, request Session, or ORM user.
+    """
+    from ..services.db_runtime import is_database_pool_timeout
+
+    tool_credentials: dict[tuple[str, str], str | None] = {}
+    sql_connections: dict[str, str] = {}
+    failed_inputs: set[str] = set()
+    custom_api_configs: list[dict[str, Any]] = []
+    tool_overrides: dict[str, Any] = {}
+    tool_allowlist: list[str] | None = None
+    vision_model: Any | None = None
+    image_models: dict[str, Any] = {}
+    image_generate_model: Any | None = None
+    image_edit_model: Any | None = None
+    video_models: dict[str, Any] = {}
+    video_model: Any | None = None
+    asr_models: dict[str, Any] = {}
+    asr_model: Any | None = None
+    tts_models: dict[str, Any] = {}
+    tts_model: Any | None = None
+    sound_effect_models: dict[str, Any] = {}
+    sound_effect_model: Any | None = None
+    music_models: dict[str, Any] = {}
+    music_model: Any | None = None
+    published_agent_records: list[Any] = []
+
+    def load_optional_input(
+        input_name: str,
+        loader: Callable[[], Any],
+        default: Any,
+    ) -> Any:
+        try:
+            return loader()
+        except Exception as exc:
+            if is_database_pool_timeout(exc):
+                raise
+            logger.warning(
+                "Failed to prefetch %s tool input",
+                input_name,
+                exc_info=True,
+            )
+            return default
+
+    db = None
+    if plan.requires_direct_db:
+        db = session_factory()
+        try:
+            # Fail before creator-level broad exception handling can turn a
+            # saturated QueuePool into an empty/partial tool set.
+            db.connection()
+
+            if plan.load_policy and plan.user_id is not None:
+                from ..models.user import User
+
+                user = db.query(User).filter(User.id == plan.user_id).first()
+                if user is not None:
+                    try:
+                        overrides = get_user_tool_overrides(db, user)
+                        if isinstance(overrides, dict):
+                            tool_overrides = dict(overrides)
+                    except Exception:
+                        logger.exception("Failed to get user tool overrides")
+                    try:
+                        tool_allowlist = normalize_tool_allowlist(
+                            get_user_tool_allowlist(db, user)
+                        )
+                    except Exception:
+                        logger.exception("Failed to get user tool allowlist")
+
+            if plan.load_basic:
+                try:
+                    for tool_name, field_specs in TOOL_CREDENTIAL_SPECS.items():
+                        for field_name in field_specs:
+                            tool_credentials[(tool_name, field_name)] = (
+                                resolve_tool_credential(db, tool_name, field_name)
+                            )
+                except Exception as exc:
+                    if is_database_pool_timeout(exc):
+                        raise
+                    failed_inputs.add("basic")
+                    logger.warning(
+                        "Failed to prefetch tool credentials",
+                        exc_info=True,
+                    )
+
+            if plan.load_sql:
+                try:
+                    sql_connections = get_sql_connection_map(db, plan.user_id)
+                except Exception as exc:
+                    if is_database_pool_timeout(exc):
+                        raise
+                    failed_inputs.add("database")
+                    logger.warning(
+                        "Failed to prefetch SQL connections",
+                        exc_info=True,
+                    )
+
+            if plan.load_custom_api:
+                try:
+                    custom_api_configs = _load_custom_api_factory_inputs(
+                        db,
+                        user_id=plan.user_id,
+                        task_id=plan.task_id,
+                        connector_runtime_turn_id=plan.connector_runtime_turn_id,
+                    )
+                except ConnectorRuntimeError:
+                    raise
+                except Exception as exc:
+                    if is_database_pool_timeout(exc):
+                        raise
+                    logger.error(
+                        "Failed to get Custom API configs from database: %s",
+                        exc,
+                        exc_info=True,
+                    )
+
+            if (
+                plan.published_agent_policy is not None
+                and plan.published_agent_policy.query_required
+                and plan.user_id is not None
+            ):
+                try:
+                    from ...core.tools.adapters.vibe.agent_tool import (
+                        load_published_agent_tool_records,
+                    )
+
+                    published_agent_records = load_published_agent_tool_records(
+                        db,
+                        user_id=plan.user_id,
+                        policy=plan.published_agent_policy,
+                    )
+                except Exception as exc:
+                    if is_database_pool_timeout(exc):
+                        raise
+                    logger.warning(
+                        "Failed to prefetch published-agent tools",
+                        exc_info=True,
+                    )
+
+            from ..services import model_service
+
+            if plan.load_image:
+                image_models = load_optional_input(
+                    "image",
+                    lambda: model_service.get_image_models(db, plan.user_id),
+                    {},
+                )
+            if plan.load_video:
+                video_models = load_optional_input(
+                    "video",
+                    lambda: model_service.get_video_models(db, plan.user_id),
+                    {},
+                )
+            if plan.load_audio:
+                asr_models = load_optional_input(
+                    "audio",
+                    lambda: model_service.get_asr_models(db, plan.user_id),
+                    {},
+                )
+                tts_models = load_optional_input(
+                    "audio",
+                    lambda: model_service.get_tts_models(db, plan.user_id),
+                    {},
+                )
+                sound_effect_models = load_optional_input(
+                    "audio",
+                    lambda: model_service.get_sound_effect_models(db, plan.user_id),
+                    {},
+                )
+                music_models = load_optional_input(
+                    "audio",
+                    lambda: model_service.get_music_models(db, plan.user_id),
+                    {},
+                )
+
+            if plan.load_vision:
+                vision_model = load_optional_input(
+                    "vision",
+                    lambda: model_service.get_default_vision_model(plan.user_id, db=db),
+                    None,
+                )
+            if plan.load_image and image_models:
+                image_generate_model = load_optional_input(
+                    "image",
+                    lambda: model_service.get_default_image_generate_model(
+                        plan.user_id, db=db
+                    ),
+                    None,
+                )
+                image_edit_model = load_optional_input(
+                    "image",
+                    lambda: model_service.get_default_image_edit_model(
+                        plan.user_id, db=db
+                    ),
+                    None,
+                )
+            if plan.load_video and video_models:
+                video_model = load_optional_input(
+                    "video",
+                    lambda: model_service.get_default_video_model(plan.user_id, db=db),
+                    None,
+                )
+            if plan.load_audio:
+                if asr_models or tts_models:
+                    asr_model = load_optional_input(
+                        "audio",
+                        lambda: model_service.get_default_asr_model(
+                            plan.user_id, db=db
+                        ),
+                        None,
+                    )
+                    tts_model = load_optional_input(
+                        "audio",
+                        lambda: model_service.get_default_tts_model(
+                            plan.user_id, db=db
+                        ),
+                        None,
+                    )
+                if sound_effect_models:
+                    sound_effect_model = load_optional_input(
+                        "audio",
+                        lambda: model_service.get_default_sound_effect_model(
+                            plan.user_id, db=db
+                        ),
+                        None,
+                    )
+                if music_models:
+                    music_model = load_optional_input(
+                        "audio",
+                        lambda: model_service.get_default_music_model(
+                            plan.user_id, db=db
+                        ),
+                        None,
+                    )
+        finally:
+            if db is not None:
+                db.close()
+
+    return _ToolFactoryRuntimeSnapshot(
+        plan=plan,
+        tool_credentials=tool_credentials,
+        sql_connections=sql_connections,
+        failed_inputs=frozenset(failed_inputs),
+        custom_api_configs=custom_api_configs,
+        tool_overrides=tool_overrides,
+        tool_allowlist=tool_allowlist,
+        vision_model=vision_model,
+        image_models=image_models,
+        image_generate_model=image_generate_model,
+        image_edit_model=image_edit_model,
+        video_models=video_models,
+        video_model=video_model,
+        asr_models=asr_models,
+        asr_model=asr_model,
+        tts_models=tts_models,
+        tts_model=tts_model,
+        sound_effect_models=sound_effect_models,
+        sound_effect_model=sound_effect_model,
+        music_models=music_models,
+        music_model=music_model,
+        published_agent_records=published_agent_records,
+    )
+
+
 class WebToolConfig(BaseToolConfig):
     """Web-specific tool configuration that loads from database."""
 
@@ -602,6 +1052,8 @@ class WebToolConfig(BaseToolConfig):
         self._mcp_hook_resolution_failed = False
         self._cached_embedding_model: Optional[str] = None
         self._cached_rerank_model: Optional[str] = None
+        self._factory_runtime_snapshot: _ToolFactoryRuntimeSnapshot | None = None
+        self._factory_runtime_snapshot_pending_build = False
 
     def _build_mcp_file_allowed_dirs(self) -> str:
         """Build comma-separated file roots that local MCP tools may read."""
@@ -684,36 +1136,54 @@ class WebToolConfig(BaseToolConfig):
         if hasattr(self, "_explicit_vision_model") and self._explicit_vision_model:
             return self._explicit_vision_model
 
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_vision:
+            return snapshot.vision_model
         if self._cached_vision_config is None:
             self._cached_vision_config = self._load_vision_model()
         return self._cached_vision_config
 
     def get_image_models(self) -> Dict[str, Any]:
         """Load image models from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_image:
+            return snapshot.image_models
         if self._cached_image_configs is None:
             self._cached_image_configs = self._load_image_models()
         return self._cached_image_configs
 
     def get_video_models(self) -> Dict[str, Any]:
         """Load video models from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_video:
+            return snapshot.video_models
         if self._cached_video_configs is None:
             self._cached_video_configs = self._load_video_models()
         return self._cached_video_configs
 
     def get_image_generate_model(self) -> Optional[Any]:
         """Get default image generation model from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_image:
+            return snapshot.image_generate_model
         if self._cached_image_generate_model is None:
             self._cached_image_generate_model = self._load_image_generate_model()
         return self._cached_image_generate_model
 
     def get_image_edit_model(self) -> Optional[Any]:
         """Get default image editing model from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_image:
+            return snapshot.image_edit_model
         if self._cached_image_edit_model is None:
             self._cached_image_edit_model = self._load_image_edit_model()
         return self._cached_image_edit_model
 
     def get_video_model(self) -> Optional[Any]:
         """Get default video generation model from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_video:
+            return snapshot.video_model
         if self._cached_video_model is None:
             self._cached_video_model = self._load_video_model()
         return self._cached_video_model
@@ -825,6 +1295,8 @@ class WebToolConfig(BaseToolConfig):
         self._connector_runtime_turn_id = normalized_turn_id
         self._connector_runtime_view = None
         self._cached_mcp_configs = None
+        self._factory_runtime_snapshot = None
+        self._factory_runtime_snapshot_pending_build = False
         return True
 
     def _parse_numeric_task_id(self) -> Optional[int]:
@@ -1045,6 +1517,13 @@ class WebToolConfig(BaseToolConfig):
         """Get per-agent tool metadata/runtime overrides for delegation."""
         return self._agent_tool_overrides
 
+    def get_published_agent_tool_records(self) -> Optional[List[Any]]:
+        """Return worker-prefetched, ORM-free published-agent rows."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is None or snapshot.plan.published_agent_policy is None:
+            return None
+        return list(snapshot.published_agent_records)
+
     def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
         """Get remote A2A agent tool configurations."""
         return self._a2a_agent_configs
@@ -1086,6 +1565,128 @@ class WebToolConfig(BaseToolConfig):
             logger.exception("Failed to get user tool overrides")
             self._cached_tool_overrides = {}
         return self._cached_tool_overrides
+
+    def _build_factory_runtime_load_plan(self) -> _ToolFactoryRuntimeLoadPlan:
+        spec = self._tool_selection_spec
+
+        def wants_category(category: str) -> bool:
+            if spec is None:
+                return True
+            includes_category = getattr(spec, "includes_category", None)
+            if callable(includes_category):
+                return bool(includes_category(category))
+            return True
+
+        includes_custom_api = (
+            getattr(spec, "includes_custom_api", None) if spec is not None else None
+        )
+        includes_published_agent = (
+            getattr(spec, "includes_published_agent", None)
+            if spec is not None
+            else None
+        )
+        published_agent_policy = None
+        if (
+            self._user_id
+            and self.get_enable_agent_tools()
+            and (
+                spec is None
+                or not callable(includes_published_agent)
+                or bool(includes_published_agent())
+            )
+        ):
+            from ...core.tools.adapters.vibe.agent_tool import (
+                build_published_agent_tool_query_policy,
+            )
+
+            published_agent_policy = build_published_agent_tool_query_policy(
+                excluded_agent_id=self.get_excluded_agent_id(),
+                include_draft=False,
+                allowed_agent_ids=self.get_allowed_agent_ids(),
+                agent_tool_overrides=self.get_agent_tool_overrides(),
+                enable_global_agent_tools=self.get_enable_global_agent_tools(),
+                allow_cross_user_agent_ids=self.get_allow_cross_user_agent_ids(),
+                agent_call_stack=self.get_agent_call_stack(),
+            )
+        return _ToolFactoryRuntimeLoadPlan(
+            user_id=int(self._user_id) if self._user_id is not None else None,
+            task_id=self._task_id,
+            connector_runtime_turn_id=self._connector_runtime_turn_id,
+            load_policy=(self._user_id is not None and has_user_tool_policy_hooks()),
+            load_basic=(wants_category("basic") or wants_category("web_search")),
+            load_sql=wants_category("database"),
+            load_custom_api=(
+                True
+                if spec is None or not callable(includes_custom_api)
+                else bool(includes_custom_api())
+            ),
+            load_vision=(
+                wants_category("vision") and not bool(self._explicit_vision_model)
+            ),
+            load_image=wants_category("image"),
+            load_video=wants_category("video"),
+            load_audio=wants_category("audio"),
+            published_agent_policy=published_agent_policy,
+        )
+
+    def _apply_factory_runtime_snapshot(
+        self, snapshot: _ToolFactoryRuntimeSnapshot
+    ) -> None:
+        self._factory_runtime_snapshot = snapshot
+        self._cached_tool_overrides = snapshot.tool_overrides
+        self._cached_tool_allowlist = snapshot.tool_allowlist
+        self._tool_allowlist_cached = True
+
+    async def prepare_factory_runtime(self, *, force: bool = False) -> None:
+        """Prefetch synchronous ToolFactory inputs without blocking its loop.
+
+        The worker receives only a session factory and a detached load plan. It
+        owns and closes every Session it creates; the request Session and ORM
+        user retained by this config never cross the thread boundary.
+        """
+        if self._db_factory is None:
+            from sqlalchemy.orm import Session
+
+            # Some standalone/test configs supply duck-typed DB objects rather
+            # than a real SQLAlchemy Session. They retain the legacy synchronous
+            # getter contract; there is no safe engine from which to mint a
+            # worker-owned Session.
+            if not isinstance(self._live_db, Session):
+                return
+
+        plan = self._build_factory_runtime_load_plan()
+        current = self._factory_runtime_snapshot
+        if (
+            not force
+            and self._factory_runtime_snapshot_pending_build
+            and current is not None
+            and current.plan == plan
+        ):
+            self._factory_runtime_snapshot_pending_build = False
+            return
+
+        from ..services.db_runtime import run_db_io_cancellation_safe
+
+        snapshot = await run_db_io_cancellation_safe(
+            lambda: _load_tool_factory_runtime_snapshot(
+                self.get_session_factory(),
+                plan,
+            )
+        )
+        self._apply_factory_runtime_snapshot(snapshot)
+        # ``refresh_runtime_policy`` may prepare the immediately following
+        # factory build. A direct/repeated ToolFactory call always reloads;
+        # this detached state is not a persistent runtime cache.
+        self._factory_runtime_snapshot_pending_build = force
+
+    def release_prepared_factory_runtime(self) -> None:
+        """Discard construction-only detached state after a factory build."""
+        self._factory_runtime_snapshot = None
+        self._factory_runtime_snapshot_pending_build = False
+
+    async def refresh_runtime_policy(self) -> None:
+        """Refresh the per-turn tool-policy and factory input snapshot."""
+        await self.prepare_factory_runtime(force=True)
 
     def refresh_user_tool_overrides(self) -> dict:
         """Reload per-user tool overrides from the registered hook."""
@@ -1133,6 +1734,16 @@ class WebToolConfig(BaseToolConfig):
         """Return the sessionmaker used to mint per-call tool sessions."""
         if self._db_factory is not None:
             return self._db_factory
+        from sqlalchemy.orm import Session, sessionmaker
+
+        if isinstance(self._live_db, Session):
+            bind = self._live_db.get_bind()
+            engine = getattr(bind, "engine", bind)
+            return sessionmaker(
+                bind=engine,
+                autocommit=False,
+                autoflush=False,
+            )
         from ..models.database import get_session_local
 
         return get_session_local()
@@ -1164,6 +1775,7 @@ class WebToolConfig(BaseToolConfig):
 
     def close(self) -> None:
         """Close the lazily-opened factory session, if any."""
+        self.release_prepared_factory_runtime()
         if self._lazy_db is not None:
             self._lazy_db.close()
             self._lazy_db = None
@@ -1197,9 +1809,19 @@ class WebToolConfig(BaseToolConfig):
         return self._sandbox
 
     def get_tool_credential(self, tool_name: str, field_name: str) -> Optional[str]:
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_basic:
+            if "basic" in snapshot.failed_inputs:
+                raise RuntimeError("Tool credential snapshot is unavailable")
+            return snapshot.tool_credentials.get((tool_name, field_name))
         return resolve_tool_credential(self.db, tool_name, field_name)
 
     def get_sql_connections(self) -> Dict[str, str]:
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_sql:
+            if "database" in snapshot.failed_inputs:
+                raise RuntimeError("SQL connection snapshot is unavailable")
+            return snapshot.sql_connections
         return get_sql_connection_map(self.db, self._user_id)
 
     def set_sandbox(self, sandbox: Any) -> None:
@@ -1294,6 +1916,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_asr_models(self) -> Dict[str, Any]:
         """Load ASR models from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.asr_models
         if self._cached_asr_models is None:
             self._cached_asr_models = self._load_asr_models()
         return self._cached_asr_models
@@ -1312,6 +1937,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_asr_model(self) -> Optional[Any]:
         """Get default ASR model from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.asr_model
         if self._cached_asr_model is None:
             self._cached_asr_model = self._load_asr_model()
         return self._cached_asr_model
@@ -1330,6 +1958,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_tts_models(self) -> Dict[str, Any]:
         """Load TTS models from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.tts_models
         if self._cached_tts_models is None:
             self._cached_tts_models = self._load_tts_models()
         return self._cached_tts_models
@@ -1348,12 +1979,18 @@ class WebToolConfig(BaseToolConfig):
 
     def get_tts_model(self) -> Optional[Any]:
         """Get default TTS model from database."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.tts_model
         if self._cached_tts_model is None:
             self._cached_tts_model = self._load_tts_model()
         return self._cached_tts_model
 
     def get_sound_effect_models(self) -> Dict[str, Any]:
         """Load sound effect models from the independent model category."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.sound_effect_models
         if self._cached_sound_effect_models is None:
             self._cached_sound_effect_models = self._load_sound_effect_models()
         return self._cached_sound_effect_models
@@ -1370,6 +2007,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_sound_effect_model(self) -> Optional[Any]:
         """Get the user's default sound effect model."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.sound_effect_model
         if self._cached_sound_effect_model is None:
             self._cached_sound_effect_model = self._load_sound_effect_model()
         return self._cached_sound_effect_model
@@ -1386,6 +2026,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_music_models(self) -> Dict[str, Any]:
         """Load music models from the independent model category."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.music_models
         if self._cached_music_models is None:
             self._cached_music_models = self._load_music_models()
         return self._cached_music_models
@@ -1402,6 +2045,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_music_model(self) -> Optional[Any]:
         """Get the user's default music model."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_audio:
+            return snapshot.music_model
         if self._cached_music_model is None:
             self._cached_music_model = self._load_music_model()
         return self._cached_music_model
@@ -2290,6 +2936,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_custom_api_configs(self) -> List[Dict[str, Any]]:
         """Get custom API configurations."""
+        snapshot = self._factory_runtime_snapshot
+        if snapshot is not None and snapshot.plan.load_custom_api:
+            return snapshot.custom_api_configs
         if not self._user_id:
             return []
 
@@ -2311,29 +2960,14 @@ class WebToolConfig(BaseToolConfig):
             custom_api_configs = []
             for user_api in user_apis:
                 api = user_api.custom_api
-                if api:
-                    custom_api_configs.append(
-                        {
-                            "id": int(api.id),
-                            "name": api.name,
-                            "description": api.description or "",
-                            "url": api.url,
-                            "method": api.method or "GET",
-                            "headers": api.headers or {},
-                            "body": api.body,
-                            "env": api.env or {},
-                            "runtime_input_schema": getattr(
-                                api, "runtime_input_schema", None
-                            ),
-                            "runtime_bindings": getattr(api, "runtime_bindings", None),
-                            "allow_delegated_authorization": bool(
-                                getattr(api, "allow_delegated_authorization", False)
-                            ),
-                            "connector_runtime": self._get_connector_runtime_for(
-                                "custom_api", int(api.id)
-                            ),
-                        }
+                if api is None:
+                    continue
+                custom_api_configs.append(
+                    _custom_api_config_from_model(
+                        api,
+                        self._get_connector_runtime_for("custom_api", int(api.id)),
                     )
+                )
             return custom_api_configs
 
         except ConnectorRuntimeError:

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -6,6 +6,7 @@ with support for periodic updates to the database.
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from ...core.model.chat.token_context import (
@@ -17,6 +18,263 @@ from ...core.model.chat.token_context import (
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class _TaskTrackingSeed:
+    """Detached primitive state used to seed one tracking turn."""
+
+    user_id: int | None
+    usage: TokenUsage
+
+
+def _safe_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (bool, int, float, str)):
+        return _safe_int(value)
+    return None
+
+
+def _copy_details(raw_details: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_details, list):
+        return []
+    return [dict(item) for item in raw_details if isinstance(item, dict)]
+
+
+def _copy_usage(usage: TokenUsage) -> TokenUsage:
+    """Detach a stable snapshot before yielding to a database worker."""
+    return TokenUsage(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        llm_calls=usage.llm_calls,
+        tool_calls=usage.tool_calls,
+        details=_copy_details(usage.details),
+    )
+
+
+def _task_for_run(
+    db_session: Any,
+    task_id: int,
+    expected_run_id: str | None,
+    expected_runner_id: str | None = None,
+) -> Any | None:
+    from ..models.task import Task
+
+    query = db_session.query(Task).filter(Task.id == task_id)
+    if expected_run_id is not None:
+        query = query.filter(Task.run_id == expected_run_id)
+    if expected_runner_id is not None:
+        query = query.filter(Task.runner_id == expected_runner_id)
+    return query.first()
+
+
+def _task_seed_from_session(
+    db_session: Any,
+    task_id: int,
+    expected_run_id: str | None = None,
+    expected_runner_id: str | None = None,
+) -> _TaskTrackingSeed:
+    task = _task_for_run(
+        db_session,
+        task_id,
+        expected_run_id,
+        expected_runner_id,
+    )
+    if task is None:
+        run_suffix = (
+            f" for run {expected_run_id}" if expected_run_id is not None else ""
+        )
+        raise ValueError(f"Task {task_id}{run_suffix} not found")
+    return _TaskTrackingSeed(
+        user_id=_optional_int(getattr(task, "user_id", None)),
+        usage=TokenUsage(
+            input_tokens=_safe_int(getattr(task, "input_tokens", 0)),
+            output_tokens=_safe_int(getattr(task, "output_tokens", 0)),
+            llm_calls=_safe_int(getattr(task, "llm_calls", 0)),
+            details=_copy_details(getattr(task, "token_usage_details", None)),
+        ),
+    )
+
+
+def _new_short_session() -> Any:
+    from ..models.database import get_session_local
+
+    return get_session_local()()
+
+
+def _load_task_seed_sync(
+    task_id: int,
+    expected_run_id: str | None = None,
+    expected_runner_id: str | None = None,
+) -> _TaskTrackingSeed:
+    db_session = _new_short_session()
+    try:
+        return _task_seed_from_session(
+            db_session,
+            task_id,
+            expected_run_id,
+            expected_runner_id,
+        )
+    finally:
+        db_session.close()
+
+
+def _apply_usage(task: Any, usage: TokenUsage) -> None:
+    task.input_tokens = usage.input_tokens
+    task.output_tokens = usage.output_tokens
+    task.total_tokens = usage.total_tokens
+    task.llm_calls = usage.llm_calls
+    task.token_usage_details = _copy_details(usage.details)
+
+
+def _write_task_usage_sync(
+    task_id: int,
+    usage: TokenUsage,
+    expected_run_id: str | None = None,
+    expected_runner_id: str | None = None,
+) -> bool:
+    db_session = _new_short_session()
+    try:
+        task = _task_for_run(
+            db_session,
+            task_id,
+            expected_run_id,
+            expected_runner_id,
+        )
+        if task is None:
+            return False
+        _apply_usage(task, usage)
+        db_session.commit()
+        return True
+    except Exception:
+        try:
+            db_session.rollback()
+        except Exception as rollback_error:  # noqa: BLE001
+            logger.warning(
+                "Failed to rollback DB session for task %s: %s",
+                task_id,
+                rollback_error,
+            )
+        raise
+    finally:
+        db_session.close()
+
+
+def _check_quota_on_event_loop(
+    user_id: int | None,
+    delta_details: list[dict[str, Any]],
+    delta_actions: int,
+) -> str | None:
+    """Invoke the legacy progress hook on its documented event-loop thread."""
+    from ..services.quota_hooks import check_run_progress_gate
+
+    db_session = _new_short_session()
+    try:
+        return check_run_progress_gate(
+            db_session,
+            user_id,
+            delta_details,
+            delta_actions,
+        )
+    finally:
+        db_session.close()
+
+
+def _complete_task_usage_sync(
+    task_id: int,
+    usage: TokenUsage,
+    expected_run_id: str | None = None,
+    expected_runner_id: str | None = None,
+    user_id: int | None = None,
+    delta_details: list[dict[str, Any]] | None = None,
+    delta_actions: int = 0,
+) -> bool:
+    """Meter and persist one run's final counters in one worker session."""
+    from ..services.db_runtime import is_database_pool_timeout
+    from ..services.quota_hooks import record_usage
+
+    db_session = _new_short_session()
+    try:
+        task = _task_for_run(
+            db_session,
+            task_id,
+            expected_run_id,
+            expected_runner_id,
+        )
+        if task is None:
+            logger.info(
+                "Skipping final usage for task %s run %s; ownership changed",
+                task_id,
+                expected_run_id,
+            )
+            return False
+        # The usage hook owns its durability and may open an independent
+        # Session. Release the fence probe's connection before invoking it so
+        # a one-slot pool cannot deadlock on a nested checkout.
+        db_session.rollback()
+        try:
+            record_usage(
+                db_session,
+                user_id,
+                delta_details or [],
+                delta_actions,
+            )
+        except Exception as e:  # noqa: BLE001
+            if is_database_pool_timeout(e):
+                raise
+            logger.warning(f"Quota usage recording failed for task {task_id}: {e}")
+        finally:
+            # Hooks must not leave writes pending on the compatibility Session.
+            # End any read transaction they opened before the fenced write.
+            if db_session.in_transaction():
+                db_session.rollback()
+
+        task = _task_for_run(
+            db_session,
+            task_id,
+            expected_run_id,
+            expected_runner_id,
+        )
+        if task is None:
+            logger.info(
+                "Skipping final usage for task %s run %s after metering; "
+                "ownership changed",
+                task_id,
+                expected_run_id,
+            )
+            return False
+        _apply_usage(task, usage)
+        try:
+            db_session.commit()
+        except Exception as error:  # noqa: BLE001
+            logger.warning(
+                "Failed to commit final token usage for task %s: %s",
+                task_id,
+                error,
+            )
+            db_session.rollback()
+            if is_database_pool_timeout(error):
+                raise
+            return False
+        return True
+    finally:
+        db_session.close()
+
+
 class TaskTracker:
     """Track token usage for a task execution.
 
@@ -26,7 +284,7 @@ class TaskTracker:
     - Finalizing statistics on completion
 
     Usage:
-        tracker = TaskTracker(task_id=123, db_session=session)
+        tracker = TaskTracker(task_id=123)
 
         # Start tracking
         await tracker.start_tracking()
@@ -44,40 +302,51 @@ class TaskTracker:
     def __init__(
         self,
         task_id: int,
-        db_session: Any,
+        db_session: Any | None = None,
         update_interval_seconds: int = 15,
+        expected_run_id: str | None = None,
+        expected_runner_id: str | None = None,
     ) -> None:
         """Initialize the task tracker.
 
         Args:
             task_id: The task ID in the database
-            db_session: SQLAlchemy database session
+            db_session: Deprecated compatibility input. When provided, it is
+                read once to detach the task's primitive seed state; the
+                session and ORM row are never retained by this tracker.
             update_interval_seconds: Interval for periodic updates (default: 15s)
+            expected_run_id: Optional durable run fence. When provided, writes
+                are ignored after a replacement run changes the task's run id.
+            expected_runner_id: Optional durable runner fence. When provided,
+                seed reads and writes require both the expected run and runner.
         """
         self.task_id = task_id
-        self.db_session = db_session
         self.update_interval_seconds = update_interval_seconds
+        self.expected_run_id = expected_run_id
+        self.expected_runner_id = expected_runner_id
         self._is_tracking = False
         self._update_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
         self._last_reported_usage: Optional[TokenUsage] = None
         # Per-turn baselines captured in start_tracking; used to meter deltas.
         self._initial_details_len = 0
         self._initial_tool_calls = 0
 
-        # Load the task model
-        from ..models.task import Task as TaskModel
-
-        self.task_model = TaskModel
-        self.task = db_session.query(TaskModel).filter(TaskModel.id == task_id).first()
-
-        if not self.task:
-            raise ValueError(f"Task {task_id} not found")
-
-        # Cache user_id at construction: the per-step quota checker reads it every
-        # step, and `self.task` is expired after periodic_update commits
-        # (expire_on_commit), so a fresh `self.task.user_id` would trigger an
-        # implicit blocking SELECT. user_id never changes for a task.
-        self._user_id = getattr(self.task, "user_id", None)
+        # Compatibility callers may still hand us their request session. Read
+        # and detach the primitive seed now, but never retain the Session or ORM
+        # row across awaits. New callers omit this argument and start_tracking
+        # loads the same seed in a worker-owned short session.
+        self._seed = (
+            _task_seed_from_session(
+                db_session,
+                task_id,
+                expected_run_id,
+                expected_runner_id,
+            )
+            if db_session is not None
+            else None
+        )
+        self._user_id = self._seed.user_id if self._seed is not None else None
         # Fail-open logging in the per-step gate must not flood: log once per run.
         self._quota_gate_warned = False
         # Set to the gate reason if the mid-run quota gate trips, so the run's
@@ -90,31 +359,17 @@ class TaskTracker:
             logger.warning(f"Task {self.task_id} is already being tracked")
             return
 
-        details: list[dict[str, Any]] = []
-        raw_details = getattr(self.task, "token_usage_details", None)
-        if isinstance(raw_details, list):
-            details = [item for item in raw_details if isinstance(item, dict)]
-
-        def _safe_int(value: Any) -> int:
-            if isinstance(value, bool):
-                return int(value)
-            if isinstance(value, int):
-                return value
-            if isinstance(value, float):
-                return int(value)
-            if isinstance(value, str):
-                try:
-                    return int(value)
-                except ValueError:
-                    return 0
-            return 0
-
-        initial_usage = TokenUsage(
-            input_tokens=_safe_int(getattr(self.task, "input_tokens", 0)),
-            output_tokens=_safe_int(getattr(self.task, "output_tokens", 0)),
-            llm_calls=_safe_int(getattr(self.task, "llm_calls", 0)),
-            details=details,
-        )
+        seed = self._seed
+        if seed is None:
+            seed = await asyncio.to_thread(
+                _load_task_seed_sync,
+                self.task_id,
+                self.expected_run_id,
+                self.expected_runner_id,
+            )
+            self._seed = seed
+        self._user_id = seed.user_id
+        initial_usage = _copy_usage(seed.usage)
         set_token_usage(initial_usage)
 
         # Snapshot the seeded baselines so complete_tracking can meter only this
@@ -147,11 +402,17 @@ class TaskTracker:
             return
 
         try:
-            task_exists = (
-                self.db_session.query(self.task_model.id)
-                .filter(self.task_model.id == self.task_id)
-                .first()
-                is not None
+            usage = _copy_usage(get_token_usage())
+            logger.debug(
+                f"Got token usage for task {self.task_id}: input={usage.input_tokens}, output={usage.output_tokens}"
+            )
+
+            task_exists = await asyncio.to_thread(
+                _write_task_usage_sync,
+                self.task_id,
+                usage,
+                self.expected_run_id,
+                self.expected_runner_id,
             )
             if not task_exists:
                 self._is_tracking = False
@@ -159,21 +420,6 @@ class TaskTracker:
                     f"Stopping token tracking for task {self.task_id}: task no longer exists"
                 )
                 return
-
-            # Get current token usage
-            usage = get_token_usage()
-            logger.debug(
-                f"Got token usage for task {self.task_id}: input={usage.input_tokens}, output={usage.output_tokens}"
-            )
-
-            # Update database
-            self.task.input_tokens = usage.input_tokens
-            self.task.output_tokens = usage.output_tokens
-            self.task.total_tokens = usage.total_tokens
-            self.task.llm_calls = usage.llm_calls
-            self.task.token_usage_details = usage.to_dict()["details"]
-
-            self.db_session.commit()
 
             # Only log if values have changed
             if (
@@ -188,34 +434,13 @@ class TaskTracker:
                     f"input={usage.input_tokens}, output={usage.output_tokens}, "
                     f"total={usage.total_tokens}, calls={usage.llm_calls}"
                 )
-                self._last_reported_usage = usage
+                self._last_reported_usage = _copy_usage(usage)
         except Exception as e:
             logger.error(f"Failed to update token usage for task {self.task_id}: {e}")
-            try:
-                self.db_session.rollback()
-            except Exception as rollback_error:
-                logger.warning(
-                    f"Failed to rollback DB session for task {self.task_id}: {rollback_error}"
-                )
-
-            try:
-                task_exists = (
-                    self.db_session.query(self.task_model.id)
-                    .filter(self.task_model.id == self.task_id)
-                    .first()
-                    is not None
-                )
-                if not task_exists:
-                    self._is_tracking = False
-                    logger.info(
-                        f"Stopped periodic token tracking for deleted task {self.task_id}"
-                    )
-            except Exception:
-                self._is_tracking = False
-
-            import traceback
-
-            traceback.print_exc()
+            # The write helper already reports a missing row with False. Any
+            # exception here (including QueuePool timeout) is transient from the
+            # tracker's perspective: probing the row would perform a second pool
+            # checkout and can turn one timeout into a self-amplifying retry.
 
     async def start_periodic_updates(self) -> None:
         """Start periodic background updates to the database.
@@ -228,6 +453,7 @@ class TaskTracker:
             return
 
         self._is_tracking = True
+        self._stop_event.clear()
 
         async def update_loop() -> None:
             logger.debug(f"[update_loop] Starting update loop for task {self.task_id}")
@@ -237,8 +463,14 @@ class TaskTracker:
                 logger.debug(
                     f"[update_loop] Iteration {iteration} for task {self.task_id}"
                 )
-                await asyncio.sleep(self.update_interval_seconds)
-                if self._is_tracking:
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=self.update_interval_seconds,
+                    )
+                except TimeoutError:
+                    pass
+                if self._is_tracking and not self._stop_event.is_set():
                     logger.debug(
                         f"[update_loop] Calling periodic_update for task {self.task_id}"
                     )
@@ -258,14 +490,23 @@ class TaskTracker:
 
     async def stop_periodic_updates(self) -> None:
         """Stop periodic background updates."""
-        if self._update_task and not self._update_task.done():
-            self._update_task.cancel()
+        self._is_tracking = False
+        self._stop_event.set()
+        update_task = self._update_task
+        if (
+            update_task
+            and not update_task.done()
+            and update_task is not asyncio.current_task()
+        ):
             try:
-                await self._update_task
+                # Do not cancel a to_thread wait: cancellation cannot stop its
+                # database worker and would let a stale periodic write race the
+                # final completion write.
+                await update_task
             except asyncio.CancelledError:
                 pass
 
-        self._is_tracking = False
+        self._update_task = None
         logger.info(f"Stopped periodic token updates for task {self.task_id}")
 
     def _turn_delta(self, usage: TokenUsage | None = None) -> tuple[list, int]:
@@ -279,16 +520,16 @@ class TaskTracker:
             max(0, usage.tool_calls - self._initial_tool_calls),
         )
 
-    def interrupt_reason_for_quota(self) -> str | None:
+    async def interrupt_reason_for_quota(self) -> str | None:
         """Per-step interrupt-checker: return a reason when this run's live-so-far
         usage would push the team over a run-gated quota, so a single long or
         expensive run is stopped mid-flight instead of only being metered at
         completion (``complete_tracking`` still meters the partial usage on exit).
 
         Wired as the run's ``interrupt_checker`` and polled at every safe point
-        (each LLM reply / tool call). Synchronous and best-effort: it reuses the
-        exact turn-delta the metering path computes, and swallows errors so a
-        quota-infra hiccup fails open rather than wedging a run.
+        (each LLM reply / tool call). Best-effort: it reuses the exact turn-delta
+        the metering path computes, and swallows errors so a quota-infra hiccup
+        fails open rather than wedging a run.
 
         When it trips it records the reason in ``quota_interrupt_reason`` so the
         run's caller can surface *why* the run stopped (the pattern interrupt
@@ -297,23 +538,14 @@ class TaskTracker:
         if not self._is_tracking:
             return None
         try:
-            from ..services.quota_hooks import check_run_progress_gate
-
             delta_details, delta_actions = self._turn_delta()
-            reason = check_run_progress_gate(
-                self.db_session,
+            reason = _check_quota_on_event_loop(
                 self._user_id,
-                delta_details,
+                _copy_details(delta_details),
                 delta_actions,
             )
             if reason is not None:
                 self.quota_interrupt_reason = reason
-            # End the gate's read transaction so this poll doesn't leave the
-            # session's pooled connection pinned in ``idle in transaction``
-            # until the next periodic commit (issue #889).
-            from ..models.database import release_db_connection_if_clean
-
-            release_db_connection_if_clean(self.db_session)
             return reason
         except Exception as e:  # noqa: BLE001
             # Runs per step; log once per run so a persistent failure can't flood.
@@ -324,57 +556,38 @@ class TaskTracker:
                 )
             return None
 
-    async def complete_tracking(self) -> TokenUsage:
-        """Complete tracking and return final statistics.
+    async def _complete_tracking_once(self, usage: TokenUsage) -> TokenUsage:
+        """Drain periodic persistence, meter, and write one final snapshot."""
 
-        Stops periodic updates and saves final token usage to the database.
-
-        Returns:
-            Final TokenUsage object with all statistics
-
-        Raises:
-            RuntimeError: If tracking was not started
-        """
-        if not self._is_tracking:
-            raise RuntimeError(f"Task {self.task_id} is not being tracked")
-
-        # Stop periodic updates first to prevent race conditions
         await self.stop_periodic_updates()
 
-        # Get final token usage and update database
         logger.info(f"Force updating token usage for task {self.task_id}")
-        usage = get_token_usage()
+        delta_details, delta_actions = self._turn_delta(usage)
 
-        # Meter quota FIRST — on the still-clean session, from in-memory
-        # counters — so a transient commit failure below cannot zero-bill a
-        # token/tool-heavy turn. actions = tool calls; credits derive from tokens.
         try:
-            from ..services.quota_hooks import record_usage
-
-            delta_details, delta_actions = self._turn_delta(usage)
-            record_usage(
-                self.db_session,
+            persisted = await asyncio.to_thread(
+                _complete_task_usage_sync,
+                self.task_id,
+                usage,
+                self.expected_run_id,
+                self.expected_runner_id,
                 self._user_id,
-                delta_details,
+                _copy_details(delta_details),
                 delta_actions,
             )
         except Exception as e:  # noqa: BLE001
-            logger.warning(f"Quota usage recording failed for task {self.task_id}: {e}")
+            from ..services.db_runtime import is_database_pool_timeout
 
-        # Update database with final statistics
-        self.task.input_tokens = usage.input_tokens
-        self.task.output_tokens = usage.output_tokens
-        self.task.total_tokens = usage.total_tokens
-        self.task.llm_calls = usage.llm_calls
-        self.task.token_usage_details = usage.to_dict()["details"]
-
-        try:
-            self.db_session.commit()
-        except Exception as e:
             logger.warning(
                 f"Failed to commit final token usage for task {self.task_id}: {e}"
             )
-            self.db_session.rollback()
+            if is_database_pool_timeout(e):
+                # The lease owner must see the exhausted checkout. It can then
+                # retain the current run's lease for TTL recovery instead of
+                # immediately performing a second blocking DB checkout.
+                raise
+            return usage
+        if not persisted:
             return usage
 
         # Only log if values have changed from last report
@@ -390,7 +603,7 @@ class TaskTracker:
                 f"input={usage.input_tokens}, output={usage.output_tokens}, "
                 f"total={usage.total_tokens}, calls={usage.llm_calls}"
             )
-            self._last_reported_usage = usage
+            self._last_reported_usage = _copy_usage(usage)
 
         logger.info(
             f"Completed token tracking for task {self.task_id}: "
@@ -399,6 +612,51 @@ class TaskTracker:
         )
 
         return usage
+
+    async def complete_tracking(self) -> TokenUsage:
+        """Complete tracking and return final statistics.
+
+        Stops periodic updates and saves final token usage to the database.
+        If the awaiting task is cancelled, completion is allowed to finish first
+        so an already-running periodic DB worker cannot overwrite the final
+        snapshot. The original cancellation is then propagated.
+
+        Returns:
+            Final TokenUsage object with all statistics
+
+        Raises:
+            RuntimeError: If tracking was not started
+        """
+        if not self._is_tracking:
+            raise RuntimeError(f"Task {self.task_id} is not being tracked")
+
+        # Capture from the caller's ContextVar before delegating cancellation-
+        # independent cleanup to a child task.
+        usage = _copy_usage(get_token_usage())
+        completion_task = asyncio.create_task(self._complete_tracking_once(usage))
+        try:
+            return await asyncio.shield(completion_task)
+        except asyncio.CancelledError:
+            # Repeated cancellation must not detach an uncancellable to_thread
+            # worker. Wait until periodic and final writes have both settled,
+            # then preserve the caller's cancellation semantics.
+            while not completion_task.done():
+                try:
+                    await asyncio.shield(completion_task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+            if not completion_task.cancelled():
+                completion_error = completion_task.exception()
+                if completion_error is not None:
+                    logger.warning(
+                        "Token tracking completion failed after cancellation for "
+                        "task %s: %s",
+                        self.task_id,
+                        completion_error,
+                    )
+            raise
 
     def get_current_usage(self) -> TokenUsage:
         """Get current token usage without stopping tracking.
@@ -426,7 +684,7 @@ class TaskTrackerManager:
     def get_or_create_tracker(
         self,
         task_id: int,
-        db_session: Any,
+        db_session: Any | None = None,
         update_interval_seconds: int = 5,
     ) -> TaskTracker:
         """Get existing tracker or create new one."""

--- a/tests/core/agent/test_agent_service_tool_refresh.py
+++ b/tests/core/agent/test_agent_service_tool_refresh.py
@@ -38,6 +38,23 @@ class RefreshingToolConfig:
         return self.allowed_tools
 
 
+class AsyncRefreshingToolConfig(RefreshingToolConfig):
+    def __init__(self) -> None:
+        super().__init__()
+        self.async_refresh_count = 0
+        self.sync_refresh_count = 0
+
+    async def refresh_runtime_policy(self) -> None:
+        self.async_refresh_count += 1
+
+    def refresh_user_tool_overrides(self) -> None:
+        self.sync_refresh_count += 1
+        raise AssertionError("sync policy refresh ran on the event loop")
+
+    def get_user_tool_overrides(self) -> dict[str, dict[str, bool]]:
+        return {"disabled": {"enabled": self.async_refresh_count < 2}}
+
+
 class AllowedToolsConfig:
     _workspace_config = None
 
@@ -49,6 +66,20 @@ class AllowedToolsConfig:
 
     def get_allowed_tools(self) -> list[str] | None:
         return self.allowed_tools
+
+
+class SnapshotRefreshingToolConfig(AllowedToolsConfig):
+    def __init__(self) -> None:
+        super().__init__()
+        self.snapshot_prepared = False
+        self.release_count = 0
+
+    async def refresh_runtime_policy(self) -> None:
+        self.snapshot_prepared = True
+
+    def release_prepared_factory_runtime(self) -> None:
+        self.snapshot_prepared = False
+        self.release_count += 1
 
 
 class DelegationRuntimeConfig:
@@ -118,6 +149,65 @@ async def test_agent_service_refreshes_initialized_tools_when_policy_changes(
     await service._ensure_tools_initialized()
     assert {tool.name for tool in service.tools} == {"allowed"}
     assert tool_config.refresh_count == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_service_awaits_async_runtime_policy_refresh(monkeypatch) -> None:
+    tool_config = AsyncRefreshingToolConfig()
+    tool_sets: list[list[Any]] = [
+        [NamedTool("allowed"), NamedTool("disabled")],
+        [NamedTool("allowed")],
+    ]
+
+    async def create_all_tools(config: Any) -> list[Any]:
+        assert config is tool_config
+        return tool_sets.pop(0)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+    service = AgentService(
+        name="async-tool-refresh-test",
+        id="async-tool-refresh-test",
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+
+    await service._ensure_tools_initialized()
+    await service._ensure_tools_initialized()
+
+    assert tool_config.async_refresh_count == 2
+    assert tool_config.sync_refresh_count == 0
+    assert {tool.name for tool in service.tools} == {"allowed"}
+
+
+@pytest.mark.asyncio
+async def test_unchanged_policy_releases_prepared_factory_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_config = SnapshotRefreshingToolConfig()
+
+    async def unexpected_rebuild(config: Any) -> list[Any]:
+        raise AssertionError(f"unexpected tool rebuild for {config!r}")
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        unexpected_rebuild,
+    )
+    service = AgentService(
+        name="unchanged-tool-policy-test",
+        id="unchanged-tool-policy-test",
+        tools=[NamedTool("existing")],
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+
+    await service._ensure_tools_initialized()
+
+    assert tool_config.release_count == 1
+    assert not tool_config.snapshot_prepared
+    assert [tool.name for tool in service.tools] == ["existing"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/test_document_search_team_scope.py
+++ b/tests/core/tools/core/test_document_search_team_scope.py
@@ -1,0 +1,60 @@
+"""Async-boundary tests for team knowledge-base visibility overlays."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from xagent.core.tools.core import document_search
+from xagent.core.tools.core.RAG_tools.core.schemas import ListCollectionsResult
+from xagent.web.services.knowledge_base_team_scope import (
+    set_knowledge_base_team_hooks,
+)
+
+
+@pytest.mark.asyncio
+async def test_team_visibility_hook_runs_off_the_event_loop(monkeypatch):
+    async def empty_collections(*, user_id, is_admin):
+        return ListCollectionsResult(
+            status="success",
+            collections=[],
+            total_count=0,
+            message="ok",
+        )
+
+    monkeypatch.setattr(document_search, "list_collections", empty_collections)
+
+    loop_thread = threading.get_ident()
+    hook_threads: list[int] = []
+
+    def slow_visibility_hook(db, user_id):
+        assert db is None
+        assert user_id == 7
+        hook_threads.append(threading.get_ident())
+        time.sleep(0.05)
+        return []
+
+    set_knowledge_base_team_hooks(visibility=slow_visibility_hook)
+    ticks = 0
+    stop = False
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await document_search._list_visible_collections(7, False)
+    finally:
+        stop = True
+        await ticker_task
+        set_knowledge_base_team_hooks()
+
+    assert result.total_count == 0
+    assert hook_threads and hook_threads[0] != loop_thread
+    assert ticks >= 3

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -1,8 +1,10 @@
+import asyncio
 import tempfile
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.tools.adapters.vibe.agent_tool import (
     AgentTool,
@@ -13,6 +15,8 @@ from xagent.core.tools.adapters.vibe.agent_tool import (
 )
 from xagent.core.tools.adapters.vibe.agent_tool_names import gen_agent_tool_name
 from xagent.core.tools.adapters.vibe.config import ToolConfig
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
@@ -75,6 +79,77 @@ def test_web_delegation_config_defaults_are_noop() -> None:
             os.remove(db_path)
         except OSError:
             pass
+
+
+@pytest.mark.asyncio
+async def test_published_agent_prefetch_waits_for_pool_off_event_loop(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'published-agents.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.5,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    with SessionLocal() as db:
+        owner = User(username="prefetch-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.commit()
+        db.refresh(owner)
+        owner_id = int(owner.id)
+        published = Agent(
+            user_id=owner_id,
+            name="Prefetched Agent",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(published)
+        db.commit()
+        db.refresh(published)
+        published_id = int(published.id)
+        published_tool_name = gen_agent_tool_name(published_id, published.name)
+
+    held_connection = engine.connect()
+    config = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=SessionLocal,
+        user_id=owner_id,
+        task_id="_mock_",
+        workspace_config={"task_id": "_mock_"},
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=None),
+    )
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.create_task(ticker())
+    build_task = asyncio.create_task(ToolFactory.create_all_tools(config))
+    try:
+        await asyncio.sleep(0.08)
+        assert ticks >= 4
+        assert not build_task.done()
+
+        held_connection.close()
+        tools = await build_task
+        assert published_tool_name in {tool.name for tool in tools}
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        if not build_task.done():
+            build_task.cancel()
+            await asyncio.gather(build_task, return_exceptions=True)
+        stop.set()
+        await ticker_task
+        config.close()
+        engine.dispose()
 
 
 def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -1191,15 +1191,10 @@ class TestGetVisionTool:
 class TestGetDefaultVisionModel:
     """Test cases for get_default_vision_model function"""
 
-    @patch("xagent.web.models.database.get_db")
     @patch("xagent.web.services.llm_utils._create_llm_instance")
-    def test_get_default_vision_model_from_db_success(
-        self, mock_create_llm, mock_get_db
-    ):
+    def test_get_default_vision_model_from_db_success(self, mock_create_llm):
         """Test get_default_vision_model successful creation from database"""
-        # Mock database session generator
         mock_db = Mock()
-        mock_get_db.return_value = iter([mock_db])
 
         # Mock database model
         mock_db_model = Mock()
@@ -1223,24 +1218,21 @@ class TestGetDefaultVisionModel:
         mock_llm = Mock(spec=BaseLLM)
         mock_create_llm.return_value = mock_llm
 
-        result = get_default_vision_model(user_id=1)
+        result = get_default_vision_model(user_id=1, db=mock_db)
 
         assert result == mock_llm
         mock_create_llm.assert_called_once_with(mock_db_model)
 
-    @patch("xagent.web.models.database.get_db")
-    def test_get_default_vision_model_no_db_model(self, mock_get_db):
+    def test_get_default_vision_model_no_db_model(self):
         """Test get_default_vision_model when no database model found"""
-        # Mock database session generator
         mock_db = Mock()
-        mock_get_db.return_value = iter([mock_db])
 
         # Mock empty query result
         mock_query = Mock()
         mock_query.filter.return_value.first.return_value = None
         mock_db.query.return_value = mock_query
 
-        result = get_default_vision_model()
+        result = get_default_vision_model(db=mock_db)
 
         assert result is None
 

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -45,7 +45,7 @@ class TestWebSocket(unittest.IsolatedAsyncioTestCase):
         self.assertIn(2, manager.active_connections)
 
         # 测试断开连接
-        manager.disconnect(websocket1, 1)
+        manager.disconnect(websocket1)
 
         # 验证断开连接
         self.assertEqual(len(manager.active_connections), 1)
@@ -417,7 +417,7 @@ class TestWebSocket(unittest.IsolatedAsyncioTestCase):
         await manager.connect(websocket1, 1)
 
         # 模拟连接断开
-        manager.disconnect(websocket1, 1)
+        manager.disconnect(websocket1)
 
         # 验证连接已断开
         self.assertEqual(len(manager.active_connections), 0)

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1,20 +1,37 @@
+import asyncio
 import json
+import threading
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import Request
+from sqlalchemy import create_engine
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.web.api import a2a as a2a_api
-from xagent.web.models.agent import Agent
+from xagent.web.models import database as database_module
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.agent_api_key import AgentApiKey
+from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.user import User
 from xagent.web.services.a2a_protocol import A2A_MAX_MESSAGE_TEXT_LENGTH
+from xagent.web.services.api_keys import AgentApiIdentity
 from xagent.web.services.task_command_transport import (
+    COMMAND_COMPLETED,
     COMMAND_FAILED,
     MAX_COMMAND_DEFERS,
     MAX_COMMAND_FAILURES,
+)
+from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
 )
 from xagent.web.services.task_orchestrator import TaskTurnError
 
@@ -28,6 +45,99 @@ def _bearer(full_key: str) -> dict[str, str]:
         "Authorization": f"Bearer {full_key}",
         "A2A-Version": "1.0",
     }
+
+
+def _request_with_json(path: str, payload: dict[str, object]) -> Request:
+    body = json.dumps(payload).encode()
+    delivered = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.disconnect"}
+        delivered = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1),
+            "server": ("testserver", 80),
+        },
+        receive,
+    )
+
+
+def _detached_identity(agent: Agent, key: AgentApiKey) -> AgentApiIdentity:
+    raw_categories = agent.tool_categories
+    return AgentApiIdentity(
+        agent_id=int(agent.id),
+        user_id=int(agent.user_id),
+        execution_mode=(
+            str(agent.execution_mode) if agent.execution_mode is not None else None
+        ),
+        tool_categories=(
+            tuple(raw_categories) if isinstance(raw_categories, list) else None
+        ),
+        status=str(getattr(agent.status, "value", agent.status)),
+        origin=str(agent.origin),
+        key_prefix=str(key.key_prefix),
+    )
+
+
+@pytest.fixture()
+def single_connection_a2a_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Real one-slot pool shared by an A2A request and runtime workers."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'a2a-turn-boundary.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.15,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    monkeypatch.setattr(database_module, "_SessionLocal", session_local)
+
+    db = session_local()
+    user = User(
+        username="a2a-turn-boundary-owner",
+        password_hash="hash",
+        is_admin=False,
+    )
+    db.add(user)
+    db.flush()
+    agent = Agent(
+        user_id=int(user.id),
+        name="A2A turn boundary agent",
+        description="test",
+        instructions="test",
+        execution_mode="balanced",
+        models={},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=[],
+        suggested_prompts=[],
+        status=AgentStatus.PUBLISHED,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    key = SimpleNamespace(key_prefix="a2atest")
+    try:
+        yield engine, db, agent, key
+    finally:
+        db.close()
+        engine.dispose()
 
 
 def _create_agent(headers: dict[str, str], name: str = "A2A Test Agent") -> int:
@@ -187,6 +297,202 @@ def test_message_send_creates_hidden_a2a_task() -> None:
 
     assert schedule_bg.call_count == 1
     assert schedule_bg.call_args.kwargs["task_id"] == int(task["id"])
+
+
+@pytest.mark.asyncio
+async def test_message_send_releases_one_slot_request_pool_before_turn_start(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A2A startup must not pin the request checkout needed by the worker."""
+
+    engine, db, agent, key = single_connection_a2a_db
+    from xagent.web.services import task_orchestrator as orchestrator_module
+
+    observed_checked_out: list[int] = []
+    original_begin = a2a_api.TaskTurnOrchestrator.create_and_begin_turn
+    original_atomic = orchestrator_module._create_turn_atomic_sync
+
+    async def observed_begin(**kwargs: object) -> object:
+        observed_checked_out.append(engine.pool.checkedout())
+        return await original_begin(**kwargs)  # type: ignore[arg-type]
+
+    def slow_atomic(*args: object, **kwargs: object) -> object:
+        time.sleep(0.05)
+        return original_atomic(*args, **kwargs)  # type: ignore[arg-type]
+
+    ticks = 0
+    stop_ticker = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop_ticker.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    monkeypatch.setattr(
+        a2a_api.TaskTurnOrchestrator,
+        "create_and_begin_turn",
+        observed_begin,
+    )
+    monkeypatch.setattr(orchestrator_module, "_create_turn_atomic_sync", slow_atomic)
+    monkeypatch.setattr(a2a_api, "record_key_usage", AsyncMock())
+    identity = _detached_identity(agent, key)
+    db.close()
+
+    path = f"/api/a2a/agents/{int(agent.id)}/message:send"
+    request = _request_with_json(
+        path,
+        {
+            "message": {
+                "messageId": "msg-one-slot",
+                "role": "ROLE_USER",
+                "parts": [{"text": "keep the request pool free"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with patch(
+            "xagent.web.services.task_orchestrator._schedule_bg",
+            new=MagicMock(),
+        ):
+            response = await a2a_api.send_message(
+                int(agent.id),
+                request,
+                identity,
+            )
+    finally:
+        stop_ticker.set()
+        await ticker_task
+
+    assert response.status_code == 200
+    assert observed_checked_out == [0]
+    assert ticks >= 3, "A2A turn startup blocked the asyncio event loop"
+
+
+@pytest.mark.asyncio
+async def test_create_cancellation_after_commit_drains_turn_start(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation drains scheduling after the atomic create commit."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    from xagent.web.services import task_orchestrator as orchestrator_module
+
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    db.close()
+
+    committed = threading.Event()
+    allow_worker_return = threading.Event()
+    original_create = orchestrator_module._create_turn_atomic_sync
+
+    def create_then_block(*args: object, **kwargs: object):
+        created = original_create(*args, **kwargs)  # type: ignore[arg-type]
+        committed.set()
+        assert allow_worker_return.wait(timeout=1.0)
+        return created
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_create_turn_atomic_sync",
+        create_then_block,
+    )
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as schedule_bg:
+        request_task = asyncio.create_task(
+            a2a_api._start_a2a_turn(
+                agent_id=agent_id,
+                task_owner_user_id=owner_id,
+                execution_mode="balanced",
+                text="cancel after commit",
+                message_id="msg-cancel-after-commit",
+                context_id="ctx-cancel-after-commit",
+                task_id=None,
+            )
+        )
+        try:
+            assert await asyncio.to_thread(committed.wait, 1.0)
+            with database_module.get_session_local()() as verify_db:
+                started = verify_db.query(Task).filter(Task.source == "a2a").one()
+                assert started.status == TaskStatus.RUNNING
+
+            request_task.cancel()
+            await asyncio.sleep(0)
+            assert not request_task.done()
+        finally:
+            allow_worker_return.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+    with database_module.get_session_local()() as verify_db:
+        pending = (
+            verify_db.query(Task)
+            .filter(Task.source == "a2a", Task.status == TaskStatus.PENDING)
+            .count()
+        )
+        assert pending == 0
+        started = verify_db.query(Task).filter(Task.source == "a2a").one()
+        assert started.status == TaskStatus.RUNNING
+
+    schedule_bg.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wait_poll_checkout_does_not_block_the_event_loop(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A contended A2A status poll belongs on a worker, not the main loop."""
+
+    engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    db.close()
+    held_connection = engine.connect()
+    task = Task(
+        id=999,
+        user_id=owner_id,
+        title="poll boundary",
+        status=TaskStatus.RUNNING,
+        agent_id=agent_id,
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-poll-boundary"},
+    )
+    monkeypatch.setattr(a2a_api, "A2A_BLOCKING_WAIT_TIMEOUT_SECONDS", 1.0)
+
+    tick_times: list[float] = []
+    stop_ticker = asyncio.Event()
+
+    async def ticker() -> None:
+        while not stop_ticker.is_set():
+            tick_times.append(time.monotonic())
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with pytest.raises(Exception, match="QueuePool limit"):
+            await a2a_api._wait_for_task(agent_id, a2a_api._task_snapshot(task))
+        # Let the ticker record the gap across the failed checkout.
+        await asyncio.sleep(0.02)
+    finally:
+        stop_ticker.set()
+        await ticker_task
+        held_connection.close()
+
+    gaps = [right - left for left, right in zip(tick_times, tick_times[1:])]
+    assert len(tick_times) >= 10
+    assert max(gaps, default=0.0) < 0.08, (
+        "A2A polling performed the QueuePool wait on the asyncio event loop"
+    )
 
 
 def test_message_send_rejects_key_bound_to_different_agent() -> None:
@@ -351,21 +657,29 @@ def test_a2a_auth_error_includes_bearer_challenge() -> None:
 
 def test_message_send_blocks_by_default_until_task_finishes() -> None:
     agent_id, full_key = _create_published_agent_with_key()
+    original_create = a2a_api.TaskTurnOrchestrator.create_and_begin_turn
 
     async def _complete_turn(**kwargs: object) -> object:
+        started = await original_create(**kwargs)  # type: ignore[arg-type]
         db = _direct_db_session()
         try:
-            row = db.query(Task).filter(Task.id == int(kwargs["task_id"])).one()
+            row = db.query(Task).filter(Task.id == started.task_id).one()
             row.status = TaskStatus.COMPLETED
             row.output = "blocking response"
             db.commit()
         finally:
             db.close()
-        return object()
+        return started
 
-    with patch(
-        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
-        new=_complete_turn,
+    with (
+        patch(
+            "xagent.web.api.a2a.TaskTurnOrchestrator.create_and_begin_turn",
+            new=_complete_turn,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator._schedule_bg",
+            new=MagicMock(),
+        ),
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -415,7 +729,7 @@ def test_failed_create_does_not_leave_pending_a2a_task() -> None:
     agent_id, full_key = _create_published_agent_with_key()
 
     with patch(
-        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        "xagent.web.api.a2a.TaskTurnOrchestrator.create_and_begin_turn",
         side_effect=TaskTurnError("busy"),
     ):
         response = client.post(
@@ -439,11 +753,78 @@ def test_failed_create_does_not_leave_pending_a2a_task() -> None:
         db.close()
 
 
+@pytest.mark.asyncio
+async def test_pool_timeout_during_atomic_turn_create_leaves_no_a2a_task(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed atomic create leaves no task and keeps the event loop live."""
+
+    engine, db, agent, key = single_connection_a2a_db
+    recovery = MagicMock()
+    monkeypatch.setattr(a2a_api, "_recover_failed_turn_start", recovery)
+    monkeypatch.setattr(a2a_api, "record_key_usage", AsyncMock())
+    identity = _detached_identity(agent, key)
+    db.close()
+    held_connection = engine.connect()
+
+    path = f"/api/a2a/agents/{int(agent.id)}/message:send"
+    request = _request_with_json(
+        path,
+        {
+            "message": {
+                "messageId": "msg-pool-timeout",
+                "role": "ROLE_USER",
+                "parts": [{"text": "do not retry the exhausted pool"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    ticks = 0
+    stop_ticker = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop_ticker.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as schedule_bg:
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            with pytest.raises(SQLAlchemyTimeoutError):
+                await a2a_api.send_message(
+                    int(agent.id),
+                    request,
+                    identity,
+                )
+        finally:
+            held_connection.close()
+            stop_ticker.set()
+            await ticker_task
+
+    with database_module.get_session_local()() as verify_db:
+        pending = (
+            verify_db.query(Task)
+            .filter(Task.source == "a2a", Task.status == TaskStatus.PENDING)
+            .count()
+        )
+        assert pending == 0
+
+    assert ticks >= 5, "pool checkout blocked the asyncio event loop"
+    recovery.assert_not_called()
+    schedule_bg.assert_not_called()
+
+
 def test_unexpected_a2a_error_uses_internal_protocol_envelope() -> None:
     agent_id, full_key = _create_published_agent_with_key()
 
     with patch(
-        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        "xagent.web.api.a2a.TaskTurnOrchestrator.create_and_begin_turn",
         side_effect=RuntimeError("sensitive implementation detail"),
     ):
         response = client.post(
@@ -589,7 +970,7 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
     assert response.json()["task"]["contextId"] == "ctx-follow-up"
     assert response.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
     agent_service.post_user_message.assert_awaited_once_with(
-        task_id,
+        str(task_id),
         execution_message="follow up",
         display_message="follow up",
         turn_id=f"a2a:{task_id}:msg-follow-up",
@@ -605,6 +986,545 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
         assert resumed.input == "follow up"
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_uses_one_offloop_scope_and_no_request_session(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Checkpoint resume passes one frozen setup/scope into the live runtime."""
+
+    _engine, db, agent, key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting boundary",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-boundary"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    identity = _detached_identity(agent, key)
+    db.close()
+
+    main_thread = threading.get_ident()
+    scope = object()
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    scope_threads: list[int] = []
+    snapshot_threads: list[int] = []
+
+    def resolve_scope(resolved_task_id: int) -> object:
+        assert resolved_task_id == task_id
+        scope_threads.append(threading.get_ident())
+        return scope
+
+    def load_snapshot(resolved_task_id: int, user_id: int):
+        assert (resolved_task_id, user_id) == (task_id, owner_id)
+        snapshot_threads.append(threading.get_ident())
+        return setup_snapshot
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    schedule_resume = MagicMock()
+
+    monkeypatch.setattr(
+        a2a_api,
+        "resolve_execution_scope",
+        resolve_scope,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        load_snapshot,
+        raising=False,
+    )
+    monkeypatch.setattr(a2a_api, "_schedule_waiting_a2a_resume", schedule_resume)
+    monkeypatch.setattr(a2a_api, "record_key_usage", AsyncMock())
+
+    path = f"/api/a2a/agents/{agent_id}/message:send"
+    request = _request_with_json(
+        path,
+        {
+            "message": {
+                "messageId": "msg-waiting-boundary",
+                "taskId": task_id,
+                "role": "ROLE_USER",
+                "parts": [{"text": "resume safely"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = await a2a_api.send_message(
+            agent_id,
+            request,
+            identity,
+        )
+
+    assert response.status_code == 200
+    assert scope_threads and all(thread != main_thread for thread in scope_threads)
+    assert snapshot_threads and all(
+        thread != main_thread for thread in snapshot_threads
+    )
+    assert len(scope_threads) == 1
+    assert len(snapshot_threads) == 1
+    manager_args = agent_manager.get_agent_for_task.await_args.args
+    manager_kwargs = agent_manager.get_agent_for_task.await_args.kwargs
+    assert manager_args[:2] == (task_id, None)
+    assert manager_kwargs["task_setup_snapshot"] is setup_snapshot
+    assert manager_kwargs["resolved_execution_scope"] is scope
+    assert schedule_resume.call_args.kwargs["resolved_execution_scope"] is scope
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_cancellation_drains_finalize_before_schedule(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled request cannot strand a committed resume claim."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting cancellation",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-cancel"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    db.close()
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    finalize_started = threading.Event()
+    allow_finalize = threading.Event()
+    schedule_resume = MagicMock()
+    original_finalize = a2a_api._finalize_waiting_a2a_resume
+
+    def delayed_finalize(**kwargs):
+        finalize_started.set()
+        assert allow_finalize.wait(timeout=1.0)
+        return original_finalize(**kwargs)
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "_finalize_waiting_a2a_resume",
+        delayed_finalize,
+    )
+    monkeypatch.setattr(a2a_api, "_schedule_waiting_a2a_resume", schedule_resume)
+
+    with patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager):
+        resume = asyncio.create_task(
+            a2a_api._resume_waiting_a2a_task(
+                task_id=task_id,
+                agent_id=agent_id,
+                task_owner_user_id=owner_id,
+                text="resume after cancellation",
+                message_id="msg-waiting-cancel",
+            )
+        )
+        assert await asyncio.to_thread(finalize_started.wait, 1.0)
+        resume.cancel()
+        allow_finalize.set()
+        with pytest.raises(asyncio.CancelledError):
+            await resume
+
+    schedule_resume.assert_called_once()
+    with database_module.get_session_local()() as verify_db:
+        claimed = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert claimed.status == TaskStatus.RUNNING
+        assert claimed.runner_id is not None
+        assert claimed.run_id is not None
+        assert claimed.lease_expires_at is not None
+        assert schedule_resume.call_args.kwargs["run_id"] == claimed.run_id
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_finalize_pool_timeout_retains_fenced_lease(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pool timeout retains the exact claim for TTL without another checkout."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting pool timeout",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-pool-timeout"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    db.close()
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    restore_claim = MagicMock()
+    schedule_resume = MagicMock()
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "_finalize_waiting_a2a_resume",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            SQLAlchemyTimeoutError("QueuePool limit reached")
+        ),
+    )
+    monkeypatch.setattr(a2a_api, "_restore_waiting_resume_claim", restore_claim)
+    monkeypatch.setattr(a2a_api, "_schedule_waiting_a2a_resume", schedule_resume)
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        pytest.raises(SQLAlchemyTimeoutError, match="QueuePool limit"),
+    ):
+        await a2a_api._resume_waiting_a2a_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            text="resume during pool exhaustion",
+            message_id="msg-waiting-pool-timeout",
+        )
+
+    restore_claim.assert_not_called()
+    schedule_resume.assert_not_called()
+    with database_module.get_session_local()() as verify_db:
+        claimed = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert claimed.status == TaskStatus.RUNNING
+        assert claimed.runner_id is not None
+        assert claimed.run_id is not None
+        assert claimed.lease_expires_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("heartbeat_outcome", "expected_exception", "expected_match"),
+    [
+        (
+            TaskLeaseHeartbeatOutcome(lease_lost=True),
+            RuntimeError,
+            "lease heartbeat lost",
+        ),
+        (
+            TaskLeaseHeartbeatOutcome(
+                pool_timeout=SQLAlchemyTimeoutError("heartbeat pool timeout")
+            ),
+            SQLAlchemyTimeoutError,
+            "heartbeat pool timeout",
+        ),
+    ],
+)
+async def test_waiting_resume_heartbeat_starts_before_post_and_unhealthy_lease_stops_work(
+    monkeypatch: pytest.MonkeyPatch,
+    heartbeat_outcome: TaskLeaseHeartbeatOutcome,
+    expected_exception: type[BaseException],
+    expected_match: str,
+) -> None:
+    """A slow checkpoint post must stay fenced until finalize and schedule."""
+
+    task_id = 701
+    agent_id = 702
+    owner_id = 703
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="a2a-resume-runner",
+        run_id="a2a-resume-run",
+    )
+    heartbeat_started = asyncio.Event()
+
+    async def lost_heartbeat(
+        heartbeat_lease: TaskLease,
+        stop_event: asyncio.Event,
+    ) -> TaskLeaseHeartbeatOutcome:
+        assert heartbeat_lease == lease
+        heartbeat_started.set()
+        await stop_event.wait()
+        return heartbeat_outcome
+
+    async def post_user_message(*_args, **_kwargs) -> bool:
+        assert heartbeat_started.is_set(), (
+            "lease heartbeat started after external await"
+        )
+        return True
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(side_effect=post_user_message)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    finalize = MagicMock()
+    restore = MagicMock()
+    schedule = MagicMock()
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "_claim_waiting_a2a_resume",
+        lambda _task_id, _agent_id: lease,
+    )
+    monkeypatch.setattr(
+        a2a_api, "run_task_lease_heartbeat", lost_heartbeat, raising=False
+    )
+    monkeypatch.setattr(a2a_api, "_finalize_waiting_a2a_resume", finalize)
+    monkeypatch.setattr(a2a_api, "_restore_waiting_resume_claim", restore)
+    monkeypatch.setattr(a2a_api, "_schedule_waiting_a2a_resume", schedule)
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        pytest.raises(expected_exception, match=expected_match),
+    ):
+        await a2a_api._resume_waiting_a2a_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            text="slow checkpoint response",
+            message_id="message-with-live-lease",
+        )
+
+    finalize.assert_not_called()
+    restore.assert_not_called()
+    schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_schedule_failure_restores_exact_claim(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local scheduling failure releases only this resume's exact lease."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting schedule failure",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-schedule-failure"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    db.close()
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "_schedule_waiting_a2a_resume",
+        MagicMock(side_effect=RuntimeError("scheduler unavailable")),
+    )
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        pytest.raises(RuntimeError, match="scheduler unavailable"),
+    ):
+        await a2a_api._resume_waiting_a2a_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            text="resume before scheduling",
+            message_id="msg-waiting-schedule-failure",
+        )
+
+    with database_module.get_session_local()() as verify_db:
+        restored = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert restored.status == TaskStatus.WAITING_FOR_USER
+        assert restored.runner_id is None
+        assert restored.lease_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_recovery_does_not_overwrite_replacement_owner(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Late recovery is fenced by both runner_id and run_id."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting replacement owner",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-replacement-owner"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    db.close()
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+
+    def replace_owner_then_fail(**_kwargs) -> None:
+        with database_module.get_session_local()() as replacement_db:
+            replacement = replacement_db.query(Task).filter(Task.id == task_id).one()
+            replacement.runner_id = "replacement-runner"
+            replacement.run_id = "replacement-run"
+            replacement_db.commit()
+        raise RuntimeError("scheduler unavailable after replacement")
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(
+        a2a_api,
+        "_schedule_waiting_a2a_resume",
+        replace_owner_then_fail,
+    )
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        pytest.raises(RuntimeError, match="scheduler unavailable after replacement"),
+    ):
+        await a2a_api._resume_waiting_a2a_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            text="resume before ownership change",
+            message_id="msg-waiting-replacement-owner",
+        )
+
+    with database_module.get_session_local()() as verify_db:
+        replacement = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert replacement.status == TaskStatus.RUNNING
+        assert replacement.runner_id == "replacement-runner"
+        assert replacement.run_id == "replacement-run"
+        assert replacement.lease_expires_at is not None
+
+
+@pytest.mark.asyncio
+async def test_waiting_resume_without_checkpoint_releases_lease_for_fallback(
+    single_connection_a2a_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """posted=False leaves a clean PAUSED row for the APPEND fallback."""
+
+    _engine, db, agent, _key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    waiting = Task(
+        user_id=owner_id,
+        title="waiting missing checkpoint",
+        status=TaskStatus.WAITING_FOR_USER,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-waiting-missing-checkpoint"},
+    )
+    db.add(waiting)
+    db.commit()
+    db.refresh(waiting)
+    task_id = int(waiting.id)
+    db.close()
+
+    setup_snapshot = SimpleNamespace(runtime_user=SimpleNamespace(id=owner_id))
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=False)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    schedule_resume = MagicMock()
+
+    monkeypatch.setattr(a2a_api, "resolve_execution_scope", lambda _task_id: None)
+    monkeypatch.setattr(
+        a2a_api,
+        "load_task_setup_snapshot_sync",
+        lambda _task_id, _owner_id: setup_snapshot,
+    )
+    monkeypatch.setattr(a2a_api, "_schedule_waiting_a2a_resume", schedule_resume)
+
+    with patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager):
+        posted, finalized = await a2a_api._resume_waiting_a2a_task(
+            task_id=task_id,
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            text="fallback to a fresh turn",
+            message_id="msg-waiting-missing-checkpoint",
+        )
+
+    assert posted is False
+    assert finalized.status == TaskStatus.PAUSED
+    schedule_resume.assert_not_called()
+    with database_module.get_session_local()() as verify_db:
+        fallback = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert fallback.status == TaskStatus.PAUSED
+        assert fallback.runner_id is None
+        assert fallback.lease_expires_at is None
 
 
 def test_failed_follow_up_restores_input_required_status() -> None:
@@ -849,13 +1769,13 @@ async def test_stream_artifact_updates_are_incremental_and_finalize(
         return None
 
     monkeypatch.setattr(a2a_api.asyncio, "sleep", no_sleep)
-    monkeypatch.setattr(
-        a2a_api,
-        "_fetch_fresh_a2a_task",
-        lambda _agent_id, _task_id: next(fresh_tasks),
-    )
 
-    response = a2a_api._task_stream_response(SimpleNamespace(id=7), task)
+    async def fetch_fresh(_agent_id: int, _task_id: int):
+        return a2a_api._task_snapshot(next(fresh_tasks))
+
+    monkeypatch.setattr(a2a_api, "_fetch_fresh_a2a_task", fetch_fresh)
+
+    response = a2a_api._task_stream_response(7, a2a_api._task_snapshot(task))
     events = [
         json.loads(chunk.removeprefix("data: "))
         async for chunk in response.body_iterator
@@ -911,6 +1831,70 @@ def test_cancel_is_idempotent_and_subscribe_rejects_terminal_task() -> None:
     assert second.json()["status"]["state"] == "TASK_STATE_CANCELED"
     assert subscribed.status_code == 400
     assert subscribed.json()["error"]["details"][0]["reason"] == "UNSUPPORTED_OPERATION"
+
+
+@pytest.mark.asyncio
+async def test_cancel_existing_command_releases_request_session_before_poll(
+    single_connection_a2a_db,
+) -> None:
+    """An idempotent cancel must not pin the only connection while polling."""
+
+    engine, db, agent, key = single_connection_a2a_db
+    agent_id = int(agent.id)
+    owner_id = int(agent.user_id)
+    task = Task(
+        user_id=owner_id,
+        title="already canceled",
+        status=TaskStatus.FAILED,
+        agent_id=agent_id,
+        source="a2a",
+        is_visible=False,
+        state_version=7,
+        agent_config={
+            "a2a_context_id": "ctx-existing-cancel",
+            "a2a_state": "TASK_STATE_CANCELED",
+        },
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    task_id = int(task.id)
+    command_identity = f"cancel:{task_id}:7"
+    db.add(
+        TaskExecutionCommand(
+            task_id=task_id,
+            actor_user_id=owner_id,
+            command_id=command_identity,
+            kind="cancel",
+            payload={"agent_id": agent_id},
+            status=COMMAND_COMPLETED,
+        )
+    )
+    db.commit()
+    identity = _detached_identity(agent, key)
+    db.close()
+
+    checked_out_at_dispatch: list[int] = []
+
+    async def observe_dispatch(_executor, *, command_db_id=None):
+        checked_out_at_dispatch.append(engine.pool.checkedout())
+        return False
+
+    with patch.object(
+        a2a_api,
+        "dispatch_one_task_command",
+        new=observe_dispatch,
+    ):
+        response = await a2a_api.cancel_task(
+            agent_id,
+            task_id,
+            identity,
+        )
+
+    assert response.status_code == 200
+    assert checked_out_at_dispatch == [0]
+    assert response.body is not None
+    assert json.loads(response.body)["status"]["state"] == "TASK_STATE_CANCELED"
 
 
 def test_cancel_retries_a_previous_terminal_transport_failure() -> None:
@@ -1067,8 +2051,7 @@ async def test_cancel_does_not_overwrite_a_concurrent_completion() -> None:
         ):
             await a2a_api._cancel_task_unserialized(
                 task_id=task_id,
-                agent=agent,
-                db=db,
+                agent_id=agent_id,
             )
 
         db.expire_all()

--- a/tests/web/api/test_agent_cache_scope_fingerprint.py
+++ b/tests/web/api/test_agent_cache_scope_fingerprint.py
@@ -35,6 +35,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -79,6 +80,8 @@ def _build_snapshot() -> TaskSetupSnapshot:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -1,5 +1,4 @@
-"""Test that ``execute_task_background`` consumes the snapshot when
-provided and falls back to its legacy Task SELECT when it isn't.
+"""Test that ``execute_task_background`` consumes an off-loop snapshot.
 
 Background:
     Profiling measured the inline ``db.query(Task)`` at the top of
@@ -13,26 +12,25 @@ Background:
 
 What this test pins:
 
-    * Snapshot path: ``db.query(Task)`` is **not** called on the
-      request session. ``db.query(User)`` still fires once because
-      ``get_user_tool_overrides`` is a hook (``Callable[[Session,
-      Any], dict]``) that may read arbitrary ORM fields off the user
-      object -- swapping in a primitive shim would be a quiet BC
-      break.
-    * Legacy / WS path (``task_setup_snapshot=None``):
-      ``db.query(Task)`` fires once (the existence check) and
-      ``db.query(User)`` fires once. This pins the WS-fallback
-      behaviour so a future refactor that drops the fallback branch
-      gets caught here, not in production logs.
+    * Snapshot path performs no event-loop Task/User query.
+    * A caller that omits the snapshot loads the same primitive snapshot in a
+      worker thread instead of reintroducing an event-loop Session.
 """
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from collections import Counter
+from time import monotonic
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.web.api.websocket import execute_task_background
 from xagent.web.models.agent import AgentStatus
@@ -40,6 +38,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -77,6 +76,8 @@ def _make_snapshot(*, source: str | None = "trigger") -> TaskSetupSnapshot:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,
@@ -136,50 +137,43 @@ def _build_db_mock(*, task_row: Any, user_row: Any) -> tuple[MagicMock, _QueryCo
 
 
 def _common_patches(db: Any, agent_service: Any) -> list[Any]:
-    """Patch the rest of ``execute_task_background``'s body so the
-    test focuses on the Task / User query counters at the top.
-    Downstream layers (transcript load, agent run, status update,
-    persist) are stubbed -- a failure there would mask the counter
-    assertions which run before the call returns / raises.
-    """
+    """Stub persistence so this test observes only snapshot handoff."""
 
-    def _fake_get_db():
-        yield db
-
-    # ``execute_task_background`` re-imports these names inside the
-    # function body, so patches must target the source modules (the
-    # local rebind inside the function picks up whatever the source
-    # module's attribute resolves to at lookup time).
     return [
         patch(
-            "xagent.web.models.database.get_db",
-            return_value=_fake_get_db(),
+            "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+            return_value=_make_snapshot(),
         ),
         patch(
             "xagent.web.api.websocket.background_task_manager.wait_for_previous",
             new=AsyncMock(),
         ),
         patch(
-            "xagent.web.api.websocket._register_uploaded_files_for_agent",
+            "xagent.web.api.websocket._register_uploaded_files_for_agent_isolated",
         ),
         patch(
-            "xagent.web.api.websocket._normalize_file_outputs",
-            return_value=([], {}),
+            "xagent.web.api.websocket._finalize_task_execution_result_isolated",
+            return_value=SimpleNamespace(
+                normalized_outputs=[],
+                ai_response="ok",
+                chat_response=None,
+                waiting_for_control=False,
+                terminal_state_committed=True,
+                final_control_snapshot=None,
+                final_task_status=TaskStatus.COMPLETED.value,
+                broadcast_meta={
+                    "id": 42,
+                    "title": "exec-bg test",
+                    "description": "x",
+                    "execution_mode": "flash",
+                    "updated_at": None,
+                },
+                late_result=False,
+            ),
         ),
         patch(
-            "xagent.web.api.websocket._rewrite_file_links_to_file_id",
-            side_effect=lambda s, _m: s,
-        ),
-        patch(
-            "xagent.web.services.task_execution_context_service.load_task_execution_recovery_state",
-            new=AsyncMock(return_value={"messages": [], "skill_context": None}),
-        ),
-        patch(
-            "xagent.web.services.chat_history_service.persist_assistant_message",
-        ),
-        patch(
-            "xagent.web.services.chat_history_service.load_task_transcript",
-            return_value=[],
+            "xagent.web.api.websocket.manager.broadcast_to_task",
+            new=AsyncMock(),
         ),
     ]
 
@@ -203,14 +197,17 @@ def _build_fake_agent_service() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_snapshot_path_skips_task_query_keeps_user_query() -> None:
-    """Snapshot provided → Task SELECT must not fire on the request
-    session; User SELECT must still fire once (kept for hook compat).
-    """
+async def test_snapshot_path_skips_task_and_user_queries() -> None:
+    """A supplied snapshot must require no task/user checkout on the loop."""
     db, counter = _build_db_mock(task_row=_make_task_orm(), user_row=_make_user_orm())
     snapshot = _make_snapshot()
     agent_service = _build_fake_agent_service()
-    agent_manager = MagicMock(get_agent_for_task=AsyncMock(return_value=agent_service))
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(return_value=agent_service),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
+    )
 
     with _Patches(_common_patches(db, agent_service)):
         try:
@@ -232,15 +229,97 @@ async def test_snapshot_path_skips_task_query_keeps_user_query() -> None:
         "session with snapshot provided -- expected 0. The snapshot "
         "passthrough exists to skip this re-read."
     )
-    assert counter.calls_by_model[User] == 1, (
-        f"User queried {counter.calls_by_model[User]} time(s) -- expected 1 "
-        "(kept for get_user_tool_overrides hook compat)."
+    assert counter.calls_by_model[User] == 0, (
+        f"User queried {counter.calls_by_model[User]} time(s) on the event-loop "
+        "session with snapshot provided -- expected 0."
     )
     forwarded_snapshot = agent_manager.get_agent_for_task.await_args.kwargs[
         "task_setup_snapshot"
     ]
     assert forwarded_snapshot is snapshot
     assert forwarded_snapshot.task.source == "trigger"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_execution_start_stays_responsive_with_exhausted_pool(
+    tmp_path,
+) -> None:
+    """The snapshot-to-manager handoff must not checkout on the event loop."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'execute-startup-pool.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.25,
+    )
+    SessionLocal = sessionmaker(bind=engine)
+    held_connection = engine.connect()
+    db = SessionLocal()
+    snapshot = _make_snapshot()
+    manager_entered = asyncio.Event()
+    release_manager = asyncio.Event()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def blocked_get_agent(*_args: Any, **_kwargs: Any) -> None:
+        manager_entered.set()
+        await release_manager.wait()
+        raise RuntimeError("stop after the manager boundary")
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(side_effect=blocked_get_agent)
+    )
+
+    with _Patches(
+        [
+            *_common_patches(db, MagicMock()),
+            patch(
+                "xagent.web.api.websocket._terminal_task_error_payload",
+                return_value=None,
+            ),
+        ]
+    ):
+        started = monotonic()
+        execution_task = asyncio.create_task(
+            execute_task_background(
+                task_id=42,
+                user_message="hi",
+                context={},
+                agent_manager=agent_manager,
+                task_owner_user_id=1,
+                task_setup_snapshot=snapshot,
+                resolved_execution_scope=None,
+            )
+        )
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await asyncio.wait_for(manager_entered.wait(), timeout=0.4)
+            elapsed = monotonic() - started
+            await asyncio.sleep(0.04)
+            assert elapsed < 0.15, (
+                "Snapshot handoff waited for the exhausted request pool; "
+                f"manager reached after {elapsed:.3f}s."
+            )
+            assert ticks >= 3, f"Event-loop ticker advanced only {ticks} time(s)."
+        finally:
+            release_manager.set()
+            ticker_stop.set()
+            await asyncio.gather(
+                execution_task,
+                ticker_task,
+                return_exceptions=True,
+            )
+            db.close()
+            held_connection.close()
+            engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -275,30 +354,41 @@ async def test_execute_task_background_accepts_missing_context() -> None:
 
 
 @pytest.mark.asyncio
-async def test_legacy_path_runs_task_and_user_queries() -> None:
-    """No snapshot (WS path) → both legacy queries fire exactly once."""
+async def test_missing_snapshot_is_loaded_off_loop_without_event_loop_queries() -> None:
+    """A legacy caller is upgraded to the worker-owned snapshot boundary."""
     db, counter = _build_db_mock(task_row=_make_task_orm(), user_row=_make_user_orm())
     agent_service = _build_fake_agent_service()
-    agent_manager = MagicMock(get_agent_for_task=AsyncMock(return_value=agent_service))
-
-    with _Patches(_common_patches(db, agent_service)):
-        try:
-            await execute_task_background(
-                task_id=42,
-                user_message="hi",
-                context={},
-                agent_manager=agent_manager,
-                task_owner_user_id=1,
-                task_setup_snapshot=None,
-            )
-        except Exception:
-            pass
-
-    assert counter.calls_by_model[Task] == 1, (
-        f"Task queried {counter.calls_by_model[Task]} time(s) on legacy path "
-        "-- expected 1 (the existence check). WS fallback must not regress."
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(return_value=agent_service),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
     )
-    assert counter.calls_by_model[User] == 1
+    loader_threads: list[int] = []
+
+    def load_snapshot(*_args: Any, **_kwargs: Any) -> TaskSetupSnapshot:
+        loader_threads.append(threading.get_ident())
+        return _make_snapshot()
+
+    patches = _common_patches(db, agent_service)
+    patches[0] = patch(
+        "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+        side_effect=load_snapshot,
+    )
+    with _Patches(patches):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+            task_setup_snapshot=None,
+        )
+
+    assert counter.calls_by_model[Task] == 0
+    assert counter.calls_by_model[User] == 0
+    assert loader_threads and loader_threads[0] != threading.get_ident()
+    assert agent_manager.get_agent_for_task.await_args.args[1] is None
 
 
 class _Patches:

--- a/tests/web/api/test_execution_scope_e2e.py
+++ b/tests/web/api/test_execution_scope_e2e.py
@@ -38,6 +38,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -106,6 +107,8 @@ def _build_snapshot(task_id: int) -> TaskSetupSnapshot:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -14,10 +14,15 @@ fake resolver to pin that:
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import threading
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from xagent.core.execution_scope import (
     ExecutionScope,
@@ -25,11 +30,17 @@ from xagent.core.execution_scope import (
     set_execution_scope_resolver,
 )
 from xagent.web.api.websocket import (
+    _acquire_resume_task_lease,
+    _handle_resume_task_unserialized,
     execute_resume_background,
     execute_task_background,
 )
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -74,41 +85,51 @@ def _build_db_mock() -> MagicMock:
 
 
 def _bg_patches(db: Any) -> list[Any]:
-    """Stub ``execute_task_background``'s surroundings (DB sessions, file
-    normalization, transcript persistence) so the tests observe only the
-    scope activation around the agent build/run."""
+    """Stub persistence so tests observe only scope activation."""
 
-    def _fresh_db_gen():
-        yield db
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(
+            id=42,
+            user_id=1,
+            status=TaskStatus.RUNNING,
+            agent_id=None,
+        ),
+        runtime_user=SimpleNamespace(id=1, is_admin=False),
+        agent=None,
+        conversation_history=(),
+        execution_recovery=SimpleNamespace(messages=(), selected_skill_name=None),
+    )
 
     return [
         patch(
-            "xagent.web.models.database.get_db",
-            side_effect=lambda: _fresh_db_gen(),
+            "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+            return_value=snapshot,
         ),
         patch(
             "xagent.web.api.websocket.background_task_manager.wait_for_previous",
             new=AsyncMock(),
         ),
-        patch("xagent.web.api.websocket._register_uploaded_files_for_agent"),
+        patch("xagent.web.api.websocket._register_uploaded_files_for_agent_isolated"),
         patch(
-            "xagent.web.api.websocket._normalize_task_file_outputs",
-            return_value=([], {}),
+            "xagent.web.api.websocket._finalize_task_execution_result_isolated",
+            return_value=SimpleNamespace(
+                normalized_outputs=[],
+                ai_response="ok",
+                chat_response=None,
+                waiting_for_control=False,
+                terminal_state_committed=True,
+                final_control_snapshot=None,
+                final_task_status=TaskStatus.COMPLETED.value,
+                broadcast_meta={
+                    "id": 42,
+                    "title": "scope wiring test",
+                    "description": "x",
+                    "execution_mode": None,
+                    "updated_at": None,
+                },
+                late_result=False,
+            ),
         ),
-        patch(
-            "xagent.web.api.websocket._rewrite_file_links_to_file_id",
-            side_effect=lambda s, _m: s,
-        ),
-        patch(
-            "xagent.web.services.task_execution_context_service.load_task_execution_recovery_state",
-            new=AsyncMock(return_value={"messages": [], "skill_context": None}),
-        ),
-        patch("xagent.web.services.chat_history_service.persist_assistant_message"),
-        patch(
-            "xagent.web.services.chat_history_service.load_task_transcript",
-            return_value=[],
-        ),
-        patch("xagent.web.api.websocket.sync_workforce_run_status", return_value=False),
         patch(
             "xagent.web.api.websocket.manager", MagicMock(broadcast_to_task=AsyncMock())
         ),
@@ -205,6 +226,96 @@ async def test_bg_turn_without_resolver_runs_unscoped() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bg_turn_explicit_unscoped_does_not_resolve_again() -> None:
+    """A caller that already resolved the turn to ``None`` must be able to
+    pass that result through without making ``None`` look like "not resolved".
+    """
+
+    def unexpected_resolver(task_id: str) -> ExecutionScope:
+        raise AssertionError(f"scope for task {task_id} was resolved twice")
+
+    set_execution_scope_resolver(unexpected_resolver)
+    agent_service = MagicMock()
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(return_value=agent_service),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
+    )
+
+    with _Patches(_bg_patches(_build_db_mock())):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    assert (
+        agent_manager.get_agent_for_task.await_args.kwargs["resolved_execution_scope"]
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_bg_turn_resolves_scope_before_loading_snapshot_off_loop() -> None:
+    """Scope and setup snapshot are resolved sequentially in workers."""
+    main_thread_id = threading.get_ident()
+    events: list[tuple[str, int]] = []
+    scope = ExecutionScope(sandbox_key_suffix="tenant-a")
+
+    def resolver(task_id: str) -> ExecutionScope:
+        events.append(("resolve", threading.get_ident()))
+        return scope
+
+    set_execution_scope_resolver(resolver)
+
+    def load_snapshot(*_args: Any, **_kwargs: Any) -> Any:
+        events.append(("snapshot", threading.get_ident()))
+        return SimpleNamespace(
+            task=SimpleNamespace(
+                id=42,
+                user_id=1,
+                status=TaskStatus.RUNNING,
+                agent_id=None,
+            ),
+            runtime_user=SimpleNamespace(id=1, is_admin=False),
+            agent=None,
+            conversation_history=(),
+            execution_recovery=SimpleNamespace(messages=(), selected_skill_name=None),
+        )
+
+    agent_service = MagicMock()
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(return_value=agent_service),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
+    )
+    patches = _bg_patches(_build_db_mock())
+    patches[0] = patch(
+        "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+        side_effect=load_snapshot,
+    )
+
+    with _Patches(patches):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+        )
+
+    assert events[0][0] == "resolve"
+    assert events[0][1] != main_thread_id
+    assert events[1][0] == "snapshot"
+    assert events[1][1] != main_thread_id
+
+
+@pytest.mark.asyncio
 async def test_resumed_turn_re_resolves_scope() -> None:
     """A resumed execution re-resolves through the hook and runs with the
     identical scope — this is what makes scope survive a process restart:
@@ -243,7 +354,10 @@ async def test_resumed_turn_re_resolves_scope() -> None:
                 "xagent.web.models.database.get_db",
                 side_effect=lambda: _fresh_db_gen(),
             ),
-            patch("xagent.web.api.websocket.acquire_task_lease", return_value=object()),
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=object(),
+            ),
             patch(
                 "xagent.web.api.websocket.run_task_lease_heartbeat",
                 side_effect=_heartbeat,
@@ -252,16 +366,21 @@ async def test_resumed_turn_re_resolves_scope() -> None:
                 "xagent.web.api.websocket.stop_task_lease_heartbeat", new=AsyncMock()
             ),
             patch(
-                "xagent.web.api.websocket.release_current_runner_task_lease_with_workforce_sync",
-                return_value=True,
-            ),
-            patch(
-                "xagent.web.api.websocket.sync_workforce_run_status",
-                return_value=False,
-            ),
-            patch(
-                "xagent.web.api.websocket._normalize_task_file_outputs",
-                return_value=([], {}),
+                "xagent.web.api.websocket._finalize_resumed_task",
+                return_value={
+                    "task_title": "scope wiring test",
+                    "task_description": "x",
+                    "task_execution_mode": "flash",
+                    "task_agent_id": None,
+                    "agent_name": None,
+                    "agent_logo_url": None,
+                    "final_status": TaskStatus.COMPLETED.value,
+                    "lease_released": True,
+                    "control_event_state": {},
+                    "normalized_outputs": [],
+                    "output": "ok",
+                    "late_result": False,
+                },
             ),
             patch(
                 "xagent.web.api.websocket.manager",
@@ -282,3 +401,727 @@ async def test_resumed_turn_re_resolves_scope() -> None:
     assert resolver_calls == ["42"]
     assert seen["scope_at_resume"] is scope
     assert get_execution_scope() is None
+
+
+@pytest.mark.asyncio
+async def test_resume_handler_resolves_scope_once_off_loop_and_passes_it_through() -> (
+    None
+):
+    main_thread_id = threading.get_ident()
+    scope = ExecutionScope(
+        sandbox_key_suffix="tenant-a", workspace_segments=("tenant-a",)
+    )
+    resolver_threads: list[int] = []
+
+    def resolver(task_id: str) -> ExecutionScope:
+        assert task_id == "42"
+        resolver_threads.append(threading.get_ident())
+        return scope
+
+    set_execution_scope_resolver(resolver)
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(
+            id=42,
+            user_id=1,
+            status=TaskStatus.PAUSED,
+            control_state="paused",
+            run_id="run-a",
+            state_version=3,
+        ),
+        runtime_user=SimpleNamespace(id=1, is_admin=False),
+    )
+    agent_service = MagicMock()
+    agent_service.supports_live_control.return_value = True
+    agent_manager = MagicMock(get_agent_for_task=AsyncMock(return_value=agent_service))
+    resume_started = asyncio.Event()
+    resume_kwargs: dict[str, Any] = {}
+
+    async def execute_resume(**kwargs: Any) -> None:
+        resume_kwargs.update(kwargs)
+        resume_started.set()
+
+    background_manager = MagicMock()
+    background_manager.running_tasks = {}
+    background_manager.reserve_resume.return_value = True
+    transition = AsyncMock(
+        return_value=SimpleNamespace(run_id="run-a", status=TaskStatus.PAUSED)
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+                return_value=snapshot,
+            ),
+            patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+            patch(
+                "xagent.web.api.websocket.task_execution_controller.transition",
+                new=transition,
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager",
+                background_manager,
+            ),
+            patch(
+                "xagent.web.api.websocket.execute_resume_background",
+                side_effect=execute_resume,
+            ),
+        ]
+    ):
+        await _handle_resume_task_unserialized(
+            MagicMock(),
+            42,
+            {"user": SimpleNamespace(id=1, is_admin=False)},
+        )
+        await asyncio.wait_for(resume_started.wait(), timeout=1)
+
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0] != main_thread_id
+    assert (
+        agent_manager.get_agent_for_task.await_args.kwargs["resolved_execution_scope"]
+        is scope
+    )
+    assert resume_kwargs["resolved_execution_scope"] is scope
+
+
+def test_resume_acquire_checkout_timeout_before_claim_does_not_try_cleanup() -> None:
+    query = MagicMock()
+    query.filter.return_value = query
+    query.first.side_effect = SQLAlchemyTimeoutError("pool exhausted")
+    db = MagicMock()
+    db.query.return_value = query
+    session_context = MagicMock()
+    session_context.__enter__.return_value = db
+    session_context.__exit__.return_value = False
+    session_factory = MagicMock(return_value=session_context)
+    transaction_claim = MagicMock()
+
+    with (
+        patch(
+            "xagent.web.api.websocket.get_session_local",
+            return_value=session_factory,
+        ),
+        patch(
+            "xagent.web.api.websocket.acquire_task_lease_no_commit",
+            transaction_claim,
+        ),
+        pytest.raises(SQLAlchemyTimeoutError, match="pool exhausted"),
+    ):
+        _acquire_resume_task_lease(42, 1, "run-a")
+
+    transaction_claim.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_db_lifecycle_runs_in_short_session_workers() -> None:
+    """Resume lease acquisition, terminal persistence, and fallback release
+    must all run off-loop, while the tracker is constructed without a caller
+    Session and the resolved unscoped value stays explicit.
+    """
+    main_thread_id = threading.get_ident()
+    worker_events: list[tuple[str, int]] = []
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+
+    def acquire_resume_lease(*args: Any, **kwargs: Any) -> object:
+        worker_events.append(("acquire", threading.get_ident()))
+        return lease
+
+    def finalize_resume(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        worker_events.append(("finalize", threading.get_ident()))
+        return {
+            "task_title": "scope wiring test",
+            "task_description": "x",
+            "task_execution_mode": "flash",
+            "task_agent_id": None,
+            "agent_name": None,
+            "agent_logo_url": None,
+            "final_status": TaskStatus.COMPLETED.value,
+            "lease_released": False,
+            "control_event_state": {},
+            "normalized_outputs": [],
+            "output": "ok",
+            "late_result": False,
+        }
+
+    def release_resume_lease(
+        acquired_lease: object, *, error_message: str | None
+    ) -> None:
+        assert acquired_lease is lease
+        assert error_message is None
+        worker_events.append(("release", threading.get_ident()))
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        return_value={"status": "completed", "success": True, "output": "ok"}
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                side_effect=acquire_resume_lease,
+                create=True,
+            ),
+            patch(
+                "xagent.web.api.websocket._finalize_resumed_task",
+                side_effect=finalize_resume,
+                create=True,
+            ),
+            patch(
+                "xagent.web.api.websocket._settle_resumed_task_lease",
+                side_effect=release_resume_lease,
+                create=True,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    assert [name for name, _thread_id in worker_events] == [
+        "acquire",
+        "finalize",
+        "release",
+    ]
+    assert all(thread_id != main_thread_id for _, thread_id in worker_events)
+
+
+@pytest.mark.asyncio
+async def test_resume_final_usage_and_heartbeat_finish_before_lease_release() -> None:
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    events: list[str] = []
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            events.append("usage")
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    async def stop_heartbeat(*_args: Any) -> None:
+        events.append("heartbeat")
+
+    def finalize(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        events.append("lease-finalizer")
+        return {
+            "task_title": "scope wiring test",
+            "task_description": "x",
+            "task_execution_mode": "flash",
+            "task_agent_id": None,
+            "agent_name": None,
+            "agent_logo_url": None,
+            "final_status": TaskStatus.COMPLETED.value,
+            "lease_released": True,
+            "control_event_state": {},
+            "normalized_outputs": [],
+            "output": "ok",
+            "late_result": False,
+        }
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        return_value={"status": "completed", "success": True, "output": "ok"}
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                side_effect=stop_heartbeat,
+            ),
+            patch(
+                "xagent.web.api.websocket._finalize_resumed_task",
+                side_effect=finalize,
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    assert events == ["usage", "heartbeat", "lease-finalizer"]
+
+
+@pytest.mark.asyncio
+async def test_resume_pool_timeout_does_not_start_secondary_db_cleanup(caplog) -> None:
+    """A resume checkout timeout retains its exact lease for TTL recovery."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    mark_delivery = MagicMock()
+    settle = MagicMock()
+    snapshot = AsyncMock()
+    tracker_instances: list[Any] = []
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+            tracker_instances.append(self)
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        return_value={"status": "completed", "success": True, "output": "ok"}
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+    caplog.set_level(logging.ERROR, logger="xagent.web.api.websocket")
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch(
+                "xagent.web.api.websocket._finalize_resumed_task",
+                side_effect=SQLAlchemyTimeoutError("pool exhausted"),
+            ),
+            patch(
+                "xagent.web.api.websocket._settle_resumed_task_lease",
+                settle,
+            ),
+            patch(
+                "xagent.web.api.websocket.mark_user_message_delivery_sync",
+                mark_delivery,
+            ),
+            patch(
+                "xagent.web.api.websocket.task_execution_controller.snapshot",
+                new=snapshot,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            delivery_turn_id="resume-turn",
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    assert tracker_instances
+    tracker_instances[0].complete_tracking.assert_awaited_once()
+    tracker_instances[0].stop_periodic_updates.assert_not_awaited()
+    mark_delivery.assert_not_called()
+    snapshot.assert_not_awaited()
+    settle.assert_not_called()
+    assert "task_id=42" in caplog.text
+    assert "component=resume" in caplog.text
+    assert "retaining lease for TTL recovery" in caplog.text
+    assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_tracker_pool_timeout_skips_result_and_lease_checkouts() -> None:
+    """A final-usage timeout is the only checkout attempted during cleanup."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    finalize = MagicMock()
+    settle = MagicMock()
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            raise SQLAlchemyTimeoutError("pool exhausted")
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        return_value={"status": "completed", "success": True, "output": "ok"}
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch("xagent.web.api.websocket._finalize_resumed_task", finalize),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    finalize.assert_not_called()
+    settle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_heartbeat_pool_timeout_skips_result_and_lease_checkouts() -> None:
+    """Heartbeat exhaustion retains the lease instead of checking out again."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    finalize = MagicMock()
+    settle = MagicMock()
+    heartbeat_timeout = SQLAlchemyTimeoutError("heartbeat pool exhausted")
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        return_value={"status": "completed", "success": True, "output": "ok"}
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch("xagent.web.api.websocket._finalize_resumed_task", finalize),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(
+                    return_value=TaskLeaseHeartbeatOutcome(
+                        pool_timeout=heartbeat_timeout
+                    )
+                ),
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    finalize.assert_not_called()
+    settle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_error_delivery_pool_timeout_skips_lease_checkout() -> None:
+    """A timeout while recording failure must not trigger lease settlement."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    settle = MagicMock()
+    snapshot = AsyncMock()
+    mark_delivery = MagicMock(
+        side_effect=SQLAlchemyTimeoutError("delivery pool exhausted")
+    )
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=RuntimeError("resume failed")
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch(
+                "xagent.web.api.websocket._settle_resumed_task_lease",
+                settle,
+            ),
+            patch(
+                "xagent.web.api.websocket.mark_user_message_delivery_sync",
+                mark_delivery,
+            ),
+            patch(
+                "xagent.web.api.websocket.task_execution_controller.snapshot",
+                new=snapshot,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            delivery_turn_id="resume-turn",
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    mark_delivery.assert_called_once()
+    snapshot.assert_not_awaited()
+    settle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_cancellation_drains_all_final_cleanup() -> None:
+    """Caller cancellation must not skip heartbeat stop or exact settlement."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    completion_started = asyncio.Event()
+    allow_completion = asyncio.Event()
+    events: list[str] = []
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            assert task_id == 42
+            assert kwargs == {
+                "expected_run_id": "run-a",
+                "expected_runner_id": "runner-a",
+            }
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def complete_tracking(self) -> None:
+            completion_started.set()
+            try:
+                await allow_completion.wait()
+            except asyncio.CancelledError:
+                # Match TaskTracker's contract: drain its inner worker before
+                # returning the caller's cancellation.
+                await allow_completion.wait()
+                events.append("usage")
+                raise
+            events.append("usage")
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    async def stop_heartbeat(*_args: Any) -> None:
+        events.append("heartbeat")
+
+    def settle(*_args: Any, **_kwargs: Any) -> bool:
+        events.append("lease")
+        return True
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=RuntimeError("run failed")
+    )
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                return_value=lease,
+            ),
+            patch(
+                "xagent.web.api.websocket._settle_resumed_task_lease",
+                side_effect=settle,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                side_effect=stop_heartbeat,
+            ),
+            patch(
+                "xagent.web.api.websocket.manager",
+                MagicMock(broadcast_to_task=AsyncMock()),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        execution = asyncio.create_task(
+            execute_resume_background(
+                task_id=42,
+                agent_service=agent_service,
+                task_owner_user_id=1,
+                resolved_execution_scope=None,
+            )
+        )
+        await asyncio.wait_for(completion_started.wait(), timeout=1)
+        execution.cancel()
+        await asyncio.sleep(0)
+        allow_completion.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execution, timeout=1)
+
+    assert events == ["usage", "heartbeat", "lease"]

--- a/tests/web/api/test_get_agent_for_task_dedup.py
+++ b/tests/web/api/test_get_agent_for_task_dedup.py
@@ -29,6 +29,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -144,6 +145,8 @@ async def test_existing_task_with_agent_dedups_task_and_agent_queries() -> None:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -6,17 +6,15 @@ Background:
     to ``RUNNING`` before ``get_agent_for_task`` is called. A naive
     ``should_reconstruct = status in {RUNNING, PAUSED,
     WAITING_FOR_USER}`` test would route every brand-new SDK task
-    into ``_reconstruct_agent_from_history``, which queries
-    ``TraceEvent`` and ``DAGExecution.current_plan``, finds nothing,
-    logs a misleading "Failed to reconstruct agent from history"
-    warning, and falls through to normal creation. The full
-    reconstruct path is 1-2s of wasted DB work plus a noisy log line
-    that confuses incident triage.
+    into ``_reconstruct_agent_from_history``. The worker-owned task
+    snapshot finds no ``TraceEvent`` or ``DAGExecution`` state, so
+    reconstruction would only log a misleading warning and fall
+    through to normal creation.
 
-    ``_has_reconstructable_history`` gates the reconstruct branch
-    for ``RUNNING`` tasks: if neither a ``TraceEvent`` row nor a
-    ``DAGExecution`` row exists for the task, the reconstruct branch
-    is skipped and the function goes straight to normal creation.
+    ``TaskSetupSnapshot.has_reconstructable_history`` gates the
+    reconstruct branch for ``RUNNING`` tasks. The same detached
+    snapshot is then reused for reconstruction or normal creation;
+    no history probe is allowed on the asyncio event loop.
 
     ``PAUSED`` / ``WAITING_FOR_USER`` tasks are NOT gated on the
     pre-check -- those states by definition have prior runtime state
@@ -46,6 +44,13 @@ from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import DAGExecution, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskOwnerMismatchError,
+    TaskReconstructionSnapshot,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
 
 
 def _make_user() -> User:
@@ -83,10 +88,66 @@ def _make_agent() -> Agent:
     )
 
 
+def _build_snapshot(
+    task: Task,
+    user: User,
+    *,
+    trace_event: Any | None = None,
+    dag_execution: Any | None = None,
+) -> TaskSetupSnapshot:
+    """Build the detached state produced by the worker-owned snapshot loader."""
+    has_history = trace_event is not None or dag_execution is not None
+    reconstruction = TaskReconstructionSnapshot(
+        tracer_events=(
+            (
+                {
+                    "id": "event-1",
+                    "event_type": "agent_step",
+                    "task_id": str(task.id),
+                    "step_id": None,
+                    "timestamp": None,
+                    "data": {},
+                    "parent_id": None,
+                },
+            )
+            if trace_event is not None
+            else ()
+        ),
+        plan_state={"steps": []} if dag_execution is not None else None,
+        has_history=has_history,
+    )
+    return TaskSetupSnapshot(
+        task=_TaskFields(
+            id=int(task.id),
+            user_id=int(task.user_id),
+            status=task.status,
+            source=task.source,
+            agent_id=task.agent_id,
+            agent_config=task.agent_config,
+            model_name=task.model_name,
+            compact_model_name=task.compact_model_name,
+            execution_mode=task.execution_mode,
+            agent_type=task.agent_type,
+        ),
+        runtime_user=RuntimeUserFields(
+            id=int(user.id),
+            is_admin=bool(user.is_admin),
+        ),
+        has_reconstructable_history=has_history,
+        task_pattern="single_call",
+        task_llm=MagicMock(),
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=None,
+        agent_config=None,
+        excluded_agent_id=None,
+        reconstruction=reconstruction,
+    )
+
+
 class _Fake:
-    """Sentinel for a non-None trace event / DAG plan row -- the
-    pre-check only does ``.first() is not None``, the row's contents
-    are not inspected by the pre-check itself."""
+    """Sentinel used to select trace- or DAG-backed snapshot history."""
 
 
 def _build_db(
@@ -193,9 +254,22 @@ async def test_running_with_no_history_skips_reconstruct() -> None:
         agent=agent_row,
         user=user,
     )
+    snapshot = _build_snapshot(task, user)
 
     reconstruct = AsyncMock()
-    with patch.object(manager, "_reconstruct_agent_from_history", reconstruct):
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+        patch.object(
+            manager,
+            "_has_reconstructable_history",
+            side_effect=AssertionError("history pre-check ran on the event loop"),
+            create=True,
+        ),
+    ):
         with _Patches(_stub_downstream(manager)):
             try:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
@@ -206,6 +280,7 @@ async def test_running_with_no_history_skips_reconstruct() -> None:
                 pass
 
     reconstruct.assert_not_awaited()
+    snapshot_loader.assert_called_once_with(42, 1)
 
 
 @pytest.mark.asyncio
@@ -226,16 +301,34 @@ async def test_running_with_prior_trace_event_runs_reconstruct() -> None:
         agent=agent_row,
         user=user,
     )
+    snapshot = _build_snapshot(task, user, trace_event=_Fake())
 
     reconstruct = AsyncMock()
-    with patch.object(manager, "_reconstruct_agent_from_history", reconstruct):
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+        patch.object(
+            manager,
+            "_has_reconstructable_history",
+            side_effect=AssertionError("history pre-check ran on the event loop"),
+            create=True,
+        ),
+    ):
         with _Patches(_stub_downstream(manager)):
             try:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
             except Exception:
                 pass
-
-    reconstruct.assert_awaited_once_with(42, db, scope=None)
+    reconstruct.assert_awaited_once_with(
+        42,
+        db,
+        scope=None,
+        task_setup_snapshot=snapshot,
+    )
+    snapshot_loader.assert_called_once_with(42, 1)
 
 
 @pytest.mark.asyncio
@@ -252,6 +345,7 @@ async def test_required_mcp_failure_does_not_fall_back_after_reconstruct() -> No
     error = RequiredMCPUnavailableError(
         [MCPUnavailableSummary.from_values("Gmail", "oauth_token_required")]
     )
+    snapshot = _build_snapshot(task, user, trace_event=_Fake())
 
     async def fail_reconstruct(*args, **kwargs):
         manager._agents[42] = MagicMock()
@@ -262,15 +356,48 @@ async def test_required_mcp_failure_does_not_fall_back_after_reconstruct() -> No
         patch.object(
             manager, "_reconstruct_agent_from_history", side_effect=fail_reconstruct
         ),
-        patch("xagent.web.api.chat.load_task_setup_snapshot_sync") as snapshot_loader,
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+        patch.object(
+            manager,
+            "_has_reconstructable_history",
+            side_effect=AssertionError("history pre-check ran on the event loop"),
+            create=True,
+        ),
     ):
         with pytest.raises(RequiredMCPUnavailableError) as exc_info:
             await manager.get_agent_for_task(task_id=42, db=db, user=user)
 
     assert exc_info.value is error
-    snapshot_loader.assert_not_called()
+    snapshot_loader.assert_called_once_with(42, 1)
     assert 42 not in manager._agents
     assert 42 not in manager._agent_owner_ids
+
+
+@pytest.mark.asyncio
+async def test_active_snapshot_owner_mismatch_does_not_fall_back() -> None:
+    manager = AgentServiceManager()
+    user = _make_user()
+    task = _make_task(TaskStatus.RUNNING, agent_id=7)
+    db = _build_db(task, agent=_make_agent(), user=user)
+    mismatch = TaskOwnerMismatchError(42, expected=999, actual=1)
+
+    with patch(
+        "xagent.web.api.chat.load_task_setup_snapshot_sync",
+        side_effect=mismatch,
+    ) as snapshot_loader:
+        with pytest.raises(TaskOwnerMismatchError) as exc_info:
+            await manager.get_agent_for_task(
+                task_id=42,
+                db=db,
+                user=user,
+                task_owner_user_id=999,
+            )
+
+    assert exc_info.value is mismatch
+    snapshot_loader.assert_called_once_with(42, 999)
 
 
 @pytest.mark.asyncio
@@ -289,16 +416,34 @@ async def test_running_with_dag_plan_runs_reconstruct() -> None:
         agent=agent_row,
         user=user,
     )
+    snapshot = _build_snapshot(task, user, dag_execution=_Fake())
 
     reconstruct = AsyncMock()
-    with patch.object(manager, "_reconstruct_agent_from_history", reconstruct):
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+        patch.object(
+            manager,
+            "_has_reconstructable_history",
+            side_effect=AssertionError("history pre-check ran on the event loop"),
+            create=True,
+        ),
+    ):
         with _Patches(_stub_downstream(manager)):
             try:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
             except Exception:
                 pass
-
-    reconstruct.assert_awaited_once_with(42, db, scope=None)
+    reconstruct.assert_awaited_once_with(
+        42,
+        db,
+        scope=None,
+        task_setup_snapshot=snapshot,
+    )
+    snapshot_loader.assert_called_once_with(42, 1)
 
 
 @pytest.mark.asyncio
@@ -320,16 +465,28 @@ async def test_paused_with_no_history_still_runs_reconstruct() -> None:
         agent=agent_row,
         user=user,
     )
+    snapshot = _build_snapshot(task, user)
 
     reconstruct = AsyncMock()
-    with patch.object(manager, "_reconstruct_agent_from_history", reconstruct):
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+    ):
         with _Patches(_stub_downstream(manager)):
             try:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
             except Exception:
                 pass
-
-    reconstruct.assert_awaited_once_with(42, db, scope=None)
+    reconstruct.assert_awaited_once_with(
+        42,
+        db,
+        scope=None,
+        task_setup_snapshot=snapshot,
+    )
+    snapshot_loader.assert_called_once_with(42, 1)
 
 
 @pytest.mark.asyncio
@@ -347,16 +504,28 @@ async def test_waiting_for_user_with_no_history_still_runs_reconstruct() -> None
         agent=agent_row,
         user=user,
     )
+    snapshot = _build_snapshot(task, user)
 
     reconstruct = AsyncMock()
-    with patch.object(manager, "_reconstruct_agent_from_history", reconstruct):
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
+    ):
         with _Patches(_stub_downstream(manager)):
             try:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
             except Exception:
                 pass
-
-    reconstruct.assert_awaited_once_with(42, db, scope=None)
+    reconstruct.assert_awaited_once_with(
+        42,
+        db,
+        scope=None,
+        task_setup_snapshot=snapshot,
+    )
+    snapshot_loader.assert_called_once_with(42, 1)
 
 
 @pytest.mark.asyncio
@@ -368,6 +537,7 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
     db = _build_db(
         task, trace_event=None, dag_execution=None, agent=agent_row, user=user
     )
+    snapshot = _build_snapshot(task, user)
 
     class _ToolConfig:
         def __init__(self) -> None:
@@ -387,11 +557,21 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
 
     reconstructed_agent = _Agent()
 
-    async def reconstruct(task_id: int, _db: Any, scope: Any = None) -> None:
+    async def reconstruct(
+        task_id: int,
+        _db: Any,
+        scope: Any = None,
+        task_setup_snapshot: TaskSetupSnapshot | None = None,
+    ) -> None:
+        assert task_setup_snapshot is snapshot
         manager._agents[task_id] = reconstructed_agent
 
     with (
         patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ) as snapshot_loader,
         patch.object(manager, "_load_persisted_conversation_history"),
         patch.object(manager, "_load_persisted_execution_context", new=AsyncMock()),
     ):
@@ -403,6 +583,7 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
         )
 
     assert agent is reconstructed_agent
+    snapshot_loader.assert_called_once_with(42, 1)
     assert reconstructed_agent.tool_config.turn_ids == ["turn-reconstructed"]
     assert reconstructed_agent.invalidated is True
 

--- a/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
@@ -25,18 +25,25 @@ What this test pins:
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import ExitStack
+from time import monotonic
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
+from xagent.core.execution_scope import scope_fingerprint
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskOwnerMismatchError,
     TaskSetupSnapshot,
     _TaskFields,
@@ -60,6 +67,8 @@ def _build_snapshot() -> TaskSetupSnapshot:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,
@@ -84,11 +93,7 @@ def _build_snapshot() -> TaskSetupSnapshot:
 
 
 def _build_db_mock(task_row: Task) -> MagicMock:
-    """Mock ``db`` whose ``query(Task)...first()`` returns the row.
-    The existence check at the top of ``get_agent_for_task`` still
-    runs against this; the snapshot path only skips the LLM-config
-    re-read further down.
-    """
+    """Mock request session used by legacy-path tests."""
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = task_row
     return db
@@ -154,6 +159,83 @@ async def test_caller_supplied_snapshot_skips_internal_to_thread() -> None:
             pass
 
     loader_mock.assert_not_called()
+    db.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_startup_stays_responsive_with_exhausted_pool(tmp_path) -> None:
+    """A ready snapshot must reach non-DB setup without waiting on QueuePool."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'startup-pool.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.25,
+    )
+    SessionLocal = sessionmaker(bind=engine)
+    held_connection = engine.connect()
+    db = SessionLocal()
+    manager = AgentServiceManager()
+    manager._default_llm = MagicMock()
+    snapshot = _build_snapshot()
+    sandbox_entered = asyncio.Event()
+    release_sandbox = asyncio.Event()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def blocked_sandbox(**_kwargs: Any) -> None:
+        sandbox_entered.set()
+        await release_sandbox.wait()
+        raise RuntimeError("stop after the startup boundary")
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    with ExitStack() as stack:
+        for p in _common_patches(manager):
+            stack.enter_context(p)
+        stack.enter_context(
+            patch.object(manager, "_get_or_create_task_sandbox", blocked_sandbox)
+        )
+        started = monotonic()
+        build_task = asyncio.create_task(
+            manager.get_agent_for_task(
+                task_id=42,
+                db=db,
+                user=None,
+                task_setup_snapshot=snapshot,
+                task_owner_user_id=1,
+                resolved_execution_scope=None,
+            )
+        )
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await asyncio.wait_for(sandbox_entered.wait(), timeout=0.4)
+            elapsed = monotonic() - started
+            await asyncio.sleep(0.04)
+            assert elapsed < 0.15, (
+                "Snapshot startup waited for the exhausted request pool; "
+                f"sandbox boundary reached after {elapsed:.3f}s."
+            )
+            assert ticks >= 3, f"Event-loop ticker advanced only {ticks} time(s)."
+        finally:
+            release_sandbox.set()
+            ticker_stop.set()
+            results = await asyncio.gather(
+                build_task,
+                ticker_task,
+                return_exceptions=True,
+            )
+            db.close()
+            held_connection.close()
+            engine.dispose()
+
+    assert isinstance(results[0], RuntimeError)
 
 
 @pytest.mark.asyncio
@@ -197,6 +279,29 @@ async def test_no_snapshot_falls_back_to_internal_to_thread() -> None:
         "means either the in-method fallback was removed (breaking WS / "
         "non-passthrough callers) or the snapshot is being loaded twice."
     )
+
+
+@pytest.mark.asyncio
+async def test_explicit_unscoped_result_skips_internal_scope_resolver() -> None:
+    """Explicit ``None`` is a resolved unscoped turn, not an instruction to
+    resolve again inside the cache owner.
+    """
+    manager = AgentServiceManager()
+    cached_agent = MagicMock()
+    manager._agents[42] = cached_agent
+    manager._agent_owner_ids[42] = 1
+    manager._agent_scope_fingerprints[42] = scope_fingerprint(None)
+
+    with patch("xagent.web.api.chat.resolve_execution_scope") as resolver_mock:
+        resolved = await manager.get_agent_for_task(
+            task_id=42,
+            user=_make_user(),
+            task_owner_user_id=1,
+            resolved_execution_scope=None,
+        )
+
+    assert resolved is cached_agent
+    resolver_mock.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
@@ -37,6 +37,7 @@ from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.task import TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -60,6 +61,8 @@ def _build_snapshot(*, source: str | None = "internal") -> TaskSetupSnapshot:
             execution_mode="flash",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="single_call",
         task_llm=None,
         task_fast_llm=None,
@@ -247,6 +250,12 @@ async def test_loop_consumes_snapshot_after_session_close() -> None:
 
         def cleanup_workspace(self) -> None: ...
 
+        def set_conversation_history(self, _messages: Any) -> None: ...
+
+        def set_execution_context_messages(self, _messages: Any) -> None: ...
+
+        def set_recovered_skill_context(self, _context: Any) -> None: ...
+
     manager = AgentServiceManager()
     user = _make_user()
     db = MagicMock()
@@ -364,6 +373,8 @@ async def test_snapshot_fallback_raises_on_no_default_llm_with_agent_builder() -
             execution_mode="balanced",
             agent_type="standard",
         ),
+        runtime_user=RuntimeUserFields(id=1, is_admin=False),
+        has_reconstructable_history=False,
         task_pattern="react",
         task_llm=None,
         task_fast_llm=None,

--- a/tests/web/api/test_websocket_error_payload.py
+++ b/tests/web/api/test_websocket_error_payload.py
@@ -1,18 +1,24 @@
+import sys
+import threading
 from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import _terminal_task_error_payload
+from xagent.web.models.database import get_engine
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
-from xagent.web.services.task_lease_service import get_runner_id
+from xagent.web.services.task_lease_service import TaskLease, get_runner_id
 
 from .conftest import _direct_db_session
 
 
-def test_terminal_task_error_payload_marks_task_failed(_test_db):
+def test_terminal_task_error_payload_marks_unowned_task_failed(_test_db):
     db = _direct_db_session()
     try:
         user = User(username="owner", password_hash="hash")
@@ -24,19 +30,39 @@ def test_terminal_task_error_payload_marks_task_failed(_test_db):
             title="Failing task",
             description="Failing task",
             status=TaskStatus.RUNNING,
-            runner_id=get_runner_id(),
-            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            runner_id=None,
+            lease_expires_at=None,
         )
         db.add(task)
         db.commit()
         task_id = task.id
 
-        payload = _terminal_task_error_payload(task_id, "Runtime error")
+        task_updates: list[str] = []
+
+        def record_task_update(
+            _connection,
+            _cursor,
+            statement,
+            _parameters,
+            _context,
+            _executemany,
+        ):
+            if statement.lstrip().lower().startswith("update tasks"):
+                task_updates.append(statement)
+
+        engine = get_engine()
+        event.listen(engine, "before_cursor_execute", record_task_update)
+        try:
+            payload = _terminal_task_error_payload(task_id, "Runtime error")
+        finally:
+            event.remove(engine, "before_cursor_execute", record_task_update)
 
         assert payload["type"] == "agent_error"
         assert payload["message"] == "Runtime error"
         assert payload["task"]["id"] == task_id
         assert payload["task"]["status"] == "failed"
+        assert len(task_updates) == 1
+        assert "tasks.runner_id IS NULL" in task_updates[0]
 
         db.expire_all()
         persisted_task = db.query(Task).filter(Task.id == task_id).one()
@@ -65,8 +91,8 @@ def test_terminal_task_error_payload_persists_error_chat_message(_test_db):
             title="Rejected task",
             description="Rejected task",
             status=TaskStatus.RUNNING,
-            runner_id=get_runner_id(),
-            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            runner_id=None,
+            lease_expires_at=None,
         )
         db.add(task)
         db.commit()
@@ -86,6 +112,169 @@ def test_terminal_task_error_payload_persists_error_chat_message(_test_db):
         )
         assert len(messages) == 1
         assert error_text in messages[0].content
+    finally:
+        db.close()
+
+
+def test_terminal_task_error_payload_rejects_replacement_runner_same_run(_test_db):
+    """A late legacy error cannot fail a run after another runner took it over.
+
+    Lease recovery deliberately keeps ``run_id`` when a RUNNING task's expired
+    lease is claimed by a replacement runner.  The runner predicate is therefore
+    independently required; matching only ``run_id`` is not ownership proof.
+    """
+    db = _direct_db_session()
+    try:
+        user = User(username="replacement-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+
+        task = Task(
+            user_id=user.id,
+            title="Replacement runner",
+            description="Replacement runner",
+            status=TaskStatus.RUNNING,
+            runner_id="replacement-runner",
+            run_id="same-run",
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            output="replacement output",
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    payload = _terminal_task_error_payload(
+        task_id,
+        "late old failure",
+        expected_run_id="same-run",
+    )
+
+    assert payload is not None
+    assert payload["task"]["status"] == TaskStatus.RUNNING.value
+    db = _direct_db_session()
+    try:
+        persisted = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted.status == TaskStatus.RUNNING
+        assert persisted.runner_id == "replacement-runner"
+        assert persisted.run_id == "same-run"
+        assert persisted.lease_expires_at is not None
+        assert persisted.output == "replacement output"
+        assert persisted.error_message is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "failure_type"),
+    [
+        ("chat", ValueError),
+        ("chat", RuntimeError),
+        ("execute", ValueError),
+        ("execute", RuntimeError),
+    ],
+)
+async def test_legacy_handler_does_not_steal_live_foreign_lease(
+    _test_db,
+    monkeypatch,
+    handler_name,
+    failure_type,
+):
+    """Legacy handlers must not mutate a task owned by another runner."""
+    db = _direct_db_session()
+    try:
+        user = User(
+            username=f"{handler_name}-{failure_type.__name__}", password_hash="hash"
+        )
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=user.id,
+            title="Owned task",
+            description="Owned task",
+            status=TaskStatus.RUNNING,
+            runner_id="replacement-runner",
+            run_id="replacement-run",
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            output="replacement output",
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+        user_id = int(user.id)
+    finally:
+        db.close()
+
+    class FailingAgentManager:
+        async def get_agent_for_task(self, *args, **kwargs):
+            raise failure_type("setup failed")
+
+    fake_chat_module = ModuleType("xagent.web.api.chat")
+    fake_chat_module.get_agent_manager = lambda: FailingAgentManager()  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "xagent.web.api.chat",
+        fake_chat_module,
+    )
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "send_personal_message",
+        AsyncMock(),
+    )
+    broadcasts = AsyncMock()
+    monkeypatch.setattr(websocket_api.manager, "broadcast_to_task", broadcasts)
+
+    real_session_factory = websocket_api.get_session_local()
+    main_thread_id = threading.get_ident()
+    payload_session_threads: list[int] = []
+
+    def tracked_get_session_local():
+        payload_session_threads.append(threading.get_ident())
+        return real_session_factory
+
+    monkeypatch.setattr(
+        websocket_api,
+        "get_session_local",
+        tracked_get_session_local,
+    )
+
+    message_data = {
+        "message": "continue",
+        "context": {},
+        "user": SimpleNamespace(id=user_id, is_admin=False),
+    }
+    if handler_name == "chat":
+        await websocket_api._handle_chat_message_unserialized(
+            object(),
+            task_id,
+            message_data,
+        )
+    else:
+        await websocket_api.handle_execute_task(object(), task_id, message_data)
+
+    assert payload_session_threads
+    assert all(thread_id != main_thread_id for thread_id in payload_session_threads)
+    payload = broadcasts.await_args_list[-1].args[0]
+    if handler_name == "execute":
+        # The execute command now enters the shared lease-aware scheduler. A
+        # live foreign lease stops it before agent setup, so task_info is the
+        # last event rather than a synthetic setup error.
+        assert payload["event_type"] == "task_info"
+        assert payload["data"]["status"] == TaskStatus.RUNNING.value
+    else:
+        assert payload["task"]["status"] == TaskStatus.RUNNING.value
+
+    db = _direct_db_session()
+    try:
+        persisted = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted.status == TaskStatus.RUNNING
+        assert persisted.runner_id == "replacement-runner"
+        assert persisted.run_id == "replacement-run"
+        assert persisted.lease_expires_at is not None
+        assert persisted.output == "replacement output"
+        assert persisted.error_message is None
     finally:
         db.close()
 
@@ -232,8 +421,8 @@ async def test_execute_task_background_error_marks_task_failed(_test_db, monkeyp
             title="Failing background task",
             description="Failing background task",
             status=TaskStatus.RUNNING,
-            runner_id=get_runner_id(),
-            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            runner_id=None,
+            lease_expires_at=None,
         )
         db.add(task)
         db.commit()
@@ -281,3 +470,204 @@ async def test_execute_task_background_error_marks_task_failed(_test_db, monkeyp
         assert persisted_task.error_message == "setup failed"
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_background_error_defers_database_settlement(
+    _test_db, monkeypatch
+):
+    """The lease-owning orchestrator gets the exception and owns one DB settle.
+
+    ``execute_task_background`` may still notify the client, but it must not
+    open its own terminal-error Session before the orchestrator finalizes the
+    concrete run/runner lease.
+    """
+    db = _direct_db_session()
+    try:
+        user = User(username="orchestrated-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=user.id,
+            title="Orchestrated failure",
+            description="Orchestrated failure",
+            status=TaskStatus.RUNNING,
+            runner_id="runner-a",
+            run_id="run-a",
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+        user_id = int(user.id)
+    finally:
+        db.close()
+
+    broadcasts: list[dict] = []
+
+    async def fake_broadcast_to_task(message, _task_id):
+        broadcasts.append(message)
+
+    class FailingAgentManager:
+        async def get_agent_for_task(self, *args, **kwargs):
+            raise RuntimeError("setup failed before execution")
+
+    monkeypatch.setattr(
+        websocket_api.manager, "broadcast_to_task", fake_broadcast_to_task
+    )
+    terminal_writer = MagicMock()
+    monkeypatch.setattr(websocket_api, "_terminal_task_error_payload", terminal_writer)
+
+    with pytest.raises(RuntimeError, match="setup failed before execution"):
+        await websocket_api.execute_task_background(
+            task_id=task_id,
+            user_message="run",
+            context={},
+            agent_manager=FailingAgentManager(),
+            task_owner_user_id=user_id,
+            expected_run_id="run-a",
+            task_lease=TaskLease(task_id, "runner-a", "run-a"),
+        )
+
+    terminal_writer.assert_not_called()
+    assert broadcasts[-1]["type"] == "task_error"
+
+    db = _direct_db_session()
+    try:
+        persisted = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted.status == TaskStatus.RUNNING
+        assert persisted.runner_id == "runner-a"
+        assert persisted.run_id == "run-a"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_background_pool_timeout_is_not_broadcast_as_failed(
+    _test_db, monkeypatch
+):
+    """A fenced run kept for TTL recovery is not a FAILED task."""
+    db = _direct_db_session()
+    try:
+        user = User(username="pool-timeout-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=user.id,
+            title="Pool timeout",
+            description="Pool timeout",
+            status=TaskStatus.RUNNING,
+            runner_id="runner-a",
+            run_id="run-a",
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+        user_id = int(user.id)
+    finally:
+        db.close()
+
+    broadcasts: list[dict] = []
+
+    async def fake_broadcast_to_task(message, _task_id):
+        broadcasts.append(message)
+
+    class PoolExhaustedAgentManager:
+        async def get_agent_for_task(self, *args, **kwargs):
+            raise SQLAlchemyTimeoutError("setup pool exhausted")
+
+    monkeypatch.setattr(
+        websocket_api.manager, "broadcast_to_task", fake_broadcast_to_task
+    )
+    terminal_writer = MagicMock()
+    monkeypatch.setattr(websocket_api, "_terminal_task_error_payload", terminal_writer)
+
+    with pytest.raises(SQLAlchemyTimeoutError, match="setup pool exhausted"):
+        await websocket_api.execute_task_background(
+            task_id=task_id,
+            user_message="run",
+            context={},
+            agent_manager=PoolExhaustedAgentManager(),
+            task_owner_user_id=user_id,
+            expected_run_id="run-a",
+            task_lease=TaskLease(task_id, "runner-a", "run-a"),
+        )
+
+    terminal_writer.assert_not_called()
+    assert not any(event.get("type") == "task_error" for event in broadcasts)
+
+    db = _direct_db_session()
+    try:
+        persisted = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted.status == TaskStatus.RUNNING
+        assert persisted.runner_id == "runner-a"
+        assert persisted.run_id == "run-a"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_background_failure_uses_worker_owned_setup_and_terminal_sessions(
+    monkeypatch,
+):
+    """Setup and terminal persistence both stay off the event-loop thread."""
+    main_thread_id = threading.get_ident()
+    setup_threads: list[int] = []
+    payload_calls: list[tuple[int, bool]] = []
+
+    def load_snapshot(*_args, **_kwargs):
+        setup_threads.append(threading.get_ident())
+        return SimpleNamespace(
+            task=SimpleNamespace(user_id=1, status=TaskStatus.RUNNING),
+            runtime_user=SimpleNamespace(id=1, is_admin=False),
+        )
+
+    def terminal_payload(
+        task_id,
+        message,
+        *,
+        event_type="agent_error",
+        expected_run_id=None,
+        only_if_running=False,
+    ):
+        payload_calls.append((threading.get_ident(), only_if_running))
+        return {"type": event_type, "message": message}
+
+    class FailingAgentManager:
+        async def get_agent_for_task(self, *args, **kwargs):
+            raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+        load_snapshot,
+    )
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "wait_for_previous",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_terminal_task_error_payload",
+        terminal_payload,
+    )
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "broadcast_to_task",
+        AsyncMock(),
+    )
+
+    await websocket_api.execute_task_background(
+        task_id=42,
+        user_message="run",
+        context={},
+        agent_manager=FailingAgentManager(),
+        task_owner_user_id=1,
+    )
+
+    assert not hasattr(websocket_api, "_task_is_still_running")
+    assert setup_threads and setup_threads[0] != main_thread_id
+    assert len(payload_calls) == 1
+    assert payload_calls[0][0] != main_thread_id
+    assert payload_calls[0][1] is True

--- a/tests/web/api/test_websocket_execute_task_db_boundary.py
+++ b/tests/web/api/test_websocket_execute_task_db_boundary.py
@@ -1,0 +1,187 @@
+"""Issue #935 regression tests for legacy WebSocket task execution."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import event
+
+from xagent.web.api import chat as chat_api
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.database import get_engine
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services import task_orchestrator as orchestrator_module
+from xagent.web.services.task_orchestrator import (
+    TaskTurnOrchestrator,
+    TaskTurnPayload,
+)
+
+from .conftest import _direct_db_session
+
+
+@pytest.mark.asyncio
+async def test_legacy_execute_uses_worker_snapshot_and_primitive_scheduler_boundary(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No request Session or ORM row may survive into async execution."""
+    db = _direct_db_session()
+    try:
+        user = User(username="legacy-execute-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=int(user.id),
+            title="Legacy execution",
+            description="Run the existing task",
+            status=TaskStatus.PENDING,
+            execution_mode="balanced",
+            process_description="Follow the saved process",
+            examples=[{"input": "a", "output": "b"}],
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+        user_id = int(user.id)
+    finally:
+        db.close()
+
+    # The pre-fix handler directly calls these collaborators while retaining
+    # its request Session. Keeping them harmless lets the assertion below
+    # fail specifically because the primitive scheduler boundary is absent.
+    agent_service = MagicMock()
+    agent_service.set_outbound_message_handler = MagicMock()
+    agent_service.set_execution_context_messages = MagicMock()
+    agent_service.set_recovered_skill_context = MagicMock()
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    agent_manager.execute_task = AsyncMock(
+        return_value={"success": True, "output": "done", "file_outputs": []}
+    )
+    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: agent_manager)
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    async def completed_execution() -> None:
+        return None
+
+    main_thread_id = threading.get_ident()
+    database_thread_ids: list[int] = []
+    checked_out_connections = 0
+
+    def record_database_thread(*_args: object) -> None:
+        database_thread_ids.append(threading.get_ident())
+
+    def record_checkout(*_args: object) -> None:
+        nonlocal checked_out_connections
+        checked_out_connections += 1
+
+    def record_checkin(*_args: object) -> None:
+        nonlocal checked_out_connections
+        checked_out_connections -= 1
+
+    scheduled_background = asyncio.create_task(completed_execution())
+
+    async def schedule_at_closed_session_boundary(**_kwargs: object) -> asyncio.Task:
+        assert checked_out_connections == 0
+        return scheduled_background
+
+    schedule = AsyncMock(side_effect=schedule_at_closed_session_boundary)
+    monkeypatch.setattr(
+        TaskTurnOrchestrator,
+        "schedule_existing_task_execution",
+        schedule,
+        raising=False,
+    )
+
+    engine = get_engine()
+    event.listen(engine, "before_cursor_execute", record_database_thread)
+    event.listen(engine, "checkout", record_checkout)
+    event.listen(engine, "checkin", record_checkin)  # codespell:ignore checkin
+    try:
+        await websocket_api.handle_execute_task(
+            MagicMock(),
+            task_id,
+            {"user": SimpleNamespace(id=user_id, is_admin=False)},
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", record_database_thread)
+        event.remove(engine, "checkout", record_checkout)
+        event.remove(engine, "checkin", record_checkin)  # codespell:ignore checkin
+
+    assert database_thread_ids
+    assert all(thread_id != main_thread_id for thread_id in database_thread_ids)
+    schedule.assert_awaited_once()
+    schedule_call = schedule.await_args
+    assert schedule_call.kwargs["task_id"] == task_id
+    assert schedule_call.kwargs["task_owner_user_id"] == user_id
+    assert schedule_call.kwargs["task_source"] == "internal"
+    assert schedule_call.kwargs["actor_user_id"] == user_id
+    assert schedule_call.kwargs["context"] == {
+        "execution_mode": "balanced",
+        "process_description": "Follow the saved process",
+        "examples": [{"input": "a", "output": "b"}],
+    }
+    payload = schedule_call.kwargs["payload"]
+    assert isinstance(payload, TaskTurnPayload)
+    assert payload.transcript_message == "Run the existing task"
+    assert payload.execution_message == "Run the existing task"
+
+    # The legacy protocol still emits the immediate acknowledgement and
+    # task-info event before waiting for the scheduled execution to finish.
+    connection_manager.send_personal_message.assert_awaited_once()
+    assert (
+        connection_manager.send_personal_message.await_args.args[0]["type"]
+        == "execution_started"
+    )
+    task_info = connection_manager.broadcast_to_task.await_args_list[0].args[0]
+    assert task_info["event_type"] == "task_info"
+    assert task_info["data"]["id"] == task_id
+    assert task_info["data"]["status"] == TaskStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_existing_task_scheduler_reuses_shared_runtime_without_turn_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compatibility entry schedules runtime work without a new message."""
+
+    async def completed_execution() -> None:
+        return None
+
+    background_task = asyncio.create_task(completed_execution())
+    schedule = MagicMock(return_value=background_task)
+    monkeypatch.setattr(orchestrator_module, "_schedule_bg", schedule)
+
+    payload = TaskTurnPayload(
+        transcript_message="already stored description",
+        execution_message="already stored description",
+    )
+    returned = await TaskTurnOrchestrator.schedule_existing_task_execution(
+        task_id=23,
+        task_owner_user_id=9,
+        task_source="internal",
+        payload=payload,
+        context={"execution_mode": "balanced"},
+        actor_user_id=11,
+    )
+
+    assert returned is background_task
+    schedule.assert_called_once_with(
+        task_id=23,
+        task_owner_user_id=9,
+        task_source="internal",
+        payload=payload,
+        force_fresh=False,
+        context={"execution_mode": "balanced"},
+    )
+    await background_task

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -10,12 +10,20 @@ isolation; here we exercise the handlers end to end).
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    set_execution_scope_resolver,
+)
 from xagent.web.api.websocket import (
+    _claim_user_message_delivery_isolated,
+    _handle_chat_message_unserialized,
     _handle_pause_task_unserialized,
     _handle_resume_task_unserialized,
     background_task_manager,
@@ -86,7 +94,9 @@ def _patched_manager_and_agent():
     agent_service.resume_execution = AsyncMock()
     agent_service.supports_live_control = MagicMock(return_value=False)
 
-    async def _get_agent_for_task(task_id, db, *, user=None, task_owner_user_id=None):
+    async def _get_agent_for_task(
+        task_id, db, *, user=None, task_owner_user_id=None, **_kwargs
+    ):
         captured["task_owner_user_id"] = task_owner_user_id
         return agent_service
 
@@ -154,6 +164,102 @@ async def test_chat_admin_append_to_other_users_task_claims_as_owner(
     assert len(accepted) == 1
     assert accepted[0]["client_message_id"] == "client-turn-1"
     assert accepted[0]["turn_id"] == "client-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_chat_new_turn_releases_request_transaction_before_orchestrator(
+    db_session,
+) -> None:
+    """The worker claim must not compete with the request's prior checkout."""
+    from xagent.web.models.database import get_session_local
+
+    owner = _user(db_session, "new-turn-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    request_sessions = []
+    transaction_open_at_begin: list[bool] = []
+
+    def request_db_generator():
+        request_db = get_session_local()()
+        request_sessions.append(request_db)
+        try:
+            yield request_db
+        finally:
+            request_db.close()
+
+    async def begin_turn(**_kwargs):
+        transaction_open_at_begin.append(request_sessions[-1].in_transaction())
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    with (
+        patch("xagent.web.api.websocket.get_db", side_effect=request_db_generator),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            side_effect=begin_turn,
+        ),
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "follow-up",
+                "client_message_id": "pool-boundary-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    assert transaction_open_at_begin == [False]
+
+
+@pytest.mark.asyncio
+async def test_chat_busy_error_payload_is_loaded_off_loop(db_session) -> None:
+    from xagent.web.services.task_orchestrator import TaskTurnError
+
+    owner = _user(db_session, "busy-payload-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    event_loop_thread = threading.get_ident()
+    payload_threads: list[int] = []
+
+    def read_payload(*_args, **_kwargs):
+        payload_threads.append(threading.get_ident())
+        return {"type": "agent_error", "message": "busy"}
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            side_effect=TaskTurnError("busy"),
+        ),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            side_effect=read_payload,
+        ),
+        patch(
+            "xagent.web.api.websocket._task_error_payload",
+            side_effect=AssertionError("payload query ran on the event loop"),
+        ),
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "follow-up",
+                "client_message_id": "busy-payload-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    assert len(payload_threads) == 1
+    assert payload_threads[0] != event_loop_thread
 
 
 @pytest.mark.asyncio
@@ -258,6 +364,137 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
     ]
     assert len(accepted) == 1
     assert accepted[0]["client_message_id"] == "live-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_running_chat_message_uses_one_offloop_scope_and_no_request_session(
+    db_session,
+) -> None:
+    """The MESSAGE -> live resume handoff must not keep the request Session
+    while agent construction or resume coordination awaits.
+    """
+
+    owner = _user(db_session, "scope-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    scope = ExecutionScope(
+        sandbox_key_suffix="tenant-a", workspace_segments=("tenant-a",)
+    )
+    main_thread_id = threading.get_ident()
+    resolver_threads: list[int] = []
+
+    def resolver(resolved_task_id: str) -> ExecutionScope:
+        assert resolved_task_id == str(task.id)
+        resolver_threads.append(threading.get_ident())
+        return scope
+
+    set_execution_scope_resolver(resolver)
+    original_get_db = get_db
+    tracked_sessions: list[SimpleNamespace] = []
+
+    class TrackingSession:
+        def __init__(self, inner: object) -> None:
+            self.inner = inner
+            self.state = SimpleNamespace(closed=False)
+            tracked_sessions.append(self.state)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self.inner, name)
+
+        def close(self) -> None:
+            self.state.closed = True
+            self.inner.close()  # type: ignore[attr-defined]
+
+    def tracked_get_db():
+        inner_generator = original_get_db()
+        tracked = TrackingSession(next(inner_generator))
+        try:
+            yield tracked
+        finally:
+            tracked.close()
+            inner_generator.close()
+
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    manager_calls: list[tuple[object, dict]] = []
+    claim_threads: list[int] = []
+
+    def claim_delivery(**kwargs: object):
+        claim_threads.append(threading.get_ident())
+        return _claim_user_message_delivery_isolated(**kwargs)  # type: ignore[arg-type]
+
+    async def get_agent_for_task(_task_id: int, db: object, **kwargs: object) -> object:
+        manager_calls.append(
+            (
+                db,
+                {
+                    **kwargs,
+                    "request_sessions_closed": all(
+                        session.closed for session in tracked_sessions
+                    ),
+                },
+            )
+        )
+        return agent
+
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(side_effect=get_agent_for_task)
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    resume_bg = AsyncMock()
+    bg_manager = MagicMock()
+    bg_manager.reserve_resume.return_value = True
+    bg_manager.running_tasks.get.return_value = None
+
+    try:
+        with (
+            patch("xagent.web.api.websocket.get_db", side_effect=tracked_get_db),
+            patch(
+                "xagent.web.api.websocket._claim_user_message_delivery_isolated",
+                side_effect=claim_delivery,
+            ),
+            patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+            patch("xagent.web.api.websocket.background_task_manager", bg_manager),
+            patch(
+                "xagent.web.api.websocket.task_execution_controller.transition",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(
+                        run_id="live-run", status=TaskStatus.RUNNING
+                    )
+                ),
+            ),
+        ):
+            await _handle_chat_message_unserialized(
+                MagicMock(),
+                int(task.id),
+                {
+                    "message": "continue safely",
+                    "client_message_id": "scope-live-turn",
+                    "user": owner,
+                    "files": [],
+                    "_durable_ack_sent": True,
+                },
+            )
+            await asyncio.sleep(0)
+    finally:
+        set_execution_scope_resolver(None)
+
+    assert len(manager_calls) == 1
+    manager_db, manager_kwargs = manager_calls[0]
+    assert manager_db is None
+    assert manager_kwargs["request_sessions_closed"] is True
+    assert manager_kwargs["task_setup_snapshot"] is not None
+    assert manager_kwargs["resolved_execution_scope"] is scope
+    assert resolver_threads and resolver_threads[0] != main_thread_id
+    assert len(resolver_threads) == 1
+    assert claim_threads and claim_threads[0] != main_thread_id
+    assert resume_bg.await_args.kwargs["resolved_execution_scope"] is scope
 
 
 @pytest.mark.asyncio
@@ -390,6 +627,67 @@ async def test_resume_registration_failure_preserves_dispatched_delivery(
         if call.args[0].get("type") == "message_accepted"
     ]
     assert len(accepted) == 1
+
+
+@pytest.mark.asyncio
+async def test_live_control_delivery_failure_pool_timeout_is_not_retried(
+    db_session,
+) -> None:
+    """One failed DELIVERY_FAILED checkout still produces one rejection ack."""
+    owner = _user(db_session, "pool-timeout-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(side_effect=RuntimeError("inject failed"))
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    mark_delivery = MagicMock(
+        side_effect=SQLAlchemyTimeoutError("delivery pool exhausted")
+    )
+    error_payload_reader = MagicMock()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch(
+            "xagent.web.api.websocket.mark_user_message_delivery_sync",
+            mark_delivery,
+        ),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            error_payload_reader,
+        ),
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "apply once",
+                "client_message_id": "live-control-pool-timeout",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    mark_delivery.assert_called_once_with(
+        int(task.id), "live-control-pool-timeout", DELIVERY_FAILED
+    )
+    error_payload_reader.assert_not_called()
+    rejected = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_rejected"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["client_message_id"] == "live-control-pool-timeout"
+    assert "inject failed" in rejected[0]["message"]
 
 
 @pytest.mark.asyncio
@@ -583,7 +881,7 @@ async def test_durable_pause_propagates_stale_run_error(db_session) -> None:
         patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
         patch("xagent.web.api.websocket.manager", ws_manager),
         patch(
-            "xagent.web.api.websocket.apply_task_control_transition",
+            "xagent.web.api.websocket._apply_pause_requested_isolated",
             side_effect=StaleTaskRunError("run rotated"),
         ),
         pytest.raises(StaleTaskRunError, match="run rotated"),
@@ -653,6 +951,16 @@ async def test_resume_admin_on_other_users_task_runs_as_owner(db_session) -> Non
         patch("xagent.web.api.websocket.manager", ws_manager),
     ):
         await handle_resume_task(MagicMock(), int(task.id), {"user": admin})
+
+        # Command dispatch may detach after its short prompt deadline. Wait for
+        # the worker to reach agent construction instead of racing that
+        # documented durable-dispatch boundary.
+        for _ in range(100):
+            if "task_owner_user_id" in captured:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("resume command did not reach agent construction")
 
     assert captured["task_owner_user_id"] == int(owner.id)
 
@@ -731,6 +1039,17 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
     ):
         await handle_resume_task(MagicMock(), int(task.id), {"user": admin})
 
+        # Durable dispatch intentionally detaches after its short prompt
+        # deadline. Keep the patched runtime owners in place until the command
+        # reaches agent construction instead of racing that boundary under
+        # parallel test load.
+        for _ in range(100):
+            if "task_owner_user_id" in captured:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("resume command did not reach agent construction")
+
     # Agent built as owner, and the background resume runs as owner.
     assert captured["task_owner_user_id"] == int(owner.id)
     resume_bg.assert_called_once()
@@ -789,8 +1108,6 @@ async def test_execute_resume_background_rejects_owner_mismatch(db_session) -> N
     ws_manager.broadcast_to_task = AsyncMock()
 
     with (
-        patch("xagent.web.api.websocket.acquire_task_lease", return_value=object()),
-        patch("xagent.web.api.websocket.release_task_lease_with_workforce_sync"),
         patch("xagent.web.api.websocket.stop_task_lease_heartbeat", new=AsyncMock()),
         patch("xagent.web.api.websocket.manager", ws_manager),
     ):
@@ -1003,7 +1320,7 @@ async def test_deferred_injection_rejects_before_post_when_lease_is_denied(
     )
 
     with (
-        patch("xagent.web.api.websocket.acquire_task_lease", return_value=None),
+        patch("xagent.web.api.websocket._acquire_resume_task_lease", return_value=None),
         patch("xagent.web.api.websocket.manager", ws_manager),
         patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
     ):

--- a/tests/web/api/test_websocket_pause_db_boundary.py
+++ b/tests/web/api/test_websocket_pause_db_boundary.py
@@ -1,0 +1,198 @@
+"""Issue #935 regression tests for the WebSocket pause DB boundary."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from xagent.web.api import chat as chat_api
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models import database as database_module
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services import task_setup_snapshot as snapshot_module
+from xagent.web.services.task_execution_controller import (
+    StaleTaskRunError,
+    TaskControlState,
+)
+
+
+@pytest.fixture()
+def db_session(tmp_path: Path) -> Iterator[Session]:
+    init_db(db_url=f"sqlite:///{tmp_path / 'pause-boundary.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.mark.asyncio
+async def test_pause_handler_keeps_database_work_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_loop_thread = threading.get_ident()
+    worker_threads: dict[str, int] = {}
+    task_id = 41
+    owner_id = 7
+    actor = SimpleNamespace(id=owner_id, is_admin=False)
+    runtime_user = SimpleNamespace(id=owner_id, is_admin=False)
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(
+            user_id=owner_id,
+            status=TaskStatus.RUNNING,
+            run_id="run-1",
+        ),
+        runtime_user=runtime_user,
+    )
+
+    def load_snapshot(*args: object, **kwargs: object) -> object:
+        worker_threads["snapshot"] = threading.get_ident()
+        assert args == (task_id, None)
+        assert kwargs == {
+            "actor_user_id": owner_id,
+            "actor_is_admin": False,
+        }
+        return snapshot
+
+    def resolve_scope(resolved_task_id: int) -> None:
+        worker_threads["scope"] = threading.get_ident()
+        assert resolved_task_id == task_id
+        return None
+
+    def finalize_pause(resolved_task_id: int, *, expected_run_id: str | None) -> bool:
+        worker_threads["finalize"] = threading.get_ident()
+        assert resolved_task_id == task_id
+        assert expected_run_id == "run-1"
+        return True
+
+    def forbidden_event_loop_db() -> object:
+        raise AssertionError("pause handler opened a request Session on the event loop")
+
+    agent_service = MagicMock()
+    agent_service.pause_execution = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+
+    monkeypatch.setattr(snapshot_module, "load_task_setup_snapshot_sync", load_snapshot)
+    monkeypatch.setattr(websocket_api, "resolve_execution_scope", resolve_scope)
+    monkeypatch.setattr(
+        websocket_api,
+        "_apply_pause_requested_isolated",
+        finalize_pause,
+        raising=False,
+    )
+    monkeypatch.setattr(database_module, "get_db", forbidden_event_loop_db)
+    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: agent_manager)
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    try:
+        await websocket_api._handle_pause_task_unserialized(
+            MagicMock(),
+            task_id,
+            {"user": actor},
+        )
+    finally:
+        websocket_api._clear_task_pause_accepted(task_id)
+
+    assert set(worker_threads) == {"snapshot", "scope", "finalize"}
+    assert all(thread_id != event_loop_thread for thread_id in worker_threads.values())
+    agent_manager.get_agent_for_task.assert_awaited_once()
+    call = agent_manager.get_agent_for_task.await_args
+    assert call.args == (task_id, None)
+    assert call.kwargs == {
+        "user": runtime_user,
+        "task_setup_snapshot": snapshot,
+        "task_owner_user_id": owner_id,
+        "resolved_execution_scope": None,
+    }
+    agent_service.pause_execution.assert_awaited_once_with()
+    connection_manager.broadcast_to_task.assert_awaited_once()
+
+
+def _running_task(db_session: Session, *, run_id: str = "run-1") -> Task:
+    user = User(username=f"pause-owner-{run_id}", password_hash="x")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    task = Task(
+        user_id=int(user.id),
+        title="pause boundary",
+        description="pause boundary",
+        status=TaskStatus.RUNNING,
+        execution_mode="balanced",
+        run_id=run_id,
+        state_version=3,
+        control_state=TaskControlState.RUNNING.value,
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+def test_pause_transition_updates_only_the_expected_running_run(
+    db_session: Session,
+) -> None:
+    task = _running_task(db_session)
+
+    applied = websocket_api._apply_pause_requested_isolated(
+        int(task.id),
+        expected_run_id="run-1",
+    )
+
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == int(task.id)).one()
+    assert applied is True
+    assert stored.status == TaskStatus.RUNNING
+    assert stored.run_id == "run-1"
+    assert stored.control_state == TaskControlState.PAUSE_REQUESTED.value
+    assert stored.state_version == 4
+
+
+def test_pause_transition_rejects_a_replacement_run(db_session: Session) -> None:
+    task = _running_task(db_session, run_id="replacement-run")
+
+    with pytest.raises(StaleTaskRunError, match="run changed"):
+        websocket_api._apply_pause_requested_isolated(
+            int(task.id),
+            expected_run_id="original-run",
+        )
+
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == int(task.id)).one()
+    assert stored.run_id == "replacement-run"
+    assert stored.control_state == TaskControlState.RUNNING.value
+    assert stored.state_version == 3
+
+
+def test_pause_transition_leaves_a_terminal_task_unchanged(
+    db_session: Session,
+) -> None:
+    task = _running_task(db_session)
+    setattr(task, "status", TaskStatus.COMPLETED)
+    setattr(task, "control_state", TaskControlState.COMPLETED.value)
+    db_session.commit()
+
+    applied = websocket_api._apply_pause_requested_isolated(
+        int(task.id),
+        expected_run_id="run-1",
+    )
+
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == int(task.id)).one()
+    assert applied is False
+    assert stored.status == TaskStatus.COMPLETED
+    assert stored.control_state == TaskControlState.COMPLETED.value
+    assert stored.state_version == 3

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,8 +9,10 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.web.api import websocket as websocket_api
 from xagent.web.api.chat import AgentServiceManager, resolve_agent_service_memory_policy
 from xagent.web.api.websocket import (
+    ConnectionManager,
     _normalize_file_outputs,
     handle_build_preview_execution,
 )
@@ -21,6 +25,58 @@ from xagent.web.services.managed_file_ref import (
     DurableStorageOperationError,
     build_task_output_storage_key,
 )
+
+
+class _BlockingPreviewWebSocket:
+    def __init__(self) -> None:
+        self.receive_count = 0
+        self.waiting_for_next_message = asyncio.Event()
+
+    async def accept(self) -> None:
+        return None
+
+    async def receive_text(self) -> str:
+        self.receive_count += 1
+        if self.receive_count == 1:
+            return json.dumps({"type": "preview"})
+        self.waiting_for_next_message.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+
+@pytest.mark.asyncio
+async def test_build_preview_endpoint_disconnects_when_cancelled(monkeypatch) -> None:
+    task_id = 123
+    websocket = _BlockingPreviewWebSocket()
+    connection_manager = ConnectionManager()
+
+    async def register_preview_connection(*args) -> None:
+        connection_manager.register_connection(websocket, task_id)
+
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "get_authenticated_user",
+        AsyncMock(return_value=SimpleNamespace(id=7)),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "handle_build_preview_execution",
+        AsyncMock(side_effect=register_preview_connection),
+    )
+
+    endpoint = asyncio.create_task(
+        websocket_api.websocket_build_preview_endpoint(websocket, "token")
+    )
+    await websocket.waiting_for_next_message.wait()
+
+    assert connection_manager.active_connections == {task_id: [websocket]}
+
+    endpoint.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await endpoint
+
+    assert connection_manager.active_connections == {}
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_task_control_state.py
+++ b/tests/web/api/test_websocket_task_control_state.py
@@ -1,11 +1,62 @@
 from __future__ import annotations
 
-import pytest
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-from xagent.web.api.websocket import _with_current_task_control_state
+import pytest
+from anyio import BrokenResourceError, ClosedResourceError
+
+from xagent.web.api import websocket as websocket_api
+from xagent.web.api.websocket import (
+    ConnectionManager,
+    _with_current_task_control_state,
+)
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+
+
+class _BlockingWebSocket:
+    def __init__(self) -> None:
+        self.receive_started = asyncio.Event()
+
+    async def accept(self) -> None:
+        return None
+
+    async def receive_text(self) -> str:
+        self.receive_started.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+
+class _ClosedWebSocket:
+    def __init__(self, error_type: type[Exception]) -> None:
+        self._error_type = error_type
+
+    async def send_text(self, message: str) -> None:
+        raise self._error_type
+
+
+class _RecordingWebSocket:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send_text(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class _BlockingSendWebSocket(_RecordingWebSocket):
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def send_text(self, message: str) -> None:
+        self.send_started.set()
+        await self.release_send.wait()
+        await super().send_text(message)
 
 
 @pytest.fixture()
@@ -113,3 +164,171 @@ async def test_boolean_state_version_is_replaced_with_current_snapshot(
     assert event["state_version"] == 7
     assert event["control_state"] == "running"
     assert event["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_websocket_endpoint_disconnects_when_cancelled(monkeypatch) -> None:
+    task_id = 42
+    websocket = _BlockingWebSocket()
+    connection_manager = ConnectionManager()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "get_authenticated_user",
+        AsyncMock(return_value=SimpleNamespace(id=7)),
+    )
+    monkeypatch.setattr(websocket_api, "handle_status_request", AsyncMock())
+
+    endpoint = asyncio.create_task(
+        websocket_api.websocket_chat_endpoint(websocket, task_id, "token")
+    )
+    await websocket.receive_started.wait()
+
+    assert connection_manager.active_connections[task_id] == [websocket]
+
+    endpoint.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await endpoint
+
+    assert task_id not in connection_manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_websocket_endpoint_disconnects_moved_connection_when_cancelled(
+    monkeypatch,
+) -> None:
+    initial_task_id = 42
+    moved_task_id = 99
+    websocket = _BlockingWebSocket()
+    connection_manager = ConnectionManager()
+
+    async def move_connection_during_initial_status(*args) -> None:
+        connection_manager.move_connection(websocket, moved_task_id)
+
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "get_authenticated_user",
+        AsyncMock(return_value=SimpleNamespace(id=7)),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "handle_status_request",
+        AsyncMock(side_effect=move_connection_during_initial_status),
+    )
+
+    endpoint = asyncio.create_task(
+        websocket_api.websocket_chat_endpoint(websocket, initial_task_id, "token")
+    )
+    await websocket.receive_started.wait()
+
+    assert connection_manager.active_connections == {moved_task_id: [websocket]}
+
+    endpoint.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await endpoint
+
+    assert connection_manager.active_connections == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type",
+    [ClosedResourceError, BrokenResourceError],
+)
+async def test_broadcast_skips_closed_connection_and_reaches_live_connection(
+    error_type: type[Exception],
+) -> None:
+    task_id = 42
+    closed_websocket = _ClosedWebSocket(error_type)
+    live_websocket = _RecordingWebSocket()
+    connection_manager = ConnectionManager()
+    connection_manager.register_connection(closed_websocket, task_id)
+    connection_manager.register_connection(live_websocket, task_id)
+
+    message = {"type": "diagnostic", "message": "still live"}
+    await connection_manager.broadcast_to_task(message, task_id)
+
+    assert live_websocket.messages == [json.dumps(message)]
+    assert connection_manager.active_connections[task_id] == [live_websocket]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reraises_unexpected_connection_error() -> None:
+    task_id = 42
+    failed_websocket = _ClosedWebSocket(ValueError)
+    connection_manager = ConnectionManager()
+    connection_manager.register_connection(failed_websocket, task_id)
+
+    with pytest.raises(ValueError):
+        await connection_manager.broadcast_to_task({"type": "diagnostic"}, task_id)
+
+    assert task_id not in connection_manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rechecks_membership_after_message_enrichment(
+    monkeypatch,
+) -> None:
+    task_id = 42
+    websocket = _RecordingWebSocket()
+    connection_manager = ConnectionManager()
+    connection_manager.register_connection(websocket, task_id)
+
+    async def detach_during_enrichment(message, **kwargs):
+        connection_manager.detach_task_connections(task_id)
+        return message
+
+    monkeypatch.setattr(
+        websocket_api,
+        "_with_current_task_control_state",
+        detach_during_enrichment,
+    )
+
+    await connection_manager.broadcast_to_task({"type": "diagnostic"}, task_id)
+
+    assert websocket.messages == []
+    assert connection_manager.active_connections == {}
+
+
+@pytest.mark.asyncio
+async def test_broadcast_skips_connection_moved_during_fanout() -> None:
+    task_id = 42
+    moved_task_id = 99
+    blocking_websocket = _BlockingSendWebSocket()
+    moved_websocket = _RecordingWebSocket()
+    connection_manager = ConnectionManager()
+    connection_manager.register_connection(blocking_websocket, task_id)
+    connection_manager.register_connection(moved_websocket, task_id)
+
+    broadcast = asyncio.create_task(
+        connection_manager.broadcast_to_task({"type": "diagnostic"}, task_id)
+    )
+    await blocking_websocket.send_started.wait()
+    connection_manager.move_connection(moved_websocket, moved_task_id)
+    blocking_websocket.release_send.set()
+    await broadcast
+
+    assert moved_websocket.messages == []
+    assert connection_manager.active_connections == {
+        task_id: [blocking_websocket],
+        moved_task_id: [moved_websocket],
+    }
+
+
+def test_detach_task_connections_removes_forward_and_reverse_membership() -> None:
+    task_id = 42
+    other_task_id = 99
+    first_websocket = _RecordingWebSocket()
+    second_websocket = _RecordingWebSocket()
+    other_websocket = _RecordingWebSocket()
+    connection_manager = ConnectionManager()
+    connection_manager.register_connection(first_websocket, task_id)
+    connection_manager.register_connection(second_websocket, task_id)
+    connection_manager.register_connection(other_websocket, other_task_id)
+
+    detached = connection_manager.detach_task_connections(task_id)
+
+    assert detached == [first_websocket, second_websocket]
+    assert connection_manager.active_connections == {other_task_id: [other_websocket]}
+    assert connection_manager._connection_task_ids == {other_websocket: other_task_id}

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -103,3 +103,31 @@ async def test_unregistered_resume_coordinator_cannot_promote_itself() -> None:
         manager.promote_resume_task(7, current)
 
     assert 7 not in manager.running_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancelling_waiter_does_not_cancel_previous_execution() -> None:
+    manager = BackgroundTaskManager()
+    previous_started = asyncio.Event()
+    allow_previous_to_finish = asyncio.Event()
+
+    async def previous_execution() -> None:
+        previous_started.set()
+        await allow_previous_to_finish.wait()
+
+    previous = asyncio.create_task(previous_execution())
+    manager.register_task(7, previous)
+    await previous_started.wait()
+
+    waiter = asyncio.create_task(manager.wait_for_previous(7))
+    await asyncio.sleep(0)
+    waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert not previous.done()
+    assert not previous.cancelled()
+
+    allow_previous_to_finish.set()
+    await previous

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -264,7 +264,8 @@ def _usage_snapshot(prefix: str):
         db.close()
 
 
-def test_record_key_usage_skips_revoked_key():
+@pytest.mark.asyncio
+async def test_record_key_usage_skips_revoked_key():
     """Direct-call test for the defense-in-depth guard in ``record_key_usage``.
 
     Both real call sites (create task / append message) are gated by
@@ -287,11 +288,12 @@ def test_record_key_usage_skips_revoked_key():
         db.close()
 
     before = _usage_snapshot(prefix)
-    record_key_usage(prefix)
+    await record_key_usage(prefix)
     assert _usage_snapshot(prefix) == before
 
 
-def test_record_key_usage_skips_paused_key():
+@pytest.mark.asyncio
+async def test_record_key_usage_skips_paused_key():
     from xagent.web.api.v1.deps import record_key_usage
     from xagent.web.models.agent_api_key import AgentApiKey
 
@@ -306,17 +308,18 @@ def test_record_key_usage_skips_paused_key():
         db.close()
 
     before = _usage_snapshot(prefix)
-    record_key_usage(prefix)
+    await record_key_usage(prefix)
     assert _usage_snapshot(prefix) == before
 
 
-def test_record_key_usage_updates_active_key():
+@pytest.mark.asyncio
+async def test_record_key_usage_updates_active_key():
     """Sanity counterpart: the guard doesn't block a legitimately active key."""
     from xagent.web.api.v1.deps import record_key_usage
 
     _agent_id, _full_key, prefix = _create_agent_and_key()
 
-    record_key_usage(prefix)
+    await record_key_usage(prefix)
 
     last_used_at, usage_month, usage_month_calls = _usage_snapshot(prefix)
     assert last_used_at is not None
@@ -388,7 +391,7 @@ def test_internal_exception_returns_v1_envelope_not_fastapi_detail():
     """
     secret_internal_msg = "secret-internal-detail-do-not-leak"
     with patch(
-        "xagent.web.api.v1.deps.parse_api_key",
+        "xagent.web.services.api_keys.parse_api_key",
         side_effect=RuntimeError(secret_internal_msg),
     ):
         resp = client.get(

--- a/tests/web/api/v1/test_auth_worker_boundary.py
+++ b/tests/web/api/v1/test_auth_worker_boundary.py
@@ -1,0 +1,188 @@
+"""Concurrency and ownership invariants for /v1 API-key authentication."""
+
+import threading
+from dataclasses import FrozenInstanceError
+
+import httpx
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy import event
+
+from xagent.core.utils.api_key import verify_api_key as real_verify_api_key
+from xagent.web.api.v1 import deps
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import get_engine
+from xagent.web.services import api_keys as api_key_service
+
+from ..conftest import (
+    _admin_headers,
+    _direct_db_session,
+    app_for_tests,
+    client,
+)
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _create_agent_key(*, tool_categories: list[str] | None = None) -> tuple[str, int]:
+    headers = _admin_headers()
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "worker boundary agent",
+            "description": "auth worker test",
+            "instructions": "test",
+            "execution_mode": "balanced",
+        },
+    )
+    assert response.status_code == 200, response.text
+    agent_id = int(response.json()["id"])
+
+    db = _direct_db_session()
+    try:
+        db.query(Agent).filter(Agent.id == agent_id).update(
+            {
+                "status": AgentStatus.PUBLISHED,
+                "tool_categories": tool_categories,
+            }
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    key_response = client.post(
+        f"/api/agents/{agent_id}/api-key",
+        headers=headers,
+    )
+    assert key_response.status_code == 200, key_response.text
+    return str(key_response.json()["full_key"]), agent_id
+
+
+def _create_personal_key() -> str:
+    response = client.post("/api/me/personal-keys", headers=_admin_headers())
+    assert response.status_code == 200, response.text
+    return str(response.json()["full_key"])
+
+
+@pytest.mark.asyncio
+async def test_personal_auth_checks_in_connection_before_bcrypt_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_key = _create_personal_key()
+    engine = get_engine()
+    loop_thread_id = threading.get_ident()
+    events: list[tuple[str, int]] = []
+
+    def on_checkout(*_args: object) -> None:
+        events.append(("checkout", threading.get_ident()))
+
+    def on_checkin(*_args: object) -> None:
+        events.append(("checkin", threading.get_ident()))  # codespell:ignore checkin
+
+    def observed_verify(raw: str, stored_hash: str) -> bool:
+        events.append(("bcrypt", threading.get_ident()))
+        return real_verify_api_key(raw, stored_hash)
+
+    event.listen(engine, "checkout", on_checkout)
+    event.listen(engine, "checkin", on_checkin)  # codespell:ignore checkin
+    monkeypatch.setattr(
+        api_key_service,
+        "verify_api_key",
+        observed_verify,
+    )
+    try:
+        transport = httpx.ASGITransport(
+            app=app_for_tests,
+            raise_app_exceptions=False,
+        )
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as async_client:
+            response = await async_client.get(
+                "/v1/me",
+                headers={"Authorization": f"Bearer {full_key}"},
+            )
+    finally:
+        event.remove(engine, "checkout", on_checkout)
+        event.remove(engine, "checkin", on_checkin)  # codespell:ignore checkin
+
+    assert response.status_code == 200, response.text
+    names = [name for name, _thread_id in events]
+    checkin_index = names.index("checkin")  # codespell:ignore checkin
+    assert names.index("checkout") < checkin_index < names.index("bcrypt")
+    bcrypt_thread_id = next(thread_id for name, thread_id in events if name == "bcrypt")
+    assert bcrypt_thread_id != loop_thread_id
+
+
+def test_agent_auth_service_returns_frozen_detached_identity() -> None:
+    full_key, agent_id = _create_agent_key(tool_categories=["mcp:ShiftCare"])
+
+    identity = api_key_service.authenticate_agent_api_key(full_key)
+
+    assert identity.agent_id == agent_id
+    assert identity.user_id > 0
+    assert identity.execution_mode == "balanced"
+    assert identity.tool_categories == ("mcp:ShiftCare",)
+    assert identity.status == AgentStatus.PUBLISHED.value
+    assert identity.key_prefix
+    assert not hasattr(identity, "_sa_instance_state")
+    with pytest.raises(FrozenInstanceError):
+        identity.agent_id = -1  # type: ignore[misc]
+
+
+def test_personal_auth_service_returns_frozen_detached_identity() -> None:
+    full_key = _create_personal_key()
+
+    identity = api_key_service.authenticate_personal_api_key(full_key)
+
+    assert identity.user_id > 0
+    assert identity.is_admin is True
+    assert identity.username == "admin"
+    assert identity.email == "admin@example.com"
+    assert identity.key_prefix
+    assert not hasattr(identity, "_sa_instance_state")
+    with pytest.raises(FrozenInstanceError):
+        identity.user_id = -1  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_returns_agent_identity_without_request_session() -> None:
+    full_key, agent_id = _create_agent_key(tool_categories=[])
+
+    identity = await deps.get_agent_from_api_key(
+        HTTPAuthorizationCredentials(scheme="Bearer", credentials=full_key)
+    )
+
+    assert identity.agent_id == agent_id
+    assert identity.tool_categories == ()
+
+
+def test_usage_tracking_swallows_update_rollback_and_close_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FailingUsageSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            raise RuntimeError("close failed")
+
+        def query(self, _model):
+            raise RuntimeError("update failed")
+
+        def rollback(self) -> None:
+            raise RuntimeError("rollback failed")
+
+    monkeypatch.setattr(
+        api_key_service,
+        "get_session_local",
+        lambda: FailingUsageSession,
+    )
+
+    with caplog.at_level("WARNING", logger="xagent.web.services.api_keys"):
+        api_key_service.record_agent_api_key_usage("best-effort-prefix")
+
+    assert "Failed to record API key usage" in caplog.text

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -1,15 +1,26 @@
 """Integration tests for /v1 management endpoints."""
 
+import asyncio
+import inspect
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.templates.manager import TemplateManager
+from xagent.web.api.v1 import agents as v1_agents
+from xagent.web.models import database as database_module
 from xagent.web.models.agent import Agent
+from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.model import Model as DBModel
 from xagent.web.models.user import User, UserModel
+from xagent.web.services import agent_management
 
 from ..conftest import _admin_headers, _direct_db_session, app_for_tests, client
 
@@ -25,6 +36,36 @@ def _personal_key() -> str:
 
 def _bearer(full_key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {full_key}"}
+
+
+def _post_commit_pool_exhausting_session_factory():
+    """Return a real one-slot QueuePool occupied immediately after commit."""
+    engine = create_engine(
+        database_module.get_engine().url,
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.05,
+    )
+    held_connections = []
+
+    class PostCommitPoolExhaustingSession(Session):
+        def commit(self) -> None:
+            super().commit()
+            if not held_connections:
+                # ``super().commit()`` returned the transaction's connection.
+                # Occupy that sole slot so any post-commit ORM refresh or
+                # expired-attribute load exercises a real QueuePool timeout.
+                held_connections.append(engine.connect())
+
+    factory = sessionmaker(
+        bind=engine,
+        class_=PostCommitPoolExhaustingSession,
+        autocommit=False,
+        autoflush=False,
+    )
+    return factory, held_connections, engine
 
 
 def _write_template(root: Path) -> None:
@@ -72,6 +113,571 @@ agent_config:
 """.strip(),
         encoding="utf-8",
     )
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [
+        v1_agents.list_agents,
+        v1_agents.create_agent,
+        v1_agents.create_agent_from_template,
+        v1_agents.rotate_agent_runtime_key,
+    ],
+)
+def test_v1_agent_routes_do_not_inject_request_db_session(handler):
+    """A /v1 agent request must not own a Session across async work."""
+    assert "db" not in inspect.signature(handler).parameters
+
+
+@pytest.mark.asyncio
+async def test_agent_list_worker_owns_session_and_does_not_block_event_loop(
+    monkeypatch,
+):
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    operation = getattr(agent_management, "list_agents_for_user_worker_owned", None)
+    assert callable(operation), "missing worker-owned agent-list entry point"
+
+    loop_thread = threading.get_ident()
+    service_threads: list[int] = []
+    original = agent_management.AgentManagementService.list_agents_for_user
+
+    def slow_list(self, requested_user_id):
+        service_threads.append(threading.get_ident())
+        time.sleep(0.05)
+        return original(self, requested_user_id)
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "list_agents_for_user",
+        slow_list,
+    )
+
+    ticks = 0
+    stop = False
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await operation(user_id=user_id)
+    finally:
+        stop = True
+        await ticker_task
+
+    assert isinstance(result, list)
+    assert service_threads and service_threads[0] != loop_thread
+    assert ticks >= 3
+
+
+@pytest.mark.asyncio
+async def test_agent_create_opens_worker_session_after_kb_await(monkeypatch):
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    operation = getattr(agent_management, "create_agent_worker_owned", None)
+    assert callable(operation), "missing worker-owned agent-create entry point"
+
+    real_factory = database_module.get_session_local()
+    session_threads: list[int] = []
+
+    class TrackingSessionFactory:
+        def __call__(self):
+            session_threads.append(threading.get_ident())
+            return real_factory()
+
+    monkeypatch.setattr(
+        agent_management,
+        "get_session_local",
+        lambda: TrackingSessionFactory(),
+    )
+
+    async def visible_kbs(names, *, user_id, is_admin):
+        assert names == ["visible-kb"]
+        assert session_threads == []
+        await asyncio.sleep(0)
+        assert session_threads == []
+        return []
+
+    monkeypatch.setattr(agent_management, "find_missing_knowledge_bases", visible_kbs)
+
+    loop_thread = threading.get_ident()
+    result = await operation(
+        user_id=user_id,
+        is_admin=True,
+        name="worker-owned create",
+        description=None,
+        instructions="Be useful.",
+        knowledge_bases=["visible-kb"],
+        tool_categories=["knowledge"],
+        generate_runtime_key=False,
+    )
+
+    assert isinstance(result.agent, dict)
+    assert result.agent["name"] == "worker-owned create"
+    assert session_threads and all(tid != loop_thread for tid in session_threads)
+
+    db = _direct_db_session()
+    try:
+        assert db.query(Agent).filter(Agent.name == "worker-owned create").count() == 1
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_template_resolution_finishes_before_worker_session_opens(monkeypatch):
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    operation = getattr(
+        agent_management, "create_agent_from_template_worker_owned", None
+    )
+    assert callable(operation), "missing worker-owned template-create entry point"
+
+    real_factory = database_module.get_session_local()
+    session_threads: list[int] = []
+
+    class TrackingSessionFactory:
+        def __call__(self):
+            session_threads.append(threading.get_ident())
+            return real_factory()
+
+    monkeypatch.setattr(
+        agent_management,
+        "get_session_local",
+        lambda: TrackingSessionFactory(),
+    )
+
+    class FakeTemplateManager:
+        async def get_template(self, template_id):
+            assert template_id == "worker-template"
+            assert session_threads == []
+            await asyncio.sleep(0)
+            assert session_threads == []
+            return {
+                "name": "Worker template",
+                "descriptions": {"en": "Template description"},
+                "agent_config": {"instructions": "Template instructions"},
+            }
+
+    result = await operation(
+        template_manager=FakeTemplateManager(),
+        user_id=user_id,
+        is_admin=True,
+        template_id="worker-template",
+        generate_runtime_key=False,
+    )
+
+    assert isinstance(result.agent, dict)
+    assert result.agent["name"] == "Worker template"
+    assert session_threads
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_rotation_runs_in_worker_owned_session(monkeypatch):
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+        assert user_id is not None
+        agent = Agent(
+            user_id=user_id,
+            name="worker rotation",
+            instructions="Be useful.",
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        agent_id = int(agent.id)
+    finally:
+        db.close()
+
+    operation = getattr(agent_management, "rotate_agent_runtime_key_worker_owned", None)
+    assert callable(operation), "missing worker-owned key-rotation entry point"
+
+    loop_thread = threading.get_ident()
+    service_threads: list[int] = []
+    original = agent_management.AgentManagementService.generate_agent_runtime_key
+
+    def tracked_rotation(self, *, user_id, agent_id):
+        service_threads.append(threading.get_ident())
+        return original(self, user_id=user_id, agent_id=agent_id)
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "generate_agent_runtime_key",
+        tracked_rotation,
+    )
+
+    result = await operation(user_id=user_id, agent_id=agent_id)
+
+    assert result is not None
+    assert result.full_key.startswith("xag_")
+    assert service_threads and service_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_agent_create_does_not_checkout_again_after_secret_commit(monkeypatch):
+    """A committed agent/key must not be stranded by post-commit pool pressure."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    factory, held_connections, engine = _post_commit_pool_exhausting_session_factory()
+    monkeypatch.setattr(agent_management, "get_session_local", lambda: factory)
+    name = "create without post-commit checkout"
+    try:
+        result = await agent_management.create_agent_worker_owned(
+            user_id=user_id,
+            is_admin=True,
+            name=name,
+            description=None,
+            instructions="Be useful.",
+        )
+    finally:
+        for connection in held_connections:
+            connection.close()
+        engine.dispose()
+
+    assert result.api_key is not None
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.name == name).one()
+        active_prefixes = {
+            row.key_prefix
+            for row in db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent.id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .all()
+        }
+        assert active_prefixes == {result.api_key.key_prefix}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_rotation_does_not_checkout_again_after_commit(monkeypatch):
+    """A rotation succeeds even when no pool slot exists after its commit."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+        assert user_id is not None
+        agent = Agent(
+            user_id=user_id,
+            name="rotation without post-commit checkout",
+            instructions="Be useful.",
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        agent_id = int(agent.id)
+    finally:
+        db.close()
+
+    factory, held_connections, engine = _post_commit_pool_exhausting_session_factory()
+    monkeypatch.setattr(agent_management, "get_session_local", lambda: factory)
+    try:
+        result = await agent_management.rotate_agent_runtime_key_worker_owned(
+            user_id=user_id,
+            agent_id=agent_id,
+        )
+    finally:
+        for connection in held_connections:
+            connection.close()
+        engine.dispose()
+
+    assert result is not None
+    db = _direct_db_session()
+    try:
+        assert db.query(Agent).filter(Agent.id == agent_id).count() == 1
+        active_prefixes = {
+            row.key_prefix
+            for row in db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .all()
+        }
+        assert active_prefixes == {result.key_prefix}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("from_template", [False, True])
+async def test_cancelled_agent_create_revokes_only_committed_undelivered_runtime_key(
+    monkeypatch,
+    from_template: bool,
+):
+    """Cancellation keeps the durable agent but revokes its undelivered key."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    entered_after_commit = threading.Event()
+    release_worker = threading.Event()
+    initial_key_prefix: list[str] = []
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def create_then_block(self, **kwargs):
+        result = original_create(self, **kwargs)
+        assert result[1] is not None
+        initial_key_prefix.append(result[1].key_prefix)
+        entered_after_commit.set()
+        assert release_worker.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        create_then_block,
+    )
+
+    name = f"cancelled-{'template' if from_template else 'plain'}-create"
+    if from_template:
+
+        class TemplateManager:
+            async def get_template(self, template_id):
+                assert template_id == "cancelled-template"
+                return {
+                    "name": name,
+                    "descriptions": {"en": "test"},
+                    "agent_config": {"instructions": "Be useful."},
+                }
+
+        caller = asyncio.create_task(
+            agent_management.create_agent_from_template_worker_owned(
+                template_manager=TemplateManager(),
+                user_id=user_id,
+                is_admin=True,
+                template_id="cancelled-template",
+            )
+        )
+    else:
+        caller = asyncio.create_task(
+            agent_management.create_agent_worker_owned(
+                user_id=user_id,
+                is_admin=True,
+                name=name,
+                description=None,
+                instructions="Be useful.",
+            )
+        )
+
+    assert await asyncio.to_thread(entered_after_commit.wait, 5)
+    caller.cancel()
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.name == name).one()
+        assert initial_key_prefix
+        assert (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent.id,
+                AgentApiKey.key_prefix == initial_key_prefix[0],
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .count()
+            == 0
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_agent_create_preserves_concurrent_rotation(monkeypatch):
+    """Create compensation cannot delete a concurrently updated durable agent."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+    finally:
+        db.close()
+    assert user_id is not None
+
+    entered_after_commit = threading.Event()
+    release_worker = threading.Event()
+    initial_key_prefix: list[str] = []
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def create_then_block(self, **kwargs):
+        result = original_create(self, **kwargs)
+        assert result[1] is not None
+        initial_key_prefix.append(result[1].key_prefix)
+        entered_after_commit.set()
+        assert release_worker.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        create_then_block,
+    )
+
+    name = "cancelled create with concurrent rotation"
+    caller = asyncio.create_task(
+        agent_management.create_agent_worker_owned(
+            user_id=user_id,
+            is_admin=True,
+            name=name,
+            description=None,
+            instructions="Be useful.",
+        )
+    )
+    assert await asyncio.to_thread(entered_after_commit.wait, 5)
+
+    db = _direct_db_session()
+    try:
+        agent_id = int(db.query(Agent.id).filter(Agent.name == name).scalar())
+    finally:
+        db.close()
+    concurrent_key = await agent_management.rotate_agent_runtime_key_worker_owned(
+        user_id=user_id,
+        agent_id=agent_id,
+    )
+    assert concurrent_key is not None
+
+    caller.cancel()
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    db = _direct_db_session()
+    try:
+        assert db.query(Agent).filter(Agent.id == agent_id).count() == 1
+        initial_key = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.key_prefix == initial_key_prefix[0],
+            )
+            .one()
+        )
+        assert initial_key.revoked_at is not None
+        concurrent_row = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.key_prefix == concurrent_key.key_prefix,
+            )
+            .one()
+        )
+        assert concurrent_row.revoked_at is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_runtime_key_rotation_revokes_the_undelivered_key(monkeypatch):
+    """A cancelled rotation must not leave its newly minted key active."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = db.query(User.id).filter(User.username == "admin").scalar()
+        assert user_id is not None
+        agent = Agent(
+            user_id=user_id,
+            name="cancelled runtime rotation",
+            instructions="Be useful.",
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        agent_id = int(agent.id)
+    finally:
+        db.close()
+
+    first_key = await agent_management.rotate_agent_runtime_key_worker_owned(
+        user_id=user_id, agent_id=agent_id
+    )
+    assert first_key is not None
+
+    entered_after_commit = threading.Event()
+    release_worker = threading.Event()
+    created_prefix: list[str] = []
+    original_rotate = agent_management.AgentManagementService.generate_agent_runtime_key
+
+    def rotate_then_block(self, *, user_id, agent_id):
+        result = original_rotate(self, user_id=user_id, agent_id=agent_id)
+        assert result is not None
+        created_prefix.append(result.key_prefix)
+        entered_after_commit.set()
+        assert release_worker.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "generate_agent_runtime_key",
+        rotate_then_block,
+    )
+
+    caller = asyncio.create_task(
+        agent_management.rotate_agent_runtime_key_worker_owned(
+            user_id=user_id,
+            agent_id=agent_id,
+        )
+    )
+    assert await asyncio.to_thread(entered_after_commit.wait, 5)
+    caller.cancel()
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    assert created_prefix
+    db = _direct_db_session()
+    try:
+        assert (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.key_prefix == created_prefix[0],
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .count()
+            == 0
+        )
+    finally:
+        db.close()
 
 
 @pytest.fixture

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -14,6 +14,8 @@ real :class:`TraceEvent` rows inserted directly into the test DB to
 drive the mapping.
 """
 
+import asyncio
+import time
 from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -21,10 +23,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
+from xagent.web.models import database as database_module
 from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.task import (
@@ -34,6 +41,10 @@ from xagent.web.models.task import (
     TraceEvent,
 )
 from xagent.web.models.user import User
+from xagent.web.schemas.v1 import AppendMessageRequest, CreateTaskRequest
+from xagent.web.services import sdk_task_service
+from xagent.web.services import task_orchestrator as task_orchestrator_module
+from xagent.web.services.api_keys import AgentApiIdentity
 from xagent.web.services.connector_runtime import (
     ConnectorRuntimeValues,
     drop_ephemeral_runtime_values_for_testing,
@@ -646,7 +657,7 @@ def test_upload_oversized_maps_to_413(mock_start_task):
     _agent_id, full_key = _create_agent_with_key()
 
     with patch(
-        "xagent.web.api.files.store_uploaded_files",
+        "xagent.web.api.files.store_v1_uploaded_files",
         new=AsyncMock(side_effect=HTTPException(status_code=413, detail="too big")),
     ):
         resp = client.post(
@@ -665,7 +676,7 @@ def test_upload_storage_unavailable_maps_to_503(mock_start_task):
     _agent_id, full_key = _create_agent_with_key()
 
     with patch(
-        "xagent.web.api.files.store_uploaded_files",
+        "xagent.web.api.files.store_v1_uploaded_files",
         new=AsyncMock(side_effect=HTTPException(status_code=503, detail="down")),
     ):
         resp = client.post(
@@ -911,7 +922,7 @@ def test_create_task_maps_runtime_plan_identity_mismatch_to_domain_error(
     mock_start_task,
 ) -> None:
     agent_id, full_key = _create_agent_with_key()
-    prepare_runtime_plan = v1_tasks.prepare_create_connector_runtime
+    prepare_runtime_plan = sdk_task_service.prepare_create_connector_runtime
 
     def prepare_mismatched_identity(**kwargs):
         plan = prepare_runtime_plan(**kwargs)
@@ -921,7 +932,7 @@ def test_create_task_maps_runtime_plan_identity_mismatch_to_domain_error(
         )
 
     monkeypatch.setattr(
-        v1_tasks,
+        sdk_task_service,
         "prepare_create_connector_runtime",
         prepare_mismatched_identity,
     )
@@ -1250,26 +1261,35 @@ def test_create_task_marks_failed_when_runtime_secret_store_fails(mock_start_tas
         db.close()
 
 
-def test_runtime_setup_failed_mark_swallows_secondary_rollback_failure(caplog):
-    class RollbackFailingDB:
-        rollback_calls = 0
+def test_runtime_setup_failed_mark_swallows_secondary_db_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+) -> None:
+    class QueryFailingDB:
+        def __enter__(self):
+            return self
 
-        def rollback(self):
-            self.rollback_calls += 1
-            if self.rollback_calls > 1:
-                raise RuntimeError("rollback failed")
+        def __exit__(self, *_args):
+            return None
 
         def query(self, _model):
             raise RuntimeError("query failed")
 
-    db = RollbackFailingDB()
+    monkeypatch.setattr(
+        sdk_task_service,
+        "get_session_local",
+        lambda: QueryFailingDB,
+    )
 
-    with caplog.at_level("WARNING", logger="xagent.web.api.v1.tasks"):
-        v1_tasks._mark_task_failed_after_runtime_setup_error(db, 123)
+    with caplog.at_level("WARNING", logger="xagent.web.services.sdk_task_service"):
+        sdk_task_service.mark_pending_sdk_task_failed_sync(
+            123,
+            "Connector runtime setup failed.",
+            expected_agent_id=456,
+            expected_owner_user_id=789,
+        )
 
-    assert db.rollback_calls == 2
-    assert "Failed to roll back task 123 session" in caplog.text
-    assert "Failed to mark task 123 failed" in caplog.text
+    assert "Failed to mark pending SDK task 123 as failed" in caplog.text
 
 
 def test_create_task_cleans_runtime_secret_when_schedule_fails(mock_start_task):
@@ -2683,6 +2703,9 @@ def test_append_message_bg_inflight_does_not_corrupt_task_state(mock_start_task)
             # affected.
             background_task_manager.running_tasks.pop(task_id, None)
             fake_inflight.cancel()
+            loop.run_until_complete(
+                asyncio.gather(fake_inflight, return_exceptions=True)
+            )
     finally:
         loop.close()
 
@@ -3346,3 +3369,205 @@ def test_append_message_clears_stale_output_for_sdk_caller(mock_start_task):
         assert task_after.error_message is None
     finally:
         db.close()
+
+
+# ===== Turn-start database boundary =====
+
+
+@pytest.fixture()
+def single_connection_turn_db(tmp_path, monkeypatch):
+    """Real one-slot pool shared by sequential worker-owned Sessions."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'v1-turn-boundary.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.15,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+    )
+    monkeypatch.setattr(database_module, "_SessionLocal", session_local)
+
+    with session_local() as db:
+        user = User(
+            username="v1-turn-boundary-owner",
+            password_hash="hash",
+            is_admin=False,
+        )
+        db.add(user)
+        db.flush()
+        agent = Agent(
+            user_id=int(user.id),
+            name="V1 turn boundary agent",
+            description="test",
+            instructions="test",
+            execution_mode="balanced",
+            models={},
+            knowledge_bases=[],
+            skills=[],
+            tool_categories=[],
+            suggested_prompts=[],
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        identity = _detached_agent_identity(agent)
+    try:
+        yield engine, session_local, identity
+    finally:
+        engine.dispose()
+
+
+async def _run_with_ticker(awaitable):
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await awaitable
+    finally:
+        ticker_stop.set()
+        await ticker_task
+    return result, ticks
+
+
+def _observe_turn_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    engine,
+) -> list[int]:
+    checked_out: list[int] = []
+    original = task_orchestrator_module._begin_turn_atomic_sync
+
+    def observed(*args, **kwargs):
+        checked_out.append(engine.pool.checkedout())
+        time.sleep(0.05)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        task_orchestrator_module,
+        "_begin_turn_atomic_sync",
+        observed,
+    )
+    return checked_out
+
+
+def _observe_sdk_prepare_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    engine,
+    function_name: str,
+) -> list[int]:
+    """Delay one sync prepare unit and prove it runs off the event loop."""
+
+    checked_out: list[int] = []
+    original = getattr(v1_tasks, function_name)
+
+    def observed(*args, **kwargs):
+        checked_out.append(engine.pool.checkedout())
+        time.sleep(0.05)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(v1_tasks, function_name, observed)
+    return checked_out
+
+
+def _detached_agent_identity(agent: Agent) -> AgentApiIdentity:
+    raw_categories = agent.tool_categories
+    return AgentApiIdentity(
+        agent_id=int(agent.id),
+        user_id=int(agent.user_id),
+        execution_mode=str(agent.execution_mode),
+        tool_categories=(
+            tuple(raw_categories) if isinstance(raw_categories, list) else None
+        ),
+        status=str(getattr(agent.status, "value", agent.status)),
+        origin=str(agent.origin),
+        key_prefix="abc123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_task_prepare_and_begin_turn_use_worker_owned_connection(
+    single_connection_turn_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, _session_local, identity = single_connection_turn_db
+    prepare_checked_out = _observe_sdk_prepare_checkout(
+        monkeypatch,
+        engine,
+        "prepare_create_sdk_task_sync",
+    )
+    turn_checked_out = _observe_turn_checkout(monkeypatch, engine)
+    monkeypatch.setattr(v1_tasks, "record_key_usage", AsyncMock())
+
+    response, ticks = await _run_with_ticker(
+        v1_tasks.create_chat_task(
+            CreateTaskRequest(
+                agent_id=identity.agent_id,
+                message={"role": "user", "content": "hello"},
+            ),
+            identity,
+        )
+    )
+
+    assert response.status == TaskStatus.RUNNING.value
+    assert prepare_checked_out == [0]
+    assert turn_checked_out == [0]
+    assert ticks >= 6, "task preparation or turn startup blocked the event loop"
+
+
+@pytest.mark.asyncio
+async def test_append_task_prepare_and_begin_turn_use_worker_owned_connection(
+    single_connection_turn_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, session_local, identity = single_connection_turn_db
+    with session_local() as db:
+        task = Task(
+            user_id=identity.user_id,
+            title="existing sdk task",
+            description="first",
+            status=TaskStatus.COMPLETED,
+            agent_id=identity.agent_id,
+            input="first",
+            source="sdk",
+            is_visible=False,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    prepare_checked_out = _observe_sdk_prepare_checkout(
+        monkeypatch,
+        engine,
+        "prepare_append_sdk_task_sync",
+    )
+    turn_checked_out = _observe_turn_checkout(monkeypatch, engine)
+    monkeypatch.setattr(v1_tasks, "record_key_usage", AsyncMock())
+
+    response, ticks = await _run_with_ticker(
+        v1_tasks.append_message_to_task(
+            task_id,
+            AppendMessageRequest(
+                agent_id=identity.agent_id,
+                message={"role": "user", "content": "second"},
+            ),
+            identity,
+        )
+    )
+
+    assert response.status == TaskStatus.RUNNING.value
+    assert prepare_checked_out == [0]
+    assert turn_checked_out == [0]
+    assert ticks >= 6, "task preparation or turn startup blocked the event loop"

--- a/tests/web/api/v1/test_upload_db_boundary.py
+++ b/tests/web/api/v1/test_upload_db_boundary.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import UploadFile
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from xagent.core.file_storage.factory import get_unscoped_file_storage
+from xagent.core.file_storage.storage import FsspecFileStorage
+from xagent.web.api import files as files_api
+from xagent.web.models import Base
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+from xagent.web.services import uploaded_file_store
+
+
+class _ObservedStream(io.BytesIO):
+    def __init__(
+        self,
+        *,
+        content: bytes,
+        assert_no_checkout: Any,
+    ) -> None:
+        super().__init__(content)
+        self._assert_no_checkout = assert_no_checkout
+
+    def read(self, size: int = -1) -> bytes:
+        self._assert_no_checkout()
+        return super().read(size)
+
+
+class _ObservedUpload(UploadFile):
+    def __init__(
+        self,
+        *,
+        filename: str,
+        content: bytes,
+        assert_no_checkout: Any,
+    ) -> None:
+        super().__init__(
+            file=_ObservedStream(
+                content=content,
+                assert_no_checkout=assert_no_checkout,
+            ),
+            filename=filename,
+        )
+
+
+class _CancellingAfterFirstChunk(io.BytesIO):
+    def __init__(self, content: bytes) -> None:
+        super().__init__(content)
+        self._reads = 0
+
+    def read(self, size: int = -1) -> bytes:
+        self._reads += 1
+        if self._reads > 1:
+            raise asyncio.CancelledError
+        return super().read(size)
+
+
+@pytest.fixture
+def isolated_upload_runtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[tuple[sessionmaker[Session], QueuePool, Path, Path]]:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'uploads.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.2,
+    )
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with session_factory.begin() as db:
+        db.add(
+            User(
+                id=7,
+                username="upload-boundary-user",
+                password_hash="unused",
+                is_admin=False,
+            )
+        )
+
+    uploads_root = tmp_path / "uploads"
+    durable_root = tmp_path / "durable"
+    uploads_root.mkdir()
+    durable_root.mkdir()
+
+    def upload_path(
+        filename: str,
+        task_id: str | None = None,
+        folder: str | None = None,
+        user_id: int | None = None,
+        **_kwargs: Any,
+    ) -> Path:
+        del task_id, folder
+        target_dir = uploads_root / str(user_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        return target_dir / Path(filename).name
+
+    monkeypatch.setattr(files_api, "get_upload_path", upload_path)
+    monkeypatch.setattr(
+        uploaded_file_store, "get_session_local", lambda: session_factory
+    )
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", durable_root.as_uri())
+    get_unscoped_file_storage.cache_clear()
+
+    try:
+        yield session_factory, engine.pool, uploads_root, durable_root
+    finally:
+        get_unscoped_file_storage.cache_clear()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_reads_and_durable_work_without_a_checked_out_connection(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory, pool, _uploads_root, _durable_root = isolated_upload_runtime
+    event_loop_thread = threading.get_ident()
+    checkout_threads: list[int] = []
+    durable_threads: list[int] = []
+
+    @event.listens_for(pool, "checkout")
+    def record_checkout(*_args: Any) -> None:
+        checkout_threads.append(threading.get_ident())
+
+    original_put_file = FsspecFileStorage.put_file
+
+    def observed_put_file(self: FsspecFileStorage, *args: Any, **kwargs: Any):
+        assert pool.checkedout() == 0
+        durable_threads.append(threading.get_ident())
+        return original_put_file(self, *args, **kwargs)
+
+    monkeypatch.setattr(FsspecFileStorage, "put_file", observed_put_file)
+    uploads = [
+        _ObservedUpload(
+            filename="first.txt",
+            content=b"first",
+            assert_no_checkout=lambda: (
+                pool.checkedout() == 0
+                or pytest.fail("upload read held a database connection")
+            ),
+        ),
+        _ObservedUpload(
+            filename="second.txt",
+            content=b"second",
+            assert_no_checkout=lambda: (
+                pool.checkedout() == 0
+                or pytest.fail("upload read held a database connection")
+            ),
+        ),
+    ]
+
+    result = await files_api.store_v1_uploaded_files(
+        upload_items=uploads,
+        task_type="general",
+        folder=None,
+        owner_user_id=7,
+        single_file_mode=False,
+    )
+
+    assert result["total_files"] == 2
+    assert pool.checkedout() == 0
+    assert checkout_threads
+    assert all(thread_id != event_loop_thread for thread_id in checkout_threads)
+    assert durable_threads
+    assert all(thread_id != event_loop_thread for thread_id in durable_threads)
+    with session_factory() as db:
+        rows = db.query(UploadedFile).order_by(UploadedFile.filename).all()
+        assert [str(row.filename) for row in rows] == ["first.txt", "second.txt"]
+        assert all(str(row.storage_status) == "available" for row in rows)
+        assert all(row.task_id is None for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_path_and_local_copy_run_off_the_event_loop(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _session_factory, pool, _uploads_root, _durable_root = isolated_upload_runtime
+    resolve_path = getattr(files_api, "_resolve_v1_upload_path_sync", None)
+    copy_local = getattr(files_api, "_copy_upload_to_local_path_sync", None)
+    assert callable(resolve_path), "missing worker-owned upload path resolver"
+    assert callable(copy_local), "missing worker-owned local upload copier"
+
+    loop_thread = threading.get_ident()
+    path_threads: list[int] = []
+    copy_threads: list[int] = []
+
+    def observed_path(*args: Any, **kwargs: Any):
+        path_threads.append(threading.get_ident())
+        return resolve_path(*args, **kwargs)
+
+    def observed_copy(*args: Any, **kwargs: Any):
+        assert pool.checkedout() == 0
+        copy_threads.append(threading.get_ident())
+        return copy_local(*args, **kwargs)
+
+    monkeypatch.setattr(files_api, "_resolve_v1_upload_path_sync", observed_path)
+    monkeypatch.setattr(files_api, "_copy_upload_to_local_path_sync", observed_copy)
+
+    await files_api.store_v1_uploaded_files(
+        upload_items=[
+            UploadFile(file=io.BytesIO(b"local staging"), filename="staging.txt")
+        ],
+        task_type="general",
+        folder=None,
+        owner_user_id=7,
+        single_file_mode=False,
+    )
+
+    assert path_threads and all(thread_id != loop_thread for thread_id in path_threads)
+    assert copy_threads and all(thread_id != loop_thread for thread_id in copy_threads)
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_read_cancellation_removes_partial_local_file(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+) -> None:
+    session_factory, pool, uploads_root, durable_root = isolated_upload_runtime
+    upload = UploadFile(
+        file=_CancellingAfterFirstChunk(b"partial"),
+        filename="cancelled.txt",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await files_api.store_v1_uploaded_files(
+            upload_items=[upload],
+            task_type="general",
+            folder=None,
+            owner_user_id=7,
+            single_file_mode=False,
+        )
+
+    assert pool.checkedout() == 0
+    with session_factory() as db:
+        assert db.query(UploadedFile).count() == 0
+    assert [path for path in uploads_root.rglob("*") if path.is_file()] == []
+    assert [path for path in durable_root.rglob("*") if path.is_file()] == []
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_durable_failure_leaves_no_rows_or_artifacts(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory, _pool, uploads_root, durable_root = isolated_upload_runtime
+    original_put_file = FsspecFileStorage.put_file
+    call_count = 0
+
+    def fail_second_put(self: FsspecFileStorage, *args: Any, **kwargs: Any):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError("durable write failed")
+        return original_put_file(self, *args, **kwargs)
+
+    monkeypatch.setattr(FsspecFileStorage, "put_file", fail_second_put)
+
+    with pytest.raises(Exception, match="Durable storage is temporarily unavailable"):
+        await files_api.store_v1_uploaded_files(
+            upload_items=[
+                UploadFile(file=io.BytesIO(b"one"), filename="one.txt"),
+                UploadFile(file=io.BytesIO(b"two"), filename="two.txt"),
+            ],
+            task_type="general",
+            folder=None,
+            owner_user_id=7,
+            single_file_mode=False,
+        )
+
+    with session_factory() as db:
+        assert db.query(UploadedFile).count() == 0
+    assert [path for path in uploads_root.rglob("*") if path.is_file()] == []
+    assert [path for path in durable_root.rglob("*") if path.is_file()] == []
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_db_failure_compensates_durable_and_local_artifacts(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory, _pool, uploads_root, durable_root = isolated_upload_runtime
+
+    class _CommitFailingSession(Session):
+        def commit(self) -> None:
+            self.flush()
+            raise RuntimeError("database commit failed")
+
+    failing_session_factory = sessionmaker(
+        bind=session_factory.kw["bind"],
+        class_=_CommitFailingSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(
+        uploaded_file_store, "get_session_local", lambda: failing_session_factory
+    )
+
+    with pytest.raises(RuntimeError, match="database commit failed"):
+        await files_api.store_v1_uploaded_files(
+            upload_items=[UploadFile(file=io.BytesIO(b"one"), filename="one.txt")],
+            task_type="general",
+            folder=None,
+            owner_user_id=7,
+            single_file_mode=False,
+        )
+
+    with session_factory() as db:
+        assert db.query(UploadedFile).count() == 0
+    assert [path for path in uploads_root.rglob("*") if path.is_file()] == []
+    assert [path for path in durable_root.rglob("*") if path.is_file()] == []
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_cancellation_drains_commit_to_an_all_state(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory, pool, uploads_root, durable_root = isolated_upload_runtime
+    entered_persist = threading.Event()
+    release_persist = threading.Event()
+    original_persist = uploaded_file_store.persist_prepared_uploaded_files
+
+    def blocked_persist(files: Any) -> Any:
+        entered_persist.set()
+        assert release_persist.wait(timeout=5)
+        return original_persist(files)
+
+    monkeypatch.setattr(
+        uploaded_file_store, "persist_prepared_uploaded_files", blocked_persist
+    )
+
+    upload_task = asyncio.create_task(
+        files_api.store_v1_uploaded_files(
+            upload_items=[UploadFile(file=io.BytesIO(b"one"), filename="one.txt")],
+            task_type="general",
+            folder=None,
+            owner_user_id=7,
+            single_file_mode=False,
+        )
+    )
+    assert await asyncio.to_thread(entered_persist.wait, 5)
+    upload_task.cancel()
+    release_persist.set()
+    with pytest.raises(asyncio.CancelledError):
+        await upload_task
+
+    assert pool.checkedout() == 0
+    with session_factory() as db:
+        row = db.query(UploadedFile).one()
+        assert row.task_id is None
+    assert len([path for path in uploads_root.rglob("*") if path.is_file()]) == 1
+    assert len([path for path in durable_root.rglob("*") if path.is_file()]) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_upload_cancellation_drains_failed_commit_to_a_none_state(
+    isolated_upload_runtime: tuple[sessionmaker[Session], QueuePool, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_factory, pool, uploads_root, durable_root = isolated_upload_runtime
+    entered_commit = threading.Event()
+    release_commit = threading.Event()
+
+    class _BlockedCommitFailingSession(Session):
+        def commit(self) -> None:
+            entered_commit.set()
+            assert release_commit.wait(timeout=5)
+            self.flush()
+            raise RuntimeError("database commit failed")
+
+    failing_session_factory = sessionmaker(
+        bind=session_factory.kw["bind"],
+        class_=_BlockedCommitFailingSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(
+        uploaded_file_store, "get_session_local", lambda: failing_session_factory
+    )
+
+    upload_task = asyncio.create_task(
+        files_api.store_v1_uploaded_files(
+            upload_items=[UploadFile(file=io.BytesIO(b"one"), filename="one.txt")],
+            task_type="general",
+            folder=None,
+            owner_user_id=7,
+            single_file_mode=False,
+        )
+    )
+    assert await asyncio.to_thread(entered_commit.wait, 5)
+    upload_task.cancel()
+    release_commit.set()
+    with pytest.raises(asyncio.CancelledError):
+        await upload_task
+
+    assert pool.checkedout() == 0
+    with session_factory() as db:
+        assert db.query(UploadedFile).count() == 0
+    assert [path for path in uploads_root.rglob("*") if path.is_file()] == []
+    assert [path for path in durable_root.rglob("*") if path.is_file()] == []

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -57,6 +57,54 @@ def _create_user(db: Session, username: str) -> User:
     return user
 
 
+def test_create_runtime_plan_accepts_detached_tool_categories(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "detached-create-owner")
+    server = _create_runtime_mcp(db_session, owner, "detached-create-runtime")
+
+    plan = prepare_create_connector_runtime(
+        db=db_session,
+        tool_categories=("mcp",),
+        task_source="sdk",
+        connector_user_id=int(owner.id),
+        payload_items=None,
+    )
+
+    assert [ref.connector_id for ref in plan.selected_refs] == [int(server.id)]
+
+
+def test_append_runtime_plan_does_not_require_agent_orm(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "detached-append-owner")
+    agent = Agent(user_id=owner.id, name="detached append agent")
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(db_session, owner, "detached-append-runtime")
+    task = Task(
+        user_id=owner.id,
+        agent_id=agent.id,
+        title="detached append task",
+        source="sdk",
+        status=TaskStatus.COMPLETED,
+        connector_runtime_selected_refs=[
+            {"connector_type": "mcp", "connector_id": int(server.id)}
+        ],
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    plan = prepare_append_connector_runtime(
+        db=db_session,
+        task=task,
+        connector_user_id=int(owner.id),
+        payload_items=None,
+    )
+
+    assert plan.ephemeral_by_ref == {}
+
+
 def _create_runtime_mcp(
     db: Session,
     user: User,
@@ -284,7 +332,7 @@ def test_scoped_resolver_applies_consistently_to_create_and_binding(
     try:
         plan = prepare_create_connector_runtime(
             db=db_session,
-            agent=agent,
+            tool_categories=agent.tool_categories,
             task_source="external",
             connector_user_id=int(task_owner.id),
             payload_items=None,
@@ -342,7 +390,7 @@ def test_scoped_resolver_does_not_bypass_other_create_sources(
         with pytest.raises(ConnectorRuntimeError) as exc_info:
             prepare_create_connector_runtime(
                 db=db_session,
-                agent=agent,
+                tool_categories=agent.tool_categories,
                 task_source=task_source,
                 connector_user_id=int(owner.id),
                 payload_items=None,
@@ -376,7 +424,7 @@ def test_create_plan_rejects_task_identity_mismatch(
     _create_runtime_mcp(db_session, owner, "identity-runtime")
     plan = prepare_create_connector_runtime(
         db=db_session,
-        agent=agent,
+        tool_categories=agent.tool_categories,
         task_source="external",
         connector_user_id=int(owner.id),
         payload_items=None,
@@ -427,7 +475,6 @@ def test_append_uses_persisted_task_owner_connector_visibility(
 
     plan = prepare_append_connector_runtime(
         db=db_session,
-        agent=agent,
         task=task,
         connector_user_id=int(task_owner.id),
         payload_items=[
@@ -453,7 +500,6 @@ def test_append_uses_persisted_task_owner_connector_visibility(
     with pytest.raises(ConnectorRuntimeError) as exc_info:
         prepare_append_connector_runtime(
             db=db_session,
-            agent=agent,
             task=task,
             connector_user_id=int(agent_owner.id),
             payload_items=None,
@@ -649,7 +695,7 @@ def test_resolver_registration_copies_mutable_source_scope(
     with pytest.raises(ConnectorRuntimeError) as exc_info:
         prepare_create_connector_runtime(
             db=db_session,
-            agent=agent,
+            tool_categories=agent.tool_categories,
             task_source="sdk",
             connector_user_id=int(owner.id),
             payload_items=None,

--- a/tests/web/services/test_db_runtime.py
+++ b/tests/web/services/test_db_runtime.py
@@ -1,0 +1,208 @@
+"""Tests for the shared synchronous database worker boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+from xagent.web.services.db_runtime import (
+    await_task_settlement,
+    drain_async_task_cancellation_safe,
+    is_database_pool_timeout,
+    run_db_io_cancellation_safe,
+    run_one_shot_secret_db_io_cancellation_safe,
+)
+
+
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    async with asyncio.timeout(1):
+        while not event.is_set():
+            await asyncio.sleep(0.001)
+
+
+@pytest.mark.asyncio
+async def test_run_db_io_offloads_operation_from_event_loop() -> None:
+    loop_thread_id = threading.get_ident()
+    operation_thread_ids: list[int] = []
+
+    def operation() -> str:
+        operation_thread_ids.append(threading.get_ident())
+        return "done"
+
+    result = await run_db_io_cancellation_safe(operation)
+
+    assert result == "done"
+    assert len(operation_thread_ids) == 1
+    assert operation_thread_ids[0] != loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_run_db_io_drains_worker_before_propagating_cancellation() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def operation() -> str:
+        started.set()
+        assert release.wait(timeout=2)
+        finished.set()
+        return "done"
+
+    caller = asyncio.create_task(run_db_io_cancellation_safe(operation))
+    await _wait_for_thread_event(started)
+
+    caller.cancel()
+    await asyncio.sleep(0.02)
+
+    assert not caller.done()
+    assert not finished.is_set()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(caller, timeout=1)
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_db_io_preserves_worker_error_as_cancellation_cause() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    worker_error = RuntimeError("worker failed after caller cancellation")
+
+    def operation() -> None:
+        started.set()
+        assert release.wait(timeout=2)
+        finished.set()
+        raise worker_error
+
+    caller = asyncio.create_task(run_db_io_cancellation_safe(operation))
+    await _wait_for_thread_event(started)
+
+    caller.cancel()
+    await asyncio.sleep(0.02)
+    assert not caller.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+
+    assert finished.is_set()
+    assert exc_info.value.__cause__ is worker_error
+
+
+@pytest.mark.asyncio
+async def test_one_shot_secret_worker_compensates_before_propagating_cancellation() -> (
+    None
+):
+    started = threading.Event()
+    release = threading.Event()
+    compensated: list[str] = []
+
+    def operation() -> tuple[str, str]:
+        started.set()
+        assert release.wait(timeout=2)
+        return "public-secret", "receipt-1"
+
+    def compensate(receipt: str) -> None:
+        compensated.append(receipt)
+
+    caller = asyncio.create_task(
+        run_one_shot_secret_db_io_cancellation_safe(operation, compensate)
+    )
+    await _wait_for_thread_event(started)
+
+    caller.cancel()
+    await asyncio.sleep(0.02)
+    assert not caller.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(caller, timeout=1)
+    assert compensated == ["receipt-1"]
+
+
+@pytest.mark.asyncio
+async def test_one_shot_secret_worker_preserves_compensation_error_on_cancellation() -> (
+    None
+):
+    started = threading.Event()
+    release = threading.Event()
+    compensation_error = RuntimeError("compensation failed")
+
+    def operation() -> tuple[str, str]:
+        started.set()
+        assert release.wait(timeout=2)
+        return "public-secret", "receipt-1"
+
+    def compensate(_receipt: str) -> None:
+        raise compensation_error
+
+    caller = asyncio.create_task(
+        run_one_shot_secret_db_io_cancellation_safe(operation, compensate)
+    )
+    await _wait_for_thread_event(started)
+
+    caller.cancel()
+    await asyncio.sleep(0.02)
+    release.set()
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+    assert exc_info.value.__cause__ is compensation_error
+
+
+@pytest.mark.asyncio
+async def test_await_task_settlement_returns_late_result_and_cancellation() -> None:
+    release = asyncio.Event()
+
+    async def operation() -> str:
+        await release.wait()
+        return "settled"
+
+    child = asyncio.create_task(operation())
+    waiter = asyncio.create_task(await_task_settlement(child))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    release.set()
+    result, cancellation = await asyncio.wait_for(waiter, timeout=1)
+
+    assert result == "settled"
+    assert isinstance(cancellation, asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_drain_async_task_propagates_cancellation_after_child_settles() -> None:
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def operation() -> str:
+        await release.wait()
+        finished.set()
+        return "settled"
+
+    child = asyncio.create_task(operation())
+    waiter = asyncio.create_task(drain_async_task_cancellation_safe(child))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(waiter, timeout=1)
+    assert finished.is_set()
+
+
+def test_pool_timeout_classifier_walks_exception_chain() -> None:
+    timeout = SQLAlchemyTimeoutError("pool checkout timed out")
+    wrapped = RuntimeError("database operation failed")
+    wrapped.__cause__ = timeout
+
+    assert is_database_pool_timeout(wrapped) is True
+    assert is_database_pool_timeout(RuntimeError("different failure")) is False

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import asyncio
+import threading
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.managed_task_lease import (
+    ManagedTaskLease,
     claim_managed_task_lease,
     start_managed_task_lease,
 )
-from xagent.web.services.task_lease_service import acquire_task_lease
+from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    acquire_task_lease,
+)
 
 
 @pytest.fixture()
@@ -70,3 +80,63 @@ async def test_managed_lease_fails_an_unfinished_task(db_session) -> None:
     assert task.status == TaskStatus.FAILED
     assert task.control_state == "failed"
     assert task.runner_id is None
+
+
+@pytest.mark.asyncio
+async def test_managed_lease_heartbeat_timeout_skips_release_checkout() -> None:
+    heartbeat_task = asyncio.create_task(asyncio.sleep(0))
+    managed = ManagedTaskLease(
+        lease=TaskLease(task_id=7, runner_id="runner-a", run_id="run-a"),
+        stop_event=asyncio.Event(),
+        heartbeat_task=heartbeat_task,  # type: ignore[arg-type]
+    )
+    timeout = SQLAlchemyTimeoutError("heartbeat pool timeout")
+
+    with (
+        patch(
+            "xagent.web.services.managed_task_lease.stop_task_lease_heartbeat",
+            new=AsyncMock(return_value=TaskLeaseHeartbeatOutcome(pool_timeout=timeout)),
+        ),
+        patch(
+            "xagent.web.services.managed_task_lease._release_managed_task_lease_sync"
+        ) as release,
+    ):
+        assert await managed.close() is False
+
+    release.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_managed_lease_close_drains_release_before_cancellation() -> None:
+    heartbeat_task = asyncio.create_task(asyncio.sleep(0))
+    managed = ManagedTaskLease(
+        lease=TaskLease(task_id=8, runner_id="runner-a", run_id="run-a"),
+        stop_event=asyncio.Event(),
+        heartbeat_task=heartbeat_task,  # type: ignore[arg-type]
+    )
+    release_started = threading.Event()
+    allow_release = threading.Event()
+
+    def blocking_release(_lease: TaskLease) -> bool:
+        release_started.set()
+        assert allow_release.wait(timeout=2)
+        return True
+
+    with (
+        patch(
+            "xagent.web.services.managed_task_lease.stop_task_lease_heartbeat",
+            new=AsyncMock(return_value=TaskLeaseHeartbeatOutcome()),
+        ),
+        patch(
+            "xagent.web.services.managed_task_lease._release_managed_task_lease_sync",
+            side_effect=blocking_release,
+        ),
+    ):
+        closing = asyncio.create_task(managed.close())
+        assert await asyncio.to_thread(release_started.wait, 1)
+        closing.cancel()
+        await asyncio.sleep(0.02)
+        assert not closing.done()
+        allow_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await closing

--- a/tests/web/services/test_sdk_task_service.py
+++ b/tests/web/services/test_sdk_task_service.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine, event, update
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from xagent.web.api.v1 import tasks as v1_tasks
+from xagent.web.models import database as database_module
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+from xagent.web.schemas.v1 import AppendMessageRequest, CreateTaskRequest
+from xagent.web.services import sdk_task_service
+from xagent.web.services.api_keys import AgentApiIdentity
+from xagent.web.services.sdk_task_service import (
+    SdkAgentMismatchError,
+    SdkTaskNotFoundError,
+    load_sdk_task_snapshot_sync,
+    load_sdk_task_steps_snapshot_sync,
+    load_sdk_task_steps_version_sync,
+    prepare_append_sdk_task_sync,
+    prepare_create_sdk_task_sync,
+    resolve_sdk_upload_owner_sync,
+)
+from xagent.web.services.task_orchestrator import TaskTurnError
+
+
+@pytest.fixture()
+def sdk_task_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'sdk-task-worker.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=1,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+    )
+    monkeypatch.setattr(database_module, "_SessionLocal", session_local)
+
+    with session_local() as db:
+        user = User(
+            username="sdk-task-worker-owner",
+            password_hash="hash",
+            is_admin=False,
+        )
+        db.add(user)
+        db.flush()
+        agent = Agent(
+            user_id=int(user.id),
+            name="SDK task worker agent",
+            description="test",
+            instructions="test",
+            execution_mode="balanced",
+            models={},
+            knowledge_bases=[],
+            skills=[],
+            tool_categories=[],
+            suggested_prompts=[],
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(user)
+        db.refresh(agent)
+        user_id = int(user.id)
+        agent_id = int(agent.id)
+
+    identity = AgentApiIdentity(
+        agent_id=agent_id,
+        user_id=user_id,
+        execution_mode="balanced",
+        tool_categories=(),
+        status="draft",
+        origin="user",
+        key_prefix="sdk-worker-key",
+    )
+    try:
+        yield engine, session_local, identity
+    finally:
+        engine.dispose()
+
+
+def _insert_sdk_task(session_local, identity: AgentApiIdentity) -> int:
+    with session_local() as db:
+        task = Task(
+            user_id=identity.user_id,
+            title="existing sdk task",
+            description="first",
+            status=TaskStatus.COMPLETED,
+            agent_id=identity.agent_id,
+            input="first",
+            source="sdk",
+            is_visible=False,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return int(task.id)
+
+
+def test_five_task_routes_do_not_accept_request_sessions() -> None:
+    for endpoint in (
+        v1_tasks.upload_task_files,
+        v1_tasks.create_chat_task,
+        v1_tasks.append_message_to_task,
+        v1_tasks.get_chat_task,
+        v1_tasks.get_chat_task_steps,
+    ):
+        assert "db" not in inspect.signature(endpoint).parameters
+
+
+def test_upload_owner_defaults_to_authenticated_agents_user(sdk_task_db) -> None:
+    _engine, _session_local, identity = sdk_task_db
+
+    owner_user_id = resolve_sdk_upload_owner_sync(
+        task_id=None,
+        authenticated_agent_id=identity.agent_id,
+        default_user_id=identity.user_id,
+    )
+
+    assert owner_user_id == identity.user_id
+
+
+def test_task_aware_upload_uses_persisted_owner_after_agent_owner_drift(
+    sdk_task_db,
+) -> None:
+    _engine, session_local, identity = sdk_task_db
+    task_id = _insert_sdk_task(session_local, identity)
+    with session_local() as db:
+        replacement_owner = User(
+            username="sdk-task-current-agent-owner",
+            password_hash="hash",
+            is_admin=False,
+        )
+        db.add(replacement_owner)
+        db.flush()
+        replacement_owner_id = int(replacement_owner.id)
+        db.query(Agent).filter(Agent.id == identity.agent_id).update(
+            {"user_id": replacement_owner_id}
+        )
+        db.commit()
+
+    owner_user_id = resolve_sdk_upload_owner_sync(
+        task_id=task_id,
+        authenticated_agent_id=identity.agent_id,
+        default_user_id=replacement_owner_id,
+    )
+
+    assert owner_user_id == identity.user_id
+
+
+def test_task_aware_upload_hides_other_agent_and_non_sdk_tasks(sdk_task_db) -> None:
+    _engine, session_local, identity = sdk_task_db
+    task_id = _insert_sdk_task(session_local, identity)
+
+    with pytest.raises(SdkTaskNotFoundError):
+        resolve_sdk_upload_owner_sync(
+            task_id=task_id,
+            authenticated_agent_id=identity.agent_id + 1,
+            default_user_id=identity.user_id,
+        )
+
+    with session_local() as db:
+        db.query(Task).filter(Task.id == task_id).update({"source": "web"})
+        db.commit()
+
+    with pytest.raises(SdkTaskNotFoundError):
+        resolve_sdk_upload_owner_sync(
+            task_id=task_id,
+            authenticated_agent_id=identity.agent_id,
+            default_user_id=identity.user_id,
+        )
+
+
+def test_create_preparation_materializes_after_session_checkin(
+    sdk_task_db,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, session_local, identity = sdk_task_db
+    local_path = tmp_path / "attachment.txt"
+    local_path.write_text("hello", encoding="utf-8")
+    with session_local() as db:
+        uploaded = UploadedFile(
+            file_id="attachment-1",
+            user_id=identity.user_id,
+            task_id=None,
+            filename=local_path.name,
+            storage_path=str(local_path),
+            storage_status="legacy",
+            mime_type="text/plain",
+            file_size=local_path.stat().st_size,
+        )
+        db.add(uploaded)
+        db.commit()
+
+    original_materialize = sdk_task_service.materialize_turn_file_lookups
+    checked_out: list[int] = []
+
+    def observed_materialize(lookups):
+        checked_out.append(engine.pool.checkedout())
+        return original_materialize(lookups)
+
+    monkeypatch.setattr(
+        sdk_task_service,
+        "materialize_turn_file_lookups",
+        observed_materialize,
+    )
+
+    prepared = prepare_create_sdk_task_sync(
+        agent_id=identity.agent_id,
+        task_owner_user_id=identity.user_id,
+        actor_user_id=identity.user_id,
+        tool_categories=identity.tool_categories,
+        content="first message",
+        file_ids=("attachment-1",),
+        connector_runtime_context=None,
+    )
+
+    assert prepared.agent_id == identity.agent_id
+    assert prepared.file_infos[0]["file_id"] == "attachment-1"
+    assert checked_out == [0]
+    assert engine.pool.checkedout() == 0
+
+
+def test_append_preserves_not_found_before_body_agent_mismatch(sdk_task_db) -> None:
+    _engine, session_local, identity = sdk_task_db
+
+    with pytest.raises(SdkTaskNotFoundError):
+        prepare_append_sdk_task_sync(
+            task_id=999999,
+            authenticated_agent_id=identity.agent_id,
+            actor_user_id=identity.user_id,
+            requested_agent_id=identity.agent_id + 1,
+            file_ids=(),
+            connector_runtime_context=None,
+        )
+
+    task_id = _insert_sdk_task(session_local, identity)
+    with pytest.raises(SdkAgentMismatchError):
+        prepare_append_sdk_task_sync(
+            task_id=task_id,
+            authenticated_agent_id=identity.agent_id,
+            actor_user_id=identity.user_id,
+            requested_agent_id=identity.agent_id + 1,
+            file_ids=(),
+            connector_runtime_context=None,
+        )
+
+
+def test_read_snapshots_are_detached_primitives(sdk_task_db) -> None:
+    _engine, session_local, identity = sdk_task_db
+    task_id = _insert_sdk_task(session_local, identity)
+    timestamp = datetime(2026, 7, 21, 12, 0, tzinfo=UTC)
+    with session_local() as db:
+        db.add(
+            TraceEvent(
+                task_id=task_id,
+                event_id="evt-1",
+                event_type="ai_message",
+                timestamp=timestamp,
+                data={"content": "done"},
+            )
+        )
+        db.commit()
+
+    task = load_sdk_task_snapshot_sync(task_id, identity.agent_id)
+    version = load_sdk_task_steps_version_sync(task_id, identity.agent_id)
+    steps = load_sdk_task_steps_snapshot_sync(task_id, identity.agent_id)
+
+    assert task is not None
+    assert task.task_id == task_id
+    assert task.status is TaskStatus.COMPLETED
+    assert version is not None and version.max_event_id > 0
+    assert steps is not None and steps.max_event_id == version.max_event_id
+    assert steps.events[0].event_type == "ai_message"
+    assert not hasattr(task, "_sa_instance_state")
+    assert not hasattr(steps.events[0], "_sa_instance_state")
+
+
+def test_steps_snapshot_copies_trace_payloads_after_session_checkin(
+    sdk_task_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, session_local, identity = sdk_task_db
+    task_id = _insert_sdk_task(session_local, identity)
+    with session_local() as db:
+        db.add(
+            TraceEvent(
+                task_id=task_id,
+                event_id="evt-copy-boundary",
+                event_type="ai_message",
+                timestamp=datetime(2026, 7, 21, 12, 0, tzinfo=UTC),
+                data={"content": "done", "nested": {"value": [1, 2, 3]}},
+            )
+        )
+        db.commit()
+
+    original_deepcopy = sdk_task_service.deepcopy
+    checked_out: list[int] = []
+
+    def observed_deepcopy(value):
+        checked_out.append(engine.pool.checkedout())
+        return original_deepcopy(value)
+
+    monkeypatch.setattr(sdk_task_service, "deepcopy", observed_deepcopy)
+
+    snapshot = load_sdk_task_steps_snapshot_sync(task_id, identity.agent_id)
+
+    assert snapshot is not None
+    assert snapshot.events[0].data["nested"] == {"value": [1, 2, 3]}
+    assert checked_out == [0]
+
+
+def test_pending_failure_compensation_does_not_overwrite_concurrent_claim(
+    sdk_task_db,
+) -> None:
+    engine, session_local, identity = sdk_task_db
+    with session_local() as db:
+        task = Task(
+            user_id=identity.user_id,
+            title="pending compensation race",
+            status=TaskStatus.PENDING,
+            agent_id=identity.agent_id,
+            input="race",
+            source="sdk",
+            is_visible=False,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+
+    injected = False
+
+    def claim_immediately_before_compensation(
+        connection,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        nonlocal injected
+        normalized = statement.lower()
+        if (
+            injected
+            or not normalized.lstrip().startswith("update tasks set")
+            or "control_state" not in normalized
+        ):
+            return
+        injected = True
+        connection.execute(
+            update(Task)
+            .where(Task.id == task_id, Task.status == TaskStatus.PENDING)
+            .values(
+                status=TaskStatus.RUNNING,
+                control_state="running",
+                run_id="concurrent-run",
+                state_version=Task.state_version + 1,
+            )
+        )
+
+    event.listen(engine, "before_cursor_execute", claim_immediately_before_compensation)
+    try:
+        sdk_task_service.mark_pending_sdk_task_failed_sync(
+            task_id,
+            "compensation must not win",
+            expected_agent_id=identity.agent_id,
+            expected_owner_user_id=identity.user_id,
+        )
+    finally:
+        event.remove(
+            engine,
+            "before_cursor_execute",
+            claim_immediately_before_compensation,
+        )
+
+    assert injected
+    with session_local() as db:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status is TaskStatus.RUNNING
+        assert task.control_state == "running"
+        assert task.run_id == "concurrent-run"
+        assert task.error_message is None
+
+
+async def _wait_for_async_event(event: asyncio.Event) -> None:
+    await asyncio.wait_for(event.wait(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_finishes_turn_claim_after_caller_cancellation(
+    sdk_task_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _engine, session_local, identity = sdk_task_db
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_begin_turn = v1_tasks.TaskTurnOrchestrator.begin_turn
+
+    async def gated_begin_turn(**kwargs):
+        entered.set()
+        await release.wait()
+        return await original_begin_turn(**kwargs)
+
+    monkeypatch.setattr(
+        v1_tasks.TaskTurnOrchestrator,
+        "begin_turn",
+        gated_begin_turn,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        MagicMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(v1_tasks, "record_key_usage", AsyncMock())
+
+    caller = asyncio.create_task(
+        v1_tasks.create_chat_task(
+            CreateTaskRequest(
+                agent_id=identity.agent_id,
+                message={"role": "user", "content": "cancel after commit"},
+            ),
+            identity,
+        )
+    )
+    await _wait_for_async_event(entered)
+    caller.cancel()
+    await asyncio.sleep(0)
+    assert not caller.done()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    with session_local() as db:
+        task = db.query(Task).filter(Task.input == "cancel after commit").one()
+        assert task.status is TaskStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_compensates_begin_failure_without_pending_task(
+    sdk_task_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _engine, session_local, identity = sdk_task_db
+    monkeypatch.setattr(
+        v1_tasks.TaskTurnOrchestrator,
+        "begin_turn",
+        AsyncMock(side_effect=TaskTurnError("bg_inflight")),
+    )
+    monkeypatch.setattr(v1_tasks, "record_key_usage", AsyncMock())
+
+    with pytest.raises(v1_tasks.V1ApiError):
+        await v1_tasks.create_chat_task(
+            CreateTaskRequest(
+                agent_id=identity.agent_id,
+                message={"role": "user", "content": "begin failure"},
+            ),
+            identity,
+        )
+
+    with session_local() as db:
+        task = db.query(Task).filter(Task.input == "begin failure").one()
+        assert task.status is TaskStatus.FAILED
+        assert task.error_message == "Task turn start failed."
+
+
+@pytest.mark.asyncio
+async def test_append_workflow_finishes_turn_claim_after_caller_cancellation(
+    sdk_task_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _engine, session_local, identity = sdk_task_db
+    task_id = _insert_sdk_task(session_local, identity)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_begin_turn = v1_tasks.TaskTurnOrchestrator.begin_turn
+
+    async def gated_begin_turn(**kwargs):
+        entered.set()
+        await release.wait()
+        return await original_begin_turn(**kwargs)
+
+    monkeypatch.setattr(
+        v1_tasks.TaskTurnOrchestrator,
+        "begin_turn",
+        gated_begin_turn,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        MagicMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(v1_tasks, "record_key_usage", AsyncMock())
+
+    caller = asyncio.create_task(
+        v1_tasks.append_message_to_task(
+            task_id,
+            AppendMessageRequest(
+                agent_id=identity.agent_id,
+                message={"role": "user", "content": "cancel append"},
+            ),
+            identity,
+        )
+    )
+    await _wait_for_async_event(entered)
+    caller.cancel()
+    await asyncio.sleep(0)
+    assert not caller.done()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    with session_local() as db:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status is TaskStatus.RUNNING
+        assert task.input == "cancel append"

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError, is_dataclass
 from datetime import datetime, timedelta
-from threading import Barrier
+from threading import Barrier, Event, get_ident
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
     _load_command_message_delivery_status,
     execute_durable_task_command,
 )
+from xagent.web.models import database as database_module
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import (
     Base,
@@ -26,6 +31,7 @@ from xagent.web.models.database import (
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.user import User
+from xagent.web.services import task_command_transport as task_command_transport_module
 from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
     COMMAND_FAILED,
@@ -62,6 +68,26 @@ def db_session(tmp_path):
     finally:
         db.close()
         Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.fixture()
+def queue_pool_command_db(tmp_path):
+    """A real one-slot QueuePool for dispatcher checkout contention."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'task-command-queue-pool.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.2,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    try:
+        yield engine, SessionLocal
+    finally:
+        engine.dispose()
 
 
 def _create_running_task(db) -> tuple[User, Task]:
@@ -378,6 +404,44 @@ async def test_cancel_command_does_not_require_persisted_actor(db_session) -> No
     ):
         await execute_durable_task_command(command)
     load_actor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_passes_only_primitive_identity_to_cancel_runtime(
+    db_session,
+) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="primitive-cancel",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 77},
+        target_run_id=None,
+        attempt_count=1,
+    )
+    cancel = AsyncMock()
+
+    with (
+        patch(
+            "xagent.web.api.a2a._cancel_task_unserialized",
+            new=cancel,
+        ),
+        patch.object(
+            websocket_api,
+            "get_session_local",
+            side_effect=AssertionError(
+                "durable cancel retained an outer database session"
+            ),
+        ),
+    ):
+        await execute_durable_task_command(command)
+
+    cancel.assert_awaited_once_with(task_id=int(task.id), agent_id=77)
 
 
 @pytest.mark.asyncio
@@ -881,7 +945,7 @@ async def test_dispatcher_recovers_unrelated_tasks_concurrently(db_session) -> N
         await stop_task_command_dispatcher()
 
 
-def test_load_task_command_returns_an_explicit_detached_snapshot(db_session) -> None:
+def test_load_task_command_returns_an_immutable_primitive_snapshot(db_session) -> None:
     user, task = _create_running_task(db_session)
     task.runner_id = None
     task.lease_expires_at = None
@@ -894,13 +958,28 @@ def test_load_task_command_returns_an_explicit_detached_snapshot(db_session) -> 
         kind=TaskCommandKind.PAUSE,
         payload={"type": "pause_task"},
     )
+    row = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert row is not None
+    row.attempt_count = 3
+    row.failure_count = 2
+    row.defer_count = 1
+    row.result = {"rejection_reason": "stale_run", "mutable": ["ignored"]}
+    db_session.commit()
 
     stored = load_task_command(enqueued.command_id)
 
     assert stored is not None
-    assert sa_inspect(stored).detached
+    assert is_dataclass(stored)
+    assert not isinstance(stored, TaskExecutionCommand)
+    assert stored.command_db_id == enqueued.command_id
     assert stored.status == "pending"
     assert stored.error is None
+    assert stored.rejection_reason == "stale_run"
+    assert stored.attempt_count == 3
+    assert stored.failure_count == 2
+    assert stored.defer_count == 1
+    with pytest.raises(FrozenInstanceError):
+        stored.status = "failed"  # type: ignore[misc]
 
 
 def test_legacy_delivery_status_preserves_none(db_session) -> None:
@@ -921,6 +1000,578 @@ def test_legacy_delivery_status_preserves_none(db_session) -> None:
     assert (
         _load_command_message_delivery_status(int(task.id), "legacy-delivery") is None
     )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_claim_pool_wait_does_not_block_event_loop(
+    queue_pool_command_db,
+    monkeypatch,
+) -> None:
+    engine, SessionLocal = queue_pool_command_db
+    with SessionLocal() as seed_db:
+        user, task = _create_running_task(seed_db)
+        task.runner_id = None
+        task.lease_expires_at = None
+        seed_db.commit()
+        enqueued = enqueue_task_command(
+            seed_db,
+            task_id=int(task.id),
+            actor_user_id=int(user.id),
+            command_id="contended-dispatch-claim",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    session_threads: list[int] = []
+
+    def session_factory():
+        session_threads.append(get_ident())
+        return SessionLocal()
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_factory)
+
+    held_connection = engine.connect()
+    loop_thread = get_ident()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    async def execute(command: ClaimedTaskCommand) -> None:
+        assert isinstance(command, ClaimedTaskCommand)
+
+    ticker_task = asyncio.create_task(ticker())
+    dispatch_task = asyncio.create_task(
+        dispatch_one_task_command(execute, command_db_id=enqueued.command_id)
+    )
+    try:
+        await asyncio.sleep(0.08)
+        assert ticks >= 3, "command claim QueuePool checkout blocked the event loop"
+        assert not dispatch_task.done()
+    finally:
+        held_connection.close()
+        ticker_stop.set()
+        await ticker_task
+
+    assert await asyncio.wait_for(dispatch_task, timeout=1)
+    assert session_threads
+    assert session_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_command_handler_pool_timeout_does_not_checkout_again(
+    queue_pool_command_db,
+    monkeypatch,
+    caplog,
+) -> None:
+    """A handler checkout timeout leaves its durable claim for expiry/retry."""
+    engine, SessionLocal = queue_pool_command_db
+    with SessionLocal() as seed_db:
+        user, task = _create_running_task(seed_db)
+        task.runner_id = None
+        task.lease_expires_at = None
+        seed_db.commit()
+        enqueued = enqueue_task_command(
+            seed_db,
+            task_id=int(task.id),
+            actor_user_id=int(user.id),
+            command_id="handler-pool-timeout",
+            kind=TaskCommandKind.RESUME,
+            payload={"type": "resume_task"},
+        )
+        task_id = int(task.id)
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    held_connections = []
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    def checkout_from_exhausted_pool() -> None:
+        with SessionLocal() as db:
+            db.execute(text("SELECT 1")).scalar()
+
+    async def execute(_command: ClaimedTaskCommand) -> None:
+        held_connections.append(engine.connect())
+        await asyncio.to_thread(checkout_from_exhausted_pool)
+
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_command_transport",
+    )
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        assert await dispatch_one_task_command(
+            execute,
+            command_db_id=enqueued.command_id,
+        )
+        assert ticks >= 10, (
+            "command handler QueuePool timeout blocked the event loop; "
+            f"ticker advanced only {ticks} times"
+        )
+    finally:
+        ticker_stop.set()
+        await ticker_task
+        for connection in held_connections:
+            connection.close()
+
+    with SessionLocal() as verify_db:
+        stored = verify_db.get(TaskExecutionCommand, enqueued.command_id)
+        assert stored is not None
+        assert stored.status == "processing"
+        assert stored.claim_expires_at is not None
+
+    assert f"task_id={task_id}" in caplog.text
+    assert "component=task-command-handler" in caplog.text
+    assert "retaining command claim for expiry" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("executor_outcome", "disposition_name"),
+    [
+        ("success", "finish_task_command"),
+        ("failure", "fail_task_command"),
+        ("deferred", "defer_task_command"),
+    ],
+)
+async def test_final_disposition_pool_timeout_retains_claim_for_ttl(
+    db_session,
+    monkeypatch,
+    caplog,
+    executor_outcome: str,
+    disposition_name: str,
+) -> None:
+    """A final write timeout must not trigger another checkout or lose fencing."""
+
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id=f"{executor_outcome}-disposition-timeout",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    disposition_calls: list[tuple[str, str, int]] = []
+
+    def pool_timeout(*args, **kwargs) -> bool:
+        disposition_calls.append(
+            (
+                disposition_name,
+                str(args[1]),
+                int(kwargs["expected_attempt_count"]),
+            )
+        )
+        raise SQLAlchemyTimeoutError("synthetic final disposition pool timeout")
+
+    def unexpected_disposition(*_args, **_kwargs) -> bool:
+        raise AssertionError("pool timeout triggered a second disposition checkout")
+
+    for candidate in (
+        "finish_task_command",
+        "fail_task_command",
+        "defer_task_command",
+    ):
+        monkeypatch.setattr(
+            task_command_transport_module,
+            candidate,
+            pool_timeout if candidate == disposition_name else unexpected_disposition,
+        )
+
+    async def execute(_command: ClaimedTaskCommand) -> None:
+        if executor_outcome == "failure":
+            raise RuntimeError("executor failed")
+        if executor_outcome == "deferred":
+            raise TaskCommandDeferred("handoff not ready")
+
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_command_transport",
+    )
+
+    assert await dispatch_one_task_command(
+        execute,
+        command_db_id=enqueued.command_id,
+    )
+
+    assert len(disposition_calls) == 1
+    observed_disposition, observed_runner_id, observed_attempt = disposition_calls[0]
+    assert observed_disposition == disposition_name
+    assert observed_attempt == 1
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == "processing"
+    assert stored.claimed_by == observed_runner_id
+    assert stored.claim_expires_at is not None
+    assert stored.attempt_count == 1
+    assert "component=task-command-disposition" in caplog.text
+    assert f"disposition={disposition_name}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_real_final_disposition_pool_timeout_stays_off_event_loop(
+    queue_pool_command_db,
+    monkeypatch,
+    caplog,
+) -> None:
+    """A real one-slot pool timeout leaves the exact processing claim intact."""
+
+    engine, SessionLocal = queue_pool_command_db
+    with SessionLocal() as seed_db:
+        user, task = _create_running_task(seed_db)
+        task.runner_id = None
+        task.lease_expires_at = None
+        seed_db.commit()
+        enqueued = enqueue_task_command(
+            seed_db,
+            task_id=int(task.id),
+            actor_user_id=int(user.id),
+            command_id="real-finish-disposition-timeout",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    held_connections = []
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    async def execute(_command: ClaimedTaskCommand) -> dict[str, bool]:
+        held_connections.append(engine.connect())
+        return {"ok": True}
+
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_command_transport",
+    )
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        assert await dispatch_one_task_command(
+            execute,
+            command_db_id=enqueued.command_id,
+        )
+        assert ticks >= 10, (
+            "final disposition QueuePool timeout blocked the event loop; "
+            f"ticker advanced only {ticks} times"
+        )
+    finally:
+        ticker_stop.set()
+        await ticker_task
+        for connection in held_connections:
+            connection.close()
+
+    with SessionLocal() as verify_db:
+        stored = verify_db.get(TaskExecutionCommand, enqueued.command_id)
+        assert stored is not None
+        assert stored.status == "processing"
+        assert stored.claimed_by is not None
+        assert stored.claim_expires_at is not None
+        assert stored.attempt_count == 1
+
+    assert "component=task-command-disposition" in caplog.text
+    assert "disposition=finish_task_command" in caplog.text
+    assert "retaining command claim for expiry" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("heartbeat_failure", ["pool_timeout", "claim_lost"])
+async def test_dispatch_skips_disposition_after_unhealthy_heartbeat(
+    db_session,
+    monkeypatch,
+    caplog,
+    heartbeat_failure: str,
+) -> None:
+    """An unresolved heartbeat cannot be followed by another DB checkout."""
+
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id=f"heartbeat-{heartbeat_failure}",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+
+    class HeartbeatOutcome:
+        claim_lost = heartbeat_failure == "claim_lost"
+        pool_timeout = (
+            SQLAlchemyTimeoutError("heartbeat pool timeout")
+            if heartbeat_failure == "pool_timeout"
+            else None
+        )
+        requires_ttl_recovery = claim_lost or pool_timeout is not None
+
+    async def unhealthy_heartbeat(
+        _command_db_id: int,
+        _runner_id: str,
+        _attempt_count: int,
+        stop_event: asyncio.Event,
+    ) -> HeartbeatOutcome:
+        await stop_event.wait()
+        return HeartbeatOutcome()
+
+    def unexpected_disposition(*_args, **_kwargs) -> bool:
+        raise AssertionError("unhealthy heartbeat triggered a final checkout")
+
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "_claim_heartbeat",
+        unhealthy_heartbeat,
+    )
+    for candidate in (
+        "finish_task_command",
+        "fail_task_command",
+        "defer_task_command",
+    ):
+        monkeypatch.setattr(
+            task_command_transport_module,
+            candidate,
+            unexpected_disposition,
+        )
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_command_transport",
+    )
+
+    assert await dispatch_one_task_command(
+        lambda _command: asyncio.sleep(0),
+        command_db_id=enqueued.command_id,
+    )
+
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == "processing"
+    assert stored.claimed_by is not None
+    assert stored.claim_expires_at is not None
+    assert "component=task-command-heartbeat" in caplog.text
+    assert "retaining command claim for expiry" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_worker_isolates_one_command_error(
+    monkeypatch,
+    caplog,
+) -> None:
+    """One command failure must not terminate its long-lived dispatcher worker."""
+
+    recovered = asyncio.Event()
+    calls = 0
+
+    async def dispatch(_executor, *, command_db_id=None) -> bool:
+        nonlocal calls
+        del command_db_id
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("single command failure")
+        recovered.set()
+        return False
+
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "dispatch_one_task_command",
+        dispatch,
+    )
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "_dispatcher_wakeup",
+        asyncio.Event(),
+    )
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "DISPATCHER_IDLE_SECONDS",
+        0.01,
+    )
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_command_transport",
+    )
+    worker = asyncio.create_task(
+        task_command_transport_module._run_task_command_dispatcher_worker(
+            lambda _command: asyncio.sleep(0)
+        )
+    )
+    try:
+        await asyncio.wait_for(recovered.wait(), timeout=0.25)
+    finally:
+        worker.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker
+    assert calls >= 2
+    assert "component=task-command-dispatcher" in caplog.text
+    assert "single command failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancellation_drains_inflight_completion_worker(
+    db_session,
+    monkeypatch,
+) -> None:
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="cancel-during-command-finish",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    finish_started = Event()
+    allow_finish = Event()
+    finish_completed = Event()
+
+    def blocking_finish(*_args, **_kwargs) -> bool:
+        finish_started.set()
+        assert allow_finish.wait(timeout=2)
+        finish_completed.set()
+        return True
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.finish_task_command",
+        blocking_finish,
+    )
+
+    async def execute(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    dispatch_task = asyncio.create_task(
+        dispatch_one_task_command(execute, command_db_id=enqueued.command_id)
+    )
+    await asyncio.wait_for(asyncio.to_thread(finish_started.wait, 1), timeout=1)
+    dispatch_task.cancel()
+    try:
+        await asyncio.sleep(0.02)
+        assert not dispatch_task.done()
+    finally:
+        allow_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(dispatch_task, timeout=1)
+    assert finish_completed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_claim_heartbeat_cancellation_drains_inflight_renewal(
+    monkeypatch,
+) -> None:
+    renew_started = Event()
+    allow_renew = Event()
+    renew_completed = Event()
+
+    def blocking_renew(*_args, **_kwargs) -> bool:
+        renew_started.set()
+        assert allow_renew.wait(timeout=2)
+        renew_completed.set()
+        return True
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_command_transport.renew_task_command_claim",
+        blocking_renew,
+    )
+
+    heartbeat = asyncio.create_task(_claim_heartbeat(7, "runner-a", 1, asyncio.Event()))
+    await asyncio.wait_for(asyncio.to_thread(renew_started.wait, 1), timeout=1)
+    heartbeat.cancel()
+    try:
+        await asyncio.sleep(0.02)
+        assert not heartbeat.done()
+    finally:
+        allow_renew.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(heartbeat, timeout=1)
+    assert renew_completed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_claim_heartbeat_reports_unresolved_pool_timeout(monkeypatch) -> None:
+    stop_event = asyncio.Event()
+    timeout = SQLAlchemyTimeoutError("heartbeat checkout timed out")
+
+    def renew(*_args, **_kwargs) -> bool:
+        stop_event.set()
+        raise timeout
+
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "renew_task_command_claim",
+        renew,
+    )
+
+    outcome = await _claim_heartbeat(7, "runner-a", 1, stop_event)
+
+    assert outcome.claim_lost is False
+    assert outcome.pool_timeout is timeout
+    assert outcome.requires_ttl_recovery is True
+
+
+@pytest.mark.asyncio
+async def test_claim_heartbeat_clears_pool_timeout_after_success(monkeypatch) -> None:
+    stop_event = asyncio.Event()
+    attempts = 0
+
+    def renew(*_args, **_kwargs) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise SQLAlchemyTimeoutError("transient heartbeat checkout timeout")
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "renew_task_command_claim",
+        renew,
+    )
+
+    outcome = await _claim_heartbeat(7, "runner-a", 1, stop_event)
+
+    assert attempts == 2
+    assert outcome.claim_lost is False
+    assert outcome.pool_timeout is None
+    assert outcome.requires_ttl_recovery is False
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -18,13 +18,17 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
-from threading import Barrier
+from threading import Barrier, get_ident
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRef
+from xagent.web.models import database as database_module
 from xagent.web.models.agent import Agent
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
@@ -36,9 +40,11 @@ from xagent.web.models.trigger import (
     TriggerType,
 )
 from xagent.web.models.user import User
+from xagent.web.services import task_orchestrator as task_orchestrator_module
 from xagent.web.services.chat_history_service import (
     DELIVERY_DISPATCHED,
     DELIVERY_FAILED,
+    DELIVERY_PENDING,
 )
 from xagent.web.services.connector_runtime import (
     get_ephemeral_runtime_values,
@@ -47,6 +53,8 @@ from xagent.web.services.connector_runtime import (
 )
 from xagent.web.services.task_execution_controller import task_execution_controller
 from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
     acquire_task_lease_isolated,
     get_runner_id,
 )
@@ -76,6 +84,25 @@ def db_session(tmp_path):
     finally:
         db.close()
         Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.fixture()
+def queue_pool_runtime_db(tmp_path):
+    """A real one-slot QueuePool used to exercise checkout contention."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'orchestrator-queue-pool.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.4,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    try:
+        yield engine, SessionLocal
+    finally:
+        engine.dispose()
 
 
 def _create_user(db) -> User:
@@ -253,6 +280,139 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
         .one()
     )
     assert delivery.delivery_status == DELIVERY_DISPATCHED
+
+
+@pytest.mark.asyncio
+async def test_create_and_begin_turn_commits_one_running_task_transaction(
+    db_session,
+    mock_schedule_bg,
+) -> None:
+    user = _create_user(db_session)
+    creation = task_orchestrator_module.TaskCreationSpec(
+        task_owner_user_id=int(user.id),
+        title="Atomic task",
+        description="created and claimed together",
+        agent_id=17,
+        execution_mode="balanced",
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-atomic"},
+    )
+    payload = TaskTurnPayload("atomic first turn")
+
+    started = await TaskTurnOrchestrator.create_and_begin_turn(
+        creation=creation,
+        payload=payload,
+        actor_user_id=int(user.id),
+    )
+
+    task = db_session.query(Task).filter(Task.id == started.task_id).one()
+    assert task.status == TaskStatus.RUNNING
+    assert task.user_id == int(user.id)
+    assert task.agent_id == 17
+    assert task.source == "a2a"
+    assert task.is_visible is False
+    assert task.input == "atomic first turn"
+    assert task.agent_config == {"a2a_context_id": "ctx-atomic"}
+    assert task.run_id == started.run_id
+    assert task.state_version == started.state_version == 1
+    assert task.control_state == started.control_state == "running"
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == payload.turn_id)
+        .one()
+    )
+    assert delivery.task_id == started.task_id
+    assert delivery.delivery_status == DELIVERY_DISPATCHED
+    assert mock_schedule_bg.call_args.kwargs["task_id"] == started.task_id
+
+
+@pytest.mark.asyncio
+async def test_create_and_begin_turn_pool_timeout_leaves_no_task(
+    queue_pool_runtime_db,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_schedule_bg,
+) -> None:
+    """A failed first checkout rolls back the insert and keeps the loop live."""
+
+    engine, SessionLocal = queue_pool_runtime_db
+    monkeypatch.setattr(database_module, "_SessionLocal", SessionLocal)
+    with SessionLocal() as seed_db:
+        user = _create_user(seed_db)
+        owner_id = int(user.id)
+
+    creation = task_orchestrator_module.TaskCreationSpec(
+        task_owner_user_id=owner_id,
+        title="Atomic timeout",
+        description="must not persist",
+        agent_id=None,
+        execution_mode="balanced",
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-timeout"},
+    )
+    held_connection = engine.connect()
+    stop_ticker = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop_ticker.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with pytest.raises(SQLAlchemyTimeoutError):
+            await TaskTurnOrchestrator.create_and_begin_turn(
+                creation=creation,
+                payload=TaskTurnPayload("cannot acquire pool"),
+                actor_user_id=owner_id,
+            )
+    finally:
+        held_connection.close()
+        stop_ticker.set()
+        await ticker_task
+
+    assert ticks >= 3, "atomic task creation blocked the asyncio event loop"
+    with SessionLocal() as verify_db:
+        assert verify_db.query(Task).filter(Task.source == "a2a").count() == 0
+    mock_schedule_bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_and_begin_turn_message_failure_rolls_back_task(
+    db_session,
+    mock_schedule_bg,
+) -> None:
+    """The task insert cannot commit without its first transcript message."""
+
+    user = _create_user(db_session)
+    creation = task_orchestrator_module.TaskCreationSpec(
+        task_owner_user_id=int(user.id),
+        title="Atomic rollback",
+        description="message persistence fails",
+        agent_id=None,
+        execution_mode="balanced",
+        source="a2a",
+        is_visible=False,
+        agent_config={"a2a_context_id": "ctx-rollback"},
+    )
+
+    with patch(
+        "xagent.web.services.chat_history_service.persist_user_message_no_commit",
+        side_effect=RuntimeError("message insert failed"),
+    ):
+        with pytest.raises(RuntimeError, match="message insert failed"):
+            await TaskTurnOrchestrator.create_and_begin_turn(
+                creation=creation,
+                payload=TaskTurnPayload("must roll back together"),
+                actor_user_id=int(user.id),
+            )
+
+    db_session.expire_all()
+    assert db_session.query(Task).filter(Task.source == "a2a").count() == 0
+    mock_schedule_bg.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -557,6 +717,98 @@ async def test_begin_turn_marks_failed_when_schedule_raises(
         .one()
     )
     assert delivery.delivery_status == DELIVERY_FAILED
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_dispatch_timeout_does_not_reject_scheduled_turn(
+    db_session,
+    mock_schedule_bg,
+    caplog,
+) -> None:
+    """A post-schedule delivery write is best-effort under pool exhaustion.
+
+    The claim is already committed and the background task is already
+    scheduled.  Reporting the checkout timeout to the API would tell the
+    caller that a turn which is actually running was rejected.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+    payload = TaskTurnPayload("start once")
+
+    caplog.set_level(logging.ERROR, logger="xagent.web.services.task_orchestrator")
+    with patch(
+        "xagent.web.services.task_orchestrator.mark_user_message_delivery_sync",
+        side_effect=SQLAlchemyTimeoutError("delivery pool exhausted"),
+    ) as mark_delivery:
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            payload=payload,
+            kind=TurnKind.CREATE,
+        )
+
+    assert started.task_id == int(task.id)
+    mock_schedule_bg.assert_called_once()
+    mark_delivery.assert_called_once_with(
+        int(task.id), payload.turn_id, DELIVERY_DISPATCHED
+    )
+    db_session.expire_all()
+    stored_task = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored_task.status == TaskStatus.RUNNING
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == payload.turn_id)
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_PENDING
+    assert "component=turn-delivery database pool checkout timed out" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_schedule_failure_pool_timeout_does_not_checkout_delivery_again(
+    db_session,
+    caplog,
+) -> None:
+    """A failed terminal write is the last checkout after schedule failure."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+    payload = TaskTurnPayload("cannot schedule")
+    mark_delivery = MagicMock()
+    terminal_session = MagicMock()
+    terminal_db = terminal_session.__enter__.return_value
+    terminal_db.query.side_effect = SQLAlchemyTimeoutError("terminal pool exhausted")
+    terminal_session_factory = MagicMock(return_value=terminal_session)
+    claim_session_factory = database_module.get_session_local()
+
+    caplog.set_level(logging.ERROR, logger="xagent.web.services.task_orchestrator")
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator._schedule_bg",
+            side_effect=RuntimeError("schedule boom"),
+        ),
+        patch(
+            "xagent.web.models.database.get_session_local",
+            side_effect=(claim_session_factory, terminal_session_factory),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.mark_user_message_delivery_sync",
+            mark_delivery,
+        ),
+        pytest.raises(RuntimeError, match="schedule boom"),
+    ):
+        await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            payload=payload,
+            kind=TurnKind.CREATE,
+        )
+
+    terminal_db.query.assert_called_once_with(Task)
+    mark_delivery.assert_not_called()
+    assert (
+        "component=turn-schedule-terminal database pool checkout timed out"
+        in caplog.text
+    )
 
 
 @pytest.mark.asyncio
@@ -873,6 +1125,37 @@ def test_finish_turn_running_flips_failed_when_we_own_lease(db_session) -> None:
     assert task.status == TaskStatus.FAILED
 
 
+def test_finish_turn_does_not_touch_a_new_run_owned_by_same_process(
+    db_session,
+) -> None:
+    """The concrete lease, not the process-global runner id, fences cleanup.
+
+    A worker process can finish an old coroutine after the same process has
+    already claimed a newer run.  Matching only ``get_runner_id()`` would let
+    the stale coroutine fail the new run because both leases share that value.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task.runner_id = get_runner_id()
+    task.run_id = "new-run"
+    task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    db_session.commit()
+
+    stale_lease = TaskLease(
+        task_id=int(task.id),
+        runner_id=get_runner_id(),
+        run_id="old-run",
+    )
+    finish_turn(db_session, int(task.id), task_lease=stale_lease)
+
+    db_session.expire_all()
+    persisted = db_session.query(Task).filter(Task.id == task.id).one()
+    assert persisted.status == TaskStatus.RUNNING
+    assert persisted.runner_id == get_runner_id()
+    assert persisted.run_id == "new-run"
+    assert persisted.error_message is None
+
+
 def test_finish_turn_mirrors_failed_task_to_trigger_run(db_session) -> None:
     """The existing terminal-state owner mirrors setup failures to TriggerRun."""
     user = _create_user(db_session)
@@ -966,6 +1249,545 @@ async def test_schedule_bg_skips_finish_turn_when_lease_acquire_fails(
 
 
 @pytest.mark.asyncio
+async def test_schedule_bg_resolves_scope_off_loop_before_execution(
+    db_session,
+    queue_pool_runtime_db,
+) -> None:
+    """A contended scope lookup must not block the main event loop."""
+    from xagent.web.api.websocket import background_task_manager
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task_id = int(task.id)
+    fake_lease = TaskLease(task_id=task_id, runner_id="test-runner")
+    engine, SessionLocal = queue_pool_runtime_db
+    events: list[str] = []
+    resolver_threads: list[int] = []
+    loop_thread = get_ident()
+
+    def load_snapshot(*_args, **_kwargs):
+        events.append("snapshot")
+        return MagicMock()
+
+    def resolve_scope(resolved_task_id):
+        assert resolved_task_id == task_id
+        resolver_threads.append(get_ident())
+        with SessionLocal() as scope_db:
+            scope_db.execute(text("SELECT 1")).scalar()
+        events.append("scope")
+        return None
+
+    async def execute(**kwargs):
+        events.append("execute")
+        assert "resolved_execution_scope" in kwargs
+        assert kwargs["resolved_execution_scope"] is None
+
+    held_connection = engine.connect()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=fake_lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            side_effect=load_snapshot,
+        ),
+        patch.object(
+            task_orchestrator_module,
+            "resolve_execution_scope",
+            side_effect=resolve_scope,
+            create=True,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=execute,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await asyncio.sleep(0.12)
+            assert ticks >= 3, "scope QueuePool checkout blocked the event loop"
+            assert not bg_task.done(), "execution started before scope resolution"
+        finally:
+            held_connection.close()
+            await asyncio.wait_for(bg_task, timeout=1)
+            ticker_stop.set()
+            await ticker_task
+
+    assert events == ["snapshot", "scope", "execute"]
+    assert resolver_threads and resolver_threads[0] != loop_thread
+
+
+@pytest.mark.parametrize("failure_point", ["missing_snapshot", "execute_error"])
+@pytest.mark.asyncio
+async def test_schedule_bg_persists_setup_failures_off_loop(
+    db_session,
+    failure_point,
+) -> None:
+    from xagent.web.api.websocket import background_task_manager
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task_id = int(task.id)
+    fake_lease = TaskLease(task_id=task_id, runner_id="test-runner")
+    loop_thread = get_ident()
+    marker_threads: list[int] = []
+    snapshot = None if failure_point == "missing_snapshot" else MagicMock()
+    execute = AsyncMock(
+        side_effect=(
+            RuntimeError("simulated execute failure")
+            if failure_point == "execute_error"
+            else None
+        )
+    )
+
+    def record_failure(*_args, **_kwargs) -> None:
+        marker_threads.append(get_ident())
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=fake_lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=snapshot,
+        ),
+        patch.object(
+            task_orchestrator_module,
+            "resolve_execution_scope",
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=execute,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+            side_effect=record_failure,
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        await _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+
+    assert marker_threads and marker_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery(
+    queue_pool_runtime_db,
+    caplog,
+) -> None:
+    """One exhausted checkout must not trigger an immediate second checkout."""
+    from xagent.web.api.websocket import background_task_manager
+
+    engine, SessionLocal = queue_pool_runtime_db
+    with SessionLocal() as seed_db:
+        user = _create_user(seed_db)
+        task = _create_task(seed_db, user.id, status=TaskStatus.RUNNING)
+        task_id = int(task.id)
+        user_id = int(user.id)
+        task_source = task.source
+        task.runner_id = "test-runner"
+        task.run_id = "run-a"
+        seed_db.commit()
+
+    lease = TaskLease(task_id=task_id, runner_id="test-runner", run_id="run-a")
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    def load_snapshot_from_contended_pool(*_args, **_kwargs):
+        with SessionLocal() as snapshot_db:
+            snapshot_db.execute(text("SELECT 1")).scalar()
+        return MagicMock()
+
+    held_connection = engine.connect()
+    caplog.set_level(
+        logging.ERROR,
+        logger="xagent.web.services.task_orchestrator",
+    )
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with (
+            patch(
+                "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+                return_value=lease,
+            ),
+            patch(
+                "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.services.task_orchestrator.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ) as mock_stop_heartbeat,
+            patch(
+                "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+                side_effect=load_snapshot_from_contended_pool,
+            ),
+            patch(
+                "xagent.web.api.websocket.execute_task_background",
+                new=AsyncMock(),
+            ) as mock_execute,
+            patch(
+                "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+            ) as mock_settle,
+            patch.object(background_task_manager, "register_task"),
+            patch(
+                "xagent.web.services.task_orchestrator._get_agent_manager",
+                return_value=MagicMock(),
+            ),
+        ):
+            await _schedule_bg(
+                task_id=task_id,
+                task_owner_user_id=user_id,
+                task_source=task_source,
+                run_id="run-a",
+                payload=TaskTurnPayload("hello"),
+                force_fresh=False,
+                context=None,
+            )
+
+        mock_execute.assert_not_awaited()
+        mock_stop_heartbeat.assert_awaited_once()
+        mock_settle.assert_not_called()
+        assert ticks >= 10, (
+            "setup QueuePool timeout blocked the asyncio event loop; "
+            f"ticker advanced only {ticks} times"
+        )
+    finally:
+        ticker_stop.set()
+        await ticker_task
+        held_connection.close()
+
+    with SessionLocal() as verify_db:
+        retained = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert retained.status == TaskStatus.RUNNING
+        assert retained.runner_id == lease.runner_id
+        assert retained.run_id == lease.run_id
+
+    assert f"task_id={task_id}" in caplog.text
+    assert "component=setup/run" in caplog.text
+    assert "retaining lease for TTL recovery" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_heartbeat_pool_timeout_skips_settlement(
+    db_session,
+) -> None:
+    """A heartbeat checkout timeout must not trigger a cleanup checkout."""
+    from xagent.web.api.websocket import background_task_manager
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task_id = int(task.id)
+    lease = TaskLease(task_id=task_id, runner_id="test-runner", run_id="run-a")
+    heartbeat_timeout = SQLAlchemyTimeoutError("heartbeat pool timeout")
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.stop_task_lease_heartbeat",
+            new=AsyncMock(
+                return_value=TaskLeaseHeartbeatOutcome(pool_timeout=heartbeat_timeout)
+            ),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            task_orchestrator_module,
+            "resolve_execution_scope",
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+        ) as settle,
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        await _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            run_id="run-a",
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+
+    settle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_settles_owned_terminal_task_observed_by_heartbeat(
+    db_session,
+    monkeypatch,
+) -> None:
+    """A terminal commit is settlement-ready, not evidence of lease loss."""
+    from xagent.web.api.websocket import background_task_manager
+
+    user = _create_user(db_session)
+    agent = Agent(user_id=user.id, name="terminal heartbeat agent")
+    db_session.add(agent)
+    db_session.flush()
+    trigger = AgentTrigger(
+        user_id=user.id,
+        agent_id=agent.id,
+        type=TriggerType.SCHEDULED.value,
+        name="terminal heartbeat trigger",
+        config={},
+    )
+    db_session.add(trigger)
+    db_session.flush()
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task_id = int(task.id)
+    task.source = "trigger"
+    task.runner_id = "terminal-runner"
+    task.run_id = "terminal-run"
+    task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    run = TriggerRun(
+        trigger_id=trigger.id,
+        task_id=task.id,
+        status=TriggerRunStatus.RUNNING.value,
+        idempotency_key="terminal-heartbeat-race",
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="terminal-runner",
+        run_id="terminal-run",
+    )
+    terminal_committed = asyncio.Event()
+    allow_execution_return = asyncio.Event()
+
+    async def execute_then_wait(**_kwargs) -> None:
+        def commit_terminal_status() -> None:
+            SessionLocal = database_module.get_session_local()
+            with SessionLocal() as terminal_db:
+                terminal_task = terminal_db.query(Task).filter(Task.id == task_id).one()
+                terminal_task.status = TaskStatus.COMPLETED
+                terminal_task.control_state = "completed"
+                terminal_db.commit()
+
+        await asyncio.to_thread(commit_terminal_status)
+        terminal_committed.set()
+        await allow_execution_return.wait()
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_lease_service.get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            task_orchestrator_module,
+            "resolve_execution_scope",
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=execute_then_wait,
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            run_id="terminal-run",
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+        await asyncio.wait_for(terminal_committed.wait(), timeout=1)
+        await asyncio.sleep(0.02)
+        allow_execution_return.set()
+        await asyncio.wait_for(bg_task, timeout=1)
+
+    db_session.expire_all()
+    persisted_task = db_session.query(Task).filter(Task.id == task_id).one()
+    persisted_run = db_session.query(TriggerRun).filter(TriggerRun.id == run.id).one()
+    assert persisted_task.status == TaskStatus.COMPLETED
+    assert persisted_task.runner_id is None
+    assert persisted_task.lease_expires_at is None
+    assert persisted_run.status == TriggerRunStatus.COMPLETED.value
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
+    queue_pool_runtime_db,
+    monkeypatch,
+) -> None:
+    """Final status read and workforce-aware release share one worker session."""
+    from xagent.web.api.websocket import background_task_manager
+
+    engine, SessionLocal = queue_pool_runtime_db
+    runner_id = get_runner_id()
+    with SessionLocal() as seed_db:
+        user = _create_user(seed_db)
+        task = _create_task(seed_db, user.id, status=TaskStatus.RUNNING)
+        task_id = int(task.id)
+        user_id = int(user.id)
+        task_source = task.source
+        task.runner_id = runner_id
+        task.run_id = "run-a"
+        seed_db.commit()
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    held_connection = engine.connect()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=TaskLease(
+                task_id=task_id,
+                runner_id=runner_id,
+                run_id="run-a",
+            ),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            task_orchestrator_module,
+            "resolve_execution_scope",
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=AsyncMock(),
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=task_id,
+            task_owner_user_id=user_id,
+            task_source=task_source,
+            run_id="run-a",
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await asyncio.sleep(0.12)
+            assert ticks >= 3, "lease release QueuePool checkout blocked the loop"
+            assert not bg_task.done(), "lease release skipped the contended checkout"
+        finally:
+            held_connection.close()
+            await asyncio.wait_for(bg_task, timeout=1)
+            ticker_stop.set()
+            await ticker_task
+
+    with SessionLocal() as verify_db:
+        released = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert released.status == TaskStatus.FAILED
+        assert released.run_id == "run-a"
+        assert released.runner_id is None
+
+
+@pytest.mark.asyncio
 async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
     db_session,
 ) -> None:
@@ -995,11 +1817,8 @@ async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
             new=AsyncMock(side_effect=RuntimeError("boom")),
         ),
         patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ) as mock_release,
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
-        ),
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+        ) as mock_settle,
         patch.object(background_task_manager, "register_task"),
         patch(
             "xagent.web.services.task_orchestrator._get_agent_manager",
@@ -1022,7 +1841,7 @@ async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
         except RuntimeError:
             pass
 
-    mock_release.assert_called_once()
+    mock_settle.assert_called_once()
     assert get_ephemeral_runtime_values(payload.turn_id) is None
     assert pop_ephemeral_runtime_values(payload.turn_id) is None
 
@@ -1070,10 +1889,7 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
             new=AsyncMock(),
         ) as mock_exec,
         patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
         ),
         patch.object(background_task_manager, "register_task"),
         patch(
@@ -1136,10 +1952,7 @@ async def test_schedule_bg_acquires_expired_lease_on_first_try(db_session) -> No
             new=AsyncMock(),
         ) as mock_exec,
         patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
         ),
         patch.object(background_task_manager, "register_task"),
         patch(
@@ -1182,17 +1995,20 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
     leaving the task displayed as running but with no worker
     executing it.
 
-    The outer ``except`` in ``_runner`` calls
-    ``_mark_task_failed_if_running`` so the row is pushed to
-    ``FAILED`` before release. This test pins both halves: the
-    helper is invoked, and the row is FAILED at the end.
+    The outer ``except`` records the error and the one fenced settlement
+    transaction pushes the exact run to ``FAILED`` while releasing it.
     """
     from xagent.web.api.websocket import background_task_manager
     from xagent.web.services.task_lease_service import TaskLease
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
     payload = TaskTurnPayload("x")
     _store_runtime_secret_for_turn(payload.turn_id)
     assert get_ephemeral_runtime_values(payload.turn_id) is not None
@@ -1214,12 +2030,6 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
             "xagent.web.api.websocket.execute_task_background",
             new=AsyncMock(),
         ) as mock_exec,
-        patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ) as mock_release,
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
-        ),
         patch.object(background_task_manager, "register_task"),
         patch(
             "xagent.web.services.task_orchestrator._get_agent_manager",
@@ -1241,15 +2051,14 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
 
     # execute_task_background must not run when snapshot load raised.
     mock_exec.assert_not_called()
-    # Lease must still be released (otherwise the task TTL-stucks).
-    mock_release.assert_called_once()
     # The row should now be FAILED, not the zombie RUNNING.
     db_session.refresh(task)
     assert task.status == TaskStatus.FAILED, (
         f"Expected task.status == FAILED after snapshot raise, got {task.status}. "
-        "If this fails, ``_mark_task_failed_if_running`` is not running, and the "
-        "zombie-RUNNING regression is back."
+        "If this fails, the fenced settlement did not close the zombie-RUNNING "
+        "window."
     )
+    assert task.runner_id is None
     assert task.error_message is not None
     assert "simulated snapshot load failure" in str(task.error_message)
     assert get_ephemeral_runtime_values(payload.turn_id) is None
@@ -1283,10 +2092,7 @@ async def test_schedule_bg_cleanup_handles_missing_payload_turn_id(db_session) -
             new=AsyncMock(),
         ) as mock_exec,
         patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ) as mock_release,
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
         ),
         patch.object(background_task_manager, "register_task"),
         patch(
@@ -1305,24 +2111,24 @@ async def test_schedule_bg_cleanup_handles_missing_payload_turn_id(db_session) -
         await bg_task
 
     mock_exec.assert_not_called()
-    mock_release.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_schedule_bg_marks_task_failed_when_execute_raises(
     db_session,
 ) -> None:
-    """Same safety net for exceptions out of ``execute_task_background``
-    that bypass its inner ``try/except``. The outer ``except`` in
-    ``_runner`` catches them and routes through
-    ``_mark_task_failed_if_running``.
-    """
+    """An execution exception is persisted by the one fenced settlement."""
     from xagent.web.api.websocket import background_task_manager
     from xagent.web.services.task_lease_service import TaskLease
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
 
     # Snapshot loader returns a minimal sentinel snapshot so the test
     # proceeds past the snapshot-None branch.
@@ -1345,12 +2151,6 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
             "xagent.web.api.websocket.execute_task_background",
             new=AsyncMock(side_effect=RuntimeError("simulated agent boom")),
         ),
-        patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ) as mock_release,
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
-        ),
         patch.object(background_task_manager, "register_task"),
         patch(
             "xagent.web.services.task_orchestrator._get_agent_manager",
@@ -1370,7 +2170,6 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
         except RuntimeError:
             pass
 
-    mock_release.assert_called_once()
     db_session.refresh(task)
     assert task.status == TaskStatus.FAILED
     assert task.error_message is not None
@@ -1381,10 +2180,7 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
 async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
     db_session,
 ) -> None:
-    """``_mark_task_failed_if_running`` is guarded by ``status==RUNNING``
-    so it never overwrites a terminal / control status that
-    ``execute_task_background`` may have set inside its own
-    try/except (PAUSED, WAITING_FOR_USER, FAILED, COMPLETED).
+    """Fenced settlement never overwrites a committed control status.
 
     Simulate the inner handler setting PAUSED before raising. After
     ``_runner`` returns, the row must remain PAUSED, not be flipped
@@ -1395,7 +2191,12 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
     fake_snapshot = MagicMock()
 
     async def fake_execute(*args, **kwargs):
@@ -1426,12 +2227,6 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
             "xagent.web.api.websocket.execute_task_background",
             new=fake_execute,
         ),
-        patch(
-            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.finish_turn",
-        ),
         patch.object(background_task_manager, "register_task"),
         patch(
             "xagent.web.services.task_orchestrator._get_agent_manager",
@@ -1454,5 +2249,6 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
     db_session.refresh(task)
     assert task.status == TaskStatus.PAUSED, (
         f"Expected PAUSED (set by execute), got {task.status}. If this fails, "
-        "``_mark_task_failed_if_running``'s status==RUNNING guard regressed."
+        "the concrete-lease settlement overwrote a control status."
     )
+    assert task.runner_id is None

--- a/tests/web/services/test_task_setup_snapshot.py
+++ b/tests/web/services/test_task_setup_snapshot.py
@@ -24,19 +24,28 @@ existing ``test_task_orchestrator`` fixture style.
 from __future__ import annotations
 
 from dataclasses import is_dataclass
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
 
+from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import DAGExecution, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
+from xagent.web.models.workforce import WorkforceRun
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
     TaskSetupSnapshot,
     _TaskFields,
     load_task_setup_snapshot_sync,
+)
+from xagent.web.services.trace_message_storage import (
+    MESSAGE_REFS_ENCODING,
+    encode_checkpoint_data_for_storage,
 )
 
 
@@ -126,6 +135,33 @@ def test_owner_mismatch_raises_distinct_from_missing(db_session) -> None:
     )
 
 
+def test_actor_authorization_is_applied_inside_snapshot_session(db_session) -> None:
+    owner = _create_user(db_session)
+    stranger = User(username="stranger", password_hash="hash", is_admin=False)
+    admin = User(username="admin", password_hash="hash", is_admin=True)
+    db_session.add_all([stranger, admin])
+    db_session.commit()
+    task = _create_task(db_session, user_id=int(owner.id))
+
+    assert (
+        load_task_setup_snapshot_sync(
+            task_id=int(task.id),
+            task_owner_user_id=None,
+            actor_user_id=int(stranger.id),
+            actor_is_admin=False,
+        )
+        is None
+    )
+    admin_snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id),
+        task_owner_user_id=None,
+        actor_user_id=int(admin.id),
+        actor_is_admin=True,
+    )
+    assert admin_snapshot is not None
+    assert admin_snapshot.task.user_id == int(owner.id)
+
+
 def test_basic_task_no_agent_builder(db_session) -> None:
     """Happy path: standalone task with no ``agent_id``. Snapshot
     populates ``task`` and resolves LLMs from task fields only;
@@ -147,8 +183,13 @@ def test_basic_task_no_agent_builder(db_session) -> None:
     assert snapshot.task.user_id == int(user.id)
     assert snapshot.task.status == TaskStatus.PENDING
     assert snapshot.task.source == "sdk"
+    assert snapshot.task.run_id == task.run_id
+    assert snapshot.task.state_version == int(task.state_version or 0)
+    assert snapshot.task.control_state == task.control_state
     assert snapshot.task.agent_id is None
     assert snapshot.task.execution_mode == "flash"
+    assert snapshot.runtime_user == RuntimeUserFields(id=int(user.id), is_admin=False)
+    assert snapshot.has_reconstructable_history is False
 
     # No agent-builder branch fired
     assert snapshot.agent is None
@@ -178,6 +219,240 @@ def test_task_source_is_preserved(db_session, source: str | None) -> None:
 
     assert snapshot is not None
     assert snapshot.task.source == source
+
+
+def test_reconstructable_history_is_captured_in_snapshot(db_session) -> None:
+    """The retry pre-check is read in the worker-owned snapshot session."""
+    user = _create_user(db_session)
+    task = _create_task(
+        db_session,
+        user_id=int(user.id),
+        status=TaskStatus.RUNNING,
+    )
+
+    build_event = TraceEvent(
+        task_id=int(task.id),
+        build_id="builder-session",
+        event_id="build-only",
+        event_type="build_step",
+        timestamp=datetime.now(timezone.utc),
+        data={},
+    )
+    db_session.add(build_event)
+    db_session.commit()
+
+    without_runtime_history = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+    assert without_runtime_history is not None
+    assert without_runtime_history.has_reconstructable_history is False
+
+    runtime_event = TraceEvent(
+        task_id=int(task.id),
+        build_id=None,
+        event_id="runtime-event",
+        event_type="agent_step",
+        timestamp=datetime.now(timezone.utc),
+        data={},
+    )
+    db_session.add(runtime_event)
+    db_session.commit()
+
+    with_trace_history = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+    assert with_trace_history is not None
+    assert with_trace_history.has_reconstructable_history is True
+
+    db_session.delete(runtime_event)
+    db_session.add(DAGExecution(task_id=int(task.id), current_plan={"steps": []}))
+    db_session.commit()
+
+    with_dag_history = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+    assert with_dag_history is not None
+    assert with_dag_history.has_reconstructable_history is True
+
+
+def test_snapshot_captures_turn_transcript_recovery_and_decoded_reconstruction(
+    db_session,
+) -> None:
+    """Every retry read is completed inside the snapshot's worker session."""
+    user = _create_user(db_session)
+    task = _create_task(
+        db_session,
+        user_id=int(user.id),
+        status=TaskStatus.RUNNING,
+    )
+    prior_message = TaskChatMessage(
+        task_id=int(task.id),
+        user_id=int(user.id),
+        role="user",
+        content="prior turn",
+        message_type="user_message",
+    )
+    current_message = TaskChatMessage(
+        task_id=int(task.id),
+        user_id=int(user.id),
+        role="user",
+        content="current turn",
+        message_type="user_message",
+    )
+    db_session.add_all([prior_message, current_message])
+    db_session.flush()
+
+    checkpoint_messages = [{"role": "user", "content": "checkpoint input"}]
+    checkpoint_data = {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "root_execution_id": "execution-1",
+        "execution_id": "execution-1",
+        "label": "after_llm",
+        "snapshot": {
+            "type": "checkpoint",
+            "label": "after_llm",
+            "execution_id": "execution-1",
+            "context": {"messages": checkpoint_messages},
+            "pattern": "ReActPattern",
+            "pattern_state": {"current_iteration": 1},
+        },
+    }
+    encoded_checkpoint = encode_checkpoint_data_for_storage(
+        db_session,
+        task_id=int(task.id),
+        data=checkpoint_data,
+        use_v2=False,
+    )
+    assert (
+        encoded_checkpoint["snapshot"]["context"]["messages"]["__encoding"]
+        == MESSAGE_REFS_ENCODING
+    )
+    now = datetime.now(timezone.utc)
+    db_session.add_all(
+        [
+            TraceEvent(
+                task_id=int(task.id),
+                build_id=None,
+                event_id="checkpoint-event",
+                event_type="pattern_checkpoint",
+                timestamp=now,
+                data=encoded_checkpoint,
+            ),
+            TraceEvent(
+                task_id=int(task.id),
+                build_id=None,
+                event_id="tool-event",
+                event_type="tool_execution_end",
+                timestamp=now,
+                data={
+                    "tool_name": "web_search",
+                    "success": True,
+                    "result": {"title": "prior evidence"},
+                },
+            ),
+            TraceEvent(
+                task_id=int(task.id),
+                build_id=None,
+                event_id="skill-event",
+                event_type="skill_select_end",
+                timestamp=now,
+                data={"selected": True, "skill_name": "translator"},
+            ),
+            DAGExecution(
+                task_id=int(task.id),
+                current_plan={"steps": [{"id": "step-1"}]},
+            ),
+        ]
+    )
+    db_session.commit()
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id),
+        task_owner_user_id=int(user.id),
+        before_message_id=int(current_message.id),
+    )
+
+    assert snapshot is not None
+    assert snapshot.conversation_history == ({"role": "user", "content": "prior turn"},)
+    assert snapshot.execution_recovery.selected_skill_name == "translator"
+    assert len(snapshot.execution_recovery.messages) == 1
+    assert "prior evidence" in snapshot.execution_recovery.messages[0]["content"]
+    assert snapshot.reconstruction.plan_state == {"steps": [{"id": "step-1"}]}
+    checkpoint_event = next(
+        event
+        for event in snapshot.reconstruction.tracer_events
+        if event["id"] == "checkpoint-event"
+    )
+    assert checkpoint_event["data"]["snapshot"]["context"]["messages"] == (
+        checkpoint_messages
+    )
+
+
+def test_snapshot_carries_verified_workforce_runtime(db_session) -> None:
+    """The runtime resolved by llm_utils is not discarded and re-queried later."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, user_id=int(user.id), agent_config={})
+    workforce_snapshot = {
+        "version": 1,
+        "workforce": {"id": 41, "name": "Research team"},
+        "manager": {"agent_id": 51, "runtime_prompt": "Coordinate workers"},
+        "workers": [
+            {
+                "agent_id": 61,
+                "name": "Researcher",
+                "alias": "Researcher",
+                "description": "Find evidence",
+                "assignment_instructions": "Find evidence",
+                "enabled": True,
+            }
+        ],
+    }
+    run = WorkforceRun(
+        workforce_id=41,
+        task_id=int(task.id),
+        user_id=int(user.id),
+        status="pending",
+        snapshot=workforce_snapshot,
+    )
+    db_session.add(run)
+    db_session.flush()
+    task.agent_config = {"workforce_run_id": int(run.id)}
+    db_session.commit()
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+
+    assert snapshot is not None
+    assert snapshot.workforce_runtime is not None
+    assert snapshot.workforce_runtime.workforce_run_id == int(run.id)
+    assert snapshot.workforce_runtime.allowed_agent_ids == [61]
+
+
+def test_inline_published_preview_agent_is_excluded_in_snapshot(db_session) -> None:
+    """Preview exclusion uses the same owner/team visibility rule off-loop."""
+    user = _create_user(db_session)
+    preview_agent = _create_agent(db_session, user_id=int(user.id))
+    task = _create_task(
+        db_session,
+        user_id=int(user.id),
+        agent_id=None,
+        agent_config={
+            "instructions": "preview instructions",
+            "skills": [],
+            "knowledge_bases": [],
+            "tool_categories": [],
+            "preview_agent_id": int(preview_agent.id),
+        },
+    )
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+
+    assert snapshot is not None
+    assert snapshot.agent is None
+    assert snapshot.excluded_agent_id == int(preview_agent.id)
 
 
 def test_agent_builder_published_sets_excluded_agent_id(db_session) -> None:
@@ -299,6 +574,10 @@ def test_no_orm_leak_in_returned_fields(db_session) -> None:
         snapshot.task.execution_mode, str
     )
     assert snapshot.task.agent_type is None or isinstance(snapshot.task.agent_type, str)
+    assert isinstance(snapshot.runtime_user, RuntimeUserFields)
+    assert isinstance(snapshot.runtime_user.id, int)
+    assert isinstance(snapshot.runtime_user.is_admin, bool)
+    assert isinstance(snapshot.has_reconstructable_history, bool)
     # agent_config is JSON column -- dict or None, never an ORM proxy.
     assert snapshot.task.agent_config is None or isinstance(
         snapshot.task.agent_config, dict

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -8,7 +8,6 @@ import pytest
 
 from xagent.core.tools.adapters.vibe.config import MCPFailurePolicy
 from xagent.web.api.chat import AgentServiceManager
-from xagent.web.models.agent import Agent
 from xagent.web.models.task import (
     DAGExecution,
     DAGExecutionPhase,
@@ -17,6 +16,78 @@ from xagent.web.models.task import (
     TraceEvent,
 )
 from xagent.web.models.user import User
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskReconstructionSnapshot,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
+
+
+def _build_reconstruction_snapshot(
+    task: Task,
+    user: User,
+    *,
+    trace_events: list[TraceEvent] | None = None,
+    dag_execution: DAGExecution | None = None,
+    task_llm=None,
+    task_pattern: str = "dag_plan_execute",
+    agent_config: dict | None = None,
+) -> TaskSetupSnapshot:
+    """Build the detached reconstruction contract consumed on the event loop."""
+    trace_events = trace_events or []
+    reconstruction = TaskReconstructionSnapshot(
+        tracer_events=tuple(
+            {
+                "id": str(event.event_id),
+                "event_type": str(event.event_type),
+                "task_id": str(event.task_id),
+                "step_id": str(event.step_id) if event.step_id is not None else None,
+                "timestamp": event.timestamp.timestamp() if event.timestamp else None,
+                "data": dict(event.data or {}),
+                "parent_id": (
+                    str(event.parent_event_id)
+                    if event.parent_event_id is not None
+                    else None
+                ),
+            }
+            for event in trace_events
+        ),
+        plan_state=(
+            dict(dag_execution.current_plan)
+            if dag_execution is not None and dag_execution.current_plan
+            else None
+        ),
+        has_history=bool(trace_events) or dag_execution is not None,
+    )
+    return TaskSetupSnapshot(
+        task=_TaskFields(
+            id=int(task.id),
+            user_id=int(task.user_id),
+            status=task.status,
+            source=task.source,
+            agent_id=task.agent_id,
+            agent_config=task.agent_config,
+            model_name=task.model_name,
+            compact_model_name=task.compact_model_name,
+            execution_mode=task.execution_mode,
+            agent_type=task.agent_type,
+        ),
+        runtime_user=RuntimeUserFields(
+            id=int(user.id),
+            is_admin=bool(user.is_admin),
+        ),
+        has_reconstructable_history=reconstruction.has_history,
+        task_pattern=task_pattern,
+        task_llm=task_llm,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=None,
+        agent_config=agent_config,
+        excluded_agent_id=None,
+        reconstruction=reconstruction,
+    )
 
 
 class TestAgentServiceManagerReconstruction:
@@ -409,7 +480,6 @@ class TestAgentServiceManagerReconstruction:
     async def test_get_agent_for_task_existing_task_with_reconstruction(
         self,
         agent_manager,
-        mock_db,
         sample_task,
         sample_trace_events,
         sample_dag_execution,
@@ -417,56 +487,35 @@ class TestAgentServiceManagerReconstruction:
     ):
         """测试获取已存在任务的agent，并进行重建"""
         sample_task.status = TaskStatus.RUNNING
+        runtime_llm = MagicMock()
+        snapshot = _build_reconstruction_snapshot(
+            sample_task,
+            mock_user,
+            trace_events=sample_trace_events,
+            dag_execution=sample_dag_execution,
+            task_llm=runtime_llm,
+        )
         # 使用更高级的方法直接patch AgentService创建
         with (
             patch("xagent.web.api.chat.AgentService") as mock_agent_service_class,
             patch(
-                "xagent.web.services.llm_utils.UserAwareModelStorage.resolve_llms_from_names"
-            ) as mock_resolve_llms,
-            patch("xagent.web.api.chat.get_memory_store") as mock_get_memory,
-            patch(
-                "xagent.core.tools.adapters.vibe.factory.ToolFactory"
-            ) as mock_tool_factory,
+                "xagent.web.api.chat.create_default_tools",
+                new=AsyncMock(return_value=([], MagicMock())),
+            ),
+            patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
         ):
-            # 设置所有必要的mock
-            mock_resolve_llms.return_value = (MagicMock(), None, None, None)
-            mock_get_memory.return_value = MagicMock()
-            mock_tool_factory.create_all_tools = AsyncMock(return_value=[])
-
             # 创建mock AgentService实例
             mock_agent_instance = MagicMock()
             mock_agent_instance.reconstruct_from_history = AsyncMock()
             mock_agent_service_class.return_value = mock_agent_instance
 
-            # Mock database查询
-            mock_task_query = MagicMock()
-            mock_task_query.first.return_value = sample_task
-            mock_task_query.filter.return_value = mock_task_query
-
-            mock_dag_query = MagicMock()
-            mock_dag_query.first.return_value = sample_dag_execution
-            mock_dag_query.filter.return_value = mock_dag_query
-
-            mock_trace_query = MagicMock()
-            mock_trace_query.all.return_value = sample_trace_events
-            mock_trace_query.filter.return_value = mock_trace_query
-
-            def mock_query_side_effect(model):
-                from xagent.web.models.task import DAGExecution, Task, TraceEvent
-
-                if model == Task:
-                    return mock_task_query
-                elif model == DAGExecution:
-                    return mock_dag_query
-                elif model == TraceEvent:
-                    return mock_trace_query
-                else:
-                    return MagicMock()
-
-            mock_db.query.side_effect = mock_query_side_effect
-
             # 调用方法
-            agent = await agent_manager.get_agent_for_task(1, mock_db, user=mock_user)
+            agent = await agent_manager.get_agent_for_task(
+                1,
+                None,
+                user=mock_user,
+                task_setup_snapshot=snapshot,
+            )
 
         # 验证结果
         assert agent is not None
@@ -486,44 +535,17 @@ class TestAgentServiceManagerReconstruction:
         sample_dag_execution,
     ):
         """测试从历史数据重建agent成功"""
-        # Mock查询
-        mock_task_query = MagicMock()
-        mock_task_query.first.return_value = sample_task
-        mock_task_query.filter.return_value = mock_task_query
-        mock_user_query = MagicMock()
-        mock_user_query.first.return_value = mock_user
-        mock_user_query.filter.return_value = mock_user_query
-        mock_trace_query = MagicMock()
-        mock_trace_query.all.return_value = sample_trace_events
-        mock_trace_query.filter.return_value = mock_trace_query
-        mock_dag_query = MagicMock()
-        mock_dag_query.first.return_value = sample_dag_execution
-        mock_dag_query.filter.return_value = mock_dag_query
-
-        def mock_query_side_effect(model):
-            from xagent.web.models.task import DAGExecution, TraceEvent
-
-            if model == Task:
-                return mock_task_query
-            elif model == User:
-                return mock_user_query
-            elif model == TraceEvent:
-                return mock_trace_query
-            elif model == DAGExecution:
-                return mock_dag_query
-            else:
-                return MagicMock()
-
-        mock_db.query.side_effect = mock_query_side_effect
-
         # Mock AgentService创建和reconstruct_from_history
         runtime_llm = MagicMock()
         runtime_llm.model_name = "task-qwen"
+        snapshot = _build_reconstruction_snapshot(
+            sample_task,
+            mock_user,
+            trace_events=sample_trace_events,
+            dag_execution=sample_dag_execution,
+            task_llm=runtime_llm,
+        )
         with (
-            patch(
-                "xagent.web.services.llm_utils.UserAwareModelStorage.resolve_llms_from_names",
-                return_value=(runtime_llm, None, None, None),
-            ),
             patch(
                 "xagent.web.api.chat.create_default_tools",
                 new=AsyncMock(return_value=(["tool"], "tool_config")),
@@ -537,7 +559,11 @@ class TestAgentServiceManagerReconstruction:
             mock_agent_service_class.return_value = mock_agent_instance
 
             # 调用方法
-            await agent_manager._reconstruct_agent_from_history(1, mock_db)
+            await agent_manager._reconstruct_agent_from_history(
+                1,
+                None,
+                task_setup_snapshot=snapshot,
+            )
 
         # 验证agent被创建
         assert 1 in agent_manager._agents
@@ -557,54 +583,26 @@ class TestAgentServiceManagerReconstruction:
         sample_trace_events,
         sample_dag_execution,
     ):
-        """Active-task reconstruction should reuse the normal LLM merge contract."""
+        """Active-task reconstruction consumes the shared runtime snapshot."""
         sample_task.agent_id = 9
         runtime_llm = MagicMock()
         runtime_llm.model_name = "task-qwen"
-
-        mock_task_query = MagicMock()
-        mock_task_query.first.return_value = sample_task
-        mock_task_query.filter.return_value = mock_task_query
-        mock_user_query = MagicMock()
-        mock_user_query.first.return_value = mock_user
-        mock_user_query.filter.return_value = mock_user_query
-        mock_trace_query = MagicMock()
-        mock_trace_query.all.return_value = sample_trace_events
-        mock_trace_query.filter.return_value = mock_trace_query
-        mock_dag_query = MagicMock()
-        mock_dag_query.first.return_value = sample_dag_execution
-        mock_dag_query.filter.return_value = mock_dag_query
-        mock_agent_query = MagicMock()
-        mock_agent_query.first.return_value = None
-        mock_agent_query.filter.return_value = mock_agent_query
-
-        def mock_query_side_effect(model):
-            if model == Task:
-                return mock_task_query
-            if model == User:
-                return mock_user_query
-            if model == TraceEvent:
-                return mock_trace_query
-            if model == DAGExecution:
-                return mock_dag_query
-            if model == Agent:
-                return mock_agent_query
-            return MagicMock()
-
-        mock_db.query.side_effect = mock_query_side_effect
+        agent_config = {
+            "instructions": "",
+            "skills": [],
+            "knowledge_bases": [],
+        }
+        snapshot = _build_reconstruction_snapshot(
+            sample_task,
+            mock_user,
+            trace_events=sample_trace_events,
+            dag_execution=sample_dag_execution,
+            task_llm=runtime_llm,
+            task_pattern="react",
+            agent_config=agent_config,
+        )
         agent_manager._resolve_task_runtime_config = MagicMock(
-            return_value={
-                "agent_config": {
-                    "instructions": "",
-                    "skills": [],
-                    "knowledge_bases": [],
-                },
-                "task_llm": runtime_llm,
-                "task_fast_llm": None,
-                "task_vision_llm": None,
-                "task_compact_llm": None,
-                "task_pattern": "react",
-            }
+            side_effect=AssertionError("reconstruction re-read runtime config")
         )
 
         with (
@@ -619,51 +617,55 @@ class TestAgentServiceManagerReconstruction:
             mock_agent_instance.reconstruct_from_history = AsyncMock()
             mock_agent_service_class.return_value = mock_agent_instance
 
-            await agent_manager._reconstruct_agent_from_history(1, mock_db)
+            await agent_manager._reconstruct_agent_from_history(
+                1,
+                None,
+                task_setup_snapshot=snapshot,
+            )
 
-        agent_manager._resolve_task_runtime_config.assert_called_once_with(
-            task_id=1,
-            task=sample_task,
-            db=mock_db,
-            user=mock_user,
-        )
+        agent_manager._resolve_task_runtime_config.assert_not_called()
         _, agent_kwargs = mock_agent_service_class.call_args
         assert agent_kwargs["llm"] is runtime_llm
         assert agent_kwargs["pattern"] == "react"
 
     @pytest.mark.asyncio
-    async def test_reconstruct_agent_from_history_no_data(self, agent_manager, mock_db):
+    async def test_reconstruct_agent_from_history_no_data(
+        self,
+        agent_manager,
+        sample_task,
+        mock_user,
+    ):
         """测试没有历史数据时的重建"""
-        # Mock查询返回空结果
-        mock_trace_query = MagicMock()
-        mock_trace_query.all.return_value = []
-        mock_dag_query = MagicMock()
-        mock_dag_query.first.return_value = None
-
-        query_results = [mock_trace_query, mock_dag_query]
-        mock_db.query.side_effect = lambda model: (
-            query_results.pop(0) if query_results else MagicMock()
+        snapshot = _build_reconstruction_snapshot(
+            sample_task,
+            mock_user,
+            task_llm=MagicMock(),
         )
 
         # 调用方法应该抛出异常
         with pytest.raises(ValueError) as exc_info:
-            await agent_manager._reconstruct_agent_from_history(1, mock_db)
+            await agent_manager._reconstruct_agent_from_history(
+                1,
+                None,
+                task_setup_snapshot=snapshot,
+            )
 
         assert "No historical data found" in str(exc_info.value)
         # 验证没有创建agent
         assert 1 not in agent_manager._agents
 
     @pytest.mark.asyncio
-    async def test_reconstruct_agent_from_history_error_handling(
-        self, agent_manager, mock_db
-    ):
+    async def test_reconstruct_agent_from_history_error_handling(self, agent_manager):
         """测试重建过程中的错误处理"""
-        # Mock查询抛出异常
-        mock_db.query.side_effect = Exception("Database error")
-
         # 调用方法应该抛出异常
-        with pytest.raises(Exception) as exc_info:
-            await agent_manager._reconstruct_agent_from_history(1, mock_db)
+        with (
+            patch(
+                "xagent.web.api.chat.load_task_setup_snapshot_sync",
+                side_effect=Exception("Database error"),
+            ),
+            pytest.raises(Exception) as exc_info,
+        ):
+            await agent_manager._reconstruct_agent_from_history(1, None)
 
         assert "Database error" in str(exc_info.value)
 

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -172,6 +172,7 @@ async def test_execute_task_releases_sandbox_workers_after_task(sandbox_mgr) -> 
         agent_service=agent_service,
         task="run",
         task_id="1",
+        manage_task_lease=False,
     )
 
     assert result == {"success": True}
@@ -199,6 +200,7 @@ async def test_execute_task_evicts_agents_for_released_sandbox_provider(
         agent_service=agent_service,
         task="run",
         task_id="1",
+        manage_task_lease=False,
     )
 
     assert "user::7" not in sandbox_mgr._lease_providers
@@ -241,6 +243,7 @@ async def test_execute_task_keeps_workers_until_last_same_user_task_finishes(
             agent_service=first_agent_service,
             task="first",
             task_id="1",
+            manage_task_lease=False,
         )
     )
     await first_started.wait()
@@ -250,6 +253,7 @@ async def test_execute_task_keeps_workers_until_last_same_user_task_finishes(
             agent_service=second_agent_service,
             task="second",
             task_id="2",
+            manage_task_lease=False,
         )
     )
     await second_started.wait()

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.agent import Agent, AgentStatus
@@ -12,7 +17,10 @@ from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceRun
-from xagent.web.services.task_lease_service import TaskLease
+from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+)
 from xagent.web.services.workforce_runtime import sync_workforce_run_status
 
 
@@ -38,6 +46,93 @@ class _FakeAgentService:
 
 
 @pytest.mark.asyncio
+async def test_execute_task_preflight_pool_wait_does_not_block_event_loop(
+    tmp_path,
+) -> None:
+    """Quota/workforce preflight must wait for the pool off the event loop."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'execute-preflight-pool.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.5,
+        connect_args={"check_same_thread": False},
+    )
+    User.__table__.create(bind=engine)
+    Task.__table__.create(bind=engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    with factory() as setup_db:
+        user = User(username="pool-user", password_hash="hash", is_admin=False)
+        setup_db.add(user)
+        setup_db.flush()
+        task = Task(
+            user_id=user.id,
+            title="pool test",
+            description="test",
+            status=TaskStatus.RUNNING,
+            execution_mode="auto",
+        )
+        setup_db.add(task)
+        setup_db.commit()
+        task_id = int(task.id)
+
+    held_connection = engine.connect()
+    caller_db = factory()
+    manager = AgentServiceManager()
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with (
+            patch(
+                "xagent.web.models.database.get_session_local",
+                return_value=factory,
+            ),
+            patch.object(
+                manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
+            ),
+            patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
+            patch(
+                "xagent.web.tracking.task_tracker.TaskTracker",
+                side_effect=RuntimeError("skip tracking in pool-boundary test"),
+            ),
+        ):
+            await asyncio.sleep(0.02)
+            ticks_before_wait = ticks
+            execute = asyncio.create_task(
+                manager.execute_task(
+                    agent_service=_FakeAgentService(),
+                    task="hello",
+                    tracking_task_id=str(task_id),
+                    db_session=caller_db,
+                    manage_task_lease=False,
+                )
+            )
+            await asyncio.sleep(0.08)
+
+            assert ticks - ticks_before_wait >= 4
+            assert not execute.done()
+
+            held_connection.close()
+            result = await execute
+            assert result["success"] is True
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        stop.set()
+        await ticker_task
+        caller_db.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_execute_task_acquires_and_releases_lease_when_manage_true(
     db_session,
 ) -> None:
@@ -59,7 +154,7 @@ async def test_execute_task_acquires_and_releases_lease_when_manage_true(
 
     with (
         patch(
-            "xagent.web.api.chat.acquire_task_lease",
+            "xagent.web.api.chat.acquire_task_lease_isolated",
             return_value=fake_lease,
         ) as mock_acquire,
         patch(
@@ -117,7 +212,7 @@ async def test_execute_task_skips_lease_but_syncs_running_when_manage_false(
 
     with (
         patch(
-            "xagent.web.api.chat.acquire_task_lease",
+            "xagent.web.api.chat.acquire_task_lease_isolated",
         ) as mock_acquire,
         patch(
             "xagent.web.api.chat.release_task_lease_with_workforce_sync",
@@ -295,7 +390,7 @@ async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
 
     with (
         patch(
-            "xagent.web.api.chat.acquire_task_lease",
+            "xagent.web.api.chat.acquire_task_lease_isolated",
             return_value=fake_lease,
         ),
         patch(
@@ -342,6 +437,328 @@ async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
     # The mid-run quota checker must be cleared in the finally so a reused
     # agent_service can't keep calling this finished run's tracker.
     agent_service.set_interrupt_checker.assert_any_call(None)
+
+
+@pytest.mark.asyncio
+async def test_execute_task_persists_final_usage_before_releasing_lease() -> None:
+    """The final usage snapshot belongs to the current run, so it must land
+    while that run still owns its lease."""
+    task_id = 101
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="test-run",
+    )
+    manager = AgentServiceManager()
+    events: list[str] = []
+
+    tracker = MagicMock()
+    tracker.start_tracking = AsyncMock()
+    tracker.quota_interrupt_reason = None
+
+    async def complete_tracking() -> None:
+        events.append("usage")
+
+    tracker.complete_tracking = AsyncMock(side_effect=complete_tracking)
+
+    async def stop_heartbeat(*_args) -> None:
+        events.append("heartbeat")
+
+    def release_lease(*_args, **_kwargs) -> bool:
+        events.append("lease")
+        return True
+
+    async def release_sandbox(*_args) -> None:
+        events.append("sandbox")
+
+    with (
+        patch(
+            "xagent.web.api.chat._check_task_run_gate_isolated",
+            return_value=None,
+        ),
+        patch(
+            "xagent.web.api.chat.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.api.chat._sync_task_workforce_running_isolated",
+            return_value=False,
+        ),
+        patch(
+            "xagent.web.api.chat._release_managed_task_lease_isolated",
+            side_effect=release_lease,
+        ),
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=stop_heartbeat,
+        ),
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            return_value=tracker,
+        ) as tracker_factory,
+        patch.object(
+            manager,
+            "_acquire_sandbox_task",
+            new=AsyncMock(return_value="user:101"),
+        ),
+        patch.object(manager, "_release_sandbox_task", new=release_sandbox),
+    ):
+        result = await manager.execute_task(
+            agent_service=_FakeAgentService(),
+            task="hello",
+            tracking_task_id=str(task_id),
+            manage_task_lease=True,
+        )
+
+    assert result["success"] is True
+    tracker_factory.assert_called_once_with(
+        task_id=task_id,
+        expected_run_id="test-run",
+        expected_runner_id="test-runner",
+    )
+    assert events == ["usage", "heartbeat", "lease", "sandbox"]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_final_usage_pool_timeout_retains_lease() -> None:
+    """One exhausted final checkout must not trigger a second lease checkout."""
+    task_id = 103
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="test-run",
+    )
+    manager = AgentServiceManager()
+    tracker = MagicMock()
+    tracker.start_tracking = AsyncMock()
+    tracker.complete_tracking = AsyncMock(
+        side_effect=SQLAlchemyTimeoutError("pool exhausted")
+    )
+    tracker.quota_interrupt_reason = None
+
+    release_lease = MagicMock()
+    stop_heartbeat = AsyncMock()
+    release_sandbox = AsyncMock()
+
+    with (
+        patch(
+            "xagent.web.api.chat._check_task_run_gate_isolated",
+            return_value=None,
+        ),
+        patch(
+            "xagent.web.api.chat.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.api.chat._sync_task_workforce_running_isolated",
+            return_value=False,
+        ),
+        patch(
+            "xagent.web.api.chat._release_managed_task_lease_isolated",
+            release_lease,
+        ),
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=stop_heartbeat,
+        ),
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            return_value=tracker,
+        ),
+        patch.object(
+            manager,
+            "_acquire_sandbox_task",
+            new=AsyncMock(return_value="user:103"),
+        ),
+        patch.object(manager, "_release_sandbox_task", new=release_sandbox),
+    ):
+        with pytest.raises(SQLAlchemyTimeoutError, match="pool exhausted"):
+            await manager.execute_task(
+                agent_service=_FakeAgentService(),
+                task="hello",
+                tracking_task_id=str(task_id),
+                manage_task_lease=True,
+            )
+
+    tracker.complete_tracking.assert_awaited_once()
+    stop_heartbeat.assert_awaited_once()
+    release_lease.assert_not_called()
+    release_sandbox.assert_awaited_once_with("user:103")
+
+
+@pytest.mark.asyncio
+async def test_execute_task_heartbeat_pool_timeout_retains_lease() -> None:
+    """Heartbeat pool exhaustion must not be followed by lease release I/O."""
+    task_id = 104
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="test-run",
+    )
+    manager = AgentServiceManager()
+    tracker = MagicMock()
+    tracker.start_tracking = AsyncMock()
+    tracker.complete_tracking = AsyncMock()
+    tracker.quota_interrupt_reason = None
+    heartbeat_timeout = SQLAlchemyTimeoutError("heartbeat pool exhausted")
+    release_lease = MagicMock()
+    release_sandbox = AsyncMock()
+
+    with (
+        patch(
+            "xagent.web.api.chat._check_task_run_gate_isolated",
+            return_value=None,
+        ),
+        patch(
+            "xagent.web.api.chat.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.api.chat._sync_task_workforce_running_isolated",
+            return_value=False,
+        ),
+        patch(
+            "xagent.web.api.chat._release_managed_task_lease_isolated",
+            release_lease,
+        ),
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=AsyncMock(
+                return_value=TaskLeaseHeartbeatOutcome(pool_timeout=heartbeat_timeout)
+            ),
+        ),
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            return_value=tracker,
+        ),
+        patch.object(
+            manager,
+            "_acquire_sandbox_task",
+            new=AsyncMock(return_value="user:104"),
+        ),
+        patch.object(manager, "_release_sandbox_task", new=release_sandbox),
+    ):
+        with pytest.raises(SQLAlchemyTimeoutError, match="heartbeat pool exhausted"):
+            await manager.execute_task(
+                agent_service=_FakeAgentService(),
+                task="hello",
+                tracking_task_id=str(task_id),
+                manage_task_lease=True,
+            )
+
+    tracker.complete_tracking.assert_awaited_once()
+    release_lease.assert_not_called()
+    release_sandbox.assert_awaited_once_with("user:104")
+
+
+@pytest.mark.asyncio
+async def test_execute_task_cancellation_during_heartbeat_stop_drains_cleanup() -> None:
+    """Caller cancellation during heartbeat shutdown must not strand the
+    lease or skip tracker and sandbox cleanup."""
+    task_id = 102
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="test-run",
+    )
+    manager = AgentServiceManager()
+    events: list[str] = []
+    heartbeat_stop_entered = asyncio.Event()
+    allow_heartbeat_stop = asyncio.Event()
+
+    tracker = MagicMock()
+    tracker.start_tracking = AsyncMock()
+    tracker.quota_interrupt_reason = None
+
+    async def complete_tracking() -> None:
+        events.append("usage")
+
+    tracker.complete_tracking = AsyncMock(side_effect=complete_tracking)
+
+    async def stop_heartbeat(*_args) -> None:
+        events.append("heartbeat-enter")
+        heartbeat_stop_entered.set()
+        await allow_heartbeat_stop.wait()
+        events.append("heartbeat-finish")
+
+    def release_lease(*_args, **_kwargs) -> bool:
+        events.append("lease")
+        return True
+
+    async def release_sandbox(*_args) -> None:
+        events.append("sandbox")
+
+    with (
+        patch(
+            "xagent.web.api.chat._check_task_run_gate_isolated",
+            return_value=None,
+        ),
+        patch(
+            "xagent.web.api.chat.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.api.chat._sync_task_workforce_running_isolated",
+            return_value=False,
+        ),
+        patch(
+            "xagent.web.api.chat._release_managed_task_lease_isolated",
+            side_effect=release_lease,
+        ),
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=stop_heartbeat,
+        ),
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            return_value=tracker,
+        ),
+        patch.object(
+            manager,
+            "_acquire_sandbox_task",
+            new=AsyncMock(return_value="user:102"),
+        ),
+        patch.object(manager, "_release_sandbox_task", new=release_sandbox),
+    ):
+        execution = asyncio.create_task(
+            manager.execute_task(
+                agent_service=_FakeAgentService(),
+                task="hello",
+                tracking_task_id=str(task_id),
+                manage_task_lease=True,
+            )
+        )
+        await asyncio.wait_for(heartbeat_stop_entered.wait(), timeout=1)
+        execution.cancel()
+        await asyncio.sleep(0)
+        allow_heartbeat_stop.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execution, timeout=1)
+
+    assert events == [
+        "usage",
+        "heartbeat-enter",
+        "heartbeat-finish",
+        "lease",
+        "sandbox",
+    ]
 
 
 def test_sync_workforce_run_status_running_is_idempotent(db_session) -> None:

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -661,19 +661,18 @@ class TestModelService:
         "get_default",
         [get_default_sound_effect_model, get_default_music_model],
     )
-    def test_audio_generation_default_closes_database_generator(self, get_default):
+    def test_audio_generation_default_closes_owned_session(self, get_default):
         mock_db = MagicMock()
         filter_query = (
             mock_db.query.return_value.join.return_value.join.return_value.filter
         )
         shared_query = filter_query.return_value
         shared_query.limit.return_value.all.return_value = []
-        db_gen = MagicMock()
-        db_gen.__next__.return_value = mock_db
+        session_factory = MagicMock(return_value=mock_db)
 
         with patch(
-            "xagent.web.models.database.get_db",
-            return_value=db_gen,
+            "xagent.web.models.database.get_session_local",
+            return_value=session_factory,
         ):
             result = get_default(user_id=None)
 
@@ -682,7 +681,8 @@ class TestModelService:
             getattr(getattr(condition, "right", None), "value", None) == '"generate"'
             for condition in filter_query.call_args.args
         )
-        db_gen.close.assert_called_once_with()
+        session_factory.assert_called_once_with()
+        mock_db.close.assert_called_once_with()
 
     def test_embedding_fallback_skips_invisible_returns_none(self, monkeypatch):
         """System fallback returns None when no visible embedding model exists."""

--- a/tests/web/test_task_execution_context_service.py
+++ b/tests/web/test_task_execution_context_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
+from xagent.web.services import task_execution_context_service as context_service
 from xagent.web.services.task_execution_context_service import (
     load_task_execution_context_messages,
     load_task_execution_recovery_state,
@@ -267,3 +268,80 @@ async def test_load_task_execution_recovery_state_recovers_skill_context(monkeyp
         assert recovery_state["messages"] == []
     finally:
         db_session.close()
+
+
+def test_recovery_snapshot_separates_database_read_from_skill_loading() -> None:
+    """The worker-side read returns primitives and never awaits skill I/O."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        now = datetime.now(timezone.utc)
+        db_session.add_all(
+            [
+                TraceEvent(
+                    task_id=int(task.id),
+                    build_id=None,
+                    event_id="tool-event-snapshot",
+                    event_type="tool_execution_end",
+                    timestamp=now,
+                    step_id="step_1",
+                    parent_event_id=None,
+                    data={
+                        "tool_name": "web_search",
+                        "success": True,
+                        "result": {"title": "Snapshot evidence"},
+                    },
+                ),
+                TraceEvent(
+                    task_id=int(task.id),
+                    build_id=None,
+                    event_id="skill-event-snapshot",
+                    event_type="skill_select_end",
+                    timestamp=now,
+                    step_id=None,
+                    parent_event_id=None,
+                    data={"selected": True, "skill_name": "translator"},
+                ),
+            ]
+        )
+        db_session.commit()
+
+        snapshot = context_service.load_task_execution_recovery_snapshot_sync(
+            db_session,
+            int(task.id),
+        )
+
+        assert snapshot.selected_skill_name == "translator"
+        assert len(snapshot.messages) == 1
+        assert "Snapshot evidence" in snapshot.messages[0]["content"]
+        assert isinstance(snapshot.messages, tuple)
+    finally:
+        db_session.close()
+
+
+@pytest.mark.asyncio
+async def test_materialize_recovery_snapshot_loads_skill_without_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only async skill loading remains after the DB snapshot is detached."""
+    snapshot = context_service.TaskExecutionRecoverySnapshot(
+        messages=({"role": "system", "content": "prior result"},),
+        selected_skill_name="translator",
+    )
+
+    async def fake_load_skill_context_by_name(skill_name: str) -> str:
+        assert skill_name == "translator"
+        return "## Available Skill: translator\n\nUse translation workflow."
+
+    monkeypatch.setattr(
+        context_service,
+        "_load_skill_context_by_name",
+        fake_load_skill_context_by_name,
+    )
+
+    state = await context_service.materialize_task_execution_recovery_state(snapshot)
+
+    assert state == {
+        "messages": [{"role": "system", "content": "prior result"}],
+        "skill_context": "## Available Skill: translator\n\nUse translation workflow.",
+    }

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1,18 +1,32 @@
 """Tests for task execution leases."""
 
+import asyncio
+import threading
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, LEGACY_CHECKPOINT_TYPES
+from xagent.web.models import database as database_module
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import ExecutionMode, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
+from xagent.web.services import task_lease_service
+from xagent.web.services.db_runtime import is_database_pool_timeout
 from xagent.web.services.task_lease_service import (
+    TaskLease,
+    TaskLeaseRefreshState,
     acquire_task_lease,
+    acquire_task_lease_no_commit,
     mark_task_paused_if_stale,
     refresh_task_lease,
     release_task_lease,
+    run_task_lease_heartbeat,
+    stop_task_lease_heartbeat,
     utc_now,
 )
 
@@ -26,6 +40,25 @@ def db_session(tmp_path):
     finally:
         db.close()
         Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.fixture()
+def queue_pool_runtime_db(tmp_path):
+    """A real one-slot QueuePool used to exercise checkout contention."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'lease-queue-pool.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.4,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    try:
+        yield engine, SessionLocal
+    finally:
+        engine.dispose()
 
 
 def _create_task(db, *, status=TaskStatus.PENDING) -> Task:
@@ -81,7 +114,7 @@ def test_task_lease_acquire_refresh_and_release(db_session) -> None:
     assert task.control_state == "running"
 
     assert acquire_task_lease(db_session, int(task.id), runner_id="runner-b") is None
-    assert refresh_task_lease(db_session, lease) is True
+    assert refresh_task_lease(db_session, lease) == TaskLeaseRefreshState.REFRESHED
     assert release_task_lease(db_session, lease, status=TaskStatus.COMPLETED) is True
     db_session.refresh(task)
     assert task.status == TaskStatus.COMPLETED
@@ -89,6 +122,441 @@ def test_task_lease_acquire_refresh_and_release(db_session) -> None:
     assert task.control_state == "completed"
     assert task.runner_id is None
     assert task.lease_expires_at is None
+
+
+def test_acquire_returns_run_id_from_update_without_followup_select(
+    queue_pool_runtime_db,
+) -> None:
+    engine, SessionLocal = queue_pool_runtime_db
+    with SessionLocal() as seed_db:
+        task = _create_task(seed_db)
+        task_id = int(task.id)
+
+    statements: list[str] = []
+
+    def record_statement(
+        _conn,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        with SessionLocal() as db:
+            lease = acquire_task_lease(db, task_id, runner_id="runner-returning")
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    assert lease is not None
+    assert lease.run_id
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("UPDATE")
+    assert "RETURNING" in statements[0].upper()
+
+
+def test_acquire_no_commit_leaves_transaction_owned_by_caller(db_session) -> None:
+    task = _create_task(db_session)
+
+    lease = acquire_task_lease_no_commit(
+        db_session,
+        int(task.id),
+        runner_id="transaction-owner",
+    )
+
+    assert lease is not None
+    db_session.rollback()
+    db_session.refresh(task)
+    assert task.status == TaskStatus.PENDING
+    assert task.runner_id is None
+    assert task.run_id is None
+
+
+def test_fail_and_release_task_lease_rejects_superseded_owner(db_session) -> None:
+    task = _create_task(db_session)
+    stale_lease = acquire_task_lease(
+        db_session,
+        int(task.id),
+        runner_id="old-runner",
+    )
+    assert stale_lease is not None
+
+    task.runner_id = "new-runner"
+    task.run_id = "new-run"
+    task.error_message = None
+    task.output = "new owner output"
+    db_session.commit()
+
+    changed = task_lease_service.fail_and_release_task_lease_no_commit(
+        db_session,
+        stale_lease,
+        error_message="stale runner failed",
+    )
+    db_session.commit()
+
+    assert changed is False
+    db_session.refresh(task)
+    assert task.status == TaskStatus.RUNNING
+    assert task.runner_id == "new-runner"
+    assert task.run_id == "new-run"
+    assert task.error_message is None
+    assert task.output == "new owner output"
+
+
+def test_fail_and_release_task_lease_atomically_fails_current_owner(db_session) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    task.output = "stale output"
+    db_session.commit()
+    state_version = int(task.state_version)
+
+    changed = task_lease_service.fail_and_release_task_lease_no_commit(
+        db_session,
+        lease,
+        error_message="setup failed",
+    )
+    db_session.commit()
+
+    assert changed is True
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
+    assert task.control_state == "failed"
+    assert task.state_version == state_version + 1
+    assert task.error_message == "setup failed"
+    assert task.output is None
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
+
+
+def test_release_task_lease_refuses_ownerless_running_state(db_session) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+
+    with pytest.raises(ValueError, match="RUNNING"):
+        release_task_lease(db_session, lease, status=TaskStatus.RUNNING)
+
+    db_session.refresh(task)
+    assert task.status == TaskStatus.RUNNING
+    assert task.runner_id == "runner-a"
+    assert task.lease_expires_at is not None
+
+
+@pytest.mark.asyncio
+async def test_lease_heartbeat_keeps_loop_responsive_during_pool_checkout(
+    queue_pool_runtime_db,
+    monkeypatch,
+) -> None:
+    engine, SessionLocal = queue_pool_runtime_db
+    with SessionLocal() as seed_db:
+        task = _create_task(seed_db, status=TaskStatus.RUNNING)
+        task_id = int(task.id)
+        task.runner_id = "runner-a"
+        task.run_id = "run-a"
+        seed_db.commit()
+
+    def constrained_get_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_db",
+        constrained_get_db,
+        raising=False,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    held_connection = engine.connect()
+    stop_event = asyncio.Event()
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        await asyncio.sleep(0.12)
+        assert ticks >= 3, "QueuePool checkout blocked the asyncio event loop"
+    finally:
+        held_connection.close()
+        stop_event.set()
+        await asyncio.wait_for(heartbeat_task, timeout=1)
+        ticker_stop.set()
+        await ticker_task
+
+    with SessionLocal() as verify_db:
+        refreshed = verify_db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.last_heartbeat_at is not None
+
+
+@pytest.mark.asyncio
+async def test_stop_heartbeat_drains_inflight_refresh(monkeypatch) -> None:
+    refresh_started = threading.Event()
+    allow_refresh_to_finish = threading.Event()
+
+    def blocking_refresh(_lease: TaskLease) -> TaskLeaseRefreshState:
+        refresh_started.set()
+        assert allow_refresh_to_finish.wait(timeout=2)
+        return TaskLeaseRefreshState.REFRESHED
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "refresh_task_lease_isolated",
+        blocking_refresh,
+    )
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(refresh_started.wait, 1), timeout=1)
+
+    stopper = asyncio.create_task(stop_task_lease_heartbeat(heartbeat_task, stop_event))
+    await asyncio.sleep(0.02)
+    assert not stopper.done()
+
+    allow_refresh_to_finish.set()
+    await asyncio.wait_for(stopper, timeout=1)
+    assert heartbeat_task.done()
+
+
+@pytest.mark.asyncio
+async def test_stop_heartbeat_propagates_cancellation_after_drain(monkeypatch) -> None:
+    refresh_started = threading.Event()
+    allow_refresh_to_finish = threading.Event()
+
+    def blocking_refresh(_lease: TaskLease) -> TaskLeaseRefreshState:
+        refresh_started.set()
+        assert allow_refresh_to_finish.wait(timeout=2)
+        return TaskLeaseRefreshState.REFRESHED
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "refresh_task_lease_isolated",
+        blocking_refresh,
+    )
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(refresh_started.wait, 1), timeout=1)
+
+    stopper = asyncio.create_task(stop_task_lease_heartbeat(heartbeat_task, stop_event))
+    await asyncio.sleep(0)
+    stopper.cancel()
+    await asyncio.sleep(0.02)
+    assert not stopper.done()
+
+    allow_refresh_to_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(stopper, timeout=1)
+    assert heartbeat_task.done()
+
+
+@pytest.mark.asyncio
+async def test_stop_heartbeat_reports_unresolved_pool_timeout(monkeypatch) -> None:
+    refresh_attempted = threading.Event()
+
+    def timed_out_refresh(_lease: TaskLease) -> TaskLeaseRefreshState:
+        refresh_attempted.set()
+        raise SQLAlchemyTimeoutError("pool checkout timed out")
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "refresh_task_lease_isolated",
+        timed_out_refresh,
+    )
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(refresh_attempted.wait, 1), timeout=1)
+
+    outcome = await stop_task_lease_heartbeat(heartbeat_task, stop_event)
+
+    assert outcome.pool_timeout is not None
+    assert is_database_pool_timeout(outcome.pool_timeout)
+    assert outcome.lease_lost is False
+
+
+@pytest.mark.asyncio
+async def test_stop_heartbeat_reports_lost_ownership(monkeypatch) -> None:
+    monkeypatch.setattr(
+        task_lease_service,
+        "refresh_task_lease_isolated",
+        lambda _lease: TaskLeaseRefreshState.LOST,
+    )
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    await asyncio.wait_for(heartbeat_task, timeout=1)
+
+    outcome = await stop_task_lease_heartbeat(heartbeat_task, stop_event)
+
+    assert outcome.lease_lost is True
+    assert outcome.pool_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_does_not_report_owned_terminal_task_as_lease_lost(
+    db_session,
+    monkeypatch,
+) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+
+    task.status = TaskStatus.COMPLETED
+    task.control_state = "completed"
+    db_session.commit()
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    outcome = await asyncio.wait_for(
+        run_task_lease_heartbeat(lease, asyncio.Event()),
+        timeout=1,
+    )
+
+    assert outcome.lease_lost is False
+    assert outcome.requires_ttl_recovery is False
+
+
+@pytest.mark.asyncio
+async def test_successful_heartbeat_clears_prior_pool_timeout(monkeypatch) -> None:
+    refresh_recovered = threading.Event()
+    attempts = 0
+
+    def recovering_refresh(_lease: TaskLease) -> TaskLeaseRefreshState:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise SQLAlchemyTimeoutError("transient pool checkout timeout")
+        refresh_recovered.set()
+        return TaskLeaseRefreshState.REFRESHED
+
+    monkeypatch.setattr(
+        task_lease_service,
+        "refresh_task_lease_isolated",
+        recovering_refresh,
+    )
+    monkeypatch.setattr(
+        task_lease_service,
+        "get_task_lease_heartbeat_seconds",
+        lambda: 0.001,
+    )
+
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(
+            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            stop_event,
+        )
+    )
+    assert await asyncio.to_thread(refresh_recovered.wait, 1)
+
+    outcome = await stop_task_lease_heartbeat(heartbeat_task, stop_event)
+
+    assert outcome.requires_ttl_recovery is False
+
+
+@pytest.mark.asyncio
+async def test_cancellation_safe_acquire_drains_and_cleans_returned_lease() -> None:
+    acquire_started = threading.Event()
+    allow_acquire_to_finish = threading.Event()
+    cleanup_started = threading.Event()
+    allow_cleanup_to_finish = threading.Event()
+    expected_lease = TaskLease(task_id=9, runner_id="runner-a", run_id="run-a")
+    cleaned_leases: list[TaskLease] = []
+
+    def acquire() -> TaskLease:
+        acquire_started.set()
+        assert allow_acquire_to_finish.wait(timeout=2)
+        return expected_lease
+
+    def cleanup(lease: TaskLease) -> None:
+        cleanup_started.set()
+        assert allow_cleanup_to_finish.wait(timeout=2)
+        cleaned_leases.append(lease)
+
+    operation = asyncio.create_task(
+        task_lease_service.acquire_task_lease_cancellation_safe(acquire, cleanup)
+    )
+    await asyncio.wait_for(asyncio.to_thread(acquire_started.wait, 1), timeout=1)
+    operation.cancel()
+    await asyncio.sleep(0.02)
+    assert not operation.done()
+
+    allow_acquire_to_finish.set()
+    await asyncio.wait_for(asyncio.to_thread(cleanup_started.wait, 1), timeout=1)
+    assert not operation.done()
+
+    allow_cleanup_to_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(operation, timeout=1)
+    assert cleaned_leases == [expected_lease]
 
 
 def test_new_run_lease_claim_rejects_a_second_claim(db_session) -> None:
@@ -146,7 +614,7 @@ def test_old_lease_cannot_refresh_or_release_a_new_run(db_session) -> None:
     task.runner_id = "runner-a"
     db_session.commit()
 
-    assert refresh_task_lease(db_session, old_lease) is False
+    assert refresh_task_lease(db_session, old_lease) == TaskLeaseRefreshState.LOST
     assert release_task_lease(db_session, old_lease, status=TaskStatus.FAILED) is False
     db_session.refresh(task)
     assert task.run_id == "new-run"

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -13,6 +13,7 @@ from xagent.web.api.websocket import (
     _build_uploaded_files_context,
     _display_file_refs_from_file_info,
     _display_message_for_user,
+    _finalize_task_execution_result_isolated,
     _normalize_attachments_for_persistence,
     _normalize_file_outputs,
     _normalize_task_file_outputs,
@@ -27,6 +28,7 @@ from xagent.web.models import database as database_models
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
+from xagent.web.services.task_lease_service import TaskLease
 
 
 @pytest.fixture()
@@ -103,6 +105,49 @@ def _create_uploaded_file(
     return file_record
 
 
+def test_normalize_file_outputs_skips_scope_lookup_for_empty_outputs(
+    db_session, monkeypatch
+) -> None:
+    """An empty output list must not spend a database checkout on scope."""
+
+    def unexpected_lookup(_task_id):
+        raise AssertionError("scope resolver must not run for empty outputs")
+
+    monkeypatch.setattr(
+        websocket_api,
+        "_scope_segments_for_task",
+        unexpected_lookup,
+    )
+
+    assert _normalize_file_outputs(db_session, 10, 1, []) == ([], {})
+
+
+def test_normalize_file_outputs_uses_the_turns_resolved_scope(
+    db_session, monkeypatch
+) -> None:
+    """Explicit scope primitives prevent a second resolver call in one turn."""
+
+    def unexpected_lookup(_task_id):
+        raise AssertionError("turn scope was already resolved")
+
+    monkeypatch.setattr(
+        websocket_api,
+        "_scope_segments_for_task",
+        unexpected_lookup,
+    )
+
+    normalized, aliases = _normalize_file_outputs(
+        db_session,
+        10,
+        1,
+        [{"unexpected": "shape"}],
+        resolved_scope_segments=("tenant-a",),
+    )
+
+    assert normalized == []
+    assert aliases == {}
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "terminal_status",
@@ -159,10 +204,7 @@ async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
     def fake_get_db():
         yield db_session
 
-    def fake_release_current_runner_task_lease_with_workforce_sync(
-        db, task_id, *, status
-    ):
-        return True
+    test_sessionmaker = sessionmaker(bind=db_session.get_bind())
 
     monkeypatch.setattr(
         websocket_api,
@@ -170,23 +212,26 @@ async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
         BackgroundTaskManager(),
     )
     monkeypatch.setattr(websocket_api, "manager", BroadcastManager())
-    monkeypatch.setattr(
-        websocket_api,
-        "release_current_runner_task_lease_with_workforce_sync",
-        fake_release_current_runner_task_lease_with_workforce_sync,
-    )
     monkeypatch.setattr(database_models, "get_db", fake_get_db)
+    monkeypatch.setattr(websocket_api, "get_session_local", lambda: test_sessionmaker)
     monkeypatch.setattr(
-        "xagent.web.services.chat_history_service.persist_assistant_message",
+        "xagent.web.services.task_setup_snapshot.get_session_local",
+        lambda: test_sessionmaker,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.chat_history_service.persist_assistant_message_no_commit",
         lambda *args, **kwargs: None,
     )
+
+    user_id = int(user.id)
+    db_session.commit()
 
     await execute_task_background(
         task_id=10,
         user_message="重试",
         context={},
         agent_manager=AgentManager(),
-        task_owner_user_id=int(user.id),
+        task_owner_user_id=user_id,
         llm_user_message="重试",
     )
 
@@ -225,31 +270,25 @@ def _wire_execute_task_background(monkeypatch, db_session, manager):
     def fake_get_db():
         yield db_session
 
-    def fake_release(db, task_id, *, status):
-        return True
-
     test_sessionmaker = sessionmaker(bind=db_session.get_bind())
 
     monkeypatch.setattr(
         websocket_api, "background_task_manager", _NoopBackgroundTaskManager()
     )
     monkeypatch.setattr(websocket_api, "manager", manager)
-    monkeypatch.setattr(
-        websocket_api,
-        "release_current_runner_task_lease_with_workforce_sync",
-        fake_release,
-    )
     monkeypatch.setattr(websocket_api, "get_session_local", lambda: test_sessionmaker)
+    monkeypatch.setattr(
+        "xagent.web.services.task_setup_snapshot.get_session_local",
+        lambda: test_sessionmaker,
+    )
     monkeypatch.setattr(database_models, "get_db", fake_get_db)
 
     def fake_persist_assistant_message(db, *args, **kwargs):
-        # The real helper commits the session; mirror that so the pending
-        # terminal status set by execute_task_background is durably landed
-        # (the status commit now rides on the assistant-message write).
-        db.commit()
+        # Finalization owns the single commit after staging the message.
+        return None
 
     monkeypatch.setattr(
-        "xagent.web.services.chat_history_service.persist_assistant_message",
+        "xagent.web.services.chat_history_service.persist_assistant_message_no_commit",
         fake_persist_assistant_message,
     )
 
@@ -259,8 +298,8 @@ async def test_completion_broadcast_failure_keeps_task_completed(
     db_session, monkeypatch
 ):
     """A failure in the post-completion broadcast must not be treated as an
-    execution failure: the already-COMPLETED row is left untouched, no
-    task_error is emitted, and the terminal failure writer is not invoked."""
+    execution failure: the already-COMPLETED row is left untouched and no
+    task_error is emitted."""
     user = _create_user(db_session, 1, "owner")
     _create_task(db_session, task_id=10, user_id=1, status=TaskStatus.RUNNING)
     db_session.commit()
@@ -283,9 +322,16 @@ async def test_completion_broadcast_failure_keeps_task_completed(
             return {"success": True, "output": "ok", "file_outputs": []}
 
     def fake_payload(
-        task_id, message, *, event_type="agent_error", expected_run_id=None
+        task_id,
+        message,
+        *,
+        event_type="agent_error",
+        expected_run_id=None,
+        only_if_running=False,
     ):
-        payload_calls.append((task_id, message, event_type))
+        payload_calls.append((task_id, message, event_type, only_if_running))
+        if only_if_running:
+            return None
         return {"type": event_type, "task_id": task_id}
 
     _wire_execute_task_background(monkeypatch, db_session, BroadcastManager())
@@ -306,7 +352,7 @@ async def test_completion_broadcast_failure_keeps_task_completed(
     assert task.error_message is None
     assert "task_completed" in sent_events
     assert "task_error" not in sent_events
-    assert payload_calls == []
+    assert payload_calls == [(10, "websocket client disconnected", "task_error", True)]
 
 
 @pytest.mark.asyncio
@@ -356,6 +402,65 @@ async def test_late_execution_result_does_not_resurrect_canceled_a2a_task(
     assert task.error_message == "Task canceled by A2A client."
 
 
+def test_result_finalization_rejects_replacement_run_with_same_runner(
+    db_session, monkeypatch
+) -> None:
+    """A process-global runner id is insufficient fencing after a new turn.
+
+    The old coroutine must be rejected by ``run_id`` before it can normalize
+    files, append a transcript row, or rewrite the replacement run's state.
+    """
+    _create_user(db_session, 1, "owner")
+    task = _create_task(
+        db_session,
+        task_id=15,
+        user_id=1,
+        status=TaskStatus.RUNNING,
+    )
+    task.runner_id = "shared-process-runner"
+    task.run_id = "replacement-run"
+    task.output = "replacement output"
+    db_session.commit()
+
+    test_sessionmaker = sessionmaker(bind=db_session.get_bind())
+    monkeypatch.setattr(websocket_api, "get_session_local", lambda: test_sessionmaker)
+
+    def unexpected_file_normalization(*_args, **_kwargs):
+        raise AssertionError("late result reached file persistence")
+
+    monkeypatch.setattr(
+        websocket_api,
+        "_normalize_task_file_outputs",
+        unexpected_file_normalization,
+    )
+
+    finalized = _finalize_task_execution_result_isolated(
+        task_id=15,
+        task_user_id=1,
+        pre_run_status=TaskStatus.RUNNING,
+        result={
+            "success": True,
+            "output": "stale output",
+            "file_outputs": [{"file_id": "stale-file"}],
+        },
+        expected_run_id="old-run",
+        task_lease=TaskLease(
+            task_id=15,
+            runner_id="shared-process-runner",
+            run_id="old-run",
+        ),
+        resolved_scope_segments=(),
+    )
+
+    db_session.expire_all()
+    current = db_session.query(Task).filter(Task.id == 15).one()
+    assert finalized.late_result is True
+    assert current.status == TaskStatus.RUNNING
+    assert current.runner_id == "shared-process-runner"
+    assert current.run_id == "replacement-run"
+    assert current.output == "replacement output"
+
+
 @pytest.mark.asyncio
 async def test_execution_failure_routes_real_error_to_terminal_payload(
     db_session, monkeypatch
@@ -382,9 +487,14 @@ async def test_execution_failure_routes_real_error_to_terminal_payload(
             raise RuntimeError("agent boom xyz")
 
     def fake_payload(
-        task_id, message, *, event_type="agent_error", expected_run_id=None
+        task_id,
+        message,
+        *,
+        event_type="agent_error",
+        expected_run_id=None,
+        only_if_running=False,
     ):
-        payload_calls.append((task_id, message, event_type))
+        payload_calls.append((task_id, message, event_type, only_if_running))
         return {"type": event_type, "task_id": task_id}
 
     _wire_execute_task_background(monkeypatch, db_session, BroadcastManager())
@@ -399,7 +509,7 @@ async def test_execution_failure_routes_real_error_to_terminal_payload(
         llm_user_message="hi",
     )
 
-    assert payload_calls == [(11, "agent boom xyz", "task_error")]
+    assert payload_calls == [(11, "agent boom xyz", "task_error", True)]
     assert "task_error" in sent_events
 
 
@@ -433,15 +543,21 @@ async def test_assistant_persist_failure_surfaces_as_task_failure(
         raise RuntimeError("durable persist failed")
 
     def fake_payload(
-        task_id, message, *, event_type="agent_error", expected_run_id=None
+        task_id,
+        message,
+        *,
+        event_type="agent_error",
+        expected_run_id=None,
+        only_if_running=False,
     ):
-        payload_calls.append((task_id, event_type))
+        payload_calls.append((task_id, event_type, only_if_running))
         return {"type": event_type, "task_id": task_id}
 
     _wire_execute_task_background(monkeypatch, db_session, BroadcastManager())
     # Override the no-op persist with one that fails (durable write error).
     monkeypatch.setattr(
-        "xagent.web.services.chat_history_service.persist_assistant_message", boom
+        "xagent.web.services.chat_history_service.persist_assistant_message_no_commit",
+        boom,
     )
     monkeypatch.setattr(websocket_api, "_terminal_task_error_payload", fake_payload)
 
@@ -457,7 +573,7 @@ async def test_assistant_persist_failure_surfaces_as_task_failure(
     # The COMPLETED status was never committed (pending until the message
     # write that failed), so the status probe still sees RUNNING and the
     # failure is routed to the terminal payload writer.
-    assert payload_calls == [(12, "task_error")]
+    assert payload_calls == [(12, "task_error", True)]
 
 
 @pytest.mark.asyncio
@@ -492,7 +608,7 @@ async def test_empty_reply_turn_still_completes(db_session, monkeypatch):
     _wire_execute_task_background(monkeypatch, db_session, BroadcastManager())
     # Empty-content path: persist early-returns None without committing.
     monkeypatch.setattr(
-        "xagent.web.services.chat_history_service.persist_assistant_message",
+        "xagent.web.services.chat_history_service.persist_assistant_message_no_commit",
         lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(websocket_api, "_terminal_task_error_payload", fake_payload)

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +7,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import QueuePool, StaticPool
 
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.api.chat import (
@@ -15,6 +16,7 @@ from xagent.web.api.chat import (
     create_default_tools,
 )
 from xagent.web.models import Agent, Base, Task, User, Workforce, WorkforceRun
+from xagent.web.models import database as database_module
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.task import TaskStatus
@@ -59,6 +61,33 @@ def db_session() -> Session:
         session.close()
         _db_module._SessionLocal = _prev_session_local
         Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def single_connection_workforce_db(tmp_path, monkeypatch):
+    """Real one-slot pool shared by the caller and turn orchestrator."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'workforce-turn-boundary.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.15,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+    )
+    monkeypatch.setattr(database_module, "_SessionLocal", session_local)
+    db = session_local()
+    try:
+        yield engine, db
+    finally:
+        db.close()
         engine.dispose()
 
 
@@ -237,6 +266,62 @@ async def test_create_workforce_run_creates_task_run_and_starts_turn(
         .count()
         == 1
     )
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_run_releases_connection_before_begin_turn(
+    single_connection_workforce_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, db = single_connection_workforce_db
+    _patch_schedule_bg(monkeypatch)
+    user = _create_user(db, "single-pool-owner")
+    manager = _create_agent(db, user, "Manager")
+    worker_agent = _create_agent(db, user, "Analyst")
+    workforce = _create_workforce(db, user, manager)
+    _add_worker(db, user, workforce, worker_agent)
+    db.commit()
+
+    checked_out: list[int] = []
+    original = task_orchestrator_module._begin_turn_atomic_sync
+
+    def observed(*args: Any, **kwargs: Any):
+        checked_out.append(engine.pool.checkedout())
+        time.sleep(0.05)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        task_orchestrator_module,
+        "_begin_turn_atomic_sync",
+        observed,
+    )
+
+    ticker_stop = asyncio.Event()
+    ticks = 0
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not ticker_stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await create_workforce_run(
+            db,
+            user,
+            workforce,
+            message="Coordinate a launch brief",
+        )
+        await result.background_task
+    finally:
+        ticker_stop.set()
+        await ticker_task
+
+    assert result.task.status == TaskStatus.RUNNING
+    assert result.workforce_run.status == "running"
+    assert checked_out == [0]
+    assert ticks >= 3, "workforce turn startup blocked the asyncio event loop"
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -1,14 +1,25 @@
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.tools.adapters.vibe.config import MCPConfigLoadError
 from xagent.core.tools.adapters.vibe.connector_runtime import (
     ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
     ConnectorRuntimeError,
+)
+from xagent.core.tools.adapters.vibe.factory import ToolFactory, ToolRegistry
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+from xagent.web.models.tool_config import ToolConfig
+from xagent.web.models.user import User
+from xagent.web.services.tool_credentials import (
+    set_user_tool_allowlist_hook,
+    set_user_tool_overrides_hook,
 )
 from xagent.web.tools.config import WebToolConfig
 
@@ -75,6 +86,12 @@ class _TrackingSession:
     def close(self):
         self.closed = True
 
+    def connection(self):
+        return object()
+
+    def rollback(self):
+        return None
+
 
 class _FailingQuerySession:
     def __init__(self):
@@ -107,6 +124,505 @@ def test_live_db_path_unchanged():
     cfg = WebToolConfig(db=sentinel, request=None)
     assert cfg.get_db() is sentinel
     cfg.close()  # must not raise; caller owns the request session
+
+
+def _saturated_tool_config(
+    tmp_path, *, pool_timeout: float
+) -> tuple[object, object, WebToolConfig]:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'tool-factory.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=pool_timeout,
+        connect_args={"check_same_thread": False},
+    )
+    ToolConfig.__table__.create(bind=engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    held_connection = engine.connect()
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=factory,
+        user_id=1,
+        workspace_config={"task_id": "_mock_"},
+        task_id="_mock_",
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=["basic"]),
+    )
+    return engine, held_connection, cfg
+
+
+@pytest.mark.asyncio
+async def test_tool_factory_credential_prefetch_waits_off_event_loop(tmp_path):
+    """Credential checkout must not freeze unrelated async work."""
+    engine, held_connection, cfg = _saturated_tool_config(tmp_path, pool_timeout=0.5)
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    async def build_tools() -> list:
+        return await ToolFactory.create_all_tools(cfg)
+
+    ticker_task = asyncio.create_task(ticker())
+    build_task = asyncio.create_task(build_tools())
+    try:
+        await asyncio.sleep(0.08)
+        assert ticks >= 4
+        assert not build_task.done()
+
+        held_connection.close()
+        await build_task
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        if not build_task.done():
+            build_task.cancel()
+            await asyncio.gather(build_task, return_exceptions=True)
+        stop.set()
+        await ticker_task
+        cfg.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_tool_factory_prefetch_propagates_pool_timeout(tmp_path):
+    """A build-time checkout timeout must stop the build and reach its owner."""
+    engine, held_connection, cfg = _saturated_tool_config(tmp_path, pool_timeout=0.05)
+    try:
+        with pytest.raises(SQLAlchemyTimeoutError):
+            await ToolFactory.create_all_tools(cfg)
+    finally:
+        held_connection.close()
+        cfg.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_factory_runtime_snapshot_is_rebuilt_for_each_build(monkeypatch):
+    sessions: list[_TrackingSession] = []
+
+    def session_factory() -> _TrackingSession:
+        session = _TrackingSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "xagent.web.tools.config.resolve_tool_credential",
+        lambda *_args: None,
+    )
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=session_factory,
+        user_id=1,
+        workspace_config={"task_id": "_mock_"},
+        task_id="_mock_",
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=["basic"]),
+    )
+
+    await ToolFactory.create_all_tools(cfg)
+    await ToolFactory.create_all_tools(cfg)
+
+    assert len(sessions) == 2
+    assert all(session.closed for session in sessions)
+    assert cfg._factory_runtime_snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_refreshed_factory_runtime_is_consumed_by_next_build(monkeypatch):
+    sessions: list[_TrackingSession] = []
+
+    def session_factory() -> _TrackingSession:
+        session = _TrackingSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "xagent.web.tools.config.resolve_tool_credential",
+        lambda *_args: None,
+    )
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=session_factory,
+        user_id=1,
+        workspace_config={"task_id": "_mock_"},
+        task_id="_mock_",
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=["basic"]),
+    )
+
+    await cfg.refresh_runtime_policy()
+    assert len(sessions) == 1
+    assert cfg._factory_runtime_snapshot is not None
+
+    await ToolFactory.create_all_tools(cfg)
+
+    assert len(sessions) == 1
+    assert sessions[0].closed
+    assert cfg._factory_runtime_snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_factory_runtime_snapshot_is_released_when_build_raises(monkeypatch):
+    sessions: list[_TrackingSession] = []
+
+    def session_factory() -> _TrackingSession:
+        session = _TrackingSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "xagent.web.tools.config.resolve_tool_credential",
+        lambda *_args: None,
+    )
+
+    async def fail_build(_cls, _config):
+        raise RuntimeError("registered tool build failed")
+
+    monkeypatch.setattr(
+        ToolRegistry,
+        "create_registered_tools",
+        classmethod(fail_build),
+    )
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=session_factory,
+        user_id=1,
+        workspace_config={"task_id": "_mock_"},
+        task_id="_mock_",
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=["basic"]),
+    )
+
+    with pytest.raises(RuntimeError, match="registered tool build failed"):
+        await ToolFactory.create_all_tools(cfg)
+
+    assert len(sessions) == 1
+    assert sessions[0].closed
+    assert cfg._factory_runtime_snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_snapshots_selected_sync_factory_inputs(
+    monkeypatch,
+):
+    """After refresh, selected synchronous getters read only cached values."""
+    main_thread_id = threading.get_ident()
+    loader_thread_ids: list[int] = []
+    session = _TrackingSession()
+
+    def record(value):
+        loader_thread_ids.append(threading.get_ident())
+        return value
+
+    monkeypatch.setattr(
+        "xagent.web.tools.config.resolve_tool_credential",
+        lambda *_args: record("credential"),
+    )
+    monkeypatch.setattr(
+        "xagent.web.tools.config.get_sql_connection_map",
+        lambda *_args: record({"WAREHOUSE": "sqlite:///warehouse.db"}),
+    )
+
+    model_values = {
+        "get_default_vision_model": object(),
+        "get_image_models": {"image": object()},
+        "get_default_image_generate_model": object(),
+        "get_default_image_edit_model": object(),
+        "get_video_models": {"video": object()},
+        "get_default_video_model": object(),
+        "get_asr_models": {"asr": object()},
+        "get_default_asr_model": object(),
+        "get_tts_models": {"tts": object()},
+        "get_default_tts_model": object(),
+        "get_sound_effect_models": {"sound": object()},
+        "get_default_sound_effect_model": object(),
+        "get_music_models": {"music": object()},
+        "get_default_music_model": object(),
+    }
+    for name, value in model_values.items():
+        monkeypatch.setattr(
+            f"xagent.web.services.model_service.{name}",
+            lambda *_args, _value=value, **_kwargs: record(_value),
+        )
+
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=lambda: session,
+        user_id=1,
+        task_id="_mock_",
+        workspace_config={"task_id": "_mock_"},
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(
+            tool_categories=[
+                "basic",
+                "database",
+                "image",
+                "video",
+                "audio",
+                "vision",
+                "mcp:custom-api",
+            ]
+        ),
+    )
+
+    await cfg.refresh_runtime_policy()
+
+    def fail_factory():
+        raise AssertionError("factory getter attempted a second database checkout")
+
+    cfg._db_factory = fail_factory
+    assert cfg.get_tool_credential("web_search", "api_key") == "credential"
+    assert cfg.get_sql_connections() == {"WAREHOUSE": "sqlite:///warehouse.db"}
+    assert cfg.get_custom_api_configs() == []
+    assert cfg.get_vision_model() is model_values["get_default_vision_model"]
+    assert cfg.get_image_models() is model_values["get_image_models"]
+    assert (
+        cfg.get_image_generate_model()
+        is model_values["get_default_image_generate_model"]
+    )
+    assert cfg.get_image_edit_model() is model_values["get_default_image_edit_model"]
+    assert cfg.get_video_models() is model_values["get_video_models"]
+    assert cfg.get_video_model() is model_values["get_default_video_model"]
+    assert cfg.get_asr_models() is model_values["get_asr_models"]
+    assert cfg.get_asr_model() is model_values["get_default_asr_model"]
+    assert cfg.get_tts_models() is model_values["get_tts_models"]
+    assert cfg.get_tts_model() is model_values["get_default_tts_model"]
+    assert cfg.get_sound_effect_models() is model_values["get_sound_effect_models"]
+    assert (
+        cfg.get_sound_effect_model() is model_values["get_default_sound_effect_model"]
+    )
+    assert cfg.get_music_models() is model_values["get_music_models"]
+    assert cfg.get_music_model() is model_values["get_default_music_model"]
+    assert loader_thread_ids
+    assert all(thread_id != main_thread_id for thread_id in loader_thread_ids)
+
+
+@pytest.mark.asyncio
+async def test_default_model_prefetch_returns_every_pool_checkout(
+    monkeypatch,
+    tmp_path,
+):
+    from xagent.web.models import database
+    from xagent.web.models.database import Base
+    from xagent.web.services import model_service
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'default-models.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.1,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    monkeypatch.setattr(database, "_SessionLocal", factory)
+
+    checkouts = 0
+    checkins = 0
+
+    def record_checkout(*_args) -> None:
+        nonlocal checkouts
+        checkouts += 1
+
+    def record_checkin(*_args) -> None:
+        nonlocal checkins
+        checkins += 1
+
+    event.listen(engine, "checkout", record_checkout)
+    event.listen(engine, "checkin", record_checkin)  # codespell:ignore checkin
+
+    collection_getters = (
+        "get_image_models",
+        "get_video_models",
+        "get_asr_models",
+        "get_tts_models",
+        "get_sound_effect_models",
+        "get_music_models",
+    )
+    for getter_name in collection_getters:
+        monkeypatch.setattr(
+            f"xagent.web.services.model_service.{getter_name}",
+            lambda *_args: {"configured": object()},
+        )
+
+    default_getters = (
+        "get_default_vision_model",
+        "get_default_image_generate_model",
+        "get_default_image_edit_model",
+        "get_default_video_model",
+        "get_default_asr_model",
+        "get_default_tts_model",
+        "get_default_sound_effect_model",
+        "get_default_music_model",
+    )
+    default_calls: list[str] = []
+    for getter_name in default_getters:
+        real_getter = getattr(model_service, getter_name)
+
+        def record_default_call(
+            *args,
+            _getter_name=getter_name,
+            _real_getter=real_getter,
+            **kwargs,
+        ):
+            default_calls.append(_getter_name)
+            return _real_getter(*args, **kwargs)
+
+        monkeypatch.setattr(model_service, getter_name, record_default_call)
+
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=factory,
+        user_id=1,
+        task_id="_mock_",
+        workspace_config={"task_id": "_mock_"},
+        include_mcp_tools=False,
+        tool_selection_spec=ToolSelectionSpec.from_raw(
+            tool_categories=["vision", "image", "video", "audio"]
+        ),
+    )
+    try:
+        await cfg.prepare_factory_runtime()
+
+        assert default_calls == list(default_getters)
+        assert checkouts == checkins == 1
+        assert engine.pool.checkedout() == 0
+    finally:
+        cfg.close()
+        engine.dispose()
+
+
+def test_legacy_default_model_resolvers_close_owned_pool_connections(
+    monkeypatch,
+    tmp_path,
+):
+    from xagent.web.models import database
+    from xagent.web.models.database import Base
+    from xagent.web.services import model_service
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'legacy-default-models.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.1,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    monkeypatch.setattr(database, "_SessionLocal", factory)
+
+    checkouts = 0
+    checkins = 0
+
+    def record_checkout(*_args) -> None:
+        nonlocal checkouts
+        checkouts += 1
+
+    def record_checkin(*_args) -> None:
+        nonlocal checkins
+        checkins += 1
+
+    event.listen(engine, "checkout", record_checkout)
+    event.listen(engine, "checkin", record_checkin)  # codespell:ignore checkin
+
+    default_getters = (
+        model_service.get_default_vision_model,
+        model_service.get_default_image_generate_model,
+        model_service.get_default_image_edit_model,
+        model_service.get_default_video_model,
+        model_service.get_default_asr_model,
+        model_service.get_default_tts_model,
+        model_service.get_default_sound_effect_model,
+        model_service.get_default_music_model,
+    )
+    try:
+        for getter in default_getters:
+            assert getter() is None
+            assert engine.pool.checkedout() == 0
+
+        assert checkouts == checkins == len(default_getters)
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_policy_refresh_waits_for_pool_off_event_loop(tmp_path):
+    """A saturated policy-query pool must not freeze unrelated coroutines."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'tool-policy.db'}",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.5,
+        connect_args={"check_same_thread": False},
+    )
+    User.__table__.create(bind=engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    with factory() as db:
+        user = User(username="policy-user", password_hash="hash", is_admin=False)
+        db.add(user)
+        db.commit()
+        user_id = int(user.id)
+
+    def policy_hook(db, user):
+        assert db.query(User.id).filter(User.id == user.id).scalar() == user_id
+        return {"calculator": {"enabled": False}}
+
+    set_user_tool_overrides_hook(policy_hook)
+    set_user_tool_allowlist_hook(lambda _db, _user: ["file"])
+    held_connection = engine.connect()
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=factory,
+        user_id=user_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        await asyncio.sleep(0.02)
+        ticks_before_wait = ticks
+        refresh_task = asyncio.create_task(cfg.refresh_runtime_policy())
+        await asyncio.sleep(0.08)
+        assert ticks - ticks_before_wait >= 4
+        assert not refresh_task.done()
+
+        held_connection.close()
+        await refresh_task
+        assert cfg.get_user_tool_overrides() == {"calculator": {"enabled": False}}
+        assert cfg.get_user_tool_allowlist() == ["file"]
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        stop.set()
+        await ticker_task
+        cfg.close()
+        set_user_tool_overrides_hook(None)
+        set_user_tool_allowlist_hook(None)
+        engine.dispose()
 
 
 def test_legacy_oauth_session_uses_engine_when_caller_is_connection_bound():

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -1,8 +1,14 @@
 """Test cases for TaskTracker and TaskTrackerManager."""
 
+import asyncio
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from xagent.core.model.chat.token_context import add_token_usage, get_token_usage
 from xagent.web.models.task import Task, TaskStatus
@@ -13,8 +19,10 @@ class TestTaskTracker:
     """Test cases for TaskTracker."""
 
     @pytest.fixture
-    def db_session(self):
+    def db_session(self, monkeypatch):
         """Fixture providing a mock database session."""
+        from xagent.web.models import database
+
         session = MagicMock()
 
         # Mock Task object
@@ -29,6 +37,7 @@ class TestTaskTracker:
 
         # Mock query to return the task
         session.query.return_value.filter.return_value.first.return_value = mock_task
+        monkeypatch.setattr(database, "get_session_local", lambda: lambda: session)
 
         return session
 
@@ -43,9 +52,501 @@ class TestTaskTracker:
         tracker = TaskTracker(task_id=123, db_session=db_session)
 
         assert tracker.task_id == 123
-        assert tracker.db_session == db_session
+        assert not hasattr(tracker, "db_session")
+        assert not hasattr(tracker, "task")
         assert tracker.update_interval_seconds == 15  # default
         assert not tracker.is_tracking
+
+    @pytest.mark.asyncio
+    async def test_start_tracking_does_not_block_event_loop_when_pool_is_full(
+        self, monkeypatch, tmp_path
+    ):
+        """A pool wait belongs in a worker thread, never on the event loop."""
+        from xagent.web.models import database
+
+        engine = create_engine(
+            f"sqlite:///{tmp_path / 'tracker.db'}",
+            connect_args={"check_same_thread": False},
+            poolclass=QueuePool,
+            pool_size=1,
+            max_overflow=0,
+            pool_timeout=1,
+        )
+        Task.__table__.create(engine)
+        session_factory = sessionmaker(
+            autocommit=False,
+            autoflush=False,
+            bind=engine,
+        )
+        with session_factory() as db:
+            db.add(
+                Task(
+                    id=123,
+                    user_id=1,
+                    title="pool isolation",
+                    status=TaskStatus.RUNNING,
+                )
+            )
+            db.commit()
+
+        monkeypatch.setattr(database, "get_session_local", lambda: session_factory)
+        held_connection = engine.connect()
+        tracker = None
+        try:
+            tracker = TaskTracker(task_id=123)
+            start_task = asyncio.create_task(tracker.start_tracking())
+
+            # The worker is waiting for the only pool slot, but the event loop
+            # must remain responsive enough to run this ticker.
+            await asyncio.sleep(0.05)
+            assert not start_task.done()
+
+            held_connection.close()
+            await asyncio.wait_for(start_task, timeout=1)
+            assert tracker.is_tracking
+        finally:
+            held_connection.close()
+            if tracker is not None and tracker.is_tracking:
+                await tracker.stop_periodic_updates()
+            engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_final_usage_does_not_overwrite_a_replacement_run(
+        self, monkeypatch, tmp_path
+    ):
+        from xagent.web.models import database
+        from xagent.web.services import quota_hooks
+
+        engine = create_engine(
+            f"sqlite:///{tmp_path / 'tracker-run-fence.db'}",
+            connect_args={"check_same_thread": False},
+        )
+        Task.__table__.create(engine)
+        session_factory = sessionmaker(
+            autocommit=False,
+            autoflush=False,
+            bind=engine,
+        )
+        with session_factory() as db:
+            db.add(
+                Task(
+                    id=123,
+                    user_id=1,
+                    title="run fence",
+                    status=TaskStatus.RUNNING,
+                    run_id="run-a",
+                    input_tokens=4,
+                    output_tokens=2,
+                    total_tokens=6,
+                    llm_calls=1,
+                )
+            )
+            db.commit()
+
+        monkeypatch.setattr(database, "get_session_local", lambda: session_factory)
+        usage_hook_calls: list[int] = []
+        quota_hooks.set_usage_record_hook(
+            lambda _db, _user_id, _details, _actions: usage_hook_calls.append(1)
+        )
+        try:
+            tracker = TaskTracker(task_id=123, expected_run_id="run-a")
+            await tracker.start_tracking()
+            add_token_usage(input_tokens=10, output_tokens=5)
+
+            with session_factory() as replacement_db:
+                replacement = replacement_db.get(Task, 123)
+                assert replacement is not None
+                replacement.run_id = "run-b"
+                replacement.input_tokens = 100
+                replacement.output_tokens = 50
+                replacement.total_tokens = 150
+                replacement_db.commit()
+
+            await tracker.complete_tracking()
+        finally:
+            quota_hooks.set_usage_record_hook(None)
+
+        with session_factory() as verify_db:
+            replacement = verify_db.get(Task, 123)
+            assert replacement is not None
+            assert replacement.run_id == "run-b"
+            assert replacement.input_tokens == 100
+            assert replacement.output_tokens == 50
+            assert replacement.total_tokens == 150
+        assert usage_hook_calls == []
+        engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_runner_fence_rejects_same_run_takeover_at_every_db_boundary(
+        self, monkeypatch, tmp_path
+    ):
+        """A stale tracker must not seed or write after runner ownership changes."""
+        from xagent.web.models import database
+        from xagent.web.services import quota_hooks
+
+        engine = create_engine(
+            f"sqlite:///{tmp_path / 'tracker-runner-fence.db'}",
+            connect_args={"check_same_thread": False},
+        )
+        Task.__table__.create(engine)
+        session_factory = sessionmaker(
+            autocommit=False,
+            autoflush=False,
+            bind=engine,
+        )
+        with session_factory() as db:
+            for task_id in (123, 124, 125):
+                db.add(
+                    Task(
+                        id=task_id,
+                        user_id=1,
+                        title=f"runner fence {task_id}",
+                        status=TaskStatus.RUNNING,
+                        run_id="run-a",
+                        runner_id="runner-a",
+                        input_tokens=4,
+                        output_tokens=2,
+                        total_tokens=6,
+                        llm_calls=1,
+                    )
+                )
+            db.commit()
+
+        monkeypatch.setattr(database, "get_session_local", lambda: session_factory)
+        usage_hook_calls: list[int] = []
+        quota_hooks.set_usage_record_hook(
+            lambda _db, _user_id, _details, _actions: usage_hook_calls.append(1)
+        )
+        periodic_tracker = None
+        try:
+            periodic_tracker = TaskTracker(
+                task_id=123,
+                update_interval_seconds=60,
+                expected_run_id="run-a",
+                expected_runner_id="runner-a",
+            )
+            final_tracker = TaskTracker(
+                task_id=124,
+                update_interval_seconds=60,
+                expected_run_id="run-a",
+                expected_runner_id="runner-a",
+            )
+            await periodic_tracker.start_tracking()
+            await final_tracker.start_tracking()
+
+            with session_factory() as takeover_db:
+                for task_id in (123, 124, 125):
+                    replacement = takeover_db.get(Task, task_id)
+                    assert replacement is not None
+                    replacement.runner_id = "runner-b"
+                    replacement.input_tokens = 100
+                    replacement.output_tokens = 50
+                    replacement.total_tokens = 150
+                takeover_db.commit()
+
+            add_token_usage(input_tokens=10, output_tokens=5)
+            await periodic_tracker.periodic_update()
+            await final_tracker.complete_tracking()
+
+            seed_tracker = TaskTracker(
+                task_id=125,
+                expected_run_id="run-a",
+                expected_runner_id="runner-a",
+            )
+            with pytest.raises(ValueError, match="Task 125.*not found"):
+                await seed_tracker.start_tracking()
+        finally:
+            quota_hooks.set_usage_record_hook(None)
+            if periodic_tracker is not None and periodic_tracker.is_tracking:
+                await periodic_tracker.stop_periodic_updates()
+
+        with session_factory() as verify_db:
+            for task_id in (123, 124, 125):
+                replacement = verify_db.get(Task, task_id)
+                assert replacement is not None
+                assert replacement.run_id == "run-a"
+                assert replacement.runner_id == "runner-b"
+                assert replacement.input_tokens == 100
+                assert replacement.output_tokens == 50
+                assert replacement.total_tokens == 150
+        assert not periodic_tracker.is_tracking
+        assert usage_hook_calls == []
+        engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_db_writes_and_usage_hook_run_off_loop(self, monkeypatch):
+        """Blocking final metering shares the worker-owned DB boundary."""
+        from xagent.web.models import database
+        from xagent.web.services import quota_hooks
+
+        event_loop_thread = threading.get_ident()
+        session_threads = []
+        sessions = []
+        hook_threads = []
+        hook_sessions = []
+
+        def create_session():
+            session_threads.append(threading.get_ident())
+            session = MagicMock()
+            task = MagicMock(spec=Task)
+            task.id = 123
+            task.user_id = 7
+            task.input_tokens = 0
+            task.output_tokens = 0
+            task.total_tokens = 0
+            task.llm_calls = 0
+            task.token_usage_details = None
+            session.query.return_value.filter.return_value.first.return_value = task
+            sessions.append(session)
+            return session
+
+        monkeypatch.setattr(database, "get_session_local", lambda: create_session)
+
+        def progress_hook(db, user_id, delta_details, delta_actions):
+            hook_threads.append(threading.get_ident())
+            hook_sessions.append(db)
+            return None
+
+        def usage_hook(db, user_id, delta_details, delta_actions):
+            hook_threads.append(threading.get_ident())
+            hook_sessions.append(db)
+
+        quota_hooks.set_run_progress_gate_hook(progress_hook)
+        quota_hooks.set_usage_record_hook(usage_hook)
+        try:
+            tracker = TaskTracker(task_id=123, update_interval_seconds=60)
+            await tracker.start_tracking()
+            await tracker.periodic_update()
+            assert await tracker.interrupt_reason_for_quota() is None
+            await tracker.complete_tracking()
+        finally:
+            quota_hooks.set_run_progress_gate_hook(None)
+            quota_hooks.set_usage_record_hook(None)
+
+        assert len(hook_threads) == 2
+        assert hook_threads[0] == event_loop_thread
+        assert hook_threads[1] != event_loop_thread
+        assert len(hook_sessions) == 2
+        assert len(sessions) == 4
+        assert session_threads.count(event_loop_thread) == 1
+        assert all(
+            thread_id != event_loop_thread
+            for thread_id in session_threads
+            if thread_id not in hook_threads
+        )
+        for session in sessions:
+            session.close.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_completion_waits_for_inflight_periodic_worker(
+        self, db_session, monkeypatch
+    ):
+        """An uncancellable thread write must finish before the final write."""
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        periodic_started = threading.Event()
+        release_periodic = threading.Event()
+        writes = []
+
+        def blocking_periodic_write(*_args):
+            periodic_started.set()
+            assert release_periodic.wait(timeout=1)
+            writes.append("periodic")
+            return True
+
+        def final_write(*_args):
+            writes.append("complete")
+            return True
+
+        monkeypatch.setattr(
+            tracker_module, "_write_task_usage_sync", blocking_periodic_write
+        )
+        monkeypatch.setattr(tracker_module, "_complete_task_usage_sync", final_write)
+
+        tracker = TaskTracker(
+            task_id=123,
+            db_session=db_session,
+            update_interval_seconds=0.01,
+        )
+        await tracker.start_tracking()
+        assert await asyncio.to_thread(periodic_started.wait, 1)
+
+        completion = asyncio.create_task(tracker.complete_tracking())
+        try:
+            await asyncio.sleep(0.02)
+            assert not completion.done()
+            release_periodic.set()
+            await asyncio.wait_for(completion, timeout=1)
+        finally:
+            release_periodic.set()
+            if not completion.done():
+                await asyncio.wait_for(completion, timeout=1)
+
+        assert writes == ["periodic", "complete"]
+
+    @pytest.mark.asyncio
+    async def test_periodic_pool_timeout_does_not_checkout_again_or_stop_tracking(
+        self, db_session, monkeypatch
+    ):
+        """A transient pool timeout is one failed write, not a second probe."""
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        attempts = 0
+
+        def write_with_one_timeout(*_args):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise SQLAlchemyTimeoutError("pool exhausted")
+            return True
+
+        tracker = TaskTracker(
+            task_id=123,
+            db_session=db_session,
+            update_interval_seconds=60,
+        )
+        await tracker.start_tracking()
+        monkeypatch.setattr(
+            tracker_module,
+            "_write_task_usage_sync",
+            write_with_one_timeout,
+        )
+        monkeypatch.setattr(
+            tracker_module,
+            "_new_short_session",
+            lambda: pytest.fail("periodic failure performed a second checkout"),
+        )
+
+        try:
+            await tracker.periodic_update()
+            assert tracker.is_tracking
+
+            await tracker.periodic_update()
+            assert tracker.is_tracking
+            assert attempts == 2
+        finally:
+            await tracker.stop_periodic_updates()
+
+    @pytest.mark.asyncio
+    async def test_final_pool_timeout_is_reported_to_the_lease_owner(
+        self, db_session, monkeypatch
+    ):
+        """The lease owner must be able to avoid a second checkout after timeout."""
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        attempts = 0
+
+        def final_write(*_args):
+            nonlocal attempts
+            attempts += 1
+            raise SQLAlchemyTimeoutError("pool exhausted")
+
+        tracker = TaskTracker(
+            task_id=123,
+            db_session=db_session,
+            update_interval_seconds=60,
+        )
+        await tracker.start_tracking()
+        monkeypatch.setattr(
+            tracker_module,
+            "_complete_task_usage_sync",
+            final_write,
+        )
+
+        with pytest.raises(SQLAlchemyTimeoutError, match="pool exhausted"):
+            await tracker.complete_tracking()
+
+        assert attempts == 1
+        assert not tracker.is_tracking
+
+    @pytest.mark.asyncio
+    async def test_periodic_missing_row_stops_tracking_without_a_followup_checkout(
+        self, db_session, monkeypatch
+    ):
+        """The write helper's False result is the only missing-row signal."""
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        tracker = TaskTracker(
+            task_id=123,
+            db_session=db_session,
+            update_interval_seconds=60,
+        )
+        await tracker.start_tracking()
+        monkeypatch.setattr(
+            tracker_module,
+            "_write_task_usage_sync",
+            lambda *_args: False,
+        )
+        monkeypatch.setattr(
+            tracker_module,
+            "_new_short_session",
+            lambda: pytest.fail("missing-row result performed a second checkout"),
+        )
+
+        try:
+            await tracker.periodic_update()
+            assert not tracker.is_tracking
+        finally:
+            await tracker.stop_periodic_updates()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_completion_drains_periodic_then_persists_final_usage(
+        self, db_session, monkeypatch
+    ):
+        """Cancellation is propagated only after stale writes can no longer win."""
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        periodic_started = threading.Event()
+        release_periodic = threading.Event()
+        writes = []
+
+        def blocking_periodic_write(*_args):
+            periodic_started.set()
+            assert release_periodic.wait(timeout=1)
+            writes.append("periodic")
+            return True
+
+        def final_write(*_args):
+            writes.append("complete")
+            return True
+
+        monkeypatch.setattr(
+            tracker_module,
+            "_write_task_usage_sync",
+            blocking_periodic_write,
+        )
+        monkeypatch.setattr(tracker_module, "_complete_task_usage_sync", final_write)
+
+        tracker = TaskTracker(
+            task_id=123,
+            db_session=db_session,
+            update_interval_seconds=0.01,
+        )
+        await tracker.start_tracking()
+        assert await asyncio.to_thread(periodic_started.wait, 1)
+
+        completion = asyncio.create_task(tracker.complete_tracking())
+        try:
+            await asyncio.sleep(0.02)
+            completion.cancel()
+            await asyncio.sleep(0.02)
+
+            assert not completion.done()
+            assert writes == []
+
+            release_periodic.set()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(completion, timeout=1)
+        finally:
+            release_periodic.set()
+            if not completion.done():
+                try:
+                    await asyncio.wait_for(asyncio.shield(completion), timeout=1)
+                except BaseException:
+                    pass
+
+        assert completion.cancelled()
+        assert writes == ["periodic", "complete"]
 
     @pytest.mark.asyncio
     async def test_complete_tracking_reports_only_current_turn_delta(self, db_session):
@@ -119,13 +620,13 @@ class TestTaskTracker:
         try:
             tracker = TaskTracker(task_id=123, db_session=db_session)
             # Before tracking starts, the checker is a no-op (fails open).
-            assert tracker.interrupt_reason_for_quota() is None
+            assert await tracker.interrupt_reason_for_quota() is None
             await tracker.start_tracking()
             add_token_usage(
                 input_tokens=10, output_tokens=5, model="m", call_type="chat"
             )
             add_tool_call_usage(2)
-            reason = tracker.interrupt_reason_for_quota()
+            reason = await tracker.interrupt_reason_for_quota()
         finally:
             quota_hooks.set_run_progress_gate_hook(None)
 
@@ -158,9 +659,9 @@ class TestTaskTracker:
             assert tracker._user_id == 7  # F1: cached at construction
             await tracker.start_tracking()
             with caplog.at_level(logging.WARNING):
-                assert tracker.interrupt_reason_for_quota() is None
-                assert tracker.interrupt_reason_for_quota() is None
-                assert tracker.interrupt_reason_for_quota() is None
+                assert await tracker.interrupt_reason_for_quota() is None
+                assert await tracker.interrupt_reason_for_quota() is None
+                assert await tracker.interrupt_reason_for_quota() is None
         finally:
             quota_hooks.set_run_progress_gate_hook(None)
 
@@ -255,7 +756,7 @@ class TestTaskTracker:
         assert "already being tracked" in mock_warning.call_args.args[0]
 
     @pytest.mark.asyncio
-    async def test_periodic_update(self, task_tracker):
+    async def test_periodic_update(self, task_tracker, db_session):
         """Test periodic database update."""
         await task_tracker.start_tracking()
 
@@ -266,12 +767,13 @@ class TestTaskTracker:
         await task_tracker.periodic_update()
 
         # Verify database was updated
-        task_tracker.task.input_tokens = 100
-        task_tracker.task.output_tokens = 50
-        task_tracker.task.total_tokens = 150
-        task_tracker.task.llm_calls = 1
-
-        task_tracker.db_session.commit.assert_called_once()
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        assert task.input_tokens == 100
+        assert task.output_tokens == 50
+        assert task.total_tokens == 150
+        assert task.llm_calls == 1
+        db_session.commit.assert_called_once()
+        db_session.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_periodic_update_not_tracking(self, task_tracker, caplog):
@@ -286,7 +788,7 @@ class TestTaskTracker:
         assert "not being tracked" in mock_warning.call_args.args[0]
 
     @pytest.mark.asyncio
-    async def test_complete_tracking(self, task_tracker):
+    async def test_complete_tracking(self, task_tracker, db_session):
         """Test completing tracking."""
         await task_tracker.start_tracking()
 
@@ -304,10 +806,15 @@ class TestTaskTracker:
         assert usage.llm_calls == 2
 
         # Verify database was updated
-        task_tracker.task.input_tokens = 250
-        task_tracker.task.output_tokens = 125
-        task_tracker.task.total_tokens = 375
-        task_tracker.task.llm_calls = 2
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        assert task.input_tokens == 250
+        assert task.output_tokens == 125
+        assert task.total_tokens == 375
+        assert task.llm_calls == 2
+        db_session.commit.assert_called_once()
+        # Final metering and the fenced task write share one worker-owned
+        # short-lived session, so cleanup closes exactly once.
+        db_session.close.assert_called_once_with()
 
         assert not task_tracker.is_tracking
 
@@ -371,8 +878,10 @@ class TestTaskTrackerManager:
         return TaskTrackerManager()
 
     @pytest.fixture
-    def mock_session(self):
+    def mock_session(self, monkeypatch):
         """Fixture providing a mock database session."""
+        from xagent.web.models import database
+
         session = MagicMock()
 
         # Mock Task object
@@ -381,6 +890,7 @@ class TestTaskTrackerManager:
         mock_task.status = TaskStatus.RUNNING
 
         session.query.return_value.filter.return_value.first.return_value = mock_task
+        monkeypatch.setattr(database, "get_session_local", lambda: lambda: session)
 
         return session
 
@@ -448,7 +958,7 @@ class TestTaskTrackerManager:
         assert usage is None
 
     @pytest.mark.asyncio
-    async def test_complete_all(self, manager):
+    async def test_complete_all(self, manager, mock_session):
         """Test completing all trackers."""
         # Create multiple trackers with independent token tracking
         # Note: In real usage, each task would have its own execution context
@@ -499,8 +1009,10 @@ class TestTaskTrackerIntegration:
     """Integration tests for TaskTracker with real token tracking."""
 
     @pytest.fixture
-    def db_session(self):
+    def db_session(self, monkeypatch):
         """Fixture providing a mock database session."""
+        from xagent.web.models import database
+
         session = MagicMock()
 
         mock_task = MagicMock(spec=Task)
@@ -513,6 +1025,7 @@ class TestTaskTrackerIntegration:
         mock_task.token_usage_details = None
 
         session.query.return_value.filter.return_value.first.return_value = mock_task
+        monkeypatch.setattr(database, "get_session_local", lambda: lambda: session)
 
         return session
 


### PR DESCRIPTION
## Summary

This change prevents synchronous database work from blocking the asyncio event loop when the SQLAlchemy connection pool is under pressure.

It introduces a shared cancellation-safe database boundary, moves task-runtime persistence into short-lived worker-owned sessions, and returns detached snapshots instead of carrying SQLAlchemy sessions or ORM objects across async/thread boundaries.

The same invariant is applied to task execution, A2A, `/v1` task APIs, authentication, personal-key agent management, and upload workflows.

Fixes #935.

## Confirmed incident behavior addressed

During the SG incident, the configured pool reached its limit:

```text
pool_size=10
max_overflow=20
pool_timeout=10s
```

The confirmed code amplification was:

1. task execution retained an outer session and then requested another connection while resolving execution scope;
2. after that checkout timed out, failure handling immediately requested another connection before releasing the outer session;
3. lease heartbeat, tracker, and cleanup paths performed synchronous database work from async code;
4. each synchronous pool wait blocked the main event loop, affecting unrelated requests such as login and health checks.

This change addresses those nested/repeated checkouts and event-loop stalls. It does not claim that execution-scope resolution initiated the original pool exhaustion or that every overlapping task continuously held a connection.

## Changes

### Shared async database boundary

- Add cancellation-safe helpers for running synchronous database operations in worker threads.
- Require worker operations to create, use, and close their own sessions.
- Return immutable or detached snapshots instead of ORM objects.
- Drain in-flight worker operations before propagating cancellation so late commits cannot race cleanup.
- Classify SQLAlchemy pool timeouts through the full exception chain.

### Task runtime and lifecycle

- Load task setup, execution scope, runtime identity, model configuration, reconstruction state, and execution recovery state through worker-owned snapshot boundaries.
- Reuse the same setup snapshot for normal construction and reconstruction instead of probing history and reloading runtime configuration through separate sessions.
- Resolve execution scope before the main execution session is opened and pass it into the runtime.
- Move task claim, lease acquisition, heartbeat, failure persistence, final settlement, pause/resume, command handling, and tracker writes off the event loop.
- Refactor `TaskTracker` to retain primitive identifiers and counters rather than a caller-owned session and ORM task.
- Avoid an immediate second checkout after a pool-timeout failure; retain the fenced lease for TTL recovery when capacity is still unavailable.
- Distinguish an owned terminal task from genuine lease ownership loss, allowing terminal state, lease release, and trigger projection to settle correctly.
- Stop delivery-status persistence from performing another checkout when scheduling-failure compensation itself cannot obtain a connection.
- Preserve task/run/runner fencing and terminal-state predicates across normal, retry, resume, cancellation, and failure paths.

### SDK, A2A, and API paths

- Move `/v1/chat/tasks` create, append, status, steps, file binding, and usage tracking database work into the shared worker-owned boundary.
- Create and claim a new A2A task together with its first message in one worker-owned transaction, so a failed initial checkout cannot leave an ownerless `PENDING` row.
- Make SDK and A2A task-start workflows drain committed work before propagating caller cancellation.
- Move A2A task reads, polling, resume, and cancel persistence off the event loop.
- Move agent-key and personal-key database lookup plus bcrypt verification off the event loop while preserving opaque authentication failures and timing symmetry.
- Return detached authentication identities instead of request-session ORM rows.
- Move personal-key `/v1/agents` management paths off the event loop: list, create, create from template, and runtime-key rotation.
- Protect one-shot runtime secrets across cancellation: receipts identify the exact undelivered key, compensation revokes only that key, and concurrent successful rotations remain intact.
- Materialize one-shot key responses before commit and avoid any post-commit ORM refresh or pool checkout.
- Keep `/v1/me` on the detached personal-key identity contract.
- Refactor JWT and `/v1` uploads into cancellation-safe local staging, durable storage, short database persistence, and compensating cleanup steps.
- Move agent/tool configuration and reconstruction database reads into detached snapshots used by their async consumers.

## Compatibility

- No database schema or migration changes.
- No connection-pool size, overflow, or timeout default changes.
- No public API response-shape changes.
- Existing owner/actor separation, task status semantics, run fencing, and lease ownership predicates are preserved.
- Authentication still returns the same opaque invalid-key contract.
- File and task authorization scopes remain unchanged.

## Verification

- `pre-commit run --all-files`: passed, including Ruff, formatting, mypy, Alembic head validation, frontend lint, and frontend type-check.
- All 40 changed test modules passed.
- Full `tests/web` CI-equivalent shard reached 100%; 9 environment-dependent tests were skipped (PostgreSQL URL, Pub/Sub emulator, and KB ingestion).
- Constrained-pool regressions cover event-loop responsiveness, A2A atomic creation, cancellation after commit, terminal/heartbeat races, reconstruction, authentication, uploads, SDK tasks, tracker, and lease settlement.
- One-shot-secret regressions cover post-commit cancellation, concurrent rotation, and a one-slot `QueuePool` with no post-commit checkout.
- `git diff --check`: passed.

### PostgreSQL load test

During development, the application was exercised against PostgreSQL 16 with the production-style pool configuration `10 / 20 / 10`, the real `/v1/chat/tasks` API, and a local fake OpenAI endpoint with a 12-second response delay.

| Scenario | Result | Responsiveness and pool behavior |
| --- | --- | --- |
| 43 overlapping task submissions | 43/43 accepted and 43/43 completed | Submission median `0.7582s` vs `6.99s` before; max `1.0432s` vs `8.2577s`; total `14.39s` vs `21.57s` |
| Event loop during the 43-task run | Remained responsive | Maximum ticker gap `0.1568s` vs `7.7239s`; health max `0.1565s` vs `7.9073s`; login 14/14 successful, max `0.3153s` |
| Pool during the 43-task run | Recovered cleanly | Peak checked out `22`, peak overflow `12`; longest checkout `0.2044s`; no checkout over one second; no idle-in-transaction sessions; final checked-out/overflow `0/0` |
| 31 concurrent task-status polls | 31/31 returned HTTP 200 | Median `0.2941s` vs `3.3893s`; max `0.4616s` vs `5.2593s` |
| Event loop during status polling | Remained responsive | Ticker max `3.94ms` vs `4.2523s`; health max `4.12ms` vs `521.95ms`; login `11.27ms` vs `4.7679s`; longest checkout `18.8ms` |
| Deliberate full-capacity exhaustion | All 30 connections held | Login failed after the configured `10.0082s` checkout timeout, while the event loop remained responsive (`6.47ms`) and health remained responsive (`6.22ms`); the pool returned to zero checked-out connections after release |

## Scope boundary

This change fixes the code-level amplification and failure-isolation behavior covered by #935.

It does not attempt to eliminate genuine capacity exhaustion. If all 30 connections are deliberately held, endpoints that require a database connection can still fail after the configured timeout. Admission control, task concurrency limits, reserved control-plane/login capacity, priority queues, and separate connection pools require a separate capacity-isolation design.

The MCP handshake issue tracked by #889 is also outside this change. This PR does not change MCP transport initialization or the external-network connection-holding behavior covered there.
