### PR TITLE
fix(widget): re-validate agent widget guest tokens per request

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -120,7 +120,7 @@ def ensure_widget_agent_available(
     if (
         not agent
         or is_workforce_generated_manager_agent(agent)
-        or int(agent.user_id) != int(user_id)
+        or agent.user_id != user_id
         or not agent.widget_enabled
         or not agent.widget_key
         or (expected_widget_key is not None and agent.widget_key != expected_widget_key)

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -95,6 +95,40 @@ def create_public_chat_access_token(data: dict[str, Any]) -> str:
     return encoded_jwt
 
 
+def ensure_widget_agent_available(
+    db: Session,
+    widget_agent_id: int,
+    user_id: int,
+    *,
+    expected_widget_key: str | None = None,
+) -> Agent:
+    """Resolve a widget-guest agent id to a live, widget-enabled agent.
+
+    Mirrors :func:`ensure_share_agent_available` for the widget channel. The
+    guest JWT is long-lived (30-day TTL), so access is re-derived from the
+    agent's *current* widget state on every request rather than trusted from
+    the token alone: disabling the widget (``widget_enabled = False``) or
+    rotating ``widget_key`` cuts off outstanding guest tokens on their next
+    request.
+
+    ``expected_widget_key`` is the key carried by the guest JWT; when present
+    it must still match the agent's live key. Tokens minted before the key was
+    embedded carry no key and skip that comparison — they stay gated on
+    ``widget_enabled`` so the disable path still revokes them.
+    """
+    agent = db.query(Agent).filter(Agent.id == widget_agent_id).first()
+    if (
+        not agent
+        or is_workforce_generated_manager_agent(agent)
+        or int(agent.user_id) != int(user_id)
+        or not agent.widget_enabled
+        or not agent.widget_key
+        or (expected_widget_key is not None and agent.widget_key != expected_widget_key)
+    ):
+        raise HTTPException(status_code=403, detail="Widget is unavailable")
+    return agent
+
+
 def ensure_share_agent_available(
     db: Session,
     share_agent_id: int,
@@ -239,8 +273,21 @@ def get_public_chat_user(
                 widget_workforce_id=widget_workforce_id,
             )
 
+        # Agent widget: re-validate against the live agent every request so
+        # disabling the widget or rotating its key revokes outstanding guest
+        # tokens (mirrors the share path). The per-message WS revalidation
+        # calls back through here, so live sessions drop on the next inbound
+        # message too.
         if not isinstance(widget_agent_id, int):
             raise ValueError("Invalid widget token payload")
+        ensure_widget_agent_available(
+            db,
+            widget_agent_id,
+            user_id,
+            expected_widget_key=widget_key
+            if isinstance(widget_key, str) and widget_key
+            else None,
+        )
 
         return PublicChatAccessContext(
             user=user,

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -171,7 +171,7 @@ def ensure_share_workforce_available(
     deployment = get_deployment(db, DeploymentOwnerType.WORKFORCE, share_workforce_id)
     if (
         not workforce
-        or int(workforce.owner_user_id) != user_id
+        or workforce.owner_user_id != user_id
         or workforce.status != "active"
         or deployment is None
         or not deployment.share_enabled
@@ -204,7 +204,7 @@ def ensure_widget_workforce_available(
     deployment = get_deployment(db, DeploymentOwnerType.WORKFORCE, widget_workforce_id)
     if (
         not workforce
-        or int(workforce.owner_user_id) != user_id
+        or workforce.owner_user_id != user_id
         or workforce.status != "active"
         or deployment is None
         or not deployment.widget_enabled

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -401,6 +401,9 @@ async def authenticate_widget(
             "guest_id": request.guest_id,
             "auth_mode": "widget",
             "widget_agent_id": int(agent.id),
+            # Carried so per-request revalidation can reject the token once the
+            # owner rotates the key (see ensure_widget_agent_available).
+            "widget_key": agent.widget_key,
         }
     )
 

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -974,6 +974,69 @@ def test_widget_task_create_persists_connector_runtime_selection_snapshot() -> N
         db.close()
 
 
+def _create_widget_task(guest_headers: dict[str, str], agent_id: int) -> Any:
+    return client.post(
+        "/api/widget/chat/task/create",
+        json={
+            "title": "hello",
+            "description": "hello",
+            "agent_id": agent_id,
+        },
+        headers=guest_headers,
+    )
+
+
+def test_disabled_widget_invalidates_existing_guest_tokens() -> None:
+    """Disabling an agent's widget must invalidate already-issued guest JWTs
+    on their next request (mirrors the workforce/share widget path)."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Disable Invalidate Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+
+    # Sanity: the guest token works while the widget is enabled.
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    disabled = client.put(
+        f"/api/agents/{agent_id}",
+        headers=headers,
+        json={"widget_enabled": False},
+    )
+    assert disabled.status_code == 200, disabled.text
+
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
+def test_rotated_widget_key_invalidates_existing_guest_tokens() -> None:
+    """Rotating an agent's widget key must invalidate already-issued guest
+    JWTs on their next request."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Rotate Invalidate Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    rotate = client.post(f"/api/agents/{agent_id}/widget-key/rotate", headers=headers)
+    assert rotate.status_code == 200, rotate.text
+
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
 def test_share_link_requires_published_agent() -> None:
     headers = _admin_headers()
     owner_id = _user_id("admin")

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 
 from xagent.config import get_uploads_dir
 from xagent.web.api import agents as agents_api
+from xagent.web.api.public_chat_access import create_public_chat_access_token
 from xagent.web.api.widget import (
     EMBED_TICKET_TYPE,
     WIDGET_CREDENTIAL_REQUIRED_DETAIL,
@@ -1032,6 +1033,99 @@ def test_rotated_widget_key_invalidates_existing_guest_tokens() -> None:
     rotate = client.post(f"/api/agents/{agent_id}/widget-key/rotate", headers=headers)
     assert rotate.status_code == 200, rotate.text
 
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
+def test_widget_guest_token_rejected_when_agent_becomes_generated_manager() -> None:
+    """``ensure_widget_agent_available`` must reject a live guest token once the
+    backing agent is a workforce-generated manager, tripping the check at the
+    task-create site (not just at ``/api/widget/auth``)."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Becomes Manager Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    # Flip the agent into a generated manager after the token was issued.
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.origin = AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+        db.commit()
+    finally:
+        db.close()
+
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
+def _mint_legacy_widget_guest_token(
+    *,
+    user_id: int,
+    agent_id: int,
+    guest_id: str = "guest-legacy",
+) -> dict[str, str]:
+    """Mint a widget guest JWT the way it was minted before the ``widget_key``
+    claim shipped (issue #988): no key embedded. Exercises the backward-compat
+    branch in ``ensure_widget_agent_available``."""
+    db = _direct_db_session()
+    try:
+        user = db.query(User).filter(User.id == user_id).one()
+        username = str(user.username)
+    finally:
+        db.close()
+    token = create_public_chat_access_token(
+        {
+            "sub": username,
+            "user_id": user_id,
+            "channel_id": None,
+            "guest_id": guest_id,
+            "auth_mode": "widget",
+            "widget_agent_id": agent_id,
+        }
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_legacy_guest_token_without_widget_key_stays_gated_on_widget_enabled() -> None:
+    """Guest tokens minted before the ``widget_key`` claim shipped carry no key:
+    they still work while the widget is enabled, survive key rotation (no key to
+    compare), but are revoked when the widget is disabled. Locks in the
+    transitional contract documented on ``ensure_widget_agent_available``."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Legacy Token Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _mint_legacy_widget_guest_token(user_id=owner_id, agent_id=agent_id)
+
+    # (a) A keyless legacy token works while the widget is enabled.
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    # (c) Rotating the key does not revoke a keyless token: there is no key
+    # claim to compare, so it stays gated on widget_enabled only.
+    rotate = client.post(f"/api/agents/{agent_id}/widget-key/rotate", headers=headers)
+    assert rotate.status_code == 200, rotate.text
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    # (b) Disabling the widget still revokes it.
+    disabled = client.put(
+        f"/api/agents/{agent_id}",
+        headers=headers,
+        json={"widget_enabled": False},
+    )
+    assert disabled.status_code == 200, disabled.text
     response = _create_widget_task(guest_headers, agent_id)
     assert response.status_code == 403, response.text
     assert response.json()["detail"] == "Widget is unavailable"


### PR DESCRIPTION
## What & why

Follow-up to #985. The **workforce/share** widget paths re-validate a guest's JWT on every request against the live deployment, so disabling the widget or rotating its key immediately cuts off live guests. The pre-existing **agent** widget path did not: `get_public_chat_user` only checked that `widget_agent_id` was an int — it never reloaded the agent to re-check `widget_enabled` or compare the key. With a 30-day guest-JWT TTL, a leaked/old token kept working regardless of owner action.

This brings the agent widget path in line.

## Changes

- **Mint the guest JWT with `widget_key`** (`widget.py`), mirroring the workforce path.
- **Add `ensure_widget_agent_available(...)`** (`public_chat_access.py`): reloads the agent and rejects when the widget is disabled, the agent is a workforce-generated manager, or the token's `widget_key` no longer matches — mirroring `ensure_share_agent_available`.
- **Wire it into `get_public_chat_user`.** Because the WS loop re-calls `get_public_chat_user` per inbound message, live sessions are dropped on the next message.

Transitional note: tokens minted before this change carry no `widget_key`, so they skip the key comparison and stay gated on `widget_enabled` only (documented in the helper docstring). All newly minted tokens carry the key, so rotation-based invalidation works going forward.

## Acceptance

- [x] Disabling an agent widget invalidates existing guest tokens on their next request.
- [x] Rotating an agent widget key invalidates existing guest tokens **minted after this change ships** on their next request. Pre-existing (keyless) tokens carry no key to compare, so they stay gated on `widget_enabled` only — the transitional contract above, matching `ensure_widget_workforce_available`.
- [x] The live WS session is dropped on the next inbound message (per-message revalidation).
- [x] Tests mirroring `test_rotated_widget_key_invalidates_existing_guest_tokens` / `test_disabled_widget_invalidates_existing_guest_tokens`, plus a legacy-token contract test and a manager-agent rejection test at the task-create site.

## Testing

Full `tests/web` suite passes (only env-gated skips: postgres / pubsub / KB).

Closes #988

