### PR TITLE
fix(ssh): restore cross-seam SshErrorCode members removed as false dead code

### DIFF
--- a/src/xagent/core/ssh/errors.py
+++ b/src/xagent/core/ssh/errors.py
@@ -7,11 +7,24 @@ from typing import Any
 
 
 class SshErrorCode(str, Enum):
-    """Stable, public error codes. Values are a contract; do not rename."""
+    """Stable, public error codes. Values are a contract; do not rename.
+
+    Several codes are part of the cross-seam contract: they are raised by
+    out-of-repo consumers on the other side of the provider / secret-store /
+    audit seam and only *recorded* by core's audit sink, never raised inside
+    this repo. A grep for raise-sites within this repo alone will find them
+    unused — do NOT remove them on that basis; that breaks the consumer
+    contract. TARGET_IN_USE / CREDENTIAL_REVOKED / CREDENTIAL_IN_USE /
+    HOST_KEY_UNVERIFIED are such consumer-raised codes.
+    """
 
     TARGET_NOT_FOUND = "ssh_target_not_found"
     TARGET_DISABLED = "ssh_target_disabled"
+    TARGET_IN_USE = "ssh_target_in_use"
     OPERATION_NOT_ALLOWED = "ssh_operation_not_allowed"
+    CREDENTIAL_REVOKED = "ssh_credential_revoked"
+    CREDENTIAL_IN_USE = "ssh_credential_in_use"
+    HOST_KEY_UNVERIFIED = "ssh_host_key_unverified"
     HOST_KEY_MISMATCH = "ssh_host_key_mismatch"
     EGRESS_DENIED = "ssh_egress_denied"
     APPROVAL_REQUIRED = "ssh_approval_required"

--- a/tests/core/ssh/test_errors.py
+++ b/tests/core/ssh/test_errors.py
@@ -10,6 +10,17 @@ def test_error_codes_have_stable_string_values() -> None:
     assert SshErrorCode.CONCURRENT_UPDATE.value == "ssh_concurrent_update"
 
 
+def test_cross_seam_consumer_raised_codes_are_stable() -> None:
+    # These four are raised by out-of-repo consumers across the provider /
+    # secret-store / audit seam and only *recorded* by core, so an in-repo grep
+    # sees no raise-site and can wrongly flag them as dead (this already happened
+    # once). Pinning their values here makes a delete/rename fail CI in-repo.
+    assert SshErrorCode.TARGET_IN_USE.value == "ssh_target_in_use"
+    assert SshErrorCode.CREDENTIAL_REVOKED.value == "ssh_credential_revoked"
+    assert SshErrorCode.CREDENTIAL_IN_USE.value == "ssh_credential_in_use"
+    assert SshErrorCode.HOST_KEY_UNVERIFIED.value == "ssh_host_key_unverified"
+
+
 def test_all_codes_are_lowercase_ssh_prefixed() -> None:
     for code in SshErrorCode:
         assert code.value.startswith("ssh_")


### PR DESCRIPTION
The SSH MCP re-review removed four `SshErrorCode` members as unused, based on a grep of this repo only:

- `TARGET_IN_USE` / `CREDENTIAL_REVOKED` / `CREDENTIAL_IN_USE` / `HOST_KEY_UNVERIFIED`

These are **not raised inside core**, but they are part of the cross-seam error contract: out-of-repo consumers on the other side of the provider / secret-store / audit seam raise them, and core only *records* them via the audit sink. An in-repo grep therefore wrongly flags them as dead code, and removing them broke consumers — every consumer call site now hits `AttributeError` on the missing enum member.

This restores the four members with their original (contract) string values and documents that consumer-raised codes must not be pruned based on in-repo usage.

The other three removed at the same time — `EXTERNAL_POLICY_DENIED`, `CONNECTION_TIMEOUT`, `OUTPUT_LIMIT_EXCEEDED` — have no consumer and remain removed.