### PR TITLE
fix: stage uploaded files off the event loop

### DIFF
--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -301,7 +301,7 @@ def _delete_staged_upload(path: Path) -> None:
 
     try:
         path.unlink(missing_ok=True)
-    except BaseException:
+    except OSError:
         logger.warning("Failed to clean up local upload: %s", path)
 
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -311,7 +311,7 @@ def _reserve_and_copy_upload(
     task_id: str | None,
     folder: str | None,
     user_id: int,
-) -> tuple[Path, int]:
+) -> Path:
     """Reserve one local upload path and copy bytes through its descriptor.
 
     This synchronous worker owns path construction, exclusive reservation, and
@@ -357,7 +357,7 @@ def _reserve_and_copy_upload(
         except BaseException:
             _delete_staged_upload(candidate)
             raise
-        return candidate, total_size
+        return candidate
 
 
 async def _stage_uploaded_file(
@@ -367,8 +367,8 @@ async def _stage_uploaded_file(
     folder: str | None,
     user_id: int,
     written_paths: list[Path],
-) -> tuple[Path, int]:
-    """Run local staging off-loop and drain exact cleanup on cancellation."""
+) -> Path:
+    """Run local staging off-loop and publish its path to request cleanup."""
 
     worker = asyncio.create_task(
         asyncio.to_thread(
@@ -379,17 +379,13 @@ async def _stage_uploaded_file(
             user_id=user_id,
         )
     )
-    (target_path, file_size), cancellation = await await_task_settlement(worker)
+    target_path, cancellation = await await_task_settlement(worker)
     # The request cleanup owner knows this exact path before any subsequent
     # preview, registration, or cancellation-cleanup await point.
     written_paths.append(target_path)
     if cancellation is not None:
-        cleanup_worker = asyncio.create_task(
-            asyncio.to_thread(_delete_staged_upload, target_path)
-        )
-        await drain_async_task_cancellation_safe(cleanup_worker)
         raise cancellation
-    return target_path, file_size
+    return target_path
 
 
 async def store_uploaded_files(
@@ -428,7 +424,7 @@ async def store_uploaded_files(
                 )
 
             try:
-                target_path, _file_size = await _stage_uploaded_file(
+                target_path = await _stage_uploaded_file(
                     uploaded,
                     task_id=task_id,
                     folder=folder,
@@ -526,13 +522,7 @@ async def store_uploaded_files(
 
                     def _delete_local_paths() -> None:
                         for path in written_paths:
-                            try:
-                                path.unlink(missing_ok=True)
-                            except OSError:
-                                logger.warning(
-                                    "Failed to clean up local upload: %s",
-                                    path,
-                                )
+                            _delete_staged_upload(path)
 
                     cleanup_worker = asyncio.create_task(
                         asyncio.to_thread(_delete_local_paths)

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -43,6 +43,7 @@ from ..models.task import Task
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..services.db_runtime import (
+    await_task_settlement,
     drain_async_task_cancellation_safe,
     run_db_io_cancellation_safe,
 )
@@ -288,35 +289,107 @@ def _accel_redirect_response(
     )
 
 
-async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path) -> int:
-    """Persist an uploaded file while enforcing the configured size limit."""
-    total_size = 0
-    read_buffer_size = 1024 * 1024  # 1MB chunks keep memory bounded for large files.
+_UPLOAD_COPY_BUFFER_SIZE = 1024 * 1024
+
+
+class _InvalidUploadPathError(ValueError):
+    """Path-construction validation failure for a request upload."""
+
+
+def _delete_staged_upload(path: Path) -> None:
+    """Best-effort removal which never replaces the staging failure."""
 
     try:
-        with open(target_path, "wb") as buffer:
-            while True:
-                chunk = await uploaded.read(read_buffer_size)
-                if not chunk:
-                    break
-                total_size += len(chunk)
-                if total_size > MAX_FILE_SIZE:
-                    raise HTTPException(
-                        status_code=413,
-                        detail=(
-                            f"File size exceeds maximum limit of {MAX_FILE_SIZE_LABEL}"
-                        ),
-                    )
-                buffer.write(chunk)
+        path.unlink(missing_ok=True)
     except BaseException:
-        try:
-            if target_path.exists():
-                target_path.unlink()
-        except OSError:
-            pass
-        raise
+        logger.warning("Failed to clean up local upload: %s", path)
 
-    return total_size
+
+def _reserve_and_copy_upload(
+    uploaded: UploadFile,
+    *,
+    task_id: str | None,
+    folder: str | None,
+    user_id: int,
+) -> tuple[Path, int]:
+    """Reserve one local upload path and copy bytes through its descriptor.
+
+    This synchronous worker owns path construction, exclusive reservation, and
+    bounded source reads. A collision is only a ``FileExistsError`` raised by
+    the exclusive create itself; errors from source reads or destination writes
+    remain I/O failures and clean the exact reserved candidate.
+    """
+
+    try:
+        path = get_upload_path(uploaded.filename or "", task_id, folder, user_id)
+    except ValueError as exc:
+        raise _InvalidUploadPathError(str(exc)) from exc
+    stem = path.stem
+    suffix = path.suffix
+    candidate = path
+    suffix_index = 1
+
+    while True:
+        try:
+            destination = open(candidate, "xb")
+        except FileExistsError:
+            candidate = path.parent / f"{stem}_{suffix_index}{suffix}"
+            suffix_index += 1
+            continue
+
+        total_size = 0
+        try:
+            with destination:
+                while True:
+                    chunk = uploaded.file.read(_UPLOAD_COPY_BUFFER_SIZE)
+                    if not chunk:
+                        break
+                    total_size += len(chunk)
+                    if total_size > MAX_FILE_SIZE:
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(
+                                f"File size exceeds maximum limit of "
+                                f"{MAX_FILE_SIZE_LABEL}"
+                            ),
+                        )
+                    destination.write(chunk)
+        except BaseException:
+            _delete_staged_upload(candidate)
+            raise
+        return candidate, total_size
+
+
+async def _stage_uploaded_file(
+    uploaded: UploadFile,
+    *,
+    task_id: str | None,
+    folder: str | None,
+    user_id: int,
+    written_paths: list[Path],
+) -> tuple[Path, int]:
+    """Run local staging off-loop and drain exact cleanup on cancellation."""
+
+    worker = asyncio.create_task(
+        asyncio.to_thread(
+            _reserve_and_copy_upload,
+            uploaded,
+            task_id=task_id,
+            folder=folder,
+            user_id=user_id,
+        )
+    )
+    (target_path, file_size), cancellation = await await_task_settlement(worker)
+    # The request cleanup owner knows this exact path before any subsequent
+    # preview, registration, or cancellation-cleanup await point.
+    written_paths.append(target_path)
+    if cancellation is not None:
+        cleanup_worker = asyncio.create_task(
+            asyncio.to_thread(_delete_staged_upload, target_path)
+        )
+        await drain_async_task_cancellation_safe(cleanup_worker)
+        raise cancellation
+    return target_path, file_size
 
 
 async def store_uploaded_files(
@@ -355,18 +428,20 @@ async def store_uploaded_files(
                 )
 
             try:
-                target_path = _build_unique_file_path(
-                    get_upload_path(uploaded.filename, task_id, folder, user_id)
+                target_path, _file_size = await _stage_uploaded_file(
+                    uploaded,
+                    task_id=task_id,
+                    folder=folder,
+                    user_id=user_id,
+                    written_paths=written_paths,
                 )
-            except ValueError as e:
+            except _InvalidUploadPathError as e:
                 logger.warning(f"Invalid folder name rejected: {folder!r} - {e}")
                 raise HTTPException(
                     status_code=422, detail=f"Invalid folder name: {str(e)}"
                 ) from e
 
-            written_paths.append(target_path)
             file_id = str(uuid4())
-            await _write_upload_with_size_limit(uploaded, target_path)
 
             content_preview = ""
             file_extension = Path(uploaded.filename).suffix.lower()
@@ -513,20 +588,6 @@ def _parse_task_id(task_id: Optional[str]) -> Optional[int]:
         return int(task_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Invalid task_id") from exc
-
-
-def _build_unique_file_path(path: Path) -> Path:
-    if not path.exists():
-        return path
-    stem = path.stem
-    suffix = path.suffix
-    parent = path.parent
-    i = 1
-    while True:
-        candidate = parent / f"{stem}_{i}{suffix}"
-        if not candidate.exists():
-            return candidate
-        i += 1
 
 
 def _ensure_under_uploads(path: Path, user_id: int) -> None:

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import io
 import threading
+import time
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 from fastapi.datastructures import UploadFile
 
 from xagent.core.file_storage.factory import get_unscoped_file_storage
@@ -68,6 +71,430 @@ def _record_durable_pool_ownership(
 
     monkeypatch.setattr(ManagedFileRef, "sync_to_durable", recording_sync)
     return checked_out
+
+
+def _stage_path_in(root: Path, user_id: int):
+    """Return a shared deterministic staging candidate for collision tests."""
+
+    def get_upload_path(
+        filename: str,
+        task_id: str | None,
+        folder: str | None,
+        requested_user_id: int,
+    ) -> Path:
+        del task_id, folder
+        assert requested_user_id == user_id
+        path = root / f"user_{user_id}" / Path(filename).name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    return get_upload_path
+
+
+class _SlowTrackingSource(io.BytesIO):
+    """A synchronous source that reveals an accidental event-loop read."""
+
+    def __init__(self, payload: bytes, delay_seconds: float) -> None:
+        super().__init__(payload)
+        self._rolled = False
+        self.delay_seconds = delay_seconds
+        self.read_threads: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_threads.append(threading.get_ident())
+        time.sleep(self.delay_seconds)
+        return super().read(size)
+
+
+class _BlockingSource(io.BytesIO):
+    """Hold a worker-owned read until a cancellation test releases it."""
+
+    def __init__(self, payload: bytes) -> None:
+        super().__init__(payload)
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def read(self, size: int = -1) -> bytes:
+        self.started.set()
+        assert self.release.wait(timeout=2)
+        return super().read(size)
+
+
+def _admin_user_id() -> int:
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        return int(db.query(User.id).filter(User.username == "admin").scalar())
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_name_uploads_reserve_distinct_paths_and_contents(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_upload_storage,
+) -> None:
+    """The shared staging boundary must make naming reservation atomic."""
+
+    upload_root, _object_root = isolated_upload_storage
+    user_id = _admin_user_id()
+    monkeypatch.setattr(
+        files_api, "get_upload_path", _stage_path_in(upload_root, user_id)
+    )
+
+    writes_started = 0
+    both_writes_started = asyncio.Event()
+
+    async def interleaved_write(upload, target_path):  # type: ignore[no-untyped-def]
+        nonlocal writes_started
+        writes_started += 1
+        if writes_started == 2:
+            both_writes_started.set()
+        await both_writes_started.wait()
+        payload = await upload.read()
+        target_path.write_bytes(payload)
+        return len(payload)
+
+    monkeypatch.setattr(
+        files_api,
+        "_write_upload_with_size_limit",
+        interleaved_write,
+        raising=False,
+    )
+    first = UploadFile(
+        filename="same-name.txt",
+        file=io.BytesIO(b"first exact contents"),
+        headers={"content-type": "text/plain"},
+    )
+    second = UploadFile(
+        filename="same-name.txt",
+        file=io.BytesIO(b"second exact contents"),
+        headers={"content-type": "text/plain"},
+    )
+
+    await asyncio.gather(
+        files_api.store_uploaded_files(
+            upload_items=[first],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        ),
+        files_api.store_uploaded_files(
+            upload_items=[second],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        ),
+    )
+
+    staged = sorted((upload_root / f"user_{user_id}").glob("same-name*.txt"))
+    assert len(staged) == 2
+    assert {path.read_bytes() for path in staged} == {
+        b"first exact contents",
+        b"second exact contents",
+    }
+
+
+@pytest.mark.asyncio
+async def test_staging_copy_reads_off_loop_with_no_database_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_upload_storage,
+) -> None:
+    """Slow synchronous upload reads must not stall the request loop or hold DB."""
+
+    upload_root, _object_root = isolated_upload_storage
+    user_id = _admin_user_id()
+    monkeypatch.setattr(
+        files_api, "get_upload_path", _stage_path_in(upload_root, user_id)
+    )
+    engine = _install_one_slot_queue_pool(monkeypatch)
+    source = _SlowTrackingSource(b"bounded-copy", delay_seconds=0.05)
+    upload = UploadFile(
+        filename="off-loop.txt",
+        file=source,
+        headers={"content-type": "text/plain"},
+    )
+    loop_thread = threading.get_ident()
+    started_at = asyncio.get_running_loop().time()
+    task = asyncio.create_task(
+        files_api.store_uploaded_files(
+            upload_items=[upload],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        )
+    )
+    try:
+        await asyncio.sleep(0.01)
+        assert asyncio.get_running_loop().time() - started_at < 0.04
+        assert engine.pool.checkedout() == 0
+        await task
+        assert source.read_threads
+        assert all(thread_id != loop_thread for thread_id in source.read_threads)
+        assert engine.pool.checkedout() == 0
+    finally:
+        engine.dispose()
+
+
+def test_reserve_and_copy_enforces_max_size_and_cleans_partial_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The worker returns an exact size and removes MAX+1 partial output."""
+
+    monkeypatch.setattr(files_api, "MAX_FILE_SIZE", 4)
+    monkeypatch.setattr(files_api, "MAX_FILE_SIZE_LABEL", "4B")
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+
+    exact_path, exact_size = files_api._reserve_and_copy_upload(
+        UploadFile(filename="exact.txt", file=io.BytesIO(b"1234")),
+        task_id=None,
+        folder=None,
+        user_id=user_id,
+    )
+    assert exact_size == 4
+    assert exact_path.read_bytes() == b"1234"
+
+    with pytest.raises(HTTPException, match="maximum limit"):
+        files_api._reserve_and_copy_upload(
+            UploadFile(filename="too-large.txt", file=io.BytesIO(b"12345")),
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+        )
+    assert not (tmp_path / f"user_{user_id}" / "too-large.txt").exists()
+
+
+def test_reserve_and_copy_does_not_mistake_source_file_exists_error_for_collision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only an exclusive-open collision may select the next candidate."""
+
+    class SourceThatFailsWithFileExists:
+        def read(self, _size: int = -1) -> bytes:
+            raise FileExistsError("source read failure")
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    with pytest.raises(FileExistsError, match="source read failure"):
+        files_api._reserve_and_copy_upload(
+            UploadFile(
+                filename="source-error.txt", file=SourceThatFailsWithFileExists()
+            ),
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+        )
+    assert not list(tmp_path.rglob("source-error*"))
+
+
+def test_reserve_and_copy_cleans_exact_file_after_write_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """I/O errors after reservation must not leave an empty staged file."""
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    original_open = builtins.open
+
+    class FailingWriter:
+        def __init__(self, buffer) -> None:  # type: ignore[no-untyped-def]
+            self.buffer = buffer
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *args) -> None:  # type: ignore[no-untyped-def]
+            self.buffer.close()
+
+        def write(self, _chunk: bytes) -> int:
+            raise OSError("write failed")
+
+    def failing_open(path, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        buffer = original_open(path, mode, *args, **kwargs)
+        return FailingWriter(buffer) if "x" in mode else buffer
+
+    monkeypatch.setattr(builtins, "open", failing_open)
+    with pytest.raises(OSError, match="write failed"):
+        files_api._reserve_and_copy_upload(
+            UploadFile(filename="write-error.txt", file=io.BytesIO(b"payload")),
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+        )
+    assert not (tmp_path / f"user_{user_id}" / "write-error.txt").exists()
+
+
+def test_reserve_and_copy_propagates_open_error_without_creating_an_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exclusive-open failures are I/O failures, never candidate collisions."""
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+
+    def failing_open(*_args, **_kwargs) -> None:  # type: ignore[no-untyped-def]
+        raise PermissionError("open denied")
+
+    monkeypatch.setattr(builtins, "open", failing_open)
+    with pytest.raises(PermissionError, match="open denied"):
+        files_api._reserve_and_copy_upload(
+            UploadFile(filename="open-error.txt", file=io.BytesIO(b"payload")),
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+        )
+    assert not list(tmp_path.rglob("open-error*"))
+
+
+@pytest.mark.asyncio
+async def test_store_uploaded_files_preserves_source_value_error_and_cleans_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A source failure is not a client folder-validation error."""
+
+    class SourceThatFailsWithValueError:
+        def read(self, _size: int = -1) -> bytes:
+            raise ValueError("source read failure")
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+
+    with pytest.raises(ValueError, match="source read failure"):
+        await files_api.store_uploaded_files(
+            upload_items=[
+                UploadFile(
+                    filename="source-value-error.txt",
+                    file=SourceThatFailsWithValueError(),
+                )
+            ],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        )
+
+    assert not list(tmp_path.rglob("source-value-error*"))
+
+
+@pytest.mark.asyncio
+async def test_store_uploaded_files_preserves_write_value_error_and_cleans_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A destination failure is not a client folder-validation error."""
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    original_open = builtins.open
+
+    class ValueErrorWriter:
+        def __init__(self, buffer) -> None:  # type: ignore[no-untyped-def]
+            self.buffer = buffer
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *args) -> None:  # type: ignore[no-untyped-def]
+            self.buffer.close()
+
+        def write(self, _chunk: bytes) -> int:
+            raise ValueError("destination write failure")
+
+    def failing_open(path, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        buffer = original_open(path, mode, *args, **kwargs)
+        return ValueErrorWriter(buffer) if "x" in mode else buffer
+
+    monkeypatch.setattr(builtins, "open", failing_open)
+
+    with pytest.raises(ValueError, match="destination write failure"):
+        await files_api.store_uploaded_files(
+            upload_items=[
+                UploadFile(
+                    filename="write-value-error.txt",
+                    file=io.BytesIO(b"payload"),
+                )
+            ],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        )
+
+    assert not list(tmp_path.rglob("write-value-error*"))
+
+
+@pytest.mark.asyncio
+async def test_store_uploaded_files_maps_path_validation_error_to_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only path construction turns a validation error into a client 422."""
+
+    def invalid_upload_path(*_args, **_kwargs) -> Path:  # type: ignore[no-untyped-def]
+        raise ValueError("invalid folder")
+
+    monkeypatch.setattr(files_api, "get_upload_path", invalid_upload_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await files_api.store_uploaded_files(
+            upload_items=[
+                UploadFile(
+                    filename="invalid-folder.txt",
+                    file=io.BytesIO(b"payload"),
+                )
+            ],
+            task_type="general",
+            task_id=None,
+            folder="bad-folder",
+            user_id=7,
+            single_file_mode=True,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Invalid folder name: invalid folder"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_staging_worker_deletes_its_exact_late_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation drains copy, deletes its returned path, then propagates."""
+
+    user_id = 7
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    source = _BlockingSource(b"late worker result")
+    written_paths: list[Path] = []
+    task = asyncio.create_task(
+        files_api._stage_uploaded_file(
+            UploadFile(filename="cancelled.txt", file=source),
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            written_paths=written_paths,
+        )
+    )
+    assert await asyncio.to_thread(source.started.wait, 2)
+    task.cancel()
+    source.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert written_paths == [tmp_path / f"user_{user_id}" / "cancelled.txt"]
+    assert not written_paths[0].exists()
 
 
 def test_jwt_upload_releases_auth_session_before_durable_io(

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -357,6 +357,52 @@ def test_reserve_and_copy_propagates_open_error_without_creating_an_artifact(
     assert not list(tmp_path.rglob("open-error*"))
 
 
+@pytest.mark.parametrize(
+    "control_error",
+    [SystemExit("stop"), KeyboardInterrupt()],
+    ids=["system-exit", "keyboard-interrupt"],
+)
+def test_delete_staged_upload_preserves_process_control(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    control_error: BaseException,
+) -> None:
+    """Best-effort cleanup must not suppress process-control exceptions."""
+
+    def interrupting_unlink(
+        _path: Path,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        del missing_ok
+        raise control_error
+
+    monkeypatch.setattr(Path, "unlink", interrupting_unlink)
+    with pytest.raises(BaseException) as raised:
+        files_api._delete_staged_upload(tmp_path / "staged.txt")
+    assert raised.value is control_error
+
+
+def test_delete_staged_upload_suppresses_operational_unlink_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unlink failure is logged without replacing the staging failure."""
+
+    def failing_unlink(
+        _path: Path,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        del missing_ok
+        raise OSError("unlink failed")
+
+    monkeypatch.setattr(Path, "unlink", failing_unlink)
+    files_api._delete_staged_upload(tmp_path / "staged.txt")
+    assert "Failed to clean up local upload" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_store_uploaded_files_preserves_source_value_error_and_cleans_candidate(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -142,24 +142,22 @@ async def test_concurrent_same_name_uploads_reserve_distinct_paths_and_contents(
         files_api, "get_upload_path", _stage_path_in(upload_root, user_id)
     )
 
-    writes_started = 0
-    both_writes_started = asyncio.Event()
+    original_reserve = files_api._reserve_and_copy_upload
+    workers_started = 0
+    workers_ready = threading.Barrier(2)
+    workers_lock = threading.Lock()
 
-    async def interleaved_write(upload, target_path):  # type: ignore[no-untyped-def]
-        nonlocal writes_started
-        writes_started += 1
-        if writes_started == 2:
-            both_writes_started.set()
-        await both_writes_started.wait()
-        payload = await upload.read()
-        target_path.write_bytes(payload)
-        return len(payload)
+    def synchronized_reserve(upload, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal workers_started
+        with workers_lock:
+            workers_started += 1
+        workers_ready.wait(timeout=2)
+        return original_reserve(upload, **kwargs)
 
     monkeypatch.setattr(
         files_api,
-        "_write_upload_with_size_limit",
-        interleaved_write,
-        raising=False,
+        "_reserve_and_copy_upload",
+        synchronized_reserve,
     )
     first = UploadFile(
         filename="same-name.txt",
@@ -192,6 +190,7 @@ async def test_concurrent_same_name_uploads_reserve_distinct_paths_and_contents(
     )
 
     staged = sorted((upload_root / f"user_{user_id}").glob("same-name*.txt"))
+    assert workers_started == 2
     assert len(staged) == 2
     assert {path.read_bytes() for path in staged} == {
         b"first exact contents",

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -96,7 +96,6 @@ class _SlowTrackingSource(io.BytesIO):
 
     def __init__(self, payload: bytes, delay_seconds: float) -> None:
         super().__init__(payload)
-        self._rolled = False
         self.delay_seconds = delay_seconds
         self.read_threads: list[int] = []
 
@@ -121,6 +120,7 @@ class _BlockingSource(io.BytesIO):
 
 
 def _admin_user_id() -> int:
+    # The helper also creates the admin record when the test database is empty.
     _admin_headers()
     db = _direct_db_session()
     try:
@@ -211,7 +211,7 @@ async def test_staging_copy_reads_off_loop_with_no_database_checkout(
         files_api, "get_upload_path", _stage_path_in(upload_root, user_id)
     )
     engine = _install_one_slot_queue_pool(monkeypatch)
-    source = _SlowTrackingSource(b"bounded-copy", delay_seconds=0.05)
+    source = _SlowTrackingSource(b"bounded-copy", delay_seconds=0.2)
     upload = UploadFile(
         filename="off-loop.txt",
         file=source,
@@ -231,7 +231,7 @@ async def test_staging_copy_reads_off_loop_with_no_database_checkout(
     )
     try:
         await asyncio.sleep(0.01)
-        assert asyncio.get_running_loop().time() - started_at < 0.04
+        assert asyncio.get_running_loop().time() - started_at < 0.1
         assert engine.pool.checkedout() == 0
         await task
         assert source.read_threads
@@ -245,20 +245,19 @@ def test_reserve_and_copy_enforces_max_size_and_cleans_partial_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """The worker returns an exact size and removes MAX+1 partial output."""
+    """The worker returns the path and removes MAX+1 partial output."""
 
     monkeypatch.setattr(files_api, "MAX_FILE_SIZE", 4)
     monkeypatch.setattr(files_api, "MAX_FILE_SIZE_LABEL", "4B")
     user_id = 7
     monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
 
-    exact_path, exact_size = files_api._reserve_and_copy_upload(
+    exact_path = files_api._reserve_and_copy_upload(
         UploadFile(filename="exact.txt", file=io.BytesIO(b"1234")),
         task_id=None,
         folder=None,
         user_id=user_id,
     )
-    assert exact_size == 4
     assert exact_path.read_bytes() == b"1234"
 
     with pytest.raises(HTTPException, match="maximum limit"):
@@ -342,8 +341,12 @@ def test_reserve_and_copy_propagates_open_error_without_creating_an_artifact(
     user_id = 7
     monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
 
-    def failing_open(*_args, **_kwargs) -> None:  # type: ignore[no-untyped-def]
-        raise PermissionError("open denied")
+    original_open = builtins.open
+
+    def failing_open(path, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "x" in mode:
+            raise PermissionError("open denied")
+        return original_open(path, mode, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "open", failing_open)
     with pytest.raises(PermissionError, match="open denied"):
@@ -400,6 +403,45 @@ def test_delete_staged_upload_suppresses_operational_unlink_failure(
     monkeypatch.setattr(Path, "unlink", failing_unlink)
     files_api._delete_staged_upload(tmp_path / "staged.txt")
     assert "Failed to clean up local upload" in caplog.text
+
+
+def test_delete_staged_upload_does_not_hide_programming_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only operational unlink failures are best-effort."""
+
+    def invalid_unlink(
+        _path: Path,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        del missing_ok
+        raise ValueError("invalid cleanup call")
+
+    monkeypatch.setattr(Path, "unlink", invalid_unlink)
+    with pytest.raises(ValueError, match="invalid cleanup call"):
+        files_api._delete_staged_upload(tmp_path / "staged.txt")
+
+
+def test_reserve_and_copy_uses_real_upload_path_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The worker remains compatible with the production path builder."""
+
+    from xagent.web import config as web_config
+
+    monkeypatch.setattr(web_config, "get_uploads_dir", lambda: tmp_path)
+    target = files_api._reserve_and_copy_upload(
+        UploadFile(filename="../real-path.txt", file=io.BytesIO(b"payload")),
+        task_id="42",
+        folder="documents",
+        user_id=7,
+    )
+
+    assert target == tmp_path / "user_7" / "task_42" / "documents" / "real-path.txt"
+    assert target.read_bytes() == b"payload"
 
 
 @pytest.mark.asyncio
@@ -513,23 +555,32 @@ async def test_store_uploaded_files_maps_path_validation_error_to_422(
 
 
 @pytest.mark.asyncio
-async def test_cancelled_staging_worker_deletes_its_exact_late_result(
+async def test_cancelled_store_cleans_its_exact_late_result_once(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Cancellation drains copy, deletes its returned path, then propagates."""
+    """The request cleanup owner deletes a drained staging result exactly once."""
 
     user_id = 7
     monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
     source = _BlockingSource(b"late worker result")
-    written_paths: list[Path] = []
+    target = tmp_path / f"user_{user_id}" / "cancelled.txt"
+    unlink_calls: list[Path] = []
+    original_unlink = Path.unlink
+
+    def recording_unlink(path: Path, *, missing_ok: bool = False) -> None:
+        unlink_calls.append(path)
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", recording_unlink)
     task = asyncio.create_task(
-        files_api._stage_uploaded_file(
-            UploadFile(filename="cancelled.txt", file=source),
+        files_api.store_uploaded_files(
+            upload_items=[UploadFile(filename="cancelled.txt", file=source)],
+            task_type="general",
             task_id=None,
             folder=None,
             user_id=user_id,
-            written_paths=written_paths,
+            single_file_mode=True,
         )
     )
     assert await asyncio.to_thread(source.started.wait, 2)
@@ -538,8 +589,47 @@ async def test_cancelled_staging_worker_deletes_its_exact_late_result(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert written_paths == [tmp_path / f"user_{user_id}" / "cancelled.txt"]
-    assert not written_paths[0].exists()
+    assert unlink_calls.count(target) == 1
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_failed_store_reuses_shared_staged_cleanup_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Request cleanup delegates operational error handling to one helper."""
+
+    user_id = 7
+    target = tmp_path / f"user_{user_id}" / "cleanup.txt"
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    cleanup_calls: list[Path] = []
+    original_delete = files_api._delete_staged_upload
+
+    def recording_delete(path: Path) -> None:
+        cleanup_calls.append(path)
+        original_delete(path)
+
+    def fail_registration(_registrations) -> None:  # type: ignore[no-untyped-def]
+        raise RuntimeError("registration failed")
+
+    monkeypatch.setattr(files_api, "_delete_staged_upload", recording_delete)
+    monkeypatch.setattr(files_api, "register_local_uploads_sync", fail_registration)
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        await files_api.store_uploaded_files(
+            upload_items=[
+                UploadFile(filename="cleanup.txt", file=io.BytesIO(b"payload"))
+            ],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        )
+
+    assert cleanup_calls == [target]
+    assert not target.exists()
 
 
 def test_jwt_upload_releases_auth_session_before_durable_io(

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -566,19 +566,26 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
     finally:
         db.close()
 
-    write_started = asyncio.Event()
-    allow_write = asyncio.Event()
+    write_started = threading.Event()
+    allow_write = threading.Event()
     written_path = None
 
-    async def delayed_write(_uploaded, target_path):  # type: ignore[no-untyped-def]
+    def delayed_copy(uploaded, *, task_id, folder, user_id):  # type: ignore[no-untyped-def]
         nonlocal written_path
+        target_path = files_api.get_upload_path(
+            uploaded.filename or "",
+            task_id,
+            folder,
+            user_id,
+        )
         written_path = target_path
-        target_path.write_bytes(b"partial")
+        with open(target_path, "xb") as buffer:
+            buffer.write(b"partial")
         write_started.set()
-        await allow_write.wait()
-        return 7
+        assert allow_write.wait(timeout=2)
+        return target_path, 7
 
-    monkeypatch.setattr(files_api, "_write_upload_with_size_limit", delayed_write)
+    monkeypatch.setattr(files_api, "_reserve_and_copy_upload", delayed_copy)
     upload = UploadFile(
         filename="cancelled-upload.txt",
         file=io.BytesIO(b"payload"),
@@ -594,7 +601,7 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
             user_id=user_id,
         )
     )
-    await write_started.wait()
+    assert await asyncio.to_thread(write_started.wait, 2)
     upload_task.cancel()
     allow_write.set()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -583,7 +583,7 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
             buffer.write(b"partial")
         write_started.set()
         assert allow_write.wait(timeout=2)
-        return target_path, 7
+        return target_path
 
     monkeypatch.setattr(files_api, "_reserve_and_copy_upload", delayed_copy)
     upload = UploadFile(


### PR DESCRIPTION
## Summary

- move local upload path reservation, source reads, size enforcement, and destination writes into one synchronous worker
- reserve same-name files atomically with exclusive creation
- make the request-level failure path the sole owner of completed staging cleanup

## Root cause

The shared upload service selected a unique filename with a check-then-open sequence and performed local destination writes from the async request flow. Concurrent same-name uploads could choose the same path. Cancellation also split cleanup between the staging helper and the outer request failure path, so the same late result could be unlinked twice.

## What changed

- keep path construction, exclusive `xb` reservation, bounded reads, and same-descriptor writes in one worker
- treat only an exclusive-open `FileExistsError` as a filename collision
- keep partial-copy cleanup inside the worker that owns the reserved descriptor
- drain a cancelled staging worker, publish its exact late path to `written_paths`, and let the outer `finally` clean it once
- reuse `_delete_staged_upload` for request-level cleanup so operational unlink handling has one implementation
- remove the unused copied-size return value while retaining maximum-size enforcement
- add real `get_upload_path`, exact cleanup-count, exception-narrowing, and non-broad `open` mock coverage

## Compatibility and scope

- no route, response schema, database schema, durable-registration, preview, or storage-CAS changes
- maximum file-size behavior and existing upload authorization remain unchanged
- collision retry policy and executor sizing remain unchanged; those require separate operational evidence and configuration ownership

## Verification

- `uv run pytest tests/web/api/test_upload_connection_boundary.py tests/web/api/test_kb_web_ingestion_uploaded_file.py -q`
- changed-file pre-commit checks passed, including Ruff, formatting, mypy, isort, and codespell
- `git diff --check` passed

This is follow-up boundary hardening related to #935; it does not close the task-runtime acceptance criteria in that issue.