### PR TITLE
fix: persist omitted tool_categories as NULL instead of [] (#944)

### DIFF
--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -460,7 +460,7 @@ class AgentStore:
 
         for field, value in updates.items():
             if field == "tool_categories":
-                value = clean_tool_categories(value)
+                value = normalize_tool_categories(value)
             setattr(agent, field, value)
 
         self.db.commit()

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -108,12 +108,29 @@ def _assert_can_set_visibility(
         )
 
 
+def normalize_tool_categories(categories: Any) -> list[str] | None:
+    """Drop non-assignable categories while preserving ``None``.
+
+    ``None`` and ``[]`` are distinct at runtime
+    (:meth:`ToolSelectionSpec.from_raw`): ``None`` is the legacy
+    "unconfigured" value that keeps the full default tool set, while
+    ``[]`` means the caller explicitly selected zero tools. Write paths
+    must use this helper so an omitted selection is not persisted as
+    "zero tools" (issue #944).
+    """
+    parsed = ensure_list(categories)
+    if parsed is None:
+        return None
+    return [c for c in parsed if c not in AGENT_CONFIG_UNASSIGNABLE_CATEGORIES]
+
+
 def clean_tool_categories(categories: Any) -> list[str]:
-    return [
-        c
-        for c in (ensure_list(categories) or [])
-        if c not in AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
-    ]
+    """``normalize_tool_categories`` coerced for response payloads.
+
+    Response schemas type ``tool_categories`` as a non-optional list,
+    so ``None`` renders as ``[]`` here. Never use this on a write path.
+    """
+    return normalize_tool_categories(categories) or []
 
 
 def new_widget_key() -> str:
@@ -373,7 +390,7 @@ class AgentStore:
             models=models,
             knowledge_bases=knowledge_bases or [],
             skills=skills or [],
-            tool_categories=clean_tool_categories(tool_categories),
+            tool_categories=normalize_tool_categories(tool_categories),
             suggested_prompts=suggested_prompts or [],
             origin=origin,
             status=status,

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -962,6 +962,134 @@ class TestCreateAgentTool:
                 pass
 
     @pytest.mark.asyncio
+    async def test_create_agent_omitted_tool_categories_persists_none(self) -> None:
+        """Omitted ``tool_categories`` persists NULL, not ``[]`` (#944).
+
+        ``ToolSelectionSpec.from_raw`` reads ``None`` as the full default
+        tool set and ``[]`` as explicitly zero tools, so coercing the
+        omitted value to ``[]`` would create an agent with no tools.
+        """
+        db, db_path, SessionLocal = _create_session()
+        try:
+            user = User(username="testuser_no_cats", password_hash="x", is_admin=False)
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+            user_id = user.id
+            db.close()
+
+            mock_llm = Mock()
+            mock_llm.model_id = "gpt-4"
+
+            with patch(
+                "xagent.web.services.llm_utils.UserAwareModelStorage"
+            ) as mock_storage_class:
+                mock_storage = Mock()
+                mock_storage.get_configured_defaults.return_value = (
+                    mock_llm,
+                    None,
+                    None,
+                    None,
+                )
+                mock_storage_class.return_value = mock_storage
+
+                tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
+
+                result = await tool.run_json_async(
+                    {
+                        "name": "default_tools_agent",
+                        "description": "Agent without explicit tool selection",
+                        "instructions": "Agent without explicit tool selection",
+                    }
+                )
+
+                assert result["status"] == "success"
+
+                verify_db = SessionLocal()
+                try:
+                    agent = (
+                        verify_db.query(Agent)
+                        .filter(Agent.name == "default_tools_agent")
+                        .first()
+                    )
+                    assert agent is not None
+                    assert agent.tool_categories is None
+                finally:
+                    verify_db.close()
+
+        finally:
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_create_agent_explicit_empty_tool_categories_persists_empty(
+        self,
+    ) -> None:
+        """Explicit ``tool_categories=[]`` still persists ``[]`` (zero tools)."""
+        db, db_path, SessionLocal = _create_session()
+        try:
+            user = User(
+                username="testuser_empty_cats", password_hash="x", is_admin=False
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+            user_id = user.id
+            db.close()
+
+            mock_llm = Mock()
+            mock_llm.model_id = "gpt-4"
+
+            with patch(
+                "xagent.web.services.llm_utils.UserAwareModelStorage"
+            ) as mock_storage_class:
+                mock_storage = Mock()
+                mock_storage.get_configured_defaults.return_value = (
+                    mock_llm,
+                    None,
+                    None,
+                    None,
+                )
+                mock_storage_class.return_value = mock_storage
+
+                tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
+
+                result = await tool.run_json_async(
+                    {
+                        "name": "zero_tools_agent",
+                        "description": "Agent with explicitly zero tools",
+                        "instructions": "Agent with explicitly zero tools",
+                        "tool_categories": [],
+                    }
+                )
+
+                assert result["status"] == "success"
+
+                verify_db = SessionLocal()
+                try:
+                    agent = (
+                        verify_db.query(Agent)
+                        .filter(Agent.name == "zero_tools_agent")
+                        .first()
+                    )
+                    assert agent is not None
+                    assert agent.tool_categories == []
+                finally:
+                    verify_db.close()
+
+        finally:
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
     async def test_create_agent_duplicate_name_auto_renames(self) -> None:
         """Test that duplicate agent names are auto-renamed and created."""
         db, db_path, SessionLocal = _create_session()

--- a/tests/web/services/test_agent_store_tool_categories.py
+++ b/tests/web/services/test_agent_store_tool_categories.py
@@ -91,6 +91,64 @@ def test_add_agent_empty_tool_categories_persists_empty_list(
     assert agent.tool_categories == []
 
 
+def test_update_agent_fields_preserves_none_tool_categories(
+    db: Session, user_id: int
+) -> None:
+    store = AgentStore(db)
+    agent = store.add_agent(
+        user_id=user_id,
+        name="update-to-unconfigured",
+        description=None,
+        instructions=None,
+        tool_categories=["file"],
+    )
+    db.commit()
+
+    updated = store.update_agent_fields(
+        user_id, int(agent.id), {"tool_categories": None}
+    )
+    assert updated is not None
+    assert updated.tool_categories is None
+
+
+def test_update_agent_fields_keeps_empty_tool_categories(
+    db: Session, user_id: int
+) -> None:
+    store = AgentStore(db)
+    agent = store.add_agent(
+        user_id=user_id,
+        name="update-to-zero-tools",
+        description=None,
+        instructions=None,
+        tool_categories=["file"],
+    )
+    db.commit()
+
+    updated = store.update_agent_fields(user_id, int(agent.id), {"tool_categories": []})
+    assert updated is not None
+    assert updated.tool_categories == []
+
+
+def test_update_agent_fields_strips_unassignable_tool_categories(
+    db: Session, user_id: int
+) -> None:
+    store = AgentStore(db)
+    agent = store.add_agent(
+        user_id=user_id,
+        name="update-strips-unassignable",
+        description=None,
+        instructions=None,
+        tool_categories=[],
+    )
+    db.commit()
+
+    updated = store.update_agent_fields(
+        user_id, int(agent.id), {"tool_categories": ["file", "agent", "other"]}
+    )
+    assert updated is not None
+    assert updated.tool_categories == ["file"]
+
+
 def test_agent_response_dict_renders_null_as_empty_list(
     db: Session, user_id: int
 ) -> None:

--- a/tests/web/services/test_agent_store_tool_categories.py
+++ b/tests/web/services/test_agent_store_tool_categories.py
@@ -1,0 +1,106 @@
+"""Tool-categories persistence semantics in AgentStore (issue #944).
+
+``None`` and ``[]`` mean different things at runtime
+(``ToolSelectionSpec.from_raw``): ``None`` is the legacy "unconfigured"
+value that keeps the full default tool set, ``[]`` is explicitly zero
+tools. The store must preserve that distinction on writes while response
+payloads keep rendering ``None`` as ``[]``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+from xagent.web.services.agent_store import (
+    AgentStore,
+    clean_tool_categories,
+    normalize_tool_categories,
+)
+
+
+@pytest.fixture()
+def db() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def user_id(db: Session) -> int:
+    user = User(username="store_user", password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return int(user.id)
+
+
+def test_normalize_preserves_none() -> None:
+    assert normalize_tool_categories(None) is None
+
+
+def test_normalize_keeps_empty_list() -> None:
+    assert normalize_tool_categories([]) == []
+
+
+def test_normalize_strips_unassignable_categories() -> None:
+    assert normalize_tool_categories(["file", "agent", "other"]) == ["file"]
+
+
+def test_clean_coerces_none_for_responses() -> None:
+    assert clean_tool_categories(None) == []
+    assert clean_tool_categories(["file", "agent"]) == ["file"]
+
+
+def test_add_agent_omitted_tool_categories_persists_null(
+    db: Session, user_id: int
+) -> None:
+    agent = AgentStore(db).add_agent(
+        user_id=user_id,
+        name="unconfigured",
+        description=None,
+        instructions=None,
+    )
+    db.commit()
+    db.refresh(agent)
+    assert agent.tool_categories is None
+
+
+def test_add_agent_empty_tool_categories_persists_empty_list(
+    db: Session, user_id: int
+) -> None:
+    agent = AgentStore(db).add_agent(
+        user_id=user_id,
+        name="zero-tools",
+        description=None,
+        instructions=None,
+        tool_categories=[],
+    )
+    db.commit()
+    db.refresh(agent)
+    assert agent.tool_categories == []
+
+
+def test_agent_response_dict_renders_null_as_empty_list(
+    db: Session, user_id: int
+) -> None:
+    store = AgentStore(db)
+    agent = store.add_agent(
+        user_id=user_id,
+        name="unconfigured-response",
+        description=None,
+        instructions=None,
+    )
+    db.commit()
+    db.refresh(agent)
+    assert store.agent_to_response_dict(agent)["tool_categories"] == []


### PR DESCRIPTION
Fixes #944

## Problem

`clean_tool_categories` in `agent_store.py` coerced `None` to `[]` on the write path. At runtime, `ToolSelectionSpec.from_raw` treats the two values very differently:

- `tool_categories=None` → `_SpecAll` (legacy "unconfigured" — full default tool set)
- `tool_categories=[]` → `_SpecNone` (explicitly zero tools)

So a conversational-builder `create_agent` call that omitted `tool_categories` persisted the agent with `[]` and it ran with **zero tools**, contradicting the tool's own schema description ("If None, all tools are available"). The preview endpoint (`AgentPreviewRequest`) already documents the intended `None` vs `[]` semantics — this change aligns persistence with it.

## Fix

Split the helper in `agent_store.py`:

- **`normalize_tool_categories`** (new) — drops non-assignable categories (`agent`, `other`) but preserves `None`. Used by the write path (`add_agent`), so an omitted selection is persisted as NULL and keeps the full default tool set at runtime.
- **`clean_tool_categories`** — now delegates to the above and coerces `None` → `[]`. Kept for response payloads (`agent_to_response_dict`), whose schemas type `tool_categories` as a non-optional `list[str]`.

## Unaffected paths (verified)

- **Web create API**: `AgentCreateRequest.tool_categories` is a required `List[str]` — always sends a list.
- **Web / builder update**: both only include `tool_categories` in the updates dict when explicitly provided, so `update_agent_fields` never receives `None`.
- **v1 management service**: coerces `tool_categories or []` itself, matching its explicit-list contract.
- **Workforce manager creation**: passes an explicit `[]` (workers are injected via name allowlist).

## Tests

- New `tests/web/services/test_agent_store_tool_categories.py`: helper semantics (`None` preserved, `[]` kept, unassignable stripped), `add_agent` persists NULL / `[]` faithfully, response dict still renders NULL as `[]`.
- `tests/core/tools/test_create_agent_tool.py`: two new end-to-end builder cases — omitted `tool_categories` persists NULL; explicit `[]` persists `[]`.

## Pre-existing edge cases (intentionally out of scope)

- A NULL (all-tools) agent opened and saved in the web UI writes back `[]` — the UI selector renders NULL as empty. Same display behavior as today; a follow-up could make the response schema `Optional` to fix the round-trip.
- `promote_agent_to_team` validates `clean_tool_categories(agent.tool_categories)`, so a NULL agent validates an empty connector set. This matches today's behavior for legacy NULL rows.
