### PR TITLE
ci: prepare main for a merge queue and harden the alembic head check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+  # Required once "CI Summary" is a required status check and a merge queue is
+  # enabled: without this the context is never reported on a merge group, its
+  # entries time out, and every merge stalls. Harmless before a queue exists --
+  # merge_group simply never fires. Note the jobs' `draft == false` guards all
+  # short-circuit on `github.event_name != 'pull_request'`, so they do run here.
+  merge_group:
 
 env:
   DEEPDOC_CACHE_PATH: .cache/deepdoc

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -13,6 +13,10 @@ on:
       - 'tests/web/services/test_gmail_provisioning.py'
   pull_request:
     branches: [main]
+  # Required by the merge queue: without this the two required contexts below
+  # are never reported on a merge group, its entries time out, and every merge
+  # stalls. Harmless before a queue exists -- merge_group simply never fires.
+  merge_group:
 
 jobs:
   detect-migration-changes:
@@ -32,18 +36,43 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            echo "should-test=true" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-            src/xagent/migrations \
-            tests/migrations \
-            .github/workflows/test-migrations.yml \
-            src/xagent/db \
-            src/xagent/web/services/gmail_provisioning.py \
-            tests/web/services/test_gmail_provisioning.py; then
+          # Note: this is deliberately a two-dot diff (base tip vs head), not
+          # merge-base vs head. It over-triggers once main moves past a
+          # migration, and that over-triggering is load-bearing today -- it is
+          # what catches a migration that landed on main but is absent from
+          # this branch. Do not "fix" it to merge-base while that matters.
+          RELEVANT_PATHS=(
+            src/xagent/migrations
+            tests/migrations
+            .github/workflows/test-migrations.yml
+            src/xagent/db
+            src/xagent/web/services/gmail_provisioning.py
+            tests/web/services/test_gmail_provisioning.py
+          )
+
+          case "$EVENT_NAME" in
+            pull_request)
+              base="$PR_BASE_SHA"
+              head="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              # The merge group branch contains main plus every entry ahead of
+              # this one plus this PR, so this diff covers the whole group.
+              base="$MERGE_GROUP_BASE_SHA"
+              head="$MERGE_GROUP_HEAD_SHA"
+              ;;
+            *)
+              echo "should-test=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if git diff --quiet "$base" "$head" -- "${RELEVANT_PATHS[@]}"; then
             echo "should-test=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-test=true" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -231,8 +231,11 @@ examples/*.html
 # filelock artifacts from tests (mock paths like <MagicMock ...>.lock)
 *MagicMock*.lock
 
-# Root directory markdown files (except README.md, AGENTS.md, CLAUDE.md, CHANGELOG.md)
-*.md
+# Root directory markdown files (except README.md, AGENTS.md, CLAUDE.md, CHANGELOG.md).
+# The leading slash matters: a bare `*.md` matches at every depth, so any doc
+# added in a subdirectory was silently ignored unless it happened to be named
+# README.md (which `!README.md` below un-ignores at every depth).
+/*.md
 !README.md
 !AGENTS.md
 !CLAUDE.md

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,113 @@
+# Branch protection and the merge queue
+
+How `main` is protected, why it is set up this way, and what to do when it
+blocks something urgent.
+
+## What is being protected against
+
+Two migrations branched off the same Alembic revision will each declare the same
+`down_revision`. Individually both are valid; merged together they leave `main`
+with two heads, and `alembic upgrade head` can no longer resolve a single
+target. This has happened repeatedly -- the repository carries 13 hand-written
+`*_merge_*.py` revisions and a trail of `fix(migrations): merge alembic heads`
+commits -- and each occurrence is a fire drill that blocks everyone.
+
+Alembic does not prevent any of this. A branched graph is legal to Alembic, and
+`ScriptDirectory.get_heads()` returns every head with no warning and no error.
+The single-head invariant is a policy this repository enforces, not something
+the tool gives us.
+
+## How it is enforced
+
+| Layer | What it catches | Where |
+| --- | --- | --- |
+| `alembic-check` pre-commit hook | multiple heads, duplicate revision IDs, unresolvable `down_revision` | locally on commit, and on every PR via the `pre-commit` job |
+| Merge queue | the same defects, evaluated against the tree that will actually land | at merge time |
+| `Test SQLite/PostgreSQL Migrations` | a real `alembic upgrade head` on both backends | required status check |
+| `ci.yml` on `push: main` | post-merge detection if something slipped through | red build on `main`, emailed to the pusher |
+
+`scripts/check_alembic_heads.sh` is the single implementation of the graph
+check. Its regression coverage lives in
+`tests/migrations/test_check_alembic_heads.py`, which injects each defect into a
+throwaway Alembic environment and asserts the script rejects it. Those negative
+tests exist because a check that cannot fail is worse than no check: it reads as
+protection that is not there.
+
+## Why a merge queue instead of "require branches to be up to date"
+
+`required_status_checks.strict` is a per-branch boolean -- it cannot be scoped to
+PRs that touch migrations. Turning it on therefore serialized *every* PR: after
+each merge, every other open PR went stale and had to re-sync `main` by hand.
+
+The merge queue reaches the same guarantee without that cost. For each entry it
+builds `gh-readonly-queue/main/pr-N-<sha>` containing `main` plus the entries
+ahead of it plus that PR, and runs the required checks on that branch. Two
+conflicting migrations produce two heads there, so the second entry fails and is
+ejected while the first merges. This is evaluated at merge time against the exact
+tree that will land, not as a point-in-time snapshot that can go stale.
+
+It also catches defects the graph check cannot -- two migrations that each add
+the same column produce a valid single-head graph that still fails on upgrade.
+
+### Queue configuration
+
+```
+mergeMethod:                  SQUASH   # the only method enabled on this repo
+maxEntriesToBuild:            5        # speculative builds; this is what keeps throughput up
+maxEntriesToMerge:            1        # merge one PR at a time
+minEntriesToMerge:            1
+minEntriesToMergeWaitMinutes: 5        # inactive while minEntriesToMerge is 1
+groupingStrategy:             ALLGREEN
+checkResponseTimeoutMinutes:  60       # worst observed ci.yml run is 29.4 min
+```
+
+`maxEntriesToMerge: 1` means every commit on `main` was validated on its own, so
+`git bisect` and reverts stay meaningful. It does not slow the queue down:
+throughput comes from `maxEntriesToBuild`, which builds later entries while
+earlier ones are still being checked.
+
+`groupingStrategy` has no effect while `maxEntriesToMerge` is 1. It is set to
+`ALLGREEN` so that raising the batch size later cannot silently downgrade to the
+weaker "only the group head must pass" semantics.
+
+### Workflows must opt in
+
+Any workflow producing a required status check needs a `merge_group:` trigger.
+Without it the context is never reported on a merge group, the entry times out,
+and **every merge stalls**. `ci.yml` and `test-migrations.yml` both carry it.
+Adding a new required check means adding that trigger first.
+
+The queue also needs to be able to create its branches: ruleset
+"Restrict new branches to main and rls" must exclude
+`refs/heads/gh-readonly-queue/**`.
+
+## Break-glass
+
+`enforce_admins` is enabled, and pushes to `main` are restricted with an empty
+allowlist -- so nobody, including administrators, can push directly or merge
+around the required checks. The only override is to disable admin enforcement,
+merge, and immediately re-enable it.
+
+**Authorized:** `qinxuye`, `rogercloud` (organization owners).
+
+**Use it only for:**
+
+1. the queue is stuck and a fix must land now;
+2. a required check is failing for infrastructure reasons and is blocking every PR;
+3. an urgent revert of something already merged.
+
+```bash
+gh api -X DELETE repos/xorbitsai/xagent/branches/main/protection/enforce_admins
+```
+
+Merge the PR, then restore immediately:
+
+```bash
+gh api -X POST repos/xorbitsai/xagent/branches/main/protection/enforce_admins
+```
+
+Use these dedicated endpoints rather than `PUT .../protection`. The full-object
+PUT replaces the entire configuration, and omitting the empty-allowlist
+`restrictions` block silently removes the push restriction with no error.
+
+Say in the PR why the override was used, so it stays auditable.

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -10,13 +10,23 @@ blocks something urgent.
 > 1. `CI Summary` as a required status check -- independent of the queue.
 > 2. Exclude `refs/heads/gh-readonly-queue/**` from the branch-creation ruleset,
 >    or the queue cannot build anything.
-> 3. **Set `required_status_checks.strict` to `false`.** It is still `true` on
->    `main`. Leaving it on would defeat the entire change: a PR must satisfy its
->    branch-protection requirements before it is admitted to the queue, so with
->    strict on, every PR would still have to sync `main` and re-run its checks
->    first -- exactly the serialization the queue is meant to remove.
-> 4. Enable the merge queue.
-> 5. `enforce_admins` -- deliberately last, once the queue is proven.
+> 3. Enable the merge queue, **leaving `required_status_checks.strict` on**.
+> 4. Verify the queue end to end: a merge-group branch is created, and every
+>    required context reports on it. An already-up-to-date PR satisfies strict, so
+>    it can be enqueued for this without relaxing anything first.
+> 5. **Only now set `required_status_checks.strict` to `false`.** It is still
+>    `true` on `main`, and it has to go: a PR must satisfy its branch-protection
+>    requirements before it is admitted to the queue, so leaving strict on
+>    permanently would keep every PR syncing `main` and re-running checks first --
+>    exactly the serialization the queue exists to remove.
+> 6. `enforce_admins` -- deliberately last, once the queue is proven.
+>
+> **The order of 3 and 5 matters.** Turning strict off first would leave a window
+> where neither protection applies: `main` would accept an approved but stale PR
+> on the strength of green checks that never saw the combined tree, which is the
+> migration race this whole change exists to prevent. If queue activation then
+> failed, the repository would be stuck in that weaker state. Keeping strict on
+> until the queue is confirmed working means the worst case is the status quo.
 >
 > Sections below describe the mechanism; anything above that is still pending is
 > not in force yet. Update this block as each step lands.
@@ -99,10 +109,13 @@ The queue also needs to be able to create its branches: ruleset
 "Restrict new branches to main and rls" must exclude
 `refs/heads/gh-readonly-queue/**`.
 
-And `required_status_checks.strict` must be `false`. GitHub tracks the
+And `required_status_checks.strict` must end up `false`. GitHub tracks the
 up-to-date requirement separately from the queue, and a PR has to satisfy its
 branch-protection requirements before it is admitted -- so leaving strict on
 keeps every PR syncing `main` by hand before it can even enter the queue.
+
+Turn it off *after* the queue is confirmed working, not before; see the ordering
+note in the status block above.
 
 ## Break-glass (`enforce_admins` pending)
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -5,10 +5,21 @@ blocks something urgent.
 
 > **Status.** Live today: the `alembic-check` hook, the required
 > `Test SQLite/PostgreSQL Migrations` checks, and the `merge_group:` triggers
-> (inert until a queue exists). Still pending: `CI Summary` as a required check,
-> the merge queue itself, and `enforce_admins`. Sections below describe the
-> mechanism; anything marked *pending* is not in force yet. Update this block as
-> each lands.
+> (inert until a queue exists). Still pending, in this order:
+>
+> 1. `CI Summary` as a required status check -- independent of the queue.
+> 2. Exclude `refs/heads/gh-readonly-queue/**` from the branch-creation ruleset,
+>    or the queue cannot build anything.
+> 3. **Set `required_status_checks.strict` to `false`.** It is still `true` on
+>    `main`. Leaving it on would defeat the entire change: a PR must satisfy its
+>    branch-protection requirements before it is admitted to the queue, so with
+>    strict on, every PR would still have to sync `main` and re-run its checks
+>    first -- exactly the serialization the queue is meant to remove.
+> 4. Enable the merge queue.
+> 5. `enforce_admins` -- deliberately last, once the queue is proven.
+>
+> Sections below describe the mechanism; anything above that is still pending is
+> not in force yet. Update this block as each step lands.
 
 ## What is being protected against
 
@@ -87,6 +98,11 @@ Adding a new required check means adding that trigger first.
 The queue also needs to be able to create its branches: ruleset
 "Restrict new branches to main and rls" must exclude
 `refs/heads/gh-readonly-queue/**`.
+
+And `required_status_checks.strict` must be `false`. GitHub tracks the
+up-to-date requirement separately from the queue, and a PR has to satisfy its
+branch-protection requirements before it is admitted -- so leaving strict on
+keeps every PR syncing `main` by hand before it can even enter the queue.
 
 ## Break-glass (`enforce_admins` pending)
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -3,6 +3,13 @@
 How `main` is protected, why it is set up this way, and what to do when it
 blocks something urgent.
 
+> **Status.** Live today: the `alembic-check` hook, the required
+> `Test SQLite/PostgreSQL Migrations` checks, and the `merge_group:` triggers
+> (inert until a queue exists). Still pending: `CI Summary` as a required check,
+> the merge queue itself, and `enforce_admins`. Sections below describe the
+> mechanism; anything marked *pending* is not in force yet. Update this block as
+> each lands.
+
 ## What is being protected against
 
 Two migrations branched off the same Alembic revision will each declare the same
@@ -81,12 +88,15 @@ The queue also needs to be able to create its branches: ruleset
 "Restrict new branches to main and rls" must exclude
 `refs/heads/gh-readonly-queue/**`.
 
-## Break-glass
+## Break-glass (`enforce_admins` pending)
 
-`enforce_admins` is enabled, and pushes to `main` are restricted with an empty
-allowlist -- so nobody, including administrators, can push directly or merge
-around the required checks. The only override is to disable admin enforcement,
-merge, and immediately re-enable it.
+Pushes to `main` are restricted with an empty allowlist, so nobody can push
+directly. `enforce_admins` is **not yet enabled**: until it is, administrators
+can still merge around the required checks, and this procedure is not needed.
+
+Once it is enabled, nobody -- administrators included -- can bypass the required
+checks, and the only override is to disable admin enforcement, merge, and
+immediately re-enable it.
 
 **Authorized:** `qinxuye`, `rogercloud` (organization owners).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,14 +19,21 @@ PYTHONPATH=src python scripts/backfill_uploaded_files.py --user-id 1
 
 ## `check_alembic_heads.sh`
 
-Verifies that Alembic currently has exactly one migration head. This is a quick
-CI/local guard for accidental migration branching.
+Checks the Alembic revision graph and reports which invariant broke: more than
+one head, a duplicate revision ID, or a `down_revision` that is not on disk.
+Alembic enforces none of these itself -- a branched graph is legal to it, and a
+duplicate ID only produces a warning -- so this is the guard against accidental
+migration branching, run both locally via pre-commit and on every PR.
 
 Common usage:
 
 ```bash
 PYTHONPATH=src scripts/check_alembic_heads.sh
 ```
+
+Set `ALEMBIC_CHECK_CMD` to override how alembic is invoked (default: `uv run
+alembic`, falling back to `python -m alembic`). Its regression coverage is
+`tests/migrations/test_check_alembic_heads.py`.
 
 ## `convert_trace_checkpoint_messages.py`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,9 +31,9 @@ Common usage:
 PYTHONPATH=src scripts/check_alembic_heads.sh
 ```
 
-Set `ALEMBIC_CHECK_CMD` to override how alembic is invoked (default: `uv run
-alembic`, falling back to `python -m alembic`). Its regression coverage is
-`tests/migrations/test_check_alembic_heads.py`.
+Set `ALEMBIC_CHECK_PYTHON` to a specific interpreter to run alembic under
+(default: `uv run alembic`, falling back to `python -m alembic`). Its regression
+coverage is `tests/migrations/test_check_alembic_heads.py`.
 
 ## `convert_trace_checkpoint_messages.py`
 

--- a/scripts/check_alembic_heads.sh
+++ b/scripts/check_alembic_heads.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env bash
-# Check Alembic has exactly one head
+# Check the Alembic revision graph: exactly one head, no duplicate revision IDs,
+# and every down_revision resolvable.
+#
+# Alembic does not enforce any of this on its own: a branched graph is legal and
+# `get_heads()` returns every head without complaint, while a duplicate revision
+# ID only produces a warning. So each invariant is asserted explicitly here.
+#
+# Regression coverage: tests/migrations/test_check_alembic_heads.py
+# Set ALEMBIC_CHECK_CMD to override how alembic is invoked (used by the tests).
 
-set -e
+set -uo pipefail
 
-if command -v uv >/dev/null 2>&1; then
+if [ -n "${ALEMBIC_CHECK_CMD:-}" ]; then
+    read -r -a ALEMBIC_CMD <<<"$ALEMBIC_CHECK_CMD"
+elif command -v uv >/dev/null 2>&1; then
     ALEMBIC_CMD=(uv run alembic)
 else
     ALEMBIC_CMD=(python -m alembic)
 fi
 
-HEADS=$("${ALEMBIC_CMD[@]}" heads | grep -c " (head)" || true)
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file"' EXIT
 
-if [ "$HEADS" -eq 1 ]; then
-    echo "Alembic: Single head confirmed"
-    exit 0
-else
-    echo "Alembic: Expected 1 head, found $HEADS"
-    echo "Run '${ALEMBIC_CMD[*]} heads' to see all heads"
+if ! heads_output=$("${ALEMBIC_CMD[@]}" heads 2>"$stderr_file"); then
+    echo "Alembic: could not read the revision graph." >&2
+    echo "A down_revision most likely points at a revision that is not on disk." >&2
+    sed 's/^/  /' "$stderr_file" >&2
     exit 1
 fi
+
+if grep -q "present more than once" "$stderr_file"; then
+    echo "Alembic: duplicate revision ID." >&2
+    grep "present more than once" "$stderr_file" | sed 's/^/  /' >&2
+    echo "Two migration files declare the same revision; give one a new ID." >&2
+    exit 1
+fi
+
+head_count=$(printf '%s\n' "$heads_output" | grep -c " (head)")
+
+if [ "$head_count" -eq 1 ]; then
+    echo "Alembic: single head confirmed"
+    exit 0
+fi
+
+echo "Alembic: expected exactly 1 head, found ${head_count}." >&2
+printf '%s\n' "$heads_output" | sed 's/^/  /' >&2
+echo "Merge the branches with '${ALEMBIC_CMD[*]} merge heads'." >&2
+exit 1

--- a/scripts/check_alembic_heads.sh
+++ b/scripts/check_alembic_heads.sh
@@ -7,12 +7,15 @@
 # ID only produces a warning. So each invariant is asserted explicitly here.
 #
 # Regression coverage: tests/migrations/test_check_alembic_heads.py
-# Set ALEMBIC_CHECK_CMD to override how alembic is invoked (used by the tests).
+# Set ALEMBIC_CHECK_PYTHON to run alembic under a specific interpreter (the tests
+# use it to pin their own). It names an interpreter rather than a whole command
+# line on purpose: the value goes straight into a quoted array element, so it
+# needs no word splitting and stays correct when the path contains spaces.
 
 set -uo pipefail
 
-if [ -n "${ALEMBIC_CHECK_CMD:-}" ]; then
-    read -r -a ALEMBIC_CMD <<<"$ALEMBIC_CHECK_CMD"
+if [ -n "${ALEMBIC_CHECK_PYTHON:-}" ]; then
+    ALEMBIC_CMD=("$ALEMBIC_CHECK_PYTHON" -m alembic)
 elif command -v uv >/dev/null 2>&1; then
     ALEMBIC_CMD=(uv run alembic)
 else

--- a/tests/migrations/test_check_alembic_heads.py
+++ b/tests/migrations/test_check_alembic_heads.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+"""Regression coverage for scripts/check_alembic_heads.sh.
+
+That script is the repository's guard against a broken Alembic revision graph,
+and it runs on every PR through the pre-commit job. Until these tests existed,
+nothing proved it could actually fail -- and a check that cannot fail is worse
+than no check, because it reads as protection that is not there.
+
+Alembic enforces none of these invariants by itself:
+
+* a branched graph is legal, and ``get_heads()`` returns every head with no
+  warning and no error;
+* a duplicate revision ID only produces a ``UserWarning``;
+* only an unresolvable ``down_revision`` raises, and it raises a bare
+  ``KeyError``.
+
+Each test below builds a throwaway Alembic environment with one defect injected
+and asserts the script rejects it, plus a healthy control that must pass so a
+failure is attributable to the defect rather than to the fixture harness.
+
+Usage:
+    pytest tests/migrations/test_check_alembic_heads.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+SCRIPT = project_root / "scripts" / "check_alembic_heads.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+
+
+def _write_migration(
+    versions_dir: Path, filename: str, revision: str, down_revision: str | None
+) -> None:
+    down = "None" if down_revision is None else f'"{down_revision}"'
+    versions_dir.joinpath(filename).write_text(
+        textwrap.dedent(
+            f'''\
+            """fixture migration"""
+
+            revision = "{revision}"
+            down_revision = {down}
+            branch_labels = None
+            depends_on = None
+
+
+            def upgrade() -> None:
+                pass
+
+
+            def downgrade() -> None:
+                pass
+            '''
+        ),
+        encoding="utf-8",
+    )
+
+
+def _alembic_env(tmp_path: Path, migrations: list[tuple[str, str, str | None]]) -> Path:
+    """Build a minimal Alembic environment and return its root directory."""
+    versions = tmp_path / "mig" / "versions"
+    versions.mkdir(parents=True)
+    tmp_path.joinpath("alembic.ini").write_text(
+        "[alembic]\nscript_location = mig\n", encoding="utf-8"
+    )
+    for filename, revision, down_revision in migrations:
+        _write_migration(versions, filename, revision, down_revision)
+    return tmp_path
+
+
+def _run_check(env_root: Path) -> subprocess.CompletedProcess[str]:
+    """Run the script against env_root.
+
+    ALEMBIC_CHECK_CMD pins the invocation to this interpreter: the script's
+    default `uv run alembic` would try to resolve a uv project, and the fixture
+    directory deliberately is not one.
+    """
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=env_root,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "ALEMBIC_CHECK_CMD": f"{sys.executable} -m alembic",
+            "HOME": str(env_root),
+        },
+    )
+
+
+def _report(result: subprocess.CompletedProcess[str]) -> str:
+    """Render a script run for an assertion message."""
+    return (
+        f"exit={result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_accepts_single_head(tmp_path: Path) -> None:
+    """Positive control: without this, a failing test below proves nothing."""
+    env = _alembic_env(tmp_path, [("a.py", "aaa", None), ("b.py", "bbb", "aaa")])
+    result = _run_check(env)
+    assert result.returncode == 0, _report(result)
+    assert "single head confirmed" in result.stdout, _report(result)
+
+
+def test_rejects_multiple_heads(tmp_path: Path) -> None:
+    env = _alembic_env(
+        tmp_path,
+        [("a.py", "aaa", None), ("b.py", "bbb", "aaa"), ("c.py", "ccc", "aaa")],
+    )
+    result = _run_check(env)
+    assert result.returncode == 1, _report(result)
+    assert "expected exactly 1 head, found 2" in result.stderr, _report(result)
+    assert "merge heads" in result.stderr, _report(result)
+
+
+def test_rejects_duplicate_revision_ids(tmp_path: Path) -> None:
+    """A duplicate ID must be named as such.
+
+    Alembic only warns here, and the pre-fix script mis-reported it as two
+    heads, sending the reader looking for a branch that does not exist.
+    """
+    env = _alembic_env(
+        tmp_path,
+        [("a.py", "aaa", None), ("d1.py", "bbb", "aaa"), ("d2.py", "bbb", "aaa")],
+    )
+    result = _run_check(env)
+    assert result.returncode == 1, _report(result)
+    assert "duplicate revision ID" in result.stderr, _report(result)
+
+
+def test_rejects_unresolvable_down_revision(tmp_path: Path) -> None:
+    """An orphaned down_revision must be named as such.
+
+    Alembic raises a bare KeyError; the pre-fix script mis-reported it as
+    "found 0 heads".
+    """
+    env = _alembic_env(
+        tmp_path, [("a.py", "aaa", None), ("orphan.py", "bbb", "does_not_exist")]
+    )
+    result = _run_check(env)
+    assert result.returncode == 1, _report(result)
+    assert "could not read the revision graph" in result.stderr, _report(result)
+    assert "not on disk" in result.stderr, _report(result)
+
+
+def test_accepts_this_repository(tmp_path: Path) -> None:
+    """The script must pass against the real migrations directory.
+
+    Also a sanity check on the fixture-based tests above: if the script were
+    broken outright, this would fail too.
+    """
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "ALEMBIC_CHECK_CMD": f"{sys.executable} -m alembic",
+            "HOME": str(tmp_path),
+        },
+    )
+    assert result.returncode == 0, _report(result)
+    assert "single head confirmed" in result.stdout, _report(result)

--- a/tests/migrations/test_check_alembic_heads.py
+++ b/tests/migrations/test_check_alembic_heads.py
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -77,24 +78,32 @@ def _alembic_env(tmp_path: Path, migrations: list[tuple[str, str, str | None]]) 
     return tmp_path
 
 
-def _run_check(env_root: Path) -> subprocess.CompletedProcess[str]:
-    """Run the script against env_root.
+def _run_script(cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
+    """Run the script with cwd as the Alembic root.
 
-    ALEMBIC_CHECK_CMD pins the invocation to this interpreter: the script's
-    default `uv run alembic` would try to resolve a uv project, and the fixture
-    directory deliberately is not one.
+    The parent environment is inherited so that bash and the coreutils the
+    script shells out to stay findable wherever they live -- a pinned PATH
+    breaks on any host that does not keep them under /usr/bin.
+
+    ALEMBIC_CHECK_CMD pins the invocation to this interpreter, which also makes
+    the inherited PATH harmless: the script's default `uv run alembic` would try
+    to resolve a uv project, and a fixture directory deliberately is not one.
+    HOME is redirected so no user-level config leaks into the run.
     """
+    env = os.environ.copy()
+    env["ALEMBIC_CHECK_CMD"] = f"{sys.executable} -m alembic"
+    env["HOME"] = str(home)
     return subprocess.run(
         ["bash", str(SCRIPT)],
-        cwd=env_root,
+        cwd=cwd,
         capture_output=True,
         text=True,
-        env={
-            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-            "ALEMBIC_CHECK_CMD": f"{sys.executable} -m alembic",
-            "HOME": str(env_root),
-        },
+        env=env,
     )
+
+
+def _run_check(env_root: Path) -> subprocess.CompletedProcess[str]:
+    return _run_script(cwd=env_root, home=env_root)
 
 
 def _report(result: subprocess.CompletedProcess[str]) -> str:
@@ -161,16 +170,6 @@ def test_accepts_this_repository(tmp_path: Path) -> None:
     Also a sanity check on the fixture-based tests above: if the script were
     broken outright, this would fail too.
     """
-    result = subprocess.run(
-        ["bash", str(SCRIPT)],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-        env={
-            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-            "ALEMBIC_CHECK_CMD": f"{sys.executable} -m alembic",
-            "HOME": str(tmp_path),
-        },
-    )
+    result = _run_script(cwd=project_root, home=tmp_path)
     assert result.returncode == 0, _report(result)
     assert "single head confirmed" in result.stdout, _report(result)

--- a/tests/migrations/test_check_alembic_heads.py
+++ b/tests/migrations/test_check_alembic_heads.py
@@ -85,13 +85,15 @@ def _run_script(cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
     script shells out to stay findable wherever they live -- a pinned PATH
     breaks on any host that does not keep them under /usr/bin.
 
-    ALEMBIC_CHECK_CMD pins the invocation to this interpreter, which also makes
-    the inherited PATH harmless: the script's default `uv run alembic` would try
-    to resolve a uv project, and a fixture directory deliberately is not one.
-    HOME is redirected so no user-level config leaks into the run.
+    ALEMBIC_CHECK_PYTHON pins the invocation to this interpreter, which also
+    makes the inherited PATH harmless: the script's default `uv run alembic`
+    would try to resolve a uv project, and a fixture directory deliberately is
+    not one. It carries a bare path, never a command line, so it needs no shell
+    quoting even when sys.executable contains spaces. HOME is redirected so no
+    user-level config leaks into the run.
     """
     env = os.environ.copy()
-    env["ALEMBIC_CHECK_CMD"] = f"{sys.executable} -m alembic"
+    env["ALEMBIC_CHECK_PYTHON"] = sys.executable
     env["HOME"] = str(home)
     return subprocess.run(
         ["bash", str(SCRIPT)],


### PR DESCRIPTION
Groundwork for replacing the global serial-merge rule on `main` with a merge
queue. Nothing here changes branch protection or enables a queue -- every change
is inert until those settings move, and can be reviewed and landed on its own.

## Why

`main` has `required_status_checks.strict: true` ("require branches to be up to
date"). That setting is a per-branch boolean, so it cannot be scoped to the PRs
that actually need it, and the practical effect is that every PR merges one at a
time: each merge makes every other open PR stale and someone has to re-sync
`main` by hand.

The rule exists for a real reason. Two migrations branched off the same Alembic
revision each declare the same `down_revision`; individually valid, merged
together they leave `main` with two heads. The repository carries 13 hand-written
`*_merge_*.py` revisions from cleaning that up. A merge queue reaches the same
guarantee -- it validates the exact tree that will land, at the moment it lands --
while letting unrelated PRs merge freely.

## What is in here

**`fix(migrations)`** -- `scripts/check_alembic_heads.sh` detected all three
defects it cares about but described two of them wrongly: a duplicate revision ID
was reported as "found 2 heads", and an unresolvable `down_revision` as "found 0
heads". Both send the reader looking for a branch that does not exist. Now each
case says which one it is.

Nothing proved this hook could fail before now. `tests/migrations/test_check_alembic_heads.py`
injects each defect into a throwaway Alembic environment and asserts rejection,
plus a healthy control so a failure is attributable to the defect rather than to
the fixture harness. Verified by crippling the script to always exit 0 and
confirming all three rejection tests fail while the control still passes.

**`ci`** -- `merge_group:` triggers on `test-migrations.yml` (owns the two
currently required contexts) and `ci.yml` (whose `CI Summary` is about to become
required). A required check that does not report on a merge group times out and
stalls every merge, so this has to be in place before a queue exists. Both are
no-ops until then.

`test-migrations.yml` also needs to recognise the event when deciding whether to
run -- left alone it fell through to the non-`pull_request` branch and ran the
full 5-6 minute suite on every merge, including for changes touching no
migrations. Verified across all six event/diff combinations against a real
migration commit.

**`docs`** -- `docs/branch-protection.md` records the configuration, the
reasoning, and the break-glass procedure, including why it uses the dedicated
`enforce_admins` endpoint rather than a full protection `PUT` (which would
silently drop the empty-allowlist push restriction).

The `.gitignore` change is a fix in its own right: `*.md` has no leading slash,
so it matched at every depth and silently ignored any doc added in a
subdirectory unless it happened to be named `README.md`. The comment above it
already said "Root directory markdown files"; now it is scoped to that. Verified
that no other file in the tree changes tracking status.

## Deliberately not here

* No branch protection or ruleset changes.
* No new implementation of the Alembic graph check -- the existing hook is the
  single implementation, and this only fixes its diagnostics and covers it.
* No `merge_group:` on `ci-real-rag.yml`. That suite has never executed once, and
  `merge_group` runs with secret access, so adding it would let a never-run suite
  start gating merges. See #1004.

## Checks

`ruff check`, `ruff format`, and `alembic-check` all pass. `mypy` is unaffected
(no `src/xagent/**` changes) and the npm hooks do not trigger (no JS/TS/JSON
changes). `tests/migrations` is already in the `pytest-fast-deepdoc` core matrix,
so the new tests run in CI without further wiring.
