### PR TITLE
ci: add a fail-closed Migrations Summary check

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -204,3 +204,44 @@ jobs:
           pytest tests/web/services/test_gmail_provisioning.py -k contend -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+  migrations-summary:
+    name: Migrations Summary
+    runs-on: ubuntu-latest
+    # always() is what makes this fail-closed. Without it a failure in
+    # detect-migration-changes would skip this job too, and a *skipped* required
+    # check is reported to branch protection as a success -- so the merge would
+    # go through with neither migration job having run. The individual job names
+    # cannot be required contexts for the same reason; this one can, because it
+    # always runs and turns every non-success into an explicit failure.
+    if: always()
+    needs:
+      - detect-migration-changes
+      - test-sqlite-migrations
+      - test-postgresql-migrations
+
+    steps:
+      - name: Check required jobs
+        shell: bash
+        env:
+          DETECT_RESULT: ${{ needs.detect-migration-changes.result }}
+          SQLITE_RESULT: ${{ needs.test-sqlite-migrations.result }}
+          POSTGRESQL_RESULT: ${{ needs.test-postgresql-migrations.result }}
+        run: |
+          set -uo pipefail
+
+          failed=0
+          check_job() {
+            local name="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::$name finished with result: $result"
+              failed=1
+            fi
+          }
+
+          check_job "detect-migration-changes" "$DETECT_RESULT"
+          check_job "test-sqlite-migrations" "$SQLITE_RESULT"
+          check_job "test-postgresql-migrations" "$POSTGRESQL_RESULT"
+
+          exit "$failed"


### PR DESCRIPTION
`Test SQLite Migrations` and `Test PostgreSQL Migrations` are the required
status checks on `main`. Requiring individual job names is not fail-closed: a
**skipped** job is reported to branch protection as a success, so if
`detect-migration-changes` ever fails, both jobs are skipped, both contexts go
green, and the merge proceeds with no migration check having run.

This adds a `Migrations Summary` job that always runs and turns any non-success
into an explicit failure, so it can be the required context instead.

## Why a skipped check passes

GitHub documents this in "Troubleshooting required status checks", in the table
"Handling skipped but required checks":

* a job skipped by a conditional -- "The job reports 'Success'"
* a job whose `needs` dependency failed -- "The dependent job is skipped and may
  not block merging", with the stated fix being to "use `always()` with `needs`
  for required checks that depend on other jobs"

Successful check statuses are `success`, `skipped`, and `neutral`. Only a
workflow that never triggers at all stays pending and blocks.

This was found during review of the equivalent change on the SaaS repository,
where the same pattern is considerably more reachable. Here the exposure is
narrower -- `detect-migration-changes` is a checkout and a `git diff`, and the
two test jobs carry no job-level `if:`, so they run whenever the detect job
succeeds -- but narrower is not closed, and the merge queue makes a silently
green required check materially worse.

## What the new job does

`Migrations Summary` declares `if: always()` and `needs` all three jobs, then
fails unless every one of them reports `success`. `skipped`, `failure`,
`cancelled` and an empty result all fail.

`always()` is the whole point and is commented as such in the file, because
removing it looks harmless and silently restores the hole.

Job results are passed through `env:` rather than interpolated into the script
body, matching how `detect-migration-changes` already handles its inputs in this
file.

## Verification

The step's `run` script was extracted verbatim from the workflow and exercised
against each result combination:

| detect | sqlite | postgresql | exit |
| --- | --- | --- | --- |
| success | success | success | 0 |
| failure | skipped | skipped | 1 |
| success | failure | success | 1 |
| success | success | failure | 1 |
| success | skipped | success | 1 |
| cancelled | cancelled | cancelled | 1 |
| success | success | *(empty)* | 1 |

Row two is the case this PR exists for. Every failing row names the offending
job in its `::error::` output.

actionlint reports no new findings; the two `actions/setup-python@v4` warnings
it emits are byte-for-byte identical before and after this change.

## Follow-up, not included here

Merging this does not close anything on its own -- the required contexts on
`main` still point at the two job names. The protection change is a separate
step, and it has to come after this so the new context exists and has reported:

1. this PR
2. change the required contexts on `main` from `Test SQLite Migrations` +
   `Test PostgreSQL Migrations` to `Migrations Summary`
3. add `CI Summary` as a required context (already pending independently -- today
   a PR with red pytest, e2e or pre-commit is still mergeable)

`docs/branch-protection.md` names the current contexts and will be updated when
step 2 lands, to avoid colliding with #1008 which is still open against that
file.
