### PR TITLE
feat(mcp): add Google Ads connector via OAuth + platform developer token

### DIFF
--- a/example.env
+++ b/example.env
@@ -300,6 +300,14 @@ GOOGLE_CLIENT_SECRET=""
 # Example: http://localhost:8000/api/auth/google/callback
 GOOGLE_REDIRECT_URI=""
 
+# Google Ads developer token (Optional)
+# Required for the Google Ads connector in MCP. Apply for/find this token in
+# the Ads API Center of a Google Ads manager (MCC) account:
+# https://ads.google.com/aw/apicenter
+# This is a single platform-wide token shared by all users who connect the
+# Google Ads app (not a per-user secret), analogous to GOOGLE_CLIENT_ID above.
+GOOGLE_ADS_DEVELOPER_TOKEN=""
+
 # ===========================================
 # LinkedIn OAuth Configuration (Optional)
 # ===========================================

--- a/src/xagent/migrations/versions/20260724_seed_google_ads_mcp_app.py
+++ b/src/xagent/migrations/versions/20260724_seed_google_ads_mcp_app.py
@@ -1,0 +1,82 @@
+"""seed built-in Google Ads (OAuth) MCP connector
+
+Revision ID: 20260724_seed_google_ads_mcp_app
+Revises: 20260722_add_workforce_id_to_agent_api_keys
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260724_seed_google_ads_mcp_app"
+down_revision: Union[str, None] = "20260722_add_workforce_id_to_agent_api_keys"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "google-ads"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Google Ads",
+    "description": "Connect to Google Ads to list accessible accounts, inspect campaigns, and run GAQL reports.",
+    "icon": "https://www.google.com/s2/favicons?domain=ads.google.com&sz=128",
+    "transport": "oauth",
+    "provider_name": "google",
+    "category": "Marketing",
+    "oauth_scopes": ["https://www.googleapis.com/auth/adwords"],
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.google_ads"],
+        "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+        "static_env": {"GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. The shared "google" oauth_providers row
+    # is left untouched since it is reused by Gmail/Drive/Calendar/Docs/Slides.
+    # Any MCPServer/UserMCPServer rows created by users who already connected are
+    # intentionally left in place — connect-driven rows are not owned by this
+    # migration and are cleaned up through the normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -220,6 +220,25 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "google-ads",
+            "name": "Google Ads",
+            "description": "Connect to Google Ads to list accessible accounts, inspect campaigns, and run GAQL reports.",
+            "icon": "https://www.google.com/s2/favicons?domain=ads.google.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "google",
+            "category": "Marketing",
+            "oauth_scopes": ["https://www.googleapis.com/auth/adwords"],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.google_ads"],
+                "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+                "static_env": {
+                    "GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"
+                },
+            },
+        },
+        {
             "app_id": "hubspot",
             "name": "HubSpot",
             "description": "Connect to HubSpot CRM to search, create, and update contacts and companies, read deals, and log notes.",

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -2514,9 +2514,9 @@ class WebToolConfig(BaseToolConfig):
             for env_key, host_env_var in _oauth_launch_config_static_env(
                 launch_config
             ).items():
-                value = os.environ.get(str(host_env_var), "")
-                if value:
-                    env[env_key] = value
+                value = os.environ.get(str(host_env_var))
+                if value is not None:
+                    env[env_key] = str(value)
 
             env.update(
                 {

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -357,6 +357,27 @@ def _oauth_launch_config_command(launch_config: Mapping[str, Any]) -> str:
     raise _OAuthLaunchConfigInvalid(field="command")
 
 
+def _oauth_launch_config_static_env(
+    launch_config: Mapping[str, Any],
+) -> Mapping[str, str]:
+    """Server-only static secrets forwarded verbatim from the host process env.
+
+    Unlike env_mapping (per-user OAuth token values), these are platform-wide
+    values read from this process's own environment at transport-config build
+    time — e.g. a shared API developer token that isn't tied to any one user's
+    OAuth grant.
+    """
+    static_env = launch_config.get("static_env")
+    if static_env is None:
+        return {}
+    if isinstance(static_env, Mapping):
+        return static_env
+    logger.warning(
+        "Ignoring OAuth MCP launch config static_env because static_env must be a mapping"
+    )
+    return {}
+
+
 def _oauth_launch_config_env_mapping(
     launch_config: Mapping[str, Any],
 ) -> Mapping[str, Any]:
@@ -2489,6 +2510,13 @@ class WebToolConfig(BaseToolConfig):
             ).items():
                 if token_type == "access_token":
                     env[env_key] = access_token
+
+            for env_key, host_env_var in _oauth_launch_config_static_env(
+                launch_config
+            ).items():
+                value = os.environ.get(str(host_env_var), "")
+                if value:
+                    env[env_key] = value
 
             env.update(
                 {

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -366,6 +366,11 @@ def _oauth_launch_config_static_env(
     values read from this process's own environment at transport-config build
     time — e.g. a shared API developer token that isn't tied to any one user's
     OAuth grant.
+
+    A static_env entry can name *any* host env var to forward, so this is
+    only safe as long as launch_config is written exclusively by migrations,
+    the builtin registry, and admin-gated API routes — never by an
+    end-user-writable path.
     """
     static_env = launch_config.get("static_env")
     if static_env is None:

--- a/src/xagent/web/tools/mcp/google_ads.py
+++ b/src/xagent/web/tools/mcp/google_ads.py
@@ -65,6 +65,57 @@ def _headers(login_customer_id: str | None = None) -> dict[str, str]:
     return headers
 
 
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message(s) out of a Google Ads error body.
+
+    Google Ads error responses are a large structured JSON payload
+    (``{"error": {"message": ..., "details": [{"errors": [...]}]}}``);
+    returning that whole blob to the LLM wastes tokens and is harder for it
+    to act on than the plain message(s) it actually needs to fix a bad GAQL
+    query. Returns None if the body isn't in the expected shape, so the
+    caller can fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+
+    messages: list[str] = []
+    top_message = error.get("message")
+    if isinstance(top_message, str) and top_message:
+        messages.append(top_message)
+
+    for detail in error.get("details") or []:
+        if not isinstance(detail, dict):
+            continue
+        for sub_error in detail.get("errors") or []:
+            if not isinstance(sub_error, dict):
+                continue
+            sub_message = sub_error.get("message")
+            if isinstance(sub_message, str) and sub_message:
+                messages.append(sub_message)
+
+    if not messages:
+        return None
+    return "; ".join(dict.fromkeys(messages))
+
+
+def _require_dict_result(result: Any) -> dict[str, Any]:
+    """Guard against a non-dict payload (e.g. a list or string) before
+    calling dict methods on it. A dict that's merely empty (zero
+    accessible customers, zero GAQL rows) is a normal, valid response and
+    must not be rejected here."""
+    if not isinstance(result, dict):
+        raise ValueError("Unexpected response format from Google Ads API")
+    return result
+
+
 def _request(
     method: str,
     path: str,
@@ -82,10 +133,12 @@ def _request(
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
-        response_text = response.text.strip()
         message = str(exc)
-        if response_text:
-            message = f"{message} - {response_text}"
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+        if detail:
+            message = f"{message} - {detail}"
         raise RuntimeError(message) from exc
 
     if response.status_code == 204 or not response.content:
@@ -100,9 +153,13 @@ def google_ads_list_accessible_customers() -> str:
     Use this first to discover which customer_id values are available for google_ads_search.
     """
     try:
-        result = _request("GET", "/customers:listAccessibleCustomers")
+        result = _require_dict_result(
+            _request("GET", "/customers:listAccessibleCustomers")
+        )
         resource_names = result.get("resourceNames", [])
-        customer_ids = [name.rsplit("/", 1)[-1] for name in resource_names]
+        customer_ids = [
+            name.rsplit("/", 1)[-1] for name in resource_names if isinstance(name, str)
+        ]
         return _success(customer_ids=customer_ids)
     except Exception as e:
         logger.error(f"Error listing accessible customers: {e}")
@@ -124,11 +181,13 @@ def google_ads_search(
         normalized_customer_id = _normalize_customer_id(
             customer_id, field_name="customer_id"
         )
-        result = _request(
-            "POST",
-            f"/customers/{normalized_customer_id}/googleAds:search",
-            login_customer_id=login_customer_id,
-            body={"query": query},
+        result = _require_dict_result(
+            _request(
+                "POST",
+                f"/customers/{normalized_customer_id}/googleAds:search",
+                login_customer_id=login_customer_id,
+                body={"query": query},
+            )
         )
         return _success(results=result.get("results", []))
     except Exception as e:

--- a/src/xagent/web/tools/mcp/google_ads.py
+++ b/src/xagent/web/tools/mcp/google_ads.py
@@ -20,7 +20,7 @@ mcp = FastMCP("google-ads-mcp")
 GOOGLE_ADS_BASE_URL = "https://googleads.googleapis.com/v23"
 DEFAULT_TIMEOUT_SECONDS = 30
 
-_CUSTOMER_ID_PATTERN = re.compile(r"^[0-9-]+\Z")
+_CUSTOMER_ID_PATTERN = re.compile(r"^[0-9][0-9-]*\Z")
 
 
 def _success(**payload: Any) -> str:
@@ -32,12 +32,16 @@ def _error(message: str) -> str:
 
 
 def _normalize_customer_id(customer_id: str, *, field_name: str) -> str:
-    """Validate a customer id is digits/dashes only, then strip the dashes.
+    """Validate a customer id is digits/dashes (starting with a digit), then
+    strip the dashes.
 
     Rejects anything else (rather than silently sanitizing it) since this
     value is interpolated directly into an HTTP header and a URL path —
     a malformed value could otherwise inject headers or redirect the request
-    to an unintended API path.
+    to an unintended API path. Requiring a leading digit also rules out an
+    all-dash input (e.g. "---"), which would otherwise strip down to an
+    empty string and silently produce a malformed header/URL instead of
+    failing validation.
     """
     if not _CUSTOMER_ID_PATTERN.match(str(customer_id)):
         raise ValueError(f"{field_name} must contain only digits and dashes")

--- a/src/xagent/web/tools/mcp/google_ads.py
+++ b/src/xagent/web/tools/mcp/google_ads.py
@@ -20,7 +20,7 @@ mcp = FastMCP("google-ads-mcp")
 GOOGLE_ADS_BASE_URL = "https://googleads.googleapis.com/v23"
 DEFAULT_TIMEOUT_SECONDS = 30
 
-_CUSTOMER_ID_PATTERN = re.compile(r"^[0-9-]+$")
+_CUSTOMER_ID_PATTERN = re.compile(r"^[0-9-]+\Z")
 
 
 def _success(**payload: Any) -> str:

--- a/src/xagent/web/tools/mcp/google_ads.py
+++ b/src/xagent/web/tools/mcp/google_ads.py
@@ -1,0 +1,119 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("google-ads-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("google-ads-mcp")
+
+GOOGLE_ADS_BASE_URL = "https://googleads.googleapis.com/v23"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers(login_customer_id: str | None = None) -> dict[str, str]:
+    access_token = os.environ.get("GOOGLE_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("GOOGLE_ACCESS_TOKEN environment variable is missing")
+
+    developer_token = os.environ.get("GOOGLE_ADS_DEVELOPER_TOKEN")
+    if not developer_token:
+        raise ValueError("GOOGLE_ADS_DEVELOPER_TOKEN environment variable is missing")
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "developer-token": developer_token,
+        "Content-Type": "application/json",
+    }
+    if login_customer_id:
+        headers["login-customer-id"] = login_customer_id.replace("-", "")
+    return headers
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    login_customer_id: str | None = None,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=f"{GOOGLE_ADS_BASE_URL}{path}",
+        headers=_headers(login_customer_id),
+        json=body,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        response_text = response.text.strip()
+        message = str(exc)
+        if response_text:
+            message = f"{message} - {response_text}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+@mcp.tool()
+def google_ads_list_accessible_customers() -> str:
+    """
+    List the Google Ads customer IDs accessible to the connected account.
+    Use this first to discover which customer_id values are available for google_ads_search.
+    """
+    try:
+        result = _request("GET", "/customers:listAccessibleCustomers")
+        resource_names = result.get("resourceNames", [])
+        customer_ids = [name.rsplit("/", 1)[-1] for name in resource_names]
+        return _success(customer_ids=customer_ids)
+    except Exception as e:
+        logger.error(f"Error listing accessible customers: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_ads_search(
+    customer_id: str, query: str, login_customer_id: str | None = None
+) -> str:
+    """
+    Run a Google Ads Query Language (GAQL) query against one customer account,
+    e.g. to list campaigns, ad groups, or performance metrics.
+    customer_id is the account to query (digits only, no dashes).
+    login_customer_id is required when customer_id is a client account managed
+    under a manager (MCC) account, and should be the manager's customer id.
+    """
+    try:
+        result = _request(
+            "POST",
+            f"/customers/{customer_id.replace('-', '')}/googleAds:search",
+            login_customer_id=login_customer_id,
+            body={"query": query},
+        )
+        return _success(results=result.get("results", []))
+    except Exception as e:
+        logger.error(f"Error running Google Ads search: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/google_ads.py
+++ b/src/xagent/web/tools/mcp/google_ads.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import requests
@@ -19,6 +20,8 @@ mcp = FastMCP("google-ads-mcp")
 GOOGLE_ADS_BASE_URL = "https://googleads.googleapis.com/v23"
 DEFAULT_TIMEOUT_SECONDS = 30
 
+_CUSTOMER_ID_PATTERN = re.compile(r"^[0-9-]+$")
+
 
 def _success(**payload: Any) -> str:
     return json.dumps({"status": "success", **payload}, ensure_ascii=False)
@@ -26,6 +29,19 @@ def _success(**payload: Any) -> str:
 
 def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _normalize_customer_id(customer_id: str, *, field_name: str) -> str:
+    """Validate a customer id is digits/dashes only, then strip the dashes.
+
+    Rejects anything else (rather than silently sanitizing it) since this
+    value is interpolated directly into an HTTP header and a URL path —
+    a malformed value could otherwise inject headers or redirect the request
+    to an unintended API path.
+    """
+    if not _CUSTOMER_ID_PATTERN.match(str(customer_id)):
+        raise ValueError(f"{field_name} must contain only digits and dashes")
+    return str(customer_id).replace("-", "")
 
 
 def _headers(login_customer_id: str | None = None) -> dict[str, str]:
@@ -43,7 +59,9 @@ def _headers(login_customer_id: str | None = None) -> dict[str, str]:
         "Content-Type": "application/json",
     }
     if login_customer_id:
-        headers["login-customer-id"] = login_customer_id.replace("-", "")
+        headers["login-customer-id"] = _normalize_customer_id(
+            login_customer_id, field_name="login_customer_id"
+        )
     return headers
 
 
@@ -103,9 +121,12 @@ def google_ads_search(
     under a manager (MCC) account, and should be the manager's customer id.
     """
     try:
+        normalized_customer_id = _normalize_customer_id(
+            customer_id, field_name="customer_id"
+        )
         result = _request(
             "POST",
-            f"/customers/{customer_id.replace('-', '')}/googleAds:search",
+            f"/customers/{normalized_customer_id}/googleAds:search",
             login_customer_id=login_customer_id,
             body={"query": query},
         )

--- a/tests/alembic/test_20260724_seed_google_ads_mcp_app.py
+++ b/tests/alembic/test_20260724_seed_google_ads_mcp_app.py
@@ -1,0 +1,109 @@
+"""Tests for the Google Ads MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260724_seed_google_ads_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_google_ads_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_google_ads(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "google-ads" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps WHERE app_id='google-ads'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "google"
+        assert "xagent.web.tools.mcp.google_ads" in str(row[2])
+        assert "GOOGLE_ADS_DEVELOPER_TOKEN" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='google-ads'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    google-ads row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "google-ads"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_google_ads(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "google-ads" not in _app_ids(connection)

--- a/tests/web/tools/test_google_ads_mcp.py
+++ b/tests/web/tools/test_google_ads_mcp.py
@@ -1,0 +1,126 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import google_ads
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ACCESS_TOKEN"):
+        google_ads._headers()
+
+
+def test_headers_require_developer_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ADS_DEVELOPER_TOKEN"):
+        google_ads._headers()
+
+
+def test_headers_include_bearer_and_developer_token():
+    headers = google_ads._headers()
+
+    assert headers["Authorization"] == "Bearer access-token"
+    assert headers["developer-token"] == "dev-token"
+    assert "login-customer-id" not in headers
+
+
+def test_headers_include_normalized_login_customer_id():
+    headers = google_ads._headers(login_customer_id="123-456-7890")
+
+    assert headers["login-customer-id"] == "1234567890"
+
+
+def test_request_wraps_http_error_with_response_body(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400, text='{"error": {"message": "invalid query"}}'
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid query"):
+        google_ads._request("GET", "/customers:listAccessibleCustomers")
+
+
+def test_list_accessible_customers_strips_resource_prefix(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "resourceNames": ["customers/1112223333", "customers/4445556666"]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(google_ads.google_ads_list_accessible_customers())
+
+    assert result["status"] == "success"
+    assert result["customer_ids"] == ["1112223333", "4445556666"]
+
+
+def test_google_ads_search_sends_gaql_query_and_login_customer_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": [{"foo": 1}]}))
+    monkeypatch.setattr(google_ads.requests, "request", mock_request)
+
+    result = json.loads(
+        google_ads.google_ads_search(
+            "111-222-3333",
+            "SELECT campaign.id FROM campaign",
+            login_customer_id="999-888-7777",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["results"] == [{"foo": 1}]
+
+    call_kwargs = mock_request.call_args.kwargs
+    assert call_kwargs["url"].endswith("/customers/1112223333/googleAds:search")
+    assert call_kwargs["json"] == {"query": "SELECT campaign.id FROM campaign"}
+    assert call_kwargs["headers"]["login-customer-id"] == "9998887777"
+
+
+def test_google_ads_search_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=400, text="bad request")),
+    )
+
+    result = json.loads(
+        google_ads.google_ads_search("1112223333", "SELECT campaign.id")
+    )
+
+    assert result["status"] == "error"
+    assert "bad request" in result["message"]

--- a/tests/web/tools/test_google_ads_mcp.py
+++ b/tests/web/tools/test_google_ads_mcp.py
@@ -78,6 +78,44 @@ def test_request_wraps_http_error_with_response_body(monkeypatch):
         google_ads._request("GET", "/customers:listAccessibleCustomers")
 
 
+def test_request_extracts_structured_error_message(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "error": {
+                        "message": "Request contains an invalid argument.",
+                        "details": [
+                            {
+                                "errors": [
+                                    {"message": "Unrecognized field in GAQL query."}
+                                ]
+                            }
+                        ],
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unrecognized field in GAQL query"):
+        google_ads._request("GET", "/customers:listAccessibleCustomers")
+
+
+def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="upstream 500")),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        google_ads._request("GET", "/customers:listAccessibleCustomers")
+
+
 def test_list_accessible_customers_strips_resource_prefix(monkeypatch):
     monkeypatch.setattr(
         google_ads.requests,
@@ -95,6 +133,36 @@ def test_list_accessible_customers_strips_resource_prefix(monkeypatch):
 
     assert result["status"] == "success"
     assert result["customer_ids"] == ["1112223333", "4445556666"]
+
+
+def test_list_accessible_customers_filters_non_string_resource_names(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={"resourceNames": ["customers/111", 42, None]}
+            )
+        ),
+    )
+
+    result = json.loads(google_ads.google_ads_list_accessible_customers())
+
+    assert result["status"] == "success"
+    assert result["customer_ids"] == ["111"]
+
+
+def test_list_accessible_customers_rejects_non_dict_response(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["unexpected", "list"])),
+    )
+
+    result = json.loads(google_ads.google_ads_list_accessible_customers())
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]
 
 
 def test_google_ads_search_sends_gaql_query_and_login_customer_id(monkeypatch):
@@ -131,6 +199,21 @@ def test_google_ads_search_returns_error_payload_on_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "bad request" in result["message"]
+
+
+def test_google_ads_search_handles_empty_dict_result(monkeypatch):
+    monkeypatch.setattr(
+        google_ads.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={})),
+    )
+
+    result = json.loads(
+        google_ads.google_ads_search("1112223333", "SELECT campaign.id")
+    )
+
+    assert result["status"] == "success"
+    assert result["results"] == []
 
 
 def test_google_ads_search_rejects_customer_id_with_invalid_characters(monkeypatch):

--- a/tests/web/tools/test_google_ads_mcp.py
+++ b/tests/web/tools/test_google_ads_mcp.py
@@ -56,6 +56,11 @@ def test_headers_include_normalized_login_customer_id():
     assert headers["login-customer-id"] == "1234567890"
 
 
+def test_headers_reject_login_customer_id_with_invalid_characters():
+    with pytest.raises(ValueError, match="login_customer_id"):
+        google_ads._headers(login_customer_id="1234567890\r\nX-Injected: 1")
+
+
 def test_request_wraps_http_error_with_response_body(monkeypatch):
     monkeypatch.setattr(
         google_ads.requests,
@@ -124,3 +129,16 @@ def test_google_ads_search_returns_error_payload_on_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "bad request" in result["message"]
+
+
+def test_google_ads_search_rejects_customer_id_with_invalid_characters(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_ads.requests, "request", mock_request)
+
+    result = json.loads(
+        google_ads.google_ads_search("111/../other", "SELECT campaign.id")
+    )
+
+    assert result["status"] == "error"
+    assert "customer_id" in result["message"]
+    mock_request.assert_not_called()

--- a/tests/web/tools/test_google_ads_mcp.py
+++ b/tests/web/tools/test_google_ads_mcp.py
@@ -59,6 +59,8 @@ def test_headers_include_normalized_login_customer_id():
 def test_headers_reject_login_customer_id_with_invalid_characters():
     with pytest.raises(ValueError, match="login_customer_id"):
         google_ads._headers(login_customer_id="1234567890\r\nX-Injected: 1")
+    with pytest.raises(ValueError, match="login_customer_id"):
+        google_ads._headers(login_customer_id="1234567890\n")
 
 
 def test_request_wraps_http_error_with_response_body(monkeypatch):

--- a/tests/web/tools/test_google_ads_mcp.py
+++ b/tests/web/tools/test_google_ads_mcp.py
@@ -63,6 +63,12 @@ def test_headers_reject_login_customer_id_with_invalid_characters():
         google_ads._headers(login_customer_id="1234567890\n")
 
 
+def test_headers_reject_all_dash_login_customer_id():
+    """An all-dash value would otherwise strip to "" and send an empty header."""
+    with pytest.raises(ValueError, match="login_customer_id"):
+        google_ads._headers(login_customer_id="---")
+
+
 def test_request_wraps_http_error_with_response_body(monkeypatch):
     monkeypatch.setattr(
         google_ads.requests,
@@ -223,6 +229,18 @@ def test_google_ads_search_rejects_customer_id_with_invalid_characters(monkeypat
     result = json.loads(
         google_ads.google_ads_search("111/../other", "SELECT campaign.id")
     )
+
+    assert result["status"] == "error"
+    assert "customer_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_google_ads_search_rejects_all_dash_customer_id(monkeypatch):
+    """An all-dash value would otherwise strip to "" and hit /customers//... ."""
+    mock_request = Mock()
+    monkeypatch.setattr(google_ads.requests, "request", mock_request)
+
+    result = json.loads(google_ads.google_ads_search("---", "SELECT campaign.id"))
 
     assert result["status"] == "error"
     assert "customer_id" in result["message"]

--- a/tests/web/tools/test_oauth_launch_config_static_env.py
+++ b/tests/web/tools/test_oauth_launch_config_static_env.py
@@ -53,6 +53,29 @@ def test_transport_config_forwards_static_env_value(monkeypatch):
     assert transport_config["env"]["GOOGLE_ADS_DEVELOPER_TOKEN"] == "dev-token-value"
 
 
+def test_transport_config_forwards_empty_string_static_env_value(monkeypatch):
+    """An explicitly empty host value is still forwarded (distinct from unset)."""
+    monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "")
+
+    cfg = WebToolConfig(db=None, request=None)
+    app_info = {
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.google_ads"],
+            "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            "static_env": {"GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"},
+        }
+    }
+
+    transport_config = cfg._build_oauth_mcp_stdio_transport_config(
+        server=SimpleNamespace(name="Google Ads"),
+        app_info=app_info,
+        access_token="user-access-token",
+    )
+
+    assert transport_config["env"]["GOOGLE_ADS_DEVELOPER_TOKEN"] == ""
+
+
 def test_transport_config_omits_static_env_when_host_var_missing(monkeypatch):
     monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
 

--- a/tests/web/tools/test_oauth_launch_config_static_env.py
+++ b/tests/web/tools/test_oauth_launch_config_static_env.py
@@ -1,0 +1,75 @@
+"""Tests for forwarding platform-level static secrets (e.g. a shared API
+developer token) into OAuth-transport MCP subprocess environments, alongside
+the existing per-user OAuth access token forwarded via env_mapping."""
+
+from types import SimpleNamespace
+
+from xagent.web.tools.config import (
+    WebToolConfig,
+    _oauth_launch_config_static_env,
+)
+
+
+def test_static_env_returns_empty_mapping_when_absent():
+    assert _oauth_launch_config_static_env({}) == {}
+
+
+def test_static_env_returns_mapping_when_present():
+    launch_config = {
+        "static_env": {"GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"}
+    }
+
+    assert _oauth_launch_config_static_env(launch_config) == {
+        "GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"
+    }
+
+
+def test_static_env_ignores_non_mapping_value(caplog):
+    launch_config = {"static_env": ["not", "a", "mapping"]}
+
+    assert _oauth_launch_config_static_env(launch_config) == {}
+
+
+def test_transport_config_forwards_static_env_value(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-token-value")
+
+    cfg = WebToolConfig(db=None, request=None)
+    app_info = {
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.google_ads"],
+            "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            "static_env": {"GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"},
+        }
+    }
+
+    transport_config = cfg._build_oauth_mcp_stdio_transport_config(
+        server=SimpleNamespace(name="Google Ads"),
+        app_info=app_info,
+        access_token="user-access-token",
+    )
+
+    assert transport_config["env"]["GOOGLE_ACCESS_TOKEN"] == "user-access-token"
+    assert transport_config["env"]["GOOGLE_ADS_DEVELOPER_TOKEN"] == "dev-token-value"
+
+
+def test_transport_config_omits_static_env_when_host_var_missing(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+
+    cfg = WebToolConfig(db=None, request=None)
+    app_info = {
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.google_ads"],
+            "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            "static_env": {"GOOGLE_ADS_DEVELOPER_TOKEN": "GOOGLE_ADS_DEVELOPER_TOKEN"},
+        }
+    }
+
+    transport_config = cfg._build_oauth_mcp_stdio_transport_config(
+        server=SimpleNamespace(name="Google Ads"),
+        app_info=app_info,
+        access_token="user-access-token",
+    )
+
+    assert "GOOGLE_ADS_DEVELOPER_TOKEN" not in transport_config["env"]


### PR DESCRIPTION
## Summary
- Add a Google Ads MCP connector (`google_ads.py`) with two tools:
  `google_ads_list_accessible_customers` and `google_ads_search` (GAQL),
  built on the Google Ads REST API v23 with plain `requests` (no new
  dependency, matches the existing HubSpot connector's style).
- Register the connector in `builtin_mcp_registry.py` + a seed migration,
  reusing the existing "google" OAuth provider (scope: `.../auth/adwords`).
  No per-user API key form needed — same OAuth "Connect" flow as Gmail.
- Add a generic `static_env` mechanism to the OAuth launch-config builder
  in `tools/config.py`, so an OAuth-transport connector can forward one
  platform-wide secret (here, `GOOGLE_ADS_DEVELOPER_TOKEN`) into its MCP
  subprocess alongside the per-user OAuth token. MCP subprocesses don't
  inherit the parent process's env, so this was previously not possible
  without a per-app special case.
- Document `GOOGLE_ADS_DEVELOPER_TOKEN` in `example.env` as a
  platform-wide secret (analogous to `GOOGLE_CLIENT_ID`), not a per-user
  key.

## Test plan
- [x] `pytest tests/web/tools/test_google_ads_mcp.py
      tests/alembic/test_20260724_seed_google_ads_mcp_app.py
      tests/web/tools/test_oauth_launch_config_static_env.py -v`
- [x] `pytest tests/web/api/test_public_mcp_connector_visibility.py -v`
      (regression: new app doesn't break existing catalog assertions)
- [x] `ruff check` / `ruff format --check` on all changed files
- [x] Manual: connect Google Ads via the OAuth popup in the connector UI,
      confirm `google_ads_list_accessible_customers` returns real
      customer IDs, then run a GAQL query with `google_ads_search`
      against one of them