### PR TITLE
fix: optimize trigger switch state submission logic

### DIFF
--- a/frontend/src/components/build/agent-builder-triggers.test.tsx
+++ b/frontend/src/components/build/agent-builder-triggers.test.tsx
@@ -3,6 +3,35 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
+// Stable references across renders — an inline `t: (key) => key` (or a fresh
+// `apps: []`/`dispatch: vi.fn()`) recreated on every useI18n()/useMcpApps()/
+// useApp() call defeats every useCallback/useMemo keyed on it throughout the
+// real component tree (e.g. AgentTriggersDialog's loadRunsFor depends on
+// `t`), making dependent effects re-run on every render instead of only when
+// something real changed.
+const translateMock = vi.hoisted(() => (key: string) => key)
+const mcpAppsMock = vi.hoisted(() => ({ apps: [] as unknown[], getAppIcon: () => null }))
+const appContextMock = vi.hoisted(() => ({
+  state: {
+    messages: [],
+    traceEvents: [],
+    currentTask: null,
+    isProcessing: false,
+    isHistoryLoading: false,
+    taskId: null,
+    filePreview: { isOpen: false },
+    dagExecution: null,
+    steps: [],
+  },
+  setTaskId: vi.fn(),
+  sendMessage: vi.fn(),
+  dispatch: vi.fn(),
+  closeFilePreview: vi.fn(),
+  pauseTask: vi.fn(),
+  resumeTask: vi.fn(),
+  openFilePreview: vi.fn(),
+  requestStatus: vi.fn(),
+}))
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -25,27 +54,7 @@ vi.mock("@/lib/utils", async () => {
 })
 
 vi.mock("@/contexts/app-context-chat", () => ({
-  useApp: () => ({
-    state: {
-      messages: [],
-      traceEvents: [],
-      currentTask: null,
-      isProcessing: false,
-      isHistoryLoading: false,
-      taskId: null,
-      filePreview: { isOpen: false },
-      dagExecution: null,
-      steps: [],
-    },
-    setTaskId: vi.fn(),
-    sendMessage: vi.fn(),
-    dispatch: vi.fn(),
-    closeFilePreview: vi.fn(),
-    pauseTask: vi.fn(),
-    resumeTask: vi.fn(),
-    openFilePreview: vi.fn(),
-    requestStatus: vi.fn(),
-  }),
+  useApp: () => appContextMock,
 }))
 
 vi.mock("@/contexts/auth-context", () => ({
@@ -55,12 +64,12 @@ vi.mock("@/contexts/auth-context", () => ({
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     locale: "en",
-    t: (key: string) => key,
+    t: translateMock,
   }),
 }))
 
 vi.mock("@/contexts/mcp-apps-context", () => ({
-  useMcpApps: () => ({ apps: [], getAppIcon: () => null }),
+  useMcpApps: () => mcpAppsMock,
 }))
 
 vi.mock("@/lib/branding", () => ({
@@ -141,6 +150,7 @@ function jsonResponse(body: unknown): Response {
 }
 
 const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+const GMAIL_ACCOUNTS_URL = "http://api.local/api/cloud/accounts?provider=gmail"
 
 describe("AgentBuilder trigger summary cards", () => {
   const originalWebSocket = globalThis.WebSocket
@@ -346,5 +356,74 @@ describe("AgentBuilder trigger summary cards", () => {
     await waitFor(() => {
       expect(getCallsAfterFailure).toBeGreaterThan(0)
     })
+  })
+})
+
+describe("AgentBuilder trigger summary cards (agent not created yet)", () => {
+  const originalWebSocket = globalThis.WebSocket
+
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    globalThis.WebSocket = vi.fn() as unknown as typeof WebSocket
+
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === GMAIL_ACCOUNTS_URL) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url.endsWith("/api/kb/collections")) {
+        return Promise.resolve(jsonResponse({ collections: [] }))
+      }
+      if (url.endsWith("/api/tools/available")) {
+        return Promise.resolve(jsonResponse({ tools: [] }))
+      }
+      if (url.endsWith("/api/skills/") || url.endsWith("/api/mcp/servers")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url.endsWith("/api/models/?category=llm") || url.endsWith("/api/models/user-default")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it("disables a staged trigger type in place, without any network call, before the agent exists", async () => {
+    render(<AgentBuilder />)
+
+    // Stage an enabled webhook trigger via the dialog (no agentId yet, so
+    // creation only touches the parent-owned staged list, no API call).
+    fireEvent.click(await screen.findByText("triggers.builder.open"))
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.name")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+    await waitFor(() => {
+      expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    })
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
+
+    // The summary card appears once the staged trigger is enabled.
+    expect(await screen.findByText("triggers.cards.webhook.title")).toBeInTheDocument()
+    apiRequestMock.mockClear()
+
+    const cardSwitch = screen
+      .getAllByRole("switch")
+      .find((el) => el.getAttribute("aria-checked") === "true")
+    expect(cardSwitch).toBeDefined()
+    fireEvent.click(cardSwitch!)
+
+    // disableTriggerType's `!localAgentId` branch patches stagedTriggers
+    // directly — no PATCH/GET to any trigger endpoint.
+    await waitFor(() => {
+      expect(screen.queryByText("triggers.cards.webhook.title")).not.toBeInTheDocument()
+    })
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/triggers"),
+      expect.anything(),
+    )
   })
 })

--- a/frontend/src/components/build/agent-builder-triggers.test.tsx
+++ b/frontend/src/components/build/agent-builder-triggers.test.tsx
@@ -141,12 +141,33 @@ vi.mock("@/components/build/build-file-preview-sheet", () => ({
 }))
 
 import { AgentBuilder } from "./agent-builder"
+import type { AgentTrigger } from "@/lib/agent-triggers-api"
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   })
+}
+
+function makeTrigger(overrides: Partial<AgentTrigger> & { id: number }): AgentTrigger {
+  return {
+    user_id: 1,
+    agent_id: 42,
+    type: "webhook",
+    name: "Trigger",
+    enabled: true,
+    config: {},
+    prompt_template: null,
+    webhook_token: "tok",
+    webhook_secret: null,
+    next_run_at: null,
+    last_run_at: null,
+    last_error: null,
+    created_at: null,
+    updated_at: null,
+    ...overrides,
+  }
 }
 
 const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
@@ -159,25 +180,7 @@ describe("AgentBuilder trigger summary cards", () => {
     apiRequestMock.mockReset()
     globalThis.WebSocket = vi.fn() as unknown as typeof WebSocket
 
-    let triggers = [
-      {
-        id: 9,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "API / Webhook",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: "tok",
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
-    ]
+    let triggers = [makeTrigger({ id: 9, name: "API / Webhook" })]
 
     apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
       if (url === "http://api.local/api/agents/42") {
@@ -258,40 +261,8 @@ describe("AgentBuilder trigger summary cards", () => {
 
   it("resyncs the summary via refreshTriggerSummary when a batch disable partially fails", async () => {
     let triggers = [
-      {
-        id: 9,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "Hook A",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: "tok",
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
-      {
-        id: 10,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "Hook B",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: "tok",
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
+      makeTrigger({ id: 9, name: "Hook A" }),
+      makeTrigger({ id: 10, name: "Hook B" }),
     ]
     let getCallsAfterFailure = 0
     let patchAttempted = false

--- a/frontend/src/components/build/agent-builder-triggers.test.tsx
+++ b/frontend/src/components/build/agent-builder-triggers.test.tsx
@@ -245,4 +245,106 @@ describe("AgentBuilder trigger summary cards", () => {
       expect(screen.queryByText("triggers.cards.webhook.title")).not.toBeInTheDocument()
     })
   })
+
+  it("resyncs the summary via refreshTriggerSummary when a batch disable partially fails", async () => {
+    let triggers = [
+      {
+        id: 9,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "Hook A",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: "tok",
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+      {
+        id: 10,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "Hook B",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: "tok",
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+    ]
+    let getCallsAfterFailure = 0
+    let patchAttempted = false
+
+    apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "http://api.local/api/agents/42") {
+        return Promise.resolve(
+          jsonResponse({
+            id: 42,
+            name: "Trigger agent",
+            description: "",
+            instructions: "",
+            execution_mode: "balanced",
+            suggested_prompts: [],
+            visibility: "team",
+            team_id: null,
+            knowledge_bases: [],
+            skills: [],
+            tool_categories: [],
+            can_edit: true,
+          }),
+        )
+      }
+      if (url === TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        if (patchAttempted) getCallsAfterFailure += 1
+        return Promise.resolve(jsonResponse(triggers))
+      }
+      if (url === `${TRIGGERS_URL}/9` && init?.method === "PATCH") {
+        triggers = triggers.map((item) => (item.id === 9 ? { ...item, enabled: false } : item))
+        return Promise.resolve(jsonResponse(triggers[0]))
+      }
+      if (url === `${TRIGGERS_URL}/10` && init?.method === "PATCH") {
+        patchAttempted = true
+        return Promise.reject(new Error("boom"))
+      }
+      if (url.endsWith("/api/kb/collections")) {
+        return Promise.resolve(jsonResponse({ collections: [] }))
+      }
+      if (url.endsWith("/api/tools/available")) {
+        return Promise.resolve(jsonResponse({ tools: [] }))
+      }
+      if (url.endsWith("/api/skills/") || url.endsWith("/api/mcp/servers")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url.endsWith("/api/models/?category=llm") || url.endsWith("/api/models/user-default")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+
+    render(<AgentBuilder agentId="42" />)
+
+    const cardSwitch = (
+      await screen.findAllByRole("switch")
+    ).find((el) => el.getAttribute("aria-checked") === "true")
+    expect(cardSwitch).toBeDefined()
+    fireEvent.click(cardSwitch!)
+
+    // One PATCH in the batch rejected: disableTriggerType's catch resyncs via
+    // refreshTriggerSummary (a fresh GET) instead of trusting the optimistic
+    // merge, which would otherwise wrongly report both hooks disabled.
+    await waitFor(() => {
+      expect(getCallsAfterFailure).toBeGreaterThan(0)
+    })
+  })
 })

--- a/frontend/src/components/build/agent-builder-triggers.test.tsx
+++ b/frontend/src/components/build/agent-builder-triggers.test.tsx
@@ -1,0 +1,248 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://api.local",
+    getWsUrl: () => "ws://api.local",
+  }
+})
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    state: {
+      messages: [],
+      traceEvents: [],
+      currentTask: null,
+      isProcessing: false,
+      isHistoryLoading: false,
+      taskId: null,
+      filePreview: { isOpen: false },
+      dagExecution: null,
+      steps: [],
+    },
+    setTaskId: vi.fn(),
+    sendMessage: vi.fn(),
+    dispatch: vi.fn(),
+    closeFilePreview: vi.fn(),
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    openFilePreview: vi.fn(),
+    requestStatus: vi.fn(),
+  }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token" }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => ({ apps: [], getAppIcon: () => null }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("@/components/layout/resizable-three-column-layout", () => ({
+  ResizableThreeColumnLayout: ({ middlePanel, rightPanel }: { middlePanel: React.ReactNode; rightPanel: React.ReactNode }) => (
+    <div>
+      <div data-testid="middle-panel">{middlePanel}</div>
+      <div data-testid="right-panel">{rightPanel}</div>
+    </div>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => null,
+}))
+
+vi.mock("@/components/build/agent-builder-chat", () => ({
+  AgentBuilderChat: () => null,
+}))
+
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+
+vi.mock("@/components/mcp/connect-mcp-dialog", () => ({
+  ConnectMcpDialog: () => null,
+}))
+
+vi.mock("@/components/chat/FileMentionDropdown", () => ({
+  FileMentionDropdown: () => null,
+}))
+
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    isOpen: false,
+    items: [],
+    selectedIndex: 0,
+    selectItem: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+
+vi.mock("@/components/ui/multi-select", () => ({
+  MultiSelect: () => null,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: () => null,
+}))
+
+vi.mock("@/components/build/build-file-preview-sheet", () => ({
+  BuildFilePreviewSheet: () => null,
+}))
+
+import { AgentBuilder } from "./agent-builder"
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+
+describe("AgentBuilder trigger summary cards", () => {
+  const originalWebSocket = globalThis.WebSocket
+
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    globalThis.WebSocket = vi.fn() as unknown as typeof WebSocket
+
+    let triggers = [
+      {
+        id: 9,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "API / Webhook",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: "tok",
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+    ]
+
+    apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "http://api.local/api/agents/42") {
+        return Promise.resolve(
+          jsonResponse({
+            id: 42,
+            name: "Trigger agent",
+            description: "",
+            instructions: "",
+            execution_mode: "balanced",
+            suggested_prompts: [],
+            visibility: "team",
+            team_id: null,
+            knowledge_bases: [],
+            skills: [],
+            tool_categories: [],
+            can_edit: true,
+          }),
+        )
+      }
+      if (url === TRIGGERS_URL) {
+        return Promise.resolve(jsonResponse(triggers))
+      }
+      if (url === `${TRIGGERS_URL}/9` && init?.method === "PATCH") {
+        triggers = triggers.map((item) => ({ ...item, enabled: false }))
+        return Promise.resolve(jsonResponse(triggers[0]))
+      }
+      if (url.endsWith("/api/kb/collections")) {
+        return Promise.resolve(jsonResponse({ collections: [] }))
+      }
+      if (url.endsWith("/api/tools/available")) {
+        return Promise.resolve(jsonResponse({ tools: [] }))
+      }
+      if (url.endsWith("/api/skills/") || url.endsWith("/api/mcp/servers")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url.endsWith("/api/models/?category=llm") || url.endsWith("/api/models/user-default")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it("disables the trigger type in place when its card switch is toggled off", async () => {
+    render(<AgentBuilder agentId="42" />)
+
+    // The webhook summary card shows up once the trigger list loads.
+    expect(await screen.findByText("triggers.cards.webhook.title")).toBeInTheDocument()
+
+    const cardSwitch = screen
+      .getAllByRole("switch")
+      .find((el) => el.getAttribute("aria-checked") === "true")
+    expect(cardSwitch).toBeDefined()
+    fireEvent.click(cardSwitch!)
+
+    // Toggling off patches the trigger directly instead of opening the dialog.
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        `${TRIGGERS_URL}/9`,
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ enabled: false }),
+        }),
+      )
+    })
+    expect(screen.queryByText("triggers.subtitle")).not.toBeInTheDocument()
+
+    // The card disappears after the refreshed summary reports 0 enabled.
+    await waitFor(() => {
+      expect(screen.queryByText("triggers.cards.webhook.title")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -57,7 +57,9 @@ import {
   StagedTrigger,
   createAgentTrigger,
   createStagedTriggers,
+  disableAgentTriggersOfType,
   listAgentTriggers,
+  mergeUpdatedTriggers,
   stagedToCreatePayload,
   stagedToPseudoTrigger,
 } from "@/lib/agent-triggers-api"
@@ -425,6 +427,40 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const dismissWebhookSecrets = () => {
     setCreatedWebhookSecrets([])
     reconcileDeferredNavigation(failedStagedTriggers, [])
+  }
+
+  // Builder card switch: toggling it off disables every enabled trigger of
+  // that type in place — no dialog. The card disappears afterwards because
+  // the summary section only lists types with enabled > 0. A Set (not a
+  // single value) so two types disabling concurrently keep their own guard.
+  const [disablingTriggerTypes, setDisablingTriggerTypes] = useState<ReadonlySet<AgentTriggerType>>(
+    new Set(),
+  )
+  const disableTriggerType = async (type: AgentTriggerType) => {
+    if (!localAgentId) {
+      setStagedTriggers((prev) =>
+        prev.map((item) => (item.type === type ? { ...item, enabled: false } : item)),
+      )
+      toast.success(t("triggers.messages.disabled"))
+      return
+    }
+    setDisablingTriggerTypes((prev) => new Set(prev).add(type))
+    try {
+      const updated = await disableAgentTriggersOfType(localAgentId, triggerSummary, type)
+      setTriggerSummary((prev) => mergeUpdatedTriggers(prev, updated))
+      toast.success(t("triggers.messages.disabled"))
+    } catch (error) {
+      console.error(error)
+      toast.error(error instanceof Error ? error.message : t("triggers.messages.saveFailed"))
+      // A partial failure may have disabled some triggers; resync the summary.
+      void refreshTriggerSummary()
+    } finally {
+      setDisablingTriggerTypes((prev) => {
+        const next = new Set(prev)
+        next.delete(type)
+        return next
+      })
+    }
   }
 
   // During creation the agent has no server-side triggers yet; the summary
@@ -2438,7 +2474,14 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                           </div>
                         </div>
                       </button>
-                      <Switch checked onCheckedChange={openDialog} className="scale-75" />
+                      <Switch
+                        checked
+                        disabled={disablingTriggerTypes.has(item.type)}
+                        onCheckedChange={(checked) => {
+                          if (!checked) void disableTriggerType(item.type)
+                        }}
+                        className="scale-75"
+                      />
                       <Button
                         type="button"
                         variant="ghost"
@@ -2857,10 +2900,11 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         open={isTriggersDialogOpen}
         onOpenChange={(dialogOpen) => {
           setIsTriggersDialogOpen(dialogOpen)
-          if (!dialogOpen) {
-            setTriggerDialogInitialType(null)
-            void refreshTriggerSummary()
-          }
+          // No refetch here: every mutation inside the dialog already calls
+          // onChanged (refreshTriggerSummary) as it happens, so closing the
+          // dialog has nothing left to resync — doing it anyway doubled the
+          // request for every Done/dismiss that just committed an edit.
+          if (!dialogOpen) setTriggerDialogInitialType(null)
         }}
         onChanged={refreshTriggerSummary}
         initialType={triggerDialogInitialType}

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@/lib/clipboard", () => ({
 }))
 
 import { AgentTriggersDialog } from "./agent-triggers-dialog"
-import type { StagedTrigger } from "@/lib/agent-triggers-api"
+import type { AgentTrigger, StagedTrigger } from "@/lib/agent-triggers-api"
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -54,25 +54,15 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
   })
 }
 
-const GMAIL_ACCOUNTS_URL = "http://api.local/api/cloud/accounts?provider=gmail"
-
-describe("AgentTriggersDialog", () => {
-  let gmailAccounts: Array<{ id: number; provider: string; email: string | null }>
-
-  const baseTrigger9 = {
-    id: 9,
+function makeTrigger(overrides: Partial<AgentTrigger> & { id: number }): AgentTrigger {
+  return {
     user_id: 1,
     agent_id: 42,
-    type: "gmail" as const,
-    name: "Support inbox",
+    type: "webhook",
+    name: "Trigger",
     enabled: true,
-    config: {
-      watch_label: "INBOX",
-      sender_filter: "boss@company.com",
-      subject_keyword: "urgent",
-      oauth_account_id: 7,
-    },
-    prompt_template: "Reply to {{payload}}",
+    config: {},
+    prompt_template: null,
     webhook_token: null,
     webhook_secret: null,
     next_run_at: null,
@@ -80,7 +70,27 @@ describe("AgentTriggersDialog", () => {
     last_error: null,
     created_at: null,
     updated_at: null,
+    ...overrides,
   }
+}
+
+const GMAIL_ACCOUNTS_URL = "http://api.local/api/cloud/accounts?provider=gmail"
+
+describe("AgentTriggersDialog", () => {
+  let gmailAccounts: Array<{ id: number; provider: string; email: string | null }>
+
+  const baseTrigger9 = makeTrigger({
+    id: 9,
+    type: "gmail",
+    name: "Support inbox",
+    config: {
+      watch_label: "INBOX",
+      sender_filter: "boss@company.com",
+      subject_keyword: "urgent",
+      oauth_account_id: 7,
+    },
+    prompt_template: "Reply to {{payload}}",
+  })
 
   beforeEach(() => {
     apiRequestMock.mockReset()
@@ -352,23 +362,14 @@ describe("AgentTriggersDialog", () => {
       }
       if (url === "http://api.local/api/agents/42/triggers" && options?.method === "POST") {
         return Promise.resolve(
-          jsonResponse({
-            id: 11,
-            user_id: 1,
-            agent_id: 42,
-            type: "webhook",
-            name: "API / Webhook",
-            enabled: true,
-            config: {},
-            prompt_template: null,
-            webhook_token: "tok",
-            webhook_secret: "wh_secret_once",
-            next_run_at: null,
-            last_run_at: null,
-            last_error: null,
-            created_at: null,
-            updated_at: null,
-          }),
+          jsonResponse(
+            makeTrigger({
+              id: 11,
+              name: "API / Webhook",
+              webhook_token: "tok",
+              webhook_secret: "wh_secret_once",
+            }),
+          ),
         )
       }
       return Promise.resolve(jsonResponse([]))
@@ -454,23 +455,14 @@ describe("AgentTriggersDialog", () => {
       }
       if (url === "http://api.local/api/agents/42/triggers" && options?.method === "POST") {
         return Promise.resolve(
-          jsonResponse({
-            id: 12,
-            user_id: 1,
-            agent_id: 42,
-            type: "webhook",
-            name: "API / Webhook",
-            enabled: true,
-            config: {},
-            prompt_template: null,
-            webhook_token: "tok",
-            webhook_secret: "wh_escape_secret",
-            next_run_at: null,
-            last_run_at: null,
-            last_error: null,
-            created_at: null,
-            updated_at: null,
-          }),
+          jsonResponse(
+            makeTrigger({
+              id: 12,
+              name: "API / Webhook",
+              webhook_token: "tok",
+              webhook_secret: "wh_escape_secret",
+            }),
+          ),
         )
       }
       return Promise.resolve(jsonResponse([]))
@@ -556,40 +548,8 @@ describe("AgentTriggersDialog", () => {
       if (url === TRIGGERS_URL) {
         return Promise.resolve(
           jsonResponse([
-            {
-              id: 20,
-              user_id: 1,
-              agent_id: 42,
-              type: "webhook",
-              name: "Backup hook",
-              enabled: true,
-              config: {},
-              prompt_template: null,
-              webhook_token: null,
-              webhook_secret: null,
-              next_run_at: null,
-              last_run_at: null,
-              last_error: null,
-              created_at: null,
-              updated_at: null,
-            },
-            {
-              id: 21,
-              user_id: 1,
-              agent_id: 42,
-              type: "webhook",
-              name: "Primary hook",
-              enabled: true,
-              config: {},
-              prompt_template: null,
-              webhook_token: null,
-              webhook_secret: null,
-              next_run_at: null,
-              last_run_at: null,
-              last_error: null,
-              created_at: null,
-              updated_at: null,
-            },
+            makeTrigger({ id: 20, name: "Backup hook" }),
+            makeTrigger({ id: 21, name: "Primary hook" }),
           ]),
         )
       }
@@ -647,40 +607,8 @@ describe("AgentTriggersDialog", () => {
   it("resyncs the trigger list when a batch disable partially fails", async () => {
     const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
     let triggers = [
-      {
-        id: 30,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "Hook A",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: null,
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
-      {
-        id: 31,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "Hook B",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: null,
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
+      makeTrigger({ id: 30, name: "Hook A" }),
+      makeTrigger({ id: 31, name: "Hook B" }),
     ]
     let getCallsAfterFailure = 0
     let patchAttempted = false
@@ -730,40 +658,8 @@ describe("AgentTriggersDialog", () => {
   it("keeps each overview switch's busy guard independent across two types toggled back-to-back", async () => {
     const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
     const triggers = [
-      {
-        id: 40,
-        user_id: 1,
-        agent_id: 42,
-        type: "webhook",
-        name: "Hook",
-        enabled: true,
-        config: {},
-        prompt_template: null,
-        webhook_token: null,
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
-      {
-        id: 41,
-        user_id: 1,
-        agent_id: 42,
-        type: "scheduled",
-        name: "Schedule",
-        enabled: true,
-        config: { interval_seconds: 3600 },
-        prompt_template: null,
-        webhook_token: null,
-        webhook_secret: null,
-        next_run_at: null,
-        last_run_at: null,
-        last_error: null,
-        created_at: null,
-        updated_at: null,
-      },
+      makeTrigger({ id: 40, name: "Hook" }),
+      makeTrigger({ id: 41, type: "scheduled", name: "Schedule", config: { interval_seconds: 3600 } }),
     ]
 
     let resolveWebhookPatch: ((value: Response) => void) | undefined

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -59,46 +59,51 @@ const GMAIL_ACCOUNTS_URL = "http://api.local/api/cloud/accounts?provider=gmail"
 describe("AgentTriggersDialog", () => {
   let gmailAccounts: Array<{ id: number; provider: string; email: string | null }>
 
+  const baseTrigger9 = {
+    id: 9,
+    user_id: 1,
+    agent_id: 42,
+    type: "gmail" as const,
+    name: "Support inbox",
+    enabled: true,
+    config: {
+      watch_label: "INBOX",
+      sender_filter: "boss@company.com",
+      subject_keyword: "urgent",
+      oauth_account_id: 7,
+    },
+    prompt_template: "Reply to {{payload}}",
+    webhook_token: null,
+    webhook_secret: null,
+    next_run_at: null,
+    last_run_at: null,
+    last_error: null,
+    created_at: null,
+    updated_at: null,
+  }
+
   beforeEach(() => {
     apiRequestMock.mockReset()
     routerPushMock.mockReset()
     gmailAccounts = [
       { id: 7, provider: "gmail", email: "gerard.santos@gmail.com" },
     ]
-    apiRequestMock.mockImplementation((url: string) => {
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string; body?: string }) => {
       if (url === GMAIL_ACCOUNTS_URL) {
         return Promise.resolve(jsonResponse(gmailAccounts))
       }
       if (url === "http://api.local/api/agents/42/triggers") {
-        return Promise.resolve(
-          jsonResponse([
-            {
-              id: 9,
-              user_id: 1,
-              agent_id: 42,
-              type: "gmail",
-              name: "Support inbox",
-              enabled: true,
-              config: {
-                watch_label: "INBOX",
-                sender_filter: "boss@company.com",
-                subject_keyword: "urgent",
-                oauth_account_id: 7,
-              },
-              prompt_template: "Reply to {{payload}}",
-              webhook_token: null,
-              webhook_secret: null,
-              next_run_at: null,
-              last_run_at: null,
-              last_error: null,
-              created_at: null,
-              updated_at: null,
-            },
-          ]),
-        )
+        return Promise.resolve(jsonResponse([baseTrigger9]))
       }
       if (url === "http://api.local/api/agents/42/triggers/9/runs") {
         return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers/9" && init?.method === "PATCH") {
+        // Echo the base trigger merged with the PATCH body, like a real
+        // backend would — a bare `[]` fallback here would make `updated`
+        // shapeless for any code that reads fields off the response.
+        const patch = init.body ? JSON.parse(init.body) : {}
+        return Promise.resolve(jsonResponse({ ...baseTrigger9, ...patch }))
       }
       return Promise.resolve(jsonResponse([]))
     })
@@ -296,6 +301,48 @@ describe("AgentTriggersDialog", () => {
       )
     })
     expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("reconciles the detail switch from the PATCH response, not just the requested value", async () => {
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse(gmailAccounts))
+      if (url === "http://api.local/api/agents/42/triggers") {
+        return Promise.resolve(jsonResponse([baseTrigger9]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers/9/runs") {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers/9" && init?.method === "PATCH") {
+        // A backend that (hypothetically) overrides the requested value —
+        // the switch must reflect this, not the optimistic `checked` it was
+        // set to before the request resolved.
+        return Promise.resolve(jsonResponse({ ...baseTrigger9, enabled: true }))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: true, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.gmail.title"))
+    await screen.findByLabelText("triggers.form.watchLabel")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(detailSwitch)
+
+    // Optimistic: flips to false immediately.
+    expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+    // Reconciled: the response said `enabled: true`, so it flips back.
+    await waitFor(() => {
+      expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    })
   })
 
   it("shows the one-time webhook secret on the overview after a quick-toggle create", async () => {
@@ -677,6 +724,105 @@ describe("AgentTriggersDialog", () => {
     })
     await waitFor(() => {
       expect(getCallsAfterFailure).toBeGreaterThan(0)
+    })
+  })
+
+  it("keeps each overview switch's busy guard independent across two types toggled back-to-back", async () => {
+    const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+    const triggers = [
+      {
+        id: 40,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "Hook",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: null,
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+      {
+        id: 41,
+        user_id: 1,
+        agent_id: 42,
+        type: "scheduled",
+        name: "Schedule",
+        enabled: true,
+        config: { interval_seconds: 3600 },
+        prompt_template: null,
+        webhook_token: null,
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+    ]
+
+    let resolveWebhookPatch: ((value: Response) => void) | undefined
+    const webhookPatchPromise = new Promise<Response>((resolve) => {
+      resolveWebhookPatch = resolve
+    })
+    let resolveScheduledPatch: ((value: Response) => void) | undefined
+    const scheduledPatchPromise = new Promise<Response>((resolve) => {
+      resolveScheduledPatch = resolve
+    })
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse([]))
+      if (url === TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse(triggers))
+      }
+      if (url === `${TRIGGERS_URL}/40` && init?.method === "PATCH") return webhookPatchPromise
+      if (url === `${TRIGGERS_URL}/41` && init?.method === "PATCH") return scheduledPatchPromise
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    // TRIGGER_TYPES order is webhook, scheduled, gmail.
+    const [webhookSwitch, scheduledSwitch] = await screen.findAllByRole("switch")
+    expect(webhookSwitch).toHaveAttribute("aria-checked", "true")
+    expect(scheduledSwitch).toHaveAttribute("aria-checked", "true")
+
+    fireEvent.click(webhookSwitch)
+    await waitFor(() => {
+      expect(webhookSwitch).toBeDisabled()
+    })
+    expect(scheduledSwitch).not.toBeDisabled()
+
+    fireEvent.click(scheduledSwitch)
+    await waitFor(() => {
+      expect(scheduledSwitch).toBeDisabled()
+    })
+
+    // Resolve the scheduled toggle first. A scalar busy-guard would have
+    // cleared entirely here and wrongly re-enabled webhook's switch while
+    // its own PATCH was still in flight — the Set-based guard keeps them
+    // independent.
+    resolveScheduledPatch?.(jsonResponse({ ...triggers[1], enabled: false }))
+    await waitFor(() => {
+      expect(scheduledSwitch).not.toBeDisabled()
+    })
+    expect(webhookSwitch).toBeDisabled()
+
+    resolveWebhookPatch?.(jsonResponse({ ...triggers[0], enabled: false }))
+    await waitFor(() => {
+      expect(webhookSwitch).not.toBeDisabled()
     })
   })
 

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -29,11 +29,14 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock }),
 }))
 
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+}))
+
 vi.mock("@/components/ui/sonner", () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
+  toast: toastMocks,
 }))
 
 vi.mock("@/lib/clipboard", () => ({
@@ -265,6 +268,260 @@ describe("AgentTriggersDialog", () => {
 
     expect(await screen.findByText("triggers.gmail.accountMissing")).toBeInTheDocument()
   })
+
+  it("persists the detail switch immediately without pressing save", async () => {
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: true, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.gmail.title"))
+    await screen.findByLabelText("triggers.form.watchLabel")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/agents/42/triggers/9",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ enabled: false }),
+        }),
+      )
+    })
+    expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("shows the one-time webhook secret on the overview after a quick-toggle create", async () => {
+    apiRequestMock.mockImplementation((url: string, options?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers" && options?.method === "POST") {
+        return Promise.resolve(
+          jsonResponse({
+            id: 11,
+            user_id: 1,
+            agent_id: 42,
+            type: "webhook",
+            name: "API / Webhook",
+            enabled: true,
+            config: {},
+            prompt_template: null,
+            webhook_token: "tok",
+            webhook_secret: "wh_secret_once",
+            next_run_at: null,
+            last_run_at: null,
+            last_error: null,
+            created_at: null,
+            updated_at: null,
+          }),
+        )
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    await screen.findByText("triggers.cards.webhook.title")
+    const [webhookSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(webhookSwitch)
+
+    // The secret alert appears on the overview itself — no navigation happens.
+    expect(await screen.findByText("wh_secret_once")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "common.back" })).not.toBeInTheDocument()
+  })
+
+  it("calls onChanged exactly once for a Done that commits an edit (no redundant refetch on close)", async () => {
+    // Mirrors the builder's wiring: onChanged is the sole resync signal:
+    // onOpenChange(false) must not ALSO trigger a refetch, or every Done
+    // commits fires the same GET twice.
+    const onChanged = vi.fn()
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        onChanged={onChanged}
+        gmailConnection={{ isConnected: true, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.gmail.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    fireEvent.change(nameInput, { target: { value: "Renamed inbox" } })
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
+
+    await waitFor(() => {
+      expect(onChanged).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("creates the trigger when the switch is turned on in the creation state (live)", async () => {
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: true, connectedAccount: null }}
+      />,
+    )
+
+    // The webhook type has no triggers yet, so this opens the creation form.
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.secret")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/agents/42/triggers",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("\"enabled\":true"),
+        }),
+      )
+    })
+  })
+
+  it("keeps the dialog open on Escape when a fresh create just revealed a webhook secret", async () => {
+    const onOpenChange = vi.fn()
+    apiRequestMock.mockImplementation((url: string, options?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers" && options?.method === "POST") {
+        return Promise.resolve(
+          jsonResponse({
+            id: 12,
+            user_id: 1,
+            agent_id: 42,
+            type: "webhook",
+            name: "API / Webhook",
+            enabled: true,
+            config: {},
+            prompt_template: null,
+            webhook_token: "tok",
+            webhook_secret: "wh_escape_secret",
+            next_run_at: null,
+            last_run_at: null,
+            last_error: null,
+            created_at: null,
+            updated_at: null,
+          }),
+        )
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={onOpenChange}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.secret")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+
+    expect(await screen.findByText("wh_escape_secret")).toBeInTheDocument()
+
+    // Escape must not drop a secret that only exists because it was just
+    // generated — unlike an ordinary validation failure, it is unrecoverable.
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
+    await waitFor(() => {
+      expect(screen.getByText("wh_escape_secret")).toBeInTheDocument()
+    })
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    // Only once the secret is explicitly acknowledged does Escape close.
+    fireEvent.click(screen.getByRole("button", { name: "triggers.secret.dismiss" }))
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it("clears the dirty flag when the Gmail quick-toggle intent is reversed, so Done closes cleanly", async () => {
+    const onOpenChange = vi.fn()
+    // Zero connected accounts: the quick toggle must open the creation form
+    // instead of silently auto-binding (the default mock has exactly one).
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse([]))
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={onOpenChange}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    await screen.findByText("triggers.cards.webhook.title")
+    const switches = screen.getAllByRole("switch")
+    fireEvent.click(switches[2]) // Gmail card: no accounts connected
+
+    await screen.findByLabelText("triggers.form.watchLabel")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+
+    // Reverse the intent before picking an account.
+    fireEvent.click(detailSwitch)
+    expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+
+    // Nothing else was edited, so Done must close without attempting (and
+    // failing) a phantom create.
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it("keeps unsaved field edits when the detail switch is toggled", async () => {
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: true, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.gmail.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    fireEvent.change(nameInput, { target: { value: "Edited but unsaved" } })
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+    })
+    expect(nameInput).toHaveValue("Edited but unsaved")
+  })
 })
 
 describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
@@ -294,6 +551,36 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
     return onChange
   }
 
+  // Unlike renderStaging's vi.fn(), this harness feeds onChange back into the
+  // staged prop like agent-builder does, so list updates round-trip and the
+  // form-sync behavior under real re-renders is exercised.
+  function StatefulStagingHarness({
+    initial,
+    onChangeSpy,
+    onOpenChange,
+  }: {
+    initial: StagedTrigger[]
+    onChangeSpy?: (next: StagedTrigger[]) => void
+    onOpenChange?: (open: boolean) => void
+  }) {
+    const [triggers, setTriggers] = React.useState(initial)
+    return (
+      <AgentTriggersDialog
+        agentId={null}
+        open
+        onOpenChange={onOpenChange ?? vi.fn()}
+        staged={{
+          triggers,
+          onChange: (next) => {
+            onChangeSpy?.(next)
+            setTriggers(next)
+          },
+        }}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />
+    )
+  }
+
   beforeEach(() => {
     apiRequestMock.mockReset()
     apiRequestMock.mockResolvedValue(jsonResponse([]))
@@ -321,6 +608,59 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
         }),
       ])
     })
+
+    // The toggle stays on the overview instead of jumping into the config view.
+    expect(screen.getByText("triggers.staging.info")).toBeInTheDocument()
+    expect(screen.queryByLabelText("triggers.form.name")).not.toBeInTheDocument()
+  })
+
+  it("starts a new trigger form with the switch off, matching the overview", async () => {
+    renderStaging([])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.name")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("stages the trigger when the switch is turned on in the creation state", async () => {
+    const onChange = renderStaging([])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    fireEvent.change(nameInput, { target: { value: "Toggled hook" } })
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          clientId: -1,
+          type: "webhook",
+          name: "Toggled hook",
+          enabled: true,
+        }),
+      ])
+    })
+  })
+
+  it("applies the detail switch to the staged trigger without pressing save", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "Hook one")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.name")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -1, enabled: false }),
+      ])
+    })
   })
 
   it("appends a new staged trigger via Add instead of overwriting the selected one", async () => {
@@ -331,20 +671,24 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /triggers.actions.addAnother/ }))
 
-    // Creation state: empty form and the create label, no leaked delete action.
-    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("")
-    expect(screen.getByRole("button", { name: "triggers.actions.enable" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "triggers.actions.delete" })).not.toBeInTheDocument()
+    // Creation state: empty form; delete lives on each existing pill's X
+    // button, so exactly one remains (for "First hook").
+    await waitFor(() => {
+      expect(screen.getByLabelText("triggers.form.name")).toHaveValue("")
+    })
+    expect(screen.getAllByRole("button", { name: "triggers.actions.delete" })).toHaveLength(1)
 
     fireEvent.change(screen.getByLabelText("triggers.form.name"), {
       target: { value: "Second hook" },
     })
-    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.enable" }))
+    // No Save button: Done commits the pending creation.
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith([
         expect.objectContaining({ clientId: -1, name: "First hook" }),
-        expect.objectContaining({ clientId: -2, name: "Second hook", type: "webhook" }),
+        // New forms default to disabled; the switch was not touched here.
+        expect.objectContaining({ clientId: -2, name: "Second hook", type: "webhook", enabled: false }),
       ])
     })
   })
@@ -364,20 +708,154 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
     ).toBeTruthy()
   })
 
-  it("removes a staged trigger after delete confirmation", async () => {
+  it("removes a staged trigger after confirming in the pill's popover", async () => {
     const onChange = renderStaging([stagedWebhook(-1, "Doomed hook")])
 
     fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
 
+    // The X opens a confirmation popover; the destructive button deletes.
     fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.delete" }))
-    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.confirmDelete" }))
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.confirmDelete" }))
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith([])
     })
   })
 
-  it("updates the selected staged trigger in place on save", async () => {
+  it("keeps the trigger when the delete popover is cancelled", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "Kept hook")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.delete" }))
+    fireEvent.click(await screen.findByRole("button", { name: "common.cancel" }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "triggers.actions.confirmDelete" }),
+      ).not.toBeInTheDocument()
+    })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText("Kept hook")).toBeInTheDocument()
+  })
+
+  it("keeps unsaved edits when another pill is deleted and the staged list round-trips", async () => {
+    render(
+      <StatefulStagingHarness
+        initial={[stagedWebhook(-1, "Old hook"), stagedWebhook(-2, "New hook")]}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    expect(nameInput).toHaveValue("New hook")
+    fireEvent.change(nameInput, { target: { value: "Unsaved edit" } })
+
+    // Delete the non-selected pill ("Old hook"); the parent state update
+    // re-renders the dialog with fresh pseudo-trigger identities.
+    const [, oldHookDelete] = screen.getAllByRole("button", { name: "triggers.actions.delete" })
+    fireEvent.click(oldHookDelete)
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.confirmDelete" }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Old hook")).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("Unsaved edit")
+  })
+
+  it("keeps the detail switch usable alongside unsaved edits after a round-trip", async () => {
+    render(<StatefulStagingHarness initial={[stagedWebhook(-1, "Hook")]} />)
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    fireEvent.change(nameInput, { target: { value: "Renamed but unsaved" } })
+
+    // The immediate enabled toggle round-trips the staged list; the pending
+    // name edit must survive it.
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+    await waitFor(() => {
+      expect(detailSwitch).toHaveAttribute("aria-checked", "false")
+    })
+    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("Renamed but unsaved")
+  })
+
+  it("commits pending edits when the dialog is dismissed via Escape", async () => {
+    const onChangeSpy = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <StatefulStagingHarness
+        initial={[stagedWebhook(-1, "Old name")]}
+        onChangeSpy={onChangeSpy}
+        onOpenChange={onOpenChange}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    fireEvent.change(nameInput, { target: { value: "Saved on escape" } })
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+    expect(onChangeSpy).toHaveBeenCalledWith([
+      expect.objectContaining({ clientId: -1, name: "Saved on escape" }),
+    ])
+  })
+
+  it("keeps the Gmail quick-toggle intent as a dirty preset that Done cannot silently drop", async () => {
+    const onOpenChange = vi.fn()
+    render(
+      <StatefulStagingHarness initial={[]} onOpenChange={onOpenChange} />,
+    )
+
+    await screen.findByText("triggers.staging.info")
+    // No Gmail accounts connected: the quick toggle opens the creation form
+    // with the enable intent preset instead of creating anything.
+    const switches = screen.getAllByRole("switch")
+    fireEvent.click(switches[2])
+
+    await screen.findByLabelText("triggers.form.watchLabel")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+
+    // Done must attempt the creation and fail validation (no account picked),
+    // keeping the dialog open rather than silently dropping the intent.
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalled()
+    })
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it("keeps the form being edited when another pill is deleted", async () => {
+    const onChange = renderStaging([
+      stagedWebhook(-1, "Old hook"),
+      stagedWebhook(-2, "New hook"),
+    ])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    // Newest (-2) is selected; edit its name without saving.
+    const nameInput = await screen.findByLabelText("triggers.form.name")
+    expect(nameInput).toHaveValue("New hook")
+    fireEvent.change(nameInput, { target: { value: "Unsaved edit" } })
+
+    // Delete the other pill (-1, "Old hook") via its X button.
+    const [, oldHookDelete] = screen.getAllByRole("button", { name: "triggers.actions.delete" })
+    fireEvent.click(oldHookDelete)
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.confirmDelete" }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -2, name: "New hook" }),
+      ])
+    })
+    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("Unsaved edit")
+  })
+
+  it("commits pending edits to the selected staged trigger on Done", async () => {
     const onChange = renderStaging([stagedWebhook(-1, "Old name")])
 
     fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
@@ -386,13 +864,56 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
     fireEvent.change(screen.getByLabelText("triggers.form.name"), {
       target: { value: "New name" },
     })
-    fireEvent.click(screen.getByRole("button", { name: "triggers.actions.save" }))
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith([
         expect.objectContaining({ clientId: -1, name: "New name", type: "webhook" }),
       ])
     })
+  })
+
+  it("commits pending edits when navigating back to the overview", async () => {
+    const onChange = renderStaging([stagedWebhook(-1, "Old name")])
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("Old name")
+
+    fireEvent.change(screen.getByLabelText("triggers.form.name"), {
+      target: { value: "Renamed on back" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "common.back" }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({ clientId: -1, name: "Renamed on back" }),
+      ])
+    })
+    // Back landed on the overview.
+    expect(screen.queryByLabelText("triggers.form.name")).not.toBeInTheDocument()
+  })
+
+  it("closes without changes when Done is pressed on an untouched form", async () => {
+    const onOpenChange = vi.fn()
+    const onChange = vi.fn()
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        open
+        onOpenChange={onOpenChange}
+        staged={{ triggers: [stagedWebhook(-1, "Untouched hook")], onChange }}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.name")
+    fireEvent.click(screen.getByRole("button", { name: "common.done" }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it("disables every staged trigger of a type when its switch is toggled off", async () => {

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -500,6 +500,59 @@ describe("AgentTriggersDialog", () => {
     })
   })
 
+  it("keeps a fresh secret attached to its own trigger instead of letting Back navigate past it", async () => {
+    apiRequestMock.mockImplementation((url: string, options?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/agents/42/triggers" && options?.method === "POST") {
+        return Promise.resolve(
+          jsonResponse(
+            makeTrigger({
+              id: 13,
+              name: "API / Webhook",
+              webhook_token: "tok",
+              webhook_secret: "wh_back_secret",
+            }),
+          ),
+        )
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.secret")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+
+    expect(await screen.findByText("wh_back_secret")).toBeInTheDocument()
+
+    // Back must not leave the just-created trigger's view while its one-time
+    // secret is still unacknowledged — otherwise the reveal alert would stay
+    // mounted and read as if it belonged to whatever the user navigates to.
+    fireEvent.click(screen.getByRole("button", { name: "common.back" }))
+    await waitFor(() => {
+      expect(screen.getByText("wh_back_secret")).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText("triggers.form.name")).toBeInTheDocument()
+
+    // Once dismissed, Back proceeds normally.
+    fireEvent.click(screen.getByRole("button", { name: "triggers.secret.dismiss" }))
+    fireEvent.click(screen.getByRole("button", { name: "common.back" }))
+    await waitFor(() => {
+      expect(screen.queryByLabelText("triggers.form.name")).not.toBeInTheDocument()
+    })
+  })
+
   it("clears the dirty flag when the Gmail quick-toggle intent is reversed, so Done closes cleanly", async () => {
     const onOpenChange = vi.fn()
     // Zero connected accounts: the quick toggle must open the creation form
@@ -652,6 +705,54 @@ describe("AgentTriggersDialog", () => {
     })
     await waitFor(() => {
       expect(getCallsAfterFailure).toBeGreaterThan(0)
+    })
+  })
+
+  it("selects the newest remaining same-type trigger after deleting the selected one", async () => {
+    const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+    let triggers = [
+      makeTrigger({ id: 50, name: "Older hook" }),
+      makeTrigger({ id: 51, name: "Newer hook" }),
+    ]
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse([]))
+      if (url === TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse(triggers))
+      }
+      if (url === `${TRIGGERS_URL}/50/runs` || url === `${TRIGGERS_URL}/51/runs`) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === `${TRIGGERS_URL}/51` && init?.method === "DELETE") {
+        triggers = triggers.filter((item) => item.id !== 51)
+        return Promise.resolve(jsonResponse({}))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    // Newest enabled trigger (51) is auto-selected as primary.
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("Newer hook")
+
+    // Delete the currently-selected pill (pills list newest-first, so index 0
+    // is "Newer hook"), not another one — this is the pickNextAfterDelete
+    // branch that actually returns a next id (newest of what remains), as
+    // opposed to falling back to null/empty.
+    const [selectedHookDelete] = screen.getAllByRole("button", { name: "triggers.actions.delete" })
+    fireEvent.click(selectedHookDelete)
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.confirmDelete" }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("triggers.form.name")).toHaveValue("Older hook")
     })
   })
 
@@ -1257,6 +1358,50 @@ describe("AgentTriggersDialog owner routing", () => {
     await waitFor(() => {
       expect(apiRequestMock).toHaveBeenCalledWith(
         `${WORKFORCE_TRIGGERS_URL}/60`,
+        expect.objectContaining({ method: "PATCH" }),
+      )
+    })
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/agents/"),
+      expect.anything(),
+    )
+  })
+
+  it("toggles an existing workforce-owned trigger from the detail view via PATCH", async () => {
+    const WORKFORCE_TRIGGERS_URL = "http://api.local/api/workforces/5/triggers"
+    const trigger = makeTrigger({ id: 63, name: "Workforce hook", enabled: true })
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === WORKFORCE_TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse([trigger]))
+      }
+      if (url === `${WORKFORCE_TRIGGERS_URL}/63/runs`) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === `${WORKFORCE_TRIGGERS_URL}/63` && init?.method === "PATCH") {
+        return Promise.resolve(jsonResponse({ ...trigger, enabled: false }))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        owner={{ kind: "workforce", id: 5 }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("Workforce hook")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        `${WORKFORCE_TRIGGERS_URL}/63`,
         expect.objectContaining({ method: "PATCH" }),
       )
     })

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -500,6 +500,186 @@ describe("AgentTriggersDialog", () => {
     expect(toastMocks.error).not.toHaveBeenCalled()
   })
 
+  it("disables navigation while a detail toggle is in flight, and rolls back cleanly on rejection", async () => {
+    const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+    let rejectPatch: (err: Error) => void = () => {}
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse([]))
+      if (url === TRIGGERS_URL) {
+        return Promise.resolve(
+          jsonResponse([
+            {
+              id: 20,
+              user_id: 1,
+              agent_id: 42,
+              type: "webhook",
+              name: "Backup hook",
+              enabled: true,
+              config: {},
+              prompt_template: null,
+              webhook_token: null,
+              webhook_secret: null,
+              next_run_at: null,
+              last_run_at: null,
+              last_error: null,
+              created_at: null,
+              updated_at: null,
+            },
+            {
+              id: 21,
+              user_id: 1,
+              agent_id: 42,
+              type: "webhook",
+              name: "Primary hook",
+              enabled: true,
+              config: {},
+              prompt_template: null,
+              webhook_token: null,
+              webhook_secret: null,
+              next_run_at: null,
+              last_run_at: null,
+              last_error: null,
+              created_at: null,
+              updated_at: null,
+            },
+          ]),
+        )
+      }
+      if (url === `${TRIGGERS_URL}/20/runs` || url === `${TRIGGERS_URL}/21/runs`) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === `${TRIGGERS_URL}/21` && init?.method === "PATCH") {
+        // Never resolves on its own — held open so navigation controls can be
+        // asserted disabled, then rejected explicitly below.
+        return new Promise<Response>((_resolve, reject) => {
+          rejectPatch = reject
+        })
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    // Newest enabled trigger (21) is auto-selected as primary.
+    expect(await screen.findByLabelText("triggers.form.name")).toHaveValue("Primary hook")
+
+    const [detailSwitch] = screen.getAllByRole("switch")
+    expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(detailSwitch)
+
+    // While the PATCH is pending, every navigation control that could land
+    // the eventual rollback on an unrelated form is disabled — this is what
+    // makes the formKeyAtStart guard in handleDetailToggle unreachable via
+    // normal interaction, not just a theoretical race.
+    await waitFor(() => {
+      expect(detailSwitch).toBeDisabled()
+    })
+    expect(screen.getByRole("button", { name: "common.back" })).toBeDisabled()
+    expect(screen.getByText("Backup hook").closest("button")).toBeDisabled()
+
+    rejectPatch(new Error("network error"))
+
+    // Nothing navigated in the meantime, so the rollback correctly lands
+    // back on the same (still-selected) trigger's switch.
+    await waitFor(() => {
+      expect(detailSwitch).toHaveAttribute("aria-checked", "true")
+    })
+    expect(toastMocks.error).toHaveBeenCalled()
+    expect(screen.getByLabelText("triggers.form.name")).toHaveValue("Primary hook")
+  })
+
+  it("resyncs the trigger list when a batch disable partially fails", async () => {
+    const TRIGGERS_URL = "http://api.local/api/agents/42/triggers"
+    let triggers = [
+      {
+        id: 30,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "Hook A",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: null,
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+      {
+        id: 31,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "Hook B",
+        enabled: true,
+        config: {},
+        prompt_template: null,
+        webhook_token: null,
+        webhook_secret: null,
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      },
+    ]
+    let getCallsAfterFailure = 0
+    let patchAttempted = false
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === GMAIL_ACCOUNTS_URL) return Promise.resolve(jsonResponse([]))
+      if (url === TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        if (patchAttempted) getCallsAfterFailure += 1
+        return Promise.resolve(jsonResponse(triggers))
+      }
+      if (url === `${TRIGGERS_URL}/30` && init?.method === "PATCH") {
+        triggers = triggers.map((item) => (item.id === 30 ? { ...item, enabled: false } : item))
+        return Promise.resolve(jsonResponse(triggers[0]))
+      }
+      if (url === `${TRIGGERS_URL}/31` && init?.method === "PATCH") {
+        patchAttempted = true
+        return Promise.reject(new Error("boom"))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={42}
+        open
+        onOpenChange={vi.fn()}
+        gmailConnection={{ isConnected: false, connectedAccount: null }}
+      />,
+    )
+
+    const cardSwitch = (
+      await screen.findAllByRole("switch")
+    ).find((el) => el.getAttribute("aria-checked") === "true")
+    fireEvent.click(cardSwitch!)
+
+    // One PATCH in the batch rejected: the catch resyncs via a fresh GET
+    // instead of trusting the local list (which would otherwise wrongly
+    // report both triggers disabled).
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(getCallsAfterFailure).toBeGreaterThan(0)
+    })
+  })
+
   it("keeps unsaved field edits when the detail switch is toggled", async () => {
     render(
       <AgentTriggersDialog
@@ -803,6 +983,31 @@ describe("AgentTriggersDialog staging mode (agent not created yet)", () => {
     expect(onChangeSpy).toHaveBeenCalledWith([
       expect.objectContaining({ clientId: -1, name: "Saved on escape" }),
     ])
+  })
+
+  it("still closes on Escape when the pending commit fails validation (no secret at stake)", async () => {
+    const onChangeSpy = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <StatefulStagingHarness initial={[]} onChangeSpy={onChangeSpy} onOpenChange={onOpenChange} />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.scheduled.title"))
+    const intervalInput = await screen.findByLabelText("triggers.form.intervalSeconds")
+    // Clearing the only schedule field makes buildConfig() throw
+    // scheduleRequired on commit, while still marking the form dirty.
+    fireEvent.change(intervalInput, { target: { value: "" } })
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" })
+
+    // Unlike Done (which stays open on a failed commit), dismissal is "I
+    // don't want this saved" — it drops the invalid edit and closes anyway.
+    // Only an unrevealed one-time secret is allowed to block close.
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+    expect(toastMocks.error).toHaveBeenCalled()
+    expect(onChangeSpy).not.toHaveBeenCalled()
   })
 
   it("keeps the Gmail quick-toggle intent as a dirty preset that Done cannot silently drop", async () => {

--- a/frontend/src/components/build/agent-triggers-dialog.test.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.test.tsx
@@ -1224,4 +1224,124 @@ describe("AgentTriggersDialog owner routing", () => {
       ),
     )
   })
+
+  it("toggles a workforce-owned trigger via PATCH on the workforce route", async () => {
+    const WORKFORCE_TRIGGERS_URL = "http://api.local/api/workforces/5/triggers"
+    const trigger = makeTrigger({ id: 60, name: "Workforce hook", enabled: true })
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === WORKFORCE_TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse([trigger]))
+      }
+      if (url === `${WORKFORCE_TRIGGERS_URL}/60` && init?.method === "PATCH") {
+        return Promise.resolve(jsonResponse({ ...trigger, enabled: false }))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        owner={{ kind: "workforce", id: 5 }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    const cardSwitch = (
+      await screen.findAllByRole("switch")
+    ).find((el) => el.getAttribute("aria-checked") === "true")
+    expect(cardSwitch).toBeDefined()
+    fireEvent.click(cardSwitch!)
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        `${WORKFORCE_TRIGGERS_URL}/60`,
+        expect.objectContaining({ method: "PATCH" }),
+      )
+    })
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/agents/"),
+      expect.anything(),
+    )
+  })
+
+  it("creates a workforce-owned trigger via POST on the workforce route", async () => {
+    const WORKFORCE_TRIGGERS_URL = "http://api.local/api/workforces/5/triggers"
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === WORKFORCE_TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === WORKFORCE_TRIGGERS_URL && init?.method === "POST") {
+        return Promise.resolve(jsonResponse(makeTrigger({ id: 61, enabled: true })))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        owner={{ kind: "workforce", id: 5 }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.secret")
+    const [detailSwitch] = screen.getAllByRole("switch")
+    fireEvent.click(detailSwitch)
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        WORKFORCE_TRIGGERS_URL,
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/agents/"),
+      expect.anything(),
+    )
+  })
+
+  it("deletes a workforce-owned trigger via DELETE on the workforce route", async () => {
+    const WORKFORCE_TRIGGERS_URL = "http://api.local/api/workforces/5/triggers"
+    const trigger = makeTrigger({ id: 62, name: "Workforce hook" })
+
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === WORKFORCE_TRIGGERS_URL && (!init?.method || init.method === "GET")) {
+        return Promise.resolve(jsonResponse([trigger]))
+      }
+      if (url === `${WORKFORCE_TRIGGERS_URL}/62` && init?.method === "DELETE") {
+        return Promise.resolve(jsonResponse({}))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(
+      <AgentTriggersDialog
+        agentId={null}
+        owner={{ kind: "workforce", id: 5 }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("triggers.cards.webhook.title"))
+    await screen.findByLabelText("triggers.form.secret")
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.delete" }))
+    fireEvent.click(await screen.findByRole("button", { name: "triggers.actions.confirmDelete" }))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        `${WORKFORCE_TRIGGERS_URL}/62`,
+        expect.objectContaining({ method: "DELETE" }),
+      )
+    })
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/agents/"),
+      expect.anything(),
+    )
+  })
 })

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -211,6 +211,14 @@ function newestFirst(a: AgentTrigger, b: AgentTrigger): number {
   return Math.abs(b.id) - Math.abs(a.id)
 }
 
+// After deleting the selected trigger, the next one to show — same type,
+// newest first — or null if none remain. Shared by handleDelete's staged and
+// live branches, which otherwise differ only in whether the list still needs
+// stagedToPseudoTrigger mapping before this runs.
+function pickNextAfterDelete(remaining: AgentTrigger[], type: AgentTriggerType): number | null {
+  return remaining.filter((item) => item.type === type).sort(newestFirst)[0]?.id ?? null
+}
+
 function isValidAgentId(agentId: number | null): agentId is number {
   return typeof agentId === "number" && Number.isFinite(agentId)
 }
@@ -750,11 +758,12 @@ export function AgentTriggersDialog({
     if (!resolvedOwner) return
     setBusy(true)
     try {
-      await updateOwnerTrigger(resolvedOwner, selectedTrigger.id, { enabled: checked })
+      const updated = await updateOwnerTrigger(resolvedOwner, selectedTrigger.id, { enabled: checked })
+      // Patch from the response, not a hand-set `enabled` — a scheduled
+      // trigger's next_run_at/last_run_at can change server-side on
+      // enable/disable, matching the overview toggle's own patch.
       setLiveTriggers((current) =>
-        current.map((item) =>
-          item.id === selectedTrigger.id ? { ...item, enabled: checked } : item,
-        ),
+        current.map((item) => (item.id === updated.id ? updated : item)),
       )
       notifyChanged()
       toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
@@ -942,11 +951,7 @@ export function AgentTriggersDialog({
       // being edited; when the selected one goes, fall back to the next
       // trigger of the type (newest first), mirroring the live flow.
       if (selectedTriggerIdRef.current === trigger.id) {
-        const next = remaining
-          .map(stagedToPseudoTrigger)
-          .filter((item) => item.type === trigger.type)
-          .sort(newestFirst)[0]
-        setSelectedTriggerId(next?.id ?? null)
+        setSelectedTriggerId(pickNextAfterDelete(remaining.map(stagedToPseudoTrigger), trigger.type))
         setRuns([])
       }
       setDeleteConfirmId(null)
@@ -964,10 +969,7 @@ export function AgentTriggersDialog({
       // being edited; when the selected one goes, fall back to the next
       // trigger of the type (newest first), like the staging branch.
       if (selectedTriggerIdRef.current === trigger.id) {
-        const next = remaining
-          .filter((item) => item.type === trigger.type)
-          .sort(newestFirst)[0]
-        setSelectedTriggerId(next?.id ?? null)
+        setSelectedTriggerId(pickNextAfterDelete(remaining, trigger.type))
         setRuns([])
       }
       setSecretReveal(null)

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -244,7 +244,10 @@ export function AgentTriggersDialog({
   const [loading, setLoading] = useState(false)
   const [runsLoading, setRunsLoading] = useState(false)
   const [busy, setBusy] = useState(false)
-  const [busyType, setBusyType] = useState<AgentTriggerType | null>(null)
+  // A Set, not a scalar: two overview switches toggled back-to-back must each
+  // keep their own guard, or one PATCH resolving would re-enable the other
+  // type's still-in-flight switch (matches agent-builder.tsx's summary cards).
+  const [busyTypes, setBusyTypes] = useState<ReadonlySet<AgentTriggerType>>(new Set())
   const [form, setForm] = useState<TriggerFormState>(emptyForm)
   // True when the form holds field edits that have not been persisted yet.
   // There is no explicit Save button: pending edits are committed on Done,
@@ -652,7 +655,7 @@ export function AgentTriggersDialog({
         return
       }
     }
-    setBusyType(type)
+    setBusyTypes((current) => new Set(current).add(type))
     try {
       // Toggling from the overview never navigates into the config view; it
       // only flips (or creates) the trigger and stays on the list.
@@ -704,7 +707,11 @@ export function AgentTriggersDialog({
       // server-side, so resync rather than trusting the local list.
       if (resolvedOwner) void loadTriggers(selectedTriggerIdRef.current)
     } finally {
-      setBusyType(null)
+      setBusyTypes((current) => {
+        const next = new Set(current)
+        next.delete(type)
+        return next
+      })
     }
   }
 
@@ -765,6 +772,12 @@ export function AgentTriggersDialog({
       setLiveTriggers((current) =>
         current.map((item) => (item.id === updated.id ? updated : item)),
       )
+      // Reconcile the switch itself from the response too, in case a future
+      // backend rule ever returns an `enabled` that differs from what was
+      // requested — only while still on the same form (see the guard above).
+      if (syncedFormKeyRef.current === formKeyAtStart) {
+        setForm((current) => ({ ...current, enabled: updated.enabled }))
+      }
       notifyChanged()
       toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
     } catch (err) {
@@ -1113,7 +1126,7 @@ export function AgentTriggersDialog({
         <div className="flex items-center gap-2.5">
           <Switch
             checked={isEnabled}
-            disabled={busyType === type || !canOperate}
+            disabled={busyTypes.has(type) || !canOperate}
             onCheckedChange={(checked) => void handleTypeToggle(type, checked)}
           />
           <button

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -16,8 +16,8 @@ import {
   Plus,
   RefreshCcw,
   RotateCcw,
-  Trash2,
   Webhook,
+  X,
   Zap,
 } from "lucide-react"
 
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Select } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
@@ -41,9 +42,11 @@ import {
   TriggerOwnerRef,
   createOwnerTrigger,
   deleteOwnerTrigger,
+  disableOwnerTriggersOfType,
   listGmailAccounts,
   listOwnerTriggerRuns,
   listOwnerTriggers,
+  mergeUpdatedTriggers,
   stagedToPseudoTrigger,
   testOwnerTrigger,
   updateOwnerTrigger,
@@ -91,13 +94,32 @@ interface TriggerFormState {
 }
 
 const TRIGGER_TYPES: AgentTriggerType[] = ["webhook", "scheduled", "gmail"]
+// Field labels follow the design refresh: small, semibold, muted.
+const FIELD_LABEL_CLASS = "text-xs font-semibold text-muted-foreground"
 const DEFAULT_TEST_PAYLOAD = "{\n  \"message\": \"test trigger\"\n}"
+
+// True when `form` has no pending edits beyond `enabled` — i.e. reversing a
+// not-yet-submitted enable intent (the only way a fresh creation form gets
+// marked dirty without the user touching any other field) leaves nothing to
+// commit.
+function formMatchesEmptyIgnoringEnabled(
+  form: TriggerFormState,
+  type: AgentTriggerType,
+): boolean {
+  const empty = emptyForm(type)
+  return (Object.keys(empty) as Array<keyof TriggerFormState>).every(
+    (key) => key === "enabled" || form[key] === empty[key],
+  )
+}
 
 function emptyForm(type: AgentTriggerType = "webhook"): TriggerFormState {
   return {
     type,
     name: "",
-    enabled: true,
+    // New triggers start disabled so the detail switch matches the overview
+    // switch (which is off while no trigger of the type exists). Quick-toggle
+    // creation from the overview passes enabled=true explicitly.
+    enabled: false,
     intervalSeconds: "3600",
     nextRunAt: "",
     secret: "",
@@ -216,6 +238,11 @@ export function AgentTriggersDialog({
   const [busy, setBusy] = useState(false)
   const [busyType, setBusyType] = useState<AgentTriggerType | null>(null)
   const [form, setForm] = useState<TriggerFormState>(emptyForm)
+  // True when the form holds field edits that have not been persisted yet.
+  // There is no explicit Save button: pending edits are committed on Done,
+  // Back, and when switching to another trigger. The enabled switch persists
+  // itself immediately and never marks the form dirty.
+  const [formDirty, setFormDirty] = useState(false)
   const [testPayload, setTestPayload] = useState(DEFAULT_TEST_PAYLOAD)
   const [sourceEventId, setSourceEventId] = useState("")
   const [secretReveal, setSecretReveal] = useState<string | null>(null)
@@ -225,6 +252,14 @@ export function AgentTriggersDialog({
   const [gmailAccountsLoading, setGmailAccountsLoading] = useState(false)
   const selectedTriggerIdRef = useRef<number | null>(null)
   const activeTypeRef = useRef<AgentTriggerType | null>(null)
+  // Identity of the trigger the form was last synced from ("type:id", or
+  // "type:new" for a creation form). The form-sync effect only resyncs when
+  // this changes, so list refreshes that merely replace the selected
+  // trigger's object identity never wipe unsaved field edits. Navigation
+  // functions that set the form explicitly stamp the key themselves.
+  const syncedFormKeyRef = useRef<string | null>(null)
+  const formKeyFor = (type: AgentTriggerType, triggerId: number | null) =>
+    `${type}:${triggerId ?? "new"}`
 
   const stagedTriggersProp = staged?.triggers ?? null
   const isStaging = !isValidAgentId(agentId) && stagedTriggersProp !== null
@@ -329,21 +364,28 @@ export function AgentTriggersDialog({
     }
   }, [resolvedOwner, setSelectedTriggerId, t])
 
-  const loadRuns = useCallback(async () => {
-    if (!resolvedOwner || !selectedTrigger) {
+  // Takes the target trigger explicitly so navigation handlers can load runs
+  // for a selection they just made (before the state round-trips).
+  const loadRunsFor = useCallback(async (trigger: AgentTrigger | null) => {
+    if (!resolvedOwner || !trigger || trigger.id < 0) {
       setRuns([])
       return
     }
     setRunsLoading(true)
     try {
-      setRuns(await listOwnerTriggerRuns(resolvedOwner, selectedTrigger.id))
+      setRuns(await listOwnerTriggerRuns(resolvedOwner, trigger.id))
     } catch (err) {
       console.error(err)
       toast.error(err instanceof Error ? err.message : t("triggers.messages.runsLoadFailed"))
     } finally {
       setRunsLoading(false)
     }
-  }, [resolvedOwner, selectedTrigger, t])
+  }, [resolvedOwner, t])
+
+  const loadRuns = useCallback(
+    () => loadRunsFor(selectedTrigger),
+    [loadRunsFor, selectedTrigger],
+  )
 
   useEffect(() => {
     if (!open) return
@@ -404,43 +446,68 @@ export function AgentTriggersDialog({
   }, [activeType, gmailAccounts, open, selectedTrigger])
 
   useEffect(() => {
-    if (!open || !activeType) return
+    if (!open || !activeType) {
+      syncedFormKeyRef.current = null
+      return
+    }
+    const key = formKeyFor(activeType, selectedTrigger?.id ?? null)
+    if (syncedFormKeyRef.current === key) return
+    syncedFormKeyRef.current = key
     if (selectedTrigger) {
       setForm(formFromTrigger(selectedTrigger))
-      void loadRuns()
+      setFormDirty(false)
+      void loadRunsFor(selectedTrigger)
     } else {
       setForm(emptyForm(activeType))
+      setFormDirty(false)
       setRuns([])
     }
-  }, [activeType, loadRuns, open, selectedTrigger])
+  }, [activeType, loadRunsFor, open, selectedTrigger])
 
+  // Navigation helpers set the form synchronously (no flash of stale values)
+  // and stamp syncedFormKeyRef so the form-sync effect treats the target as
+  // already synced. secretReveal deliberately survives navigation: it is a
+  // one-time value the user must copy, so only closing the dialog or deleting
+  // a trigger clears it.
   const openType = (type: AgentTriggerType) => {
     const primary =
       triggerGroups[type].find((trigger) => trigger.enabled) ??
       triggerGroups[type][0] ??
       null
+    syncedFormKeyRef.current = formKeyFor(type, primary?.id ?? null)
     setActiveType(type)
     setSelectedTriggerId(primary?.id ?? null)
-    setSecretReveal(null)
     setDeleteConfirmId(null)
     setForm(primary ? formFromTrigger(primary) : emptyForm(type))
+    setFormDirty(false)
+    if (primary) {
+      void loadRunsFor(primary)
+    } else {
+      setRuns([])
+    }
   }
 
-  const beginCreateForType = (type: AgentTriggerType) => {
+  const beginCreateForType = (type: AgentTriggerType, initial?: Partial<TriggerFormState>) => {
+    syncedFormKeyRef.current = formKeyFor(type, null)
     setActiveType(type)
     setSelectedTriggerId(null)
-    setSecretReveal(null)
     setDeleteConfirmId(null)
-    setForm(emptyForm(type))
+    setForm({ ...emptyForm(type), ...initial })
+    // Preset values carry real user intent (e.g. the Gmail quick toggle's
+    // enabled=true); mark them dirty so Done/Back attempts the creation
+    // instead of silently dropping them.
+    setFormDirty(Boolean(initial && Object.keys(initial).length > 0))
     setRuns([])
   }
 
   const beginEdit = (trigger: AgentTrigger) => {
+    syncedFormKeyRef.current = formKeyFor(trigger.type, trigger.id)
     setActiveType(trigger.type)
     setSelectedTriggerId(trigger.id)
-    setSecretReveal(null)
     setDeleteConfirmId(null)
     setForm(formFromTrigger(trigger))
+    setFormDirty(false)
+    void loadRunsFor(trigger)
   }
 
   const setFormValue = <K extends keyof TriggerFormState>(
@@ -448,6 +515,9 @@ export function AgentTriggersDialog({
     value: TriggerFormState[K],
   ) => {
     setForm((current) => ({ ...current, [key]: value }))
+    // The enabled switch persists immediately (handleDetailToggle); every
+    // other field is a pending edit committed on Done/Back/selection change.
+    if (key !== "enabled") setFormDirty(true)
   }
 
   const buildConfig = (): Record<string, unknown> => {
@@ -562,7 +632,10 @@ export function AgentTriggersDialog({
     if (checked && type === "gmail" && !triggerGroups.gmail.length) {
       const accountCount = gmailAccounts?.length ?? 0
       if (accountCount !== 1) {
-        beginCreateForType("gmail")
+        // The user asked to enable; carry that intent into the creation form
+        // as a dirty preset, so Done/Back attempts the creation and surfaces
+        // the missing-account validation instead of silently dropping it.
+        beginCreateForType("gmail", { enabled: true })
         toast.info(
           accountCount === 0
             ? t("triggers.gmail.notConnectedDescription")
@@ -573,6 +646,8 @@ export function AgentTriggersDialog({
     }
     setBusyType(type)
     try {
+      // Toggling from the overview never navigates into the config view; it
+      // only flips (or creates) the trigger and stays on the list.
       if (isStaging && staged) {
         if (checked) {
           if (primary) {
@@ -581,14 +656,8 @@ export function AgentTriggersDialog({
                 item.clientId === primary.id ? { ...item, enabled: true } : item,
               ),
             )
-            setSelectedTriggerId(primary.id)
           } else {
-            const created = await createDefaultTrigger(type, true)
-            if (created) {
-              setActiveType(type)
-              setSelectedTriggerId(created.id)
-              setForm(formFromTrigger(created))
-            }
+            await createDefaultTrigger(type, true)
           }
         } else {
           staged.onChange(
@@ -602,49 +671,126 @@ export function AgentTriggersDialog({
         return
       }
       if (!resolvedOwner) return
-      let preferredId: number | null = primary?.id ?? null
       if (checked) {
         if (primary) {
-          const updated = await updateOwnerTrigger(resolvedOwner, primary.id, {
-            enabled: true,
-          })
-          preferredId = updated.id
+          const updated = await updateOwnerTrigger(resolvedOwner, primary.id, { enabled: true })
+          setLiveTriggers((current) =>
+            current.map((item) => (item.id === updated.id ? updated : item)),
+          )
         } else {
           const created = await createDefaultTrigger(type, true)
-          preferredId = created?.id ?? null
           if (created) {
-            setActiveType(type)
-            setSelectedTriggerId(created.id)
-            setForm(formFromTrigger(created))
+            setLiveTriggers((current) => [...current, created])
           }
         }
       } else {
-        const enabledTriggers = typeTriggers.filter((trigger) => trigger.enabled)
-        await Promise.all(
-          enabledTriggers.map((trigger) =>
-            updateOwnerTrigger(resolvedOwner, trigger.id, { enabled: false }),
-          ),
-        )
+        const updatedList = await disableOwnerTriggersOfType(resolvedOwner, typeTriggers, type)
+        setLiveTriggers((current) => mergeUpdatedTriggers(current, updatedList))
       }
-      await loadTriggers(preferredId)
       notifyChanged()
       toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
     } catch (err) {
       console.error(err)
       toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+      // A batch disable is not atomic: some triggers may already be disabled
+      // server-side, so resync rather than trusting the local list.
+      if (resolvedOwner) void loadTriggers(selectedTriggerIdRef.current)
     } finally {
       setBusyType(null)
     }
   }
 
-  const handleSubmit = async () => {
+  // The enabled switch in the detail view applies immediately — no Save
+  // needed. Toggling on in the creation state creates the trigger right away
+  // from the current form values (delegated to handleSubmit so the two create
+  // paths cannot drift), mirroring the overview quick toggle.
+  const handleDetailToggle = async (checked: boolean) => {
+    setFormValue("enabled", checked)
     if (!canOperate) return
+
+    // Identity of the form this toggle started on. If the user navigates
+    // away (Back/pill switch/Add) before an in-flight request settles, the
+    // failure handlers below check this before touching `form` — otherwise a
+    // late rejection would silently mutate whatever unrelated form is now on
+    // screen.
+    const formKeyAtStart = syncedFormKeyRef.current
+
+    if (!selectedTrigger) {
+      if (!checked) {
+        // Reversing a not-yet-submitted enable intent (the Gmail quick
+        // toggle's only way to mark a fresh creation form dirty). If nothing
+        // else was edited, there is nothing left to commit — clear the flag
+        // so Done/Back don't attempt a phantom, unvalidated create.
+        if (activeType && formMatchesEmptyIgnoringEnabled(form, activeType)) {
+          setFormDirty(false)
+        }
+        return
+      }
+      const result = await handleSubmit({ enabled: true })
+      if (!result.ok && syncedFormKeyRef.current === formKeyAtStart) {
+        setForm((current) => ({ ...current, enabled: false }))
+      }
+      return
+    }
+
+    // Existing trigger: a minimal enabled-only update that leaves any other
+    // unsaved field edits (and formDirty) untouched. The form-sync effect
+    // keys on the trigger id, so the list patch below cannot wipe them.
+    if (isStaging && staged) {
+      staged.onChange(
+        staged.triggers.map((item) =>
+          item.clientId === selectedTrigger.id ? { ...item, enabled: checked } : item,
+        ),
+      )
+      notifyChanged()
+      toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
+      return
+    }
+
+    if (!resolvedOwner) return
+    setBusy(true)
+    try {
+      await updateOwnerTrigger(resolvedOwner, selectedTrigger.id, { enabled: checked })
+      setLiveTriggers((current) =>
+        current.map((item) =>
+          item.id === selectedTrigger.id ? { ...item, enabled: checked } : item,
+        ),
+      )
+      notifyChanged()
+      toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
+    } catch (err) {
+      console.error(err)
+      if (syncedFormKeyRef.current === formKeyAtStart) {
+        setForm((current) => ({ ...current, enabled: !checked }))
+      }
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  interface SubmitResult {
+    ok: boolean
+    // One-time webhook secret generated by this submit, if any. Callers that
+    // close the dialog check it so the reveal alert is seen before closing.
+    secret: string | null
+  }
+
+  // Persists the current form (update selected / create new). `overrides`
+  // lets callers force fields on top of the form state (the detail switch
+  // passes enabled=true when creating). Returns success plus any freshly
+  // generated webhook secret so commit-on-navigation callers can stay put on
+  // failure or on a pending secret reveal.
+  const handleSubmit = async (
+    overrides?: Partial<Pick<TriggerFormState, "enabled">>,
+  ): Promise<SubmitResult> => {
+    if (!canOperate) return { ok: false, secret: null }
     let payload
     try {
-      payload = buildPayload()
+      payload = { ...buildPayload(), ...overrides }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
-      return
+      return { ok: false, secret: null }
     }
 
     if (isStaging && staged) {
@@ -664,6 +810,7 @@ export function AgentTriggersDialog({
               : item,
           ),
         )
+        setForm((current) => ({ ...current, enabled: payload.enabled }))
       } else {
         const clientId = nextStagedClientId()
         staged.onChange([
@@ -678,31 +825,89 @@ export function AgentTriggersDialog({
             secret: payload.secret,
           },
         ])
+        // No key stamp here: when the staged list round-trips through the
+        // parent, the form-sync effect re-syncs from the normalized pseudo
+        // trigger (default name etc.). The merge below keeps the switch
+        // correct in the meantime.
         setSelectedTriggerId(clientId)
+        setForm((current) => ({ ...current, enabled: payload.enabled }))
       }
+      setFormDirty(false)
       notifyChanged()
       toast.success(t("triggers.messages.staged"))
-      return
+      return { ok: true, secret: null }
     }
 
-    if (!resolvedOwner) return
+    if (!resolvedOwner) return { ok: false, secret: null }
     setBusy(true)
     try {
       const saved = selectedTrigger
         ? await updateOwnerTrigger(resolvedOwner, selectedTrigger.id, payload)
         : await createOwnerTrigger(resolvedOwner, payload)
-      setSecretReveal(saved.webhook_secret ?? null)
+      const revealedSecret = saved.webhook_secret ?? null
+      setSecretReveal(revealedSecret)
+      // Patch the local list from the response instead of refetching it; the
+      // form is synced here, so stamp the key to keep the effect from
+      // re-syncing (and re-fetching runs) for the same trigger.
+      syncedFormKeyRef.current = formKeyFor(saved.type, saved.id)
       setSelectedTriggerId(saved.id)
       setForm(formFromTrigger(saved))
-      await loadTriggers(saved.id)
+      setFormDirty(false)
+      setLiveTriggers((current) =>
+        selectedTrigger
+          ? current.map((item) => (item.id === saved.id ? saved : item))
+          : [...current, saved],
+      )
       notifyChanged()
       toast.success(selectedTrigger ? t("triggers.messages.updated") : t("triggers.messages.created"))
+      return { ok: true, secret: revealedSecret }
     } catch (err) {
       console.error(err)
       toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+      return { ok: false, secret: null }
     } finally {
       setBusy(false)
     }
+  }
+
+  // There is no Save button: pending field edits are committed when leaving
+  // the form (Done, Back, switching pills, Add, or dismissing the dialog).
+  // Callers keep the user on the current form when ok is false.
+  const commitPendingEdits = async (): Promise<SubmitResult> => {
+    if (!activeType || !formDirty || !canOperate) return { ok: true, secret: null }
+    return handleSubmit()
+  }
+
+  // A pending secret blocks close whether it was just generated by this very
+  // commit (`result.secret` — `secretReveal` itself is a stale closure value
+  // mid-await here, since the setState that wrote it happened inside the same
+  // call) or was already sitting in state from an earlier action, like the
+  // detail switch's own create (a fresh closure per render sees that fine).
+  // The alert's explicit dismiss (which clears secretReveal) is what lets a
+  // later Done/dismissal actually close.
+  const secretPending = (result: SubmitResult) => Boolean(result.secret || secretReveal)
+
+  const handleDone = async () => {
+    const result = await commitPendingEdits()
+    if (!result.ok) return
+    if (secretPending(result)) return
+    closeDialog(false)
+  }
+
+  const handleBack = async () => {
+    if (!(await commitPendingEdits()).ok) return
+    setActiveType(null)
+  }
+
+  const handleSelectTrigger = async (trigger: AgentTrigger) => {
+    if (trigger.id === selectedTriggerId) return
+    if (!(await commitPendingEdits()).ok) return
+    beginEdit(trigger)
+  }
+
+  const handleAddAnother = async (type: AgentTriggerType) => {
+    if (!(await commitPendingEdits()).ok) return
+    beginCreateForType(type)
   }
 
   const handleRotateSecret = async () => {
@@ -713,7 +918,9 @@ export function AgentTriggersDialog({
         rotate_secret: true,
       })
       setSecretReveal(updated.webhook_secret ?? null)
-      await loadTriggers(updated.id)
+      setLiveTriggers((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item)),
+      )
       notifyChanged()
       toast.success(t("triggers.messages.secretRotated"))
     } catch (err) {
@@ -724,16 +931,24 @@ export function AgentTriggersDialog({
     }
   }
 
+  // Confirmation happens in the pill's popover; by the time this runs the
+  // user has already clicked the destructive button there.
   const handleDelete = async (trigger: AgentTrigger) => {
     if (!canOperate) return
-    if (deleteConfirmId !== trigger.id) {
-      setDeleteConfirmId(trigger.id)
-      return
-    }
     if (isStaging && staged) {
-      staged.onChange(staged.triggers.filter((item) => item.clientId !== trigger.id))
-      setSelectedTriggerId(null)
-      setRuns([])
+      const remaining = staged.triggers.filter((item) => item.clientId !== trigger.id)
+      staged.onChange(remaining)
+      // Deleting a pill other than the selected one must not reset the form
+      // being edited; when the selected one goes, fall back to the next
+      // trigger of the type (newest first), mirroring the live flow.
+      if (selectedTriggerIdRef.current === trigger.id) {
+        const next = remaining
+          .map(stagedToPseudoTrigger)
+          .filter((item) => item.type === trigger.type)
+          .sort(newestFirst)[0]
+        setSelectedTriggerId(next?.id ?? null)
+        setRuns([])
+      }
       setDeleteConfirmId(null)
       notifyChanged()
       toast.success(t("triggers.messages.deleted"))
@@ -743,11 +958,20 @@ export function AgentTriggersDialog({
     setBusy(true)
     try {
       await deleteOwnerTrigger(resolvedOwner, trigger.id)
-      setSelectedTriggerId(null)
-      setRuns([])
+      const remaining = liveTriggers.filter((item) => item.id !== trigger.id)
+      setLiveTriggers(remaining)
+      // Deleting a pill other than the selected one must not reset the form
+      // being edited; when the selected one goes, fall back to the next
+      // trigger of the type (newest first), like the staging branch.
+      if (selectedTriggerIdRef.current === trigger.id) {
+        const next = remaining
+          .filter((item) => item.type === trigger.type)
+          .sort(newestFirst)[0]
+        setSelectedTriggerId(next?.id ?? null)
+        setRuns([])
+      }
       setSecretReveal(null)
       setDeleteConfirmId(null)
-      await loadTriggers(null)
       notifyChanged()
       toast.success(t("triggers.messages.deleted"))
     } catch (err) {
@@ -813,44 +1037,64 @@ export function AgentTriggersDialog({
     onOpenChange(nextOpen)
   }
 
+  // Dismissal (Esc, overlay click, header X) commits pending edits like every
+  // other exit path. A failed commit is surfaced via its toast but does not
+  // trap the user — dismissal still closes rather than forcing them to fix
+  // an invalid form just to leave. A freshly generated webhook secret is the
+  // one thing dismissal must not drop: unlike a form validation error, it
+  // already exists server-side and is unrecoverable once unseen, so — like
+  // handleDone — closing waits until it has been shown.
+  const handleDismiss = (nextOpen: boolean) => {
+    if (nextOpen) {
+      onOpenChange(true)
+      return
+    }
+    void (async () => {
+      const result = await commitPendingEdits()
+      if (secretPending(result)) return
+      closeDialog(false)
+    })()
+  }
+
   const renderTypeIcon = (type: AgentTriggerType, className?: string) => {
     if (type === "webhook") return <Webhook className={className} />
     if (type === "gmail") return <Mail className={className} />
     return <CalendarClock className={className} />
   }
 
+  const typeIconClass = (type: AgentTriggerType) =>
+    type === "webhook"
+      ? "bg-fuchsia-50 text-fuchsia-600 dark:bg-fuchsia-950/40 dark:text-fuchsia-300"
+      : type === "gmail"
+        ? "bg-rose-50 text-rose-600 dark:bg-rose-950/40 dark:text-rose-300"
+        : "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300"
+
   const renderTypeCard = (type: AgentTriggerType) => {
     const typeTriggers = triggerGroups[type]
     const enabledCount = typeTriggers.filter((trigger) => trigger.enabled).length
     const hasTriggers = typeTriggers.length > 0
     const isEnabled = enabledCount > 0
-    const iconClass =
-      type === "webhook"
-        ? "bg-fuchsia-50 text-fuchsia-600 dark:bg-fuchsia-950/40 dark:text-fuchsia-300"
-        : type === "gmail"
-          ? "bg-rose-50 text-rose-600 dark:bg-rose-950/40 dark:text-rose-300"
-          : "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300"
 
     return (
       <div
         key={type}
         className={cn(
-          "group flex w-full items-center gap-3.5 rounded-xl border bg-background p-3.5 text-left transition-colors",
-          "hover:border-primary/50 hover:bg-muted/30",
-          isEnabled && "border-primary/40 bg-primary/[0.03]",
+          "group flex w-full items-center gap-3 rounded-[10px] border bg-background px-4 py-3 text-left transition-colors",
+          "hover:border-primary/50",
+          isEnabled && "border-primary/40",
         )}
       >
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-3.5 text-left"
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
           onClick={() => openType(type)}
         >
-          <div className={cn("flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-lg", iconClass)}>
+          <div className={cn("flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-lg", typeIconClass(type))}>
             {renderTypeIcon(type, "h-4 w-4")}
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <div className="truncate text-sm font-semibold">{t(`triggers.cards.${type}.title`)}</div>
+              <div className="truncate text-[13px] font-semibold">{t(`triggers.cards.${type}.title`)}</div>
               {hasTriggers && (
                 <Badge variant={isEnabled ? "default" : "secondary"} className="h-5 px-1.5 text-[10px]">
                   {isEnabled
@@ -859,12 +1103,12 @@ export function AgentTriggersDialog({
                 </Badge>
               )}
             </div>
-            <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
               {t(`triggers.cards.${type}.description`)}
             </div>
           </div>
         </button>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2.5">
           <Switch
             checked={isEnabled}
             disabled={busyType === type || !canOperate}
@@ -883,24 +1127,53 @@ export function AgentTriggersDialog({
     )
   }
 
-  const renderOverview = () => (
-    <div className="space-y-4">
-      <Alert className="border-primary/20 bg-primary/5 text-primary">
-        <Info className="h-4 w-4" />
-        <AlertDescription className="text-sm text-foreground">
-          {t(isStaging ? "triggers.staging.info" : "triggers.overview.info")}
-        </AlertDescription>
-      </Alert>
-
-      <div className="space-y-3">
-        {loading ? (
-          <div className="flex items-center justify-center rounded-lg border border-dashed py-16 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" />
+  // One-time reveal for a freshly generated webhook secret. Rendered on both
+  // the overview (quick-toggle creation stays there) and the detail view.
+  // The explicit dismiss is what lets Done/Back/dismissal close the dialog
+  // afterward — see handleDone/handleDismiss, which refuse to close while
+  // secretReveal is still set so the secret is never lost unseen.
+  const renderSecretReveal = () =>
+    secretReveal && (
+      <Alert className="relative border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>{t("triggers.secret.title")}</AlertTitle>
+        <AlertDescription>
+          <div className="mt-2 flex gap-2">
+            <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
+              {secretReveal}
+            </code>
+            <Button
+              size="icon"
+              variant="secondary"
+              onClick={() => void handleCopy("secret", secretReveal)}
+              title={t("common.copy")}
+            >
+              {copied === "secret" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </Button>
           </div>
-        ) : (
-          TRIGGER_TYPES.map(renderTypeCard)
-        )}
-      </div>
+        </AlertDescription>
+        <button
+          type="button"
+          className="absolute right-3 top-3 rounded p-0.5 text-amber-700 hover:bg-amber-100 dark:text-amber-200 dark:hover:bg-amber-900/40"
+          onClick={() => setSecretReveal(null)}
+          aria-label={t("triggers.secret.dismiss")}
+          title={t("triggers.secret.dismiss")}
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </Alert>
+    )
+
+  const renderOverview = () => (
+    <div className="space-y-2.5">
+      {renderSecretReveal()}
+      {loading ? (
+        <div className="flex items-center justify-center rounded-lg border border-dashed py-16 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      ) : (
+        TRIGGER_TYPES.map(renderTypeCard)
+      )}
     </div>
   )
 
@@ -909,27 +1182,76 @@ export function AgentTriggersDialog({
     return (
       <div className="flex flex-wrap items-center gap-2 border-b pb-4">
         {activeTypeTriggers.map((trigger) => (
-          <button
+          <div
             key={trigger.id}
-            type="button"
             className={cn(
-              "inline-flex max-w-full items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+              "inline-flex max-w-full items-center rounded-full border text-xs transition-colors",
               selectedTrigger?.id === trigger.id
-                ? "border-primary bg-primary/5 text-foreground"
-                : "bg-background text-muted-foreground hover:text-foreground",
+                ? "border-primary bg-primary/10 font-medium text-primary"
+                : "bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground",
             )}
-            onClick={() => beginEdit(trigger)}
           >
-            <span className={cn("h-2 w-2 rounded-full", trigger.enabled ? "bg-emerald-500" : "bg-muted-foreground/40")} />
-            <span className="truncate">{trigger.name}</span>
-          </button>
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-1.5 py-1.5 pl-3 pr-1"
+              onClick={() => void handleSelectTrigger(trigger)}
+              disabled={busy}
+            >
+              <span className={cn("h-2 w-2 rounded-full", trigger.enabled ? "bg-emerald-500" : "bg-muted-foreground/40")} />
+              <span className="truncate">{trigger.name}</span>
+            </button>
+            <Popover
+              open={deleteConfirmId === trigger.id}
+              onOpenChange={(nextOpen) => setDeleteConfirmId(nextOpen ? trigger.id : null)}
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("triggers.actions.delete")}
+                  title={t("triggers.actions.delete")}
+                  className={cn(
+                    "mr-1 rounded-full p-1 transition-colors",
+                    deleteConfirmId === trigger.id
+                      ? "bg-destructive/10 text-destructive"
+                      : "text-muted-foreground/60 hover:bg-muted hover:text-destructive",
+                  )}
+                  disabled={busy}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-auto max-w-64 p-3">
+                <div className="text-sm">{t("triggers.deleteConfirm")}</div>
+                <div className="mt-2.5 flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDeleteConfirmId(null)}
+                  >
+                    {t("common.cancel")}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => void handleDelete(trigger)}
+                  >
+                    {t("triggers.actions.confirmDelete")}
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
         ))}
         <Button
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => beginCreateForType(activeType)}
-          className="border-dashed border-primary/45 bg-primary/5 text-primary hover:border-primary hover:bg-primary/10"
+          onClick={() => void handleAddAnother(activeType)}
+          disabled={busy}
+          className="h-7 rounded-full border-dashed border-primary/45 bg-primary/5 text-xs text-primary hover:border-primary hover:bg-primary/10"
         >
           <Plus className="mr-1.5 h-4 w-4" />
           {t("triggers.actions.addAnother")}
@@ -953,25 +1275,29 @@ export function AgentTriggersDialog({
       : !isNew
 
     return (
-      <div className="space-y-5">
+      <div className="space-y-4">
         <div className="flex items-center justify-between gap-3 border-b pb-4">
-          <div className="flex min-w-0 items-center gap-3">
-            <Button variant="ghost" size="sm" className="-ml-2" onClick={() => setActiveType(null)}>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="-ml-2 h-8 px-2 text-muted-foreground hover:text-foreground"
+              onClick={() => void handleBack()}
+              disabled={busy}
+            >
               <ChevronLeft className="mr-1 h-4 w-4" />
               {t("common.back")}
             </Button>
-            <div className="flex min-w-0 items-center gap-2 border-l pl-3">
-              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
-                {renderTypeIcon(activeType, "h-4 w-4")}
-              </div>
-              <div className="truncate text-sm font-semibold">
-                {t(`triggers.cards.${activeType}.title`)}
-              </div>
+            <div className={cn("flex h-6 w-6 shrink-0 items-center justify-center rounded-md", typeIconClass(activeType))}>
+              {renderTypeIcon(activeType, "h-3.5 w-3.5")}
+            </div>
+            <div className="truncate text-sm font-bold">
+              {t(`triggers.cards.${activeType}.title`)}
             </div>
           </div>
           <Switch
             checked={form.enabled}
-            onCheckedChange={(checked) => setFormValue("enabled", checked)}
+            onCheckedChange={(checked) => void handleDetailToggle(checked)}
             disabled={busy}
           />
         </div>
@@ -980,7 +1306,7 @@ export function AgentTriggersDialog({
 
         <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_220px]">
           <div className="space-y-2">
-            <Label htmlFor="trigger-name">{t("triggers.form.name")}</Label>
+            <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-name">{t("triggers.form.name")}</Label>
             <Input
               id="trigger-name"
               value={form.name}
@@ -992,7 +1318,7 @@ export function AgentTriggersDialog({
 
           {activeType === "scheduled" ? (
             <div className="space-y-2">
-              <Label htmlFor="trigger-interval">{t("triggers.form.intervalSeconds")}</Label>
+              <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-interval">{t("triggers.form.intervalSeconds")}</Label>
               <Input
                 id="trigger-interval"
                 type="number"
@@ -1003,7 +1329,7 @@ export function AgentTriggersDialog({
             </div>
           ) : activeType === "gmail" ? (
             <div className="space-y-2">
-              <Label htmlFor="trigger-watch-label">{t("triggers.form.watchLabel")}</Label>
+              <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-watch-label">{t("triggers.form.watchLabel")}</Label>
               <Input
                 id="trigger-watch-label"
                 value={form.watchLabel}
@@ -1014,7 +1340,7 @@ export function AgentTriggersDialog({
             </div>
           ) : (
             <div className="space-y-2">
-              <Label htmlFor="trigger-secret">{t("triggers.form.secret")}</Label>
+              <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-secret">{t("triggers.form.secret")}</Label>
               <Input
                 id="trigger-secret"
                 type="password"
@@ -1032,7 +1358,7 @@ export function AgentTriggersDialog({
 
         {activeType === "scheduled" && (
           <div className="space-y-2">
-            <Label htmlFor="trigger-next-run">{t("triggers.form.nextRunAt")}</Label>
+            <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-next-run">{t("triggers.form.nextRunAt")}</Label>
             <Input
               id="trigger-next-run"
               type="datetime-local"
@@ -1044,7 +1370,7 @@ export function AgentTriggersDialog({
 
         {activeType === "gmail" && (
           <div className="space-y-2">
-            <Label id="trigger-gmail-account-label">{t("triggers.form.gmailAccount")}</Label>
+            <Label className={FIELD_LABEL_CLASS} id="trigger-gmail-account-label">{t("triggers.form.gmailAccount")}</Label>
             <div aria-labelledby="trigger-gmail-account-label">
               <Select
                 value={form.oauthAccountId || undefined}
@@ -1081,7 +1407,7 @@ export function AgentTriggersDialog({
         {activeType === "gmail" && (
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="trigger-sender-filter">{t("triggers.form.senderFilter")}</Label>
+              <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-sender-filter">{t("triggers.form.senderFilter")}</Label>
               <Input
                 id="trigger-sender-filter"
                 value={form.senderFilter}
@@ -1090,7 +1416,7 @@ export function AgentTriggersDialog({
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="trigger-subject-keyword">{t("triggers.form.subjectKeyword")}</Label>
+              <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-subject-keyword">{t("triggers.form.subjectKeyword")}</Label>
               <Input
                 id="trigger-subject-keyword"
                 value={form.subjectKeyword}
@@ -1138,7 +1464,7 @@ export function AgentTriggersDialog({
         )}
 
         <div className="space-y-2">
-          <Label htmlFor="trigger-prompt">{t("triggers.form.promptTemplate")}</Label>
+          <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-prompt">{t("triggers.form.promptTemplate")}</Label>
           <Textarea
             id="trigger-prompt"
             value={form.promptTemplate}
@@ -1148,27 +1474,7 @@ export function AgentTriggersDialog({
           />
         </div>
 
-        {secretReveal && (
-          <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>{t("triggers.secret.title")}</AlertTitle>
-            <AlertDescription>
-              <div className="mt-2 flex gap-2">
-                <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
-                  {secretReveal}
-                </code>
-                <Button
-                  size="icon"
-                  variant="secondary"
-                  onClick={() => void handleCopy("secret", secretReveal)}
-                  title={t("common.copy")}
-                >
-                  {copied === "secret" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                </Button>
-              </div>
-            </AlertDescription>
-          </Alert>
-        )}
+        {renderSecretReveal()}
 
         {isStaging && activeType === "webhook" && (
           <Alert className="border-primary/20 bg-primary/5">
@@ -1180,57 +1486,42 @@ export function AgentTriggersDialog({
         )}
 
         {!isStaging && selectedTrigger?.type === "webhook" && (
-          <section className="space-y-3 rounded-lg border bg-muted/20 p-4">
-            <div className="text-sm font-medium">{t("triggers.webhook.title")}</div>
-            <div className="flex gap-2">
-              <Input readOnly value={selectedWebhookUrl} className="font-mono text-xs" />
-              <Button
-                variant="secondary"
+          <section className="space-y-1.5">
+            <div className={FIELD_LABEL_CLASS}>{t("triggers.webhook.title")}</div>
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2">
+              <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+                {selectedWebhookUrl}
+              </code>
+              <button
+                type="button"
+                className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-primary"
                 onClick={() => void handleCopy("webhook-url", selectedWebhookUrl)}
+                aria-label={t("common.copy")}
+                title={t("common.copy")}
               >
-                {copied === "webhook-url" ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
-                {t("common.copy")}
-              </Button>
+                {copied === "webhook-url" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              </button>
             </div>
-            <div className="text-xs text-muted-foreground">
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
               {t("triggers.webhook.secretHeader")}
-            </div>
+            </p>
           </section>
         )}
 
-        <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-4">
-          <div className="flex flex-wrap gap-2">
-            <Button onClick={handleSubmit} disabled={busy || !canOperate}>
-              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isNew ? t("triggers.actions.enable") : t("triggers.actions.save")}
+        {!isStaging && selectedTrigger && (
+          <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+            <Button variant="outline" onClick={handleTest} disabled={busy}>
+              <Play className="mr-2 h-4 w-4" />
+              {t("triggers.actions.test")}
             </Button>
-            {!isStaging && selectedTrigger && (
-              <Button variant="outline" onClick={handleTest} disabled={busy}>
-                <Play className="mr-2 h-4 w-4" />
-                {t("triggers.actions.test")}
-              </Button>
-            )}
-            {!isStaging && selectedTrigger?.type === "webhook" && (
+            {selectedTrigger.type === "webhook" && (
               <Button variant="outline" onClick={handleRotateSecret} disabled={busy}>
                 <RotateCcw className="mr-2 h-4 w-4" />
                 {t("triggers.actions.rotateSecret")}
               </Button>
             )}
           </div>
-          {selectedTrigger && (
-            <Button
-              variant={deleteConfirmId === selectedTrigger.id ? "destructive" : "ghost"}
-              className={cn(deleteConfirmId !== selectedTrigger.id && "text-destructive hover:text-destructive")}
-              onClick={() => void handleDelete(selectedTrigger)}
-              disabled={busy}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              {deleteConfirmId === selectedTrigger.id
-                ? t("triggers.actions.confirmDelete")
-                : t("triggers.actions.delete")}
-            </Button>
-          )}
-        </div>
+        )}
 
         {!isStaging && selectedTrigger && (
           <section className="space-y-3 rounded-lg border p-4">
@@ -1296,7 +1587,7 @@ export function AgentTriggersDialog({
                 className="min-h-[112px] font-mono text-xs"
               />
               <div className="space-y-2">
-                <Label htmlFor="trigger-source-event">{t("triggers.test.sourceEventId")}</Label>
+                <Label className={FIELD_LABEL_CLASS} htmlFor="trigger-source-event">{t("triggers.test.sourceEventId")}</Label>
                 <Input
                   id="trigger-source-event"
                   value={sourceEventId}
@@ -1312,30 +1603,37 @@ export function AgentTriggersDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={closeDialog}>
+    <Dialog open={open} onOpenChange={handleDismiss}>
       <DialogContent
         aria-describedby="agent-triggers-dialog-description"
-        className="flex max-h-[88vh] w-[calc(100vw-2rem)] max-w-none flex-col overflow-hidden p-0 sm:max-w-[680px]"
+        className="flex max-h-[88vh] w-[calc(100vw-2rem)] max-w-none flex-col overflow-hidden rounded-2xl p-0 sm:max-w-[560px]"
       >
         <DialogHeader className="border-b px-5 py-4 pr-12">
-          <DialogTitle className="flex items-center gap-2 text-base">
+          <DialogTitle className="flex items-center gap-2 text-[15px] font-bold">
             <Zap className="h-4 w-4 text-primary" />
             {t("triggers.title")}
           </DialogTitle>
-          <DialogDescription id="agent-triggers-dialog-description">
+          <DialogDescription id="agent-triggers-dialog-description" className="text-xs">
             {agentName ? `${agentName} · ${t("triggers.subtitle")}` : t("triggers.subtitle")}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+        <div className="min-h-0 flex-1 overflow-y-auto p-5 pt-4">
+          <Alert className="mb-4 rounded-lg border-primary/25 bg-primary/[0.07] px-3.5 py-2.5 text-primary">
+            <Info className="h-4 w-4" />
+            <AlertDescription className="text-xs leading-relaxed text-muted-foreground">
+              {t(isStaging ? "triggers.staging.info" : "triggers.overview.info")}
+            </AlertDescription>
+          </Alert>
           {activeType ? renderDetail() : renderOverview()}
         </div>
 
-        {!activeType && (
-          <DialogFooter className="border-t px-5 py-4">
-            <Button onClick={() => closeDialog(false)}>{t("common.done")}</Button>
-          </DialogFooter>
-        )}
+        <DialogFooter className="border-t px-5 py-3.5">
+          <Button onClick={() => void handleDone()} disabled={busy}>
+            {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t("common.done")}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -507,7 +507,7 @@ export function AgentTriggersDialog({
     // Preset values carry real user intent (e.g. the Gmail quick toggle's
     // enabled=true); mark them dirty so Done/Back attempts the creation
     // instead of silently dropping them.
-    setFormDirty(Boolean(initial && Object.keys(initial).length > 0))
+    setFormDirty(Boolean(initial))
     setRuns([])
   }
 
@@ -741,7 +741,7 @@ export function AgentTriggersDialog({
         }
         return
       }
-      const result = await handleSubmit({ enabled: true })
+      const result = await handleSubmit(true)
       if (!result.ok && syncedFormKeyRef.current === formKeyAtStart) {
         setForm((current) => ({ ...current, enabled: false }))
       }
@@ -798,18 +798,16 @@ export function AgentTriggersDialog({
     secret: string | null
   }
 
-  // Persists the current form (update selected / create new). `overrides`
-  // lets callers force fields on top of the form state (the detail switch
+  // Persists the current form (update selected / create new). `enabled`
+  // lets callers force the field on top of the form state (the detail switch
   // passes enabled=true when creating). Returns success plus any freshly
   // generated webhook secret so commit-on-navigation callers can stay put on
   // failure or on a pending secret reveal.
-  const handleSubmit = async (
-    overrides?: Partial<Pick<TriggerFormState, "enabled">>,
-  ): Promise<SubmitResult> => {
+  const handleSubmit = async (enabled?: boolean): Promise<SubmitResult> => {
     if (!canOperate) return { ok: false, secret: null }
     let payload
     try {
-      payload = { ...buildPayload(), ...overrides }
+      payload = { ...buildPayload(), ...(enabled !== undefined && { enabled }) }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
       return { ok: false, secret: null }
@@ -917,18 +915,21 @@ export function AgentTriggersDialog({
   }
 
   const handleBack = async () => {
-    if (!(await commitPendingEdits()).ok) return
+    const result = await commitPendingEdits()
+    if (!result.ok || secretPending(result)) return
     setActiveType(null)
   }
 
   const handleSelectTrigger = async (trigger: AgentTrigger) => {
     if (trigger.id === selectedTriggerId) return
-    if (!(await commitPendingEdits()).ok) return
+    const result = await commitPendingEdits()
+    if (!result.ok || secretPending(result)) return
     beginEdit(trigger)
   }
 
   const handleAddAnother = async (type: AgentTriggerType) => {
-    if (!(await commitPendingEdits()).ok) return
+    const result = await commitPendingEdits()
+    if (!result.ok || secretPending(result)) return
     beginCreateForType(type)
   }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3555,6 +3555,7 @@ Build when you need.`,
   triggers: {
     title: "Triggers",
     subtitle: "Choose how this agent gets activated",
+    deleteConfirm: "Delete this trigger?",
     defaults: {
       webhookName: "API / Webhook",
       scheduledName: "Schedule",
@@ -3637,9 +3638,6 @@ Build when you need.`,
     },
     actions: {
       new: "New",
-      create: "Create trigger",
-      enable: "Enable trigger",
-      save: "Save changes",
       delete: "Delete",
       confirmDelete: "Confirm delete",
       rotateSecret: "Rotate secret",
@@ -3650,7 +3648,8 @@ Build when you need.`,
       confirmDiscard: "Confirm discard"
     },
     secret: {
-      title: "Copy this secret now. It is shown only once."
+      title: "Copy this secret now. It is shown only once.",
+      dismiss: "I've saved this secret"
     },
     webhook: {
       title: "Webhook endpoint",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3555,6 +3555,7 @@ const zh = {
   triggers: {
     title: "Triggers",
     subtitle: "选择此 Agent 的触发方式",
+    deleteConfirm: "确定删除该触发器？",
     defaults: {
       webhookName: "API / Webhook",
       scheduledName: "Schedule",
@@ -3637,9 +3638,6 @@ const zh = {
     },
     actions: {
       new: "新建",
-      create: "创建 Trigger",
-      enable: "启用 Trigger",
-      save: "保存修改",
       delete: "删除",
       confirmDelete: "确认删除",
       rotateSecret: "轮换 secret",
@@ -3650,7 +3648,8 @@ const zh = {
       confirmDiscard: "确认丢弃"
     },
     secret: {
-      title: "请立即复制此 secret，它只显示一次。"
+      title: "请立即复制此 secret，它只显示一次。",
+      dismiss: "我已保存该 secret"
     },
     webhook: {
       title: "Webhook 地址",

--- a/frontend/src/lib/agent-triggers-api.ts
+++ b/frontend/src/lib/agent-triggers-api.ts
@@ -284,7 +284,7 @@ export async function deleteOwnerTrigger(
 // resync in their catch.
 export async function disableOwnerTriggersOfType(
   owner: TriggerOwnerRef,
-  triggers: Pick<AgentTrigger, "id" | "type" | "enabled">[],
+  triggers: AgentTrigger[],
   type: AgentTriggerType,
 ): Promise<AgentTrigger[]> {
   const enabled = triggers.filter((trigger) => trigger.type === type && trigger.enabled)
@@ -295,7 +295,7 @@ export async function disableOwnerTriggersOfType(
 
 export async function disableAgentTriggersOfType(
   agentId: number | string,
-  triggers: Pick<AgentTrigger, "id" | "type" | "enabled">[],
+  triggers: AgentTrigger[],
   type: AgentTriggerType,
 ): Promise<AgentTrigger[]> {
   return disableOwnerTriggersOfType({ kind: "agent", id: agentId }, triggers, type)

--- a/frontend/src/lib/agent-triggers-api.ts
+++ b/frontend/src/lib/agent-triggers-api.ts
@@ -275,6 +275,42 @@ export async function deleteOwnerTrigger(
   }
 }
 
+// Disables every enabled trigger of one type. Shared by the builder summary
+// card and the triggers dialog so both switches keep identical semantics.
+// Owner-based (not agentId) so it works for both agent- and workforce-owned
+// triggers (#950). Returns the updated triggers so callers can patch local
+// state without a full list reload. Promise.all is not atomic: on rejection
+// some triggers may already be disabled server-side, so callers should
+// resync in their catch.
+export async function disableOwnerTriggersOfType(
+  owner: TriggerOwnerRef,
+  triggers: Pick<AgentTrigger, "id" | "type" | "enabled">[],
+  type: AgentTriggerType,
+): Promise<AgentTrigger[]> {
+  const enabled = triggers.filter((trigger) => trigger.type === type && trigger.enabled)
+  return Promise.all(
+    enabled.map((trigger) => updateOwnerTrigger(owner, trigger.id, { enabled: false })),
+  )
+}
+
+export async function disableAgentTriggersOfType(
+  agentId: number | string,
+  triggers: Pick<AgentTrigger, "id" | "type" | "enabled">[],
+  type: AgentTriggerType,
+): Promise<AgentTrigger[]> {
+  return disableOwnerTriggersOfType({ kind: "agent", id: agentId }, triggers, type)
+}
+
+// Patches a trigger list with freshly fetched/updated rows, keyed by id.
+// Shared by the builder summary card and the triggers dialog, both of which
+// apply disableAgentTriggersOfType's response the same way.
+export function mergeUpdatedTriggers(
+  current: AgentTrigger[],
+  updated: AgentTrigger[],
+): AgentTrigger[] {
+  return current.map((item) => updated.find((next) => next.id === item.id) ?? item)
+}
+
 export async function listOwnerTriggerRuns(
   owner: TriggerOwnerRef,
   triggerId: number | string,


### PR DESCRIPTION
## Summary

- The overview switch no longer auto-navigates into the trigger config view — it just flips or creates the trigger in place.
- The detail switch persists enabled/disabled immediately; the Save button is removed — pending field edits now commit on Done, Back, switching pills, Add, and dismissing the dialog.
- New trigger forms default to disabled, matching the overview switch's default state.
- Per-pill delete confirmation moved to an inline popover on the pill itself instead of a footer button.
- Fix: dismissing the dialog (Escape / overlay click / header X) no longer silently drops unsaved edits or an unrevealed one-time webhook secret — the secret alert now requires an explicit dismiss before the dialog is allowed to close.
- Fix: reversing the Gmail quick-toggle intent (turning the switch back off before picking an account) no longer leaves `formDirty` stuck, which previously blocked Done from closing.
- Fix: a failed enable/disable toggle no longer rolls back onto whatever form the user has since navigated to (stale-closure race between an in-flight request and navigation).
- Fix: closing the dialog after committing an edit no longer issues a redundant second trigger-list refetch.
- Extracted `disableAgentTriggersOfType`/`mergeUpdatedTriggers` helpers shared by the builder summary cards and the triggers dialog.

## Test plan

- [x] `vitest run` on `agent-triggers-dialog.test.tsx` and `agent-builder-triggers.test.tsx` — all passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files (no new warnings/errors)
- [x] Manually verified in the browser preview: quick-toggle create/disable, detail switch immediate persist, delete via pill popover, Done/Back/Escape commit paths, Gmail no-account flow, webhook secret reveal + dismiss gating close

Closes #929 