### PR TITLE
chore: add widget guest regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,10 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
+      - name: Run widget regression tests with coverage
+        working-directory: ./frontend
+        run: npm run test:widget:coverage
+
       # Static export is the default build (served by FastAPI in the pip/uvx
       # deployment). Verify it produces a servable bundle: index shell plus the
       # dynamic-route __shell__ pages the SPA fallback depends on.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,6 +70,7 @@
         "@types/dagre": "^0.7.53",
         "@types/highlight.js": "^10.0.0",
         "@types/marked": "^5.0.0",
+        "@vitest/coverage-v8": "^2.1.9",
         "jsdom": "^25.0.0",
         "vitest": "^2.1.9"
       }
@@ -91,6 +92,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -122,14 +137,40 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -140,6 +181,27 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1276,6 +1338,63 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1514,6 +1633,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3888,6 +4018,39 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -5418,6 +5581,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -6305,6 +6475,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -6881,6 +7068,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7255,6 +7449,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -7521,6 +7725,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7536,6 +7794,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -7845,6 +8119,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -8837,6 +9139,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.34.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.0.tgz",
@@ -9207,6 +9519,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -9294,6 +9613,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -10494,6 +10830,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -10603,6 +10952,76 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -10730,6 +11149,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10948,6 +11381,115 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -11993,6 +12535,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "type-check": "tsc --noEmit",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:widget": "vitest run src/components/widget/widget-bootstrap.test.ts src/components/widget/public-agent-chat-page.test.tsx",
+    "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -74,6 +76,7 @@
     "@types/dagre": "^0.7.53",
     "@types/highlight.js": "^10.0.0",
     "@types/marked": "^5.0.0",
+    "@vitest/coverage-v8": "^2.1.9",
     "jsdom": "^25.0.0",
     "vitest": "^2.1.9"
   }

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -1,0 +1,459 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { AppProviderTransportConfig } from "@/contexts/app-context-chat"
+
+const app = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  sendMessage: vi.fn(),
+  setTaskId: vi.fn(),
+  state: {
+    taskId: null as number | null,
+    currentTask: null,
+    isHistoryLoading: false,
+    isProcessing: false,
+  },
+  rerender: null as null | React.Dispatch<React.SetStateAction<number>>,
+  provider: null as null | {
+    token: string
+    transport?: AppProviderTransportConfig
+  },
+}))
+
+const i18n = vi.hoisted(() => ({ t: (key: string) => key }))
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  AppProvider: ({
+    children,
+    token,
+    transport,
+  }: {
+    children: React.ReactNode
+    token: string
+    transport?: AppProviderTransportConfig
+  }) => {
+    app.provider = { token, transport }
+    return <>{children}</>
+  },
+  useApp: () => {
+    const [, rerender] = React.useState(0)
+    app.rerender = rerender
+    return {
+      state: app.state,
+      dispatch: app.dispatch,
+      sendMessage: app.sendMessage,
+      setTaskId: app.setTaskId,
+    }
+  },
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => i18n,
+}))
+
+vi.mock("@/components/chat/ChatStartScreen", () => ({
+  ChatStartScreen: ({ onSend, title }: { onSend: (message: string, files: File[], config?: Record<string, string>) => Promise<void>; title: string }) => (
+    <button type="button" onClick={() => onSend("first message", [], { mode: "balanced" })}>
+      start:{title}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => <div data-testid="conversation-panel" />,
+}))
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "https://api.example",
+  }
+})
+
+import { PublicAgentChatPage } from "./public-agent-chat-page"
+
+const successfulAgentAuth = {
+  access_token: "public-access-token",
+  token_type: "bearer",
+  agent_id: 17,
+  agent_name: "Support Agent",
+  agent_logo: null,
+  agent_description: "Answers questions",
+  suggested_prompts: [],
+  workforce_id: null,
+}
+
+const successfulWorkforceAuth = {
+  access_token: "public-access-token",
+  token_type: "bearer",
+  agent_id: null,
+  agent_name: "Support Workforce",
+  agent_logo: null,
+  agent_description: null,
+  suggested_prompts: [],
+  workforce_id: 8,
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function renderWidgetPage(overrides: Partial<React.ComponentProps<typeof PublicAgentChatPage>> = {}) {
+  return render(
+    <PublicAgentChatPage
+      authMode="widget"
+      routeToken="default"
+      guestId="guest-1"
+      searchAgentId={17}
+      {...overrides}
+    />,
+  )
+}
+
+async function expectWidgetAuthFailure(detail: string) {
+  expect(await screen.findByText(detail)).toBeInTheDocument()
+  expect(screen.queryByRole("button", { name: /start:/ })).toBeNull()
+  expect(sessionStorage.getItem("xagent_public_access_token")).toBeNull()
+  expect(app.setTaskId).not.toHaveBeenCalled()
+}
+
+function expectPublicProviderToken() {
+  expect(sessionStorage.getItem("xagent_public_access_token")).toBe("public-access-token")
+  expect(app.provider).toMatchObject({ token: "public-access-token" })
+  expect(app.provider?.transport?.buildWebSocketUrl?.({
+    baseUrl: "wss://api.example",
+    taskId: 42,
+    token: app.provider?.token,
+  })).toBe("wss://api.example/api/widget/chat/ws/42?token=public-access-token")
+}
+
+function seedStalePublicToken() {
+  sessionStorage.setItem("xagent_public_access_token", "stale-public-token")
+}
+
+function widgetTaskResponse(taskId: number, status: "pending" | "running") {
+  return {
+    task_id: taskId,
+    title: "first message",
+    status,
+    created_at: "2026-07-24T00:00:00Z",
+    model_id: null,
+    small_fast_model_id: null,
+    visual_model_id: null,
+    compact_model_id: null,
+    model_name: null,
+    small_fast_model_name: null,
+    visual_model_name: null,
+    compact_model_name: null,
+    execution_mode: null,
+    channel_id: null,
+    channel_name: "Web Widget",
+    agent_id: null,
+    agent_name: null,
+    agent_logo_url: null,
+    run_id: null,
+    state_version: 0,
+    control_state: "idle",
+  }
+}
+
+describe("PublicAgentChatPage", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    app.dispatch.mockReset()
+    app.sendMessage.mockReset()
+    app.setTaskId.mockImplementation((taskId: number | null) => {
+      app.state = { ...app.state, taskId }
+      app.rerender?.((value) => value + 1)
+    })
+    app.setTaskId.mockClear()
+    app.state = {
+      taskId: null,
+      currentTask: null,
+      isHistoryLoading: false,
+      isProcessing: false,
+    }
+    app.rerender = null
+    app.provider = null
+    sessionStorage.clear()
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("authenticates embedded widgets with the ticket and never sends the widget key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+
+    renderWidgetPage({ embedTicket: "embed-ticket", widgetKey: "widget-secret" })
+
+    await screen.findByRole("button", { name: "start:Support Agent" })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          embed_ticket: "embed-ticket",
+        }),
+      },
+    )
+    expectPublicProviderToken()
+  })
+
+  it("authenticates direct widget visits with their widget key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+
+    renderWidgetPage({ widgetKey: "widget-secret" })
+
+    await screen.findByRole("button", { name: "start:Support Agent" })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          widget_key: "widget-secret",
+        }),
+      },
+    )
+    expectPublicProviderToken()
+  })
+
+  it("fails closed for an invalid direct widget key", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: "Invalid widget key" }, 403))
+    seedStalePublicToken()
+
+    renderWidgetPage({ widgetKey: "wk-not-a-real-key" })
+
+    await expectWidgetAuthFailure("Invalid widget key")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          widget_key: "wk-not-a-real-key",
+        }),
+      },
+    )
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: "Invalid widget key" }))
+  })
+
+  it("fails closed when an embed ticket domain is no longer allowed", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      detail: "Domain not allowed: embedded.example",
+    }, 403))
+    seedStalePublicToken()
+
+    renderWidgetPage({ embedTicket: "domain-bound-ticket", widgetKey: "widget-secret" })
+
+    await expectWidgetAuthFailure("Domain not allowed: embedded.example")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          embed_ticket: "domain-bound-ticket",
+        }),
+      },
+    )
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: "Domain not allowed: embedded.example",
+    }))
+  })
+
+  it("fails closed when a widget is disabled after its embed ticket was issued", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      detail: "Widget is disabled for this agent",
+    }, 403))
+    seedStalePublicToken()
+
+    renderWidgetPage({
+      embedTicket: "ticket-issued-before-disable",
+      widgetKey: "widget-secret",
+    })
+
+    await expectWidgetAuthFailure("Widget is disabled for this agent")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          embed_ticket: "ticket-issued-before-disable",
+        }),
+      },
+    )
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: "Widget is disabled for this agent",
+    }))
+  })
+
+  it("resumes the saved task instead of showing a new-chat screen", async () => {
+    localStorage.setItem("widget_task_17_guest-1", "71")
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+
+    renderWidgetPage()
+
+    expect(await screen.findByTestId("conversation-panel")).toBeInTheDocument()
+    expect(app.setTaskId).toHaveBeenCalledWith(71, { navigate: false })
+  })
+
+  it("shows the start screen and defers task creation until the first agent message", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+
+    renderWidgetPage()
+
+    expect(await screen.findByRole("button", { name: "start:Support Agent" })).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates an agent task and then sends its opening message", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(42, "pending")))
+
+    const { unmount } = renderWidgetPage({ widgetKey: "widget-secret" })
+
+    fireEvent.click(await screen.findByRole("button", { name: "start:Support Agent" }))
+
+    await waitFor(() => {
+      expect(app.sendMessage).toHaveBeenCalledWith(
+        "first message",
+        { mode: "balanced", targetTaskId: 42 },
+        [],
+      )
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: 17,
+          widget_key: "widget-secret",
+        }),
+      },
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example/api/widget/chat/task/create",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer public-access-token",
+        },
+        body: JSON.stringify({
+          title: "first message",
+          description: "first message",
+          agent_id: 17,
+        }),
+      },
+    )
+    await waitFor(() => {
+      expect(localStorage.getItem("widget_task_17_guest-1")).toBe("42")
+    })
+
+    unmount()
+    app.state = {
+      taskId: null,
+      currentTask: null,
+      isHistoryLoading: false,
+      isProcessing: false,
+    }
+    app.setTaskId.mockClear()
+    app.rerender = null
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+
+    renderWidgetPage({ widgetKey: "widget-secret" })
+
+    expect(await screen.findByTestId("conversation-panel")).toBeInTheDocument()
+    expect(app.setTaskId).toHaveBeenCalledWith(42, { navigate: false })
+  })
+
+  it("lets workforce task creation start the opening turn without sending it again", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(43, "running")))
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+
+    fireEvent.click(await screen.findByRole("button", { name: "start:Support Workforce" }))
+
+    await waitFor(() => {
+      expect(app.setTaskId).toHaveBeenCalledWith(43, { navigate: false })
+    })
+    expect(app.sendMessage).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/api/widget/auth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          guest_id: "guest-1",
+          agent_id: null,
+          widget_key: "widget-secret",
+        }),
+      },
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example/api/widget/chat/task/create",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer public-access-token",
+        },
+        body: JSON.stringify({
+          title: "first message",
+          description: "first message",
+        }),
+      },
+    )
+    await waitFor(() => {
+      expect(localStorage.getItem("widget_task_wf8_guest-1")).toBe("43")
+    })
+  })
+})

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -59,6 +59,30 @@ describe("widget bootstrap", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Missing data-widget-key"))
   })
 
+  it("generates and persists a guest id for a first-time visitor", async () => {
+    localStorage.removeItem("xagent_guest_id")
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0.123456)
+      .mockReturnValueOnce(0.654321)
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      ticket: "ticket/one",
+      agent_id: 17,
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    runWidget({ "data-widget-key": "widget-secret" })
+
+    const guestId = localStorage.getItem("xagent_guest_id")
+    expect(guestId).toEqual(expect.stringMatching(/^guest_[a-z0-9]+$/))
+    await vi.waitFor(() => {
+      expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.src).toBe(
+        `https://chat.example/widget/chat/default?guest_id=${guestId}&agent_id=17&embed_ticket=ticket%2Fone`,
+      )
+    })
+  })
+
   it("loads an embed-ticket iframe URL without exposing the widget key", async () => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
       ticket: "ticket/one",
@@ -89,7 +113,7 @@ describe("widget bootstrap", () => {
       .not.toContain("widget-secret")
   })
 
-  it("does not navigate the iframe when embed-ticket authorization is rejected", async () => {
+  it("does not navigate the iframe on a non-OK embed-ticket response", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
 
@@ -101,7 +125,7 @@ describe("widget bootstrap", () => {
     expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.getAttribute("src")).toBeNull()
   })
 
-  it("does not navigate the iframe when embed-ticket authorization rejects", async () => {
+  it("does not navigate the iframe on an embed-ticket network failure", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     fetchMock.mockRejectedValueOnce(new Error("network unavailable"))
 

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const widgetScriptPath = resolve(process.cwd(), "public/widget.js")
+const widgetScript = readFileSync(
+  widgetScriptPath,
+  "utf8",
+)
+const widgetScriptUrl = pathToFileURL(widgetScriptPath).href
+
+function runWidget(attributes: Record<string, string>) {
+  const script = document.createElement("script")
+  script.src = "https://chat.example/widget.js"
+  for (const [name, value] of Object.entries(attributes)) {
+    script.setAttribute(name, value)
+  }
+  document.body.appendChild(script)
+  Object.defineProperty(document, "currentScript", {
+    configurable: true,
+    value: script,
+  })
+
+  window.eval(`${widgetScript}\n//# sourceURL=${widgetScriptUrl}`)
+}
+
+describe("widget bootstrap", () => {
+  const fetchMock = vi.fn()
+  let currentScriptDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, "currentScript")
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    localStorage.setItem("xagent_guest_id", "guest-fixed")
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (currentScriptDescriptor) {
+      Object.defineProperty(document, "currentScript", currentScriptDescriptor)
+    } else {
+      Reflect.deleteProperty(document, "currentScript")
+    }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("fails closed without a widget key on the default token channel", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    runWidget({})
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(document.querySelector(".xagent-widget-container")).toBeNull()
+    expect(document.head.querySelector("style")).toBeNull()
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Missing data-widget-key"))
+  })
+
+  it("loads an embed-ticket iframe URL without exposing the widget key", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      ticket: "ticket/one",
+      agent_id: 17,
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    runWidget({ "data-widget-key": "widget-secret" })
+
+    await vi.waitFor(() => {
+      expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.src).toBe(
+        "https://chat.example/widget/chat/default?guest_id=guest-fixed&agent_id=17&embed_ticket=ticket%2Fone",
+      )
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://chat.example/api/widget/embed-ticket",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ widget_key: "widget-secret" }),
+      },
+    )
+    expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.src)
+      .not.toContain("widget-secret")
+  })
+
+  it("does not navigate the iframe when embed-ticket authorization is rejected", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
+
+    runWidget({ "data-widget-key": "widget-secret" })
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("embed authorization failed"))
+    })
+    expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.getAttribute("src")).toBeNull()
+  })
+
+  it("does not navigate the iframe when embed-ticket authorization rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockRejectedValueOnce(new Error("network unavailable"))
+
+    runWidget({ "data-widget-key": "widget-secret" })
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("embed authorization request failed"))
+    })
+    expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.getAttribute("src")).toBeNull()
+  })
+
+  it("keeps the deprecated non-default token channel available without a ticket", () => {
+    runWidget({ "data-token": "legacy-token" })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.src).toBe(
+      "https://chat.example/widget/chat/legacy-token?guest_id=guest-fixed",
+    )
+  })
+})

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -75,7 +75,7 @@ describe("widget bootstrap", () => {
     runWidget({ "data-widget-key": "widget-secret" })
 
     const guestId = localStorage.getItem("xagent_guest_id")
-    expect(guestId).toEqual(expect.stringMatching(/^guest_[a-z0-9]+$/))
+    expect(guestId).toBe("guest_4fzyo82mvyqnk000qvgin")
     await vi.waitFor(() => {
       expect(document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")?.src).toBe(
         `https://chat.example/widget/chat/default?guest_id=${guestId}&agent_id=17&embed_ticket=ticket%2Fone`,

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+import baseConfig from "./vitest.config"
+
+const widgetConfig = mergeConfig(baseConfig, defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: [
+        "public/widget.js",
+        "src/components/widget/public-agent-chat-page.tsx",
+      ],
+      reporter: ["text", "json-summary"],
+      reportsDirectory: "coverage/widget",
+      thresholds: {
+        perFile: true,
+        statements: 1,
+        branches: 1,
+        functions: 1,
+        lines: 1,
+      },
+    },
+  },
+}))
+
+export default defineConfig({
+  ...widgetConfig,
+  test: {
+    ...widgetConfig.test,
+    // Vite concatenates arrays during merge, so replace the base glob after
+    // merging to keep this command strictly targeted.
+    include: [
+      "src/components/widget/widget-bootstrap.test.ts",
+      "src/components/widget/public-agent-chat-page.test.tsx",
+    ],
+  },
+})

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -12,11 +12,13 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
       reporter: ["text", "json-summary"],
       reportsDirectory: "coverage/widget",
       thresholds: {
+        // Keep a practical per-file floor while failing if either shared
+        // widget surface loses most of its regression coverage.
         perFile: true,
-        statements: 1,
-        branches: 1,
-        functions: 1,
-        lines: 1,
+        statements: 80,
+        branches: 55,
+        functions: 45,
+        lines: 80,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add widget-specific Vitest configuration and CI coverage for the bootstrap script and public agent chat page.
- Cover embed-ticket bootstrap, direct widget-key access, lazy first-message task creation, task resume, and start-screen behavior.
- Pin fail-closed behavior for missing keys, rejected tickets, disallowed domains, and disabled widgets.

## Why

The shared guest widget paths had no targeted regression net. This change protects the existing integration contract before further widget bootstrap work, without modifying production runtime behavior.

## Validation

- `npm run test:widget` — 15 tests passed
- `npm run test:widget:coverage` — 15 tests passed
- `npm run type-check`
- Targeted ESLint checks
- Randomized test-order runs across three seeds

## Notes

- Production source files are unchanged.
- The coverage adapter follows the repository existing Vitest 2.x line and therefore surfaces the same existing Vitest advisory; a major Vitest upgrade is outside this regression-only change.

Closes #981