### PR TITLE
docs: correct branch protection to match the shipped merge queue

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -3,33 +3,16 @@
 How `main` is protected, why it is set up this way, and what to do when it
 blocks something urgent.
 
-> **Status.** Live today: the `alembic-check` hook, the required
-> `Test SQLite/PostgreSQL Migrations` checks, and the `merge_group:` triggers
-> (inert until a queue exists). Still pending, in this order:
+> **Status: the merge queue is live.** `required_status_checks.strict` is off, so
+> PRs no longer have to sync `main` by hand. Merging is now "Merge when ready",
+> which enqueues the PR; the queue validates it against the latest `main` and
+> merges it for you.
 >
-> 1. `CI Summary` as a required status check -- independent of the queue.
-> 2. Exclude `refs/heads/gh-readonly-queue/**` from the branch-creation ruleset,
->    or the queue cannot build anything.
-> 3. Enable the merge queue, **leaving `required_status_checks.strict` on**.
-> 4. Verify the queue end to end: a merge-group branch is created, and every
->    required context reports on it. An already-up-to-date PR satisfies strict, so
->    it can be enqueued for this without relaxing anything first.
-> 5. **Only now set `required_status_checks.strict` to `false`.** It is still
->    `true` on `main`, and it has to go: a PR must satisfy its branch-protection
->    requirements before it is admitted to the queue, so leaving strict on
->    permanently would keep every PR syncing `main` and re-running checks first --
->    exactly the serialization the queue exists to remove.
-> 6. `enforce_admins` -- deliberately last, once the queue is proven.
+> **The push restriction on `main` was removed to make this possible**, and
+> `block_creations` went with it. See "The cost: no push restriction" below --
+> that trade-off is the most important thing on this page.
 >
-> **The order of 3 and 5 matters.** Turning strict off first would leave a window
-> where neither protection applies: `main` would accept an approved but stale PR
-> on the strength of green checks that never saw the combined tree, which is the
-> migration race this whole change exists to prevent. If queue activation then
-> failed, the repository would be stuck in that weaker state. Keeping strict on
-> until the queue is confirmed working means the worst case is the status quo.
->
-> Sections below describe the mechanism; anything above that is still pending is
-> not in force yet. Update this block as each step lands.
+> Still pending: `CI Summary` as a required status check, and `enforce_admins`.
 
 ## What is being protected against
 
@@ -44,6 +27,9 @@ Alembic does not prevent any of this. A branched graph is legal to Alembic, and
 `ScriptDirectory.get_heads()` returns every head with no warning and no error.
 The single-head invariant is a policy this repository enforces, not something
 the tool gives us.
+
+Note that git cannot catch it either: two migrations are two different files, so
+the merge is clean. Only the graph check sees the problem.
 
 ## How it is enforced
 
@@ -60,6 +46,13 @@ check. Its regression coverage lives in
 throwaway Alembic environment and asserts the script rejects it. Those negative
 tests exist because a check that cannot fail is worse than no check: it reads as
 protection that is not there.
+
+The conflict-detection chain was verified by reconstructing the exact tree the
+queue builds: two branches each adding a migration off the same head are
+individually valid and merge without git conflict, but the combined tree fails
+both `alembic-check` ("expected exactly 1 head, found 2") and `alembic upgrade
+head` (`CommandError: Multiple head revisions are present`), and
+`detect-migration-changes` reports `should-test=true` for it.
 
 ## Why a merge queue instead of "require branches to be up to date"
 
@@ -80,23 +73,88 @@ the same column produce a valid single-head graph that still fails on upgrade.
 ### Queue configuration
 
 ```
-mergeMethod:                  SQUASH   # the only method enabled on this repo
-maxEntriesToBuild:            5        # speculative builds; this is what keeps throughput up
-maxEntriesToMerge:            1        # merge one PR at a time
-minEntriesToMerge:            1
-minEntriesToMergeWaitMinutes: 5        # inactive while minEntriesToMerge is 1
-groupingStrategy:             ALLGREEN
-checkResponseTimeoutMinutes:  60       # worst observed ci.yml run is 29.4 min
+merge_method:                      SQUASH   # the only method enabled on this repo
+max_entries_to_build:              5        # speculative builds; this is what keeps throughput up
+max_entries_to_merge:              1        # merge one PR at a time
+min_entries_to_merge:              1
+min_entries_to_merge_wait_minutes: 5        # inactive while min_entries_to_merge is 1
+grouping_strategy:                 ALLGREEN
+check_response_timeout_minutes:    60       # worst observed ci.yml run is 29.4 min
 ```
 
-`maxEntriesToMerge: 1` means every commit on `main` was validated on its own, so
-`git bisect` and reverts stay meaningful. It does not slow the queue down:
-throughput comes from `maxEntriesToBuild`, which builds later entries while
+`max_entries_to_merge: 1` means every commit on `main` was validated on its own,
+so `git bisect` and reverts stay meaningful. It does not slow the queue down:
+throughput comes from `max_entries_to_build`, which builds later entries while
 earlier ones are still being checked.
 
-`groupingStrategy` has no effect while `maxEntriesToMerge` is 1. It is set to
+`grouping_strategy` has no effect while `max_entries_to_merge` is 1. It is set to
 `ALLGREEN` so that raising the batch size later cannot silently downgrade to the
 weaker "only the group head must pass" semantics.
+
+## The cost: no push restriction
+
+**A merge queue and "Restrict who can push to matching branches" cannot both be
+enabled.** The queue merges by pushing to `main`, and it does so as
+`github-merge-queue[bot]`, which is not a repository admin. With a push
+restriction in place that push is rejected, and the entry is ejected with
+`branch_protection_failure` -- *after* every required check has gone green, which
+makes it look like a mystery.
+
+The bot cannot be added to the allowlist: `github-merge-queue` is an internal
+GitHub service, not an installable GitHub App, so it cannot be selected as a
+user, team, or app. GitHub's own answer to this is that using a merge queue
+requires granting push access, and that the protection you keep is the ban on
+force pushes.
+
+Removing the restriction also silently disabled `block_creations`, which depends
+on it. That one is close to harmless here -- it only blocked *creating* a branch
+named `main`, which cannot happen while `main` exists and `allow_deletions` is
+false -- but it is gone, and the API reports it as `false` even if a request
+tries to set it `true`.
+
+What still holds `main`:
+
+| | |
+| --- | --- |
+| `allow_force_pushes: false` | history cannot be rewritten |
+| `allow_deletions: false` | `main` cannot be deleted |
+| required status checks | `Test SQLite/PostgreSQL Migrations` |
+| required reviews | 1 approval, conversations resolved |
+| merge queue | validates the combined tree before it lands |
+
+So the exposure is that a collaborator with write access can push an ordinary
+commit straight to `main`, bypassing review. Nothing can rewrite or delete
+history. If that trade-off ever stops being acceptable, the queue has to go and
+`strict` comes back.
+
+## Gotchas worth knowing
+
+**The queue-branch exclusion needs a trailing `/*`.** Ruleset "Restrict new
+branches to main and rls" applies to `~ALL`, which does match
+`refs/heads/gh-readonly-queue/<target>/pr-N-<sha>` and rejects its creation. The
+exclusion must be spelled `refs/heads/gh-readonly-queue/**/*`;
+`refs/heads/gh-readonly-queue/**` does **not** match those refs -- GitHub's rules
+API reports zero applicable rules for them -- so that spelling looks like a fix
+while leaving every merge stalled.
+
+**A ruleset whose include and exclude are identical is rejected**, silently
+leaving the previous value in place. Check the response, do not assume the PUT
+applied.
+
+**Removal reasons are only in GraphQL.** The REST timeline event carries no
+reason; `RemovedFromMergeQueueEvent.reason` does:
+
+```bash
+gh api graphql -f query='
+query { repository(owner:"xorbitsai",name:"xagent"){ pullRequest(number:PR){
+  timelineItems(last:5, itemTypes:[REMOVED_FROM_MERGE_QUEUE_EVENT]){ nodes{
+    ... on RemovedFromMergeQueueEvent { createdAt reason } } } } } }'
+```
+
+**Merge queue is organization-only.** It cannot be configured on a
+personal-account repository -- a `merge_queue` ruleset there is rejected with
+`Invalid rule 'merge_queue'` regardless of any other setting -- so a personal
+fork cannot be used to rehearse queue changes.
 
 ### Workflows must opt in
 
@@ -105,25 +163,13 @@ Without it the context is never reported on a merge group, the entry times out,
 and **every merge stalls**. `ci.yml` and `test-migrations.yml` both carry it.
 Adding a new required check means adding that trigger first.
 
-The queue also needs to be able to create its branches: ruleset
-"Restrict new branches to main and rls" must exclude
-`refs/heads/gh-readonly-queue/**`.
-
-And `required_status_checks.strict` must end up `false`. GitHub tracks the
-up-to-date requirement separately from the queue, and a PR has to satisfy its
-branch-protection requirements before it is admitted -- so leaving strict on
-keeps every PR syncing `main` by hand before it can even enter the queue.
-
-Turn it off *after* the queue is confirmed working, not before; see the ordering
-note in the status block above.
-
 ## Break-glass (`enforce_admins` pending)
 
-Pushes to `main` are restricted with an empty allowlist, so nobody can push
-directly. `enforce_admins` is **not yet enabled**: until it is, administrators
-can still merge around the required checks, and this procedure is not needed.
+`enforce_admins` is **not yet enabled**, so administrators can still merge around
+the required checks and this procedure is not needed today. It is documented for
+when that changes.
 
-Once it is enabled, nobody -- administrators included -- can bypass the required
+Once enabled, nobody -- administrators included -- can bypass the required
 checks, and the only override is to disable admin enforcement, merge, and
 immediately re-enable it.
 
@@ -145,8 +191,7 @@ Merge the PR, then restore immediately:
 gh api -X POST repos/xorbitsai/xagent/branches/main/protection/enforce_admins
 ```
 
-Use these dedicated endpoints rather than `PUT .../protection`. The full-object
-PUT replaces the entire configuration, and omitting the empty-allowlist
-`restrictions` block silently removes the push restriction with no error.
+Use these dedicated endpoints rather than `PUT .../protection`, which replaces
+the entire configuration -- any field left out of the body is cleared.
 
 Say in the PR why the override was used, so it stays auditable.

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -145,11 +145,15 @@ applied.
 reason; `RemovedFromMergeQueueEvent.reason` does:
 
 ```bash
-gh api graphql -f query='
-query { repository(owner:"xorbitsai",name:"xagent"){ pullRequest(number:PR){
+gh api graphql -F number=PR_NUMBER -f query='
+query($number: Int!) { repository(owner:"xorbitsai",name:"xagent"){ pullRequest(number:$number){
   timelineItems(last:5, itemTypes:[REMOVED_FROM_MERGE_QUEUE_EVENT]){ nodes{
     ... on RemovedFromMergeQueueEvent { createdAt reason } } } } } }'
 ```
+
+Note that a *successful* merge also emits a removal event, with
+`reason: merged`. "Removed from merge queue" on its own says nothing about
+whether anything went wrong — read the reason.
 
 **Merge queue is organization-only.** It cannot be configured on a
 personal-account repository -- a `merge_queue` ruleset there is rejected with

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -8,9 +8,10 @@ blocks something urgent.
 > which enqueues the PR; the queue validates it against the latest `main` and
 > merges it for you.
 >
-> **The push restriction on `main` was removed to make this possible**, and
-> `block_creations` went with it. See "The cost: no push restriction" below --
-> that trade-off is the most important thing on this page.
+> **The push restriction on `main` was removed to make this possible**, so
+> merging is no longer limited to administrators, and `block_creations` went
+> with it. See "The cost: merging is no longer admin-only" below -- that
+> trade-off is the most important thing on this page.
 >
 > Still pending: `CI Summary` as a required status check, and `enforce_admins`.
 
@@ -91,7 +92,7 @@ earlier ones are still being checked.
 `ALLGREEN` so that raising the batch size later cannot silently downgrade to the
 weaker "only the group head must pass" semantics.
 
-## The cost: no push restriction
+## The cost: merging is no longer admin-only
 
 **A merge queue and "Restrict who can push to matching branches" cannot both be
 enabled.** The queue merges by pushing to `main`, and it does so as
@@ -103,8 +104,7 @@ makes it look like a mystery.
 The bot cannot be added to the allowlist: `github-merge-queue` is an internal
 GitHub service, not an installable GitHub App, so it cannot be selected as a
 user, team, or app. GitHub's own answer to this is that using a merge queue
-requires granting push access, and that the protection you keep is the ban on
-force pushes.
+means granting push access to the branch.
 
 Removing the restriction also silently disabled `block_creations`, which depends
 on it. That one is close to harmless here -- it only blocked *creating* a branch
@@ -112,20 +112,50 @@ named `main`, which cannot happen while `main` exists and `allow_deletions` is
 false -- but it is gone, and the API reports it as `false` even if a request
 tries to set it `true`.
 
+### What actually changed, precisely
+
+The removed `restrictions` was an **empty allowlist** (`users: []`, `teams: []`,
+`apps: []`). Combined with `enforce_admins: false`, that meant only
+administrators could merge anything into `main` -- which is why, before the
+rollout, every merge on the branch was performed by an admin.
+
+| | before | after |
+| --- | --- | --- |
+| direct push by a write collaborator | rejected | rejected |
+| direct push by an administrator | allowed (`enforce_admins: false`) | allowed (unchanged) |
+| merging an approved PR, write collaborator | rejected -- not on the allowlist | allowed |
+| merging an approved PR, administrator | allowed | allowed |
+
+**Direct pushes by ordinary collaborators were not what `restrictions` was
+holding back, and they are still blocked.** That gate is
+`required_pull_request_reviews`: with it enabled, a write collaborator can only
+change `main` through a pull request carrying the required approval.
+`restrictions` was a second, narrower gate layered on top, and what it gated was
+*who may perform the merge*.
+
+So the change is that merging widened from administrators to all write
+collaborators -- still by way of an approved PR, resolved conversations, and the
+required checks. That is the intended effect, not a side effect: self-service
+merging is the point of the queue.
+
 What still holds `main`:
 
 | | |
 | --- | --- |
+| `required_pull_request_reviews` | no change to `main` outside a PR; 1 approval, conversations resolved |
+| required status checks | `Test SQLite/PostgreSQL Migrations` |
+| merge queue | validates the combined tree before it lands |
 | `allow_force_pushes: false` | history cannot be rewritten |
 | `allow_deletions: false` | `main` cannot be deleted |
-| required status checks | `Test SQLite/PostgreSQL Migrations` |
-| required reviews | 1 approval, conversations resolved |
-| merge queue | validates the combined tree before it lands |
 
-So the exposure is that a collaborator with write access can push an ordinary
-commit straight to `main`, bypassing review. Nothing can rewrite or delete
-history. If that trade-off ever stops being acceptable, the queue has to go and
-`strict` comes back.
+The one bypass left is an administrator, because `enforce_admins` is `false` --
+and that was equally true before the rollout. Closing it is a matter of enabling
+`enforce_admins`; it does not require giving up the queue.
+
+If narrowing merge permission back to a named set ever becomes necessary, the
+lever is `restrictions`, and restoring it means giving up the queue. `strict` is
+not that lever -- it governs whether a PR must be up to date, not who may merge
+or whether a PR is required at all.
 
 ## Gotchas worth knowing
 
@@ -153,7 +183,7 @@ query($number: Int!) { repository(owner:"xorbitsai",name:"xagent"){ pullRequest(
 
 Note that a *successful* merge also emits a removal event, with
 `reason: merged`. "Removed from merge queue" on its own says nothing about
-whether anything went wrong — read the reason.
+whether anything went wrong -- read the reason.
 
 **Merge queue is organization-only.** It cannot be configured on a
 personal-account repository -- a `merge_queue` ruleset there is rejected with


### PR DESCRIPTION
The merge queue is now live on `main` and `required_status_checks.strict` is off.
`docs/branch-protection.md` landed in #1005 describing both as pending, so it is
now wrong about the current configuration — and one of the things it is wrong
about is a security control.

## The urgent part

The page states:

> Pushes to `main` are restricted with an empty allowlist, so nobody can push
> directly.

That restriction was removed during rollout. A document that claims a protection
which no longer exists is worse than no document, so this corrects it.

## Why the restriction had to go

**A merge queue and "Restrict who can push to matching branches" cannot both be
enabled.** The queue merges by pushing to `main` as `github-merge-queue[bot]`,
which is not a repository admin, so a push restriction rejects it. The entry is
then ejected with `branch_protection_failure` — *after* every required check has
gone green, which makes it look like an unrelated fault.

The bot cannot be added to the allowlist: `github-merge-queue` is an internal
GitHub service, not an installable App, so it is not selectable as a user, team,
or app. GitHub's own position on this is that using a merge queue means granting
push access, and that the protection you keep is the ban on force pushes.

Removing the restriction also silently disabled `block_creations`, which depends
on it — the API reports `false` even when a request sets it `true`. Low impact
here (it only blocked creating a branch named `main`, which cannot happen while
`main` exists and `allow_deletions` is false), but it is recorded rather than
glossed over.

What still holds `main`: no force pushes, no deletions, both migration checks
required, one approval plus resolved conversations, and the queue validating the
combined tree before it lands. The exposure is that a write collaborator can push
an ordinary commit straight to `main`, bypassing review; nothing can rewrite or
delete history.

## Gotchas recorded

Each of these presents as a silent failure, and each cost real time to find:

* **`refs/heads/gh-readonly-queue/**` does not match the queue's refs.** The
  exclusion needs a trailing `/*`. GitHub's rules API reports zero applicable
  rules for the short spelling, so it looks like a fix while leaving every merge
  stalled. `~ALL` does match those refs, and the `creation` rule does reject them
  (HTTP 422) — the blocker is real.
* **A ruleset whose include and exclude are identical is rejected** and the
  previous value stays in place, with no error surfaced by `--jq` on the happy
  path. Check the response.
* **Removal reasons exist only in GraphQL.** The REST timeline event has no
  reason field; `RemovedFromMergeQueueEvent.reason` does. Without it the
  ejections are indistinguishable from a timeout.
* **Merge queue is organization-only.** A `merge_queue` ruleset on a personal
  repository is rejected with `Invalid rule 'merge_queue'` regardless of any
  other setting, so a personal fork cannot be used to rehearse queue changes.

## Verification

Every configuration value quoted here was checked against the live settings
rather than written from memory.

The conflict-detection chain was verified by reconstructing the exact tree the
queue builds: two branches each adding a migration off the same head are
individually valid and merge with no git conflict, but the combined tree fails
`alembic-check` ("expected exactly 1 head, found 2") and `alembic upgrade head`
(`CommandError: Multiple head revisions are present`), and
`detect-migration-changes` reports `should-test=true` for it. The one link not
directly exercised is the queue ejecting on that failure; it is documented
behaviour and the queue was observed ejecting entries three times during
rollout.

Docs only — no configuration changes in this PR.
