### PR TITLE
refactor: extract widget domain matching service

### DIFF
--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -25,6 +25,7 @@ from ..schemas.agent_api_key import (
     APIKeyMetadataResponse,
     APIKeyRevokeResponse,
 )
+from ..schemas.widget import WidgetAllowedDomain
 from ..services.agent_access import (
     AccessibleAgent,
     accessible_agent_permissions,
@@ -106,7 +107,7 @@ class AgentUpdateRequest(BaseModel):
     )
     logo_base64: Optional[str] = None
     widget_enabled: Optional[bool] = None
-    allowed_domains: Optional[List[str]] = None
+    allowed_domains: Optional[List[WidgetAllowedDomain]] = None
     visibility: Optional[Literal["team", "admins"]] = Field(
         None, description="Team visibility: 'team' or 'admins' (team admins only)"
     )

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -103,9 +103,11 @@ EMBED_TICKET_OWNER_WORKFORCE = "workforce"
 @dataclass(frozen=True)
 class ResolvedWidgetOwner:
     """A validated widget owner (agent XOR workforce) plus the data the auth
-    and ticket paths need: the embedding allowlist and the resolved key."""
+    and ticket paths need: the raw persisted embedding allowlist and the
+    resolved key. The domain-policy service validates the JSON value before
+    using it as an authorization rule."""
 
-    allowed_domains: list[str]
+    allowed_domains: object
     widget_key: str
     agent: Agent | None = None
     workforce: Workforce | None = None
@@ -158,7 +160,7 @@ def _resolve_widget_owner_by_key(db: Session, widget_key: str) -> ResolvedWidget
     agent = _resolve_widget_agent_by_key(db, widget_key)
     if agent is not None:
         return ResolvedWidgetOwner(
-            allowed_domains=list(agent.allowed_domains or []),
+            allowed_domains=agent.allowed_domains,
             widget_key=widget_key,
             agent=agent,
         )
@@ -172,7 +174,7 @@ def _resolve_widget_owner_by_key(db: Session, widget_key: str) -> ResolvedWidget
         )
         if workforce is not None and workforce.status == "active":
             return ResolvedWidgetOwner(
-                allowed_domains=list(deployment.allowed_domains or []),
+                allowed_domains=deployment.allowed_domains,
                 widget_key=widget_key,
                 workforce=workforce,
             )
@@ -251,7 +253,7 @@ def _workforce_owner_from_ticket(
         or not deployment.widget_key
     ):
         raise HTTPException(status_code=403, detail="Invalid or expired embed ticket")
-    allowed_domains = list(deployment.allowed_domains or [])
+    allowed_domains = deployment.allowed_domains
     # Re-check so tickets die immediately if the allowlist shrinks.
     require_domain_allowed(origin_domain, allowed_domains)
     return ResolvedWidgetOwner(
@@ -295,11 +297,11 @@ def _owner_from_embed_ticket(db: Session, embed_ticket: str) -> ResolvedWidgetOw
     if not isinstance(ticket_agent_id, int):
         raise HTTPException(status_code=403, detail="Invalid or expired embed ticket")
     agent = _get_widget_enabled_agent(db, ticket_agent_id)
-    allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
+    allowed_domains = agent.allowed_domains
     # Re-check so tickets die immediately if the allowlist shrinks.
     require_domain_allowed(origin_domain, allowed_domains)
     return ResolvedWidgetOwner(
-        allowed_domains=list(allowed_domains),
+        allowed_domains=allowed_domains,
         widget_key=str(agent.widget_key or ""),
         agent=agent,
     )

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Optional
-from urllib.parse import urlparse
 
 from fastapi import (
     APIRouter,
@@ -28,6 +27,10 @@ from ..models.user import User
 from ..models.workforce import Workforce
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.deployments import find_enabled_widget_deployment, get_deployment
+from ..services.widget_domains import (
+    origin_to_domain,
+    require_domain_allowed,
+)
 from .auth import create_access_token
 from .public_chat_access import (
     PublicChatAccessContext,
@@ -106,36 +109,6 @@ class ResolvedWidgetOwner:
     widget_key: str
     agent: Agent | None = None
     workforce: Workforce | None = None
-
-
-def _origin_to_domain(origin: str) -> str:
-    """Extract a lowercased host[:port] from an origin/referer value."""
-    if not origin:
-        return ""
-    parsed = urlparse(origin)
-    return (parsed.netloc or parsed.path).lower()
-
-
-def _domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
-    """Check a domain against the agent allowlist (case-insensitive,
-    supports "*" and subdomain suffix matches)."""
-    for domain in allowed_domains:
-        normalized_domain = domain.strip().lower()
-        if (
-            normalized_domain == "*"
-            or normalized_domain == origin_domain
-            or (origin_domain and origin_domain.endswith("." + normalized_domain))
-        ):
-            return True
-    return False
-
-
-def _require_domain_allowed(origin_domain: str, allowed_domains: list[str]) -> None:
-    """Raise 403 unless the domain passes the agent allowlist."""
-    if not _domain_allowed(origin_domain, allowed_domains):
-        raise HTTPException(
-            status_code=403, detail=f"Domain not allowed: {origin_domain}"
-        )
 
 
 def _get_widget_enabled_agent(db: Session, agent_id: int) -> Agent:
@@ -235,8 +208,8 @@ async def issue_widget_embed_ticket(
     owner = _resolve_widget_owner_by_key(db, request.widget_key)
 
     origin = req.headers.get("origin") or req.headers.get("referer", "")
-    origin_domain = _origin_to_domain(origin)
-    _require_domain_allowed(origin_domain, owner.allowed_domains)
+    origin_domain = origin_to_domain(origin)
+    require_domain_allowed(origin_domain, owner.allowed_domains)
 
     # The ticket has no jti/nonce and is intentionally replayable within its
     # short TTL: it only re-certifies "this origin is allowed", which /auth
@@ -280,7 +253,7 @@ def _workforce_owner_from_ticket(
         raise HTTPException(status_code=403, detail="Invalid or expired embed ticket")
     allowed_domains = list(deployment.allowed_domains or [])
     # Re-check so tickets die immediately if the allowlist shrinks.
-    _require_domain_allowed(origin_domain, allowed_domains)
+    require_domain_allowed(origin_domain, allowed_domains)
     return ResolvedWidgetOwner(
         allowed_domains=allowed_domains,
         widget_key=str(deployment.widget_key),
@@ -324,7 +297,7 @@ def _owner_from_embed_ticket(db: Session, embed_ticket: str) -> ResolvedWidgetOw
     agent = _get_widget_enabled_agent(db, ticket_agent_id)
     allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
     # Re-check so tickets die immediately if the allowlist shrinks.
-    _require_domain_allowed(origin_domain, allowed_domains)
+    require_domain_allowed(origin_domain, allowed_domains)
     return ResolvedWidgetOwner(
         allowed_domains=list(allowed_domains),
         widget_key=str(agent.widget_key or ""),

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -211,7 +211,19 @@ async def issue_widget_embed_ticket(
 
     origin = req.headers.get("origin") or req.headers.get("referer", "")
     origin_domain = origin_to_domain(origin)
-    require_domain_allowed(origin_domain, owner.allowed_domains)
+    if owner.workforce is not None:
+        policy_owner_type = EMBED_TICKET_OWNER_WORKFORCE
+        policy_owner_id = int(owner.workforce.id)
+    else:
+        assert owner.agent is not None
+        policy_owner_type = EMBED_TICKET_OWNER_AGENT
+        policy_owner_id = int(owner.agent.id)
+    require_domain_allowed(
+        origin_domain,
+        owner.allowed_domains,
+        owner_type=policy_owner_type,
+        owner_id=policy_owner_id,
+    )
 
     # The ticket has no jti/nonce and is intentionally replayable within its
     # short TTL: it only re-certifies "this origin is allowed", which /auth
@@ -255,7 +267,12 @@ def _workforce_owner_from_ticket(
         raise HTTPException(status_code=403, detail="Invalid or expired embed ticket")
     allowed_domains = deployment.allowed_domains
     # Re-check so tickets die immediately if the allowlist shrinks.
-    require_domain_allowed(origin_domain, allowed_domains)
+    require_domain_allowed(
+        origin_domain,
+        allowed_domains,
+        owner_type=EMBED_TICKET_OWNER_WORKFORCE,
+        owner_id=workforce_id,
+    )
     return ResolvedWidgetOwner(
         allowed_domains=allowed_domains,
         widget_key=str(deployment.widget_key),
@@ -299,7 +316,12 @@ def _owner_from_embed_ticket(db: Session, embed_ticket: str) -> ResolvedWidgetOw
     agent = _get_widget_enabled_agent(db, ticket_agent_id)
     allowed_domains = agent.allowed_domains
     # Re-check so tickets die immediately if the allowlist shrinks.
-    require_domain_allowed(origin_domain, allowed_domains)
+    require_domain_allowed(
+        origin_domain,
+        allowed_domains,
+        owner_type=EMBED_TICKET_OWNER_AGENT,
+        owner_id=ticket_agent_id,
+    )
     return ResolvedWidgetOwner(
         allowed_domains=allowed_domains,
         widget_key=str(agent.widget_key or ""),

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -20,6 +20,7 @@ from ..models.workforce import (
     WorkforceAgent,
     WorkforceRun,
 )
+from ..schemas.widget import WidgetAllowedDomain
 from ..services.agent_access import (
     AccessibleAgent,
     accessible_agent_permissions,
@@ -1017,7 +1018,7 @@ class WorkforceWidgetUpdateRequest(BaseModel):
     """
 
     widget_enabled: bool | None = None
-    allowed_domains: list[str] | None = None
+    allowed_domains: list[WidgetAllowedDomain] | None = None
 
 
 def _serialize_workforce_widget(

--- a/src/xagent/web/schemas/widget.py
+++ b/src/xagent/web/schemas/widget.py
@@ -1,0 +1,20 @@
+"""Shared request contracts for widget configuration."""
+
+from typing import Annotated
+
+from pydantic import AfterValidator
+
+from ..services.widget_domains import normalize_widget_allowed_domain
+
+
+def _require_nonblank_widget_allowed_domain(value: str) -> str:
+    if not normalize_widget_allowed_domain(value):
+        raise ValueError("Widget allowed domain must not be blank")
+    return value
+
+
+WidgetAllowedDomain = Annotated[
+    str, AfterValidator(_require_nonblank_widget_allowed_domain)
+]
+
+__all__ = ["WidgetAllowedDomain"]

--- a/src/xagent/web/services/widget_domains.py
+++ b/src/xagent/web/services/widget_domains.py
@@ -15,15 +15,37 @@ def origin_to_domain(origin: str) -> str:
     return (parsed.netloc or parsed.path).lower()
 
 
-def domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
+def _normalize_allowed_domains(allowed_domains: object) -> list[str] | None:
+    """Validate and normalize the complete persisted allowlist.
+
+    JSON columns do not enforce their declared application-level shape. Treat
+    any non-list container or non-string element as an invalid policy rather
+    than coercing it into a potentially broader allowlist.
+    """
+    if not isinstance(allowed_domains, list):
+        return None
+
+    normalized_domains: list[str] = []
+    for domain in allowed_domains:
+        if type(domain) is not str:
+            return None
+        normalized_domains.append(domain.strip().lower())
+    return normalized_domains
+
+
+def domain_allowed(origin_domain: str, allowed_domains: object) -> bool:
     """Return whether a normalized ``origin_domain`` matches allowlist entries.
 
     ``origin_domain`` must already be normalized with :func:`origin_to_domain`.
     Allowlist entries retain their legacy surrounding-whitespace and
-    case-insensitive handling inside this matcher.
+    case-insensitive handling inside this matcher. A malformed persisted
+    allowlist denies access in full.
     """
-    for domain in allowed_domains:
-        normalized_domain = domain.strip().lower()
+    normalized_domains = _normalize_allowed_domains(allowed_domains)
+    if normalized_domains is None:
+        return False
+
+    for normalized_domain in normalized_domains:
         if (
             normalized_domain == "*"
             or normalized_domain == origin_domain
@@ -33,7 +55,7 @@ def domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
     return False
 
 
-def require_domain_allowed(origin_domain: str, allowed_domains: list[str]) -> None:
+def require_domain_allowed(origin_domain: str, allowed_domains: object) -> None:
     """Enforce a normalized origin against stored widget allowlist entries.
 
     ``origin_domain`` must be the result of :func:`origin_to_domain`.

--- a/src/xagent/web/services/widget_domains.py
+++ b/src/xagent/web/services/widget_domains.py
@@ -1,0 +1,44 @@
+"""Widget embedding-origin normalization and allowlist enforcement."""
+
+from urllib.parse import urlparse
+
+from fastapi import HTTPException
+
+__all__ = ["domain_allowed", "origin_to_domain", "require_domain_allowed"]
+
+
+def origin_to_domain(origin: str) -> str:
+    """Normalize an origin or referer value to a lowercased host[:port]."""
+    if not origin:
+        return ""
+    parsed = urlparse(origin)
+    return (parsed.netloc or parsed.path).lower()
+
+
+def domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
+    """Return whether a normalized ``origin_domain`` matches allowlist entries.
+
+    ``origin_domain`` must already be normalized with :func:`origin_to_domain`.
+    Allowlist entries retain their legacy surrounding-whitespace and
+    case-insensitive handling inside this matcher.
+    """
+    for domain in allowed_domains:
+        normalized_domain = domain.strip().lower()
+        if (
+            normalized_domain == "*"
+            or normalized_domain == origin_domain
+            or (origin_domain and origin_domain.endswith("." + normalized_domain))
+        ):
+            return True
+    return False
+
+
+def require_domain_allowed(origin_domain: str, allowed_domains: list[str]) -> None:
+    """Enforce a normalized origin against stored widget allowlist entries.
+
+    ``origin_domain`` must be the result of :func:`origin_to_domain`.
+    """
+    if not domain_allowed(origin_domain, allowed_domains):
+        raise HTTPException(
+            status_code=403, detail=f"Domain not allowed: {origin_domain}"
+        )

--- a/src/xagent/web/services/widget_domains.py
+++ b/src/xagent/web/services/widget_domains.py
@@ -1,10 +1,25 @@
 """Widget embedding-origin normalization and allowlist enforcement."""
 
+import logging
+from typing import Literal
 from urllib.parse import urlparse
 
 from fastapi import HTTPException
 
-__all__ = ["domain_allowed", "origin_to_domain", "require_domain_allowed"]
+__all__ = [
+    "domain_allowed",
+    "normalize_widget_allowed_domain",
+    "origin_to_domain",
+    "require_domain_allowed",
+]
+
+logger = logging.getLogger(__name__)
+
+_MalformedPolicyReason = Literal[
+    "not_list",
+    "non_string_entry",
+    "blank_entry",
+]
 
 
 def origin_to_domain(origin: str) -> str:
@@ -15,22 +30,51 @@ def origin_to_domain(origin: str) -> str:
     return (parsed.netloc or parsed.path).lower()
 
 
-def _normalize_allowed_domains(allowed_domains: object) -> list[str] | None:
+def normalize_widget_allowed_domain(value: str) -> str:
+    """Return the canonical form used to detect blanks and match domains."""
+    return value.strip().lower()
+
+
+def _normalize_allowed_domains(
+    allowed_domains: object,
+) -> tuple[list[str] | None, _MalformedPolicyReason | None]:
     """Validate and normalize the complete persisted allowlist.
 
     JSON columns do not enforce their declared application-level shape. Treat
-    any non-list container or non-string element as an invalid policy rather
-    than coercing it into a potentially broader allowlist.
+    any non-list container, non-string element, or blank entry as an invalid
+    policy rather than coercing or skipping it and potentially broadening
+    access.
     """
     if not isinstance(allowed_domains, list):
-        return None
+        return None, "not_list"
 
     normalized_domains: list[str] = []
     for domain in allowed_domains:
         if type(domain) is not str:
-            return None
-        normalized_domains.append(domain.strip().lower())
-    return normalized_domains
+            return None, "non_string_entry"
+        normalized_domain = normalize_widget_allowed_domain(domain)
+        if not normalized_domain:
+            return None, "blank_entry"
+        normalized_domains.append(normalized_domain)
+    return normalized_domains, None
+
+
+def _evaluate_domain_policy(
+    origin_domain: str, allowed_domains: object
+) -> tuple[bool, _MalformedPolicyReason | None]:
+    normalized_domains, malformed_reason = _normalize_allowed_domains(allowed_domains)
+    if malformed_reason is not None:
+        return False, malformed_reason
+    assert normalized_domains is not None
+
+    for normalized_domain in normalized_domains:
+        if (
+            normalized_domain == "*"
+            or normalized_domain == origin_domain
+            or (origin_domain and origin_domain.endswith("." + normalized_domain))
+        ):
+            return True, None
+    return False, None
 
 
 def domain_allowed(origin_domain: str, allowed_domains: object) -> bool:
@@ -41,26 +85,31 @@ def domain_allowed(origin_domain: str, allowed_domains: object) -> bool:
     case-insensitive handling inside this matcher. A malformed persisted
     allowlist denies access in full.
     """
-    normalized_domains = _normalize_allowed_domains(allowed_domains)
-    if normalized_domains is None:
-        return False
-
-    for normalized_domain in normalized_domains:
-        if (
-            normalized_domain == "*"
-            or normalized_domain == origin_domain
-            or (origin_domain and origin_domain.endswith("." + normalized_domain))
-        ):
-            return True
-    return False
+    allowed, _malformed_reason = _evaluate_domain_policy(origin_domain, allowed_domains)
+    return allowed
 
 
-def require_domain_allowed(origin_domain: str, allowed_domains: object) -> None:
+def require_domain_allowed(
+    origin_domain: str,
+    allowed_domains: object,
+    *,
+    owner_type: str,
+    owner_id: int,
+) -> None:
     """Enforce a normalized origin against stored widget allowlist entries.
 
     ``origin_domain`` must be the result of :func:`origin_to_domain`.
     """
-    if not domain_allowed(origin_domain, allowed_domains):
+    allowed, malformed_reason = _evaluate_domain_policy(origin_domain, allowed_domains)
+    if malformed_reason is not None:
+        logger.warning(
+            "Rejected malformed widget allowed-domains policy: "
+            "owner_type=%s owner_id=%s reason=%s",
+            owner_type,
+            owner_id,
+            malformed_reason,
+        )
+    if not allowed:
         raise HTTPException(
             status_code=403, detail=f"Domain not allowed: {origin_domain}"
         )

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -6,7 +6,7 @@ import io
 import secrets
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from jose import jwt as jose_jwt
@@ -475,6 +475,31 @@ def test_widget_embed_ticket_rejected_for_disallowed_origin() -> None:
     assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
 
 
+def test_widget_embed_ticket_rejects_malformed_persisted_agent_allowlist() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Malformed Allowlist Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        cast(Any, agent).allowed_domains = {"trusted-site.com": True}
+        db.commit()
+    finally:
+        db.close()
+
+    response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
+
+
 def test_embed_ticket_requires_valid_widget_key_despite_spoofed_origin() -> None:
     """#742 (embed-ticket path): a forged allowlisted Origin is worthless
     without the unguessable per-agent widget key."""
@@ -822,6 +847,36 @@ def test_widget_auth_rechecks_ticket_origin_against_current_allowlist() -> None:
         "/api/widget/auth",
         json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
     )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
+
+
+def test_widget_auth_rejects_ticket_when_agent_allowlist_becomes_malformed() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Malformed Live Allowlist Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    ticket = _issue_embed_ticket(agent_id, "https://trusted-site.com").json()["ticket"]
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        cast(Any, agent).allowed_domains = ["trusted-site.com", None]
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+    )
+
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
 

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -475,7 +475,10 @@ def test_widget_embed_ticket_rejected_for_disallowed_origin() -> None:
     assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
 
 
-def test_widget_embed_ticket_rejects_malformed_persisted_agent_allowlist() -> None:
+def test_widget_embed_ticket_rejects_malformed_persisted_agent_allowlist(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
     _admin_headers()
     owner_id = _user_id("admin")
     agent_id = _create_agent_row(
@@ -489,7 +492,9 @@ def test_widget_embed_ticket_rejects_malformed_persisted_agent_allowlist() -> No
     db = _direct_db_session()
     try:
         agent = db.query(Agent).filter(Agent.id == agent_id).one()
-        cast(Any, agent).allowed_domains = {"trusted-site.com": True}
+        cast(Any, agent).allowed_domains = {
+            "do-not-log-this-policy-value.example": True
+        }
         db.commit()
     finally:
         db.close()
@@ -498,6 +503,11 @@ def test_widget_embed_ticket_rejects_malformed_persisted_agent_allowlist() -> No
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
+    assert (
+        "Rejected malformed widget allowed-domains policy: "
+        f"owner_type=agent owner_id={agent_id} reason=not_list"
+    ) in caplog.text
+    assert "do-not-log-this-policy-value.example" not in caplog.text
 
 
 def test_embed_ticket_requires_valid_widget_key_despite_spoofed_origin() -> None:
@@ -851,7 +861,10 @@ def test_widget_auth_rechecks_ticket_origin_against_current_allowlist() -> None:
     assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
 
 
-def test_widget_auth_rejects_ticket_when_agent_allowlist_becomes_malformed() -> None:
+def test_widget_auth_rejects_ticket_when_agent_allowlist_becomes_malformed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
     _admin_headers()
     owner_id = _user_id("admin")
     agent_id = _create_agent_row(
@@ -867,7 +880,10 @@ def test_widget_auth_rejects_ticket_when_agent_allowlist_becomes_malformed() -> 
     db = _direct_db_session()
     try:
         agent = db.query(Agent).filter(Agent.id == agent_id).one()
-        cast(Any, agent).allowed_domains = ["trusted-site.com", None]
+        cast(Any, agent).allowed_domains = [
+            "do-not-log-this-policy-value.example",
+            None,
+        ]
         db.commit()
     finally:
         db.close()
@@ -879,6 +895,11 @@ def test_widget_auth_rejects_ticket_when_agent_allowlist_becomes_malformed() -> 
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
+    assert (
+        "Rejected malformed widget allowed-domains policy: "
+        f"owner_type=agent owner_id={agent_id} reason=non_string_entry"
+    ) in caplog.text
+    assert "do-not-log-this-policy-value.example" not in caplog.text
 
 
 def test_widget_embed_ticket_matches_domain_regardless_of_scheme() -> None:
@@ -1356,6 +1377,38 @@ def test_enabling_widget_generates_missing_key() -> None:
         agent = db.query(Agent).filter(Agent.id == agent_id).first()
         assert agent is not None
         assert isinstance(agent.widget_key, str) and len(agent.widget_key) >= 32
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    "blank_domain",
+    ["", "   ", "\u001c"],
+    ids=["empty", "spaces", "unicode-control-separator"],
+)
+def test_agent_update_rejects_blank_widget_allowed_domain(
+    blank_domain: str,
+) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers, name="Validated Widget Domain Agent")
+    configured = client.put(
+        f"/api/agents/{agent_id}",
+        headers=headers,
+        json={"allowed_domains": ["existing.example"]},
+    )
+    assert configured.status_code == 200, configured.text
+
+    response = client.put(
+        f"/api/agents/{agent_id}",
+        headers=headers,
+        json={"allowed_domains": [blank_domain]},
+    )
+
+    assert response.status_code == 422, response.text
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        assert agent.allowed_domains == ["existing.example"]
     finally:
         db.close()
 

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import io
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -117,6 +117,25 @@ def _enable_widget(
     key = body["widget_key"]
     assert isinstance(key, str) and key
     return str(key)
+
+
+def _set_workforce_allowed_domains_raw(
+    workforce_id: int, allowed_domains: object
+) -> None:
+    db = _direct_db_session()
+    try:
+        deployment = (
+            db.query(Deployment)
+            .filter(
+                Deployment.owner_type == DeploymentOwnerType.WORKFORCE.value,
+                Deployment.owner_id == workforce_id,
+            )
+            .one()
+        )
+        cast(Any, deployment).allowed_domains = allowed_domains
+        db.commit()
+    finally:
+        db.close()
 
 
 def _authenticate_widget_guest_by_key(
@@ -374,6 +393,47 @@ def test_widget_embed_ticket_enforces_allowed_domains() -> None:
         headers={"origin": "https://example.com"},
     )
     assert allowed.status_code == 200, allowed.text
+
+
+def test_widget_embed_ticket_rejects_malformed_workforce_allowlist() -> None:
+    workforce_id = _create_workforce("Malformed Domain Gate Widget Workforce")
+    key = _enable_widget(workforce_id, allowed_domains=["example.com"])
+    _set_workforce_allowed_domains_raw(workforce_id, "*")
+
+    response = client.post(
+        "/api/widget/embed-ticket",
+        json={"widget_key": key},
+        headers={"origin": "https://example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: example.com"
+
+
+def test_widget_auth_rejects_ticket_when_workforce_allowlist_becomes_malformed() -> (
+    None
+):
+    workforce_id = _create_workforce("Malformed Live Allowlist Widget Workforce")
+    key = _enable_widget(workforce_id, allowed_domains=["example.com"])
+    ticket_response = client.post(
+        "/api/widget/embed-ticket",
+        json={"widget_key": key},
+        headers={"origin": "https://example.com"},
+    )
+    assert ticket_response.status_code == 200, ticket_response.text
+
+    _set_workforce_allowed_domains_raw(workforce_id, [None, "example.com"])
+
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "guest_id": "guest_test",
+            "embed_ticket": ticket_response.json()["ticket"],
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: example.com"
 
 
 def test_widget_auth_rejects_unknown_key() -> None:

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -251,6 +251,31 @@ def test_widget_allowed_domains_update_independent_of_enable() -> None:
     assert updated.json()["widget_enabled"] is True
 
 
+@pytest.mark.parametrize(
+    "blank_domain",
+    ["", "   ", "\u001c"],
+    ids=["empty", "spaces", "unicode-control-separator"],
+)
+def test_workforce_widget_update_rejects_blank_allowed_domain(
+    blank_domain: str,
+) -> None:
+    workforce_id = _create_workforce("Validated Domains Widget Workforce")
+    _enable_widget(workforce_id, allowed_domains=["existing.example"])
+
+    response = client.put(
+        f"/api/workforces/{workforce_id}/widget",
+        headers=_admin_headers(),
+        json={"allowed_domains": [blank_domain]},
+    )
+
+    assert response.status_code == 422, response.text
+    fetched = client.get(
+        f"/api/workforces/{workforce_id}/widget-key", headers=_admin_headers()
+    )
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["allowed_domains"] == ["existing.example"]
+
+
 def test_widget_requires_workforce_owner() -> None:
     workforce_id = _create_workforce("Owner Only Widget Workforce")
     other_headers = _register_second_user()
@@ -395,10 +420,15 @@ def test_widget_embed_ticket_enforces_allowed_domains() -> None:
     assert allowed.status_code == 200, allowed.text
 
 
-def test_widget_embed_ticket_rejects_malformed_workforce_allowlist() -> None:
+def test_widget_embed_ticket_rejects_malformed_workforce_allowlist(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
     workforce_id = _create_workforce("Malformed Domain Gate Widget Workforce")
     key = _enable_widget(workforce_id, allowed_domains=["example.com"])
-    _set_workforce_allowed_domains_raw(workforce_id, "*")
+    _set_workforce_allowed_domains_raw(
+        workforce_id, "do-not-log-this-policy-value.example"
+    )
 
     response = client.post(
         "/api/widget/embed-ticket",
@@ -408,11 +438,17 @@ def test_widget_embed_ticket_rejects_malformed_workforce_allowlist() -> None:
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: example.com"
+    assert (
+        "Rejected malformed widget allowed-domains policy: "
+        f"owner_type=workforce owner_id={workforce_id} reason=not_list"
+    ) in caplog.text
+    assert "do-not-log-this-policy-value.example" not in caplog.text
 
 
-def test_widget_auth_rejects_ticket_when_workforce_allowlist_becomes_malformed() -> (
-    None
-):
+def test_widget_auth_rejects_ticket_when_workforce_allowlist_becomes_malformed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
     workforce_id = _create_workforce("Malformed Live Allowlist Widget Workforce")
     key = _enable_widget(workforce_id, allowed_domains=["example.com"])
     ticket_response = client.post(
@@ -422,7 +458,9 @@ def test_widget_auth_rejects_ticket_when_workforce_allowlist_becomes_malformed()
     )
     assert ticket_response.status_code == 200, ticket_response.text
 
-    _set_workforce_allowed_domains_raw(workforce_id, [None, "example.com"])
+    _set_workforce_allowed_domains_raw(
+        workforce_id, [None, "do-not-log-this-policy-value.example"]
+    )
 
     response = client.post(
         "/api/widget/auth",
@@ -434,6 +472,11 @@ def test_widget_auth_rejects_ticket_when_workforce_allowlist_becomes_malformed()
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: example.com"
+    assert (
+        "Rejected malformed widget allowed-domains policy: "
+        f"owner_type=workforce owner_id={workforce_id} reason=non_string_entry"
+    ) in caplog.text
+    assert "do-not-log-this-policy-value.example" not in caplog.text
 
 
 def test_widget_auth_rejects_unknown_key() -> None:

--- a/tests/web/services/test_widget_domains.py
+++ b/tests/web/services/test_widget_domains.py
@@ -49,6 +49,10 @@ def test_domain_allowed_preserves_widget_allowlist_matching(
         ("example.com", [None, "example.com"]),
         ("123", [123]),
         ("true", [True]),
+        ("example.com.", [""]),
+        ("example.com.", ["   "]),
+        ("example.com.", ["\u001c"]),
+        ("trusted.example", ["trusted.example", ""]),
     ],
 )
 def test_domain_allowed_rejects_malformed_persisted_allowlists(
@@ -76,13 +80,21 @@ def test_require_domain_allowed_accepts_case_insensitive_stored_allowlist_entrie
     None
 ):
     require_domain_allowed(
-        origin_to_domain("https://APP.EXAMPLE.COM/widget"), [" APP.example.COM "]
+        origin_to_domain("https://APP.EXAMPLE.COM/widget"),
+        [" APP.example.COM "],
+        owner_type="agent",
+        owner_id=42,
     )
 
 
 def test_require_domain_allowed_preserves_forbidden_response() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        require_domain_allowed("untrusted.example", ["trusted.example"])
+        require_domain_allowed(
+            "untrusted.example",
+            ["trusted.example"],
+            owner_type="agent",
+            owner_id=42,
+        )
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Domain not allowed: untrusted.example"
@@ -90,7 +102,63 @@ def test_require_domain_allowed_preserves_forbidden_response() -> None:
 
 def test_require_domain_allowed_maps_malformed_allowlist_to_forbidden() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        require_domain_allowed("trusted.example", [None, "trusted.example"])
+        require_domain_allowed(
+            "trusted.example",
+            [None, "trusted.example"],
+            owner_type="agent",
+            owner_id=42,
+        )
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Domain not allowed: trusted.example"
+
+
+@pytest.mark.parametrize(
+    ("allowed_domains", "expected_reason"),
+    [
+        ({"do-not-log-this-policy-value.example": True}, "not_list"),
+        (
+            ["do-not-log-this-policy-value.example", None],
+            "non_string_entry",
+        ),
+        (["do-not-log-this-policy-value.example", "   "], "blank_entry"),
+        (["do-not-log-this-policy-value.example", "\u001c"], "blank_entry"),
+    ],
+)
+def test_require_domain_allowed_logs_bounded_owner_context_for_malformed_policy(
+    caplog: pytest.LogCaptureFixture,
+    allowed_domains: object,
+    expected_reason: str,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
+    sensitive_policy_value = "do-not-log-this-policy-value.example"
+
+    with pytest.raises(HTTPException):
+        require_domain_allowed(
+            "trusted.example",
+            allowed_domains,
+            owner_type="agent",
+            owner_id=42,
+        )
+
+    assert (
+        "Rejected malformed widget allowed-domains policy: "
+        f"owner_type=agent owner_id=42 reason={expected_reason}"
+    ) in caplog.text
+    assert sensitive_policy_value not in caplog.text
+
+
+def test_require_domain_allowed_does_not_log_expected_origin_mismatch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING", logger="xagent.web.services.widget_domains")
+
+    with pytest.raises(HTTPException):
+        require_domain_allowed(
+            "untrusted.example",
+            ["trusted.example"],
+            owner_type="workforce",
+            owner_id=84,
+        )
+
+    assert "Rejected malformed widget allowed-domains policy" not in caplog.text

--- a/tests/web/services/test_widget_domains.py
+++ b/tests/web/services/test_widget_domains.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi import HTTPException
+
+from xagent.web.services.widget_domains import (
+    domain_allowed,
+    origin_to_domain,
+    require_domain_allowed,
+)
+
+
+@pytest.mark.parametrize(
+    ("origin", "expected_domain"),
+    [
+        ("https://EXAMPLE.com:8443/widget", "example.com:8443"),
+        ("EXAMPLE.com", "example.com"),
+        ("", ""),
+    ],
+)
+def test_origin_to_domain_preserves_the_current_host_port_contract(
+    origin: str, expected_domain: str
+) -> None:
+    assert origin_to_domain(origin) == expected_domain
+
+
+@pytest.mark.parametrize(
+    ("origin_domain", "allowed_domains", "expected"),
+    [
+        ("app.example.com", ["example.com"], True),
+        ("evil-example.com", ["example.com"], False),
+        ("example.com:443", ["example.com"], False),
+        ("example.com:443", ["example.com:443"], True),
+        ("example.com", [], False),
+        ("", ["*"], True),
+    ],
+)
+def test_domain_allowed_preserves_widget_allowlist_matching(
+    origin_domain: str, allowed_domains: list[str], expected: bool
+) -> None:
+    assert domain_allowed(origin_domain, allowed_domains) is expected
+
+
+def test_normalized_domain_composition_preserves_case_insensitive_allowlists() -> None:
+    raw_origin = "https://APP.EXAMPLE.COM/widget"
+    raw_allowed_domain = " APP.example.COM "
+
+    assert domain_allowed(origin_to_domain(raw_origin), [raw_allowed_domain])
+
+
+def test_domain_allowed_does_not_normalize_direct_origin_input() -> None:
+    assert not domain_allowed("APP.EXAMPLE.COM", ["app.example.com"])
+
+
+def test_domain_allowed_does_not_parse_scheme_form_allowlist_entries() -> None:
+    assert not domain_allowed("example.com", ["https://example.com"])
+
+
+def test_require_domain_allowed_accepts_case_insensitive_stored_allowlist_entries() -> (
+    None
+):
+    require_domain_allowed(
+        origin_to_domain("https://APP.EXAMPLE.COM/widget"), [" APP.example.COM "]
+    )
+
+
+def test_require_domain_allowed_preserves_forbidden_response() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        require_domain_allowed("untrusted.example", ["trusted.example"])
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Domain not allowed: untrusted.example"

--- a/tests/web/services/test_widget_domains.py
+++ b/tests/web/services/test_widget_domains.py
@@ -39,6 +39,24 @@ def test_domain_allowed_preserves_widget_allowlist_matching(
     assert domain_allowed(origin_domain, allowed_domains) is expected
 
 
+@pytest.mark.parametrize(
+    ("origin_domain", "allowed_domains"),
+    [
+        ("example.com", None),
+        ("e", "example.com"),
+        ("example.com", {"example.com": True}),
+        ("example.com", ["example.com", None]),
+        ("example.com", [None, "example.com"]),
+        ("123", [123]),
+        ("true", [True]),
+    ],
+)
+def test_domain_allowed_rejects_malformed_persisted_allowlists(
+    origin_domain: str, allowed_domains: object
+) -> None:
+    assert not domain_allowed(origin_domain, allowed_domains)
+
+
 def test_normalized_domain_composition_preserves_case_insensitive_allowlists() -> None:
     raw_origin = "https://APP.EXAMPLE.COM/widget"
     raw_allowed_domain = " APP.example.COM "
@@ -68,3 +86,11 @@ def test_require_domain_allowed_preserves_forbidden_response() -> None:
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Domain not allowed: untrusted.example"
+
+
+def test_require_domain_allowed_maps_malformed_allowlist_to_forbidden() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        require_domain_allowed("trusted.example", [None, "trusted.example"])
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Domain not allowed: trusted.example"


### PR DESCRIPTION
## Summary

- Move widget origin parsing and allowed-domain enforcement into the public `xagent.web.services.widget_domains` service.
- Preserve the existing matching contract for valid `list[str]` policies: exact hosts, wildcards, subdomains, ports, case-insensitive entries, and empty-list deny-all behavior.
- Validate raw persisted JSON before matching. A non-list container or any non-string element invalidates the complete policy and returns the existing 403 response instead of being coerced, implicitly allowed, or raising a server error.
- Route Agent and Workforce ticket issuance and live ticket revalidation through the same fail-closed policy owner.

## Why

The allowed-domain policy was implemented as private API helpers, forcing downstream enforcement points to duplicate security-sensitive matching logic. The values also come from nullable JSON columns, whose runtime shape is not enforced by the database. Converting those values with `list(...)` before validation could turn a mapping into an allowlisted key list or a scalar string into characters.

The shared service now receives the raw persisted value, validates the entire policy, and only then performs matching. Supported API writes remain typed as string lists; no schema migration or data backfill is required.

## Validation

- 127 related service and widget API tests passed.
- Agent and Workforce regressions cover both ticket issuance and live ticket revalidation.
- All configured pre-commit hooks passed.
- Ruff check and format checks passed.
- Mypy passed for the changed production modules.
- Python compile checks passed.
- 10,000-case randomized differential check confirmed unchanged behavior for valid string lists.

Closes #982
