### PR TITLE
chore: bump compose images to 0.6.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   # Xagent Frontend (Next.js)
   frontend:
-    image: xprobe/xagent-frontend:0.6.2
+    image: xprobe/xagent-frontend:0.6.3
     container_name: xagent_frontend
     restart: unless-stopped
     networks:
@@ -31,7 +31,7 @@ services:
 
   # Xagent Backend (FastAPI)
   backend:
-    image: xprobe/xagent-backend:0.6.2
+    image: xprobe/xagent-backend:0.6.3
     container_name: xagent_backend
     restart: unless-stopped
     # Don't expose ports, only accessible through nginx
@@ -66,7 +66,7 @@ services:
 
   # Celery worker for triggers and KB ingestion. Agent execution stays in backend.
   worker:
-    image: xprobe/xagent-backend:0.6.2
+    image: xprobe/xagent-backend:0.6.3
     container_name: xagent_worker
     restart: unless-stopped
     command:
@@ -103,7 +103,7 @@ services:
 
   # Celery beat schedules trigger scans. It never runs agent execution.
   scheduler:
-    image: xprobe/xagent-backend:0.6.2
+    image: xprobe/xagent-backend:0.6.3
     container_name: xagent_scheduler
     restart: unless-stopped
     command:

--- a/docker/docker-compose.sandbox.boxlite.yml
+++ b/docker/docker-compose.sandbox.boxlite.yml
@@ -3,7 +3,7 @@ services:
     environment:
       - SANDBOX_ENABLED=true
       - SANDBOX_IMPLEMENTATION=boxlite
-      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.6.2
+      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.6.3
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - BOXLITE_HOME_DIR=/root/.xagent/boxlite

--- a/docker/docker-compose.sandbox.docker.yml
+++ b/docker/docker-compose.sandbox.docker.yml
@@ -4,7 +4,7 @@ services:
       - SANDBOX_ENABLED=true
       - SANDBOX_IMPLEMENTATION=docker
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.6.2
+      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.6.3
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - XAGENT_SANDBOX_HOST_PROJECT_ROOT=${XAGENT_SANDBOX_HOST_PROJECT_ROOT:-${PWD}}


### PR DESCRIPTION
## Summary
- bump fixed Xagent compose images to 0.6.3
- bump sandbox overlay image tags to 0.6.3

## Validation
- docker compose config --quiet
- docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.boxlite.yml config --quiet
- docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.docker.yml config --quiet

Note: validation was run in a fresh worktree with a temporary empty .env because docker compose requires the referenced env_file to exist.