### PR TITLE
fix: offload team knowledge base visibility lookup

### DIFF
--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -30,6 +30,7 @@ async def _list_visible_collections(
     if user_id is None or is_admin:
         return result
 
+    from ....web.services.db_runtime import run_db_io_cancellation_safe
     from ....web.services.knowledge_base_team_scope import (
         visible_team_knowledge_bases,
     )
@@ -38,7 +39,10 @@ async def _list_visible_collections(
         collection.name: collection for collection in result.collections
     }
     refs_by_owner: dict[int, list] = {}
-    for ref in visible_team_knowledge_bases(None, int(user_id)):
+    team_refs = await run_db_io_cancellation_safe(
+        lambda: visible_team_knowledge_bases(None, int(user_id))
+    )
+    for ref in team_refs:
         refs_by_owner.setdefault(ref.storage_user_id, []).append(ref)
     for storage_user_id, refs in refs_by_owner.items():
         owner_result = await list_collections(user_id=storage_user_id, is_admin=False)

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -32,8 +32,12 @@ async def _list_visible_collections(
 
     from ....web.services.db_runtime import run_db_io_cancellation_safe
     from ....web.services.knowledge_base_team_scope import (
+        has_knowledge_base_visibility_hook,
         visible_team_knowledge_bases,
     )
+
+    if not has_knowledge_base_visibility_hook():
+        return result
 
     collections_by_name = {
         collection.name: collection for collection in result.collections

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -60,7 +60,8 @@ def visible_team_knowledge_bases(
     """Return visible team KBs through the application-owned hook.
 
     Callers may invoke the hook from a worker thread. When ``db`` is ``None``,
-    the hook must create, use, and close its own thread-confined session.
+    the hook must create, use, and close its own thread-confined session and
+    must not depend on event-loop thread-local state.
     """
     if _visibility_hook is None:
         return []

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -57,7 +57,11 @@ def set_knowledge_base_team_hooks(
 def visible_team_knowledge_bases(
     db: Session | None, user_id: int
 ) -> list[KnowledgeBaseAccess]:
-    """Return visible team KBs; hooks must open a session when ``db`` is None."""
+    """Return visible team KBs through the application-owned hook.
+
+    Callers may invoke the hook from a worker thread. When ``db`` is ``None``,
+    the hook must create, use, and close its own thread-confined session.
+    """
     if _visibility_hook is None:
         return []
     return list(_visibility_hook(db, int(user_id)))

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -54,6 +54,12 @@ def set_knowledge_base_team_hooks(
     _deleted_hook = deleted
 
 
+def has_knowledge_base_visibility_hook() -> bool:
+    """Return whether the application installed a team visibility hook."""
+
+    return _visibility_hook is not None
+
+
 def visible_team_knowledge_bases(
     db: Session | None, user_id: int
 ) -> list[KnowledgeBaseAccess]:

--- a/tests/core/tools/core/test_document_search_team_visibility_boundary.py
+++ b/tests/core/tools/core/test_document_search_team_visibility_boundary.py
@@ -1,0 +1,261 @@
+"""Regression coverage for the document-search team visibility boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import suppress
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import QueuePool
+
+from xagent.core.tools.core import document_search
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    ListCollectionsResult,
+)
+from xagent.web.services.knowledge_base_team_scope import (
+    KnowledgeBaseAccess,
+    set_knowledge_base_team_hooks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_team_knowledge_base_hooks():
+    """Keep process-global application hooks isolated between tests."""
+    set_knowledge_base_team_hooks()
+    yield
+    set_knowledge_base_team_hooks()
+
+
+def _collections_result(*collections: CollectionInfo) -> ListCollectionsResult:
+    return ListCollectionsResult(
+        status="success",
+        collections=list(collections),
+        total_count=len(collections),
+        message="ok",
+    )
+
+
+def _install_collection_listing(monkeypatch: pytest.MonkeyPatch) -> CollectionInfo:
+    personal = CollectionInfo(name="personal")
+    shared = CollectionInfo(name="shared")
+
+    async def list_for_user(
+        user_id: int | None = None, is_admin: bool = False
+    ) -> ListCollectionsResult:
+        del is_admin
+        if user_id == 2:
+            return _collections_result(shared)
+        return _collections_result(personal)
+
+    monkeypatch.setattr(document_search, "list_collections", list_for_user)
+    return personal
+
+
+def _one_slot_engine():
+    return create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.25,
+    )
+
+
+async def _wait_for(event: threading.Event) -> None:
+    await asyncio.wait_for(asyncio.to_thread(event.wait), timeout=5)
+
+
+async def _await_without_leaking(task: asyncio.Task[object]) -> None:
+    if not task.done():
+        task.cancel()
+    with suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_team_visibility_hook_waits_off_loop_and_releases_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked hook checkout must leave the loop responsive until release."""
+    _install_collection_listing(monkeypatch)
+    engine = _one_slot_engine()
+    held_connection = engine.connect()
+    hook_started = threading.Event()
+    hook_closed = threading.Event()
+    ticker_advanced = threading.Event()
+    observed: dict[str, int] = {}
+    loop_thread_id = threading.get_ident()
+
+    def visibility_hook(db: Session | None, user_id: int) -> list[KnowledgeBaseAccess]:
+        assert db is None
+        assert user_id == 1
+        observed["hook_thread_id"] = threading.get_ident()
+        hook_started.set()
+        try:
+            with Session(engine) as session:
+                observed["sql_thread_id"] = threading.get_ident()
+                session.execute(text("SELECT 1"))
+        finally:
+            hook_closed.set()
+        return [KnowledgeBaseAccess(name="shared", storage_user_id=2)]
+
+    async def tick_after_hook_starts() -> None:
+        await _wait_for(hook_started)
+        await asyncio.sleep(0)
+        ticker_advanced.set()
+
+    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    ticker = asyncio.create_task(tick_after_hook_starts())
+    listing = asyncio.create_task(
+        document_search._list_visible_collections(user_id=1, is_admin=False)
+    )
+    try:
+        await _wait_for(hook_started)
+        await _wait_for(ticker_advanced)
+        assert not listing.done()
+        assert engine.pool.checkedout() == 1
+
+        held_connection.close()
+        result = await listing
+        await _wait_for(hook_closed)
+
+        assert observed["hook_thread_id"] != loop_thread_id
+        assert observed["sql_thread_id"] != loop_thread_id
+        assert [collection.name for collection in result.collections] == [
+            "personal",
+            "shared",
+        ]
+        shared = next(
+            collection
+            for collection in result.collections
+            if collection.name == "shared"
+        )
+        assert shared.ownership == "team"
+        assert shared.storage_user_id == 2
+        assert engine.pool.checkedout() == 0
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        await _await_without_leaking(listing)
+        await _await_without_leaking(ticker)
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_drains_team_visibility_session_before_propagating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation must wait for the hook-owned Session to close."""
+    _install_collection_listing(monkeypatch)
+    engine = _one_slot_engine()
+    held_connection = engine.connect()
+    hook_started = threading.Event()
+    hook_closed = threading.Event()
+
+    def visibility_hook(db: Session | None, user_id: int) -> list[KnowledgeBaseAccess]:
+        assert db is None
+        assert user_id == 1
+        hook_started.set()
+        try:
+            with Session(engine) as session:
+                session.execute(text("SELECT 1"))
+        finally:
+            hook_closed.set()
+        return []
+
+    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    listing = asyncio.create_task(
+        document_search._list_visible_collections(user_id=1, is_admin=False)
+    )
+    try:
+        await _wait_for(hook_started)
+        listing.cancel()
+        await asyncio.sleep(0)
+        assert not listing.done()
+        assert not hook_closed.is_set()
+        assert engine.pool.checkedout() == 1
+
+        held_connection.close()
+        await _wait_for(hook_closed)
+        with pytest.raises(asyncio.CancelledError):
+            await listing
+        assert engine.pool.checkedout() == 0
+    finally:
+        if not held_connection.closed:
+            held_connection.close()
+        await _await_without_leaking(listing)
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_team_visibility_hook_error_preserves_identity_and_closes_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hook error is not wrapped and its worker-owned Session is released."""
+    _install_collection_listing(monkeypatch)
+    engine = _one_slot_engine()
+    hook_error = RuntimeError("team visibility failed")
+    hook_closed = threading.Event()
+
+    def visibility_hook(db: Session | None, user_id: int) -> list[KnowledgeBaseAccess]:
+        assert db is None
+        assert user_id == 1
+        try:
+            with Session(engine) as session:
+                session.execute(text("SELECT 1"))
+                raise hook_error
+        finally:
+            hook_closed.set()
+
+    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            await document_search._list_visible_collections(user_id=1, is_admin=False)
+        assert raised.value is hook_error
+        await _wait_for(hook_closed)
+        assert engine.pool.checkedout() == 0
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_id", "is_admin", "install_hook"),
+    [
+        (None, False, True),
+        (1, True, True),
+        (1, False, False),
+    ],
+    ids=["anonymous", "admin", "no-hook"],
+)
+async def test_visibility_bypasses_keep_personal_collections_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    user_id: int | None,
+    is_admin: bool,
+    install_hook: bool,
+) -> None:
+    """Anonymous, admin, and unconfigured hook paths keep the personal result."""
+    personal = _install_collection_listing(monkeypatch)
+    hook_calls: list[tuple[Session | None, int]] = []
+
+    def visibility_hook(
+        db: Session | None, hooked_user_id: int
+    ) -> list[KnowledgeBaseAccess]:
+        hook_calls.append((db, hooked_user_id))
+        return [KnowledgeBaseAccess(name="shared", storage_user_id=2)]
+
+    if install_hook:
+        set_knowledge_base_team_hooks(visibility=visibility_hook)
+
+    result = await document_search._list_visible_collections(
+        user_id=user_id, is_admin=is_admin
+    )
+
+    assert result.collections == [personal]
+    assert result.total_count == 1
+    assert hook_calls == []

--- a/tests/core/tools/core/test_document_search_team_visibility_boundary.py
+++ b/tests/core/tools/core/test_document_search_team_visibility_boundary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 
 import pytest
@@ -298,3 +299,44 @@ def test_visibility_test_installation_preserves_unrelated_hooks(
     install_visibility_hook(visibility_hook)
 
     assert kb_scope._access_hook is access_hook
+
+
+def test_no_visibility_hook_bypasses_saturated_default_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standalone collection listing must not queue guaranteed-empty work."""
+
+    personal = _install_collection_listing(monkeypatch)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def occupy_default_executor() -> None:
+        worker_started.set()
+        release_worker.wait()
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            loop.set_default_executor(executor)
+            occupied = loop.run_in_executor(None, occupy_default_executor)
+            while not worker_started.is_set():
+                await asyncio.sleep(0)
+
+            listing = asyncio.create_task(
+                document_search._list_visible_collections(
+                    user_id=1,
+                    is_admin=False,
+                )
+            )
+            try:
+                done, _pending = await asyncio.wait({listing}, timeout=1.0)
+                assert listing in done
+                result = listing.result()
+                assert result.collections == [personal]
+                assert result.total_count == 1
+            finally:
+                release_worker.set()
+                await occupied
+                await _await_without_leaking(listing)
+
+    asyncio.run(scenario())

--- a/tests/core/tools/core/test_document_search_team_visibility_boundary.py
+++ b/tests/core/tools/core/test_document_search_team_visibility_boundary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Callable
 from contextlib import suppress
 
 import pytest
@@ -16,18 +17,30 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     CollectionInfo,
     ListCollectionsResult,
 )
+from xagent.web.services import knowledge_base_team_scope as kb_scope
 from xagent.web.services.knowledge_base_team_scope import (
     KnowledgeBaseAccess,
-    set_knowledge_base_team_hooks,
+    KnowledgeBaseVisibilityHook,
 )
 
 
 @pytest.fixture(autouse=True)
-def _clear_team_knowledge_base_hooks():
-    """Keep process-global application hooks isolated between tests."""
-    set_knowledge_base_team_hooks()
-    yield
-    set_knowledge_base_team_hooks()
+def _isolate_team_knowledge_base_visibility_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep this suite from changing unrelated application hooks."""
+
+    monkeypatch.setattr(kb_scope, "_visibility_hook", None)
+
+
+@pytest.fixture()
+def install_visibility_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[KnowledgeBaseVisibilityHook], None]:
+    def install(hook: KnowledgeBaseVisibilityHook) -> None:
+        monkeypatch.setattr(kb_scope, "_visibility_hook", hook)
+
+    return install
 
 
 def _collections_result(*collections: CollectionInfo) -> ListCollectionsResult:
@@ -62,12 +75,14 @@ def _one_slot_engine():
         poolclass=QueuePool,
         pool_size=1,
         max_overflow=0,
-        pool_timeout=0.25,
+        pool_timeout=2.0,
     )
 
 
 async def _wait_for(event: threading.Event) -> None:
-    await asyncio.wait_for(asyncio.to_thread(event.wait), timeout=5)
+    completed = await asyncio.to_thread(event.wait, 5)
+    if not completed:
+        raise TimeoutError("thread event did not settle")
 
 
 async def _await_without_leaking(task: asyncio.Task[object]) -> None:
@@ -80,6 +95,7 @@ async def _await_without_leaking(task: asyncio.Task[object]) -> None:
 @pytest.mark.asyncio
 async def test_team_visibility_hook_waits_off_loop_and_releases_pool(
     monkeypatch: pytest.MonkeyPatch,
+    install_visibility_hook: Callable[[KnowledgeBaseVisibilityHook], None],
 ) -> None:
     """A blocked hook checkout must leave the loop responsive until release."""
     _install_collection_listing(monkeypatch)
@@ -109,7 +125,7 @@ async def test_team_visibility_hook_waits_off_loop_and_releases_pool(
         await asyncio.sleep(0)
         ticker_advanced.set()
 
-    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    install_visibility_hook(visibility_hook)
     ticker = asyncio.create_task(tick_after_hook_starts())
     listing = asyncio.create_task(
         document_search._list_visible_collections(user_id=1, is_admin=False)
@@ -149,6 +165,7 @@ async def test_team_visibility_hook_waits_off_loop_and_releases_pool(
 @pytest.mark.asyncio
 async def test_cancellation_drains_team_visibility_session_before_propagating(
     monkeypatch: pytest.MonkeyPatch,
+    install_visibility_hook: Callable[[KnowledgeBaseVisibilityHook], None],
 ) -> None:
     """Cancellation must wait for the hook-owned Session to close."""
     _install_collection_listing(monkeypatch)
@@ -168,7 +185,7 @@ async def test_cancellation_drains_team_visibility_session_before_propagating(
             hook_closed.set()
         return []
 
-    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    install_visibility_hook(visibility_hook)
     listing = asyncio.create_task(
         document_search._list_visible_collections(user_id=1, is_admin=False)
     )
@@ -195,6 +212,7 @@ async def test_cancellation_drains_team_visibility_session_before_propagating(
 @pytest.mark.asyncio
 async def test_team_visibility_hook_error_preserves_identity_and_closes_session(
     monkeypatch: pytest.MonkeyPatch,
+    install_visibility_hook: Callable[[KnowledgeBaseVisibilityHook], None],
 ) -> None:
     """The hook error is not wrapped and its worker-owned Session is released."""
     _install_collection_listing(monkeypatch)
@@ -212,7 +230,7 @@ async def test_team_visibility_hook_error_preserves_identity_and_closes_session(
         finally:
             hook_closed.set()
 
-    set_knowledge_base_team_hooks(visibility=visibility_hook)
+    install_visibility_hook(visibility_hook)
     try:
         with pytest.raises(RuntimeError) as raised:
             await document_search._list_visible_collections(user_id=1, is_admin=False)
@@ -235,6 +253,7 @@ async def test_team_visibility_hook_error_preserves_identity_and_closes_session(
 )
 async def test_visibility_bypasses_keep_personal_collections_unchanged(
     monkeypatch: pytest.MonkeyPatch,
+    install_visibility_hook: Callable[[KnowledgeBaseVisibilityHook], None],
     user_id: int | None,
     is_admin: bool,
     install_hook: bool,
@@ -250,7 +269,7 @@ async def test_visibility_bypasses_keep_personal_collections_unchanged(
         return [KnowledgeBaseAccess(name="shared", storage_user_id=2)]
 
     if install_hook:
-        set_knowledge_base_team_hooks(visibility=visibility_hook)
+        install_visibility_hook(visibility_hook)
 
     result = await document_search._list_visible_collections(
         user_id=user_id, is_admin=is_admin
@@ -259,3 +278,23 @@ async def test_visibility_bypasses_keep_personal_collections_unchanged(
     assert result.collections == [personal]
     assert result.total_count == 1
     assert hook_calls == []
+
+
+def test_visibility_test_installation_preserves_unrelated_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+    install_visibility_hook: Callable[[KnowledgeBaseVisibilityHook], None],
+) -> None:
+    """The visibility fixture must not reset access or lifecycle hooks."""
+
+    def access_hook(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    def visibility_hook(
+        _db: Session | None, _user_id: int
+    ) -> list[KnowledgeBaseAccess]:
+        return []
+
+    monkeypatch.setattr(kb_scope, "_access_hook", access_hook)
+    install_visibility_hook(visibility_hook)
+
+    assert kb_scope._access_hook is access_hook


### PR DESCRIPTION
## Summary

- move the synchronous Team Knowledge Base visibility hook off the asyncio event loop
- keep Session ownership inside the existing application hook
- harden the constrained-pool tests without changing unrelated process-global hooks

## Root cause

The async document-search collection path called the synchronous Team Knowledge Base visibility hook directly. When that hook waited for a database connection, the event-loop thread waited with it and delayed unrelated async work.

## What changed

- invoke `visible_team_knowledge_bases(None, user_id)` through the shared cancellation-safe database worker boundary
- document that a hook called with `db=None` may run in a worker thread and must create, use, and close a thread-confined Session
- isolate only the visibility hook in this test suite instead of clearing access and lifecycle hooks
- give the one-slot pool test a realistic two-second checkout window
- put the timeout inside `threading.Event.wait` so a failed test cannot leave a blocked default-executor worker behind
- preserve anonymous/admin bypasses, visibility errors, owner lookup order, and result shaping

## Compatibility and scope

- no API, schema, migration, collection-response, frontend, or SDK changes
- this PR changes only the document-search visibility lookup
- direct `kb.py` hook callers still use request-owned Sessions; moving those calls to a worker would cross Session thread ownership and requires a separate owner redesign
- no new hook registry or parallel ownership layer is introduced

## Verification

- `uv run pytest tests/core/tools/core/test_document_search_team_visibility_boundary.py tests/web/test_team_sharing_hooks.py -q`
- changed-file pre-commit checks passed, including Ruff, formatting, mypy, isort, and codespell
- `git diff --check` passed

This is follow-up event-loop hardening related to #935; it does not close the broader task-runtime acceptance criteria in that issue.