### PR TITLE
feat: add sandbox runtime spec contract and explicit lifecycle API

### DIFF
--- a/src/xagent/sandbox/__init__.py
+++ b/src/xagent/sandbox/__init__.py
@@ -15,7 +15,6 @@ from .base import (
     SandboxContractError,
     SandboxInfo,
     SandboxInspection,
-    SandboxLeaseSpec,
     SandboxMountIntent,
     SandboxNotFoundError,
     SandboxReconcileUnsupportedError,
@@ -26,6 +25,7 @@ from .base import (
     SandboxTemplate,
     SpecVerdict,
     TemplateType,
+    canonical_sandbox_path,
     spec_matches_inspection,
 )
 
@@ -51,12 +51,12 @@ __all__ = [
     "SandboxRecoveryRequiredError",
     "SandboxReconcileUnsupportedError",
     "ResolvedSandboxRuntimeSpec",
-    "SandboxLeaseSpec",
     "ObservedRuntimeFacts",
     "SandboxInspection",
     "SandboxMountIntent",
     "SpecVerdict",
     "spec_matches_inspection",
+    "canonical_sandbox_path",
     "SPEC_CONTRACT_VERSION",
 ]
 

--- a/src/xagent/sandbox/__init__.py
+++ b/src/xagent/sandbox/__init__.py
@@ -4,16 +4,29 @@ Sandbox Support.
 
 from ..config import get_sandbox_image
 from .base import (
+    SPEC_CONTRACT_VERSION,
     CodeType,
     ExecResult,
+    ObservedRuntimeFacts,
+    ResolvedSandboxRuntimeSpec,
     Sandbox,
+    SandboxAlreadyExistsError,
     SandboxConfig,
+    SandboxContractError,
     SandboxInfo,
+    SandboxInspection,
+    SandboxLeaseSpec,
+    SandboxMountIntent,
     SandboxNotFoundError,
+    SandboxReconcileUnsupportedError,
+    SandboxRecoveryRequiredError,
+    SandboxRuntimeConflictError,
     SandboxService,
     SandboxSnapshot,
     SandboxTemplate,
+    SpecVerdict,
     TemplateType,
+    spec_matches_inspection,
 )
 
 # Use the `latest` image as a fallback
@@ -32,6 +45,19 @@ __all__ = [
     "ExecResult",
     "Sandbox",
     "SandboxService",
+    "SandboxContractError",
+    "SandboxAlreadyExistsError",
+    "SandboxRuntimeConflictError",
+    "SandboxRecoveryRequiredError",
+    "SandboxReconcileUnsupportedError",
+    "ResolvedSandboxRuntimeSpec",
+    "SandboxLeaseSpec",
+    "ObservedRuntimeFacts",
+    "SandboxInspection",
+    "SandboxMountIntent",
+    "SpecVerdict",
+    "spec_matches_inspection",
+    "SPEC_CONTRACT_VERSION",
 ]
 
 try:

--- a/src/xagent/sandbox/base.py
+++ b/src/xagent/sandbox/base.py
@@ -190,6 +190,35 @@ class ExecResult(BaseModel):
 SPEC_CONTRACT_VERSION = 1
 
 
+def canonical_sandbox_path(path: str) -> str:
+    """Canonicalize one sandbox-domain path for desired-state comparison.
+
+    The sandbox path domain is POSIX on both sides of a mount: guest paths
+    are container paths, and host bind sources are paths on the machine
+    running the container backend (in Docker sibling mode, the Docker
+    host — not necessarily this process's filesystem, see
+    ``XAGENT_SANDBOX_HOST_STORAGE_ROOT``). Normalization therefore belongs
+    to ``posixpath``, never to ``os.path``.
+
+    ``posixpath.normpath`` alone is not a canonical form: POSIX reserves a
+    leading ``//`` for implementation-defined interpretation, so normpath
+    keeps exactly two leading slashes (``'//data'`` stays ``'//data'``)
+    while Docker collapses them in the paths it reports back
+    (``Mounts.Destination``, ``Config.WorkingDir``). A desired-state path
+    that keeps ``//`` can therefore never byte-match what the backend
+    echoes, which turns a correctly-created container into a
+    publish-verification mismatch, and lets ``'//x'`` and ``'/x'`` pass the
+    pre-create conflict checks as if they were different mount points when
+    the backend would collapse them onto the same one. Collapsing the
+    leading slash run is what makes the desired form the form the backend
+    reports.
+    """
+    normalized = posixpath.normpath(path)
+    if normalized.startswith("//"):
+        normalized = "/" + normalized.lstrip("/")
+    return normalized
+
+
 @dataclass(frozen=True, repr=False)
 class ResolvedSandboxRuntimeSpec:
     """Fully-resolved, canonical desired runtime configuration for a sandbox.
@@ -259,20 +288,24 @@ class ResolvedSandboxRuntimeSpec:
     ) -> "ResolvedSandboxRuntimeSpec":
         """Build a spec, normalizing all collection fields.
 
-        Paths are normalized with ``normpath``; env/volumes/ports are sorted
-        and exactly deduplicated so that input order and duplicate entries
-        never affect equality or the fingerprint. ``cpus``/``memory`` fall
-        back to the same defaults the Docker backend applies at container
-        creation (``cpus or 1``, ``memory or 512``) so a resolved spec never
-        carries a 0/None value the backend would silently have upgraded on
-        its own. ``working_dir`` defaults to ``"/home"`` and is normalized
-        with ``normpath``.
+        Paths are canonicalized with ``canonical_sandbox_path``; env/volumes/
+        ports are sorted and exactly deduplicated so that input order and
+        duplicate entries never affect equality or the fingerprint.
+        ``cpus``/``memory`` fall back to the same defaults the Docker backend
+        applies at container creation (``cpus or 1``, ``memory or 512``) so a
+        resolved spec never carries a 0/None value the backend would silently
+        have upgraded on its own. ``working_dir`` defaults to ``"/home"`` and
+        is canonicalized the same way.
         """
         normalized_env = tuple(sorted((env or {}).items()))
         normalized_volumes = tuple(
             sorted(
                 {
-                    (posixpath.normpath(host), posixpath.normpath(guest), mode)
+                    (
+                        canonical_sandbox_path(host),
+                        canonical_sandbox_path(guest),
+                        mode,
+                    )
                     for host, guest, mode in (volumes or [])
                 }
             )
@@ -284,7 +317,9 @@ class ResolvedSandboxRuntimeSpec:
             template_type=template_type,
             image=image,
             snapshot_id=snapshot_id,
-            working_dir=posixpath.normpath(working_dir) if working_dir else "/home",
+            working_dir=(
+                canonical_sandbox_path(working_dir) if working_dir else "/home"
+            ),
             cpus=cpus or 1,
             memory=memory or 512,
             env=normalized_env,
@@ -422,8 +457,8 @@ class SandboxMountIntent:
     """A desired mount root plus a set of independently-declared extra mounts.
 
     Construction never raises (aside from type errors on non-string input):
-    inputs are normalized with ``normpath``, sorted, and exactly
-    deduplicated, but nothing is dropped or rejected here.
+    inputs are canonicalized with ``canonical_sandbox_path``, sorted, and
+    exactly deduplicated, but nothing is dropped or rejected here.
 
     Classification into ``covered_extras`` / ``covering_extras`` /
     ``disjoint_extras`` is purely lexical string comparison over the
@@ -441,10 +476,12 @@ class SandboxMountIntent:
 
     def __post_init__(self) -> None:
         normalized_root = (
-            posixpath.normpath(self.mount_root) if self.mount_root is not None else None
+            canonical_sandbox_path(self.mount_root)
+            if self.mount_root is not None
+            else None
         )
         normalized_extras = tuple(
-            sorted({posixpath.normpath(path) for path in self.extra_mounts})
+            sorted({canonical_sandbox_path(path) for path in self.extra_mounts})
         )
         object.__setattr__(self, "mount_root", normalized_root)
         object.__setattr__(self, "extra_mounts", normalized_extras)

--- a/src/xagent/sandbox/base.py
+++ b/src/xagent/sandbox/base.py
@@ -5,7 +5,11 @@ Abstract interface for Sandbox Service.
 from __future__ import annotations
 
 import abc
-from typing import Literal, Optional
+import hashlib
+import posixpath
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, Field
 
@@ -18,6 +22,53 @@ CodeType = Literal["python", "javascript"]
 
 class SandboxNotFoundError(Exception):
     """Raised when a requested sandbox resource no longer exists."""
+
+
+class SandboxContractError(Exception):
+    """Base class for violations of the explicit sandbox lifecycle contract.
+
+    Deliberately does not inherit from ``RuntimeError``: some call sites
+    catch bare ``RuntimeError`` for unrelated recovery paths, and inheriting
+    it would silently fold these lifecycle contract violations into that
+    generic handling instead of surfacing as their own explicit error type.
+    """
+
+
+class SandboxAlreadyExistsError(SandboxContractError):
+    """Raised when a create() targets a name that already has a container.
+
+    The new lifecycle contract's create() is not idempotent: an existing
+    container in any state (created, running, or stopped) raises this error
+    rather than being silently adopted.
+    """
+
+
+class SandboxRuntimeConflictError(SandboxContractError):
+    """Raised when desired volume mounts conflict at the same host path.
+
+    Two mount entries that share a host path but disagree on guest path or
+    mode cannot both be honored; the backend's internal container-creation
+    path indexes mounts by host path and would silently drop one of them, so
+    this is raised instead of allowing that silent loss.
+    """
+
+
+class SandboxRecoveryRequiredError(SandboxContractError):
+    """Raised when a sandbox is in a state that needs recovery before use.
+
+    Signals that the caller (or a reconciliation pass) must resolve the
+    sandbox's state before it can be treated as available.
+    """
+
+
+class SandboxReconcileUnsupportedError(SandboxContractError):
+    """Raised by the default body of a spec-reconciliation lifecycle method.
+
+    Backends that have not implemented ``inspect``/``create``/
+    ``start_existing``/``stop_existing`` inherit this default; callers
+    should gate on ``supports_runtime_spec()`` rather than relying on this
+    exception for control flow.
+    """
 
 
 class SandboxTemplate(BaseModel):
@@ -128,6 +179,388 @@ class ExecResult(BaseModel):
     @property
     def success(self) -> bool:
         return self.exit_code == 0
+
+
+# Contract version for the fingerprint+label attestation written by create().
+# Bumped when the set of fields covered by fingerprint()/create()'s
+# publish-before-verify step changes in a way that makes an old label
+# untrustworthy for matching against a newly-desired spec. Not part of the
+# fingerprint itself (see ResolvedSandboxRuntimeSpec.fingerprint), so bumping
+# it does not change any existing fingerprint value.
+SPEC_CONTRACT_VERSION = 1
+
+
+@dataclass(frozen=True, repr=False)
+class ResolvedSandboxRuntimeSpec:
+    """Fully-resolved, canonical desired runtime configuration for a sandbox.
+
+    This is the single authoritative expression of "what should this sandbox
+    look like": structural equality between two instances is authoritative
+    equivalence, and ``fingerprint()`` is a stable hash of that same
+    structure. All collection fields are normalized primitive tuples (sorted,
+    deduplicated) so that construction order never affects equality or the
+    fingerprint.
+
+    Exactly one of ``image`` / ``snapshot_id`` must be set, matching
+    ``template_type``. The image reference is a tag, not a content digest:
+    the fingerprint intentionally does not cover what the tag currently
+    resolves to.
+
+    This type has no ``from_backend_info`` counterpart: desired state and
+    observed state are different types (``ObservedRuntimeFacts``) because
+    they are not interchangeable and must never be silently coerced into one
+    another.
+
+    Construct via ``from_parts()`` rather than the constructor directly
+    unless the caller has already normalized every field: ``working_dir``,
+    ``cpus`` and ``memory`` are declared non-optional because a resolved spec
+    always carries the backend defaults applied by ``from_parts``.
+    """
+
+    template_type: TemplateType
+    image: Optional[str]
+    snapshot_id: Optional[str]
+    working_dir: str
+    cpus: int
+    memory: int
+    env: tuple[tuple[str, str], ...]
+    volumes: tuple[tuple[str, str, str], ...]
+    network_isolated: bool
+    ports: tuple[tuple[int, int], ...]
+
+    def __post_init__(self) -> None:
+        if self.template_type == "image":
+            if not self.image or self.snapshot_id:
+                raise ValueError(
+                    "template_type='image' requires 'image' and forbids 'snapshot_id'"
+                )
+        elif self.template_type == "snapshot":
+            if not self.snapshot_id or self.image:
+                raise ValueError(
+                    "template_type='snapshot' requires 'snapshot_id' and forbids 'image'"
+                )
+        else:
+            raise ValueError(f"unknown template_type: {self.template_type!r}")
+
+    @classmethod
+    def from_parts(
+        cls,
+        *,
+        template_type: TemplateType,
+        image: Optional[str] = None,
+        snapshot_id: Optional[str] = None,
+        working_dir: Optional[str] = None,
+        cpus: Optional[int] = None,
+        memory: Optional[int] = None,
+        env: Optional[Mapping[str, str]] = None,
+        volumes: Optional[Sequence[tuple[str, str, str]]] = None,
+        network_isolated: bool = False,
+        ports: Optional[Sequence[tuple[int, int]]] = None,
+    ) -> "ResolvedSandboxRuntimeSpec":
+        """Build a spec, normalizing all collection fields.
+
+        Paths are normalized with ``normpath``; env/volumes/ports are sorted
+        and exactly deduplicated so that input order and duplicate entries
+        never affect equality or the fingerprint. ``cpus``/``memory`` fall
+        back to the same defaults the Docker backend applies at container
+        creation (``cpus or 1``, ``memory or 512``) so a resolved spec never
+        carries a 0/None value the backend would silently have upgraded on
+        its own. ``working_dir`` defaults to ``"/home"`` and is normalized
+        with ``normpath``.
+        """
+        normalized_env = tuple(sorted((env or {}).items()))
+        normalized_volumes = tuple(
+            sorted(
+                {
+                    (posixpath.normpath(host), posixpath.normpath(guest), mode)
+                    for host, guest, mode in (volumes or [])
+                }
+            )
+        )
+        normalized_ports = tuple(
+            sorted({(host, guest) for host, guest in (ports or [])})
+        )
+        return cls(
+            template_type=template_type,
+            image=image,
+            snapshot_id=snapshot_id,
+            working_dir=posixpath.normpath(working_dir) if working_dir else "/home",
+            cpus=cpus or 1,
+            memory=memory or 512,
+            env=normalized_env,
+            volumes=normalized_volumes,
+            network_isolated=network_isolated,
+            ports=normalized_ports,
+        )
+
+    def to_backend_config(self) -> tuple["SandboxTemplate", "SandboxConfig"]:
+        """Produce the backend-private (template, config) pair for this spec.
+
+        This conversion is one-way: backends consume the result to create or
+        describe a sandbox, but nothing reconstructs a
+        ``ResolvedSandboxRuntimeSpec`` from a ``SandboxTemplate``/
+        ``SandboxConfig`` pair.
+        """
+        template = SandboxTemplate(
+            type=self.template_type, image=self.image, snapshot_id=self.snapshot_id
+        )
+        config = SandboxConfig(
+            working_dir=self.working_dir,
+            cpus=self.cpus,
+            memory=self.memory,
+            env=dict(self.env) or None,
+            volumes=[tuple(volume) for volume in self.volumes] or None,
+            network_isolated=self.network_isolated,
+            ports=[tuple(port) for port in self.ports] or None,
+        )
+        return template, config
+
+    def fingerprint(self) -> str:
+        """Stable sha256 hash of this spec's full canonical structure.
+
+        Every field is covered, including ``env``. ``SPEC_CONTRACT_VERSION``
+        is not covered: it is written and checked as an independent label
+        alongside the fingerprint (see ``spec_matches_inspection``).
+        """
+        canonical = repr(
+            (
+                self.template_type,
+                self.image,
+                self.snapshot_id,
+                self.working_dir,
+                self.cpus,
+                self.memory,
+                self.env,
+                self.volumes,
+                self.network_isolated,
+                self.ports,
+            )
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def __repr__(self) -> str:
+        # Deliberately excludes env values and paths: this repr can end up in
+        # logs and error messages, and env/volumes routinely carry secrets or
+        # sensitive host paths.
+        return (
+            f"{type(self).__name__}(fingerprint={self.fingerprint()[:12]}, "
+            f"env_count={len(self.env)}, volumes_count={len(self.volumes)}, "
+            f"ports_count={len(self.ports)})"
+        )
+
+
+@dataclass(frozen=True)
+class SandboxLeaseSpec:
+    """A resolved runtime spec paired with its lease concurrency limit."""
+
+    runtime: ResolvedSandboxRuntimeSpec
+    max_concurrency: int
+
+
+@dataclass(eq=False)
+class ObservedRuntimeFacts:
+    """Raw facts read back from a live backend for a single sandbox.
+
+    Values are kept in their observed, backend-native form rather than
+    normalized to match ``ResolvedSandboxRuntimeSpec``: this type intentionally
+    has no ``fingerprint()`` and no promised equality semantics, because
+    observed state is not a desired-state expression and must never be
+    compared as if it were one. ``eq=False`` makes this explicit at the type
+    level: two instances compare by identity, never structurally, so nothing
+    can accidentally treat one as a desired-state stand-in for the other.
+
+    ``raw_nano_cpus`` / ``raw_memory_bytes`` are the untouched values from the
+    backend (e.g. Docker's ``HostConfig.NanoCpus`` / ``HostConfig.Memory``),
+    not the divided-and-clamped values a display-facing parser would produce;
+    a live edit such as ``docker update --cpus 0.5`` must be observable here.
+
+    ``runtime_networks`` reflects network attachments at inspection time; it
+    is not part of any spec comparison because network attachment can change
+    at runtime independent of the sandbox's declared configuration.
+    """
+
+    raw_status: str
+    image_ref: Optional[str]
+    image_digest: Optional[str]
+    raw_nano_cpus: Optional[int]
+    raw_memory_bytes: Optional[int]
+    env: Mapping[str, str]
+    volumes: tuple[tuple[str, str, str], ...]
+    ports: tuple[tuple[int, int], ...]
+    network_isolated: bool
+    runtime_networks: tuple[str, ...]
+    labels: Mapping[str, str]
+    created_at: Optional[str]
+    working_dir: Optional[str]
+
+
+@dataclass(eq=False)
+class SandboxInspection:
+    """Point-in-time observation of a sandbox: state, facts, and labels.
+
+    ``eq=False`` for the same reason as ``ObservedRuntimeFacts``: this is a
+    point-in-time observation, not a desired-state value, so two instances
+    compare by identity rather than structurally.
+    """
+
+    state: Literal["running", "stopped"]
+    facts: ObservedRuntimeFacts
+    fingerprint_label: Optional[str]
+    version_label: Optional[str]
+
+
+def _is_root_or_descendant(path: str, root: str) -> bool:
+    """Whether ``path`` equals ``root`` or is a lexical descendant of it."""
+    if path == root:
+        return True
+    prefix = root if root.endswith("/") else root + "/"
+    return path.startswith(prefix)
+
+
+@dataclass(frozen=True)
+class SandboxMountIntent:
+    """A desired mount root plus a set of independently-declared extra mounts.
+
+    Construction never raises (aside from type errors on non-string input):
+    inputs are normalized with ``normpath``, sorted, and exactly
+    deduplicated, but nothing is dropped or rejected here.
+
+    Classification into ``covered_extras`` / ``covering_extras`` /
+    ``disjoint_extras`` is purely lexical string comparison over the
+    normalized paths — it does not touch the filesystem and cannot detect
+    symlinks, bind-mount aliasing, or host-side path mappings. Callers must
+    pass backend-side absolute paths that have already been resolved (e.g.
+    via ``realpath``) on their own side before constructing this type; this
+    type performs no such resolution itself. Deciding what to do with the
+    disjoint set (e.g. fail-closed against an allow-list) is left to the
+    caller.
+    """
+
+    mount_root: Optional[str] = None
+    extra_mounts: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        normalized_root = (
+            posixpath.normpath(self.mount_root) if self.mount_root is not None else None
+        )
+        normalized_extras = tuple(
+            sorted({posixpath.normpath(path) for path in self.extra_mounts})
+        )
+        object.__setattr__(self, "mount_root", normalized_root)
+        object.__setattr__(self, "extra_mounts", normalized_extras)
+
+    @property
+    def covered_extras(self) -> tuple[str, ...]:
+        """Extra mounts that are the mount root itself or its descendants."""
+        if self.mount_root is None:
+            return ()
+        return tuple(
+            path
+            for path in self.extra_mounts
+            if _is_root_or_descendant(path, self.mount_root)
+        )
+
+    @property
+    def covering_extras(self) -> tuple[str, ...]:
+        """Extra mounts that are proper ancestors of the mount root."""
+        if self.mount_root is None:
+            return ()
+        return tuple(
+            path
+            for path in self.extra_mounts
+            if path != self.mount_root and _is_root_or_descendant(self.mount_root, path)
+        )
+
+    @property
+    def disjoint_extras(self) -> tuple[str, ...]:
+        """Extra mounts that are neither covered by nor covering the root."""
+        covered = set(self.covered_extras)
+        covering = set(self.covering_extras)
+        return tuple(
+            path
+            for path in self.extra_mounts
+            if path not in covered and path not in covering
+        )
+
+
+class SpecVerdict(Enum):
+    """Result of comparing a desired spec against a live inspection."""
+
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    UNVERIFIED = "unverified"
+
+
+def spec_matches_inspection(
+    desired: ResolvedSandboxRuntimeSpec,
+    inspection: SandboxInspection,
+    *,
+    current_contract_version: int = SPEC_CONTRACT_VERSION,
+) -> SpecVerdict:
+    """Compare a desired spec against a live inspection's attestation.
+
+    This is advisory, not an execution instruction: callers decide what to
+    do with each verdict rather than treating this function as authorizing
+    an action by itself.
+
+    - No fingerprint label, or a version label that is missing or does not
+      exactly match ``current_contract_version``, yields ``UNVERIFIED`` —
+      never ``MISMATCH``. An older label is a stale attestation that cannot
+      be trusted against today's fingerprint rules; a newer label means this
+      code does not yet know that version's fingerprint rules either, so
+      neither direction of mismatch can be safely compared. Treating an
+      unlabeled or version-mismatched container as a mismatch would force a
+      rebuild of every pre-existing container the first time this contract
+      is enabled or bumped, which is not an acceptable outcome; the label is
+      also immutable once written, so there is no backfill path that could
+      turn a legacy container into a verified one.
+    - A matching fingerprint label is followed by a live re-check of the
+      fields Docker allows to drift after creation (cpus/memory, compared in
+      their raw backend units) to catch e.g. ``docker update --cpus 0.5``.
+      Disagreement there is ``MISMATCH`` even though the label matched.
+    - A non-matching fingerprint label is always ``MISMATCH``.
+    - ``env`` / ``volumes`` / ``ports`` / ``image`` are not independently
+      re-compared against live facts: they are immutable after creation, so
+      the fingerprint label attests to them once and for all as long as
+      the label was written by a verified create() call. ``env`` in
+      particular cannot be reliably reconstructed from an inspection at all,
+      since a container's observed environment mixes in image-defined
+      values that were never part of the desired spec.
+
+    Callers that receive ``UNVERIFIED`` for a sandbox that has a
+    corresponding store record should fall back to a full desired-state
+    comparison against the record — recognizing that this is blind to
+    drift in the actual running container and does not verify it, only the
+    previously-recorded intent. A sandbox with a fingerprint label but no
+    store record is the one case that reconciliation must always treat as
+    needing rebuild, since it is the only situation where both label and
+    record can be brought into agreement at once. Regardless of verdict,
+    any destructive action still must go through the reference-count check
+    that applies to all sandbox teardown; the fallback for a
+    non-zero-reference-count sandbox is to reject new callers, not to tear
+    down one already in use.
+    """
+    if inspection.fingerprint_label is None or inspection.version_label is None:
+        return SpecVerdict.UNVERIFIED
+    try:
+        observed_version = int(inspection.version_label)
+    except (TypeError, ValueError):
+        return SpecVerdict.UNVERIFIED
+    if observed_version != current_contract_version:
+        return SpecVerdict.UNVERIFIED
+    if inspection.fingerprint_label != desired.fingerprint():
+        return SpecVerdict.MISMATCH
+
+    facts = inspection.facts
+    desired_nano_cpus = int(desired.cpus * 1_000_000_000)
+    desired_memory_bytes = int(desired.memory * 1024 * 1024)
+    observed_nano_cpus = facts.raw_nano_cpus or 0
+    observed_memory_bytes = facts.raw_memory_bytes or 0
+    if observed_nano_cpus != desired_nano_cpus:
+        return SpecVerdict.MISMATCH
+    if observed_memory_bytes != desired_memory_bytes:
+        return SpecVerdict.MISMATCH
+    return SpecVerdict.MATCH
 
 
 class Sandbox(abc.ABC):
@@ -327,6 +760,11 @@ class SandboxService(abc.ABC):
 
         Returns:
             Sandbox: Operational sandbox instance.
+
+        Note:
+            Managed lifecycle names are owned by the explicit lifecycle API
+            (inspect/create/start_existing/stop_existing); get_or_create
+            does not validate an existing sandbox's configuration.
         """
 
     @abc.abstractmethod
@@ -377,3 +815,116 @@ class SandboxService(abc.ABC):
         Args:
             snapshot_id: Unique snapshot identifier.
         """
+
+    # --- Spec-based reconciliation lifecycle (optional per backend) ---
+    #
+    # These four methods are deliberately concrete, not abstract: this class
+    # is a public, externally-consumed interface, and making them abstract
+    # would be a breaking change for any existing subclass with no
+    # transition period. Backends that do not implement spec-based
+    # reconciliation simply inherit the default bodies below, which raise
+    # SandboxReconcileUnsupportedError. Readiness checks must call
+    # supports_runtime_spec() rather than probing with hasattr or a
+    # try/except around a call.
+
+    async def supports_runtime_spec(self) -> bool:
+        """Whether this backend implements the reconciliation lifecycle.
+
+        Mirrors ``supports_snapshots()``: callers gate on this probe rather
+        than using hasattr/try-call detection. Defaults to False; backends
+        that implement inspect/create/start_existing/stop_existing override
+        this to return True.
+        """
+        return False
+
+    async def inspect(self, name: str) -> Optional[SandboxInspection]:
+        """Observe a sandbox's current state and runtime facts.
+
+        Returns None if no sandbox with this name exists. This call has no
+        side effects and must not acquire any lock or control handle: each
+        call re-reads backend state directly rather than reusing a cached
+        handle. Any lock this method takes internally only guarantees the
+        atomicity of that single call; a caller that needs to act on the
+        result must hold its own critical section spanning the
+        inspect-then-act sequence.
+
+        A returned inspection with ``state`` reflecting a container that
+        exists but has never been started must not, by itself, be treated as
+        grounds for destroying or reusing the sandbox.
+
+        When multiple containers carry the same sandbox name label (only
+        reachable via out-of-band operations against the backend, not
+        through this class's own API), which one this returns is undefined;
+        callers must not depend on it.
+
+        Raises:
+            SandboxReconcileUnsupportedError: This backend does not
+                implement spec-based reconciliation.
+        """
+        raise SandboxReconcileUnsupportedError(
+            f"{type(self).__name__} does not support inspect()"
+        )
+
+    async def create(
+        self, name: str, template: SandboxTemplate, config: SandboxConfig
+    ) -> Sandbox:
+        """Create a new sandbox under the explicit, verified lifecycle contract.
+
+        Conceptually an eight-step sequence: (1) reject if a container with
+        this name already exists, (2) resolve a snapshot template to its
+        backing image, (3) validate the desired volumes and ports for
+        host-path/guest-port conflicts, (4) create the container — from the
+        same normalized desired spec this validation ran against — with a
+        fingerprint label and a contract-version label written at creation
+        time, (5) start it, compensating with a forced container removal if
+        start fails, (6) verify the started container's observed facts
+        against the desired spec before publishing, removing the container
+        and raising if verification fails, (7) persist the store record only
+        after verification passes, and (8) return a live Sandbox handle.
+
+        Not idempotent: an existing container in any state (created,
+        running, or stopped) raises SandboxAlreadyExistsError rather than
+        being adopted. Callers that want get-or-create semantics must call
+        inspect() first under their own critical section.
+
+        Raises:
+            SandboxAlreadyExistsError: A container with this name exists.
+            SandboxRuntimeConflictError: The desired volumes conflict at the
+                same host path with a different guest path or mode, or the
+                desired ports conflict at the same guest port with a
+                different host port.
+            SandboxReconcileUnsupportedError: This backend does not
+                implement spec-based reconciliation.
+        """
+        raise SandboxReconcileUnsupportedError(
+            f"{type(self).__name__} does not support create()"
+        )
+
+    async def start_existing(self, name: str) -> Sandbox:
+        """Start a previously-created sandbox.
+
+        Idempotent: starting an already-running sandbox returns it
+        unchanged.
+
+        Raises:
+            SandboxNotFoundError: No sandbox with this name exists.
+            SandboxReconcileUnsupportedError: This backend does not
+                implement spec-based reconciliation.
+        """
+        raise SandboxReconcileUnsupportedError(
+            f"{type(self).__name__} does not support start_existing()"
+        )
+
+    async def stop_existing(self, name: str) -> None:
+        """Stop an existing sandbox, preserving its state.
+
+        Idempotent: stopping an already-stopped sandbox is a no-op.
+
+        Raises:
+            SandboxNotFoundError: No sandbox with this name exists.
+            SandboxReconcileUnsupportedError: This backend does not
+                implement spec-based reconciliation.
+        """
+        raise SandboxReconcileUnsupportedError(
+            f"{type(self).__name__} does not support stop_existing()"
+        )

--- a/src/xagent/sandbox/base.py
+++ b/src/xagent/sandbox/base.py
@@ -44,12 +44,21 @@ class SandboxAlreadyExistsError(SandboxContractError):
 
 
 class SandboxRuntimeConflictError(SandboxContractError):
-    """Raised when desired volume mounts conflict at the same host path.
+    """Raised when a sandbox's desired state conflicts with itself or with
+    what the backend actually materialized.
 
-    Two mount entries that share a host path but disagree on guest path or
-    mode cannot both be honored; the backend's internal container-creation
-    path indexes mounts by host path and would silently drop one of them, so
-    this is raised instead of allowing that silent loss.
+    Covers two distinct checks against the same ``create()`` desired spec:
+
+    - Static pre-create validation: two volume mounts that share a host path
+      but disagree on guest path or mode, or two port mappings that share a
+      guest port but disagree on host port (or vice versa). The backend's
+      internal container-creation path indexes mounts by host path and ports
+      by guest port, so it would otherwise silently drop one of them.
+    - Publish-before-verify: after the container is created and started, its
+      observed runtime facts disagree with the desired spec it was created
+      from (see ``create()``'s step 6). The container is removed and this is
+      raised rather than publishing a store record for a container that
+      isn't what was asked for.
     """
 
 
@@ -927,9 +936,11 @@ class SandboxService(abc.ABC):
         Raises:
             SandboxAlreadyExistsError: A container with this name exists.
             SandboxRuntimeConflictError: The desired volumes conflict at the
-                same host path with a different guest path or mode, or the
+                same host path with a different guest path or mode, the
                 desired ports conflict at the same guest port with a
-                different host port.
+                different host port, or the container's observed facts
+                disagreed with the desired spec at publish-before-verify
+                (step 6).
             SandboxReconcileUnsupportedError: This backend does not
                 implement spec-based reconciliation.
         """

--- a/src/xagent/sandbox/base.py
+++ b/src/xagent/sandbox/base.py
@@ -975,7 +975,10 @@ class SandboxService(abc.ABC):
         start fails, (6) verify the started container's observed facts
         against the desired spec before publishing, removing the container
         and raising if verification fails, (7) persist the store record only
-        after verification passes, and (8) return a live Sandbox handle.
+        after verification passes, recording the same canonical desired state
+        the container was built from and the fingerprint label attests rather
+        than the caller's raw input, so a reader never has to re-normalize the
+        row before comparing it, and (8) return a live Sandbox handle.
 
         Not idempotent: an existing container in any state (created,
         running, or stopped) raises SandboxAlreadyExistsError rather than

--- a/src/xagent/sandbox/base.py
+++ b/src/xagent/sandbox/base.py
@@ -198,6 +198,13 @@ class ExecResult(BaseModel):
 # it does not change any existing fingerprint value.
 SPEC_CONTRACT_VERSION = 1
 
+# Realizable bounds for a resolved spec, mirroring the `ge=` constraints
+# SandboxConfig declares for the same two fields. Kept here so an
+# unrealizable desired state fails at spec construction rather than later,
+# inside the backend conversion.
+_MIN_SPEC_CPUS = 1
+_MIN_SPEC_MEMORY_MB = 128
+
 
 def canonical_sandbox_path(path: str) -> str:
     """Canonicalize one sandbox-domain path for desired-state comparison.
@@ -279,6 +286,23 @@ class ResolvedSandboxRuntimeSpec:
                 )
         else:
             raise ValueError(f"unknown template_type: {self.template_type!r}")
+
+        # Keep this type's constructible domain identical to the domain
+        # to_backend_config() can actually realize. SandboxConfig declares
+        # cpus ge=1 and memory ge=128, so a spec outside those bounds used to
+        # construct fine and then fail pydantic validation later, inside
+        # create(). Since this type is the canonical desired-state
+        # expression, an unrealizable desired state must be rejected at its
+        # own boundary rather than at the backend conversion.
+        if self.cpus < _MIN_SPEC_CPUS:
+            raise ValueError(
+                f"cpus must be >= {_MIN_SPEC_CPUS} to be realizable, got {self.cpus!r}"
+            )
+        if self.memory < _MIN_SPEC_MEMORY_MB:
+            raise ValueError(
+                f"memory must be >= {_MIN_SPEC_MEMORY_MB} MB to be realizable, "
+                f"got {self.memory!r}"
+            )
 
     @classmethod
     def from_parts(
@@ -393,14 +417,6 @@ class ResolvedSandboxRuntimeSpec:
         )
 
 
-@dataclass(frozen=True)
-class SandboxLeaseSpec:
-    """A resolved runtime spec paired with its lease concurrency limit."""
-
-    runtime: ResolvedSandboxRuntimeSpec
-    max_concurrency: int
-
-
 @dataclass(eq=False)
 class ObservedRuntimeFacts:
     """Raw facts read back from a live backend for a single sandbox.
@@ -445,12 +461,34 @@ class SandboxInspection:
     ``eq=False`` for the same reason as ``ObservedRuntimeFacts``: this is a
     point-in-time observation, not a desired-state value, so two instances
     compare by identity rather than structurally.
+
+    ``state`` is a deliberate two-value reduction for the reconcile
+    decision, which only ever branches on "is it running or not". It cannot
+    express the difference between ``created`` (never started),  ``exited``,
+    ``dead`` and ``restarting`` — all four reduce to ``"stopped"``. A caller
+    that needs to treat a never-started container specially must read
+    ``facts.raw_status``, which carries the backend's own status string
+    unreduced for exactly that purpose.
     """
 
     state: Literal["running", "stopped"]
     facts: ObservedRuntimeFacts
     fingerprint_label: Optional[str]
     version_label: Optional[str]
+
+
+def _require_absolute_mount_path(path: str, field: str) -> None:
+    """Reject a mount path that lexical prefix comparison cannot classify.
+
+    ``SandboxMountIntent``'s covered/covering/disjoint split is a pure
+    string-prefix operation, so only absolute POSIX paths are comparable.
+    An empty or relative value would normalize to something like ``"."`` and
+    then read as disjoint from every absolute path.
+    """
+    if not path or not path.startswith("/"):
+        raise ValueError(
+            f"{field} must be a non-empty absolute POSIX path, got {path!r}"
+        )
 
 
 def _is_root_or_descendant(path: str, root: str) -> bool:
@@ -465,9 +503,16 @@ def _is_root_or_descendant(path: str, root: str) -> bool:
 class SandboxMountIntent:
     """A desired mount root plus a set of independently-declared extra mounts.
 
-    Construction never raises (aside from type errors on non-string input):
-    inputs are canonicalized with ``canonical_sandbox_path``, sorted, and
-    exactly deduplicated, but nothing is dropped or rejected here.
+    Inputs are canonicalized with ``canonical_sandbox_path``, sorted, and
+    exactly deduplicated. Every path must be absolute: the three
+    classification properties below are pure lexical prefix comparisons, so
+    a relative path silently classifies as ``disjoint`` against every
+    absolute extra. Because that verdict feeds callers' allow-list
+    decisions, and "disjoint" is the direction that grants a separate mount
+    rather than folding it into an already-approved root, a non-absolute
+    input is rejected here instead of being normalized into a wrong answer.
+    (``canonical_sandbox_path("")`` is ``"."``, which is exactly such a
+    silently-wrong root.)
 
     Classification into ``covered_extras`` / ``covering_extras`` /
     ``disjoint_extras`` is purely lexical string comparison over the
@@ -484,6 +529,10 @@ class SandboxMountIntent:
     extra_mounts: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        if self.mount_root is not None:
+            _require_absolute_mount_path(self.mount_root, "mount_root")
+        for path in self.extra_mounts:
+            _require_absolute_mount_path(path, "extra_mounts entry")
         normalized_root = (
             canonical_sandbox_path(self.mount_root)
             if self.mount_root is not None

--- a/src/xagent/sandbox/boxlite_sandbox.py
+++ b/src/xagent/sandbox/boxlite_sandbox.py
@@ -495,6 +495,17 @@ class BoxliteSandboxService(SandboxService):
     async def supports_snapshots(self) -> bool:
         return False
 
+    async def supports_runtime_spec(self) -> bool:
+        """Boxlite has no label carrier, hardcodes reuse_existing=True (a
+        fail-open get-or-create), cannot retrieve env/volumes/ports back
+        from a running box, and has no control/name-lock infrastructure of
+        its own. The four spec-reconciliation lifecycle methods are left
+        unimplemented (inherited from SandboxService's default, which raises
+        SandboxReconcileUnsupportedError); this probe is how callers detect
+        that up front instead of hitting that exception.
+        """
+        return False
+
     async def create_snapshot(self, name: str, snapshot_id: str) -> SandboxSnapshot:
         raise NotImplementedError("Unsupported")
 

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -26,12 +26,18 @@ import docker
 
 from ..config import get_sandbox_image
 from .base import (
+    SPEC_CONTRACT_VERSION,
     CodeType,
     ExecResult,
+    ObservedRuntimeFacts,
+    ResolvedSandboxRuntimeSpec,
     Sandbox,
+    SandboxAlreadyExistsError,
     SandboxConfig,
     SandboxInfo,
+    SandboxInspection,
     SandboxNotFoundError,
+    SandboxRuntimeConflictError,
     SandboxService,
     SandboxSnapshot,
     SandboxTemplate,
@@ -48,6 +54,11 @@ LABEL_MANAGED = "xagent.managed"
 LABEL_SANDBOX_NAME = "xagent.sandbox.name"
 LABEL_TEMPLATE_TYPE = "xagent.sandbox.template.type"
 LABEL_SNAPSHOT_ID = "xagent.sandbox.snapshot_id"
+# Written only by create() (the new explicit lifecycle API), never by the
+# legacy get_or_create() path: their presence is the attestation that
+# spec_matches_inspection() keys off of. Immutable once written.
+LABEL_SPEC_FINGERPRINT = "xagent.sandbox.spec.fingerprint"
+LABEL_SPEC_VERSION = "xagent.sandbox.spec.version"
 CONTAINER_NAME_PREFIX = "xagent_sandbox_"
 SNAPSHOT_REPOSITORY = "xagent-sandbox-snapshot"
 _CPU_NANOS = 1_000_000_000
@@ -266,6 +277,172 @@ def _merge_info(
     )
 
 
+def _build_inspection(container: Container) -> SandboxInspection:
+    """Build a point-in-time SandboxInspection directly from Docker inspect data.
+
+    Unlike ``_parse_container_config``, this keeps raw backend units
+    (``HostConfig.NanoCpus`` / ``HostConfig.Memory``) rather than the
+    divided-and-clamped ``SandboxConfig`` values, so a live edit such as
+    ``docker update --cpus 0.5`` remains observable in the returned facts.
+    Shared by ``inspect()`` (no side effects, no lock held) and ``create()``'s
+    publish-before-verify step; the caller is responsible for reloading the
+    container beforehand so ``container.attrs`` reflects current state.
+    """
+    attrs = cast(dict[str, Any], container.attrs)
+    config_data = cast(dict[str, Any], attrs.get("Config") or {})
+    host_config = cast(dict[str, Any], attrs.get("HostConfig") or {})
+    state = cast(dict[str, Any], attrs.get("State") or {})
+
+    env_map: dict[str, str] = {}
+    for item in cast(list[str], config_data.get("Env") or []):
+        if "=" in item:
+            key, value = item.split("=", 1)
+            env_map[key] = value
+
+    volumes: list[tuple[str, str, str]] = []
+    for mount in cast(list[dict[str, Any]], attrs.get("Mounts") or []):
+        if mount.get("Type") != "bind":
+            continue
+        source = str(mount.get("Source") or "")
+        target = str(mount.get("Destination") or "")
+        mode = "ro" if bool(mount.get("RW")) is False else "rw"
+        if source and target:
+            volumes.append((source, target, mode))
+
+    ports: list[tuple[int, int]] = []
+    port_bindings = cast(
+        dict[str, list[dict[str, str]]], host_config.get("PortBindings") or {}
+    )
+    for guest_port, host_bindings in port_bindings.items():
+        container_port = int(str(guest_port).split("/", 1)[0])
+        for binding in host_bindings or []:
+            host_port = binding.get("HostPort")
+            if host_port:
+                ports.append((int(host_port), container_port))
+
+    labels = dict(container.labels)
+    raw_status = str(state.get("Status") or "")
+    network_settings = cast(dict[str, Any], attrs.get("NetworkSettings") or {})
+    runtime_networks = tuple(
+        cast(dict[str, Any], network_settings.get("Networks") or {})
+    )
+
+    facts = ObservedRuntimeFacts(
+        raw_status=raw_status,
+        image_ref=cast(Optional[str], config_data.get("Image")),
+        image_digest=cast(Optional[str], attrs.get("Image")),
+        raw_nano_cpus=cast(Optional[int], host_config.get("NanoCpus")),
+        raw_memory_bytes=cast(Optional[int], host_config.get("Memory")),
+        env=env_map,
+        volumes=tuple(volumes),
+        ports=tuple(ports),
+        network_isolated=bool(config_data.get("NetworkDisabled")),
+        runtime_networks=runtime_networks,
+        labels=labels,
+        created_at=cast(Optional[str], attrs.get("Created")),
+        working_dir=cast(Optional[str], config_data.get("WorkingDir")),
+    )
+    return SandboxInspection(
+        state="running" if _get_state(raw_status) == "running" else "stopped",
+        facts=facts,
+        fingerprint_label=labels.get(LABEL_SPEC_FINGERPRINT),
+        version_label=labels.get(LABEL_SPEC_VERSION),
+    )
+
+
+def _check_no_conflicting_volumes(
+    volumes: Optional[list[tuple[str, str, str]]],
+) -> None:
+    """Reject desired volumes that share a host path but disagree downstream.
+
+    ``_create_container`` builds its Docker ``volumes`` dict keyed by host
+    path, so two entries with the same host path but a different guest path
+    or mode would silently drop one of them. Exactly identical triples
+    (duplicates) are accepted and simply collapse; this only rejects a real
+    disagreement, normalizing paths first so equivalent-but-differently-
+    spelled host paths are treated as the same key.
+    """
+    if not volumes:
+        return
+    seen: dict[str, tuple[str, str]] = {}
+    for host_path, guest_path, mode in volumes:
+        key = (posixpath.normpath(guest_path), mode)
+        normalized_host = posixpath.normpath(host_path)
+        prior = seen.get(normalized_host)
+        if prior is not None and prior != key:
+            raise SandboxRuntimeConflictError(
+                f"Conflicting desired volume mounts for host path "
+                f"{normalized_host!r}: {prior} vs {key}"
+            )
+        seen[normalized_host] = key
+
+
+def _check_no_conflicting_ports(
+    ports: Optional[list[tuple[int, int]]],
+) -> None:
+    """Reject desired ports that share a guest port but disagree on host port.
+
+    ``_create_container`` builds its Docker ``ports`` dict keyed by guest
+    port, so two entries with the same guest port but a different host port
+    would silently drop one of them. Exactly identical pairs (duplicates)
+    are accepted and simply collapse; this only rejects a real disagreement.
+    """
+    if not ports:
+        return
+    seen: dict[int, int] = {}
+    for host_port, guest_port in ports:
+        prior = seen.get(guest_port)
+        if prior is not None and prior != host_port:
+            raise SandboxRuntimeConflictError(
+                f"Conflicting desired port mappings for guest port "
+                f"{guest_port}: host {prior} vs {host_port}"
+            )
+        seen[guest_port] = host_port
+
+
+def _find_publish_mismatches(
+    desired: ResolvedSandboxRuntimeSpec,
+    resolved_image: str,
+    inspection: SandboxInspection,
+) -> list[str]:
+    """Return the field names whose observed value disagrees with ``desired``.
+
+    Used only by create()'s publish-before-verify step. Returns field names
+    only (never the actual values) since this feeds directly into a raised
+    error message and desired/observed values may carry sensitive paths.
+
+    The image check applies identically to both template types: for a
+    snapshot-based create, ``resolved_image`` is the snapshot's own image
+    tag, and ``facts.image_ref`` (Docker's ``Config.Image``) equals that tag
+    once the container has actually been created from it, so there is no
+    need for a separate label-based check on the snapshot leg.
+
+    cpus/memory are re-checked here (immediately after start, in raw backend
+    units) in addition to the live re-check ``spec_matches_inspection`` does
+    later: this is the first opportunity to catch e.g. Docker silently
+    clamping an out-of-range request, before the container is ever
+    published.
+    """
+    mismatches: list[str] = []
+    facts = inspection.facts
+
+    if facts.image_ref != resolved_image:
+        mismatches.append("image")
+    if set(facts.volumes) != set(desired.volumes):
+        mismatches.append("volumes")
+    if set(facts.ports) != set(desired.ports):
+        mismatches.append("ports")
+    if facts.working_dir != desired.working_dir:
+        mismatches.append("working_dir")
+    if facts.network_isolated != desired.network_isolated:
+        mismatches.append("network_isolated")
+    if (facts.raw_nano_cpus or 0) != int(desired.cpus * _CPU_NANOS):
+        mismatches.append("cpus")
+    if (facts.raw_memory_bytes or 0) != int(desired.memory * 1024 * 1024):
+        mismatches.append("memory")
+    return mismatches
+
+
 def _write_tar_from_local_path(
     local_path: str, arcname: str, file_obj: io.BufferedRandom
 ) -> None:
@@ -360,6 +537,14 @@ def _archive_path_exists(container: Container, remote_path: str) -> bool:
         return True
     except NotFound:
         return False
+
+
+@dataclass
+class _NamedLockEntry:
+    """Per-sandbox-name lifecycle lock with holder/waiter tracking for safe eviction."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    waiters: int = 0
 
 
 @dataclass
@@ -676,8 +861,17 @@ async def _create_container(
     image: str,
     template: SandboxTemplate,
     config: SandboxConfig,
+    extra_labels: Optional[dict[str, str]] = None,
 ) -> Container:
-    """Create a managed Docker container from sandbox template and config."""
+    """Create a managed Docker container from sandbox template and config.
+
+    ``extra_labels``, when given, is merged into the container's labels.
+    With no extra labels the label set is exactly
+    managed/name/template-type(/snapshot-id). This parameter exists so the
+    ``create()`` lifecycle method can attach the spec fingerprint/version
+    attestation labels without this shared helper (also used by the legacy
+    ``get_or_create()`` path) needing to know anything about that contract.
+    """
     await _ensure_image(client, image)
 
     volumes: dict[str, dict[str, str]] | None = None
@@ -698,6 +892,8 @@ async def _create_container(
     }
     if template.type == "snapshot" and template.snapshot_id:
         labels[LABEL_SNAPSHOT_ID] = template.snapshot_id
+    if extra_labels:
+        labels.update(extra_labels)
 
     kwargs: dict[str, Any] = {
         "image": image,
@@ -735,25 +931,97 @@ class DockerSandboxService(SandboxService):
         self._client = client or _create_docker_client()
         self._client.ping()
         self._store = store
-        # Lock for protecting concurrent creation, one lock per name
-        self._locks: dict[str, asyncio.Lock] = {}
-        # Lock for protecting the _locks dict itself
-        self._locks_lock = asyncio.Lock()
+        # Per-name lifecycle lock entries, one per sandbox name currently held
+        # or waited on.
+        self._locks: dict[str, _NamedLockEntry] = {}
         # Sandbox shared runtime control
         self._controls: dict[str, _SandboxControl] = {}
 
-    async def _get_name_lock(self, name: str) -> asyncio.Lock:
-        """Get the per-sandbox lifecycle lock, creating it on demand."""
-        async with self._locks_lock:
-            if name not in self._locks:
-                self._locks[name] = asyncio.Lock()
-            return self._locks[name]
+    @asynccontextmanager
+    async def _named_lock(self, name: str) -> AsyncIterator[None]:
+        """Serialize lifecycle operations (create/delete/snapshot) for one name.
+
+        Entries are dropped once no holder or waiter remains, so the dict
+        does not grow with every sandbox name ever seen (names such as
+        ``ssh::{task_id}`` come from an unbounded namespace).
+
+        Waiter bookkeeping is deliberately synchronous and unguarded,
+        mirroring ``SandboxManager._lifecycle_locked`` in
+        ``web/sandbox_manager.py``: every step here is a single dict
+        get/set/pop or int increment/decrement with no ``await`` in between,
+        so nothing else can interleave on this single-threaded event loop,
+        and a guarding lock would only add an extra await point that a
+        cancellation could land on mid-rollback. If the acquire is
+        cancelled, the waiter count is rolled back in the same
+        ``except BaseException`` step so a cancelled waiter never leaks
+        either the count or a now-unreferenced entry.
+        """
+        entry = self._locks.get(name)
+        if entry is None:
+            entry = _NamedLockEntry()
+            self._locks[name] = entry
+        entry.waiters += 1
+
+        try:
+            await entry.lock.acquire()
+        except BaseException:
+            entry.waiters -= 1
+            self._drop_named_lock_if_unused(name, entry)
+            raise
+
+        try:
+            yield
+        finally:
+            entry.lock.release()
+            entry.waiters -= 1
+            self._drop_named_lock_if_unused(name, entry)
+
+    def _drop_named_lock_if_unused(self, name: str, entry: _NamedLockEntry) -> None:
+        """Evict ``name``'s lock entry once it has no holder and no waiter left.
+
+        Called only from the synchronous bookkeeping steps in
+        ``_named_lock``, with no ``await`` between the waiter-count update
+        and this call, so nothing else can interleave and observe an
+        inconsistent count. Identity-checked against ``entry`` so a
+        concurrent waiter that already installed a fresh entry for the same
+        name is never evicted out from under it.
+        """
+        if entry.waiters > 0:
+            return
+        if self._locks.get(name) is entry:
+            self._locks.pop(name, None)
 
     def _get_control(self, name: str) -> _SandboxControl:
         """Get the shared runtime control object for a sandbox."""
         if name not in self._controls:
             self._controls[name] = _SandboxControl(name=name)
         return self._controls[name]
+
+    def _get_live_control(self, name: str) -> _SandboxControl:
+        """Return the live control object for a sandbox, replacing it if deleted.
+
+        This is the sole construction point for a fresh ``_SandboxControl``
+        used by the create path: if no control exists yet, or the existing
+        one was marked deleted by a prior ``delete()``, a new one is
+        installed and returned; otherwise the existing live control is
+        returned as-is so that in-flight callers sharing it are not split
+        across two control objects. Must only be called while holding
+        ``_named_lock(name)`` — that per-name mutual exclusion is what makes
+        the deleted-check-then-replace race-free. The assertion below can
+        only check that *some* task holds ``name``'s lock right now, not
+        that it is the caller: ``asyncio.Lock`` has no owner concept, so
+        this cannot be a full runtime proof of the contract, only a guard
+        against the lock not being held at all.
+        """
+        entry = self._locks.get(name)
+        assert entry is not None and entry.lock.locked(), (
+            f"_get_live_control({name!r}) called without holding _named_lock(name)"
+        )
+        existing = self._controls.get(name)
+        if existing is None or existing.deleted:
+            existing = _SandboxControl(name=name)
+            self._controls[name] = existing
+        return existing
 
     async def _find_container(self, name: str) -> Optional[Container]:
         """Find the managed Docker container for a sandbox name."""
@@ -774,13 +1042,8 @@ class DockerSandboxService(SandboxService):
         config: Optional[SandboxConfig] = None,
     ) -> DockerSandbox:
         """Get, resume, or create a Docker-backed sandbox."""
-        lock = await self._get_name_lock(name)
-        async with lock:
-            control = self._get_control(name)
-            if control.deleted:
-                # Recreate the control object after delete() so the same sandbox name can be safely reused in a later lifecycle.
-                self._controls[name] = _SandboxControl(name=name)
-                control = self._controls[name]
+        async with self._named_lock(name):
+            control = self._get_live_control(name)
 
             container = await self._find_container(name)
             if container is not None:
@@ -832,6 +1095,190 @@ class DockerSandboxService(SandboxService):
             self._store.add_info(name, info)
             return DockerSandbox(name, container, info, self._store, control)
 
+    # --- Spec-based reconciliation lifecycle ---
+    #
+    # supports_runtime_spec/inspect/create/start_existing/stop_existing do
+    # not touch the get_or_create()/list_sandboxes()/delete()/
+    # create_snapshot() code paths above, aside from sharing
+    # `_create_container`'s optional `extra_labels` parameter and the
+    # `_named_lock`/`_get_live_control` infrastructure.
+
+    async def supports_runtime_spec(self) -> bool:
+        """Docker backs the explicit spec-reconciliation lifecycle."""
+        return True
+
+    async def inspect(self, name: str) -> Optional[SandboxInspection]:
+        """Observe a sandbox's current state and runtime facts.
+
+        No side effects and no lock/control acquisition: re-finds the
+        container and reloads it fresh on every call rather than reusing a
+        cached handle, so the only atomicity guaranteed is within this one
+        call.
+
+        When multiple containers carry the same sandbox name label (only
+        reachable via out-of-band operations against the Docker daemon),
+        ``_find_container`` picks whichever one the Docker API lists first;
+        which container that is is undefined and callers must not depend
+        on it.
+        """
+        container = await self._find_container(name)
+        if container is None:
+            return None
+        await asyncio.to_thread(container.reload)
+        return _build_inspection(container)
+
+    async def create(
+        self, name: str, template: SandboxTemplate, config: SandboxConfig
+    ) -> DockerSandbox:
+        """Create a new sandbox under the explicit, verified lifecycle contract.
+
+        See ``SandboxService.create`` for the full eight-step contract this
+        implements: existence check, snapshot resolution, volume-conflict
+        validation, labeled container creation, start with raw-remove
+        compensation on failure, publish-before-verify against the desired
+        spec, store persistence, and returning a live handle.
+        """
+        async with self._named_lock(name):
+            existing = await self._find_container(name)
+            if existing is not None:
+                raise SandboxAlreadyExistsError(f"Sandbox already exists: {name!r}")
+
+            template_type = template.type or "image"
+            if template_type == "snapshot":
+                snapshot = self._store.get_snapshot(cast(str, template.snapshot_id))
+                if snapshot is None:
+                    raise FileNotFoundError(
+                        f"Snapshot not found: {template.snapshot_id}"
+                    )
+                resolved_image = cast(str, snapshot.metadata.get("image_tag"))
+                spec_image, spec_snapshot_id = None, template.snapshot_id
+            else:
+                resolved_image = template.image or DEFAULT_SANDBOX_IMAGE
+                spec_image, spec_snapshot_id = resolved_image, None
+
+            _check_no_conflicting_volumes(config.volumes)
+            _check_no_conflicting_ports(config.ports)
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type=template_type,
+                image=spec_image,
+                snapshot_id=spec_snapshot_id,
+                working_dir=config.working_dir,
+                cpus=config.cpus,
+                memory=config.memory,
+                env=config.env,
+                volumes=config.volumes,
+                network_isolated=bool(config.network_isolated),
+                ports=config.ports,
+            )
+            extra_labels = {
+                LABEL_SPEC_FINGERPRINT: desired.fingerprint(),
+                LABEL_SPEC_VERSION: str(SPEC_CONTRACT_VERSION),
+            }
+
+            # Build the container from the same normalized desired spec that
+            # publish-before-verify below compares against, so both sides of
+            # that check are computed from one canonical source instead of
+            # two independent normalizers that could silently diverge (e.g.
+            # on a volume's trailing slash or a `..` segment).
+            backend_template, backend_config = desired.to_backend_config()
+
+            try:
+                container = await _create_container(
+                    self._client,
+                    name,
+                    resolved_image,
+                    backend_template,
+                    backend_config,
+                    extra_labels=extra_labels,
+                )
+            except APIError as exc:
+                if exc.status_code == 409 or "already in use" in str(exc):
+                    raise SandboxAlreadyExistsError(
+                        f"Sandbox already exists: {name!r}"
+                    ) from exc
+                raise
+
+            try:
+                await asyncio.to_thread(container.start)
+            except BaseException as start_exc:
+                # Compensate with a raw container removal, never
+                # self.delete(): delete() acquires this same _named_lock
+                # entry, so calling it here would self-deadlock. The
+                # original start failure (including a cancellation) is
+                # preserved as the raised exception regardless of whether
+                # the compensating remove itself succeeds.
+                try:
+                    await asyncio.to_thread(container.remove, force=True)
+                except Exception as remove_exc:
+                    raise start_exc from remove_exc
+                raise start_exc
+
+            await asyncio.to_thread(container.reload)
+            inspection = _build_inspection(container)
+            mismatches = _find_publish_mismatches(desired, resolved_image, inspection)
+            if mismatches:
+                # A container whose observed facts disagree with what we
+                # asked for must never be published: remove it directly
+                # (never self.delete(), for the same self-deadlock reason as
+                # the start-failure path above) and fail loudly rather than
+                # let a lying label reach the store.
+                await asyncio.to_thread(container.remove, force=True)
+                raise SandboxRuntimeConflictError(
+                    f"Sandbox {name!r} failed publish verification; "
+                    f"mismatched fields: {', '.join(mismatches)}"
+                )
+
+            runtime_info = _parse_container_config(container)
+            stored_info = SandboxInfo(
+                name=name,
+                state=runtime_info.state,
+                template=template,
+                config=config,
+                created_at=runtime_info.created_at,
+            )
+            info = _merge_info(runtime_info, stored_info)
+            # Persisted only after verification passes; a failure here does
+            # not roll back the container — it is left running with a
+            # verified label and no store row, which the next reconcile pass
+            # converges by observing running+MATCH and recreating the row.
+            self._store.add_info(name, info)
+
+            control = self._get_live_control(name)
+            return DockerSandbox(name, container, info, self._store, control)
+
+    async def start_existing(self, name: str) -> DockerSandbox:
+        """Start a previously-created sandbox, idempotent if already running."""
+        async with self._named_lock(name):
+            control = self._get_live_control(name)
+            async with control.exclusive_access(mark_deleted=False):
+                container = await self._find_container(name)
+                if container is None:
+                    raise SandboxNotFoundError(f"Sandbox not found: {name}")
+                await asyncio.to_thread(container.reload)
+                state = _get_state(str(container.attrs.get("State", {}).get("Status")))
+                if state != "running":
+                    await asyncio.to_thread(container.start)
+                    await asyncio.to_thread(container.reload)
+                runtime_info = _parse_container_config(container)
+                info = _merge_info(runtime_info, self._store.get_info(name))
+                self._store.update_info_state(name, "running")
+                return DockerSandbox(name, container, info, self._store, control)
+
+    async def stop_existing(self, name: str) -> None:
+        """Stop an existing sandbox, idempotent if already stopped."""
+        async with self._named_lock(name):
+            control = self._get_live_control(name)
+            async with control.exclusive_access(mark_deleted=False):
+                container = await self._find_container(name)
+                if container is None:
+                    raise SandboxNotFoundError(f"Sandbox not found: {name}")
+                await asyncio.to_thread(container.reload)
+                state = _get_state(str(container.attrs.get("State", {}).get("Status")))
+                if state == "running":
+                    await asyncio.to_thread(container.stop)
+                self._store.update_info_state(name, "stopped")
+
     async def list_sandboxes(self) -> list[SandboxInfo]:
         """List all managed Docker sandboxes."""
         containers = await asyncio.to_thread(
@@ -850,17 +1297,15 @@ class DockerSandboxService(SandboxService):
 
     async def delete(self, name: str) -> None:
         """Permanently delete a sandbox container and its metadata."""
-        lock = await self._get_name_lock(name)
-        async with lock:
+        async with self._named_lock(name):
             control = self._get_control(name)
             async with control.exclusive_access(mark_deleted=True):
                 container = await self._find_container(name)
                 if container is not None:
                     await asyncio.to_thread(container.remove, force=True)
                 self._store.delete_info(name)
-                self._controls.pop(name, None)
-                async with self._locks_lock:
-                    self._locks.pop(name, None)
+                if self._controls.get(name) is control:
+                    self._controls.pop(name)
 
     async def supports_snapshots(self) -> bool:
         """Return whether snapshot operations are supported."""
@@ -868,8 +1313,7 @@ class DockerSandboxService(SandboxService):
 
     async def create_snapshot(self, name: str, snapshot_id: str) -> SandboxSnapshot:
         """Create a snapshot by committing the current container filesystem."""
-        lock = await self._get_name_lock(name)
-        async with lock:
+        async with self._named_lock(name):
             control = self._get_control(name)
             async with control.exclusive_access(mark_deleted=False):
                 container = await self._find_container(name)

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -354,30 +354,53 @@ def _build_inspection(container: Container) -> SandboxInspection:
 def _check_no_conflicting_volumes(
     volumes: Optional[list[tuple[str, str, str]]],
 ) -> None:
-    """Reject desired volumes that share a host path but disagree downstream.
+    """Reject desired volumes that collide on either side of the mount.
 
-    ``_create_container`` builds its Docker ``volumes`` dict keyed by host
-    path, so two entries with the same host path but a different guest path
-    or mode would silently drop one of them. Exactly identical triples
-    (duplicates) are accepted and simply collapse; this only rejects a real
-    disagreement, canonicalizing paths first (via
-    ``canonical_sandbox_path``, the same owner the desired spec uses) so
-    equivalent-but-differently-spelled host paths are treated as the same
-    key.
+    Two failure modes share this check, the same way
+    ``_check_no_conflicting_ports`` covers both sides of a port mapping:
+
+    - Host-side: ``_create_container`` builds its Docker ``volumes`` dict
+      keyed by host path, so two entries with the same host path but a
+      different guest path or mode would silently drop one of them — a dict
+      collapsing entries with no error.
+    - Guest-side: two entries with different host sources on the same guest
+      path pass straight through to Docker, which rejects the pair at
+      container *create* time with a raw ``APIError``/400
+      ``Duplicate mount point``.
+
+    Both become the same pre-create, typed ``SandboxRuntimeConflictError``
+    instead of surfacing later as a silent drop or a raw daemon error.
+    Exactly identical triples (duplicates) are accepted and simply
+    collapse; this only rejects a real disagreement, canonicalizing paths
+    first (via ``canonical_sandbox_path``, the same owner the desired spec
+    uses) so equivalent-but-differently-spelled paths are treated as the
+    same key on both sides.
     """
     if not volumes:
         return
-    seen: dict[str, tuple[str, str]] = {}
+    seen_by_host: dict[str, tuple[str, str]] = {}
+    seen_by_guest: dict[str, tuple[str, str]] = {}
     for host_path, guest_path, mode in volumes:
-        key = (canonical_sandbox_path(guest_path), mode)
         normalized_host = canonical_sandbox_path(host_path)
-        prior = seen.get(normalized_host)
-        if prior is not None and prior != key:
+        normalized_guest = canonical_sandbox_path(guest_path)
+
+        host_key = (normalized_guest, mode)
+        prior_for_host = seen_by_host.get(normalized_host)
+        if prior_for_host is not None and prior_for_host != host_key:
             raise SandboxRuntimeConflictError(
                 f"Conflicting desired volume mounts for host path "
-                f"{normalized_host!r}: {prior} vs {key}"
+                f"{normalized_host!r}: {prior_for_host} vs {host_key}"
             )
-        seen[normalized_host] = key
+        seen_by_host[normalized_host] = host_key
+
+        guest_key = (normalized_host, mode)
+        prior_for_guest = seen_by_guest.get(normalized_guest)
+        if prior_for_guest is not None and prior_for_guest != guest_key:
+            raise SandboxRuntimeConflictError(
+                f"Conflicting desired volume mounts for guest path "
+                f"{normalized_guest!r}: {prior_for_guest} vs {guest_key}"
+            )
+        seen_by_guest[normalized_guest] = guest_key
 
 
 def _check_no_conflicting_ports(

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -41,6 +41,7 @@ from .base import (
     SandboxService,
     SandboxSnapshot,
     SandboxTemplate,
+    canonical_sandbox_path,
 )
 
 if TYPE_CHECKING:
@@ -359,15 +360,17 @@ def _check_no_conflicting_volumes(
     path, so two entries with the same host path but a different guest path
     or mode would silently drop one of them. Exactly identical triples
     (duplicates) are accepted and simply collapse; this only rejects a real
-    disagreement, normalizing paths first so equivalent-but-differently-
-    spelled host paths are treated as the same key.
+    disagreement, canonicalizing paths first (via
+    ``canonical_sandbox_path``, the same owner the desired spec uses) so
+    equivalent-but-differently-spelled host paths are treated as the same
+    key.
     """
     if not volumes:
         return
     seen: dict[str, tuple[str, str]] = {}
     for host_path, guest_path, mode in volumes:
-        key = (posixpath.normpath(guest_path), mode)
-        normalized_host = posixpath.normpath(host_path)
+        key = (canonical_sandbox_path(guest_path), mode)
+        normalized_host = canonical_sandbox_path(host_path)
         prior = seen.get(normalized_host)
         if prior is not None and prior != key:
             raise SandboxRuntimeConflictError(

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -18,7 +18,15 @@ import textwrap
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from hashlib import sha1
-from typing import TYPE_CHECKING, Any, AsyncIterator, Coroutine, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncContextManager,
+    AsyncIterator,
+    Coroutine,
+    Optional,
+    cast,
+)
 
 from docker.errors import APIError, ImageNotFound, NotFound
 
@@ -43,6 +51,7 @@ from .base import (
     SandboxTemplate,
     canonical_sandbox_path,
 )
+from .keyed_lock import KeyedLockRegistry
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
@@ -346,9 +355,29 @@ def _build_inspection(container: Container) -> SandboxInspection:
     return SandboxInspection(
         state="running" if _get_state(raw_status) == "running" else "stopped",
         facts=facts,
-        fingerprint_label=labels.get(LABEL_SPEC_FINGERPRINT),
-        version_label=labels.get(LABEL_SPEC_VERSION),
+        fingerprint_label=_attestation_label(labels.get(LABEL_SPEC_FINGERPRINT)),
+        version_label=_attestation_label(labels.get(LABEL_SPEC_VERSION)),
     )
+
+
+def _attestation_label(value: Optional[str]) -> Optional[str]:
+    """Read one spec-attestation label, mapping a blank value to ``None``.
+
+    ``None`` is the contract's "no attestation" value, which
+    ``spec_matches_inspection`` answers with ``UNVERIFIED``. A blank string
+    means the same thing and must not be treated as a fingerprint that simply
+    fails to match, which would report ``MISMATCH`` and make a reconciler
+    rebuild a container it should have adopted.
+
+    Blank is a value this code writes on purpose: ``_create_container``
+    stamps both keys blank when it has no attestation to make, so that a
+    container never silently presents a fingerprint inherited from its base
+    image. Docker has no way to remove an inherited label, only to overwrite
+    it, so blank is the only available "absent" form on the wire.
+    """
+    if value is None:
+        return None
+    return value or None
 
 
 def _check_no_conflicting_volumes(
@@ -471,6 +500,30 @@ def _find_publish_mismatches(
     later: this is the first opportunity to catch e.g. Docker silently
     clamping an out-of-range request, before the container is ever
     published.
+
+    Failure policy: any single mismatch fails the whole publish and the
+    container is destroyed. This is deliberate and cannot be softened into a
+    per-field "hard-fail on security-relevant fields, log-and-degrade on
+    cosmetic ones" policy, because the fingerprint attestation is
+    all-or-nothing and immutable. ``create()`` stamps
+    ``LABEL_SPEC_FINGERPRINT`` over the *entire* desired spec before the
+    container starts -- it has to, since Docker offers no way to add or
+    change a label on an existing container -- and ``spec_matches_inspection``
+    trusts that one label for every field except cpus/memory, which it
+    re-reads live. Publishing a container whose ``working_dir`` was quietly
+    accepted as different would therefore leave a label positively attesting
+    a spec the container does not implement, and every later reconcile would
+    read that as MATCH. A lying attestation is a worse failure than a refused
+    create, so the tiering has to live upstream of the label: fields whose
+    exact value cannot be guaranteed must be constrained where the desired
+    spec is built, not waived after the fact.
+
+    Two such constraints already exist upstream, which is what keeps this
+    exact-equality check from being brittle in practice: paths pass through
+    ``canonical_sandbox_path`` so a desired path is spelled the way the
+    backend echoes it, and ``get_sandbox_volumes()`` clamps every volume mode
+    to exactly ``ro``/``rw``, so a mode string the daemon would rewrite (an
+    SELinux ``rw,z``, say) cannot reach this comparison from configuration.
     """
     mismatches: list[str] = []
     facts = inspection.facts
@@ -586,14 +639,6 @@ def _archive_path_exists(container: Container, remote_path: str) -> bool:
         return True
     except NotFound:
         return False
-
-
-@dataclass
-class _NamedLockEntry:
-    """Per-sandbox-name lifecycle lock with holder/waiter tracking for safe eviction."""
-
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    waiters: int = 0
 
 
 @dataclass
@@ -914,12 +959,26 @@ async def _create_container(
 ) -> Container:
     """Create a managed Docker container from sandbox template and config.
 
-    ``extra_labels``, when given, is merged into the container's labels.
-    With no extra labels the label set is exactly
-    managed/name/template-type(/snapshot-id). This parameter exists so the
-    ``create()`` lifecycle method can attach the spec fingerprint/version
-    attestation labels without this shared helper (also used by the legacy
-    ``get_or_create()`` path) needing to know anything about that contract.
+    ``extra_labels``, when given, is merged into the container's labels. This
+    parameter exists so the ``create()`` lifecycle method can attach the spec
+    fingerprint/version attestation labels without this shared helper (also
+    used by the legacy ``get_or_create()`` path) needing to know anything
+    about that contract.
+
+    Both spec-attestation label keys are always written, blank when no
+    attestation was supplied, because Docker merges an *image's* labels into
+    a new container's label set for every key the create request does not
+    itself specify. Committing a sandbox to a snapshot image copies that
+    container's labels into the image (verified on Docker 29.4.0), so a
+    container created from a snapshot of a ``create()``-made sandbox would
+    otherwise inherit that sandbox's fingerprint and present it as its own
+    attestation. Writing the keys unconditionally makes this function the
+    single owner of their value for every container it creates, regardless of
+    what the base image carries. A blank value is the wire form of "no
+    attestation": Docker offers no way to *remove* an inherited label (both
+    an empty ``labels`` value and a commit-time ``LABEL key=`` land on the
+    empty string, also verified on 29.4.0), which is why ``_build_inspection``
+    reads blank as absent rather than as a fingerprint that cannot match.
     """
     await _ensure_image(client, image)
 
@@ -938,6 +997,10 @@ async def _create_container(
         LABEL_MANAGED: "true",
         LABEL_SANDBOX_NAME: name,
         LABEL_TEMPLATE_TYPE: template.type or "image",
+        # Shadow any spec attestation inherited from the base image; see the
+        # docstring. Overwritten below when the caller supplies a real one.
+        LABEL_SPEC_FINGERPRINT: "",
+        LABEL_SPEC_VERSION: "",
     }
     if template.type == "snapshot" and template.snapshot_id:
         labels[LABEL_SNAPSHOT_ID] = template.snapshot_id
@@ -980,65 +1043,30 @@ class DockerSandboxService(SandboxService):
         self._client = client or _create_docker_client()
         self._client.ping()
         self._store = store
-        # Per-name lifecycle lock entries, one per sandbox name currently held
-        # or waited on.
-        self._locks: dict[str, _NamedLockEntry] = {}
+        # Per-name lifecycle locks, one entry per sandbox name currently held
+        # or waited on. The registry evicts unreferenced entries so it does
+        # not grow with every sandbox name ever seen (names such as
+        # ``ssh::{task_id}`` come from an unbounded namespace).
+        self._locks = KeyedLockRegistry()
         # Sandbox shared runtime control
         self._controls: dict[str, _SandboxControl] = {}
 
-    @asynccontextmanager
-    async def _named_lock(self, name: str) -> AsyncIterator[None]:
+    def _named_lock(self, name: str) -> AsyncContextManager[None]:
         """Serialize lifecycle operations (create/delete/snapshot) for one name.
 
-        Entries are dropped once no holder or waiter remains, so the dict
-        does not grow with every sandbox name ever seen (names such as
-        ``ssh::{task_id}`` come from an unbounded namespace).
+        Thin alias for the shared ``KeyedLockRegistry`` primitive, which owns
+        the waiter counting and identity-checked eviction; see
+        ``sandbox/keyed_lock.py`` for why that bookkeeping is deliberately
+        synchronous and unguarded.
 
-        Waiter bookkeeping is deliberately synchronous and unguarded,
-        mirroring ``SandboxManager._lifecycle_locked`` in
-        ``web/sandbox_manager.py``: every step here is a single dict
-        get/set/pop or int increment/decrement with no ``await`` in between,
-        so nothing else can interleave on this single-threaded event loop,
-        and a guarding lock would only add an extra await point that a
-        cancellation could land on mid-rollback. If the acquire is
-        cancelled, the waiter count is rolled back in the same
-        ``except BaseException`` step so a cancelled waiter never leaks
-        either the count or a now-unreferenced entry.
+        This lock is per *container name* and is private to this service. It
+        does not span a caller's inspect->create sequence: a caller needing
+        get-or-create semantics must hold its own critical section over the
+        whole sequence, keyed by whatever identity it owns (``SandboxManager``
+        does this with its per-lifecycle-key lock, which is a coarser key than
+        a container name).
         """
-        entry = self._locks.get(name)
-        if entry is None:
-            entry = _NamedLockEntry()
-            self._locks[name] = entry
-        entry.waiters += 1
-
-        try:
-            await entry.lock.acquire()
-        except BaseException:
-            entry.waiters -= 1
-            self._drop_named_lock_if_unused(name, entry)
-            raise
-
-        try:
-            yield
-        finally:
-            entry.lock.release()
-            entry.waiters -= 1
-            self._drop_named_lock_if_unused(name, entry)
-
-    def _drop_named_lock_if_unused(self, name: str, entry: _NamedLockEntry) -> None:
-        """Evict ``name``'s lock entry once it has no holder and no waiter left.
-
-        Called only from the synchronous bookkeeping steps in
-        ``_named_lock``, with no ``await`` between the waiter-count update
-        and this call, so nothing else can interleave and observe an
-        inconsistent count. Identity-checked against ``entry`` so a
-        concurrent waiter that already installed a fresh entry for the same
-        name is never evicted out from under it.
-        """
-        if entry.waiters > 0:
-            return
-        if self._locks.get(name) is entry:
-            self._locks.pop(name, None)
+        return self._locks.locked(name)
 
     @staticmethod
     async def _await_shielded(coro: Coroutine[Any, Any, Any]) -> Any:
@@ -1200,8 +1228,18 @@ class DockerSandboxService(SandboxService):
     # supports_runtime_spec/inspect/create/start_existing/stop_existing do
     # not touch the get_or_create()/list_sandboxes()/delete()/
     # create_snapshot() code paths above, aside from sharing
-    # `_create_container`'s optional `extra_labels` parameter and the
+    # `_create_container` (which owns the spec-attestation label keys for
+    # every container either path creates, blanking them when there is no
+    # attestation to make -- see its docstring) and the
     # `_named_lock`/`_get_live_control` infrastructure.
+    #
+    # All of it assumes a single process is the sole owner of the containers
+    # it manages. `_named_lock` and `_get_live_control` are in-process
+    # registries with no cross-process counterpart, and create()'s
+    # check-then-create sequence is only atomic against other tasks in this
+    # event loop. Two processes pointed at one Docker daemon with an
+    # overlapping name space would race each other; the guard against that is
+    # deployment topology, not this code.
 
     async def supports_runtime_spec(self) -> bool:
         """Docker backs the explicit spec-reconciliation lifecycle."""
@@ -1237,6 +1275,19 @@ class DockerSandboxService(SandboxService):
         validation, labeled container creation, start with raw-remove
         compensation on failure, publish-before-verify against the desired
         spec, store persistence, and returning a live handle.
+
+        Reference-count-blind, like the rest of this service: it knows nothing
+        about how many actors hold a sandbox and enforces no lease. The
+        existence check makes it refuse to overwrite a container that is
+        already there, but a caller that shares sandboxes between actors owns
+        the reference counting and must not route a destructive decision
+        through this service on the assumption that it will second-guess one.
+
+        ``_named_lock(name)`` is held for the whole method, so create() is
+        atomic against another create/delete/snapshot *for the same name* in
+        this process. It does not extend to a caller's own
+        inspect-then-create sequence: that window belongs to the caller's
+        critical section (see ``_named_lock``).
         """
         async with self._named_lock(name):
             existing = await self._find_container(name)
@@ -1338,9 +1389,29 @@ class DockerSandboxService(SandboxService):
                 # still in flight. If a cancellation occurs, it is re-raised
                 # once the remove settles, taking priority over the
                 # SandboxRuntimeConflictError below.
-                await self._await_shielded(
-                    asyncio.to_thread(container.remove, force=True)
-                )
+                #
+                # A failure of the remove itself is logged and swallowed so
+                # the caller still gets SandboxRuntimeConflictError naming the
+                # mismatched fields, rather than a raw docker APIError that
+                # says nothing about why the sandbox was rejected. The
+                # verification verdict is the caller-actionable fact; the
+                # leaked container is an operator-actionable one, so it goes
+                # to the log. `except Exception` deliberately excludes
+                # CancelledError, which must keep propagating.
+                try:
+                    await self._await_shielded(
+                        asyncio.to_thread(container.remove, force=True)
+                    )
+                except Exception as remove_exc:
+                    logger.error(
+                        "Failed to remove sandbox %r after it failed publish "
+                        "verification (mismatched fields: %s); the container "
+                        "is left on the host and must be removed manually. "
+                        "error=%s",
+                        name,
+                        ", ".join(mismatches),
+                        remove_exc,
+                    )
                 raise SandboxRuntimeConflictError(
                     f"Sandbox {name!r} failed publish verification; "
                     f"mismatched fields: {', '.join(mismatches)}"
@@ -1359,19 +1430,47 @@ class DockerSandboxService(SandboxService):
             # not roll back the container — it is left running with a
             # verified label and no store row, which the next reconcile pass
             # converges by observing running+MATCH and recreating the row.
+            #
+            # The row deliberately records the caller's original
+            # template/config, not the canonicalized `desired`. The store is a
+            # record of what was asked for; canonicalization is owned by
+            # `ResolvedSandboxRuntimeSpec.from_parts`, which every consumer
+            # that compares a row against a desired spec runs the row back
+            # through. Both sides of such a comparison are therefore
+            # canonicalized by the same owner, so persisting the pre-canonical
+            # form cannot produce a spurious mismatch, and persisting the
+            # canonical form would instead lose the original request.
             self._store.add_info(name, info)
 
             control = self._get_live_control(name)
             return DockerSandbox(name, container, info, self._store, control)
 
     async def start_existing(self, name: str) -> DockerSandbox:
-        """Start a previously-created sandbox, idempotent if already running."""
+        """Start a previously-created sandbox, idempotent if already running.
+
+        Adopts whatever container currently answers to ``name``: this method
+        performs no spec verification of any kind, and neither reads nor
+        writes the fingerprint attestation. A caller that cares whether the
+        running container still matches a desired spec must call ``inspect()``
+        and ``spec_matches_inspection()`` itself before adopting the result.
+
+        Like every method on this service, this is also reference-count-blind
+        (see ``create()``).
+
+        Mutual exclusion is per container name and is not shared with
+        ``Sandbox.stop()``, which takes only the sandbox's own
+        ``exclusive_access`` barrier and no named lock. A caller that can
+        issue both concurrently for one name must serialize them itself.
+        """
         async with self._named_lock(name):
+            container = await self._find_container(name)
+            if container is None:
+                # Resolved before _get_live_control so that probing a name
+                # with no container does not install a control entry that
+                # nothing would ever evict.
+                raise SandboxNotFoundError(f"Sandbox not found: {name}")
             control = self._get_live_control(name)
             async with control.exclusive_access(mark_deleted=False):
-                container = await self._find_container(name)
-                if container is None:
-                    raise SandboxNotFoundError(f"Sandbox not found: {name}")
                 await asyncio.to_thread(container.reload)
                 state = _get_state(str(container.attrs.get("State", {}).get("Status")))
                 if state != "running":
@@ -1383,13 +1482,19 @@ class DockerSandboxService(SandboxService):
                 return DockerSandbox(name, container, info, self._store, control)
 
     async def stop_existing(self, name: str) -> None:
-        """Stop an existing sandbox, idempotent if already stopped."""
+        """Stop an existing sandbox, idempotent if already stopped.
+
+        Reference-count-blind (see ``create()``) and, like
+        ``start_existing()``, not mutually exclusive with ``Sandbox.stop()``.
+        """
         async with self._named_lock(name):
+            container = await self._find_container(name)
+            if container is None:
+                # Resolved before _get_live_control for the same reason as in
+                # start_existing().
+                raise SandboxNotFoundError(f"Sandbox not found: {name}")
             control = self._get_live_control(name)
             async with control.exclusive_access(mark_deleted=False):
-                container = await self._find_container(name)
-                if container is None:
-                    raise SandboxNotFoundError(f"Sandbox not found: {name}")
                 await asyncio.to_thread(container.reload)
                 state = _get_state(str(container.attrs.get("State", {}).get("Status")))
                 if state == "running":

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -18,7 +18,7 @@ import textwrap
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from hashlib import sha1
-from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, cast
+from typing import TYPE_CHECKING, Any, AsyncIterator, Coroutine, Optional, cast
 
 from docker.errors import APIError, ImageNotFound, NotFound
 
@@ -380,24 +380,47 @@ def _check_no_conflicting_volumes(
 def _check_no_conflicting_ports(
     ports: Optional[list[tuple[int, int]]],
 ) -> None:
-    """Reject desired ports that share a guest port but disagree on host port.
+    """Reject desired ports that collide on either side of the mapping.
 
-    ``_create_container`` builds its Docker ``ports`` dict keyed by guest
-    port, so two entries with the same guest port but a different host port
-    would silently drop one of them. Exactly identical pairs (duplicates)
-    are accepted and simply collapse; this only rejects a real disagreement.
+    Two failure modes share this check:
+
+    - Guest-side: ``_create_container`` builds its Docker ``ports`` dict
+      keyed by guest port, so two entries with the same guest port but a
+      different host port would silently drop one of them — a dict
+      collapsing entries with no error.
+    - Host-side: two entries with different guest ports but the same
+      nonzero host port pass straight through to Docker, which only rejects
+      the overlap when the container *starts* (a raw ``APIError``/500), not
+      at create time.
+
+    Both are turned into the same pre-create, typed
+    ``SandboxRuntimeConflictError`` here instead of surfacing later as a
+    silent drop or a raw daemon error. Exactly identical pairs (duplicates)
+    are accepted and simply collapse; a host port of ``0`` (meaning "let
+    Docker assign an ephemeral port") is excluded from the host-side check
+    since many guest ports may legitimately share it.
     """
     if not ports:
         return
-    seen: dict[int, int] = {}
+    seen_by_guest: dict[int, int] = {}
+    seen_by_host: dict[int, int] = {}
     for host_port, guest_port in ports:
-        prior = seen.get(guest_port)
-        if prior is not None and prior != host_port:
+        prior_host = seen_by_guest.get(guest_port)
+        if prior_host is not None and prior_host != host_port:
             raise SandboxRuntimeConflictError(
                 f"Conflicting desired port mappings for guest port "
-                f"{guest_port}: host {prior} vs {host_port}"
+                f"{guest_port}: host {prior_host} vs {host_port}"
             )
-        seen[guest_port] = host_port
+        seen_by_guest[guest_port] = host_port
+
+        if host_port != 0:
+            prior_guest = seen_by_host.get(host_port)
+            if prior_guest is not None and prior_guest != guest_port:
+                raise SandboxRuntimeConflictError(
+                    f"Conflicting desired port mappings for host port "
+                    f"{host_port}: guest {prior_guest} vs {guest_port}"
+                )
+            seen_by_host[host_port] = guest_port
 
 
 def _find_publish_mismatches(
@@ -991,6 +1014,57 @@ class DockerSandboxService(SandboxService):
         if self._locks.get(name) is entry:
             self._locks.pop(name, None)
 
+    @staticmethod
+    async def _await_shielded(coro: Coroutine[Any, Any, Any]) -> Any:
+        """Run ``coro`` to completion even under repeated cancellation.
+
+        Used by create() for its two compensating ``container.remove()``
+        calls, both of which execute inside ``_named_lock(name)``. That
+        lock's ``finally: entry.lock.release()`` runs as soon as a
+        ``CancelledError`` propagates out of the ``async with`` body, so a
+        bare ``await asyncio.to_thread(container.remove, ...)`` releases the
+        lock the instant a cancellation lands on it — while the remove is
+        still running in its background thread (``to_thread`` cancellation
+        stops waiting, it does not stop the thread). A same-name create()
+        that then acquires the freed lock can race that in-flight remove and
+        observe a transient "already exists" error from Docker.
+
+        Mirrors the shield-loop in
+        ``TaskTurnOrchestrator.begin_turn`` (web/services/task_orchestrator.py):
+        wrap the coroutine in its own task and await it under
+        ``asyncio.shield`` in a loop, so any number of cancellations delivered
+        to *this* await is absorbed without cancelling the underlying task.
+        Once the task settles, the original cancellation is re-raised
+        regardless of how the task itself settled (the task's own exception,
+        if any, is logged but not raised) so the caller's cancellation is
+        still honored; if no cancellation occurred, the task's result or
+        exception is returned/propagated unchanged.
+        """
+        task = asyncio.ensure_future(coro)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            while not task.done():
+                try:
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+            if not task.cancelled():
+                task_error = task.exception()
+                if task_error is not None:
+                    logger.error(
+                        "Compensating container operation failed while a"
+                        " cancelled caller was waiting for it to settle",
+                        exc_info=(
+                            type(task_error),
+                            task_error,
+                            task_error.__traceback__,
+                        ),
+                    )
+            raise
+
     def _get_control(self, name: str) -> _SandboxControl:
         """Get the shared runtime control object for a sandbox."""
         if name not in self._controls:
@@ -1207,9 +1281,18 @@ class DockerSandboxService(SandboxService):
                 # entry, so calling it here would self-deadlock. The
                 # original start failure (including a cancellation) is
                 # preserved as the raised exception regardless of whether
-                # the compensating remove itself succeeds.
+                # the compensating remove itself succeeds. The remove runs
+                # through _await_shielded so that a cancellation landing
+                # here (e.g. a second cancel on top of the one that failed
+                # start) cannot cut the remove short and let this method's
+                # `_named_lock(name)` release while it is still in flight —
+                # that would let a same-name create() race an in-flight
+                # remove. If such a cancellation occurs, it is re-raised
+                # once the remove settles, taking priority over start_exc.
                 try:
-                    await asyncio.to_thread(container.remove, force=True)
+                    await self._await_shielded(
+                        asyncio.to_thread(container.remove, force=True)
+                    )
                 except Exception as remove_exc:
                     raise start_exc from remove_exc
                 raise start_exc
@@ -1222,8 +1305,16 @@ class DockerSandboxService(SandboxService):
                 # asked for must never be published: remove it directly
                 # (never self.delete(), for the same self-deadlock reason as
                 # the start-failure path above) and fail loudly rather than
-                # let a lying label reach the store.
-                await asyncio.to_thread(container.remove, force=True)
+                # let a lying label reach the store. Routed through
+                # _await_shielded for the same reason as the start-failure
+                # compensation above: a cancellation here must not cut the
+                # remove short and release `_named_lock(name)` while it is
+                # still in flight. If a cancellation occurs, it is re-raised
+                # once the remove settles, taking priority over the
+                # SandboxRuntimeConflictError below.
+                await self._await_shielded(
+                    asyncio.to_thread(container.remove, force=True)
+                )
                 raise SandboxRuntimeConflictError(
                     f"Sandbox {name!r} failed publish verification; "
                     f"mismatched fields: {', '.join(mismatches)}"

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -714,12 +714,22 @@ class DockerSandbox(Sandbox):
         info: SandboxInfo,
         store: DockerStore,
         control: _SandboxControl,
+        locks: KeyedLockRegistry,
     ) -> None:
+        """Bind a handle to one container plus the registries that guard it.
+
+        ``locks`` is the owning service's per-name lifecycle registry, passed
+        in so ``stop()`` can take the *same* mutex the service's own lifecycle
+        methods take (see ``stop()``). It is the registry object itself rather
+        than the service, so this handle keeps no reverse dependency on
+        ``DockerSandboxService``.
+        """
         self._container = container
         self._name = sandbox_name
         self._info = info
         self._store = store
         self._control = control
+        self._locks = locks
 
     @property
     def name(self) -> str:
@@ -777,11 +787,33 @@ class DockerSandbox(Sandbox):
         )
 
     async def stop(self) -> None:
-        """Stop the sandbox container while preserving filesystem state."""
-        async with self._control.exclusive_access(mark_deleted=False):
-            container = await self._require_container()
-            await asyncio.to_thread(container.stop)
-            self._store.update_info_state(self._name, "stopped")
+        """Stop the sandbox container while preserving filesystem state.
+
+        Takes two guards, in the same order every lifecycle method on
+        ``DockerSandboxService`` takes them: first the owning service's
+        per-container-name lock, then this sandbox's own
+        ``exclusive_access`` barrier. Acquiring the named lock is what makes
+        a stop mutually exclusive with ``start_existing``/``stop_existing``/
+        ``delete``/``create_snapshot`` for the same name -- the
+        ``exclusive_access`` barrier alone cannot do that, because it drains
+        in-flight ``operation()`` work and tracks no exclusive holder, and
+        neither ``container.stop()`` nor ``container.start()`` registers as
+        an ``operation()``. Because every holder of a named lock that also
+        takes ``exclusive_access`` acquires them in this order, the two can
+        never deadlock against each other.
+
+        The named lock is not reentrant, so no code already holding
+        ``name``'s entry may call this method: that is why
+        ``stop_existing()`` stops its container through the raw
+        ``Container.stop`` API instead of routing through a handle, the same
+        rule that keeps ``create()``'s compensating cleanup on raw
+        ``container.remove()`` rather than ``self.delete()``.
+        """
+        async with self._locks.locked(self._name):
+            async with self._control.exclusive_access(mark_deleted=False):
+                container = await self._require_container()
+                await asyncio.to_thread(container.stop)
+                self._store.update_info_state(self._name, "stopped")
 
     async def info(self) -> SandboxInfo:
         """Return current sandbox metadata derived from Docker inspect."""
@@ -1183,7 +1215,9 @@ class DockerSandboxService(SandboxService):
                 runtime_info = _parse_container_config(container)
                 info = _merge_info(runtime_info, self._store.get_info(name))
                 self._store.update_info_state(name, "running")
-                return DockerSandbox(name, container, info, self._store, control)
+                return DockerSandbox(
+                    name, container, info, self._store, control, self._locks
+                )
 
             template = template or SandboxTemplate(
                 type="image", image=DEFAULT_SANDBOX_IMAGE
@@ -1221,7 +1255,9 @@ class DockerSandboxService(SandboxService):
             )
             info = _merge_info(runtime_info, stored_info)
             self._store.add_info(name, info)
-            return DockerSandbox(name, container, info, self._store, control)
+            return DockerSandbox(
+                name, container, info, self._store, control, self._locks
+            )
 
     # --- Spec-based reconciliation lifecycle ---
     #
@@ -1421,8 +1457,26 @@ class DockerSandboxService(SandboxService):
             stored_info = SandboxInfo(
                 name=name,
                 state=runtime_info.state,
-                template=template,
-                config=config,
+                # The row records the *canonical* desired state, not the
+                # caller's raw input: `backend_template`/`backend_config` are
+                # the same `desired.to_backend_config()` products the
+                # container was built from and the fingerprint label attests.
+                # Persisting the raw input instead would make the row and the
+                # label two different spellings of one spec, leaving every
+                # future reader obliged to re-normalize the row through
+                # `from_parts` before comparing it to anything -- an
+                # obligation nothing in the type system can enforce, and one
+                # that a reconciler falling back to a desired-state
+                # comparison on UNVERIFIED (see `spec_matches_inspection`)
+                # would silently violate. One canonical source for the
+                # container, the label and the row removes that class of bug
+                # instead of documenting it. The conversion drops no
+                # information: `SandboxTemplate` is exactly
+                # (type, image, snapshot_id) and `SandboxConfig` exactly the
+                # seven fields the spec carries, so the only difference is
+                # canonical spelling.
+                template=backend_template,
+                config=backend_config,
                 created_at=runtime_info.created_at,
             )
             info = _merge_info(runtime_info, stored_info)
@@ -1430,20 +1484,12 @@ class DockerSandboxService(SandboxService):
             # not roll back the container — it is left running with a
             # verified label and no store row, which the next reconcile pass
             # converges by observing running+MATCH and recreating the row.
-            #
-            # The row deliberately records the caller's original
-            # template/config, not the canonicalized `desired`. The store is a
-            # record of what was asked for; canonicalization is owned by
-            # `ResolvedSandboxRuntimeSpec.from_parts`, which every consumer
-            # that compares a row against a desired spec runs the row back
-            # through. Both sides of such a comparison are therefore
-            # canonicalized by the same owner, so persisting the pre-canonical
-            # form cannot produce a spurious mismatch, and persisting the
-            # canonical form would instead lose the original request.
             self._store.add_info(name, info)
 
             control = self._get_live_control(name)
-            return DockerSandbox(name, container, info, self._store, control)
+            return DockerSandbox(
+                name, container, info, self._store, control, self._locks
+            )
 
     async def start_existing(self, name: str) -> DockerSandbox:
         """Start a previously-created sandbox, idempotent if already running.
@@ -1457,10 +1503,11 @@ class DockerSandboxService(SandboxService):
         Like every method on this service, this is also reference-count-blind
         (see ``create()``).
 
-        Mutual exclusion is per container name and is not shared with
-        ``Sandbox.stop()``, which takes only the sandbox's own
-        ``exclusive_access`` barrier and no named lock. A caller that can
-        issue both concurrently for one name must serialize them itself.
+        Mutual exclusion is per container name and *is* shared with
+        ``DockerSandbox.stop()``: that method acquires this same keyed lock
+        entry before its own ``exclusive_access`` barrier, so a caller may
+        issue a stop and a lifecycle transition for one name concurrently
+        without serializing them itself.
         """
         async with self._named_lock(name):
             container = await self._find_container(name)
@@ -1479,13 +1526,21 @@ class DockerSandboxService(SandboxService):
                 runtime_info = _parse_container_config(container)
                 info = _merge_info(runtime_info, self._store.get_info(name))
                 self._store.update_info_state(name, "running")
-                return DockerSandbox(name, container, info, self._store, control)
+                return DockerSandbox(
+                    name, container, info, self._store, control, self._locks
+                )
 
     async def stop_existing(self, name: str) -> None:
         """Stop an existing sandbox, idempotent if already stopped.
 
         Reference-count-blind (see ``create()``) and, like
-        ``start_existing()``, not mutually exclusive with ``Sandbox.stop()``.
+        ``start_existing()``, mutually exclusive with ``DockerSandbox.stop()``
+        through the shared per-name lock.
+
+        Stops the container through the raw ``Container.stop`` API rather than
+        through a ``DockerSandbox`` handle on purpose: the handle's ``stop()``
+        acquires this same non-reentrant lock entry, so delegating to it from
+        inside this critical section would self-deadlock.
         """
         async with self._named_lock(name):
             container = await self._find_container(name)

--- a/src/xagent/sandbox/keyed_lock.py
+++ b/src/xagent/sandbox/keyed_lock.py
@@ -1,0 +1,103 @@
+"""Per-key async mutex registry with safe entry eviction.
+
+Sandbox lifecycle code needs one mutex per sandbox name, drawn from an
+unbounded namespace (names such as ``ssh::{task_id}``), so entries must be
+evicted once nobody holds or waits on them or the registry grows forever.
+Doing that correctly is the whole difficulty: a naive "pop when released"
+scheme lets a waiter that is already blocked on the popped lock run
+concurrently with a newcomer that installed a fresh lock under the same key.
+
+This module owns that primitive once. It lives in the sandbox package
+because that is the lower of the two layers that need it -- the web layer
+already imports from ``xagent.sandbox``, while the sandbox layer must never
+import from ``xagent.web``.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import AsyncIterator, Optional
+
+
+@dataclass
+class KeyedLockEntry:
+    """One key's mutex plus the number of tasks holding or waiting on it."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    waiters: int = 0
+
+
+class KeyedLockRegistry:
+    """A dict of per-key async mutexes that evicts unreferenced entries.
+
+    Waiter bookkeeping is deliberately synchronous and unguarded: every step
+    is a single dict get/set/pop or an int increment/decrement with no
+    ``await`` in between, so nothing else can interleave on a single-threaded
+    event loop, and a guarding lock would only add another await point for a
+    cancellation to land on mid-rollback.
+
+    Eviction is identity-checked against the entry the caller actually used,
+    so a concurrent waiter that already installed a fresh entry for the same
+    key is never evicted out from under it.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, KeyedLockEntry] = {}
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._entries
+
+    def __getitem__(self, key: str) -> KeyedLockEntry:
+        return self._entries[key]
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def get(self, key: str) -> Optional[KeyedLockEntry]:
+        """Return ``key``'s entry, or ``None`` when no task holds or waits on it.
+
+        Lets a caller assert that some task currently holds a key's lock.
+        ``asyncio.Lock`` has no owner concept, so this can only show that the
+        lock is held, never by whom.
+        """
+        return self._entries.get(key)
+
+    @asynccontextmanager
+    async def locked(self, key: str) -> AsyncIterator[None]:
+        """Hold ``key``'s mutex for the duration of the body.
+
+        If the acquire is cancelled, the waiter count is rolled back in the
+        same ``except BaseException`` step, so a cancelled waiter leaks
+        neither the count nor a now-unreferenced entry.
+        """
+        entry = self._entries.get(key)
+        if entry is None:
+            entry = KeyedLockEntry()
+            self._entries[key] = entry
+        entry.waiters += 1
+
+        try:
+            await entry.lock.acquire()
+        except BaseException:
+            entry.waiters -= 1
+            self._drop_if_unused(key, entry)
+            raise
+
+        try:
+            yield
+        finally:
+            entry.lock.release()
+            entry.waiters -= 1
+            self._drop_if_unused(key, entry)
+
+    def _drop_if_unused(self, key: str, entry: KeyedLockEntry) -> None:
+        """Evict ``key``'s entry once it has no holder and no waiter left.
+
+        Called only from the synchronous bookkeeping steps in ``locked``,
+        with no ``await`` between the waiter-count update and this call, so
+        nothing else can interleave and observe an inconsistent count.
+        """
+        if entry.waiters > 0:
+            return
+        if self._entries.get(key) is entry:
+            self._entries.pop(key, None)

--- a/tests/sandbox/test_bridge_seams.py
+++ b/tests/sandbox/test_bridge_seams.py
@@ -160,3 +160,126 @@ class TestBridgeSeams:
                 await service.delete(name)
             except Exception:
                 pass
+
+
+@requires_docker
+class TestSnapshotDoesNotLaunderAttestation:
+    """A snapshot must not carry its source sandbox's attestation forward.
+
+    Docker copies a container's labels into the image produced by
+    ``commit()``, and then merges an image's labels into any container
+    created from it for every key the create request does not specify. So
+    ``create(A, spec_A)`` -> ``create_snapshot(A)`` -> a container built from
+    that snapshot would inherit ``spec_A``'s fingerprint and present it as
+    its own attestation -- reporting MISMATCH where it owes UNVERIFIED, or a
+    false MATCH when the specs happen to agree, on a container that never
+    went through the verified create() path at all.
+
+    ``_create_container`` closes this by always writing both attestation keys
+    itself, blank when there is nothing to attest.
+    """
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_legacy_container_from_a_snapshot_is_unverified(self, docker_service):
+        service = docker_service
+        source = _unique_name("snap-src")
+        derived = _unique_name("snap-derived")
+        snapshot_id = _unique_name("snapid")
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            # 1. A verified sandbox: its container carries a real fingerprint.
+            await service.create(
+                source,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            source_inspection = await service.inspect(source)
+            assert source_inspection is not None
+            assert source_inspection.fingerprint_label, (
+                "the source sandbox must actually be attested for this test to "
+                "be meaningful"
+            )
+
+            # 2. Snapshot it. The committed image inherits those labels.
+            await service.create_snapshot(source, snapshot_id)
+
+            # 3. Build a container from that snapshot via the legacy path,
+            #    which makes no attestation of its own.
+            await service.get_or_create(
+                derived,
+                template=SandboxTemplate(type="snapshot", snapshot_id=snapshot_id),
+                config=config,
+            )
+
+            derived_inspection = await service.inspect(derived)
+            assert derived_inspection is not None
+            assert derived_inspection.fingerprint_label is None, (
+                "a legacy container built from a snapshot must present no "
+                "attestation, not the source sandbox's inherited fingerprint"
+            )
+
+            # The verdict, which is what reconciliation actually consumes.
+            assert (
+                spec_matches_inspection(_spec_for(config), derived_inspection)
+                is SpecVerdict.UNVERIFIED
+            ), (
+                "an unattested container must be UNVERIFIED: MATCH would be a "
+                "forged attestation and MISMATCH would force a needless rebuild"
+            )
+        finally:
+            for name in (derived, source):
+                try:
+                    await service.delete(name)
+                except Exception:
+                    pass
+            try:
+                await service.delete_snapshot(snapshot_id)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_snapshot_derived_container_with_the_same_spec_is_not_a_false_match(
+        self, docker_service
+    ):
+        """The dangerous direction: identical specs must still not report MATCH.
+
+        With an inherited fingerprint this would compare equal and pass the
+        live cpus/memory re-check, so the container would be adopted as
+        verified without ever having been verified.
+        """
+        service = docker_service
+        source = _unique_name("snap-fm-src")
+        derived = _unique_name("snap-fm-derived")
+        snapshot_id = _unique_name("snapid-fm")
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            await service.create(
+                source,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            await service.create_snapshot(source, snapshot_id)
+            await service.get_or_create(
+                derived,
+                template=SandboxTemplate(type="snapshot", snapshot_id=snapshot_id),
+                config=config,
+            )
+
+            derived_inspection = await service.inspect(derived)
+            assert derived_inspection is not None
+            verdict = spec_matches_inspection(_spec_for(config), derived_inspection)
+            assert verdict is not SpecVerdict.MATCH, (
+                "an unverified container must never report MATCH even when the "
+                "desired spec is identical to the snapshot source's"
+            )
+            assert verdict is SpecVerdict.UNVERIFIED
+        finally:
+            for name in (derived, source):
+                try:
+                    await service.delete(name)
+                except Exception:
+                    pass
+            try:
+                await service.delete_snapshot(snapshot_id)
+            except Exception:
+                pass

--- a/tests/sandbox/test_bridge_seams.py
+++ b/tests/sandbox/test_bridge_seams.py
@@ -1,0 +1,162 @@
+"""
+Bridge tests between the legacy get_or_create()/create() lifecycle paths and
+spec_matches_inspection(): the three seams the reconciliation matcher must
+handle correctly once both paths can produce containers for the same
+service.
+
+Real Docker required (label/attestation behavior is only meaningful against
+real container attrs). Parallel discipline: uuid-suffixed names, membership-
+only list_sandboxes() assertions (none used here), try/finally cleanup per
+test.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from xagent.sandbox import DEFAULT_SANDBOX_IMAGE
+from xagent.sandbox.base import (
+    ResolvedSandboxRuntimeSpec,
+    SandboxConfig,
+    SandboxTemplate,
+    SpecVerdict,
+    spec_matches_inspection,
+)
+from xagent.sandbox.docker_sandbox import (
+    DockerSandboxService,
+    MemDockerStore,
+    is_docker_available,
+)
+
+requires_docker = pytest.mark.skipif(
+    not is_docker_available(), reason="Requires reachable Docker daemon"
+)
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="module")
+def docker_service():
+    return DockerSandboxService(MemDockerStore())
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _spec_for(config: SandboxConfig, image: str = DEFAULT_SANDBOX_IMAGE):
+    return ResolvedSandboxRuntimeSpec.from_parts(
+        template_type="image",
+        image=image,
+        working_dir=config.working_dir,
+        cpus=config.cpus,
+        memory=config.memory,
+        env=config.env,
+        volumes=config.volumes,
+        network_isolated=bool(config.network_isolated),
+        ports=config.ports,
+    )
+
+
+@requires_docker
+class TestBridgeSeams:
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_legacy_get_or_create_container_is_unverified(self, docker_service):
+        """A container created by the old get_or_create() path carries no
+        spec-attestation label, so the matcher must report UNVERIFIED rather
+        than MISMATCH (which would force-rebuild every pre-existing
+        container the moment reconciliation is turned on)."""
+        service = docker_service
+        name = _unique_name("bridge-legacy")
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            await service.get_or_create(
+                name,
+                template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config=config,
+            )
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            desired = _spec_for(config)
+
+            assert (
+                spec_matches_inspection(desired, inspection) is SpecVerdict.UNVERIFIED
+            )
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_new_create_container_is_match(self, docker_service):
+        """A container created by the new create() lifecycle carries a
+        verified fingerprint/version label pair, so the same desired spec
+        used to create it must compare as MATCH."""
+        service = docker_service
+        name = _unique_name("bridge-new")
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            desired = _spec_for(config)
+
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_label_present_but_store_row_missing_still_matches(
+        self, docker_service
+    ):
+        """The matcher itself is blind to the store: it only ever looks at
+        the live label/facts, so a container with a verified label but no
+        store row still reports MATCH here. Recognizing that this
+        specific combination (label present, store row absent) is the one
+        case reconciliation must always treat as needing a rebuild is a
+        consumer-side contract documented on spec_matches_inspection() in
+        base.py, not something this matcher call enforces on its own.
+        """
+        service = docker_service
+        name = _unique_name("bridge-no-store-row")
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            # Simulate the store row having been lost independently of the
+            # container (the label is immutable and unaffected).
+            service._store.delete_info(name)
+            assert service._store.get_info(name) is None
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            desired = _spec_for(config)
+
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -22,6 +22,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 import pytest
+from docker.errors import APIError
 
 import xagent.sandbox.docker_sandbox as docker_sandbox_module
 from xagent.sandbox import DEFAULT_SANDBOX_IMAGE
@@ -403,6 +404,167 @@ class TestCreatePublishVerification:
 
         assert created.remove_calls == [True]
         assert service._store.get_info("publish-mismatch") is None
+
+    @pytest.mark.asyncio
+    async def test_conflict_error_survives_a_failing_compensating_remove(
+        self, monkeypatch
+    ):
+        """A remove() that itself fails must not mask the verification verdict.
+
+        The mismatched fields are the caller-actionable fact; a raw docker
+        error from the cleanup says nothing about why the sandbox was
+        rejected, and the leaked container is reported to the log instead.
+        """
+        created = _FakeCreatedContainer()
+
+        def remove_that_fails(force: bool = False):
+            created.remove_calls.append(force)
+            raise APIError("daemon refused to remove")
+
+        monkeypatch.setattr(created, "remove", remove_that_fails)
+
+        async def fake_create_container(*args, **kwargs):
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+        monkeypatch.setattr(
+            docker_sandbox_module,
+            "_build_inspection",
+            lambda container: _observed_inspection(volumes=(("/x", "/y", "rw"),)),
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+
+        with pytest.raises(SandboxRuntimeConflictError, match="volumes"):
+            await service.create(
+                "publish-mismatch-remove-fails",
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(),
+            )
+
+        assert created.remove_calls == [True], "the remove must still be attempted"
+        assert service._store.get_info("publish-mismatch-remove-fails") is None, (
+            "a container that failed verification must never reach the store"
+        )
+
+
+def _observed_facts(**overrides):
+    """Observed facts that agree with ``SandboxConfig()``'s resolved spec."""
+    from xagent.sandbox.base import ObservedRuntimeFacts
+
+    defaults = dict(
+        raw_status="running",
+        image_ref=DEFAULT_SANDBOX_IMAGE,
+        image_digest="sha256:deadbeef",
+        raw_nano_cpus=1_000_000_000,
+        raw_memory_bytes=512 * 1024 * 1024,
+        env={},
+        volumes=(),
+        ports=(),
+        network_isolated=False,
+        runtime_networks=("bridge",),
+        labels={},
+        created_at="2026-01-01T00:00:00Z",
+        working_dir="/home",
+    )
+    defaults.update(overrides)
+    return ObservedRuntimeFacts(**defaults)
+
+
+def _observed_inspection(**overrides):
+    return SandboxInspection(
+        state="running",
+        facts=_observed_facts(**overrides),
+        fingerprint_label="whatever",
+        version_label="1",
+    )
+
+
+class TestFindPublishMismatchesEveryBranch:
+    """Cover all seven comparison branches, in both directions.
+
+    Publish verification is the mechanism whose *false positives* destroy a
+    just-created container, so every branch needs a negative control (an
+    agreeing value must not be reported) alongside the positive case.
+    """
+
+    @staticmethod
+    def _desired():
+        return ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image",
+            image=DEFAULT_SANDBOX_IMAGE,
+            working_dir="/home",
+            cpus=1,
+            memory=512,
+        )
+
+    def test_agreeing_observation_reports_no_mismatch(self):
+        assert (
+            docker_sandbox_module._find_publish_mismatches(
+                self._desired(), DEFAULT_SANDBOX_IMAGE, _observed_inspection()
+            )
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        "field,overrides",
+        [
+            ("image", {"image_ref": "someone/else:latest"}),
+            ("volumes", {"volumes": (("/host", "/guest", "rw"),)}),
+            ("ports", {"ports": ((18080, 80),)}),
+            ("working_dir", {"working_dir": "/somewhere/else"}),
+            ("network_isolated", {"network_isolated": True}),
+            ("cpus", {"raw_nano_cpus": 2_000_000_000}),
+            ("memory", {"raw_memory_bytes": 1024 * 1024 * 1024}),
+        ],
+    )
+    def test_each_field_is_reported_when_it_disagrees(self, field, overrides):
+        mismatches = docker_sandbox_module._find_publish_mismatches(
+            self._desired(), DEFAULT_SANDBOX_IMAGE, _observed_inspection(**overrides)
+        )
+        assert mismatches == [field]
+
+    def test_reports_every_disagreeing_field_at_once(self):
+        mismatches = docker_sandbox_module._find_publish_mismatches(
+            self._desired(),
+            "someone/else:latest",
+            _observed_inspection(
+                working_dir="/elsewhere",
+                network_isolated=True,
+                raw_memory_bytes=1024 * 1024 * 1024,
+            ),
+        )
+        assert mismatches == ["image", "working_dir", "network_isolated", "memory"]
+
+    def test_missing_raw_cpu_and_memory_read_as_zero_not_as_a_match(self):
+        """``None`` from a backend that omits the field must not pass as equal."""
+        mismatches = docker_sandbox_module._find_publish_mismatches(
+            self._desired(),
+            DEFAULT_SANDBOX_IMAGE,
+            _observed_inspection(raw_nano_cpus=None, raw_memory_bytes=None),
+        )
+        assert mismatches == ["cpus", "memory"]
+
+    def test_volume_and_port_comparison_ignores_ordering(self):
+        desired = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image",
+            image=DEFAULT_SANDBOX_IMAGE,
+            working_dir="/home",
+            volumes=[("/h1", "/g1", "rw"), ("/h2", "/g2", "ro")],
+            ports=[(18080, 80), (18081, 81)],
+        )
+        inspection = _observed_inspection(
+            volumes=(("/h2", "/g2", "ro"), ("/h1", "/g1", "rw")),
+            ports=((18081, 81), (18080, 80)),
+        )
+        assert (
+            docker_sandbox_module._find_publish_mismatches(
+                desired, DEFAULT_SANDBOX_IMAGE, inspection
+            )
+            == []
+        )
 
 
 # --- inspect(): real-container tests ---
@@ -1042,6 +1204,388 @@ class TestStartStopExisting:
             inspection = await service.inspect(name)
             assert inspection is not None
             assert inspection.state == "running"
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+
+# --- _build_inspection(): direct unit coverage ---
+
+
+class _FakeInspectableContainer:
+    """Container stub whose ``attrs``/``labels`` are supplied verbatim."""
+
+    def __init__(self, attrs: dict, labels: dict | None = None):
+        self.attrs = attrs
+        self.labels = labels if labels is not None else {}
+
+
+def _attrs(**overrides) -> dict:
+    base = {
+        "Config": {
+            "Image": "img:tag",
+            "Env": ["A=1", "B=2", "MALFORMED"],
+            "WorkingDir": "/home",
+            "NetworkDisabled": False,
+        },
+        "HostConfig": {
+            "NanoCpus": 2_000_000_000,
+            "Memory": 256 * 1024 * 1024,
+            "PortBindings": {"80/tcp": [{"HostPort": "18080"}]},
+        },
+        "State": {"Status": "running"},
+        "Image": "sha256:imagedigest",
+        "Created": "2026-01-01T00:00:00Z",
+        "Mounts": [
+            {
+                "Type": "bind",
+                "Source": "/host/rw",
+                "Destination": "/guest/rw",
+                "RW": True,
+            },
+            {
+                "Type": "bind",
+                "Source": "/host/ro",
+                "Destination": "/guest/ro",
+                "RW": False,
+            },
+            # Non-bind mounts are not desired-state bind volumes and must be
+            # skipped rather than reported as one.
+            {
+                "Type": "volume",
+                "Source": "/var/lib/docker/volumes/x",
+                "Destination": "/guest/vol",
+                "RW": True,
+            },
+        ],
+        "NetworkSettings": {"Networks": {"bridge": {}, "extra": {}}},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBuildInspectionFacts:
+    """Assert every field ``_build_inspection`` derives, not just the ones the
+    publish check happens to compare."""
+
+    def test_reports_image_ref_and_digest_separately(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs())
+        )
+        assert inspection.facts.image_ref == "img:tag"
+        assert inspection.facts.image_digest == "sha256:imagedigest"
+
+    def test_keeps_raw_backend_units_for_cpus_and_memory(self):
+        """Raw units are what make a live ``docker update`` observable."""
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs())
+        )
+        assert inspection.facts.raw_nano_cpus == 2_000_000_000
+        assert inspection.facts.raw_memory_bytes == 256 * 1024 * 1024
+
+    def test_parses_env_and_drops_entries_without_a_separator(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs())
+        )
+        assert inspection.facts.env == {"A": "1", "B": "2"}
+
+    def test_derives_volume_mode_from_the_rw_flag_and_skips_non_binds(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs())
+        )
+        assert inspection.facts.volumes == (
+            ("/host/rw", "/guest/rw", "rw"),
+            ("/host/ro", "/guest/ro", "ro"),
+        )
+
+    def test_reads_ports_from_host_config_port_bindings(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs())
+        )
+        assert inspection.facts.ports == ((18080, 80),)
+
+    def test_reports_runtime_networks_and_labels(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs(), labels={"a": "1"})
+        )
+        assert set(inspection.facts.runtime_networks) == {"bridge", "extra"}
+        assert inspection.facts.labels == {"a": "1"}
+
+    def test_network_isolated_comes_from_config_network_disabled(self):
+        attrs = _attrs()
+        attrs["Config"]["NetworkDisabled"] = True
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(attrs)
+        )
+        assert inspection.facts.network_isolated is True
+
+    def test_network_isolated_is_false_when_network_disabled_is_absent(self):
+        attrs = _attrs()
+        del attrs["Config"]["NetworkDisabled"]
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(attrs)
+        )
+        assert inspection.facts.network_isolated is False
+
+    def test_working_dir_and_created_at_are_passed_through_unnormalized(self):
+        """Observed facts stay backend-native; normalizing here would hide a
+        genuine backend rewrite."""
+        attrs = _attrs()
+        attrs["Config"]["WorkingDir"] = "//home//sub/"
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(attrs)
+        )
+        assert inspection.facts.working_dir == "//home//sub/"
+        assert inspection.facts.created_at == "2026-01-01T00:00:00Z"
+
+    def test_tolerates_completely_empty_attrs(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer({})
+        )
+        assert inspection.state == "stopped"
+        assert inspection.facts.raw_status == ""
+        assert inspection.facts.volumes == ()
+        assert inspection.facts.ports == ()
+
+
+class TestBuildInspectionStateMapping:
+    """``state`` is a two-value reduction; ``facts.raw_status`` keeps the rest."""
+
+    @pytest.mark.parametrize(
+        "raw_status,expected_state",
+        [
+            ("running", "running"),
+            ("created", "stopped"),
+            ("exited", "stopped"),
+            ("dead", "stopped"),
+            ("restarting", "stopped"),
+            ("paused", "stopped"),
+            ("", "stopped"),
+        ],
+    )
+    def test_reduces_every_status_to_running_or_stopped(
+        self, raw_status, expected_state
+    ):
+        attrs = _attrs(State={"Status": raw_status})
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(attrs)
+        )
+        assert inspection.state == expected_state
+
+    @pytest.mark.parametrize("raw_status", ["created", "exited", "dead", "restarting"])
+    def test_raw_status_stays_available_for_states_state_cannot_express(
+        self, raw_status
+    ):
+        """A caller needing "never started" vs "exited" reads raw_status."""
+        attrs = _attrs(State={"Status": raw_status})
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(attrs)
+        )
+        assert inspection.state == "stopped"
+        assert inspection.facts.raw_status == raw_status
+
+
+class TestBuildInspectionAttestationLabels:
+    """A blank attestation label means "no attestation", not "a fingerprint
+    that fails to match".
+
+    ``_create_container`` writes both keys blank when it has no attestation to
+    make, so that a container cannot silently present a fingerprint inherited
+    from its base image. Docker cannot remove an inherited label, only
+    overwrite it, so blank is the only "absent" form available on the wire --
+    and reading blank as a real value would turn UNVERIFIED into MISMATCH,
+    making a reconciler rebuild a container it should have adopted.
+    """
+
+    def test_reads_a_real_attestation(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(
+                _attrs(),
+                labels={
+                    docker_sandbox_module.LABEL_SPEC_FINGERPRINT: "abc123",
+                    docker_sandbox_module.LABEL_SPEC_VERSION: "1",
+                },
+            )
+        )
+        assert inspection.fingerprint_label == "abc123"
+        assert inspection.version_label == "1"
+
+    def test_absent_labels_read_as_none(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(_attrs(), labels={})
+        )
+        assert inspection.fingerprint_label is None
+        assert inspection.version_label is None
+
+    def test_blank_labels_read_as_none(self):
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(
+                _attrs(),
+                labels={
+                    docker_sandbox_module.LABEL_SPEC_FINGERPRINT: "",
+                    docker_sandbox_module.LABEL_SPEC_VERSION: "",
+                },
+            )
+        )
+        assert inspection.fingerprint_label is None
+        assert inspection.version_label is None
+
+    def test_a_blank_attestation_yields_unverified_not_mismatch(self):
+        desired = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="img:tag", working_dir="/home"
+        )
+        inspection = docker_sandbox_module._build_inspection(
+            _FakeInspectableContainer(
+                _attrs(),
+                labels={
+                    docker_sandbox_module.LABEL_SPEC_FINGERPRINT: "",
+                    docker_sandbox_module.LABEL_SPEC_VERSION: "",
+                },
+            )
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.UNVERIFIED
+
+
+class TestCreateContainerOwnsAttestationLabels:
+    """``_create_container`` is the single writer of both attestation label
+    keys for every container it creates, on either lifecycle path."""
+
+    @staticmethod
+    async def _captured_labels(monkeypatch, extra_labels=None):
+        captured: dict = {}
+
+        class _Collection:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return object()
+
+        class _Client:
+            containers = _Collection()
+
+        async def no_pull(client, image):
+            return None
+
+        monkeypatch.setattr(docker_sandbox_module, "_ensure_image", no_pull)
+        await docker_sandbox_module._create_container(
+            _Client(),
+            "box",
+            "img:tag",
+            SandboxTemplate(type="image", image="img:tag"),
+            SandboxConfig(),
+            extra_labels=extra_labels,
+        )
+        return captured["labels"]
+
+    @pytest.mark.asyncio
+    async def test_blanks_both_keys_when_there_is_no_attestation(self, monkeypatch):
+        labels = await self._captured_labels(monkeypatch)
+        assert labels[docker_sandbox_module.LABEL_SPEC_FINGERPRINT] == ""
+        assert labels[docker_sandbox_module.LABEL_SPEC_VERSION] == ""
+
+    @pytest.mark.asyncio
+    async def test_extra_labels_override_the_blanks(self, monkeypatch):
+        labels = await self._captured_labels(
+            monkeypatch,
+            extra_labels={
+                docker_sandbox_module.LABEL_SPEC_FINGERPRINT: "fp",
+                docker_sandbox_module.LABEL_SPEC_VERSION: "1",
+            },
+        )
+        assert labels[docker_sandbox_module.LABEL_SPEC_FINGERPRINT] == "fp"
+        assert labels[docker_sandbox_module.LABEL_SPEC_VERSION] == "1"
+
+
+class TestLifecycleDoesNotLeakControlEntries:
+    """``_controls`` is keyed by sandbox name, a name space with no bound
+    (``ssh::{task_id}``), and only ``delete()`` ever evicts from it. Probing a
+    name that has no container must therefore not install an entry, or every
+    such probe grows the dict for the life of the process."""
+
+    @pytest.mark.asyncio
+    async def test_start_existing_on_a_missing_sandbox_installs_no_control(self):
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        with pytest.raises(SandboxNotFoundError):
+            await service.start_existing("never-existed")
+        assert service._controls == {}
+
+    @pytest.mark.asyncio
+    async def test_stop_existing_on_a_missing_sandbox_installs_no_control(self):
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        with pytest.raises(SandboxNotFoundError):
+            await service.stop_existing("never-existed")
+        assert service._controls == {}
+
+    @pytest.mark.asyncio
+    async def test_repeated_probes_of_distinct_missing_names_stay_bounded(self):
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        for i in range(25):
+            with pytest.raises(SandboxNotFoundError):
+                await service.stop_existing(f"ssh::task-{i}")
+        assert service._controls == {}
+        assert len(service._locks) == 0, "the lock registry must also stay empty"
+
+    @pytest.mark.asyncio
+    async def test_inspect_of_a_missing_sandbox_installs_no_control(self):
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        assert await service.inspect("never-existed") is None
+        assert service._controls == {}
+
+
+@requires_docker
+class TestCreateNetworkIsolatedSandbox:
+    """``network_isolated`` is the one security-relevant boolean in the spec and
+    had no real-daemon coverage: nothing proved Docker round-trips
+    ``NetworkDisabled`` well enough for publish verification to pass."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_isolated_sandbox_passes_verification_and_matches(
+        self, docker_service
+    ):
+        service = docker_service
+        name = _unique_name("net-isolated")
+        config = SandboxConfig(cpus=1, memory=256, network_isolated=True)
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.facts.network_isolated is True
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                working_dir=config.working_dir,
+                cpus=config.cpus,
+                memory=config.memory,
+                network_isolated=True,
+            )
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_a_non_isolated_sandbox_reports_isolation_false(self, docker_service):
+        """Negative control: the observation must actually track the request."""
+        service = docker_service
+        name = _unique_name("net-open")
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(cpus=1, memory=256, network_isolated=False),
+            )
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.facts.network_isolated is False
         finally:
             try:
                 await service.delete(name)

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -96,7 +96,12 @@ class _FakeCreatedContainer:
         self.remove_calls: list[bool] = []
         self.start_calls = 0
         self.reload_calls = 0
-        self.attrs: dict = {"Config": {"WorkingDir": "/home"}}
+        self.name = "fake-container"
+        self.attrs: dict = {
+            "Config": {"WorkingDir": "/home"},
+            "State": {"Status": "running"},
+            "Created": "2026-01-01T00:00:00Z",
+        }
         self.labels: dict = {}
 
     def start(self):
@@ -448,6 +453,124 @@ class TestCreatePublishVerification:
         assert service._store.get_info("publish-mismatch-remove-fails") is None, (
             "a container that failed verification must never reach the store"
         )
+
+
+class TestCreatePersistsCanonicalDesiredState:
+    """Pin that the store row, the created container and the fingerprint
+    label all come from one canonical source.
+
+    If the row kept the caller's raw spelling instead, the row and the label
+    would be two different spellings of one spec, and every future reader
+    would have to re-normalize the row through ``from_parts`` before
+    comparing it -- an obligation nothing can enforce.
+    """
+
+    @pytest.mark.asyncio
+    async def test_row_matches_the_canonical_spec_the_label_attests(self, monkeypatch):
+        created = _FakeCreatedContainer()
+        captured: dict = {}
+
+        async def fake_create_container(
+            client, name, image, template, config, extra_labels=None
+        ):
+            captured["template"] = template
+            captured["config"] = config
+            captured["extra_labels"] = dict(extra_labels or {})
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+
+        # Non-canonical spellings that from_parts() normalizes: a trailing
+        # slash on working_dir, and a host source carrying both a reserved
+        # POSIX '//' prefix and a '.' segment.
+        raw_config = SandboxConfig(
+            working_dir="/home/",
+            volumes=[("//data/./sub/", "/mnt/x/", "rw")],
+        )
+        canonical_volumes = (("/data/sub", "/mnt/x", "rw"),)
+
+        monkeypatch.setattr(
+            docker_sandbox_module,
+            "_build_inspection",
+            lambda container: _observed_inspection(
+                volumes=canonical_volumes, working_dir="/home"
+            ),
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        await service.create(
+            "canonical-row",
+            SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+            raw_config,
+        )
+
+        row = service._store.get_info("canonical-row")
+        assert row is not None
+
+        # The row is the canonical form, not what the caller typed.
+        assert raw_config.working_dir == "/home/", "test input must be non-canonical"
+        assert row.config.working_dir == "/home"
+        assert row.config.volumes == [tuple(v) for v in canonical_volumes]
+
+        # Same objects the container itself was built from.
+        assert row.template == captured["template"]
+        assert row.config == captured["config"]
+
+        # And the row reproduces the fingerprint that was stamped on the
+        # container, so a reader comparing the row against the label needs no
+        # renormalization step to get a MATCH.
+        spec_from_row = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type=row.template.type,
+            image=row.template.image,
+            snapshot_id=row.template.snapshot_id,
+            working_dir=row.config.working_dir,
+            cpus=row.config.cpus,
+            memory=row.config.memory,
+            env=row.config.env,
+            volumes=row.config.volumes,
+            network_isolated=bool(row.config.network_isolated),
+            ports=row.config.ports,
+        )
+        assert (
+            spec_from_row.fingerprint()
+            == captured["extra_labels"][docker_sandbox_module.LABEL_SPEC_FINGERPRINT]
+        )
+        assert spec_from_row.to_backend_config() == (row.template, row.config), (
+            "the row must already be a fixed point of canonicalization"
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_get_or_create_still_persists_the_raw_request(
+        self, monkeypatch
+    ):
+        """The canonical-row contract belongs to create(), not to the legacy path.
+
+        ``get_or_create()`` writes no attestation label, so its row has no
+        label to agree with and it keeps recording the caller's request
+        verbatim. Pinned so the two paths' rows are not assumed identical.
+        """
+        created = _FakeCreatedContainer()
+
+        async def fake_create_container(*args, **kwargs):
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        raw_config = SandboxConfig(working_dir="/home/")
+        await service.get_or_create(
+            "legacy-row",
+            template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+            config=raw_config,
+        )
+
+        row = service._store.get_info("legacy-row")
+        assert row is not None
+        assert row.config.working_dir == "/home/"
 
 
 def _observed_facts(**overrides):

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -168,12 +168,31 @@ class TestCheckNoConflictingPorts:
 
 
 class TestCheckNoConflictingVolumes:
+    """Pin both directions of _check_no_conflicting_volumes: a host-side
+    collision (silently dropped by _create_container's host-keyed dict) and a
+    guest-side collision (only ever caught by Docker at container create, as
+    a raw 400 'Duplicate mount point')."""
+
     def test_rejects_host_path_spelled_with_a_leading_double_slash(self):
         # Docker collapses the leading slash run, so both entries land on the
         # same host key and one guest path would be silently dropped.
         with pytest.raises(SandboxRuntimeConflictError, match="host path"):
             docker_sandbox_module._check_no_conflicting_volumes(
                 [("//data", "/guest/a", "rw"), ("/data", "/guest/b", "rw")]
+            )
+
+    def test_rejects_same_guest_path_for_different_host_sources(self):
+        with pytest.raises(SandboxRuntimeConflictError, match="guest path"):
+            docker_sandbox_module._check_no_conflicting_volumes(
+                [("/data/a", "/guest", "rw"), ("/data/b", "/guest", "rw")]
+            )
+
+    def test_rejects_guest_path_spelled_with_a_leading_double_slash(self):
+        # One mount point to the backend, so canonicalization has to file both
+        # entries under the same guest key for the conflict to be caught.
+        with pytest.raises(SandboxRuntimeConflictError, match="guest path"):
+            docker_sandbox_module._check_no_conflicting_volumes(
+                [("/data/a", "//guest", "rw"), ("/data/b", "/guest", "rw")]
             )
 
     def test_accepts_duplicate_triples_spelled_differently(self):

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect as std_inspect
+import threading
 import uuid
 from contextlib import asynccontextmanager
 
@@ -148,6 +149,24 @@ class TestLabelConstants:
         assert docker_sandbox_module.LABEL_SPEC_VERSION == "xagent.sandbox.spec.version"
 
 
+class TestCheckNoConflictingPorts:
+    """Pin both directions of _check_no_conflicting_ports: a guest-side
+    collision (silently dropped by _create_container's guest-keyed dict) and
+    a host-side collision (only ever caught by Docker at container start, as
+    a raw 500)."""
+
+    def test_rejects_same_host_port_for_different_guest_ports(self):
+        with pytest.raises(SandboxRuntimeConflictError, match="host port"):
+            docker_sandbox_module._check_no_conflicting_ports(
+                [(18080, 80), (18080, 81)]
+            )
+
+    def test_accepts_multiple_ephemeral_host_ports_for_different_guests(self):
+        # host_port == 0 means "let Docker assign an ephemeral port"; many
+        # guest ports may legitimately share it.
+        docker_sandbox_module._check_no_conflicting_ports([(0, 80), (0, 81), (0, 82)])
+
+
 # --- supports_runtime_spec ---
 
 
@@ -201,6 +220,92 @@ class TestCreateStartFailureCompensation:
             )
 
         assert created.remove_calls == [True]
+
+
+class TestCreateCompensationHoldsLockUnderRepeatedCancellation:
+    """Pin the fix for _await_shielded: create()'s compensating remove()
+    must run to completion, and _named_lock(name) must stay held the whole
+    time, even if the caller's task is cancelled more than once while the
+    remove is in flight. Before this fix, a second cancellation landing on
+    the bare ``await asyncio.to_thread(container.remove, ...)`` would let
+    _named_lock's ``finally: entry.lock.release()`` run while the remove was
+    still executing in its worker thread, so a same-name create() started
+    right after could race that in-flight remove and see a transient
+    AlreadyExists error from Docker.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lock_stays_held_until_slow_remove_settles_across_two_cancels(
+        self, monkeypatch
+    ):
+        remove_started = threading.Event()
+        release_remove = threading.Event()
+        remove_finished = threading.Event()
+
+        class _SlowRemoveContainer:
+            def __init__(self):
+                self.remove_calls: list[bool] = []
+
+            def start(self):
+                raise RuntimeError("start failed, forcing compensation")
+
+            def remove(self, force: bool = False):
+                remove_started.set()
+                release_remove.wait(timeout=5)
+                self.remove_calls.append(force)
+                remove_finished.set()
+
+        created = _SlowRemoveContainer()
+
+        async def fake_create_container(*args, **kwargs):
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        name = "slow-remove-compensation"
+
+        task = asyncio.ensure_future(
+            service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(),
+            )
+        )
+
+        while not remove_started.is_set():
+            await asyncio.sleep(0.01)
+
+        # First cancellation lands while the compensating remove() is
+        # still blocked in its worker thread.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not remove_finished.is_set()
+        assert name in service._locks, (
+            "the name lock entry must not be evicted while remove() is still in flight"
+        )
+        assert service._locks[name].lock.locked(), (
+            "the name lock must still be held while remove() is still in flight"
+        )
+
+        # A second cancellation lands on top of the first, before remove()
+        # has settled.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not remove_finished.is_set()
+        assert service._locks[name].lock.locked()
+
+        # Only now let the compensating remove() actually finish.
+        release_remove.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert remove_finished.is_set()
+        assert created.remove_calls == [True]
+        assert name not in service._locks
 
 
 class TestCreatePublishVerification:

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -1,0 +1,910 @@
+"""
+Tests for DockerSandboxService's explicit lifecycle API: inspect(), create(),
+start_existing(), stop_existing(), and supports_runtime_spec().
+
+Parallel discipline: most tests here run against a real Docker daemon and
+share a module-scoped ``docker_service``/event loop (same pattern as
+test_docker_sandbox.py). Each test uses a uuid-suffixed sandbox name so
+concurrent test workers never collide on the same name; ``list_sandboxes()``
+assertions are membership-only (never exact count/content), and every test
+cleans up its own sandbox in a ``finally`` block. A handful of tests that
+exercise failure paths not practically reachable via a real daemon (start
+failure, publish-verification mismatch) use a fake Docker client/container
+instead and do not require Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect as std_inspect
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+import xagent.sandbox.docker_sandbox as docker_sandbox_module
+from xagent.sandbox import DEFAULT_SANDBOX_IMAGE
+from xagent.sandbox.base import (
+    SPEC_CONTRACT_VERSION,
+    ResolvedSandboxRuntimeSpec,
+    SandboxAlreadyExistsError,
+    SandboxConfig,
+    SandboxInspection,
+    SandboxNotFoundError,
+    SandboxRuntimeConflictError,
+    SandboxService,
+    SandboxTemplate,
+    SpecVerdict,
+    spec_matches_inspection,
+)
+from xagent.sandbox.boxlite_sandbox import BoxliteSandboxService
+from xagent.sandbox.docker_sandbox import (
+    DockerSandboxService,
+    MemDockerStore,
+    is_docker_available,
+)
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+requires_docker = pytest.mark.skipif(
+    not is_docker_available(), reason="Requires reachable Docker daemon"
+)
+
+
+@pytest.fixture(scope="module")
+def docker_service():
+    """Provide a shared Docker sandbox service for integration-style tests."""
+    return DockerSandboxService(MemDockerStore())
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+# --- Fakes for mock-layer tests (no Docker required) ---
+
+
+class _FakeContainerCollection:
+    def __init__(self, containers=()):
+        self._containers = list(containers)
+
+    def list(self, *args, **kwargs):
+        return list(self._containers)
+
+
+class _FakeDockerClient:
+    def __init__(self, containers=()):
+        self.containers = _FakeContainerCollection(containers)
+
+    def ping(self):
+        return True
+
+
+class _FakeCreatedContainer:
+    """Fake container returned by a monkeypatched ``_create_container``."""
+
+    def __init__(self, start_exc: Exception | None = None):
+        self._start_exc = start_exc
+        self.remove_calls: list[bool] = []
+        self.start_calls = 0
+        self.reload_calls = 0
+        self.attrs: dict = {"Config": {"WorkingDir": "/home"}}
+        self.labels: dict = {}
+
+    def start(self):
+        self.start_calls += 1
+        if self._start_exc is not None:
+            raise self._start_exc
+
+    def reload(self):
+        self.reload_calls += 1
+
+    def remove(self, force: bool = False):
+        self.remove_calls.append(force)
+
+
+# --- Signature / async pins ---
+
+
+class TestLifecycleApiSignatures:
+    """Pin that DockerSandboxService's overrides keep the base's async
+    signature shape (not the return annotation)."""
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "supports_runtime_spec",
+            "inspect",
+            "create",
+            "start_existing",
+            "stop_existing",
+        ],
+    )
+    def test_docker_override_matches_base_signature(self, method_name):
+        base_method = getattr(SandboxService, method_name)
+        docker_method = getattr(DockerSandboxService, method_name)
+
+        assert std_inspect.iscoroutinefunction(docker_method)
+
+        base_params = list(std_inspect.signature(base_method).parameters)
+        docker_params = list(std_inspect.signature(docker_method).parameters)
+        assert docker_params == base_params
+
+
+class TestLabelConstants:
+    def test_spec_fingerprint_label_name(self):
+        assert (
+            docker_sandbox_module.LABEL_SPEC_FINGERPRINT
+            == "xagent.sandbox.spec.fingerprint"
+        )
+
+    def test_spec_version_label_name(self):
+        assert docker_sandbox_module.LABEL_SPEC_VERSION == "xagent.sandbox.spec.version"
+
+
+# --- supports_runtime_spec ---
+
+
+class TestSupportsRuntimeSpec:
+    @pytest.mark.asyncio
+    async def test_docker_supports_runtime_spec(self):
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+        assert await service.supports_runtime_spec() is True
+
+    @pytest.mark.asyncio
+    async def test_boxlite_does_not_support_runtime_spec(self):
+        # BoxliteSandboxService.__init__ talks to a real boxlite runtime;
+        # the probe itself needs no runtime access, so we bypass __init__.
+        service = object.__new__(BoxliteSandboxService)
+        assert await service.supports_runtime_spec() is False
+
+
+# --- create(): mock-layer tests for paths that are impractical against a
+# real daemon (start failure compensation, publish-verification mismatch) ---
+
+
+class TestCreateStartFailureCompensation:
+    @pytest.mark.asyncio
+    async def test_create_removes_container_via_raw_remove_when_start_fails(
+        self, monkeypatch
+    ):
+        created = _FakeCreatedContainer(start_exc=RuntimeError("port conflict"))
+
+        async def fake_create_container(*args, **kwargs):
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+
+        async def delete_must_not_be_called(name):
+            raise AssertionError(
+                "create()'s start-failure compensation must call container.remove"
+                " directly, never self.delete() (self-deadlock risk)"
+            )
+
+        monkeypatch.setattr(service, "delete", delete_must_not_be_called)
+
+        with pytest.raises(RuntimeError, match="port conflict"):
+            await service.create(
+                "start-failure",
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(),
+            )
+
+        assert created.remove_calls == [True]
+
+
+class TestCreatePublishVerification:
+    @pytest.mark.asyncio
+    async def test_create_removes_container_and_raises_on_mismatch(self, monkeypatch):
+        created = _FakeCreatedContainer()
+
+        async def fake_create_container(*args, **kwargs):
+            return created
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_create_container", fake_create_container
+        )
+
+        def fake_build_inspection(container):
+            from xagent.sandbox.base import ObservedRuntimeFacts
+
+            return SandboxInspection(
+                state="running",
+                facts=ObservedRuntimeFacts(
+                    raw_status="running",
+                    image_ref=DEFAULT_SANDBOX_IMAGE,
+                    image_digest="sha256:deadbeef",
+                    raw_nano_cpus=1_000_000_000,
+                    raw_memory_bytes=512 * 1024 * 1024,
+                    env={},
+                    # Deliberately wrong: does not match the desired (empty)
+                    # volume set, to force a MISMATCH on publish verification.
+                    volumes=(("/tampered/host", "/tampered/guest", "rw"),),
+                    ports=(),
+                    network_isolated=False,
+                    runtime_networks=("bridge",),
+                    labels={},
+                    created_at="2026-01-01T00:00:00Z",
+                    working_dir="/home",
+                ),
+                fingerprint_label="whatever",
+                version_label="1",
+            )
+
+        monkeypatch.setattr(
+            docker_sandbox_module, "_build_inspection", fake_build_inspection
+        )
+
+        service = DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+
+        async def delete_must_not_be_called(name):
+            raise AssertionError(
+                "publish-verification failure must call container.remove"
+                " directly, never self.delete()"
+            )
+
+        monkeypatch.setattr(service, "delete", delete_must_not_be_called)
+
+        with pytest.raises(SandboxRuntimeConflictError, match="volumes"):
+            await service.create(
+                "publish-mismatch",
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(),
+            )
+
+        assert created.remove_calls == [True]
+        assert service._store.get_info("publish-mismatch") is None
+
+
+# --- inspect(): real-container tests ---
+
+
+@requires_docker
+class TestDockerInspect:
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_inspect_missing_sandbox_returns_none(self, docker_service):
+        name = _unique_name("inspect-missing")
+        assert await docker_service.inspect(name) is None
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_inspect_reflects_created_sandbox(self, docker_service):
+        name = _unique_name("inspect-created")
+        service = docker_service
+        try:
+            await service.get_or_create(
+                name,
+                template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config=SandboxConfig(cpus=1, memory=256),
+            )
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.state == "running"
+            assert inspection.facts.image_ref == DEFAULT_SANDBOX_IMAGE
+            assert inspection.facts.raw_nano_cpus == 1_000_000_000
+            assert inspection.facts.raw_memory_bytes == 256 * 1024 * 1024
+            # get_or_create() is the legacy path: it never writes the new
+            # spec-attestation labels.
+            assert inspection.fingerprint_label is None
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_inspect_has_no_side_effects_on_stopped_container(
+        self, docker_service
+    ):
+        name = _unique_name("inspect-no-side-effects")
+        service = docker_service
+        try:
+            sandbox = await service.get_or_create(
+                name,
+                template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config=SandboxConfig(cpus=1, memory=256),
+            )
+            await sandbox.stop()
+
+            before = await service.inspect(name)
+            assert before is not None
+            assert before.state == "stopped"
+
+            # Calling inspect() again must not have started/changed anything.
+            after = await service.inspect(name)
+            assert after is not None
+            assert after.state == "stopped"
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_inspect_never_acquires_name_lock(self, docker_service, monkeypatch):
+        """Liveness pin: inspect() must not go through _named_lock at all,
+        neither when no sandbox exists nor when one already does."""
+        missing_name = _unique_name("inspect-no-lock-missing")
+        existing_name = _unique_name("inspect-no-lock-existing")
+        service = docker_service
+
+        await service.get_or_create(
+            existing_name,
+            template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+            config=SandboxConfig(cpus=1, memory=256),
+        )
+
+        @asynccontextmanager
+        async def failing_named_lock(_name):
+            raise AssertionError("inspect() must never acquire the per-name lock")
+            yield  # pragma: no cover
+
+        try:
+            monkeypatch.setattr(service, "_named_lock", failing_named_lock)
+
+            # Missing sandbox: still must not touch the lock.
+            assert await service.inspect(missing_name) is None
+
+            # Existing sandbox: must return a real inspection, still without
+            # touching the lock.
+            inspection = await service.inspect(existing_name)
+            assert inspection is not None
+        finally:
+            monkeypatch.undo()
+            try:
+                await service.delete(existing_name)
+            except Exception:
+                pass
+
+
+# --- create(): real-container tests ---
+
+
+@requires_docker
+class TestDockerCreate:
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_happy_path(self, docker_service):
+        name = _unique_name("create-happy")
+        service = docker_service
+        config = SandboxConfig(cpus=1, memory=256)
+        try:
+            sandbox = await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+
+            assert sandbox.name == name
+
+            result = await sandbox.exec("echo", "hello")
+            assert result.success
+            assert result.stdout.strip() == "hello"
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.fingerprint_label is not None
+            assert inspection.version_label == str(SPEC_CONTRACT_VERSION)
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                working_dir=config.working_dir,
+                cpus=config.cpus,
+                memory=config.memory,
+                env=config.env,
+                volumes=config.volumes,
+                network_isolated=bool(config.network_isolated),
+                ports=config.ports,
+            )
+            assert inspection.fingerprint_label == desired.fingerprint()
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+
+            stored = service._store.get_info(name)
+            assert stored is not None
+            assert stored.name == name
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_rejects_name_already_used_by_get_or_create(
+        self, docker_service
+    ):
+        name = _unique_name("create-conflict-legacy")
+        service = docker_service
+        try:
+            await service.get_or_create(
+                name,
+                template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config=SandboxConfig(cpus=1, memory=256),
+            )
+
+            with pytest.raises(SandboxAlreadyExistsError):
+                await service.create(
+                    name,
+                    SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                    SandboxConfig(cpus=1, memory=256),
+                )
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_rejects_name_already_used_by_create(self, docker_service):
+        name = _unique_name("create-conflict-new")
+        service = docker_service
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(cpus=1, memory=256),
+            )
+
+            with pytest.raises(SandboxAlreadyExistsError):
+                await service.create(
+                    name,
+                    SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                    SandboxConfig(cpus=1, memory=256),
+                )
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_rejects_conflicting_volume_host_paths(self, docker_service):
+        import tempfile
+
+        name = _unique_name("create-volume-conflict")
+        service = docker_service
+        host_dir = tempfile.mkdtemp()
+        try:
+            with pytest.raises(SandboxRuntimeConflictError):
+                await service.create(
+                    name,
+                    SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                    SandboxConfig(
+                        cpus=1,
+                        memory=256,
+                        volumes=[
+                            (host_dir, "/mnt/a", "rw"),
+                            (host_dir, "/mnt/b", "rw"),
+                        ],
+                    ),
+                )
+
+            sandboxes = await service.list_sandboxes()
+            assert name not in {s.name for s in sandboxes}
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_accepts_identical_duplicate_volumes(self, docker_service):
+        import tempfile
+
+        name = _unique_name("create-volume-dup")
+        service = docker_service
+        host_dir = tempfile.mkdtemp()
+        try:
+            sandbox = await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(
+                    cpus=1,
+                    memory=256,
+                    volumes=[
+                        (host_dir, "/mnt/a", "rw"),
+                        (host_dir, "/mnt/a", "rw"),
+                    ],
+                ),
+            )
+            assert sandbox.name == name
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.facts.volumes == ((host_dir, "/mnt/a", "rw"),)
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_rejects_conflicting_port_guest_ports(self, docker_service):
+        name = _unique_name("create-port-conflict")
+        service = docker_service
+        try:
+            with pytest.raises(SandboxRuntimeConflictError):
+                await service.create(
+                    name,
+                    SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                    SandboxConfig(
+                        cpus=1,
+                        memory=256,
+                        ports=[(18080, 80), (18081, 80)],
+                    ),
+                )
+
+            sandboxes = await service.list_sandboxes()
+            assert name not in {s.name for s in sandboxes}
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_accepts_identical_duplicate_ports(self, docker_service):
+        name = _unique_name("create-port-dup")
+        service = docker_service
+        try:
+            sandbox = await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(
+                    cpus=1,
+                    memory=256,
+                    ports=[(18082, 80), (18082, 80)],
+                ),
+            )
+            assert sandbox.name == name
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.facts.ports == ((18082, 80),)
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    # --- create() builds the container from the same normalized desired
+    # spec that publish-verification compares against, so a raw input that
+    # from_parts() normalizes differently from its literal form (a trailing
+    # slash, a `..` segment, an explicit None) still ends up
+    # MATCH-verifiable. ---
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_normalizes_trailing_slash_working_dir(self, docker_service):
+        name = _unique_name("create-norm-workdir")
+        service = docker_service
+        config = SandboxConfig(cpus=1, memory=256, working_dir="/home/")
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            inspection = await service.inspect(name)
+            assert inspection is not None
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                working_dir=config.working_dir,
+                cpus=config.cpus,
+                memory=config.memory,
+            )
+            assert desired.working_dir == "/home"
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_normalizes_volume_trailing_slash(self, docker_service):
+        import tempfile
+
+        name = _unique_name("create-norm-vol-slash")
+        service = docker_service
+        host_dir = tempfile.mkdtemp()
+        config = SandboxConfig(
+            cpus=1, memory=256, volumes=[(host_dir + "/", "/mnt/a/", "rw")]
+        )
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            inspection = await service.inspect(name)
+            assert inspection is not None
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                cpus=config.cpus,
+                memory=config.memory,
+                volumes=config.volumes,
+            )
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_normalizes_volume_dot_dot_segment(self, docker_service):
+        import tempfile
+
+        name = _unique_name("create-norm-vol-dotdot")
+        service = docker_service
+        host_dir = tempfile.mkdtemp()
+        config = SandboxConfig(
+            cpus=1,
+            memory=256,
+            volumes=[(host_dir + "/nested/..", "/mnt/a", "rw")],
+        )
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            inspection = await service.inspect(name)
+            assert inspection is not None
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                cpus=config.cpus,
+                memory=config.memory,
+                volumes=config.volumes,
+            )
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_with_none_cpus_and_memory_succeeds_and_matches(
+        self, docker_service
+    ):
+        name = _unique_name("create-none-cpus-memory")
+        service = docker_service
+        config = SandboxConfig(cpus=None, memory=None)
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config,
+            )
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            # The backend default (cpus or 1, memory or 512) took effect.
+            assert inspection.facts.raw_nano_cpus == 1_000_000_000
+            assert inspection.facts.raw_memory_bytes == 512 * 1024 * 1024
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=DEFAULT_SANDBOX_IMAGE,
+                cpus=config.cpus,
+                memory=config.memory,
+            )
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_env_fact_contains_desired_key(self, docker_service):
+        """Docstring-documented fact: Config.Env mixes in image-defined ENV
+        values alongside the ones we injected, so the assertion here is
+        deliberately a subset check (``desired.items() <= actual.items()``)
+        rather than an exact-match on the full env mapping."""
+        name = _unique_name("create-env-fact")
+        service = docker_service
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(
+                    cpus=1, memory=256, env={"XAGENT_TEST_KEY": "test-value"}
+                ),
+            )
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert {
+                "XAGENT_TEST_KEY": "test-value"
+            }.items() <= inspection.facts.env.items()
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+
+# --- create() from a snapshot template: real-container tests ---
+
+
+@requires_docker
+class TestDockerCreateFromSnapshot:
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_from_snapshot_matches_and_uses_snapshot_image(
+        self, docker_service
+    ):
+        service = docker_service
+        source_name = _unique_name("snapshot-source")
+        target_name = _unique_name("snapshot-target")
+        snapshot_id = _unique_name("snap")
+        try:
+            await service.get_or_create(
+                source_name,
+                template=SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                config=SandboxConfig(cpus=1, memory=256),
+            )
+            snapshot = await service.create_snapshot(source_name, snapshot_id)
+
+            config = SandboxConfig(cpus=1, memory=256)
+            sandbox = await service.create(
+                target_name,
+                SandboxTemplate(type="snapshot", snapshot_id=snapshot_id),
+                config,
+            )
+            assert sandbox.name == target_name
+
+            inspection = await service.inspect(target_name)
+            assert inspection is not None
+            assert inspection.facts.image_ref == snapshot.metadata["image_tag"]
+            assert inspection.fingerprint_label is not None
+
+            desired = ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="snapshot",
+                snapshot_id=snapshot_id,
+                working_dir=config.working_dir,
+                cpus=config.cpus,
+                memory=config.memory,
+                env=config.env,
+                volumes=config.volumes,
+                network_isolated=bool(config.network_isolated),
+                ports=config.ports,
+            )
+            assert inspection.fingerprint_label == desired.fingerprint()
+            assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+        finally:
+            try:
+                await service.delete(target_name)
+            except Exception:
+                pass
+            try:
+                await service.delete(source_name)
+            except Exception:
+                pass
+            try:
+                await service.delete_snapshot(snapshot_id)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_create_from_missing_snapshot_raises_file_not_found(
+        self, docker_service
+    ):
+        name = _unique_name("snapshot-missing")
+        service = docker_service
+        with pytest.raises(FileNotFoundError):
+            await service.create(
+                name,
+                SandboxTemplate(type="snapshot", snapshot_id="does-not-exist"),
+                SandboxConfig(cpus=1, memory=256),
+            )
+
+
+# --- start_existing() / stop_existing(): real-container tests ---
+
+
+@requires_docker
+class TestStartStopExisting:
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_start_existing_missing_raises_not_found(self, docker_service):
+        name = _unique_name("start-missing")
+        with pytest.raises(SandboxNotFoundError):
+            await docker_service.start_existing(name)
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_stop_existing_missing_raises_not_found(self, docker_service):
+        name = _unique_name("stop-missing")
+        with pytest.raises(SandboxNotFoundError):
+            await docker_service.stop_existing(name)
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_stop_existing_then_start_existing_round_trip(self, docker_service):
+        name = _unique_name("start-stop-roundtrip")
+        service = docker_service
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(cpus=1, memory=256),
+            )
+
+            await service.stop_existing(name)
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.state == "stopped"
+            assert service._store.get_info(name).state == "stopped"
+
+            sandbox = await service.start_existing(name)
+            assert sandbox.name == name
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.state == "running"
+            assert service._store.get_info(name).state == "running"
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_stop_existing_is_idempotent(self, docker_service):
+        name = _unique_name("stop-idempotent")
+        service = docker_service
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(cpus=1, memory=256),
+            )
+            await service.stop_existing(name)
+            # Second stop on an already-stopped sandbox must be a no-op, not
+            # an error.
+            await service.stop_existing(name)
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.state == "stopped"
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_start_existing_is_idempotent(self, docker_service):
+        name = _unique_name("start-idempotent")
+        service = docker_service
+        try:
+            await service.create(
+                name,
+                SandboxTemplate(type="image", image=DEFAULT_SANDBOX_IMAGE),
+                SandboxConfig(cpus=1, memory=256),
+            )
+            # Already running: start_existing() must return happily rather
+            # than erroring on a redundant start.
+            sandbox = await service.start_existing(name)
+            assert sandbox.name == name
+
+            inspection = await service.inspect(name)
+            assert inspection is not None
+            assert inspection.state == "running"
+        finally:
+            try:
+                await service.delete(name)
+            except Exception:
+                pass

--- a/tests/sandbox/test_docker_lifecycle_api.py
+++ b/tests/sandbox/test_docker_lifecycle_api.py
@@ -167,6 +167,21 @@ class TestCheckNoConflictingPorts:
         docker_sandbox_module._check_no_conflicting_ports([(0, 80), (0, 81), (0, 82)])
 
 
+class TestCheckNoConflictingVolumes:
+    def test_rejects_host_path_spelled_with_a_leading_double_slash(self):
+        # Docker collapses the leading slash run, so both entries land on the
+        # same host key and one guest path would be silently dropped.
+        with pytest.raises(SandboxRuntimeConflictError, match="host path"):
+            docker_sandbox_module._check_no_conflicting_volumes(
+                [("//data", "/guest/a", "rw"), ("/data", "/guest/b", "rw")]
+            )
+
+    def test_accepts_duplicate_triples_spelled_differently(self):
+        docker_sandbox_module._check_no_conflicting_volumes(
+            [("//data", "//guest/a", "rw"), ("/data", "/guest/a", "rw")]
+        )
+
+
 # --- supports_runtime_spec ---
 
 

--- a/tests/sandbox/test_docker_lock_infra.py
+++ b/tests/sandbox/test_docker_lock_infra.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
 import xagent.sandbox.docker_sandbox as docker_sandbox_module
 from xagent.sandbox.docker_sandbox import (
+    LABEL_SANDBOX_NAME,
     DockerSandboxService,
     MemDockerStore,
     _SandboxControl,
@@ -39,6 +42,166 @@ class _FakeDockerClient:
 
 def _make_service() -> DockerSandboxService:
     return DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+
+
+class _StoppableContainer:
+    """Container stub whose ``stop()`` can be held open from the test.
+
+    ``stop()`` runs on a worker thread (both callers reach it through
+    ``asyncio.to_thread``), so the occupancy counter is guarded by a real
+    ``threading.Lock`` and the gate is a ``threading.Event``.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.labels = {LABEL_SANDBOX_NAME: name}
+        self.attrs: dict = {
+            "Config": {"Image": "busybox:latest", "WorkingDir": "/home"},
+            "HostConfig": {},
+            "State": {"Status": "running"},
+            "NetworkSettings": {"Networks": {"bridge": {}}},
+            "Created": "2026-01-01T00:00:00Z",
+        }
+        self.stop_calls = 0
+        self.start_calls = 0
+        self.max_concurrent_stops = 0
+        self.stop_entered = threading.Event()
+        self.release_stop = threading.Event()
+        self._occupancy = 0
+        self._guard = threading.Lock()
+
+    def reload(self):
+        return None
+
+    def start(self):
+        self.start_calls += 1
+
+    def stop(self):
+        with self._guard:
+            self.stop_calls += 1
+            self._occupancy += 1
+            self.max_concurrent_stops = max(self.max_concurrent_stops, self._occupancy)
+        self.stop_entered.set()
+        if not self.release_stop.wait(timeout=10):
+            raise AssertionError("stop() gate was never released")
+        with self._guard:
+            self._occupancy -= 1
+
+
+class _FakeClientWithContainer:
+    """Docker client stub that always resolves one managed container."""
+
+    def __init__(self, container: _StoppableContainer) -> None:
+        self.containers = _SingleContainerCollection(container)
+
+    def ping(self):
+        return True
+
+
+class _SingleContainerCollection:
+    def __init__(self, container: _StoppableContainer) -> None:
+        self._container = container
+
+    def list(self, *args, **kwargs):
+        return [self._container]
+
+
+async def _await_flag(flag: threading.Event, timeout: float = 5.0) -> None:
+    """Await a thread-set flag from the event loop without blocking it."""
+    deadline = time.monotonic() + timeout
+    while not flag.is_set():
+        if time.monotonic() > deadline:
+            raise AssertionError("timed out waiting for the worker thread")
+        await asyncio.sleep(0.01)
+
+
+class TestHandleStopSharesTheServiceLifecycleLock:
+    """Pin that ``DockerSandbox.stop()`` and the service's own lifecycle
+    methods are mutually exclusive for one container name.
+
+    ``stop()`` used to take only the sandbox's own ``exclusive_access``
+    barrier, which drains in-flight ``operation()`` work and tracks no
+    exclusive holder -- and neither ``container.stop()`` nor
+    ``container.start()`` registers as an ``operation()``, so a stop could
+    interleave with ``stop_existing``/``start_existing``/``delete``/
+    ``create_snapshot`` for the same name.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handles_are_built_with_the_services_lock_registry(self):
+        container = _StoppableContainer("wired")
+        service = DockerSandboxService(
+            MemDockerStore(), client=_FakeClientWithContainer(container)
+        )
+
+        from_start_existing = await service.start_existing("wired")
+        from_get_or_create = await service.get_or_create("wired")
+
+        # Same registry object, not a private copy: sharing the registry is
+        # the whole mechanism behind the mutual exclusion below.
+        assert from_start_existing._locks is service._locks
+        assert from_get_or_create._locks is service._locks
+
+    @pytest.mark.asyncio
+    async def test_stop_and_stop_existing_cannot_overlap_for_one_name(self):
+        name = "contended"
+        container = _StoppableContainer(name)
+        service = DockerSandboxService(
+            MemDockerStore(), client=_FakeClientWithContainer(container)
+        )
+        handle = await service.start_existing(name)
+
+        # The handle's stop() enters container.stop() and parks there.
+        stop_task = asyncio.create_task(handle.stop())
+        await _await_flag(container.stop_entered)
+        assert service._locks[name].lock.locked()
+        assert service._locks[name].waiters == 1
+
+        # A concurrent lifecycle transition for the same name must queue on
+        # the *same* lock entry rather than proceeding in parallel.
+        stop_existing_task = asyncio.create_task(service.stop_existing(name))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert service._locks[name].waiters == 2, (
+            "stop_existing() must queue on the same keyed lock entry stop() holds"
+        )
+        assert not stop_existing_task.done()
+        assert container.stop_calls == 1, (
+            "stop_existing() must not reach container.stop() while stop() holds the lock"
+        )
+
+        container.release_stop.set()
+        await asyncio.wait_for(stop_task, timeout=5)
+        await asyncio.wait_for(stop_existing_task, timeout=5)
+
+        assert container.stop_calls == 2
+        assert container.max_concurrent_stops == 1, (
+            "the two stop paths overlapped inside the critical section"
+        )
+        assert name not in service._locks
+
+    @pytest.mark.asyncio
+    async def test_lock_holding_paths_do_not_self_deadlock(self):
+        """Regression pin for the fix's own failure mode.
+
+        The keyed lock is not reentrant, so a lock-holding path that reached
+        ``DockerSandbox.stop()`` would deadlock on itself. ``stop_existing()``
+        stops its container through the raw ``Container.stop`` API for exactly
+        that reason; this asserts the real call completes rather than hanging.
+        """
+        name = "no-deadlock"
+        container = _StoppableContainer(name)
+        container.release_stop.set()
+        service = DockerSandboxService(
+            MemDockerStore(), client=_FakeClientWithContainer(container)
+        )
+
+        handle = await service.start_existing(name)
+        await asyncio.wait_for(service.stop_existing(name), timeout=5)
+        await asyncio.wait_for(handle.stop(), timeout=5)
+
+        assert container.stop_calls == 2
+        assert name not in service._locks
 
 
 class TestNamedLockIdentityAndMutualExclusion:

--- a/tests/sandbox/test_docker_lock_infra.py
+++ b/tests/sandbox/test_docker_lock_infra.py
@@ -6,6 +6,7 @@ against a minimal fake Docker client; no Docker daemon required.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 from pathlib import Path
 
@@ -184,13 +185,19 @@ class TestNamedLockCancellationSafety:
         assert "cancel-me" not in service._locks
 
     @pytest.mark.asyncio
-    async def test_double_cancel_while_waiting_rolls_back_cleanly(self):
-        # Waiter bookkeeping in _named_lock is fully synchronous: the
-        # rollback path in the `except BaseException` branch has no `await`
-        # in it, so a second cancel() delivered on top of the first, before
-        # the waiter task gets a chance to run its own cancellation
-        # handling, must still leave the waiter count and entry correctly
-        # recovered.
+    async def test_repeated_cancel_of_a_queued_waiter_rolls_back_cleanly(self):
+        # Cancelling a queued waiter must roll back its waiter count and, once
+        # the holder leaves, evict the entry. Calling cancel() a second time
+        # before the task is resumed must not double-decrement the count.
+        #
+        # Note what this can and cannot reach: the rollback in _named_lock's
+        # `except BaseException` branch contains no `await`, so a second
+        # cancellation cannot interleave *inside* it -- asyncio delivers at
+        # most one CancelledError to a task that has not resumed yet, and the
+        # synchronous rollback is indivisible on this event loop. The case of
+        # a cancellation arriving while an in-flight operation still holds the
+        # lock is a different mechanism (_await_shielded) and is covered in
+        # test_docker_lifecycle_api.py's repeated-cancellation test.
         service = _make_service()
         entered_holder = asyncio.Event()
         release_holder = asyncio.Event()
@@ -297,5 +304,26 @@ class TestSandboxControlSingleConstructionPoint:
     """
 
     def test_sandbox_control_constructed_in_exactly_two_places(self):
+        """Resolved over the AST, not raw text.
+
+        A substring count also matches occurrences in comments and
+        docstrings and breaks on reformatting, neither of which has anything
+        to do with the contract. What matters is which *functions* contain a
+        real call to the constructor.
+        """
         source = Path(docker_sandbox_module.__file__).read_text()
-        assert source.count("_SandboxControl(") == 2
+        tree = ast.parse(source)
+
+        constructing_functions: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Name)
+                    and inner.func.id == "_SandboxControl"
+                ):
+                    constructing_functions.append(node.name)
+
+        assert sorted(constructing_functions) == ["_get_control", "_get_live_control"]

--- a/tests/sandbox/test_docker_lock_infra.py
+++ b/tests/sandbox/test_docker_lock_infra.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for DockerSandboxService's per-name lifecycle lock (_named_lock)
+and control-object construction (_get_live_control). Pure asyncio tests
+against a minimal fake Docker client; no Docker daemon required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import xagent.sandbox.docker_sandbox as docker_sandbox_module
+from xagent.sandbox.docker_sandbox import (
+    DockerSandboxService,
+    MemDockerStore,
+    _SandboxControl,
+)
+
+
+class _FakeContainerCollection:
+    """Minimal Docker container collection stub: always reports no containers."""
+
+    def list(self, *args, **kwargs):
+        return []
+
+
+class _FakeDockerClient:
+    """Minimal Docker client stub sufficient for service construction and delete()."""
+
+    def __init__(self) -> None:
+        self.containers = _FakeContainerCollection()
+
+    def ping(self):
+        return True
+
+
+def _make_service() -> DockerSandboxService:
+    return DockerSandboxService(MemDockerStore(), client=_FakeDockerClient())
+
+
+class TestNamedLockIdentityAndMutualExclusion:
+    """Pin the split-brain fix: a waiter queued behind a holder must land on
+    the same lock entry the holder used, not a freshly-constructed one."""
+
+    @pytest.mark.asyncio
+    async def test_named_lock_stays_mutually_exclusive_across_release_and_requeue(
+        self,
+    ):
+        service = _make_service()
+        concurrent_holders = 0
+        max_concurrent = 0
+
+        entered_b = asyncio.Event()
+        release_b = asyncio.Event()
+        entered_a = asyncio.Event()
+        release_a = asyncio.Event()
+        entered_c = asyncio.Event()
+        release_c = asyncio.Event()
+
+        async def holder(entered: asyncio.Event, release: asyncio.Event) -> None:
+            nonlocal concurrent_holders, max_concurrent
+            async with service._named_lock("shared-name"):
+                concurrent_holders += 1
+                max_concurrent = max(max_concurrent, concurrent_holders)
+                entered.set()
+                await release.wait()
+                concurrent_holders -= 1
+
+        # B takes the lock first.
+        task_b = asyncio.create_task(holder(entered_b, release_b))
+        await entered_b.wait()
+
+        # A queues behind B while B still holds it.
+        task_a = asyncio.create_task(holder(entered_a, release_a))
+        await asyncio.sleep(0)
+        entry_while_b_holds = service._locks["shared-name"]
+        assert entry_while_b_holds.waiters == 2
+
+        # B finishes; the entry must survive (A is still waiting on it) so
+        # that A ends up acquiring the SAME entry rather than racing a
+        # newly-constructed one against a delete()/other holder.
+        release_b.set()
+        await task_b
+        await entered_a.wait()
+        assert service._locks["shared-name"] is entry_while_b_holds
+
+        # A now holds it; C attempts to acquire concurrently and must queue
+        # behind A rather than proceeding on an independent lock instance.
+        task_c = asyncio.create_task(holder(entered_c, release_c))
+        await asyncio.sleep(0)
+        assert concurrent_holders == 1
+        assert not entered_c.is_set()
+
+        release_a.set()
+        await task_a
+        await entered_c.wait()
+
+        release_c.set()
+        await task_c
+
+        assert max_concurrent == 1
+        assert "shared-name" not in service._locks
+
+
+class TestNamedLockWaiterRecycling:
+    """Pin the entry-recycling contract: only evict when unused."""
+
+    @pytest.mark.asyncio
+    async def test_entry_recycled_when_no_waiters_remain(self):
+        service = _make_service()
+        async with service._named_lock("solo"):
+            assert "solo" in service._locks
+        assert "solo" not in service._locks
+
+    @pytest.mark.asyncio
+    async def test_entry_retained_while_a_waiter_is_pending(self):
+        service = _make_service()
+        entered_holder = asyncio.Event()
+        release_holder = asyncio.Event()
+        entered_waiter = asyncio.Event()
+        release_waiter = asyncio.Event()
+
+        async def holder(entered: asyncio.Event, release: asyncio.Event) -> None:
+            async with service._named_lock("busy"):
+                entered.set()
+                await release.wait()
+
+        task_holder = asyncio.create_task(holder(entered_holder, release_holder))
+        await entered_holder.wait()
+
+        task_waiter = asyncio.create_task(holder(entered_waiter, release_waiter))
+        await asyncio.sleep(0)
+        assert service._locks["busy"].waiters == 2
+
+        # Releasing the holder must not drop the entry: the waiter is still
+        # queued on it.
+        release_holder.set()
+        await task_holder
+        assert "busy" in service._locks
+
+        release_waiter.set()
+        await task_waiter
+        assert "busy" not in service._locks
+
+
+class TestNamedLockCancellationSafety:
+    """Pin that a cancelled waiter rolls back its waiter count and leaks nothing."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_while_waiting_rolls_back_waiter_count_and_entry(self):
+        service = _make_service()
+        entered_holder = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def holder() -> None:
+            async with service._named_lock("cancel-me"):
+                entered_holder.set()
+                await release_holder.wait()
+
+        task_holder = asyncio.create_task(holder())
+        await entered_holder.wait()
+
+        async def waiter() -> None:
+            async with service._named_lock("cancel-me"):
+                raise AssertionError("cancelled waiter must never enter the body")
+
+        task_waiter = asyncio.create_task(waiter())
+        await asyncio.sleep(0)
+        assert service._locks["cancel-me"].waiters == 2
+
+        task_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task_waiter
+
+        # Cancellation rolled the waiter count back; only the holder remains.
+        assert service._locks["cancel-me"].waiters == 1
+
+        release_holder.set()
+        await task_holder
+
+        # Once the holder also finishes, the entry must not have leaked.
+        assert "cancel-me" not in service._locks
+
+    @pytest.mark.asyncio
+    async def test_double_cancel_while_waiting_rolls_back_cleanly(self):
+        # Waiter bookkeeping in _named_lock is fully synchronous: the
+        # rollback path in the `except BaseException` branch has no `await`
+        # in it, so a second cancel() delivered on top of the first, before
+        # the waiter task gets a chance to run its own cancellation
+        # handling, must still leave the waiter count and entry correctly
+        # recovered.
+        service = _make_service()
+        entered_holder = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def holder() -> None:
+            async with service._named_lock("double-cancel"):
+                entered_holder.set()
+                await release_holder.wait()
+
+        task_holder = asyncio.create_task(holder())
+        await entered_holder.wait()
+
+        async def waiter() -> None:
+            async with service._named_lock("double-cancel"):
+                raise AssertionError("cancelled waiter must never enter the body")
+
+        task_waiter = asyncio.create_task(waiter())
+        await asyncio.sleep(0)
+        assert service._locks["double-cancel"].waiters == 2
+
+        task_waiter.cancel()
+        task_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task_waiter
+
+        assert service._locks["double-cancel"].waiters == 1
+
+        release_holder.set()
+        await task_holder
+
+        assert "double-cancel" not in service._locks
+
+
+class TestGetLiveControl:
+    """Pin _get_live_control as the deleted-aware construction point.
+
+    _get_live_control() asserts that _named_lock(name) is held, so every
+    call below happens inside that context, matching its real call sites.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reuses_the_same_live_control_instance(self):
+        service = _make_service()
+        async with service._named_lock("box"):
+            first = service._get_live_control("box")
+            second = service._get_live_control("box")
+        assert second is first
+
+    @pytest.mark.asyncio
+    async def test_replaces_a_deleted_control_with_a_fresh_instance(self):
+        service = _make_service()
+        async with service._named_lock("box"):
+            first = service._get_live_control("box")
+            first.deleted = True
+
+            replaced = service._get_live_control("box")
+
+        assert replaced is not first
+        assert replaced.deleted is False
+        assert service._controls["box"] is replaced
+
+    def test_asserts_when_called_without_holding_the_named_lock(self):
+        service = _make_service()
+        with pytest.raises(AssertionError):
+            service._get_live_control("unlocked")
+
+
+class TestDeleteIdentityCheckedPop:
+    """Pin delete()'s identity-checked pop: a replaced control must survive."""
+
+    @pytest.mark.asyncio
+    async def test_delete_does_not_evict_a_control_installed_after_its_lookup(
+        self, monkeypatch
+    ):
+        service = _make_service()
+        old_control = service._get_control("box")
+        new_control = _SandboxControl(name="box")
+
+        real_find_container = service._find_container
+
+        async def find_container_and_swap(name: str):
+            # Simulate another in-flight path installing a fresh control
+            # object for this name between delete()'s control lookup and its
+            # cleanup pop.
+            service._controls[name] = new_control
+            return await real_find_container(name)
+
+        monkeypatch.setattr(service, "_find_container", find_container_and_swap)
+
+        await service.delete("box")
+
+        assert old_control is not new_control
+        assert service._controls.get("box") is new_control
+
+
+class TestSandboxControlSingleConstructionPoint:
+    """Source-level pin: only _get_control and _get_live_control may
+    construct a _SandboxControl. A new inline construction elsewhere is a
+    regression of the single-construction-point contract.
+
+    Two sanctioned construction points: _get_control (legacy paths,
+    deleted-preserving) and _get_live_control (lock-held paths,
+    deleted-replacing); no inline construction elsewhere.
+    """
+
+    def test_sandbox_control_constructed_in_exactly_two_places(self):
+        source = Path(docker_sandbox_module.__file__).read_text()
+        assert source.count("_SandboxControl(") == 2

--- a/tests/sandbox/test_keyed_lock.py
+++ b/tests/sandbox/test_keyed_lock.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for ``KeyedLockRegistry``, the shared per-key async mutex.
+
+Tested directly rather than only through ``DockerSandboxService._named_lock``,
+because the registry is now a reusable primitive with more than one intended
+consumer: its invariants have to hold on their own terms, not just as observed
+through one caller.
+
+The invariant that matters is entry identity across release-and-requeue. A
+registry that pops an entry the moment its holder releases lets a waiter
+already blocked on that entry run concurrently with a newcomer that installed
+a fresh one under the same key -- two tasks holding "the same" lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from xagent.sandbox.keyed_lock import KeyedLockEntry, KeyedLockRegistry
+
+
+class TestKeyedLockMutualExclusion:
+    @pytest.mark.asyncio
+    async def test_second_caller_waits_for_the_first(self):
+        registry = KeyedLockRegistry()
+        order: list[str] = []
+        first_holds = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def first() -> None:
+            async with registry.locked("k"):
+                order.append("first-in")
+                first_holds.set()
+                await release_first.wait()
+                order.append("first-out")
+
+        async def second() -> None:
+            async with registry.locked("k"):
+                order.append("second-in")
+
+        task_first = asyncio.create_task(first())
+        await first_holds.wait()
+        task_second = asyncio.create_task(second())
+        await asyncio.sleep(0)
+
+        assert order == ["first-in"], "second must not enter while first holds"
+
+        release_first.set()
+        await asyncio.gather(task_first, task_second)
+        assert order == ["first-in", "first-out", "second-in"]
+
+    @pytest.mark.asyncio
+    async def test_different_keys_do_not_block_each_other(self):
+        registry = KeyedLockRegistry()
+        a_holds = asyncio.Event()
+        release_a = asyncio.Event()
+        b_entered = asyncio.Event()
+
+        async def hold_a() -> None:
+            async with registry.locked("a"):
+                a_holds.set()
+                await release_a.wait()
+
+        async def hold_b() -> None:
+            async with registry.locked("b"):
+                b_entered.set()
+
+        task_a = asyncio.create_task(hold_a())
+        await a_holds.wait()
+        task_b = asyncio.create_task(hold_b())
+        await asyncio.wait_for(b_entered.wait(), timeout=1)
+
+        release_a.set()
+        await asyncio.gather(task_a, task_b)
+
+    @pytest.mark.asyncio
+    async def test_stays_exclusive_across_release_and_requeue(self):
+        """The entry a waiter is queued on must survive its holder's release."""
+        registry = KeyedLockRegistry()
+        concurrent = 0
+        max_concurrent = 0
+
+        entered_first = asyncio.Event()
+        release_first = asyncio.Event()
+        entered_second = asyncio.Event()
+        release_second = asyncio.Event()
+
+        async def holder(entered: asyncio.Event, release: asyncio.Event) -> None:
+            nonlocal concurrent, max_concurrent
+            async with registry.locked("k"):
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+                entered.set()
+                await release.wait()
+                concurrent -= 1
+
+        task_first = asyncio.create_task(holder(entered_first, release_first))
+        await entered_first.wait()
+
+        task_second = asyncio.create_task(holder(entered_second, release_second))
+        await asyncio.sleep(0)
+        entry_while_first_holds = registry["k"]
+        assert entry_while_first_holds.waiters == 2
+
+        release_first.set()
+        await task_first
+        await entered_second.wait()
+        assert registry["k"] is entry_while_first_holds, (
+            "the waiting task must end up holding the same entry it queued on"
+        )
+
+        release_second.set()
+        await task_second
+        assert max_concurrent == 1
+
+
+class TestKeyedLockEviction:
+    @pytest.mark.asyncio
+    async def test_entry_is_evicted_once_unused(self):
+        registry = KeyedLockRegistry()
+        async with registry.locked("k"):
+            assert "k" in registry
+        assert "k" not in registry
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_entry_is_retained_while_a_waiter_is_queued(self):
+        registry = KeyedLockRegistry()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        waiter_entered = asyncio.Event()
+        release_waiter = asyncio.Event()
+
+        async def holder(e: asyncio.Event, r: asyncio.Event) -> None:
+            async with registry.locked("k"):
+                e.set()
+                await r.wait()
+
+        task_holder = asyncio.create_task(holder(entered, release))
+        await entered.wait()
+        task_waiter = asyncio.create_task(holder(waiter_entered, release_waiter))
+        await asyncio.sleep(0)
+        assert registry["k"].waiters == 2
+
+        release.set()
+        await task_holder
+        assert "k" in registry, "the queued waiter still references this entry"
+
+        release_waiter.set()
+        await task_waiter
+        assert "k" not in registry
+
+    @pytest.mark.asyncio
+    async def test_eviction_is_identity_checked(self):
+        """A stale entry must never evict a fresh one installed under the key."""
+        registry = KeyedLockRegistry()
+        async with registry.locked("k"):
+            stale = registry["k"]
+        assert "k" not in registry
+
+        # Install a fresh entry, then ask the registry to drop the stale one.
+        async with registry.locked("k"):
+            fresh = registry["k"]
+            assert fresh is not stale
+            registry._drop_if_unused("k", stale)
+            assert registry["k"] is fresh, (
+                "dropping a stale entry must not evict the live one"
+            )
+
+    @pytest.mark.asyncio
+    async def test_body_raising_still_releases_and_evicts(self):
+        registry = KeyedLockRegistry()
+        with pytest.raises(ValueError):
+            async with registry.locked("k"):
+                raise ValueError("boom")
+        assert "k" not in registry, "a raising body must not leak the entry"
+
+        # The lock must be reusable, i.e. actually released.
+        async with registry.locked("k"):
+            pass
+
+
+class TestKeyedLockCancellation:
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_rolls_back_its_count_and_leaks_nothing(self):
+        registry = KeyedLockRegistry()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def holder() -> None:
+            async with registry.locked("k"):
+                entered.set()
+                await release.wait()
+
+        async def waiter() -> None:
+            async with registry.locked("k"):
+                raise AssertionError("a cancelled waiter must never enter the body")
+
+        task_holder = asyncio.create_task(holder())
+        await entered.wait()
+        task_waiter = asyncio.create_task(waiter())
+        await asyncio.sleep(0)
+        assert registry["k"].waiters == 2
+
+        task_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task_waiter
+        assert registry["k"].waiters == 1
+
+        release.set()
+        await task_holder
+        assert "k" not in registry
+
+    @pytest.mark.asyncio
+    async def test_cancelling_the_only_waiter_evicts_the_entry(self):
+        """No holder to clean up after it, so the rollback must evict itself."""
+        registry = KeyedLockRegistry()
+        started = asyncio.Event()
+
+        async def waiter() -> None:
+            started.set()
+            async with registry.locked("k"):
+                await asyncio.sleep(3600)
+
+        task = asyncio.create_task(waiter())
+        await started.wait()
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert "k" not in registry
+
+
+class TestKeyedLockRegistryMapping:
+    def test_get_returns_none_for_an_unknown_key(self):
+        assert KeyedLockRegistry().get("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_get_returns_the_live_entry_while_held(self):
+        registry = KeyedLockRegistry()
+        async with registry.locked("k"):
+            entry = registry.get("k")
+            assert isinstance(entry, KeyedLockEntry)
+            assert entry.lock.locked()
+            assert entry.waiters == 1

--- a/tests/sandbox/test_mount_intent.py
+++ b/tests/sandbox/test_mount_intent.py
@@ -3,11 +3,13 @@ Unit tests for ``SandboxMountIntent``.
 
 Classification is purely lexical: it compares already-normalized path
 strings and never touches the filesystem. These tests pin that behavior,
-including the never-raises contract and the exact descendant/ancestor/
-disjoint split.
+including the absolute-path precondition and the exact descendant/
+ancestor/disjoint split.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from xagent.sandbox.base import SandboxMountIntent
 
@@ -49,22 +51,46 @@ class TestMountIntentNormalization:
         assert intent.disjoint_extras == ()
 
 
-class TestMountIntentNeverRaises:
+class TestMountIntentRejectsUncomparablePaths:
+    """Only absolute paths are lexically comparable, so nothing else is accepted.
+
+    A relative or empty path normalizes to something like ``"."``, which then
+    reads as *disjoint* from every absolute extra mount. Disjoint is the
+    dangerous direction: it grants a path its own mount instead of folding it
+    into an already-approved root, so this classification feeds allow-list
+    decisions and must never be silently wrong.
+    """
+
     def test_empty_intent_does_not_raise(self):
         intent = SandboxMountIntent(mount_root=None, extra_mounts=())
         assert intent.mount_root is None
         assert intent.extra_mounts == ()
 
-    def test_relative_paths_do_not_raise(self):
-        # Malformed input relative to contract (paths should be absolute) but
-        # construction itself must not raise.
-        intent = SandboxMountIntent(mount_root="relative/root", extra_mounts=("x/y",))
-        assert intent.mount_root == "relative/root"
-        assert intent.extra_mounts == ("x/y",)
-
     def test_root_equal_to_slash_does_not_raise(self):
         intent = SandboxMountIntent(mount_root="/", extra_mounts=("/etc",))
         assert intent.mount_root == "/"
+
+    def test_relative_mount_root_is_rejected(self):
+        with pytest.raises(ValueError, match="mount_root must be"):
+            SandboxMountIntent(mount_root="relative/root", extra_mounts=())
+
+    def test_empty_mount_root_is_rejected(self):
+        """``canonical_sandbox_path("")`` is ``"."`` -- a silently wrong root."""
+        with pytest.raises(ValueError, match="mount_root must be"):
+            SandboxMountIntent(mount_root="", extra_mounts=("/data/x",))
+
+    def test_relative_extra_mount_is_rejected(self):
+        with pytest.raises(ValueError, match="extra_mounts entry must be"):
+            SandboxMountIntent(mount_root="/data", extra_mounts=("x/y",))
+
+    def test_empty_extra_mount_is_rejected(self):
+        with pytest.raises(ValueError, match="extra_mounts entry must be"):
+            SandboxMountIntent(mount_root="/data", extra_mounts=("",))
+
+    def test_rejection_precedes_any_classification(self):
+        """The bad value must never reach a covered/disjoint verdict at all."""
+        with pytest.raises(ValueError):
+            SandboxMountIntent(mount_root="", extra_mounts=("/data/x",))
 
 
 class TestMountIntentClassification:

--- a/tests/sandbox/test_mount_intent.py
+++ b/tests/sandbox/test_mount_intent.py
@@ -36,6 +36,18 @@ class TestMountIntentNormalization:
         intent = SandboxMountIntent(mount_root=None, extra_mounts=("/a",))
         assert intent.mount_root is None
 
+    def test_collapses_leading_double_slash(self):
+        """``normpath`` alone keeps a leading ``//``, which would make the
+        lexical prefix comparison read ``//data`` and ``/data/x`` as
+        unrelated paths."""
+        intent = SandboxMountIntent(
+            mount_root="//data", extra_mounts=("//data/x", "/data/y")
+        )
+        assert intent.mount_root == "/data"
+        assert intent.extra_mounts == ("/data/x", "/data/y")
+        assert intent.covered_extras == ("/data/x", "/data/y")
+        assert intent.disjoint_extras == ()
+
 
 class TestMountIntentNeverRaises:
     def test_empty_intent_does_not_raise(self):

--- a/tests/sandbox/test_mount_intent.py
+++ b/tests/sandbox/test_mount_intent.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for ``SandboxMountIntent``.
+
+Classification is purely lexical: it compares already-normalized path
+strings and never touches the filesystem. These tests pin that behavior,
+including the never-raises contract and the exact descendant/ancestor/
+disjoint split.
+"""
+
+from __future__ import annotations
+
+from xagent.sandbox.base import SandboxMountIntent
+
+
+class TestMountIntentNormalization:
+    def test_normalizes_mount_root(self):
+        intent = SandboxMountIntent(mount_root="/data/../data2", extra_mounts=())
+        assert intent.mount_root == "/data2"
+
+    def test_normalizes_extra_mounts(self):
+        intent = SandboxMountIntent(mount_root=None, extra_mounts=("/a/./b", "/a/../c"))
+        assert intent.extra_mounts == ("/a/b", "/c")
+
+    def test_deduplicates_after_normalization(self):
+        intent = SandboxMountIntent(
+            mount_root=None,
+            extra_mounts=("/a/b", "/a/./b", "/a/b"),
+        )
+        assert intent.extra_mounts == ("/a/b",)
+
+    def test_extra_mounts_are_sorted(self):
+        intent = SandboxMountIntent(mount_root=None, extra_mounts=("/z", "/a", "/m"))
+        assert intent.extra_mounts == ("/a", "/m", "/z")
+
+    def test_none_mount_root_stays_none(self):
+        intent = SandboxMountIntent(mount_root=None, extra_mounts=("/a",))
+        assert intent.mount_root is None
+
+
+class TestMountIntentNeverRaises:
+    def test_empty_intent_does_not_raise(self):
+        intent = SandboxMountIntent(mount_root=None, extra_mounts=())
+        assert intent.mount_root is None
+        assert intent.extra_mounts == ()
+
+    def test_relative_paths_do_not_raise(self):
+        # Malformed input relative to contract (paths should be absolute) but
+        # construction itself must not raise.
+        intent = SandboxMountIntent(mount_root="relative/root", extra_mounts=("x/y",))
+        assert intent.mount_root == "relative/root"
+        assert intent.extra_mounts == ("x/y",)
+
+    def test_root_equal_to_slash_does_not_raise(self):
+        intent = SandboxMountIntent(mount_root="/", extra_mounts=("/etc",))
+        assert intent.mount_root == "/"
+
+
+class TestMountIntentClassification:
+    def test_descendant_is_covered(self):
+        intent = SandboxMountIntent(mount_root="/data", extra_mounts=("/data/sub",))
+        assert intent.covered_extras == ("/data/sub",)
+        assert intent.covering_extras == ()
+        assert intent.disjoint_extras == ()
+
+    def test_equal_path_is_covered(self):
+        intent = SandboxMountIntent(mount_root="/data", extra_mounts=("/data",))
+        assert intent.covered_extras == ("/data",)
+        assert intent.covering_extras == ()
+        assert intent.disjoint_extras == ()
+
+    def test_ancestor_is_covering(self):
+        intent = SandboxMountIntent(mount_root="/data/sub", extra_mounts=("/data",))
+        assert intent.covered_extras == ()
+        assert intent.covering_extras == ("/data",)
+        assert intent.disjoint_extras == ()
+
+    def test_root_of_filesystem_is_covering(self):
+        intent = SandboxMountIntent(mount_root="/data/sub", extra_mounts=("/",))
+        assert intent.covering_extras == ("/",)
+
+    def test_unrelated_path_is_disjoint(self):
+        intent = SandboxMountIntent(mount_root="/data", extra_mounts=("/other",))
+        assert intent.covered_extras == ()
+        assert intent.covering_extras == ()
+        assert intent.disjoint_extras == ("/other",)
+
+    def test_sibling_with_shared_prefix_is_disjoint_not_covered(self):
+        # "/database" is not a descendant of "/data" despite the string
+        # prefix match; classification must respect path-segment boundaries.
+        intent = SandboxMountIntent(mount_root="/data", extra_mounts=("/database",))
+        assert intent.covered_extras == ()
+        assert intent.covering_extras == ()
+        assert intent.disjoint_extras == ("/database",)
+
+    def test_mixed_matrix(self):
+        intent = SandboxMountIntent(
+            mount_root="/data",
+            extra_mounts=("/data/sub", "/data", "/", "/other", "/database"),
+        )
+        assert set(intent.covered_extras) == {"/data/sub", "/data"}
+        assert set(intent.covering_extras) == {"/"}
+        assert set(intent.disjoint_extras) == {"/other", "/database"}
+
+    def test_no_mount_root_means_all_disjoint(self):
+        intent = SandboxMountIntent(mount_root=None, extra_mounts=("/a", "/b"))
+        assert intent.covered_extras == ()
+        assert intent.covering_extras == ()
+        assert intent.disjoint_extras == ("/a", "/b")

--- a/tests/sandbox/test_runtime_spec.py
+++ b/tests/sandbox/test_runtime_spec.py
@@ -1,0 +1,529 @@
+"""
+Unit tests for the sandbox runtime spec types, matcher, and lifecycle
+contract additions in ``xagent.sandbox.base``.
+
+These are pure unit tests with no Docker/Boxlite dependency: SandboxInspection
+instances are hand-constructed to drive the matcher through every verdict
+path.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from xagent.sandbox.base import (
+    SPEC_CONTRACT_VERSION,
+    ObservedRuntimeFacts,
+    ResolvedSandboxRuntimeSpec,
+    SandboxAlreadyExistsError,
+    SandboxConfig,
+    SandboxContractError,
+    SandboxInspection,
+    SandboxLeaseSpec,
+    SandboxReconcileUnsupportedError,
+    SandboxRecoveryRequiredError,
+    SandboxRuntimeConflictError,
+    SandboxService,
+    SandboxTemplate,
+    SpecVerdict,
+    spec_matches_inspection,
+)
+
+
+def _make_spec(**overrides) -> ResolvedSandboxRuntimeSpec:
+    kwargs = dict(
+        template_type="image",
+        image="python:3.12-slim",
+        working_dir="/home",
+        cpus=1,
+        memory=512,
+        env={"FOO": "bar", "BAZ": "qux"},
+        volumes=[("/host/a", "/guest/a", "ro")],
+        network_isolated=False,
+        ports=[(8080, 80)],
+    )
+    kwargs.update(overrides)
+    return ResolvedSandboxRuntimeSpec.from_parts(**kwargs)
+
+
+def _make_facts(**overrides) -> ObservedRuntimeFacts:
+    kwargs = dict(
+        raw_status="running",
+        image_ref="python:3.12-slim",
+        image_digest="sha256:deadbeef",
+        raw_nano_cpus=1_000_000_000,
+        raw_memory_bytes=512 * 1024 * 1024,
+        env={"FOO": "bar"},
+        volumes=(("/host/a", "/guest/a", "ro"),),
+        ports=((8080, 80),),
+        network_isolated=False,
+        runtime_networks=("bridge",),
+        labels={},
+        created_at="2026-01-01T00:00:00Z",
+        working_dir="/home",
+    )
+    kwargs.update(overrides)
+    return ObservedRuntimeFacts(**kwargs)
+
+
+def _make_inspection(**overrides) -> SandboxInspection:
+    kwargs = dict(
+        state="running",
+        facts=_make_facts(),
+        fingerprint_label=None,
+        version_label=str(SPEC_CONTRACT_VERSION),
+    )
+    kwargs.update(overrides)
+    return SandboxInspection(**kwargs)
+
+
+# --- ResolvedSandboxRuntimeSpec: field sensitivity ---
+
+
+class TestSpecFieldSensitivity:
+    def test_baseline_fingerprint_is_stable(self):
+        a = _make_spec()
+        b = _make_spec()
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"working_dir": "/other"},
+            {"cpus": 2},
+            {"memory": 1024},
+            {"env": {"FOO": "different", "BAZ": "qux"}},
+            {"volumes": [("/host/a", "/guest/a", "rw")]},
+            {"network_isolated": True},
+            {"ports": [(9090, 90)]},
+        ],
+    )
+    def test_perturbing_any_field_changes_fingerprint(self, overrides):
+        baseline = _make_spec()
+        perturbed = _make_spec(**overrides)
+        assert perturbed != baseline
+        assert perturbed.fingerprint() != baseline.fingerprint()
+
+    def test_perturbing_image_changes_fingerprint(self):
+        baseline = _make_spec()
+        perturbed = _make_spec(image="python:3.11-slim")
+        assert perturbed != baseline
+        assert perturbed.fingerprint() != baseline.fingerprint()
+
+
+# --- ResolvedSandboxRuntimeSpec: order insensitivity ---
+
+
+class TestSpecOrderInsensitivity:
+    def test_env_key_order_does_not_affect_equality_or_fingerprint(self):
+        a = _make_spec(env={"FOO": "bar", "BAZ": "qux"})
+        b = _make_spec(env={"BAZ": "qux", "FOO": "bar"})
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+
+    def test_volume_order_and_duplicates_do_not_affect_equality(self):
+        a = _make_spec(
+            volumes=[("/host/a", "/guest/a", "ro"), ("/host/b", "/guest/b", "rw")]
+        )
+        b = _make_spec(
+            volumes=[
+                ("/host/b", "/guest/b", "rw"),
+                ("/host/a", "/guest/a", "ro"),
+                ("/host/a", "/guest/a", "ro"),
+            ]
+        )
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+        assert len(a.volumes) == 2
+
+    def test_port_order_and_duplicates_do_not_affect_equality(self):
+        a = _make_spec(ports=[(8080, 80), (9090, 90)])
+        b = _make_spec(ports=[(9090, 90), (9090, 90), (8080, 80)])
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+        assert len(a.ports) == 2
+
+    def test_volume_paths_are_normalized(self):
+        a = _make_spec(volumes=[("/host/a", "/guest/a", "ro")])
+        b = _make_spec(volumes=[("/host/x/../a", "/guest/./a", "ro")])
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+
+
+# --- ResolvedSandboxRuntimeSpec: repr redaction ---
+
+
+class TestSpecReprRedaction:
+    def test_repr_does_not_leak_env_values_or_paths(self):
+        spec = _make_spec(
+            env={"SECRET_TOKEN": "sup3r-s3cr3t-value"},
+            volumes=[("/very/private/host/path", "/guest/a", "ro")],
+        )
+        text = repr(spec)
+        assert "sup3r-s3cr3t-value" not in text
+        assert "SECRET_TOKEN" not in text
+        assert "/very/private/host/path" not in text
+        assert "/guest/a" not in text
+        assert spec.fingerprint()[:12] in text
+
+    def test_repr_reports_field_counts(self):
+        spec = _make_spec(
+            env={"A": "1", "B": "2"},
+            volumes=[("/host/a", "/guest/a", "ro")],
+            ports=[(1, 1), (2, 2)],
+        )
+        text = repr(spec)
+        assert "env_count=2" in text
+        assert "volumes_count=1" in text
+        assert "ports_count=2" in text
+
+
+# --- ResolvedSandboxRuntimeSpec: image/snapshot mutual exclusion ---
+
+
+class TestSpecTemplateMutualExclusion:
+    def test_image_type_requires_image(self):
+        with pytest.raises(ValueError):
+            ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image=None,
+                snapshot_id=None,
+            )
+
+    def test_image_type_forbids_snapshot_id(self):
+        with pytest.raises(ValueError):
+            ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="image",
+                image="python:3.12-slim",
+                snapshot_id="snap-1",
+            )
+
+    def test_snapshot_type_requires_snapshot_id(self):
+        with pytest.raises(ValueError):
+            ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="snapshot",
+                image=None,
+                snapshot_id=None,
+            )
+
+    def test_snapshot_type_forbids_image(self):
+        with pytest.raises(ValueError):
+            ResolvedSandboxRuntimeSpec.from_parts(
+                template_type="snapshot",
+                image="python:3.12-slim",
+                snapshot_id="snap-1",
+            )
+
+    def test_snapshot_type_is_valid_on_its_own(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="snapshot",
+            image=None,
+            snapshot_id="snap-1",
+        )
+        assert spec.snapshot_id == "snap-1"
+
+
+# --- ResolvedSandboxRuntimeSpec: from_parts sentinel defaults ---
+
+
+class TestFromPartsSentinelDefaults:
+    """A resolved spec must never carry a 0/None cpus/memory or an
+    un-normalized working_dir: from_parts applies the same defaults the
+    Docker backend applies at container creation, so both sides of a later
+    publish-verification comparison are computed from one canonical form."""
+
+    def test_cpus_none_defaults_to_one(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", cpus=None
+        )
+        assert spec.cpus == 1
+
+    def test_memory_none_defaults_to_512(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", memory=None
+        )
+        assert spec.memory == 512
+
+    def test_working_dir_none_defaults_to_home(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", working_dir=None
+        )
+        assert spec.working_dir == "/home"
+
+    def test_working_dir_trailing_slash_is_normalized(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", working_dir="/home/"
+        )
+        assert spec.working_dir == "/home"
+
+
+# --- ResolvedSandboxRuntimeSpec: contract version is out-of-band ---
+
+
+class TestContractVersionNotInFingerprint:
+    def test_contract_version_is_not_a_spec_field(self):
+        field_names = {f.name for f in dataclasses.fields(ResolvedSandboxRuntimeSpec)}
+        assert "contract_version" not in field_names
+
+    def test_module_constant_exists(self):
+        assert SPEC_CONTRACT_VERSION == 1
+
+
+# --- ResolvedSandboxRuntimeSpec: to_backend_config round trip ---
+
+
+class TestToBackendConfig:
+    def test_round_trip_image_template(self):
+        spec = _make_spec()
+        template, config = spec.to_backend_config()
+        assert isinstance(template, SandboxTemplate)
+        assert isinstance(config, SandboxConfig)
+        assert template.type == "image"
+        assert template.image == "python:3.12-slim"
+        assert template.snapshot_id is None
+        assert config.working_dir == "/home"
+        assert config.cpus == 1
+        assert config.memory == 512
+        assert config.env == {"FOO": "bar", "BAZ": "qux"}
+        assert config.volumes == [("/host/a", "/guest/a", "ro")]
+        assert config.network_isolated is False
+        assert config.ports == [(8080, 80)]
+
+    def test_round_trip_snapshot_template(self):
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="snapshot",
+            image=None,
+            snapshot_id="snap-1",
+        )
+        template, _config = spec.to_backend_config()
+        assert template.type == "snapshot"
+        assert template.snapshot_id == "snap-1"
+        assert template.image is None
+
+
+# --- SandboxLeaseSpec ---
+
+
+class TestSandboxLeaseSpec:
+    def test_holds_runtime_and_max_concurrency(self):
+        runtime = _make_spec()
+        lease = SandboxLeaseSpec(runtime=runtime, max_concurrency=3)
+        assert lease.runtime == runtime
+        assert lease.max_concurrency == 3
+
+    def test_is_frozen(self):
+        lease = SandboxLeaseSpec(runtime=_make_spec(), max_concurrency=1)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            lease.max_concurrency = 5
+
+
+# --- Exceptions: never RuntimeError ---
+
+
+class TestExceptionHierarchy:
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            SandboxContractError,
+            SandboxAlreadyExistsError,
+            SandboxRuntimeConflictError,
+            SandboxRecoveryRequiredError,
+            SandboxReconcileUnsupportedError,
+        ],
+    )
+    def test_not_a_runtime_error(self, exc_cls):
+        assert not issubclass(exc_cls, RuntimeError)
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            SandboxAlreadyExistsError,
+            SandboxRuntimeConflictError,
+            SandboxRecoveryRequiredError,
+            SandboxReconcileUnsupportedError,
+        ],
+    )
+    def test_subclasses_of_contract_error(self, exc_cls):
+        assert issubclass(exc_cls, SandboxContractError)
+
+
+# --- SandboxService: default implementations ---
+
+
+class _MinimalSandboxService(SandboxService):
+    """Smallest possible concrete SandboxService for pinning default bodies."""
+
+    async def get_or_create(self, name, template=None, config=None):
+        raise NotImplementedError
+
+    async def list_sandboxes(self):
+        raise NotImplementedError
+
+    async def delete(self, name):
+        raise NotImplementedError
+
+    async def supports_snapshots(self):
+        return False
+
+    async def create_snapshot(self, name, snapshot_id):
+        raise NotImplementedError
+
+    async def list_snapshots(self):
+        raise NotImplementedError
+
+    async def delete_snapshot(self, snapshot_id):
+        raise NotImplementedError
+
+
+class TestSandboxServiceDefaults:
+    async def test_supports_runtime_spec_defaults_false(self):
+        service = _MinimalSandboxService()
+        assert await service.supports_runtime_spec() is False
+
+    async def test_inspect_defaults_to_unsupported(self):
+        service = _MinimalSandboxService()
+        with pytest.raises(SandboxReconcileUnsupportedError):
+            await service.inspect("some-name")
+
+    async def test_create_defaults_to_unsupported(self):
+        service = _MinimalSandboxService()
+        with pytest.raises(SandboxReconcileUnsupportedError):
+            await service.create("some-name", SandboxTemplate(), SandboxConfig())
+
+    async def test_start_existing_defaults_to_unsupported(self):
+        service = _MinimalSandboxService()
+        with pytest.raises(SandboxReconcileUnsupportedError):
+            await service.start_existing("some-name")
+
+    async def test_stop_existing_defaults_to_unsupported(self):
+        service = _MinimalSandboxService()
+        with pytest.raises(SandboxReconcileUnsupportedError):
+            await service.stop_existing("some-name")
+
+
+# --- Matcher: spec_matches_inspection ---
+
+
+class TestSpecMatchesInspection:
+    def test_missing_fingerprint_label_is_unverified(self):
+        desired = _make_spec()
+        inspection = _make_inspection(fingerprint_label=None)
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.UNVERIFIED
+
+    def test_missing_version_label_is_unverified(self):
+        desired = _make_spec()
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(), version_label=None
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.UNVERIFIED
+
+    def test_older_version_label_is_unverified(self):
+        desired = _make_spec()
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(),
+            version_label=str(SPEC_CONTRACT_VERSION - 1),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.UNVERIFIED
+
+    def test_matching_label_and_matching_raw_units_is_match(self):
+        desired = _make_spec(cpus=1, memory=512)
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(),
+            facts=_make_facts(
+                raw_nano_cpus=1_000_000_000, raw_memory_bytes=512 * 1024 * 1024
+            ),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+
+    def test_docker_update_cpus_drift_is_mismatch(self):
+        # `docker update --cpus 0.5` after creation with desired cpus=1.
+        desired = _make_spec(cpus=1, memory=512)
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(),
+            facts=_make_facts(
+                raw_nano_cpus=500_000_000, raw_memory_bytes=512 * 1024 * 1024
+            ),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.MISMATCH
+
+    def test_memory_drift_is_mismatch(self):
+        desired = _make_spec(cpus=1, memory=512)
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(),
+            facts=_make_facts(
+                raw_nano_cpus=1_000_000_000, raw_memory_bytes=1024 * 1024 * 1024
+            ),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.MISMATCH
+
+    def test_label_mismatch_is_mismatch_regardless_of_raw_units(self):
+        desired = _make_spec(cpus=1, memory=512)
+        inspection = _make_inspection(
+            fingerprint_label="not-the-real-fingerprint",
+            facts=_make_facts(
+                raw_nano_cpus=1_000_000_000, raw_memory_bytes=512 * 1024 * 1024
+            ),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.MISMATCH
+
+    def test_env_volumes_ports_are_not_directly_compared(self):
+        # Label + raw cpu/memory agree; env/volumes/ports on facts differ from
+        # desired entirely. Verdict must still be MATCH because these fields
+        # are covered by label attestation, not live re-comparison.
+        desired = _make_spec(cpus=1, memory=512)
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(),
+            facts=_make_facts(
+                raw_nano_cpus=1_000_000_000,
+                raw_memory_bytes=512 * 1024 * 1024,
+                env={"UNRELATED": "value"},
+                volumes=(("/totally/different", "/x", "rw"),),
+                ports=((1, 1),),
+            ),
+        )
+        assert spec_matches_inspection(desired, inspection) is SpecVerdict.MATCH
+
+    def test_current_contract_version_override(self):
+        desired = _make_spec()
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(), version_label="5"
+        )
+        assert (
+            spec_matches_inspection(desired, inspection, current_contract_version=5)
+            is SpecVerdict.MATCH
+        )
+        assert (
+            spec_matches_inspection(desired, inspection, current_contract_version=6)
+            is SpecVerdict.UNVERIFIED
+        )
+
+    def test_newer_version_label_is_unverified(self):
+        # A label written by a newer contract version than this code
+        # currently implements: the old `<` comparison would fall through
+        # to a fingerprint/raw-unit comparison this code cannot safely make
+        # sense of; `!=` correctly reports UNVERIFIED for either direction
+        # of version mismatch.
+        desired = _make_spec()
+        inspection = _make_inspection(
+            fingerprint_label=desired.fingerprint(), version_label="2"
+        )
+        assert (
+            spec_matches_inspection(desired, inspection, current_contract_version=1)
+            is SpecVerdict.UNVERIFIED
+        )
+
+
+# --- ObservedRuntimeFacts / SandboxInspection: identity equality only ---
+
+
+class TestObservedFactsAndInspectionIdentityEquality:
+    def test_facts_equality_is_identity_not_structural(self):
+        facts = _make_facts()
+        assert (facts == dataclasses.replace(facts)) is False
+
+    def test_inspection_equality_is_identity_not_structural(self):
+        inspection = _make_inspection()
+        assert (inspection == dataclasses.replace(inspection)) is False

--- a/tests/sandbox/test_runtime_spec.py
+++ b/tests/sandbox/test_runtime_spec.py
@@ -28,6 +28,7 @@ from xagent.sandbox.base import (
     SandboxService,
     SandboxTemplate,
     SpecVerdict,
+    canonical_sandbox_path,
     spec_matches_inspection,
 )
 
@@ -151,6 +152,52 @@ class TestSpecOrderInsensitivity:
         b = _make_spec(volumes=[("/host/x/../a", "/guest/./a", "ro")])
         assert a == b
         assert a.fingerprint() == b.fingerprint()
+
+
+# --- canonical_sandbox_path: the leading-// case normpath alone keeps ---
+
+
+class TestCanonicalSandboxPath:
+    """A desired path must be spelled the way the backend reports it back.
+
+    ``posixpath.normpath`` preserves exactly two leading slashes (POSIX
+    reserves ``//`` for implementation-defined interpretation) while Docker
+    collapses them in ``Mounts.Destination`` and ``Config.WorkingDir``, so a
+    ``//``-prefixed desired path would fail create()'s
+    publish-before-verify byte comparison against a container that is in
+    fact exactly what was asked for.
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("//data/uploads", "/data/uploads"),
+            ("///data/uploads", "/data/uploads"),
+            ("//data/./uploads/../uploads", "/data/uploads"),
+            ("//", "/"),
+            ("/data/uploads", "/data/uploads"),
+            ("/data//uploads", "/data/uploads"),
+        ],
+    )
+    def test_collapses_leading_slash_run(self, raw, expected):
+        assert canonical_sandbox_path(raw) == expected
+
+    def test_double_slash_spec_equals_single_slash_spec(self):
+        a = _make_spec(volumes=[("/host/a", "/guest/a", "ro")], working_dir="/home")
+        b = _make_spec(volumes=[("//host/a", "//guest/a", "ro")], working_dir="//home")
+        assert a == b
+        assert a.fingerprint() == b.fingerprint()
+
+    def test_spec_paths_match_what_the_backend_reports_back(self):
+        """The observed side stays backend-native; the desired side is the
+        one that has to be canonical."""
+        spec = _make_spec(
+            volumes=[("//data/uploads", "//workspace", "rw")],
+            working_dir="//home",
+        )
+        # What Docker echoes for that request (leading run collapsed).
+        assert spec.volumes == (("/data/uploads", "/workspace", "rw"),)
+        assert spec.working_dir == "/home"
 
 
 # --- ResolvedSandboxRuntimeSpec: repr redaction ---

--- a/tests/sandbox/test_runtime_spec.py
+++ b/tests/sandbox/test_runtime_spec.py
@@ -21,7 +21,6 @@ from xagent.sandbox.base import (
     SandboxConfig,
     SandboxContractError,
     SandboxInspection,
-    SandboxLeaseSpec,
     SandboxReconcileUnsupportedError,
     SandboxRecoveryRequiredError,
     SandboxRuntimeConflictError,
@@ -113,6 +112,102 @@ class TestSpecFieldSensitivity:
         perturbed = _make_spec(image="python:3.11-slim")
         assert perturbed != baseline
         assert perturbed.fingerprint() != baseline.fingerprint()
+
+    def test_template_type_and_snapshot_id_are_covered(self):
+        """The two remaining fingerprint fields, which the matrix above cannot
+        perturb because ``__post_init__`` constrains them against each other."""
+        image_spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", working_dir="/home"
+        )
+        snapshot_spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="snapshot", snapshot_id="snap-1", working_dir="/home"
+        )
+        assert image_spec != snapshot_spec
+        assert image_spec.fingerprint() != snapshot_spec.fingerprint()
+
+        other_snapshot = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="snapshot", snapshot_id="snap-2", working_dir="/home"
+        )
+        assert other_snapshot != snapshot_spec
+        assert other_snapshot.fingerprint() != snapshot_spec.fingerprint()
+
+    def test_every_spec_field_is_covered_by_the_fingerprint(self):
+        """Guard against a new field arriving without fingerprint coverage.
+
+        A field that does not move the fingerprint is a field two different
+        desired states can silently share one attestation for.
+        """
+        covered = {
+            "template_type",
+            "snapshot_id",
+            "image",
+            "working_dir",
+            "cpus",
+            "memory",
+            "env",
+            "volumes",
+            "network_isolated",
+            "ports",
+        }
+        actual = {f.name for f in dataclasses.fields(ResolvedSandboxRuntimeSpec)}
+        assert actual == covered, (
+            "a spec field was added or removed; fingerprint() and the "
+            "field-sensitivity tests above must be updated to match"
+        )
+
+
+class TestSpecRejectsUnrealizableValues:
+    """The spec's constructible domain must equal what the backend can realize.
+
+    ``SandboxConfig`` constrains ``cpus`` (ge=1) and ``memory`` (ge=128), so a
+    spec outside those bounds used to construct fine and then fail pydantic
+    validation later inside ``create()`` -- surfacing at the backend boundary
+    rather than at the desired-state boundary that owns the value.
+    """
+
+    @pytest.mark.parametrize("memory", [1, 64, 127])
+    def test_memory_below_the_backend_minimum_is_rejected(self, memory):
+        with pytest.raises(ValueError, match="memory must be >= 128"):
+            _make_spec(memory=memory)
+
+    @pytest.mark.parametrize("cpus", [-1, -8])
+    def test_cpus_below_the_backend_minimum_is_rejected(self, cpus):
+        with pytest.raises(ValueError, match="cpus must be >= 1"):
+            _make_spec(cpus=cpus)
+
+    def test_the_boundary_values_are_accepted(self):
+        spec = _make_spec(cpus=1, memory=128)
+        assert (spec.cpus, spec.memory) == (1, 128)
+
+    @pytest.mark.parametrize("unset", [None, 0])
+    def test_unset_falls_back_to_the_backend_defaults(self, unset):
+        """``from_parts`` treats both ``None`` and ``0`` as "not specified",
+        matching the backend's own ``cpus or 1`` / ``memory or 512``, so
+        neither reaches the bounds check as an out-of-range value."""
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="python:3.12-slim", cpus=unset, memory=unset
+        )
+        assert (spec.cpus, spec.memory) == (1, 512)
+
+    def test_anything_constructible_converts_to_a_backend_config(self):
+        """The property the bounds exist to guarantee."""
+        _make_spec(cpus=1, memory=128).to_backend_config()
+
+    def test_direct_construction_is_validated_too(self):
+        """``__post_init__`` covers the constructor, not only ``from_parts``."""
+        with pytest.raises(ValueError, match="memory must be >= 128"):
+            ResolvedSandboxRuntimeSpec(
+                template_type="image",
+                image="python:3.12-slim",
+                snapshot_id=None,
+                working_dir="/home",
+                cpus=1,
+                memory=64,
+                env=(),
+                volumes=(),
+                network_isolated=False,
+                ports=(),
+            )
 
 
 # --- ResolvedSandboxRuntimeSpec: order insensitivity ---
@@ -349,22 +444,6 @@ class TestToBackendConfig:
         assert template.type == "snapshot"
         assert template.snapshot_id == "snap-1"
         assert template.image is None
-
-
-# --- SandboxLeaseSpec ---
-
-
-class TestSandboxLeaseSpec:
-    def test_holds_runtime_and_max_concurrency(self):
-        runtime = _make_spec()
-        lease = SandboxLeaseSpec(runtime=runtime, max_concurrency=3)
-        assert lease.runtime == runtime
-        assert lease.max_concurrency == 3
-
-    def test_is_frozen(self):
-        lease = SandboxLeaseSpec(runtime=_make_spec(), max_concurrency=1)
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            lease.max_concurrency = 5
 
 
 # --- Exceptions: never RuntimeError ---


### PR DESCRIPTION
## Summary

Adds the desired-state contract and explicit lifecycle API that sandbox reconciliation needs, as a purely additive foundation. No production caller uses the new API yet; existing sandbox behavior is unchanged.

Context: same-CA external tasks fail intermittently with `Sandbox already exists with different runtime configuration` (xorbitsai/xagent-saas#296). The root cause is that desired sandbox configuration and actually-running configuration have no shared, verifiable representation: provider cache hits skip validation, restarts adopt existing containers without checking, and stored metadata can mask actual container state. This PR introduces that representation; a follow-up PR moves `SandboxManager` onto it.

## What's added

**Types (`xagent/sandbox/base.py`)**
- `ResolvedSandboxRuntimeSpec`: canonical desired runtime configuration. Structural equality is authoritative; `fingerprint()` hashes the same structure. `from_parts()` applies the same defaults and path normalization the backend applies, so desired and actual state are produced by one normalizer.
- `ObservedRuntimeFacts` / `SandboxInspection`: observation-side types with identity equality only and no fingerprint — observed state is never comparable as if it were desired state. Facts carry raw backend units (`NanoCpus`, memory bytes) so live edits such as `docker update --cpus 0.5` stay observable.
- `SandboxMountIntent`: lexical mount classification (covered / covering / disjoint) that normalizes and never raises; consumption policy belongs to the caller.
- `spec_matches_inspection()` with a three-state verdict (`MATCH` / `MISMATCH` / `UNVERIFIED`). Containers without a spec label are `UNVERIFIED`, not `MISMATCH`: a mismatch verdict is advisory, and destruction decisions additionally require the manager's ref-count safety contract.
- `SandboxContractError` hierarchy (deliberately not `RuntimeError` subclasses, so generic runtime-error recovery paths cannot swallow contract violations) and a `supports_runtime_spec()` capability probe.

**Docker backend (`xagent/sandbox/docker_sandbox.py`)**
- `inspect()`: side-effect-free snapshot built from actual `docker inspect` data; takes no locks.
- `create()`: existence check, snapshot resolution, static volume/port conflict validation, container built from the canonical spec, spec fingerprint + contract-version labels stamped at creation, publish-before-verify (a container whose observed state does not match its own label is removed and the call raises), then the store row. Docker name-conflict races normalize to `SandboxAlreadyExistsError`.
- `start_existing()` / `stop_existing()`: idempotent, guarded by the per-name lock plus the sandbox's exclusive-access drain, converging the store row unconditionally.
- Per-name locking moved to a waiter-counted, identity-checked registry (`_named_lock`), fixing a pre-existing race where `delete()` recycled a lock while other tasks held references to it, without leaking entries in the unbounded per-task name space.
- `_SandboxControl` construction consolidated behind `_get_live_control` for lock-held paths.

**Boxlite backend**: `supports_runtime_spec()` returns `False`; the lifecycle methods keep the base default (`SandboxReconcileUnsupportedError`). The Boxlite runtime cannot prove mounts/env/network on reattach, so reconciliation is Docker-only.

## Behavior compatibility

Legacy paths (`get_or_create`, `list_sandboxes`, `delete`, `create_snapshot`, `cleanup`, `warmup`, `_merge_info`) keep their semantics. Three deliberate, bounded exceptions:
1. per-name lock registry swap (fixes the lock-identity race described above; same acquire/release semantics),
2. `delete()`'s control-map removal is now identity-checked,
3. `_create_container` gained an optional `extra_labels` parameter (legacy call site passes nothing; the label set without it is unchanged).

## Testing

- `tests/sandbox/`: 137 passed, 12 skipped (Boxlite-runtime skips), sequentially and with `-n 4 --dist=loadscope`, against a real Docker daemon. Baseline before this change: 18 passed, 12 skipped.
- New suites: spec normalization/fingerprint sensitivity, mount-intent classification, matcher verdict matrix, lock-registry race and cancellation pins, lifecycle API integration (including create-from-snapshot, publish-verification failure compensation, and conflict pre-checks), and bridge seams pinning how legacy-created containers (`UNVERIFIED`) and spec-created containers (`MATCH`) are told apart.
- `tests/web/ -k sandbox`: 157 passed.
- `pre-commit` (ruff check/format, mypy, isort, codespell): clean on all changed files.
