### PR TITLE
feat: rate limiting + per-share run quota for public share channels (#973)

### DIFF
--- a/example.env
+++ b/example.env
@@ -112,13 +112,15 @@ PORT="80"
 # Public share-channel abuse controls (#973). Same Redis-backed limiter; all
 # are rate strings in the limits notation. Auth is keyed per share token +
 # per caller IP; task-create per guest + per share token; ws turns and uploads
-# per guest. The run quotas cap owner-billed runs a link/guest can start per
+# per guest; ws connection attempts (pre-auth, so no guest exists yet) per
+# caller IP. The run quotas cap owner-billed runs a link/guest can start per
 # rolling window so one public link cannot drain the owner's team quota.
 # XAGENT_SHARE_AUTH_RATE_LIMIT="60/minute"
 # XAGENT_SHARE_AUTH_IP_RATE_LIMIT="300/minute"
 # XAGENT_SHARE_TASK_CREATE_RATE_LIMIT="30/minute"
 # XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT="120/minute"
 # XAGENT_SHARE_WS_TURN_RATE_LIMIT="60/minute"
+# XAGENT_SHARE_WS_CONNECT_IP_RATE_LIMIT="120/minute"
 # XAGENT_SHARE_UPLOAD_RATE_LIMIT="60/minute"
 # XAGENT_SHARE_RUN_QUOTA="500/day"
 # XAGENT_SHARE_RUN_GUEST_QUOTA="60/hour"

--- a/example.env
+++ b/example.env
@@ -109,6 +109,19 @@ PORT="80"
 # Per-IP ceiling across all callback ids (blocks rotating-id floods).
 # XAGENT_TRIGGER_CALLBACK_IP_RATE_LIMIT="600/minute"
 # XAGENT_TRIGGER_CRUD_RATE_LIMIT="60/minute"
+# Public share-channel abuse controls (#973). Same Redis-backed limiter; all
+# are rate strings in the limits notation. Auth is keyed per share token +
+# per caller IP; task-create per guest + per share token; ws turns and uploads
+# per guest. The run quotas cap owner-billed runs a link/guest can start per
+# rolling window so one public link cannot drain the owner's team quota.
+# XAGENT_SHARE_AUTH_RATE_LIMIT="60/minute"
+# XAGENT_SHARE_AUTH_IP_RATE_LIMIT="300/minute"
+# XAGENT_SHARE_TASK_CREATE_RATE_LIMIT="30/minute"
+# XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT="120/minute"
+# XAGENT_SHARE_WS_TURN_RATE_LIMIT="60/minute"
+# XAGENT_SHARE_UPLOAD_RATE_LIMIT="60/minute"
+# XAGENT_SHARE_RUN_QUOTA="500/day"
+# XAGENT_SHARE_RUN_GUEST_QUOTA="60/hour"
 # Behind a reverse proxy, set the number of trusted proxy hops so the caller
 # IP for rate limiting is read from X-Forwarded-For. 0 = use the peer address.
 # IMPORTANT: when the backend sits behind a reverse proxy / load balancer and

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -635,7 +635,9 @@ describe("PublicAgentChatPage", () => {
     localStorage.setItem(taskKey, "71")
     // The WS layer reports a per-guest access denial as a post-accept 4003
     // whose reason surfaces here (see use-websocket.ts onclose 4003 handling).
-    app.connectionError = new Error("Access denied for this guest")
+    // The backend reuses its not-found detail for guest mismatches so task ids
+    // can't be enumerated (#973).
+    app.connectionError = new Error("Task not found or access denied")
 
     renderSharePage()
 

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -57,9 +57,12 @@ interface PublicConversationContentProps {
 // disabled the link, unpublished the agent/workforce, or the channel
 // mismatches, so treating it as recoverable would trigger a pointless clear +
 // re-auth round-trip that still lands on the terminal error.
-//   - "Access denied for this guest": the per-guest isolation denial — a
+//   - "Task not found or access denied": the per-guest isolation denial — a
 //     returning visitor's persisted taskId belongs to another (or a pre-#973)
-//     guest. Backend HTTPException.detail surfaced as event.reason on a 4003.
+//     guest — or a deleted task; both recover the same way. The backend
+//     deliberately reuses its not-found detail for guest mismatches so task
+//     ids can't be enumerated (see _require_share_guest_owns_task). Backend
+//     HTTPException.detail surfaced as event.reason on a 4003.
 //   - "Access denied": use-websocket.ts's fallback when a 4003 carries no
 //     reason.
 //   - "Invalid share token": the persisted guest JWT no longer validates
@@ -70,7 +73,7 @@ interface PublicConversationContentProps {
 //     the first send hits a task-create 401, which then re-auths. Without this,
 //     the WS-resume path would strand the visitor with no send to trigger that.
 const SHARE_ACCESS_DENIED_REASONS = new Set([
-  "Access denied for this guest",
+  "Task not found or access denied",
   "Access denied",
   "Invalid share token",
 ])

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -107,6 +107,16 @@ TRIGGER_CALLBACK_RATE_LIMIT = "XAGENT_TRIGGER_CALLBACK_RATE_LIMIT"
 TRIGGER_CALLBACK_IP_RATE_LIMIT = "XAGENT_TRIGGER_CALLBACK_IP_RATE_LIMIT"
 TRIGGER_CRUD_RATE_LIMIT = "XAGENT_TRIGGER_CRUD_RATE_LIMIT"
 TRUSTED_PROXY_HOPS = "XAGENT_TRUSTED_PROXY_HOPS"
+# Public share-channel abuse controls (#973). Each is a rate string in the
+# ``limits`` notation, e.g. "60/minute" or "500/day".
+SHARE_AUTH_RATE_LIMIT = "XAGENT_SHARE_AUTH_RATE_LIMIT"
+SHARE_AUTH_IP_RATE_LIMIT = "XAGENT_SHARE_AUTH_IP_RATE_LIMIT"
+SHARE_TASK_CREATE_RATE_LIMIT = "XAGENT_SHARE_TASK_CREATE_RATE_LIMIT"
+SHARE_TASK_CREATE_TOKEN_RATE_LIMIT = "XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT"
+SHARE_WS_TURN_RATE_LIMIT = "XAGENT_SHARE_WS_TURN_RATE_LIMIT"
+SHARE_UPLOAD_RATE_LIMIT = "XAGENT_SHARE_UPLOAD_RATE_LIMIT"
+SHARE_RUN_QUOTA = "XAGENT_SHARE_RUN_QUOTA"
+SHARE_RUN_GUEST_QUOTA = "XAGENT_SHARE_RUN_GUEST_QUOTA"
 GMAIL_PUBSUB_PROJECT_ID = "XAGENT_GMAIL_PUBSUB_PROJECT_ID"
 GMAIL_PUBSUB_TOPIC_PREFIX = "XAGENT_GMAIL_PUBSUB_TOPIC_PREFIX"
 GMAIL_PUBSUB_SUBSCRIPTION_PREFIX = "XAGENT_GMAIL_PUBSUB_SUBSCRIPTION_PREFIX"
@@ -695,6 +705,82 @@ def get_trigger_crud_rate_limit() -> str:
     """
     value = (os.getenv(TRIGGER_CRUD_RATE_LIMIT) or "").strip()
     return value or "60/minute"
+
+
+def _get_rate_limit(env_var: str, default: str) -> str:
+    """Read a ``limits``-notation rate string with an env override.
+
+    Priority: the given ``XAGENT_*`` env var, else ``default``. The value is
+    validated (and defaulted) at parse time by the rate limiter, so this only
+    trims and falls back on an empty/unset var.
+    """
+    return (os.getenv(env_var) or "").strip() or default
+
+
+def get_share_auth_rate_limit() -> str:
+    """Per-share-token limit on ``POST /api/share/auth`` (#973).
+
+    No ``guest_id`` exists before auth, so this bounds one share link's token
+    minting; the per-IP ceiling below bounds a single client across links.
+    """
+    return _get_rate_limit(SHARE_AUTH_RATE_LIMIT, "60/minute")
+
+
+def get_share_auth_ip_rate_limit() -> str:
+    """Per-IP ceiling on ``POST /api/share/auth`` across all share links."""
+    return _get_rate_limit(SHARE_AUTH_IP_RATE_LIMIT, "300/minute")
+
+
+def get_share_task_create_rate_limit() -> str:
+    """Per-guest limit on public share task creation (#973).
+
+    Task creation is the costly surface (each spawns an owner-billed run), so
+    this is the tighter of the two task-create buckets.
+    """
+    return _get_rate_limit(SHARE_TASK_CREATE_RATE_LIMIT, "30/minute")
+
+
+def get_share_task_create_token_rate_limit() -> str:
+    """Per-share-token ceiling on public share task creation.
+
+    Stops a client rotating fresh ``guest_id`` tokens (one auth each) from
+    bypassing the per-guest bucket on one share link.
+    """
+    return _get_rate_limit(SHARE_TASK_CREATE_TOKEN_RATE_LIMIT, "120/minute")
+
+
+def get_share_ws_turn_rate_limit() -> str:
+    """Per-guest limit on share websocket turns (#973).
+
+    Follow-up turns bypass task-create and each starts an owner-billed run;
+    this caps the burst rate before a turn is enqueued.
+    """
+    return _get_rate_limit(SHARE_WS_TURN_RATE_LIMIT, "60/minute")
+
+
+def get_share_upload_rate_limit() -> str:
+    """Per-guest limit on public share file uploads (#973)."""
+    return _get_rate_limit(SHARE_UPLOAD_RATE_LIMIT, "60/minute")
+
+
+def get_share_run_quota() -> str:
+    """Per-share rolling run quota (#973).
+
+    Bounds the owner-billed runs one share link can start per window so a
+    single popular/abused link cannot exhaust the owner's whole team quota.
+    Rolling (not cumulative) so a legitimately busy link self-clears rather
+    than being permanently bricked.
+    """
+    return _get_rate_limit(SHARE_RUN_QUOTA, "500/day")
+
+
+def get_share_run_guest_quota() -> str:
+    """Per-guest rolling run quota within a share link (#973).
+
+    Shorter window than the per-share quota: bounds a single visitor's burst
+    of runs so one guest cannot consume the whole link's budget.
+    """
+    return _get_rate_limit(SHARE_RUN_GUEST_QUOTA, "60/hour")
 
 
 def get_trusted_proxy_hops() -> int:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -114,6 +114,7 @@ SHARE_AUTH_IP_RATE_LIMIT = "XAGENT_SHARE_AUTH_IP_RATE_LIMIT"
 SHARE_TASK_CREATE_RATE_LIMIT = "XAGENT_SHARE_TASK_CREATE_RATE_LIMIT"
 SHARE_TASK_CREATE_TOKEN_RATE_LIMIT = "XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT"
 SHARE_WS_TURN_RATE_LIMIT = "XAGENT_SHARE_WS_TURN_RATE_LIMIT"
+SHARE_WS_CONNECT_IP_RATE_LIMIT = "XAGENT_SHARE_WS_CONNECT_IP_RATE_LIMIT"
 SHARE_UPLOAD_RATE_LIMIT = "XAGENT_SHARE_UPLOAD_RATE_LIMIT"
 SHARE_RUN_QUOTA = "XAGENT_SHARE_RUN_QUOTA"
 SHARE_RUN_GUEST_QUOTA = "XAGENT_SHARE_RUN_GUEST_QUOTA"
@@ -756,6 +757,17 @@ def get_share_ws_turn_rate_limit() -> str:
     this caps the burst rate before a turn is enqueued.
     """
     return _get_rate_limit(SHARE_WS_TURN_RATE_LIMIT, "60/minute")
+
+
+def get_share_ws_connect_ip_rate_limit() -> str:
+    """Per-IP limit on share websocket connection attempts (#973).
+
+    The share websocket accepts the handshake before auth so denial reasons
+    reach the client, which means even a garbage token completes a full 101
+    upgrade before rejection. This caps how many of those handshakes one IP
+    can open; over-limit attempts are refused pre-accept (no upgrade cost).
+    """
+    return _get_rate_limit(SHARE_WS_CONNECT_IP_RATE_LIMIT, "120/minute")
 
 
 def get_share_upload_rate_limit() -> str:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -836,6 +836,30 @@ def _load_task_run_gate_user_id_isolated(task_id: int) -> int | None:
         return int(user_id) if user_id is not None else None
 
 
+def _load_task_share_quota_config_isolated(task_id: int) -> dict[str, Any] | None:
+    """Load the share-quota markers (#973) in a worker-owned short Session.
+
+    Returns the task's ``agent_config`` only when it marks a share task
+    (``auth_mode == "share"``); ``None`` skips the share quota gate. Kept
+    separate from :func:`_load_task_run_gate_user_id_isolated` so the owner
+    gate's return contract (an ``int | None`` that tests monkeypatch) stays
+    untouched.
+    """
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as share_db:
+        agent_config = (
+            share_db.query(Task.agent_config).filter(Task.id == task_id).scalar()
+        )
+        if (
+            isinstance(agent_config, Mapping)
+            and agent_config.get("auth_mode") == "share"
+        ):
+            return dict(agent_config)
+        return None
+
+
 def _check_task_run_gate_on_event_loop(
     user_id: int | None,
 ) -> str | dict[str, Any] | None:
@@ -2636,6 +2660,59 @@ class AgentServiceManager:
                     )
                     raise
                 logger.warning("Quota gate check failed open", exc_info=True)
+
+        # Per-share run quota (#973): the run gate above bounds the OWNER's
+        # team quota, but every anonymous share run bills the owner, so one
+        # public link could still drain the whole team quota. This adds a
+        # per-link + per-guest rolling ceiling on top, keyed off the share
+        # markers PR1 stamped into agent_config. Only share tasks are gated;
+        # fails open (availability) like the run gate above, with the same
+        # pool-timeout escalation so a stalled pool doesn't cascade.
+        if tracker_task_id:
+            try:
+                share_config = await run_db_io_cancellation_safe(
+                    lambda: _load_task_share_quota_config_isolated(int(tracker_task_id))
+                )
+                if share_config is not None:
+                    guest_id = share_config.get("guest_id")
+                    workforce_id = share_config.get("share_workforce_id")
+                    agent_share_id = share_config.get("share_agent_id")
+                    if workforce_id is not None:
+                        share_key = f"workforce:{int(workforce_id)}"
+                    elif agent_share_id is not None:
+                        share_key = f"agent:{int(agent_share_id)}"
+                    else:
+                        share_key = None
+                    if share_key and isinstance(guest_id, str) and guest_id:
+                        from ..services.share_rate_limit import (
+                            get_share_rate_limiter,
+                        )
+
+                        if not get_share_rate_limiter().allow_run(share_key, guest_id):
+                            reason_message = (
+                                "This shared link has reached its usage limit. "
+                                "Please try again later."
+                            )
+                            return {
+                                "success": False,
+                                "status": "quota_exceeded",
+                                "output": reason_message,
+                                "error": reason_message,
+                                "error_code": "share_run_quota_exceeded",
+                                "error_details": None,
+                            }
+            except Exception as exc:
+                if is_database_pool_timeout(exc):
+                    logger.error(
+                        "task_id=%s component=share-quota-gate database pool "
+                        "checkout timed out; terminating before further runtime "
+                        "database work: %s",
+                        tracker_task_id,
+                        exc,
+                        exc_info=True,
+                    )
+                    raise
+                logger.warning("Share run quota check failed open", exc_info=True)
 
         if manage_task_lease and tracker_task_id:
             from ..services.task_execution_controller import (

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1229,16 +1229,27 @@ async def share_chat_websocket_endpoint(
                     current_principal.guest_id
                 )
             ):
+                client_message_id = message_data.get("client_message_id")
+                rate_limited_message = (
+                    "You're sending messages too quickly. "
+                    "Please wait a moment and try again."
+                )
                 await send_message_delivery(
                     websocket,
-                    client_message_id=message_data.get("client_message_id"),
-                    turn_id=str(message_data.get("client_message_id") or ""),
+                    client_message_id=client_message_id,
+                    turn_id=str(client_message_id or ""),
                     accepted=False,
-                    message=(
-                        "You're sending messages too quickly. "
-                        "Please wait a moment and try again."
-                    ),
+                    message=rate_limited_message,
                 )
+                # send_message_delivery no-ops without a client_message_id, so
+                # a client that didn't tag the turn would otherwise get zero
+                # feedback and see the message silently dropped. Fall back to a
+                # generic error so the throttle is always surfaced.
+                if client_message_id is None:
+                    await manager.send_personal_message(
+                        {"type": "error", "message": rate_limited_message},
+                        websocket,
+                    )
                 continue
 
             if message_type == "chat":

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -31,7 +31,10 @@ from ..services.connector_runtime import (
 )
 from ..services.db_runtime import run_db_io_cancellation_safe
 from ..services.deployments import get_deployment
-from ..services.share_rate_limit import get_share_rate_limiter
+from ..services.share_rate_limit import (
+    get_share_rate_limiter,
+    remote_ip_from_request,
+)
 from ..services.workforce_runs import create_workforce_run
 from ..utils.db_timezone import format_datetime_for_api
 from .files import store_uploaded_files
@@ -1110,6 +1113,25 @@ async def _authorize_share_chat_websocket(
     )
 
 
+_WS_CLOSE_REASON_MAX_BYTES = 123
+
+
+def _ws_close_reason(detail: object) -> str:
+    """Coerce an ``HTTPException.detail`` into a valid WS close reason.
+
+    ``detail`` is typed ``Any`` in FastAPI while the WS protocol caps close
+    reasons at 123 UTF-8 bytes — an over-long or non-string value would blow
+    up mid-close and swallow the denial the frontend recovery keys on. Every
+    detail reachable today is a short string literal; this is insurance for
+    the future one that isn't. Truncates on a codepoint boundary.
+    """
+    text = str(detail) if detail is not None else ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= _WS_CLOSE_REASON_MAX_BYTES:
+        return text
+    return encoded[:_WS_CLOSE_REASON_MAX_BYTES].decode("utf-8", errors="ignore")
+
+
 async def public_chat_websocket_endpoint(
     *,
     websocket: WebSocket,
@@ -1144,7 +1166,7 @@ async def public_chat_websocket_endpoint(
                     expected_auth_mode=expected_auth_mode,
                 )
             except HTTPException as exc:
-                await websocket.close(code=4003, reason=exc.detail)
+                await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
                 return
 
             message_data["user_id"] = current_principal.id
@@ -1174,6 +1196,17 @@ async def share_chat_websocket_endpoint(
     token: str = Query(..., description="Authentication token"),
 ) -> None:
     """Serve share websocket chat with per-message revalidation."""
+    # Handshake budget (#973): accept-before-auth (below) means every connect
+    # attempt — valid or garbage token — completes a full 101 upgrade before
+    # rejection, so the attempts themselves need a per-IP ceiling. Checked
+    # *pre-accept* on purpose: an over-limit probe is refused as a plain HTTP
+    # 403 with no upgrade performed at all, which is the cheapest rejection —
+    # unlike the auth denials below, a rate-limited connect carries no reason
+    # the frontend recovery flow needs to read.
+    if not get_share_rate_limiter().allow_ws_connect(remote_ip_from_request(websocket)):
+        await websocket.close(code=4008, reason="Too many connection attempts")
+        return
+
     # Accept the handshake *before* the auth/access checks. uvicorn only
     # preserves a close code + reason on the wire for a *post-accept* close: a
     # pre-accept ``websocket.close()`` is collapsed into a bare HTTP 403 with an
@@ -1191,7 +1224,7 @@ async def share_chat_websocket_endpoint(
             task_id=task_id,
         )
     except HTTPException as exc:
-        await websocket.close(code=4003, reason=exc.detail)
+        await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
         return
     except Exception:
         await websocket.close(code=4001, reason="Authentication required")
@@ -1213,7 +1246,7 @@ async def share_chat_websocket_endpoint(
                     task_id=task_id,
                 )
             except HTTPException as exc:
-                await websocket.close(code=4003, reason=exc.detail)
+                await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
                 return
 
             message_data["user_id"] = current_principal.id

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -469,7 +469,7 @@ def _get_task_for_workforce_widget_context(
     if task.agent_config.get("auth_mode") != "widget":
         raise HTTPException(status_code=403, detail="Widget is unavailable")
     if task.agent_config.get("guest_id") != access_context.guest_id:
-        raise HTTPException(status_code=403, detail="Access denied for this guest")
+        raise HTTPException(status_code=403, detail="Task not found or access denied")
     if int(task.agent_config.get("widget_workforce_id") or 0) != widget_workforce_id:
         raise HTTPException(status_code=403, detail="Widget is unavailable")
     workforce_run_id = task.agent_config.get("workforce_run_id")
@@ -511,7 +511,7 @@ def get_task_for_public_context(
         not task.agent_config
         or task.agent_config.get("guest_id") != access_context.guest_id
     ):
-        raise HTTPException(status_code=403, detail="Access denied for this guest")
+        raise HTTPException(status_code=403, detail="Task not found or access denied")
     if (
         access_context.widget_agent_id is not None
         and int(task.agent_id or 0) != access_context.widget_agent_id
@@ -532,9 +532,13 @@ def _require_share_guest_owns_task(
     guest_id (or a different one) fails this strict-inequality compare.
 
     Precondition: callers validate ``task.agent_config`` is a dict first.
+
+    The detail deliberately matches the callers' not-found branch: a
+    distinguishable guest-mismatch message would tell a probing visitor which
+    task ids exist on this share link (#973 enumeration oracle).
     """
     if task.agent_config.get("guest_id") != access_context.guest_id:
-        raise HTTPException(status_code=403, detail="Access denied for this guest")
+        raise HTTPException(status_code=403, detail="Task not found or access denied")
 
 
 def _get_task_for_workforce_share_context(

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -31,6 +31,7 @@ from ..services.connector_runtime import (
 )
 from ..services.db_runtime import run_db_io_cancellation_safe
 from ..services.deployments import get_deployment
+from ..services.share_rate_limit import get_share_rate_limiter
 from ..services.workforce_runs import create_workforce_run
 from ..utils.db_timezone import format_datetime_for_api
 from .files import store_uploaded_files
@@ -41,6 +42,7 @@ from .websocket import (
     handle_intervention,
     handle_status_request,
     manager,
+    send_message_delivery,
 )
 
 logger = logging.getLogger(__name__)
@@ -113,6 +115,9 @@ def mint_share_guest_id() -> str:
 class _ChatAccessContext(Protocol):
     @property
     def user(self) -> User: ...
+
+    @property
+    def guest_id(self) -> str: ...
 
 
 _ChatAccessContextT = TypeVar("_ChatAccessContextT", bound=_ChatAccessContext)
@@ -1050,6 +1055,7 @@ def _authorize_chat_websocket_sync(
         return WebSocketPrincipal(
             id=int(user_id),
             is_admin=bool(access_context.user.is_admin),
+            guest_id=access_context.guest_id,
         )
 
 
@@ -1209,11 +1215,37 @@ async def share_chat_websocket_endpoint(
             message_data["user_id"] = current_principal.id
             message_data["user"] = current_principal
 
-            if message_data.get("type") == "chat":
+            message_type = message_data.get("type")
+            # Abuse control (#973): follow-up turns bypass the HTTP task-create
+            # limiter and each starts an owner-billed run, so rate-limit the
+            # run-starting turn types per guest here. Reject the turn (the
+            # client surfaces it and can retry) rather than closing — a rate
+            # limit is transient. Interventions are control messages, not new
+            # runs, so they are not gated.
+            if (
+                message_type in ("chat", "execute_task")
+                and current_principal.guest_id
+                and not get_share_rate_limiter().allow_ws_turn(
+                    current_principal.guest_id
+                )
+            ):
+                await send_message_delivery(
+                    websocket,
+                    client_message_id=message_data.get("client_message_id"),
+                    turn_id=str(message_data.get("client_message_id") or ""),
+                    accepted=False,
+                    message=(
+                        "You're sending messages too quickly. "
+                        "Please wait a moment and try again."
+                    ),
+                )
+                continue
+
+            if message_type == "chat":
                 await handle_chat_message(websocket, task_id, message_data)
-            elif message_data.get("type") == "execute_task":
+            elif message_type == "execute_task":
                 await handle_execute_task(websocket, task_id, message_data)
-            elif message_data.get("type") == "intervention":
+            elif message_type == "intervention":
                 await handle_intervention(websocket, task_id, message_data)
     except Exception as exc:
         from fastapi import WebSocketDisconnect

--- a/src/xagent/web/api/share.py
+++ b/src/xagent/web/api/share.py
@@ -9,6 +9,7 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
+    Request,
     UploadFile,
     WebSocket,
 )
@@ -22,6 +23,10 @@ from ..models.user import User
 from ..models.workforce import Workforce
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.deployments import find_enabled_share_deployment
+from ..services.share_rate_limit import (
+    get_share_rate_limiter,
+    remote_ip_from_request,
+)
 from .public_chat_access import (
     PublicChatAuthResponse,
     ShareChatAccessContext,
@@ -43,9 +48,16 @@ class ShareAuthRequest(BaseModel):
 @share_router.post("/auth", response_model=PublicChatAuthResponse)
 async def authenticate_share_link(
     request: ShareAuthRequest,
+    http_request: Request,
     db: Session = Depends(get_db),
 ) -> Any:
     """Authenticate a public share link and issue a guest chat token."""
+    # Abuse control (#973): unauthenticated endpoint. Bucket per share token +
+    # per caller IP before any DB work; covers the workforce fallback below.
+    if not get_share_rate_limiter().allow_auth(
+        request.share_token, remote_ip_from_request(http_request)
+    ):
+        raise HTTPException(status_code=429, detail="Too many requests")
     agent = (
         db.query(Agent)
         .filter(
@@ -144,6 +156,10 @@ async def upload_share_file(
     share_info: ShareChatAccessContext = Depends(get_current_share_user_dep),
     db: Session = Depends(get_db),
 ) -> Any:
+    # Abuse control (#973): per-guest cap on public uploads. Storage-quota
+    # accounting and orphan GC are the separate hardening tracked for PR3.
+    if not get_share_rate_limiter().allow_upload(share_info.guest_id):
+        raise HTTPException(status_code=429, detail="Too many requests")
     return await upload_share_chat_files(
         file=file,
         files=files,
@@ -162,6 +178,13 @@ async def create_share_task(
     share_info: ShareChatAccessContext = Depends(get_current_share_user_dep),
     db: Session = Depends(get_db),
 ) -> Any:
+    # Abuse control (#973): task-create is the costly surface (each spawns an
+    # owner-billed run). Bucket per guest + per share token (the token bucket
+    # stops guest_id rotation from bypassing the per-guest cap).
+    if not get_share_rate_limiter().allow_task_create(
+        share_info.share_token, share_info.guest_id
+    ):
+        raise HTTPException(status_code=429, detail="Too many requests")
     return await create_share_chat_task(
         request=request,
         access_context=share_info,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -284,7 +284,7 @@ def _client_message_id(value: Any) -> str | None:
     return normalized
 
 
-async def _send_message_delivery(
+async def send_message_delivery(
     websocket: WebSocket,
     *,
     client_message_id: str | None,
@@ -2966,7 +2966,7 @@ async def execute_resume_background(
         if delivery_websocket is None or delivery_client_message_id is None:
             return
         try:
-            await _send_message_delivery(
+            await send_message_delivery(
                 delivery_websocket,
                 client_message_id=delivery_client_message_id,
                 turn_id=delivery_turn_id or delivery_client_message_id,
@@ -4471,6 +4471,9 @@ class WebSocketPrincipal:
 
     id: int
     is_admin: bool
+    # Per-guest isolation credential for public widget/share transports
+    # (#973). ``None`` for owner-authenticated sockets, which have no guest.
+    guest_id: str | None = None
 
 
 def _load_websocket_principal_sync(token: str) -> WebSocketPrincipal | None:
@@ -4528,7 +4531,7 @@ async def handle_chat_message(
         )
     except (PermissionError, ValueError) as exc:
         client_message_id = _client_message_id(message_data.get("client_message_id"))
-        await _send_message_delivery(
+        await send_message_delivery(
             websocket,
             client_message_id=client_message_id,
             turn_id=client_message_id or str(uuid.uuid4()),
@@ -4547,7 +4550,7 @@ async def handle_chat_message(
             await _handle_chat_message_unserialized(websocket, task_id, message_data)
         return
     if not enqueued.payload_matches:
-        await _send_message_delivery(
+        await send_message_delivery(
             websocket,
             client_message_id=_client_message_id(message_data.get("client_message_id")),
             turn_id=enqueued.client_command_id,
@@ -4557,7 +4560,7 @@ async def handle_chat_message(
         )
         return
     if enqueued.status == COMMAND_FAILED:
-        await _send_message_delivery(
+        await send_message_delivery(
             websocket,
             client_message_id=_client_message_id(message_data.get("client_message_id")),
             turn_id=enqueued.client_command_id,
@@ -4566,7 +4569,7 @@ async def handle_chat_message(
             retry_with_new_id=True,
         )
         return
-    await _send_message_delivery(
+    await send_message_delivery(
         websocket,
         client_message_id=_client_message_id(message_data.get("client_message_id")),
         turn_id=enqueued.client_command_id,
@@ -5212,7 +5215,7 @@ async def _handle_chat_message_unserialized(
             message_data["_durable_command_error"] = message or "Message was rejected"
         if suppress_delivery_ack:
             return
-        await _send_message_delivery(
+        await send_message_delivery(
             websocket,
             client_message_id=client_message_id,
             turn_id=turn_id,

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -1,0 +1,198 @@
+"""Rate limiting and run quotas for the public share channels (#973).
+
+A parallel of :mod:`trigger_rate_limit` for the unauthenticated share
+surfaces (``/api/share/*`` + the share websocket). It reuses the same
+``limits`` substrate — Redis storage when ``XAGENT_REDIS_URL`` is configured
+(shared limits across workers), in-memory otherwise (per-process, fine for
+dev / single-process) — and the shared :func:`remote_ip_from_request` helper.
+
+Two distinct concerns share the substrate:
+
+* **Request rate limits** on the public endpoints (auth, task-create, upload)
+  and per-turn on the websocket — cheap early throttles returning ``False``
+  when a bucket is exceeded so the caller can raise 429 / reject the turn.
+* **Per-share run quota** — a rolling window bounding the owner-billed runs a
+  single share link (and a single guest within it) can start, so one public
+  link cannot exhaust the owner's team quota. Rolling, not cumulative, so a
+  busy-but-legitimate link self-clears instead of being permanently bricked.
+
+Kept deliberately separate from :class:`TriggerRateLimiter`: no shared util is
+extracted yet, only the stable ``remote_ip_from_request`` helper is imported.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from limits import RateLimitItem, parse
+from limits.storage import MemoryStorage, storage_from_string
+from limits.strategies import MovingWindowRateLimiter
+
+from ...config import (
+    get_redis_url,
+    get_share_auth_ip_rate_limit,
+    get_share_auth_rate_limit,
+    get_share_run_guest_quota,
+    get_share_run_quota,
+    get_share_task_create_rate_limit,
+    get_share_task_create_token_rate_limit,
+    get_share_upload_rate_limit,
+    get_share_ws_turn_rate_limit,
+)
+
+# remote_ip_from_request is stable, shared reverse-proxy-aware infra; import it
+# rather than duplicate the XAGENT_TRUSTED_PROXY_HOPS parsing.
+from .trigger_rate_limit import remote_ip_from_request
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ShareRateLimiter",
+    "get_share_rate_limiter",
+    "reset_share_rate_limiter",
+    "remote_ip_from_request",
+]
+
+_AUTH_TOKEN_NAMESPACE = "share-auth"
+_AUTH_IP_NAMESPACE = "share-auth-ip"
+_TASK_CREATE_GUEST_NAMESPACE = "share-task-create"
+_TASK_CREATE_TOKEN_NAMESPACE = "share-task-create-token"
+_WS_TURN_NAMESPACE = "share-ws-turn"
+_UPLOAD_NAMESPACE = "share-upload"
+_RUN_SHARE_NAMESPACE = "share-run"
+_RUN_GUEST_NAMESPACE = "share-run-guest"
+
+
+def _parse_rate(value: str, *, fallback: str) -> RateLimitItem:
+    try:
+        return parse(value)
+    except ValueError:
+        logger.warning(
+            "Invalid share rate limit %r; falling back to %s", value, fallback
+        )
+        return parse(fallback)
+
+
+class ShareRateLimiter:
+    """Moving-window limiter over Redis or in-process memory for share channels."""
+
+    def __init__(self) -> None:
+        redis_url = get_redis_url()
+        if redis_url:
+            self.storage = storage_from_string(redis_url)
+            self.backend = "redis"
+        else:
+            self.storage = MemoryStorage()
+            self.backend = "memory"
+        self._limiter = MovingWindowRateLimiter(self.storage)
+        self._auth_token_limit = _parse_rate(
+            get_share_auth_rate_limit(), fallback="60/minute"
+        )
+        self._auth_ip_limit = _parse_rate(
+            get_share_auth_ip_rate_limit(), fallback="300/minute"
+        )
+        self._task_create_guest_limit = _parse_rate(
+            get_share_task_create_rate_limit(), fallback="30/minute"
+        )
+        self._task_create_token_limit = _parse_rate(
+            get_share_task_create_token_rate_limit(), fallback="120/minute"
+        )
+        self._ws_turn_limit = _parse_rate(
+            get_share_ws_turn_rate_limit(), fallback="60/minute"
+        )
+        self._upload_limit = _parse_rate(
+            get_share_upload_rate_limit(), fallback="60/minute"
+        )
+        self._run_share_limit = _parse_rate(get_share_run_quota(), fallback="500/day")
+        self._run_guest_limit = _parse_rate(
+            get_share_run_guest_quota(), fallback="60/hour"
+        )
+
+    def allow_auth(self, share_token: str, remote_ip: str | None) -> bool:
+        """Count one auth attempt; False when a bucket is exceeded.
+
+        Two buckets must both admit: per caller IP (across all links) and per
+        share token. No ``guest_id`` exists yet at auth time.
+        """
+        ip_key = remote_ip or "unknown"
+        if not self._limiter.hit(self._auth_ip_limit, _AUTH_IP_NAMESPACE, ip_key):
+            return False
+        return self._limiter.hit(
+            self._auth_token_limit, _AUTH_TOKEN_NAMESPACE, share_token or "unknown"
+        )
+
+    def allow_task_create(self, share_token: str, guest_id: str) -> bool:
+        """Count one task-create; False when a bucket is exceeded.
+
+        Per share token first (stops guest_id rotation bypassing the guest
+        bucket), then per guest (the tighter, owner-cost-bearing bucket).
+        """
+        if not self._limiter.hit(
+            self._task_create_token_limit,
+            _TASK_CREATE_TOKEN_NAMESPACE,
+            share_token or "unknown",
+        ):
+            return False
+        return self._limiter.hit(
+            self._task_create_guest_limit,
+            _TASK_CREATE_GUEST_NAMESPACE,
+            guest_id or "unknown",
+        )
+
+    def allow_ws_turn(self, guest_id: str) -> bool:
+        """Count one websocket turn for a guest; False when exceeded."""
+        return self._limiter.hit(
+            self._ws_turn_limit, _WS_TURN_NAMESPACE, guest_id or "unknown"
+        )
+
+    def allow_upload(self, guest_id: str) -> bool:
+        """Count one share upload for a guest; False when exceeded."""
+        return self._limiter.hit(
+            self._upload_limit, _UPLOAD_NAMESPACE, guest_id or "unknown"
+        )
+
+    def allow_run(self, share_key: str, guest_id: str) -> bool:
+        """Count one owner-billed share run; False when a quota is exceeded.
+
+        ``share_key`` identifies the link (e.g. ``"agent:42"`` /
+        ``"workforce:7"``). Both the per-share daily quota and the shorter
+        per-guest window must admit. Unlike the request throttles, this bounds
+        real billing, so both buckets are tested non-destructively first and
+        only consumed when both admit — a denial by either never burns a slot
+        in the other. (The test→hit gap can let concurrent starts overshoot by
+        a hair; acceptable for a soft quota, and it fails toward allowing.)
+        """
+        share_key = share_key or "unknown"
+        guest_id = guest_id or "unknown"
+        if not self._limiter.test(
+            self._run_share_limit, _RUN_SHARE_NAMESPACE, share_key
+        ):
+            return False
+        if not self._limiter.test(
+            self._run_guest_limit, _RUN_GUEST_NAMESPACE, guest_id
+        ):
+            return False
+        self._limiter.hit(self._run_share_limit, _RUN_SHARE_NAMESPACE, share_key)
+        self._limiter.hit(self._run_guest_limit, _RUN_GUEST_NAMESPACE, guest_id)
+        return True
+
+
+_lock = threading.Lock()
+_limiter: ShareRateLimiter | None = None
+
+
+def get_share_rate_limiter() -> ShareRateLimiter:
+    global _limiter
+    if _limiter is None:
+        with _lock:
+            if _limiter is None:
+                _limiter = ShareRateLimiter()
+    return _limiter
+
+
+def reset_share_rate_limiter() -> None:
+    """Drop the cached limiter so new env configuration takes effect (tests)."""
+    global _limiter
+    with _lock:
+        _limiter = None

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -22,8 +22,11 @@ extracted yet, only the stable ``remote_ip_from_request`` helper is imported.
 
 from __future__ import annotations
 
+import functools
 import logging
 import threading
+from collections.abc import Callable
+from typing import TypeVar
 
 from limits import RateLimitItem, parse
 from limits.storage import MemoryStorage, storage_from_string
@@ -74,6 +77,37 @@ def _parse_rate(value: str, *, fallback: str) -> RateLimitItem:
         return parse(fallback)
 
 
+_F = TypeVar("_F", bound=Callable[..., bool])
+
+
+def _fail_open(method: _F) -> _F:
+    """Make an ``allow_*`` gate fail open on storage/backend errors.
+
+    Rate limiting is a non-blocking guard, not a correctness gate: when the
+    Redis backend is down or misconfigured the limiter calls raise, and on a
+    public share surface that would 500 the auth/upload/create endpoints and
+    tear down live websockets. A transient infra blip must not lock every
+    visitor out, so any exception is logged and treated as "admit" — matching
+    the fail-open run gate at the ``execute_task`` chokepoint. (A genuine
+    over-limit still returns ``False`` normally; only raised errors admit.)
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: "ShareRateLimiter", *args: object, **kwargs: object) -> bool:
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as exc:
+            logger.warning(
+                "Share rate limiter (%s) failed open: %s",
+                method.__name__,
+                exc,
+                exc_info=True,
+            )
+            return True
+
+    return wrapper  # type: ignore[return-value]
+
+
 class ShareRateLimiter:
     """Moving-window limiter over Redis or in-process memory for share channels."""
 
@@ -109,6 +143,7 @@ class ShareRateLimiter:
             get_share_run_guest_quota(), fallback="60/hour"
         )
 
+    @_fail_open
     def allow_auth(self, share_token: str, remote_ip: str | None) -> bool:
         """Count one auth attempt; False when a bucket is exceeded.
 
@@ -122,6 +157,7 @@ class ShareRateLimiter:
             self._auth_token_limit, _AUTH_TOKEN_NAMESPACE, share_token or "unknown"
         )
 
+    @_fail_open
     def allow_task_create(self, share_token: str, guest_id: str) -> bool:
         """Count one task-create; False when a bucket is exceeded.
 
@@ -140,18 +176,21 @@ class ShareRateLimiter:
             guest_id or "unknown",
         )
 
+    @_fail_open
     def allow_ws_turn(self, guest_id: str) -> bool:
         """Count one websocket turn for a guest; False when exceeded."""
         return self._limiter.hit(
             self._ws_turn_limit, _WS_TURN_NAMESPACE, guest_id or "unknown"
         )
 
+    @_fail_open
     def allow_upload(self, guest_id: str) -> bool:
         """Count one share upload for a guest; False when exceeded."""
         return self._limiter.hit(
             self._upload_limit, _UPLOAD_NAMESPACE, guest_id or "unknown"
         )
 
+    @_fail_open
     def allow_run(self, share_key: str, guest_id: str) -> bool:
         """Count one owner-billed share run; False when a quota is exceeded.
 

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -217,8 +217,11 @@ class ShareRateLimiter:
         per-guest window must admit. Unlike the request throttles, this bounds
         real billing, so both buckets are tested non-destructively first and
         only consumed when both admit — a denial by either never burns a slot
-        in the other. (The test→hit gap can let concurrent starts overshoot by
-        a hair; acceptable for a soft quota, and it fails toward allowing.)
+        in the other. (The test→hit gap is not atomic: every request that
+        passes ``test()`` before the racing ``hit()`` calls land is admitted,
+        so the overshoot bound is the number of requests racing within that
+        window across all workers, not a fixed margin. Acceptable for a soft
+        quota, and it fails toward allowing.)
         """
         share_key = share_key or "unknown"
         guest_id = guest_id or "unknown"

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -41,6 +41,7 @@ from ...config import (
     get_share_task_create_rate_limit,
     get_share_task_create_token_rate_limit,
     get_share_upload_rate_limit,
+    get_share_ws_connect_ip_rate_limit,
     get_share_ws_turn_rate_limit,
 )
 
@@ -62,6 +63,7 @@ _AUTH_IP_NAMESPACE = "share-auth-ip"
 _TASK_CREATE_GUEST_NAMESPACE = "share-task-create"
 _TASK_CREATE_TOKEN_NAMESPACE = "share-task-create-token"
 _WS_TURN_NAMESPACE = "share-ws-turn"
+_WS_CONNECT_IP_NAMESPACE = "share-ws-connect-ip"
 _UPLOAD_NAMESPACE = "share-upload"
 _RUN_SHARE_NAMESPACE = "share-run"
 _RUN_GUEST_NAMESPACE = "share-run-guest"
@@ -135,6 +137,9 @@ class ShareRateLimiter:
         self._ws_turn_limit = _parse_rate(
             get_share_ws_turn_rate_limit(), fallback="60/minute"
         )
+        self._ws_connect_ip_limit = _parse_rate(
+            get_share_ws_connect_ip_rate_limit(), fallback="120/minute"
+        )
         self._upload_limit = _parse_rate(
             get_share_upload_rate_limit(), fallback="60/minute"
         )
@@ -181,6 +186,19 @@ class ShareRateLimiter:
         """Count one websocket turn for a guest; False when exceeded."""
         return self._limiter.hit(
             self._ws_turn_limit, _WS_TURN_NAMESPACE, guest_id or "unknown"
+        )
+
+    @_fail_open
+    def allow_ws_connect(self, remote_ip: str | None) -> bool:
+        """Count one share websocket connection attempt for an IP.
+
+        Keyed per IP because this gate runs *pre-auth* (no guest_id or share
+        token exists yet): accept-before-auth means every attempt — valid or
+        garbage token — otherwise completes a full 101 upgrade before being
+        rejected, so the handshake itself needs a budget (#993 F5).
+        """
+        return self._limiter.hit(
+            self._ws_connect_ip_limit, _WS_CONNECT_IP_NAMESPACE, remote_ip or "unknown"
         )
 
     @_fail_open

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1596,6 +1596,60 @@ class TestTriggerRateLimitConfig:
         assert get_trigger_crud_rate_limit() == "5/minute"
 
 
+class TestShareRateLimitConfig:
+    """Config for public share-channel rate limits and run quotas (#973)."""
+
+    _CASES = [
+        ("get_share_auth_rate_limit", "XAGENT_SHARE_AUTH_RATE_LIMIT", "60/minute"),
+        (
+            "get_share_auth_ip_rate_limit",
+            "XAGENT_SHARE_AUTH_IP_RATE_LIMIT",
+            "300/minute",
+        ),
+        (
+            "get_share_task_create_rate_limit",
+            "XAGENT_SHARE_TASK_CREATE_RATE_LIMIT",
+            "30/minute",
+        ),
+        (
+            "get_share_task_create_token_rate_limit",
+            "XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT",
+            "120/minute",
+        ),
+        (
+            "get_share_ws_turn_rate_limit",
+            "XAGENT_SHARE_WS_TURN_RATE_LIMIT",
+            "60/minute",
+        ),
+        ("get_share_upload_rate_limit", "XAGENT_SHARE_UPLOAD_RATE_LIMIT", "60/minute"),
+        ("get_share_run_quota", "XAGENT_SHARE_RUN_QUOTA", "500/day"),
+        ("get_share_run_guest_quota", "XAGENT_SHARE_RUN_GUEST_QUOTA", "60/hour"),
+    ]
+
+    @pytest.mark.parametrize("func_name,env_var,default", _CASES)
+    def test_default(self, monkeypatch, func_name, env_var, default):
+        import xagent.config as config
+
+        monkeypatch.delenv(env_var, raising=False)
+        assert getattr(config, func_name)() == default
+
+    @pytest.mark.parametrize("func_name,env_var,default", _CASES)
+    def test_env_override(self, monkeypatch, func_name, env_var, default):
+        import xagent.config as config
+
+        monkeypatch.setenv(env_var, "7/second")
+        assert getattr(config, func_name)() == "7/second"
+
+    @pytest.mark.parametrize("func_name,env_var,default", _CASES)
+    def test_blank_env_falls_back_to_default(
+        self, monkeypatch, func_name, env_var, default
+    ):
+        import xagent.config as config
+
+        monkeypatch.setenv(env_var, "   ")
+        assert getattr(config, func_name)() == default
+
+
 class TestGmailPubSubProvisioningConfig:
     """Config for per-mailbox Gmail Pub/Sub provisioning."""
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1621,6 +1621,11 @@ class TestShareRateLimitConfig:
             "XAGENT_SHARE_WS_TURN_RATE_LIMIT",
             "60/minute",
         ),
+        (
+            "get_share_ws_connect_ip_rate_limit",
+            "XAGENT_SHARE_WS_CONNECT_IP_RATE_LIMIT",
+            "120/minute",
+        ),
         ("get_share_upload_rate_limit", "XAGENT_SHARE_UPLOAD_RATE_LIMIT", "60/minute"),
         ("get_share_run_quota", "XAGENT_SHARE_RUN_QUOTA", "500/day"),
         ("get_share_run_guest_quota", "XAGENT_SHARE_RUN_GUEST_QUOTA", "60/hour"),

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -179,9 +179,11 @@ def _reset_trigger_rate_limiter() -> Iterator[None]:
     moving window; without a reset, fast suites reusing the same user id
     would eventually trip the CRUD limit across unrelated tests.
     """
+    from xagent.web.services.share_rate_limit import reset_share_rate_limiter
     from xagent.web.services.trigger_rate_limit import reset_trigger_rate_limiter
 
     reset_trigger_rate_limiter()
+    reset_share_rate_limiter()
     yield
 
 

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -40,7 +40,7 @@ async def test_public_access_websocket_authorization_uses_worker_owned_session(
     closed_sessions: list[bool] = []
     session = object()
     user = SimpleNamespace(id=73, is_admin=True)
-    access_context = SimpleNamespace(user=user)
+    access_context = SimpleNamespace(user=user, guest_id="guest-73")
 
     class TrackingSession:
         def __enter__(self) -> object:
@@ -119,8 +119,8 @@ async def test_public_access_websocket_authorization_uses_worker_owned_session(
     assert all(thread_id != event_loop_thread for thread_id in operation_threads)
     assert is_dataclass(principal)
     assert principal.__dataclass_params__.frozen is True
-    assert {field.name for field in fields(principal)} == {"id", "is_admin"}
-    assert principal == WebSocketPrincipal(id=73, is_admin=True)
+    assert {field.name for field in fields(principal)} == {"id", "is_admin", "guest_id"}
+    assert principal == WebSocketPrincipal(id=73, is_admin=True, guest_id="guest-73")
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -18,9 +18,14 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from fastapi import HTTPException
 from starlette.websockets import WebSocketDisconnect
 
-from xagent.web.api.public_chat_access import create_public_chat_access_token
+from xagent.web.api.public_chat_access import (
+    PublicChatAccessContext,
+    create_public_chat_access_token,
+    get_task_for_public_context,
+)
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
@@ -428,3 +433,85 @@ def test_legacy_workforce_share_token_without_guest_id_is_rejected() -> None:
         json={"title": "hi", "description": "hi"},
     )
     assert response.status_code == 401, response.text
+
+
+# ===== enumeration-oracle collapse on the widget gates (#973) =====
+
+
+class _StubQuery:
+    def __init__(self, task: object | None) -> None:
+        self._task = task
+
+    def filter(self, *_criteria: object) -> _StubQuery:
+        return self
+
+    def first(self) -> object | None:
+        return self._task
+
+
+class _StubDb:
+    """Minimal Session double: every Task lookup resolves to one canned row."""
+
+    def __init__(self, task: object | None) -> None:
+        self._task = task
+
+    def query(self, *_entities: object) -> _StubQuery:
+        return _StubQuery(self._task)
+
+
+@pytest.mark.parametrize(
+    ("context_kwargs", "mismatch_task"),
+    [
+        pytest.param(
+            {"widget_agent_id": 1},
+            SimpleNamespace(
+                agent_config={"guest_id": "guest-b"},
+                agent_id=1,
+                channel_id=None,
+            ),
+            id="widget-agent",
+        ),
+        pytest.param(
+            {"widget_workforce_id": 7},
+            SimpleNamespace(
+                agent_config={
+                    "auth_mode": "widget",
+                    "guest_id": "guest-b",
+                    "widget_workforce_id": 7,
+                },
+                channel_id=None,
+            ),
+            id="widget-workforce",
+        ),
+    ],
+)
+def test_widget_gate_guest_mismatch_matches_not_found_detail(
+    context_kwargs: dict[str, Any], mismatch_task: SimpleNamespace
+) -> None:
+    """Widget-side mirrors of the share-gate detail assertion (#973).
+
+    All three ownership gates collapsed their guest-mismatch 403 into the
+    generic not-found detail; the share gate pins this over a real WS
+    handshake above, and these pin the widget and workforce-widget gates. The
+    denial for "task exists but belongs to another guest" must stay
+    byte-identical to "task does not exist", or a probing visitor can
+    enumerate which task ids live behind the widget key.
+    """
+    context = PublicChatAccessContext(
+        user=SimpleNamespace(id=1),
+        channel_id=None,
+        guest_id="guest-a",
+        **context_kwargs,
+    )
+
+    with pytest.raises(HTTPException) as mismatch:
+        get_task_for_public_context(_StubDb(mismatch_task), 41, context)
+    with pytest.raises(HTTPException) as missing:
+        get_task_for_public_context(_StubDb(None), 41, context)
+
+    assert mismatch.value.status_code == 403
+    assert mismatch.value.detail == "Task not found or access denied"
+    assert (mismatch.value.status_code, mismatch.value.detail) == (
+        missing.value.status_code,
+        missing.value.detail,
+    )

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -214,7 +214,9 @@ def test_agent_share_ws_connect_denies_foreign_guest() -> None:
         with pytest.raises(WebSocketDisconnect) as denied:
             ws.receive_text()
     assert denied.value.code == 4003
-    assert denied.value.reason == "Access denied for this guest"
+    # Guest mismatch deliberately shares the not-found detail so probing can't
+    # enumerate task ids on a share link (#973).
+    assert denied.value.reason == "Task not found or access denied"
 
 
 def test_agent_share_task_without_guest_id_is_denied() -> None:

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -229,3 +229,58 @@ async def test_ws_turn_rate_limited_rejects_without_dispatch(
     _, kwargs = delivery.await_args
     assert kwargs["accepted"] is False
     assert kwargs["client_message_id"] == "m2"
+
+
+@pytest.mark.asyncio
+async def test_ws_turn_rate_limited_without_client_id_sends_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rate-limited turn that carries no client_message_id still surfaces the
+    throttle: send_message_delivery no-ops without an id, so a generic error
+    frame is sent instead (the client isn't left with a silently dropped turn)."""
+    from xagent.web.api import public_chat_access as pca
+
+    monkeypatch.setenv("XAGENT_SHARE_WS_TURN_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    ctx = pca.ShareChatAccessContext(
+        user=MagicMock(id=1),
+        share_token="tok",
+        guest_id="guest-noid",
+        agent=MagicMock(),
+    )
+    monkeypatch.setattr(pca, "get_share_chat_user", lambda *a, **k: ctx)
+    monkeypatch.setattr(pca, "get_task_for_share_context", lambda *a, **k: MagicMock())
+
+    @contextlib.contextmanager
+    def _fake_db():
+        yield MagicMock()
+
+    monkeypatch.setattr(pca, "db_session_context", _fake_db)
+    manager = MagicMock(
+        connect=AsyncMock(),
+        disconnect=MagicMock(),
+        send_personal_message=AsyncMock(),
+    )
+    monkeypatch.setattr(pca, "manager", manager)
+    monkeypatch.setattr(pca, "handle_status_request", AsyncMock())
+    monkeypatch.setattr(pca, "handle_chat_message", AsyncMock())
+    monkeypatch.setattr(pca, "send_message_delivery", AsyncMock())
+
+    # Two untagged chat turns: the second trips the 1/minute bucket. Without a
+    # client_message_id, the rejection must arrive as a generic error frame.
+    frames = [
+        json.dumps({"type": "chat", "message": "hi"}),
+        json.dumps({"type": "chat", "message": "again"}),
+    ]
+    await pca.share_chat_websocket_endpoint(
+        websocket=_FakeWebSocket(frames), task_id=1, token="jwt"
+    )
+
+    error_frames = [
+        call.args[0]
+        for call in manager.send_personal_message.await_args_list
+        if call.args and call.args[0].get("type") == "error"
+    ]
+    assert len(error_frames) == 1
+    assert "too quickly" in error_frames[0]["message"]

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -1,0 +1,231 @@
+"""Rate-limit enforcement on the public share endpoints (#973, PR2).
+
+Each anonymous share surface returns 429 once its bucket is exhausted. The
+autouse conftest fixture resets the share limiter before every test; each test
+tightens the relevant limit to 1/minute via env and resets again so the new
+limiter reads it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+from xagent.web.services.share_rate_limit import reset_share_rate_limiter
+
+from .conftest import _admin_headers, _direct_db_session, _setup_admin, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _user_id() -> int:
+    _setup_admin()
+    db = _direct_db_session()
+    try:
+        return int(db.query(User).filter(User.username == "admin").one().id)
+    finally:
+        db.close()
+
+
+def _published_share_agent(token: str) -> int:
+    db = _direct_db_session()
+    try:
+        agent = Agent(
+            user_id=_user_id(),
+            name="RL Agent",
+            description="d",
+            instructions="i",
+            execution_mode="balanced",
+            status=AgentStatus.PUBLISHED,
+            share_enabled=True,
+            share_token=token,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        return int(agent.id)
+    finally:
+        db.close()
+
+
+def _create_workforce(name: str) -> str:
+    headers = _admin_headers()
+    owner = _user_id()
+
+    def _agent(agent_name: str, tok: str) -> int:
+        db = _direct_db_session()
+        try:
+            a = Agent(
+                user_id=owner,
+                name=agent_name,
+                description="d",
+                instructions="i",
+                execution_mode="balanced",
+                status=AgentStatus.PUBLISHED,
+                share_enabled=True,
+                share_token=tok,
+            )
+            db.add(a)
+            db.commit()
+            db.refresh(a)
+            return int(a.id)
+        finally:
+            db.close()
+
+    resp = client.post(
+        "/api/workforces",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "rl",
+            "manager_agent_id": _agent(f"{name} Mgr", f"{name}-mgr"),
+            "workers": [
+                {
+                    "source_type": "existing",
+                    "agent_id": _agent(f"{name} Wrk", f"{name}-wrk"),
+                    "alias": "w1",
+                    "assignment_instructions": "go",
+                    "enabled": True,
+                    "sort_order": 1,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    wf_id = int(resp.json()["id"])
+    published = client.post(f"/api/workforces/{wf_id}/publish", headers=headers)
+    assert published.status_code == 200, published.text
+    share = client.post(f"/api/workforces/{wf_id}/share-link", headers=headers)
+    assert share.status_code == 200, share.text
+    return str(share.json()["share_token"])
+
+
+def _guest_headers(token: str) -> dict[str, str]:
+    resp = client.post("/api/share/auth", json={"share_token": token})
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def test_share_auth_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_SHARE_AUTH_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+    _published_share_agent("rl-auth-tok")
+
+    first = client.post("/api/share/auth", json={"share_token": "rl-auth-tok"})
+    assert first.status_code == 200, first.text
+    second = client.post("/api/share/auth", json={"share_token": "rl-auth-tok"})
+    assert second.status_code == 429, second.text
+
+
+def test_share_task_create_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _published_share_agent("rl-create-tok")
+    guest = _guest_headers("rl-create-tok")
+
+    # Tighten only after the guest token is minted (auth has its own bucket).
+    monkeypatch.setenv("XAGENT_SHARE_TASK_CREATE_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    body = {"title": "hi", "description": "hi"}
+    first = client.post("/api/share/chat/task/create", headers=guest, json=body)
+    assert first.status_code == 200, first.text
+    second = client.post("/api/share/chat/task/create", headers=guest, json=body)
+    assert second.status_code == 429, second.text
+
+
+def test_share_upload_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _create_workforce("RL Upload WF")
+    guest = _guest_headers(token)
+
+    monkeypatch.setenv("XAGENT_SHARE_UPLOAD_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    def _upload():
+        return client.post(
+            "/api/share/files/upload",
+            headers=guest,
+            data={"task_type": "task"},
+            files={"file": ("n.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+
+    assert _upload().status_code == 200
+    assert _upload().status_code == 429
+
+
+class _FakeWebSocket:
+    """Minimal websocket double: yields queued frames, then disconnects."""
+
+    def __init__(self, frames: list[str]) -> None:
+        self._frames = list(frames)
+
+    async def receive_text(self) -> str:
+        from fastapi import WebSocketDisconnect
+
+        if not self._frames:
+            raise WebSocketDisconnect(code=1000)
+        return self._frames.pop(0)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_ws_turn_rate_limited_rejects_without_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rate-limited websocket turn is rejected (message_rejected) and never
+    dispatched to handle_chat_message; the connection stays open."""
+    from xagent.web.api import public_chat_access as pca
+
+    monkeypatch.setenv("XAGENT_SHARE_WS_TURN_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    ctx = pca.ShareChatAccessContext(
+        user=MagicMock(id=1),
+        share_token="tok",
+        guest_id="guest-ws",
+        agent=MagicMock(),
+    )
+    monkeypatch.setattr(pca, "get_share_chat_user", lambda *a, **k: ctx)
+    monkeypatch.setattr(pca, "get_task_for_share_context", lambda *a, **k: MagicMock())
+
+    @contextlib.contextmanager
+    def _fake_db():
+        yield MagicMock()
+
+    monkeypatch.setattr(pca, "db_session_context", _fake_db)
+    monkeypatch.setattr(
+        pca, "manager", MagicMock(connect=AsyncMock(), disconnect=MagicMock())
+    )
+    monkeypatch.setattr(pca, "handle_status_request", AsyncMock())
+    dispatch = AsyncMock()
+    monkeypatch.setattr(pca, "handle_chat_message", dispatch)
+    delivery = AsyncMock()
+    monkeypatch.setattr(pca, "send_message_delivery", delivery)
+
+    # Two chat turns: the first is admitted (dispatched), the second trips the
+    # 1/minute per-guest bucket and is rejected.
+    frames = [
+        json.dumps({"type": "chat", "client_message_id": "m1", "message": "hi"}),
+        json.dumps({"type": "chat", "client_message_id": "m2", "message": "again"}),
+    ]
+    await pca.share_chat_websocket_endpoint(
+        websocket=_FakeWebSocket(frames), task_id=1, token="jwt"
+    )
+
+    assert dispatch.await_count == 1  # only the admitted turn dispatched
+    assert delivery.await_count == 1  # the rejected turn got a delivery ack
+    _, kwargs = delivery.await_args
+    assert kwargs["accepted"] is False
+    assert kwargs["client_message_id"] == "m2"

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -168,6 +168,12 @@ class _FakeWebSocket:
 
     def __init__(self, frames: list[str]) -> None:
         self._frames = list(frames)
+        self.accepted = False
+
+    async def accept(self) -> None:
+        # The endpoint accepts before auth so denial reasons survive the
+        # handshake (#973); the double just records it.
+        self.accepted = True
 
     async def receive_text(self) -> str:
         from fastapi import WebSocketDisconnect

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -290,3 +290,49 @@ async def test_ws_turn_rate_limited_without_client_id_sends_error(
     ]
     assert len(error_frames) == 1
     assert "too quickly" in error_frames[0]["message"]
+
+
+def test_ws_connect_over_limit_is_refused_pre_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Over-limit share WS connection attempts are refused before the
+    handshake is accepted (#993 F5): accept-before-auth means every admitted
+    attempt completes a 101 upgrade even with a garbage token, so the attempts
+    themselves carry a per-IP budget. TestClient surfaces a pre-accept close at
+    context-manager entry (post-accept denials raise at receive instead —
+    that asymmetry is what pins the ordering)."""
+    from starlette.websockets import WebSocketDisconnect
+
+    monkeypatch.setenv("XAGENT_SHARE_WS_CONNECT_IP_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    url = "/api/share/chat/ws/1?token=garbage"
+    # First attempt is admitted: it upgrades, then auth rejects it post-accept.
+    with client.websocket_connect(url) as ws:
+        with pytest.raises(WebSocketDisconnect) as first:
+            ws.receive_text()
+    assert first.value.code == 4003
+
+    # Second attempt from the same caller trips the budget pre-accept.
+    with pytest.raises(WebSocketDisconnect) as denied:
+        with client.websocket_connect(url):
+            pass
+    assert denied.value.code == 4008
+
+
+def test_ws_close_reason_clamps_to_123_utf8_bytes() -> None:
+    """WS close reasons are capped at 123 UTF-8 bytes by the protocol;
+    ``exc.detail`` is ``Any`` in FastAPI, so the close path coerces and clamps
+    on a codepoint boundary instead of blowing up mid-close (#993 F6)."""
+    from xagent.web.api.public_chat_access import _ws_close_reason
+
+    assert _ws_close_reason("short reason") == "short reason"
+    assert _ws_close_reason(None) == ""
+    assert _ws_close_reason({"nested": "detail"}) == str({"nested": "detail"})
+
+    clamped = _ws_close_reason("б" * 200)  # 2-byte codepoint
+    encoded = clamped.encode("utf-8")
+    assert len(encoded) <= 123
+    # 123 is odd, so a naive byte slice would split the final 2-byte
+    # codepoint; the clamp must land on a boundary.
+    assert clamped == "б" * 61

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -132,3 +132,24 @@ def test_run_share_quota_trips_across_guests(
     assert limiter.allow_run("workforce:5", "g1") is True
     assert limiter.allow_run("workforce:5", "g2") is True
     assert limiter.allow_run("workforce:5", "g3") is False
+
+
+def test_all_gates_fail_open_on_backend_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising storage backend (e.g. Redis down) must ADMIT, not 500/lock
+    out — every allow_* gate is decorated to fail open. A genuine over-limit
+    (returning False) is unaffected; only raised errors admit."""
+
+    def _boom(*_args: object, **_kwargs: object) -> bool:
+        raise RuntimeError("redis unavailable")
+
+    limiter = _limiter_with(monkeypatch)
+    monkeypatch.setattr(limiter._limiter, "hit", _boom)
+    monkeypatch.setattr(limiter._limiter, "test", _boom)
+
+    assert limiter.allow_auth("tok", "1.1.1.1") is True
+    assert limiter.allow_task_create("tok", "g") is True
+    assert limiter.allow_ws_turn("g") is True
+    assert limiter.allow_upload("g") is True
+    assert limiter.allow_run("agent:1", "g") is True

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -1,0 +1,134 @@
+"""Unit tests for the share-channel rate limiter / run quota (#973, PR2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.services.share_rate_limit import (
+    ShareRateLimiter,
+    get_share_rate_limiter,
+    reset_share_rate_limiter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_share_rate_limiter()
+    yield
+    reset_share_rate_limiter()
+
+
+def _limiter_with(monkeypatch: pytest.MonkeyPatch, **env: str) -> ShareRateLimiter:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    reset_share_rate_limiter()
+    return get_share_rate_limiter()
+
+
+def test_auth_per_token_bucket_trips(monkeypatch: pytest.MonkeyPatch) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_AUTH_RATE_LIMIT="2/minute",
+        XAGENT_SHARE_AUTH_IP_RATE_LIMIT="100/minute",
+    )
+    assert limiter.allow_auth("tok", "1.1.1.1") is True
+    assert limiter.allow_auth("tok", "1.1.1.1") is True
+    assert limiter.allow_auth("tok", "1.1.1.1") is False
+
+
+def test_auth_per_ip_ceiling_trips_across_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_AUTH_RATE_LIMIT="100/minute",
+        XAGENT_SHARE_AUTH_IP_RATE_LIMIT="2/minute",
+    )
+    # Rotating the share token must not escape the per-IP ceiling.
+    assert limiter.allow_auth("tok-a", "9.9.9.9") is True
+    assert limiter.allow_auth("tok-b", "9.9.9.9") is True
+    assert limiter.allow_auth("tok-c", "9.9.9.9") is False
+
+
+def test_task_create_per_guest_bucket_trips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_TASK_CREATE_RATE_LIMIT="1/minute",
+        XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT="100/minute",
+    )
+    assert limiter.allow_task_create("tok", "guest-1") is True
+    assert limiter.allow_task_create("tok", "guest-1") is False
+    # A different guest on the same link has an independent bucket.
+    assert limiter.allow_task_create("tok", "guest-2") is True
+
+
+def test_task_create_token_ceiling_trips_across_guests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_TASK_CREATE_RATE_LIMIT="100/minute",
+        XAGENT_SHARE_TASK_CREATE_TOKEN_RATE_LIMIT="2/minute",
+    )
+    assert limiter.allow_task_create("tok", "guest-1") is True
+    assert limiter.allow_task_create("tok", "guest-2") is True
+    assert limiter.allow_task_create("tok", "guest-3") is False
+
+
+def test_ws_turn_and_upload_are_per_guest(monkeypatch: pytest.MonkeyPatch) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_WS_TURN_RATE_LIMIT="1/minute",
+        XAGENT_SHARE_UPLOAD_RATE_LIMIT="1/minute",
+    )
+    assert limiter.allow_ws_turn("g") is True
+    assert limiter.allow_ws_turn("g") is False
+    assert limiter.allow_ws_turn("other") is True
+    assert limiter.allow_upload("g") is True
+    assert limiter.allow_upload("g") is False
+
+
+def test_run_quota_per_share_and_per_guest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_RUN_QUOTA="3/day",
+        XAGENT_SHARE_RUN_GUEST_QUOTA="2/hour",
+    )
+    # Per-guest window (2) trips before the per-share quota (3) for one guest.
+    assert limiter.allow_run("agent:1", "g1") is True
+    assert limiter.allow_run("agent:1", "g1") is True
+    assert limiter.allow_run("agent:1", "g1") is False
+
+
+def test_run_guest_denial_does_not_consume_share_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-guest window denial must not burn a per-share-quota slot."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_RUN_QUOTA="3/day",
+        XAGENT_SHARE_RUN_GUEST_QUOTA="1/hour",
+    )
+    assert limiter.allow_run("agent:1", "g1") is True  # share=1, g1=1
+    assert limiter.allow_run("agent:1", "g1") is False  # g1 window blocks
+    # g1's denials didn't consume the share quota, so two fresh guests still fit.
+    assert limiter.allow_run("agent:1", "g2") is True  # share=2
+    assert limiter.allow_run("agent:1", "g3") is True  # share=3
+    assert limiter.allow_run("agent:1", "g4") is False  # share quota (3) hit
+
+
+def test_run_share_quota_trips_across_guests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_RUN_QUOTA="2/day",
+        XAGENT_SHARE_RUN_GUEST_QUOTA="100/hour",
+    )
+    assert limiter.allow_run("workforce:5", "g1") is True
+    assert limiter.allow_run("workforce:5", "g2") is True
+    assert limiter.allow_run("workforce:5", "g3") is False

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -90,6 +90,23 @@ def test_ws_turn_and_upload_are_per_guest(monkeypatch: pytest.MonkeyPatch) -> No
     assert limiter.allow_upload("g") is False
 
 
+def test_ws_connect_is_per_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pre-auth handshake budget is keyed per caller IP (#993 F5)."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_SHARE_WS_CONNECT_IP_RATE_LIMIT="2/minute",
+    )
+    assert limiter.allow_ws_connect("1.2.3.4") is True
+    assert limiter.allow_ws_connect("1.2.3.4") is True
+    assert limiter.allow_ws_connect("1.2.3.4") is False
+    # Another caller is unaffected; a missing IP degrades to a shared bucket
+    # rather than bypassing the gate.
+    assert limiter.allow_ws_connect("5.6.7.8") is True
+    assert limiter.allow_ws_connect(None) is True
+    assert limiter.allow_ws_connect(None) is True
+    assert limiter.allow_ws_connect(None) is False
+
+
 def test_run_quota_per_share_and_per_guest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -168,5 +168,6 @@ def test_all_gates_fail_open_on_backend_error(
     assert limiter.allow_auth("tok", "1.1.1.1") is True
     assert limiter.allow_task_create("tok", "g") is True
     assert limiter.allow_ws_turn("g") is True
+    assert limiter.allow_ws_connect("1.1.1.1") is True
     assert limiter.allow_upload("g") is True
     assert limiter.allow_run("agent:1", "g") is True

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -411,6 +411,13 @@ async def test_execute_task_workforce_pool_timeout_stops_tracker_checkout(
                 "xagent.web.api.chat._load_task_run_gate_user_id_isolated",
                 return_value=None,
             ),
+            # The share-quota gate (#973) sits between the run gate and the
+            # lease acquisition; stub its checkout like the run gate's so the
+            # pool timeout under test still lands on the workforce stage.
+            patch(
+                "xagent.web.api.chat._load_task_share_quota_config_isolated",
+                return_value=None,
+            ),
             patch(
                 "xagent.web.api.chat.acquire_task_lease_isolated",
                 return_value=lease,

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -1,0 +1,114 @@
+"""Per-share run quota at the execute_task chokepoint (#973, PR2).
+
+The owner run gate bounds the owner's team quota, but every anonymous share
+run bills the owner, so a per-link + per-guest rolling ceiling is enforced on
+top at run start. This verifies the share-quota block short-circuits a share
+task's run when the quota is exhausted, and is skipped for non-share tasks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.share_rate_limit import reset_share_rate_limiter
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'share_run_quota.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter() -> None:
+    reset_share_rate_limiter()
+    yield
+    reset_share_rate_limiter()
+
+
+class _FakeAgentService:
+    async def execute_task(self, **_kwargs):
+        return {"success": True}
+
+    def set_interrupt_checker(self, _checker):
+        pass
+
+
+def _make_task(db_session, *, agent_config: dict) -> Task:
+    user = User(username="share-quota-user", password_hash="h", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    task = Task(
+        user_id=user.id,
+        title="share run",
+        description="test",
+        status=TaskStatus.PENDING,
+        execution_mode="auto",
+        agent_config=agent_config,
+    )
+    db_session.add(task)
+    db_session.commit()
+    return task
+
+
+@pytest.mark.asyncio
+async def test_share_run_quota_blocks_share_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # "0/day" leaves no room, so the very first share run is refused.
+    monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "share",
+            "guest_id": "guest-abc",
+            "share_agent_id": 4242,
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "quota_exceeded"
+    assert result["error_code"] == "share_run_quota_exceeded"
+    assert "usage limit" in result["output"]
+
+
+@pytest.mark.asyncio
+async def test_share_run_quota_skips_non_share_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-share task must never hit the share quota, even at 0/day."""
+    monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    # No auth_mode == "share" marker: the share-quota branch is skipped, so the
+    # run is not refused with the share error code (it proceeds to execution).
+    task = _make_task(db_session, agent_config={})
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result.get("error_code") != "share_run_quota_exceeded"


### PR DESCRIPTION
## What

**PR2 of the public-share-channel hardening pass (#973): rate limiting + per-share run quota.**

The public share endpoints (`/api/share/*`) and the share websocket are unauthenticated-visitor surfaces, and each anonymous task/turn spawns a run **billed to the owner**. With no rate limit and no per-link ceiling, a single share link could exhaust the owner's whole team quota.

> **Stacked on #993 (PR1).** This branch is based on the PR1 branch (restacked onto its current head, including all of its review-round fixes), so until #993 merges this PR's diff also shows PR1's commits. Review/merge after #993; once it lands, this diff collapses to just the PR2 changes below.

## How

**Rate limiting** — new `ShareRateLimiter`, a parallel of `TriggerRateLimiter` over the same `limits`+Redis substrate (Redis when `XAGENT_REDIS_URL` is set for shared limits across workers, in-memory fallback for dev; reuses `remote_ip_from_request`, which honors `XAGENT_TRUSTED_PROXY_HOPS`). The trigger limiter is untouched and no shared util is extracted yet.

- `POST /api/share/auth` → per share token **+** per caller IP (the IP ceiling stops share-token rotation); 429 over limit.
- `POST /api/share/chat/task/create` → per guest **+** per share token (the token bucket stops `guest_id` rotation from bypassing the per-guest cap); 429. This is the costly surface — each create spawns an owner-billed run — so it carries the tighter limit.
- Share file upload → per guest; 429.
- **Share websocket turns** → per guest, checked **before** the turn is dispatched. A rate-limited turn is rejected (`message_rejected`, so the client surfaces it and can retry) rather than closing the connection — a rate limit is transient. Interventions are control messages, not new runs, so they are not gated.
- **Share websocket connection attempts** → per caller IP, checked **pre-accept** (#993 round-4 F5). PR1's accept-before-auth means even a garbage token completes a full 101 upgrade before rejection, so the handshakes themselves carry a budget; over-limit attempts are refused without paying the upgrade at all.

**Per-share run quota** — enforced beside the owner run gate at the `execute_task` chokepoint, only for share tasks, keyed off the share markers PR1 stamped into `agent_config`. Rolling (not cumulative) so a busy-but-legitimate link self-clears rather than being permanently bricked. Two buckets: per-link daily + per-guest shorter window. Over-limit reuses the run-gate `quota_exceeded` result shape (surfaced over WS as a failed turn). Both buckets are tested non-destructively before either is consumed, so a denial in one never burns a slot in the other. Fails open (availability), matching the adjacent owner gate.

**Carried-over #993 round-4 items** (tracked in [this comment](https://github.com/xorbitsai/xagent/pull/995#issuecomment-5083231490)):

- **Enumeration oracle closed** — the per-guest isolation gates no longer return a distinguishable `"Access denied for this guest"` detail; guest mismatches now reuse the generic `"Task not found or access denied"` on all three gates (share, widget, workforce-widget), so a probing visitor can't enumerate which task ids exist on a link. The frontend recovery set tracks the new reason — a deleted task and a foreign-guest task recover identically.
- **WS close reasons clamped** — `exc.detail` is `Any` in FastAPI while the WS protocol caps close reasons at 123 UTF-8 bytes; every close site now coerces + clamps on a codepoint boundary (`_ws_close_reason`), so a future non-string or over-long detail can't blow up mid-close and swallow the denial the frontend recovery keys on.
- The shared error-code constant (backend detail ↔ frontend reason set) is deferred to the next follow-up (#996-or-next), per the tracking comment.

## Config

All thresholds are `XAGENT_SHARE_*` ops-knobs in `config.py` (env → `limits`-notation default), documented in `example.env`, tuned post-launch:

```
SHARE_AUTH_RATE_LIMIT=60/minute      SHARE_AUTH_IP_RATE_LIMIT=300/minute
SHARE_TASK_CREATE_RATE_LIMIT=30/minute   SHARE_TASK_CREATE_TOKEN_RATE_LIMIT=120/minute
SHARE_WS_TURN_RATE_LIMIT=60/minute   SHARE_WS_CONNECT_IP_RATE_LIMIT=120/minute
SHARE_UPLOAD_RATE_LIMIT=60/minute
SHARE_RUN_QUOTA=500/day              SHARE_RUN_GUEST_QUOTA=60/hour
```

## Notes

- Promoted the websocket `send_message_delivery` helper to public now that the share endpoint reuses it (previously `_`-prefixed).
- The per-share bucket is keyed on the stable share-entity id (`agent:<id>` / `workforce:<id>`) rather than the raw share token — `share_token` isn't stored in `agent_config`, and the entity id is stable across token rotation, so it bounds the same link either way.

## Scope

Rate limiting only. Owner storage-gate on uploads + orphan GC land in **PR3**. The nginx per-IP edge locations (mirroring the `/v1/external/*` `limit_req_zone` precedent) are a **companion change in the saas repo**, intentionally not in this core-repo PR.

## Tests

- `ShareRateLimiter` unit tests including the "a per-guest denial never burns a per-share slot" invariant, plus the per-IP WS-connect budget.
- Endpoint 429 tests (auth / task-create / upload), WS-turn rejection tests, a pre-accept WS-connect refusal test (pins the accept-ordering asymmetry), and a close-reason clamp test (codepoint-boundary truncation).
- Per-share run-quota chokepoint tests (blocks a share task at quota; skips non-share tasks).
- Config default / env-override / blank-fallback tests for all 9 knobs.
- Full `tests/web` suite passes; ruff / mypy / isort clean; frontend tsc + vitest pass.

Part of #973.
