### PR TITLE
fix: revoke undelivered runtime API keys

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -11,6 +11,9 @@ on:
       - 'src/xagent/db/**'
       - 'src/xagent/web/services/gmail_provisioning.py'
       - 'tests/web/services/test_gmail_provisioning.py'
+      - 'src/xagent/web/services/agent_management.py'
+      - 'src/xagent/web/services/api_keys.py'
+      - 'tests/web/services/test_runtime_key_transition_postgres.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -53,6 +56,9 @@ jobs:
             src/xagent/db
             src/xagent/web/services/gmail_provisioning.py
             tests/web/services/test_gmail_provisioning.py
+            src/xagent/web/services/agent_management.py
+            src/xagent/web/services/api_keys.py
+            tests/web/services/test_runtime_key_transition_postgres.py
           )
 
           case "$EVENT_NAME" in
@@ -202,6 +208,13 @@ jobs:
         run: |
           pip install pytest-asyncio
           pytest tests/web/services/test_gmail_provisioning.py -k contend -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test runtime-key transition fencing (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/services/test_runtime_key_transition_postgres.py -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -1262,15 +1262,11 @@ async def generate_agent_api_key(
     Notes:
         - Transactional shape mirrors ``auth.setup_admin`` and
           ``custom_api.create_custom_api`` -- we collect all writes in the
-          session and commit once. There is no ``SELECT ... FOR UPDATE``:
-          an agent may hold multiple simultaneously-active keys (the
-          ``uq_agent_api_keys_agent_active`` partial unique index that
-          used to enforce "at most one" was dropped for multi-key
-          support), so two clients racing to POST this endpoint for the
-          same agent no longer conflict at the DB level -- each
-          independently revokes whatever was active and inserts its own
-          new row; both succeed, and whichever committed last leaves its
-          key as the sole non-revoked one.
+          session and commit once. Rotations serialize on the agent row so
+          each request snapshots and revokes a coherent set of active keys.
+          An agent may still hold multiple simultaneously-active keys through
+          the multi-key endpoints; two racing legacy rotations both succeed
+          sequentially, and the later rotation leaves its key active.
         - Logs include the ``key_prefix`` only -- never the ``full_key``,
           the secret half, or the bcrypt hash.
     """

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -7,9 +7,10 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import TracebackType
-from typing import Any, Callable, Literal, cast
+from typing import Any, Callable, Generic, Literal, TypeVar, cast
 
 from sqlalchemy import func, or_, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, aliased
 
@@ -35,11 +36,17 @@ from .api_keys import (
     RuntimeKeyDeliveryError,
     RuntimeKeyReceipt,
 )
-from .db_runtime import await_task_settlement, run_db_io_cancellation_safe
+from .db_runtime import (
+    await_task_settlement,
+    is_process_control_exception,
+    propagate_deferred_cancellation,
+    run_db_io_cancellation_safe,
+)
 from .workforce_access import can_edit_workforce, filter_visible_workforces
 from .workforce_lifecycle import is_workforce_manager_discard_safe
 
 logger = logging.getLogger(__name__)
+_RuntimeKeyResultT = TypeVar("_RuntimeKeyResultT")
 
 # Agent-builder tool category that gates knowledge-base access. A KB
 # selection is only valid when this category is also enabled.
@@ -231,13 +238,21 @@ class AgentDeleteResult:
 
 
 @dataclass(frozen=True)
-class _RuntimeKeyDeliveryOutcome:
+class _RuntimeKeyDeliveryOutcome(Generic[_RuntimeKeyResultT]):
     """Detached worker result that retains an exact key receipt on failure."""
 
-    result: object | None
+    result: _RuntimeKeyResultT | None
     receipt: RuntimeKeyReceipt | None
     error: BaseException | None
     traceback: TracebackType | None
+
+
+@dataclass(frozen=True)
+class _RuntimeKeyCompensationResult:
+    """Auditable row counts from one fenced compensation transaction."""
+
+    new_key_revoked: int
+    prior_keys_restored: int
 
 
 class AgentWorkforceConflictError(RuntimeError):
@@ -587,6 +602,7 @@ class AgentManagementService:
         the conflict translation here must be split by source (agent ->
         duplicate-name 400, key -> 409).
         """
+        self.runtime_key_receipt = None
         if self.store.agent_name_exists(user_id, name):
             raise DuplicateAgentNameError(name)
 
@@ -609,31 +625,19 @@ class AgentManagementService:
         # here (agent has no unique constraint), so the conflict-to-409
         # translation wraps key staging + commit together. See the
         # contract note in the docstring above.
-        staged_key = None
-        self.runtime_key_receipt = None
-        commit_attempted = False
-        try:
+        def stage_runtime_key() -> tuple[AgentApiKey, str] | None:
             if generate_runtime_key:
                 staged_key = self.key_service.stage_rotated_key(
                     int(agent.id),
                     candidate=runtime_key_candidate,
                 )
                 self.runtime_key_receipt = self.key_service.runtime_key_receipt
-            commit_attempted = True
-            self.db.commit()  # single transaction boundary for both writes
-        except IntegrityError as exc:
-            self.db.rollback()
-            raise KeyRotationConflict(str(exc)) from exc
-        except BaseException as exc:
-            if commit_attempted and self.runtime_key_receipt is not None:
-                raise RuntimeKeyDeliveryError(
-                    self.runtime_key_receipt,
-                    exc,
-                    exc.__traceback__,
-                ) from exc
-            raise
+                return staged_key
+            return None
 
-        try:
+        def build_response(
+            staged_key: tuple[AgentApiKey, str] | None,
+        ) -> tuple[Agent, APIKeyGenerateResponse | None]:
             key_resp: APIKeyGenerateResponse | None = None
             self.db.refresh(agent)
             agent_id = int(agent.id)
@@ -665,14 +669,11 @@ class AgentManagementService:
                     exc_info=True,
                 )
             return agent, key_resp
-        except BaseException as exc:
-            if self.runtime_key_receipt is not None:
-                raise RuntimeKeyDeliveryError(
-                    self.runtime_key_receipt,
-                    exc,
-                    exc.__traceback__,
-                ) from exc
-            raise
+
+        return self.key_service.complete_runtime_key_delivery(
+            stage=stage_runtime_key,
+            build_response=build_response,
+        )
 
     async def create_agent_from_template(
         self,
@@ -872,10 +873,6 @@ def _is_runtime_key_prefix_collision(error: BaseException) -> bool:
     return False
 
 
-def _is_process_control(error: BaseException) -> bool:
-    return not isinstance(error, (Exception, asyncio.CancelledError))
-
-
 async def _validate_agent_knowledge_bases(
     *,
     knowledge_bases: tuple[str, ...],
@@ -933,8 +930,11 @@ class AgentManagementRuntime:
 
     @staticmethod
     def _run_runtime_key_session_operation(
-        operation: Callable[[AgentManagementService], _RuntimeKeyDeliveryOutcome],
-    ) -> _RuntimeKeyDeliveryOutcome:
+        operation: Callable[
+            [AgentManagementService],
+            _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT],
+        ],
+    ) -> _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT]:
         """Detach runtime-key outcomes before closing their worker Session.
 
         A committed key receipt is needed even when the service reports a
@@ -945,7 +945,7 @@ class AgentManagementRuntime:
 
         db: Session | None = None
         service: AgentManagementService | None = None
-        outcome: _RuntimeKeyDeliveryOutcome | None = None
+        outcome: _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT] | None = None
         try:
             SessionLocal = get_session_local()
             db = SessionLocal()
@@ -964,7 +964,7 @@ class AgentManagementRuntime:
                     result=None,
                     receipt=(
                         None
-                        if isinstance(exc, KeyRotationConflict) or service is None
+                        if isinstance(exc, KeyRotationConflict)
                         else service.runtime_key_receipt
                     ),
                     error=exc,
@@ -989,7 +989,7 @@ class AgentManagementRuntime:
                             error=close_error,
                             traceback=close_error.__traceback__,
                         )
-                    elif _is_process_control(close_error):
+                    elif is_process_control_exception(close_error):
                         outcome = _RuntimeKeyDeliveryOutcome(
                             result=None,
                             receipt=outcome.receipt,
@@ -1035,7 +1035,7 @@ class AgentManagementRuntime:
         *,
         user_id: int,
         spec: AgentCreateSpec,
-    ) -> _RuntimeKeyDeliveryOutcome:
+    ) -> _RuntimeKeyDeliveryOutcome[AgentCreateSnapshot]:
         attempts = PREFIX_COLLISION_RETRIES if spec.generate_runtime_key else 1
         for attempt in range(attempts):
             # Candidate generation includes bcrypt. It deliberately precedes
@@ -1048,7 +1048,8 @@ class AgentManagementRuntime:
 
             def create_attempt(
                 service: AgentManagementService,
-            ) -> _RuntimeKeyDeliveryOutcome:
+                candidate: ApiKeyCandidate | None = candidate,
+            ) -> _RuntimeKeyDeliveryOutcome[AgentCreateSnapshot]:
                 agent, key_response = service.create_agent_with_optional_key(
                     user_id=user_id,
                     name=spec.name,
@@ -1182,13 +1183,14 @@ class AgentManagementRuntime:
         *,
         user_id: int,
         agent_id: int,
-    ) -> _RuntimeKeyDeliveryOutcome:
+    ) -> _RuntimeKeyDeliveryOutcome[RuntimeKeySnapshot]:
         for attempt in range(PREFIX_COLLISION_RETRIES):
             candidate = generate_api_key(None, kind=ApiKeyKind.AGENT)
 
             def rotate_attempt(
                 service: AgentManagementService,
-            ) -> _RuntimeKeyDeliveryOutcome:
+                candidate: ApiKeyCandidate = candidate,
+            ) -> _RuntimeKeyDeliveryOutcome[RuntimeKeySnapshot]:
                 response = service.generate_agent_runtime_key(
                     user_id=user_id,
                     agent_id=agent_id,
@@ -1223,41 +1225,46 @@ class AgentManagementRuntime:
 
     async def _run_runtime_key_delivery(
         self,
-        operation: Callable[[], _RuntimeKeyDeliveryOutcome],
-    ) -> object | None:
+        operation: Callable[[], _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT]],
+    ) -> _RuntimeKeyResultT | None:
         """Settle key delivery before exposing cancellation or worker failure."""
 
         worker = asyncio.create_task(asyncio.to_thread(operation))
         outcome, cancellation = await await_task_settlement(worker)
-        compensation_error: BaseException | None = None
-        if outcome.receipt is not None and (
-            cancellation is not None or outcome.error is not None
-        ):
-            compensation_error = await self._compensate_runtime_key(outcome.receipt)
+        with propagate_deferred_cancellation(cancellation):
+            compensation_error: BaseException | None = None
+            if outcome.receipt is not None and (
+                cancellation is not None or outcome.error is not None
+            ):
+                compensation_error = await self._compensate_runtime_key(outcome.receipt)
 
-        if outcome.error is not None:
-            error = outcome.error.with_traceback(outcome.traceback)
-            if _is_process_control(error):
+            if outcome.error is not None:
+                error = outcome.error.with_traceback(outcome.traceback)
+                if compensation_error is not None:
+                    error.add_note(
+                        "Runtime-key compensation also failed: "
+                        f"{type(compensation_error).__name__}: {compensation_error}"
+                    )
                 raise error
-            if cancellation is not None:
-                raise cancellation from error
             if compensation_error is not None:
-                raise error from compensation_error
-            raise error
-        if cancellation is not None:
-            if compensation_error is not None:
-                raise cancellation from compensation_error
-            raise cancellation
+                # Compensation only runs without a worker error when caller
+                # cancellation was captured. Raising here lets the shared
+                # boundary preserve that cancellation with this failure as its
+                # cause.
+                raise compensation_error
         return outcome.result
 
     @staticmethod
-    def _revoke_runtime_key_sync(receipt: RuntimeKeyReceipt) -> None:
-        """Idempotently revoke only the exact key produced by this request."""
+    def _compensate_runtime_key_sync(
+        receipt: RuntimeKeyReceipt,
+    ) -> _RuntimeKeyCompensationResult:
+        """Fence a failed transition and restore only its replaced key rows."""
 
         SessionLocal = get_session_local()
         with SessionLocal() as db:
             now = datetime.now(timezone.utc)
-            try:
+            revoke_result = cast(
+                "CursorResult[Any]",
                 db.execute(
                     update(AgentApiKey)
                     .where(
@@ -1267,11 +1274,45 @@ class AgentManagementRuntime:
                         AgentApiKey.revoked_at.is_(None),
                     )
                     .values(revoked_at=now, updated_at=now)
+                ),
+            )
+            new_key_revoked = max(int(revoke_result.rowcount or 0), 0)
+            prior_keys_restored = 0
+            if (
+                new_key_revoked == 1
+                and receipt.replaced_key_ids
+                and receipt.rotation_timestamp is not None
+            ):
+                restore_result = cast(
+                    "CursorResult[Any]",
+                    db.execute(
+                        update(AgentApiKey)
+                        .where(
+                            AgentApiKey.agent_id == receipt.agent_id,
+                            AgentApiKey.id.in_(receipt.replaced_key_ids),
+                            AgentApiKey.revoked_at == receipt.rotation_timestamp,
+                        )
+                        .values(revoked_at=None, updated_at=now)
+                    ),
                 )
-                db.commit()
-            except BaseException:
-                db.rollback()
-                raise
+                prior_keys_restored = max(int(restore_result.rowcount or 0), 0)
+            db.commit()
+
+        result = _RuntimeKeyCompensationResult(
+            new_key_revoked=new_key_revoked,
+            prior_keys_restored=prior_keys_restored,
+        )
+        logger.info(
+            "Compensated undelivered runtime key id=%s agent_id=%s prefix=%s "
+            "(new_key_revoked=%d, prior_keys_restored=%d, expected_prior=%d)",
+            receipt.key_id,
+            receipt.agent_id,
+            receipt.key_prefix,
+            result.new_key_revoked,
+            result.prior_keys_restored,
+            len(receipt.replaced_key_ids),
+        )
+        return result
 
     async def _compensate_runtime_key(
         self,
@@ -1280,19 +1321,24 @@ class AgentManagementRuntime:
         """Run exact revocation in a fresh worker-owned Session."""
 
         worker = asyncio.create_task(
-            asyncio.to_thread(self._revoke_runtime_key_sync, receipt)
+            asyncio.to_thread(self._compensate_runtime_key_sync, receipt)
         )
         try:
-            _result, _cancellation = await await_task_settlement(worker)
+            _result, cancellation = await await_task_settlement(worker)
+        except asyncio.CancelledError:
+            raise
         except BaseException as exc:
-            if not isinstance(exc, (Exception, asyncio.CancelledError)):
+            if is_process_control_exception(exc):
                 raise
             logger.warning(
-                "Failed to revoke undelivered runtime key id=%s agent_id=%s prefix=%s",
+                "Failed to compensate undelivered runtime key "
+                "id=%s agent_id=%s prefix=%s",
                 receipt.key_id,
                 receipt.agent_id,
                 receipt.key_prefix,
                 exc_info=True,
             )
             return exc
+        with propagate_deferred_cancellation(cancellation):
+            pass
         return None

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -35,6 +35,7 @@ from .api_keys import (
     KeyRotationConflict,
     RuntimeKeyDeliveryError,
     RuntimeKeyReceipt,
+    acquire_runtime_key_transition_fence,
 )
 from .db_runtime import (
     await_task_settlement,
@@ -937,7 +938,7 @@ class AgentManagementRuntime:
     def _run_runtime_key_session_operation(
         operation: Callable[
             [AgentManagementService],
-            _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT],
+            _RuntimeKeyResultT | None,
         ],
     ) -> _RuntimeKeyDeliveryOutcome[_RuntimeKeyResultT]:
         """Detach runtime-key outcomes before closing their worker Session.
@@ -956,7 +957,13 @@ class AgentManagementRuntime:
             db = SessionLocal()
             service = AgentManagementService(db)
             try:
-                outcome = operation(service)
+                result = operation(service)
+                outcome = _RuntimeKeyDeliveryOutcome(
+                    result=result,
+                    receipt=service.runtime_key_receipt,
+                    error=None,
+                    traceback=None,
+                )
             except RuntimeKeyDeliveryError as exc:
                 outcome = _RuntimeKeyDeliveryOutcome(
                     result=None,
@@ -1055,7 +1062,7 @@ class AgentManagementRuntime:
             def create_attempt(
                 service: AgentManagementService,
                 candidate: ApiKeyCandidate | None = candidate,
-            ) -> _RuntimeKeyDeliveryOutcome[AgentCreateSnapshot]:
+            ) -> AgentCreateSnapshot:
                 agent, key_response = service.create_agent_with_optional_key(
                     user_id=user_id,
                     name=spec.name,
@@ -1073,14 +1080,9 @@ class AgentManagementRuntime:
                 agent_snapshot = _agent_response_snapshot(
                     service.store.agent_to_response_dict(agent)
                 )
-                return _RuntimeKeyDeliveryOutcome(
-                    result=AgentCreateSnapshot(
-                        agent=agent_snapshot,
-                        api_key=_runtime_key_snapshot(key_response),
-                    ),
-                    receipt=service.runtime_key_receipt,
-                    error=None,
-                    traceback=None,
+                return AgentCreateSnapshot(
+                    agent=agent_snapshot,
+                    api_key=_runtime_key_snapshot(key_response),
                 )
 
             outcome = AgentManagementRuntime._run_runtime_key_session_operation(
@@ -1195,18 +1197,13 @@ class AgentManagementRuntime:
             def rotate_attempt(
                 service: AgentManagementService,
                 candidate: ApiKeyCandidate = candidate,
-            ) -> _RuntimeKeyDeliveryOutcome[RuntimeKeySnapshot]:
+            ) -> RuntimeKeySnapshot | None:
                 response = service.generate_agent_runtime_key(
                     user_id=user_id,
                     agent_id=agent_id,
                     runtime_key_candidate=candidate,
                 )
-                return _RuntimeKeyDeliveryOutcome(
-                    result=_runtime_key_snapshot(response),
-                    receipt=service.runtime_key_receipt,
-                    error=None,
-                    traceback=None,
-                )
+                return _runtime_key_snapshot(response)
 
             outcome = AgentManagementRuntime._run_runtime_key_session_operation(
                 rotate_attempt
@@ -1268,41 +1265,51 @@ class AgentManagementRuntime:
         SessionLocal = get_session_local()
         with SessionLocal() as db:
             now = datetime.now(timezone.utc)
-            revoke_result = cast(
-                "CursorResult[Any]",
-                db.execute(
-                    update(AgentApiKey)
-                    .where(
-                        AgentApiKey.id == receipt.key_id,
-                        AgentApiKey.agent_id == receipt.agent_id,
-                        AgentApiKey.key_prefix == receipt.key_prefix,
-                        AgentApiKey.revoked_at.is_(None),
-                    )
-                    .values(revoked_at=now, updated_at=now)
-                    .execution_options(synchronize_session=False)
-                ),
+            agent_exists = acquire_runtime_key_transition_fence(
+                db,
+                receipt.agent_id,
             )
-            new_key_revoked = max(int(revoke_result.rowcount or 0), 0)
+            new_key_revoked = 0
             prior_keys_restored = 0
-            if (
-                new_key_revoked == 1
-                and receipt.replaced_key_ids
-                and receipt.rotation_timestamp is not None
-            ):
-                restore_result = cast(
+            if agent_exists:
+                revoke_result = cast(
                     "CursorResult[Any]",
                     db.execute(
                         update(AgentApiKey)
                         .where(
+                            AgentApiKey.id == receipt.key_id,
                             AgentApiKey.agent_id == receipt.agent_id,
-                            AgentApiKey.id.in_(receipt.replaced_key_ids),
-                            AgentApiKey.revoked_at == receipt.rotation_timestamp,
+                            AgentApiKey.key_prefix == receipt.key_prefix,
+                            AgentApiKey.revoked_at.is_(None),
+                            AgentApiKey.paused_at.is_(None),
                         )
-                        .values(revoked_at=None, updated_at=now)
+                        .values(revoked_at=now, updated_at=now)
                         .execution_options(synchronize_session=False)
                     ),
                 )
-                prior_keys_restored = max(int(restore_result.rowcount or 0), 0)
+                new_key_revoked = max(int(revoke_result.rowcount or 0), 0)
+                if (
+                    new_key_revoked == 1
+                    and receipt.replaced_key_ids
+                    and receipt.rotation_timestamp is not None
+                ):
+                    restore_result = cast(
+                        "CursorResult[Any]",
+                        db.execute(
+                            update(AgentApiKey)
+                            .where(
+                                AgentApiKey.agent_id == receipt.agent_id,
+                                AgentApiKey.id.in_(receipt.replaced_key_ids),
+                                AgentApiKey.revoked_at == receipt.rotation_timestamp,
+                            )
+                            .values(revoked_at=None, updated_at=now)
+                            .execution_options(synchronize_session=False)
+                        ),
+                    )
+                    prior_keys_restored = max(
+                        int(restore_result.rowcount or 0),
+                        0,
+                    )
             db.commit()
 
         result = _RuntimeKeyCompensationResult(

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Literal, cast
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Any, Callable, Literal, cast
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, aliased
 
@@ -19,14 +21,21 @@ from ...core.utils.api_key import (
 )
 from ...templates.manager import TemplateManager
 from ..models.agent import Agent
+from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_session_local, release_db_connection_if_clean
 from ..models.model import Model as DBModel
 from ..models.user import User
 from ..models.workforce import Workforce, WorkforceAgent, WorkforceRun
 from ..schemas.agent_api_key import APIKeyGenerateResponse
 from ..services.agent_store import AgentStore, invalidate_agent_cache
-from .api_keys import AgentApiKeyService, ApiKeyCandidate, KeyRotationConflict
-from .db_runtime import run_db_io_cancellation_safe
+from .api_keys import (
+    AgentApiKeyService,
+    ApiKeyCandidate,
+    KeyRotationConflict,
+    RuntimeKeyDeliveryError,
+    RuntimeKeyReceipt,
+)
+from .db_runtime import await_task_settlement, run_db_io_cancellation_safe
 from .workforce_access import can_edit_workforce, filter_visible_workforces
 from .workforce_lifecycle import is_workforce_manager_discard_safe
 
@@ -221,6 +230,16 @@ class AgentDeleteResult:
     logo_url: str | None
 
 
+@dataclass(frozen=True)
+class _RuntimeKeyDeliveryOutcome:
+    """Detached worker result that retains an exact key receipt on failure."""
+
+    result: object | None
+    receipt: RuntimeKeyReceipt | None
+    error: BaseException | None
+    traceback: TracebackType | None
+
+
 class AgentWorkforceConflictError(RuntimeError):
     """Raised when a Workforce FK prevents deletion of an Agent."""
 
@@ -249,6 +268,7 @@ class AgentManagementService:
         self.store = AgentStore(db)
         self.template_manager = template_manager
         self.key_service = AgentApiKeyService(db)
+        self.runtime_key_receipt: RuntimeKeyReceipt | None = None
 
     def list_agents_for_user(self, user_id: int) -> list[dict[str, Any]]:
         return self.store.list_agent_items(user_id)
@@ -590,41 +610,69 @@ class AgentManagementService:
         # translation wraps key staging + commit together. See the
         # contract note in the docstring above.
         staged_key = None
+        self.runtime_key_receipt = None
+        commit_attempted = False
         try:
             if generate_runtime_key:
                 staged_key = self.key_service.stage_rotated_key(
                     int(agent.id),
                     candidate=runtime_key_candidate,
                 )
+                self.runtime_key_receipt = self.key_service.runtime_key_receipt
+            commit_attempted = True
             self.db.commit()  # single transaction boundary for both writes
         except IntegrityError as exc:
             self.db.rollback()
             raise KeyRotationConflict(str(exc)) from exc
+        except BaseException as exc:
+            if commit_attempted and self.runtime_key_receipt is not None:
+                raise RuntimeKeyDeliveryError(
+                    self.runtime_key_receipt,
+                    exc,
+                    exc.__traceback__,
+                ) from exc
+            raise
 
-        key_resp: APIKeyGenerateResponse | None = None
-        self.db.refresh(agent)
-        agent_id = int(agent.id)
-        agent_team_id = cast("int | None", agent.team_id)
-        if staged_key is not None:
-            new_row, full_key = staged_key
-            self.db.refresh(new_row)
-            key_resp = APIKeyGenerateResponse(
-                full_key=full_key,
-                key_prefix=new_row.key_prefix,
-                created_at=new_row.created_at,
-            )
-        # Preserve the fully-loaded response row as a detached object. The
-        # read-only transaction release below expires attached ORM state.
-        self.db.expunge(agent)
-        # Refreshes above open a new read-only transaction. End it before
-        # cache invalidation, which may perform synchronous remote I/O.
-        release_db_connection_if_clean(self.db)
-        invalidate_agent_cache(
-            user_id,
-            agent_id,
-            agent_team_id,
-        )
-        return agent, key_resp
+        try:
+            key_resp: APIKeyGenerateResponse | None = None
+            self.db.refresh(agent)
+            agent_id = int(agent.id)
+            agent_team_id = cast("int | None", agent.team_id)
+            if staged_key is not None:
+                new_row, full_key = staged_key
+                self.db.refresh(new_row)
+                key_resp = APIKeyGenerateResponse(
+                    full_key=full_key,
+                    key_prefix=new_row.key_prefix,
+                    created_at=new_row.created_at,
+                )
+            # Preserve the fully-loaded response row as a detached object. The
+            # read-only transaction release below expires attached ORM state.
+            self.db.expunge(agent)
+            # Refreshes above open a new read-only transaction. End it before
+            # cache invalidation, which may perform synchronous remote I/O.
+            release_db_connection_if_clean(self.db)
+            try:
+                invalidate_agent_cache(
+                    user_id,
+                    agent_id,
+                    agent_team_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to invalidate cache after creating agent %s",
+                    agent_id,
+                    exc_info=True,
+                )
+            return agent, key_resp
+        except BaseException as exc:
+            if self.runtime_key_receipt is not None:
+                raise RuntimeKeyDeliveryError(
+                    self.runtime_key_receipt,
+                    exc,
+                    exc.__traceback__,
+                ) from exc
+            raise
 
     async def create_agent_from_template(
         self,
@@ -705,10 +753,12 @@ class AgentManagementService:
         agent = self.store.get_owned_agent(user_id, agent_id)
         if agent is None:
             return None
-        return self.key_service.rotate_key(
+        response = self.key_service.rotate_key_for_runtime_delivery(
             agent_id,
             candidate=runtime_key_candidate,
         )
+        self.runtime_key_receipt = self.key_service.runtime_key_receipt
+        return response
 
     def _validate_models(
         self, models: dict[str, Any] | None, *, user_id: int
@@ -822,6 +872,10 @@ def _is_runtime_key_prefix_collision(error: BaseException) -> bool:
     return False
 
 
+def _is_process_control(error: BaseException) -> bool:
+    return not isinstance(error, (Exception, asyncio.CancelledError))
+
+
 async def _validate_agent_knowledge_bases(
     *,
     knowledge_bases: tuple[str, ...],
@@ -877,6 +931,84 @@ class AgentManagementRuntime:
             payloads = AgentManagementService(db).list_agents_for_user(user_id)
             return tuple(_agent_summary_snapshot(payload) for payload in payloads)
 
+    @staticmethod
+    def _run_runtime_key_session_operation(
+        operation: Callable[[AgentManagementService], _RuntimeKeyDeliveryOutcome],
+    ) -> _RuntimeKeyDeliveryOutcome:
+        """Detach runtime-key outcomes before closing their worker Session.
+
+        A committed key receipt is needed even when the service reports a
+        post-commit failure.  ``Session.__exit__`` can itself fail, so this
+        boundary converts the service failure to detached data before close;
+        an operational close failure cannot replace that earlier failure.
+        """
+
+        db: Session | None = None
+        service: AgentManagementService | None = None
+        outcome: _RuntimeKeyDeliveryOutcome | None = None
+        try:
+            SessionLocal = get_session_local()
+            db = SessionLocal()
+            service = AgentManagementService(db)
+            try:
+                outcome = operation(service)
+            except RuntimeKeyDeliveryError as exc:
+                outcome = _RuntimeKeyDeliveryOutcome(
+                    result=None,
+                    receipt=exc.receipt,
+                    error=exc.error,
+                    traceback=exc.traceback,
+                )
+            except BaseException as exc:
+                outcome = _RuntimeKeyDeliveryOutcome(
+                    result=None,
+                    receipt=(
+                        None
+                        if isinstance(exc, KeyRotationConflict) or service is None
+                        else service.runtime_key_receipt
+                    ),
+                    error=exc,
+                    traceback=exc.__traceback__,
+                )
+        except BaseException as exc:
+            outcome = _RuntimeKeyDeliveryOutcome(
+                result=None,
+                receipt=None,
+                error=exc,
+                traceback=exc.__traceback__,
+            )
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except BaseException as close_error:
+                    if outcome is None or outcome.error is None:
+                        outcome = _RuntimeKeyDeliveryOutcome(
+                            result=None,
+                            receipt=None if outcome is None else outcome.receipt,
+                            error=close_error,
+                            traceback=close_error.__traceback__,
+                        )
+                    elif _is_process_control(close_error):
+                        outcome = _RuntimeKeyDeliveryOutcome(
+                            result=None,
+                            receipt=outcome.receipt,
+                            error=close_error,
+                            traceback=close_error.__traceback__,
+                        )
+                    else:
+                        logger.warning(
+                            "Failed to close runtime-key worker session after a "
+                            "delivery failure",
+                            exc_info=(
+                                type(close_error),
+                                close_error,
+                                close_error.__traceback__,
+                            ),
+                        )
+        assert outcome is not None
+        return outcome
+
     async def create_agent(
         self,
         *,
@@ -890,19 +1022,20 @@ class AgentManagementRuntime:
             user_id=user_id,
             is_admin=is_admin,
         )
-        return await run_db_io_cancellation_safe(
+        result = await self._run_runtime_key_delivery(
             lambda: self._create_agent_with_retry_sync(
                 user_id=user_id,
                 spec=spec,
             )
         )
+        return cast("AgentCreateSnapshot", result)
 
     @staticmethod
     def _create_agent_with_retry_sync(
         *,
         user_id: int,
         spec: AgentCreateSpec,
-    ) -> AgentCreateSnapshot:
+    ) -> _RuntimeKeyDeliveryOutcome:
         attempts = PREFIX_COLLISION_RETRIES if spec.generate_runtime_key else 1
         for attempt in range(attempts):
             # Candidate generation includes bcrypt. It deliberately precedes
@@ -912,41 +1045,56 @@ class AgentManagementRuntime:
                 if spec.generate_runtime_key
                 else None
             )
-            SessionLocal = get_session_local()
-            try:
-                with SessionLocal() as db:
-                    service = AgentManagementService(db)
-                    agent, key_response = service.create_agent_with_optional_key(
-                        user_id=user_id,
-                        name=spec.name,
-                        description=spec.description,
-                        instructions=spec.instructions,
-                        execution_mode=spec.execution_mode,
-                        models=spec.model_mapping(),
-                        knowledge_bases=list(spec.knowledge_bases),
-                        skills=list(spec.skills),
-                        tool_categories=list(spec.tool_categories),
-                        suggested_prompts=list(spec.suggested_prompts),
-                        generate_runtime_key=spec.generate_runtime_key,
-                        runtime_key_candidate=candidate,
-                    )
-                    agent_snapshot = _agent_response_snapshot(
-                        service.store.agent_to_response_dict(agent)
-                    )
-                    return AgentCreateSnapshot(
+
+            def create_attempt(
+                service: AgentManagementService,
+            ) -> _RuntimeKeyDeliveryOutcome:
+                agent, key_response = service.create_agent_with_optional_key(
+                    user_id=user_id,
+                    name=spec.name,
+                    description=spec.description,
+                    instructions=spec.instructions,
+                    execution_mode=spec.execution_mode,
+                    models=spec.model_mapping(),
+                    knowledge_bases=list(spec.knowledge_bases),
+                    skills=list(spec.skills),
+                    tool_categories=list(spec.tool_categories),
+                    suggested_prompts=list(spec.suggested_prompts),
+                    generate_runtime_key=spec.generate_runtime_key,
+                    runtime_key_candidate=candidate,
+                )
+                agent_snapshot = _agent_response_snapshot(
+                    service.store.agent_to_response_dict(agent)
+                )
+                return _RuntimeKeyDeliveryOutcome(
+                    result=AgentCreateSnapshot(
                         agent=agent_snapshot,
                         api_key=_runtime_key_snapshot(key_response),
-                    )
-            except KeyRotationConflict as exc:
-                if (
-                    candidate is not None
-                    and _is_runtime_key_prefix_collision(exc)
-                    and attempt + 1 < attempts
-                ):
-                    continue
-                raise
-        raise KeyRotationConflict(
+                    ),
+                    receipt=service.runtime_key_receipt,
+                    error=None,
+                    traceback=None,
+                )
+
+            outcome = AgentManagementRuntime._run_runtime_key_session_operation(
+                create_attempt
+            )
+            if (
+                isinstance(outcome.error, KeyRotationConflict)
+                and candidate is not None
+                and _is_runtime_key_prefix_collision(outcome.error)
+                and attempt + 1 < attempts
+            ):
+                continue
+            return outcome
+        error = KeyRotationConflict(
             "Failed to generate a unique runtime key prefix after retrying."
+        )
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=error,
+            traceback=error.__traceback__,
         )
 
     async def create_agent_from_template(
@@ -1021,37 +1169,130 @@ class AgentManagementRuntime:
         user_id: int,
         agent_id: int,
     ) -> RuntimeKeySnapshot | None:
-        return await run_db_io_cancellation_safe(
+        result = await self._run_runtime_key_delivery(
             lambda: self._rotate_agent_runtime_key_with_retry_sync(
                 user_id=user_id,
                 agent_id=agent_id,
             )
         )
+        return cast("RuntimeKeySnapshot | None", result)
 
     @staticmethod
     def _rotate_agent_runtime_key_with_retry_sync(
         *,
         user_id: int,
         agent_id: int,
-    ) -> RuntimeKeySnapshot | None:
+    ) -> _RuntimeKeyDeliveryOutcome:
         for attempt in range(PREFIX_COLLISION_RETRIES):
             candidate = generate_api_key(None, kind=ApiKeyKind.AGENT)
-            SessionLocal = get_session_local()
-            try:
-                with SessionLocal() as db:
-                    response = AgentManagementService(db).generate_agent_runtime_key(
-                        user_id=user_id,
-                        agent_id=agent_id,
-                        runtime_key_candidate=candidate,
-                    )
-                    return _runtime_key_snapshot(response)
-            except KeyRotationConflict as exc:
-                if (
-                    _is_runtime_key_prefix_collision(exc)
-                    and attempt + 1 < PREFIX_COLLISION_RETRIES
-                ):
-                    continue
-                raise
-        raise KeyRotationConflict(
+
+            def rotate_attempt(
+                service: AgentManagementService,
+            ) -> _RuntimeKeyDeliveryOutcome:
+                response = service.generate_agent_runtime_key(
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    runtime_key_candidate=candidate,
+                )
+                return _RuntimeKeyDeliveryOutcome(
+                    result=_runtime_key_snapshot(response),
+                    receipt=service.runtime_key_receipt,
+                    error=None,
+                    traceback=None,
+                )
+
+            outcome = AgentManagementRuntime._run_runtime_key_session_operation(
+                rotate_attempt
+            )
+            if (
+                isinstance(outcome.error, KeyRotationConflict)
+                and _is_runtime_key_prefix_collision(outcome.error)
+                and attempt + 1 < PREFIX_COLLISION_RETRIES
+            ):
+                continue
+            return outcome
+        error = KeyRotationConflict(
             "Failed to generate a unique runtime key prefix after retrying."
         )
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=error,
+            traceback=error.__traceback__,
+        )
+
+    async def _run_runtime_key_delivery(
+        self,
+        operation: Callable[[], _RuntimeKeyDeliveryOutcome],
+    ) -> object | None:
+        """Settle key delivery before exposing cancellation or worker failure."""
+
+        worker = asyncio.create_task(asyncio.to_thread(operation))
+        outcome, cancellation = await await_task_settlement(worker)
+        compensation_error: BaseException | None = None
+        if outcome.receipt is not None and (
+            cancellation is not None or outcome.error is not None
+        ):
+            compensation_error = await self._compensate_runtime_key(outcome.receipt)
+
+        if outcome.error is not None:
+            error = outcome.error.with_traceback(outcome.traceback)
+            if _is_process_control(error):
+                raise error
+            if cancellation is not None:
+                raise cancellation from error
+            if compensation_error is not None:
+                raise error from compensation_error
+            raise error
+        if cancellation is not None:
+            if compensation_error is not None:
+                raise cancellation from compensation_error
+            raise cancellation
+        return outcome.result
+
+    @staticmethod
+    def _revoke_runtime_key_sync(receipt: RuntimeKeyReceipt) -> None:
+        """Idempotently revoke only the exact key produced by this request."""
+
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            now = datetime.now(timezone.utc)
+            try:
+                db.execute(
+                    update(AgentApiKey)
+                    .where(
+                        AgentApiKey.id == receipt.key_id,
+                        AgentApiKey.agent_id == receipt.agent_id,
+                        AgentApiKey.key_prefix == receipt.key_prefix,
+                        AgentApiKey.revoked_at.is_(None),
+                    )
+                    .values(revoked_at=now, updated_at=now)
+                )
+                db.commit()
+            except BaseException:
+                db.rollback()
+                raise
+
+    async def _compensate_runtime_key(
+        self,
+        receipt: RuntimeKeyReceipt,
+    ) -> BaseException | None:
+        """Run exact revocation in a fresh worker-owned Session."""
+
+        worker = asyncio.create_task(
+            asyncio.to_thread(self._revoke_runtime_key_sync, receipt)
+        )
+        try:
+            _result, _cancellation = await await_task_settlement(worker)
+        except BaseException as exc:
+            if not isinstance(exc, (Exception, asyncio.CancelledError)):
+                raise
+            logger.warning(
+                "Failed to revoke undelivered runtime key id=%s agent_id=%s prefix=%s",
+                receipt.key_id,
+                receipt.agent_id,
+                receipt.key_prefix,
+                exc_info=True,
+            )
+            return exc
+        return None

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -601,6 +601,11 @@ class AgentManagementService:
         ``(user_id, name)`` unique constraint is ever added to agents,
         the conflict translation here must be split by source (agent ->
         duplicate-name 400, key -> 409).
+
+        Delivery contract: once a runtime-key receipt exists, an ambiguous
+        commit result or post-commit response failure is wrapped in
+        :class:`RuntimeKeyDeliveryError`. The runtime boundary is the sole
+        consumer and compensates the exact transition in a fresh Session.
         """
         self.runtime_key_receipt = None
         if self.store.agent_name_exists(user_id, name):
@@ -1028,7 +1033,8 @@ class AgentManagementRuntime:
                 spec=spec,
             )
         )
-        return cast("AgentCreateSnapshot", result)
+        assert result is not None
+        return result
 
     @staticmethod
     def _create_agent_with_retry_sync(
@@ -1170,13 +1176,12 @@ class AgentManagementRuntime:
         user_id: int,
         agent_id: int,
     ) -> RuntimeKeySnapshot | None:
-        result = await self._run_runtime_key_delivery(
+        return await self._run_runtime_key_delivery(
             lambda: self._rotate_agent_runtime_key_with_retry_sync(
                 user_id=user_id,
                 agent_id=agent_id,
             )
         )
-        return cast("RuntimeKeySnapshot | None", result)
 
     @staticmethod
     def _rotate_agent_runtime_key_with_retry_sync(
@@ -1274,6 +1279,7 @@ class AgentManagementRuntime:
                         AgentApiKey.revoked_at.is_(None),
                     )
                     .values(revoked_at=now, updated_at=now)
+                    .execution_options(synchronize_session=False)
                 ),
             )
             new_key_revoked = max(int(revoke_result.rowcount or 0), 0)
@@ -1293,6 +1299,7 @@ class AgentManagementRuntime:
                             AgentApiKey.revoked_at == receipt.rotation_timestamp,
                         )
                         .values(revoked_at=None, updated_at=now)
+                        .execution_options(synchronize_session=False)
                     ),
                 )
                 prior_keys_restored = max(int(restore_result.rowcount or 0), 0)

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 from types import TracebackType
 from typing import Any, Callable, NamedTuple, TypeVar
 
-from sqlalchemy import func, or_, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import func, or_, select, text
+from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import Session, joinedload
 
 from ...core.utils.api_key import ApiKeyKind, generate_api_key
@@ -85,6 +85,29 @@ class KeyRotationConflict(RuntimeError):
     """A key-prefix conflict that was rolled back before delivery."""
 
 
+def acquire_runtime_key_transition_fence(db: Session, agent_id: int) -> bool:
+    """Serialize runtime-key transitions for one agent in every database.
+
+    PostgreSQL and MySQL use a row-level ``FOR UPDATE`` lock. SQLite ignores
+    that clause, so it instead uses a no-op write to acquire its write lock
+    before callers snapshot key rows. The raw SQLite statement deliberately
+    bypasses the ``Agent.updated_at`` ORM ``onupdate`` handler.
+
+    Returns ``False`` when the agent no longer exists.
+    """
+
+    normalized_agent_id = int(agent_id)
+    agent_row = select(Agent.id).where(Agent.id == normalized_agent_id)
+    if db.get_bind().dialect.name == "sqlite":
+        db.execute(
+            text("UPDATE agents SET id = id WHERE id = :agent_id"),
+            {"agent_id": normalized_agent_id},
+        )
+    else:
+        agent_row = agent_row.with_for_update()
+    return db.execute(agent_row).scalar_one_or_none() is not None
+
+
 def _key_status(row: AgentApiKey) -> str:
     if row.revoked_at is not None:
         return "revoked"
@@ -125,12 +148,11 @@ class AgentApiKeyService:
         staged transition after the flush succeeds.
         """
         self.runtime_key_receipt = None
-        # Serialize legacy single-key rotations for this agent. Multi-key
-        # additions that commit after this snapshot are later state and must
-        # not be revoked or restored by this transition.
-        self.db.execute(
-            select(Agent.id).where(Agent.id == int(agent_id)).with_for_update()
-        ).scalar_one()
+        # Serialize legacy single-key rotations for this agent before taking
+        # the active-key snapshot. Multi-key additions that commit after this
+        # fence are later state and must not be revoked by this transition.
+        if not acquire_runtime_key_transition_fence(self.db, agent_id):
+            raise NoResultFound(f"Agent {int(agent_id)} does not exist.")
         replaced_key_ids = tuple(
             int(row_id)
             for (row_id,) in (

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -121,7 +121,8 @@ class AgentApiKeyService:
 
         Returns the staged ORM row and the one-shot plaintext key. The
         row's ``created_at`` is only populated after the caller commits
-        and refreshes.
+        and refreshes. ``runtime_key_receipt`` is replaced with the exact
+        staged transition after the flush succeeds.
         """
         self.runtime_key_receipt = None
         # Serialize legacy single-key rotations for this agent. Multi-key

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -6,9 +6,9 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import TracebackType
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple, TypeVar
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
@@ -40,19 +40,34 @@ from .personal_key_scope import PersonalKeyAccessScope
 logger = logging.getLogger(__name__)
 
 ApiKeyCandidate = tuple[str, str, str]
+_StagedRuntimeKeyT = TypeVar("_StagedRuntimeKeyT")
+_RuntimeKeyResponseT = TypeVar("_RuntimeKeyResponseT")
 
 
 @dataclass(frozen=True)
 class RuntimeKeyReceipt:
-    """Exact identity of a staged runtime key that may need revocation."""
+    """Exact, fenced transition for compensating an undelivered key."""
 
     key_id: int
     agent_id: int
     key_prefix: str
+    replaced_key_ids: tuple[int, ...] = ()
+    rotation_timestamp: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.replaced_key_ids and self.rotation_timestamp is None:
+            raise ValueError("Replaced runtime keys require a rotation timestamp.")
 
 
 class RuntimeKeyDeliveryError(Exception):
-    """Carry a post-commit runtime-key failure without losing its receipt."""
+    """Carry a possibly committed key transition through worker teardown.
+
+    This wrapper is only used after a receipt exists and commit has been
+    attempted, or while building the one-shot response after commit. An
+    ``IntegrityError`` is rolled back and translated to
+    :class:`KeyRotationConflict` instead, so that exception never carries a
+    durable receipt.
+    """
 
     def __init__(
         self,
@@ -67,7 +82,7 @@ class RuntimeKeyDeliveryError(Exception):
 
 
 class KeyRotationConflict(RuntimeError):
-    """Raised when a concurrent key rotation wins the active-key race."""
+    """A key-prefix conflict that was rolled back before delivery."""
 
 
 def _key_status(row: AgentApiKey) -> str:
@@ -108,6 +123,25 @@ class AgentApiKeyService:
         row's ``created_at`` is only populated after the caller commits
         and refreshes.
         """
+        self.runtime_key_receipt = None
+        # Serialize legacy single-key rotations for this agent. Multi-key
+        # additions that commit after this snapshot are later state and must
+        # not be revoked or restored by this transition.
+        self.db.execute(
+            select(Agent.id).where(Agent.id == int(agent_id)).with_for_update()
+        ).scalar_one()
+        replaced_key_ids = tuple(
+            int(row_id)
+            for (row_id,) in (
+                self.db.query(AgentApiKey.id)
+                .filter(
+                    AgentApiKey.agent_id == agent_id,
+                    AgentApiKey.revoked_at.is_(None),
+                )
+                .order_by(AgentApiKey.id)
+                .all()
+            )
+        )
         now = datetime.now(timezone.utc)
         # Bulk-revoke rather than ``.filter(...).first()``: an agent can now
         # hold more than one simultaneously-active key (via the multi-key
@@ -117,12 +151,15 @@ class AgentApiKeyService:
             self.db.query(AgentApiKey)
             .filter(
                 AgentApiKey.agent_id == agent_id,
+                AgentApiKey.id.in_(replaced_key_ids),
                 AgentApiKey.revoked_at.is_(None),
             )
             .update(
                 {AgentApiKey.revoked_at: now, AgentApiKey.updated_at: now},
                 synchronize_session=False,
             )
+            if replaced_key_ids
+            else 0
         )
 
         full_key, key_prefix, key_hash = candidate or generate_api_key(
@@ -139,6 +176,8 @@ class AgentApiKeyService:
             key_id=int(new_row.id),
             agent_id=int(agent_id),
             key_prefix=str(new_row.key_prefix),
+            replaced_key_ids=replaced_key_ids,
+            rotation_timestamp=now,
         )
         logger.info(
             "Staged runtime API key for agent %s (prefix=%s, revoked=%d)",
@@ -147,6 +186,41 @@ class AgentApiKeyService:
             revoked_count,
         )
         return new_row, full_key
+
+    def complete_runtime_key_delivery(
+        self,
+        *,
+        stage: Callable[[], _StagedRuntimeKeyT],
+        build_response: Callable[[_StagedRuntimeKeyT], _RuntimeKeyResponseT],
+    ) -> _RuntimeKeyResponseT:
+        """Commit one staged transition and build its one-shot response.
+
+        The receipt is captured before commit so an ambiguous commit result can
+        be compensated. Response construction runs only after commit and is
+        covered by the same receipt.
+        """
+
+        self.runtime_key_receipt = None
+        receipt: RuntimeKeyReceipt | None = None
+        try:
+            staged = stage()
+            receipt = self.runtime_key_receipt
+            self.db.commit()
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise KeyRotationConflict(str(exc)) from exc
+        except BaseException as exc:
+            receipt = receipt or self.runtime_key_receipt
+            if receipt is not None:
+                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
+            raise
+
+        try:
+            return build_response(staged)
+        except BaseException as exc:
+            if receipt is not None:
+                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
+            raise
 
     def rotate_key(
         self,
@@ -193,36 +267,27 @@ class AgentApiKeyService:
     ) -> APIKeyGenerateResponse:
         """Rotate a V1 one-shot key while retaining post-commit evidence."""
 
-        self.runtime_key_receipt = None
-        receipt: RuntimeKeyReceipt | None = None
-        commit_attempted = False
-        try:
-            new_row, full_key = self.stage_rotated_key(
+        def stage() -> tuple[AgentApiKey, str]:
+            return self.stage_rotated_key(
                 agent_id,
                 candidate=candidate,
             )
-            receipt = self.runtime_key_receipt
-            commit_attempted = True
-            self.db.commit()
-        except IntegrityError as exc:
-            self.db.rollback()
-            raise KeyRotationConflict(str(exc)) from exc
-        except BaseException as exc:
-            if commit_attempted and receipt is not None:
-                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
-            raise
 
-        try:
+        def build_response(
+            staged: tuple[AgentApiKey, str],
+        ) -> APIKeyGenerateResponse:
+            new_row, full_key = staged
             self.db.refresh(new_row)
             return APIKeyGenerateResponse(
                 full_key=full_key,
                 key_prefix=new_row.key_prefix,
                 created_at=new_row.created_at,
             )
-        except BaseException as exc:
-            if receipt is not None:
-                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
-            raise
+
+        return self.complete_runtime_key_delivery(
+            stage=stage,
+            build_response=build_response,
+        )
 
     def get_metadata(self, agent_id: int) -> APIKeyMetadataResponse | None:
         # An agent can now have more than one active key (via the

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from types import TracebackType
 from typing import Any, NamedTuple
 
 from sqlalchemy import func, or_
@@ -40,6 +42,30 @@ logger = logging.getLogger(__name__)
 ApiKeyCandidate = tuple[str, str, str]
 
 
+@dataclass(frozen=True)
+class RuntimeKeyReceipt:
+    """Exact identity of a staged runtime key that may need revocation."""
+
+    key_id: int
+    agent_id: int
+    key_prefix: str
+
+
+class RuntimeKeyDeliveryError(Exception):
+    """Carry a post-commit runtime-key failure without losing its receipt."""
+
+    def __init__(
+        self,
+        receipt: RuntimeKeyReceipt,
+        error: BaseException,
+        traceback: TracebackType | None,
+    ) -> None:
+        super().__init__(str(error))
+        self.receipt = receipt
+        self.error = error
+        self.traceback = traceback
+
+
 class KeyRotationConflict(RuntimeError):
     """Raised when a concurrent key rotation wins the active-key race."""
 
@@ -61,6 +87,7 @@ class AgentApiKeyService:
 
     def __init__(self, db: Session) -> None:
         self.db = db
+        self.runtime_key_receipt: RuntimeKeyReceipt | None = None
 
     def stage_rotated_key(
         self,
@@ -108,6 +135,11 @@ class AgentApiKeyService:
         )
         self.db.add(new_row)
         self.db.flush()
+        self.runtime_key_receipt = RuntimeKeyReceipt(
+            key_id=int(new_row.id),
+            agent_id=int(agent_id),
+            key_prefix=str(new_row.key_prefix),
+        )
         logger.info(
             "Staged runtime API key for agent %s (prefix=%s, revoked=%d)",
             agent_id,
@@ -152,6 +184,45 @@ class AgentApiKeyService:
             key_prefix=new_row.key_prefix,
             created_at=new_row.created_at,
         )
+
+    def rotate_key_for_runtime_delivery(
+        self,
+        agent_id: int,
+        *,
+        candidate: ApiKeyCandidate | None = None,
+    ) -> APIKeyGenerateResponse:
+        """Rotate a V1 one-shot key while retaining post-commit evidence."""
+
+        self.runtime_key_receipt = None
+        receipt: RuntimeKeyReceipt | None = None
+        commit_attempted = False
+        try:
+            new_row, full_key = self.stage_rotated_key(
+                agent_id,
+                candidate=candidate,
+            )
+            receipt = self.runtime_key_receipt
+            commit_attempted = True
+            self.db.commit()
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise KeyRotationConflict(str(exc)) from exc
+        except BaseException as exc:
+            if commit_attempted and receipt is not None:
+                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
+            raise
+
+        try:
+            self.db.refresh(new_row)
+            return APIKeyGenerateResponse(
+                full_key=full_key,
+                key_prefix=new_row.key_prefix,
+                created_at=new_row.created_at,
+            )
+        except BaseException as exc:
+            if receipt is not None:
+                raise RuntimeKeyDeliveryError(receipt, exc, exc.__traceback__) from exc
+            raise
 
     def get_metadata(self, agent_id: int) -> APIKeyMetadataResponse | None:
         # An agent can now have more than one active key (via the

--- a/src/xagent/web/services/db_runtime.py
+++ b/src/xagent/web/services/db_runtime.py
@@ -11,6 +11,10 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 _T = TypeVar("_T")
 
 
+def _is_process_control(error: BaseException) -> bool:
+    return not isinstance(error, (Exception, asyncio.CancelledError))
+
+
 def is_database_pool_timeout(error: BaseException) -> bool:
     """Return whether an exception chain represents pool checkout exhaustion."""
     current: BaseException | None = error
@@ -49,8 +53,12 @@ async def await_task_settlement(
             try:
                 result = task.result()
             except BaseException as task_error:
+                if _is_process_control(task_error):
+                    raise
                 raise cancellation from task_error
         except BaseException as task_error:
+            if _is_process_control(task_error):
+                raise
             if cancellation is not None:
                 raise cancellation from task_error
             raise

--- a/src/xagent/web/services/db_runtime.py
+++ b/src/xagent/web/services/db_runtime.py
@@ -11,7 +11,9 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 _T = TypeVar("_T")
 
 
-def _is_process_control(error: BaseException) -> bool:
+def is_process_control_exception(error: BaseException) -> bool:
+    """Return whether ``error`` must bypass operational error handling."""
+
     return not isinstance(error, (Exception, asyncio.CancelledError))
 
 
@@ -53,11 +55,11 @@ async def await_task_settlement(
             try:
                 result = task.result()
             except BaseException as task_error:
-                if _is_process_control(task_error):
+                if is_process_control_exception(task_error):
                     raise
                 raise cancellation from task_error
         except BaseException as task_error:
-            if _is_process_control(task_error):
+            if is_process_control_exception(task_error):
                 raise
             if cancellation is not None:
                 raise cancellation from task_error

--- a/tests/web/api/v1/test_agent_management_runtime.py
+++ b/tests/web/api/v1/test_agent_management_runtime.py
@@ -7,6 +7,7 @@ import threading
 
 import pytest
 from sqlalchemy import event, text
+from sqlalchemy.orm import Session
 
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
@@ -54,6 +55,18 @@ def _create_spec(
         suggested_prompts=(),
         generate_runtime_key=generate_runtime_key,
     )
+
+
+async def _cancel_after_runtime_key_commit(
+    operation: asyncio.Task[object],
+    committed: threading.Event,
+    release: threading.Event,
+) -> None:
+    assert await asyncio.to_thread(committed.wait, 2)
+    operation.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(operation, timeout=2)
 
 
 @pytest.mark.asyncio
@@ -274,6 +287,638 @@ async def test_cancelled_pool_wait_drains_worker_before_propagating(
         await listing
     assert engine.pool.checkedout() == 0
     engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("from_template", [False, True])
+async def test_cancel_after_committed_create_revokes_the_undelivered_exact_key(
+    monkeypatch: pytest.MonkeyPatch,
+    from_template: bool,
+) -> None:
+    """The generated V1 key is revoked when delivery is cancelled after commit."""
+
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    committed = threading.Event()
+    release = threading.Event()
+    captured: dict[str, int | str] = {}
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        agent, response = original_create(service, *args, **kwargs)
+        assert response is not None
+        captured["agent_id"] = int(agent.id)
+        captured["prefix"] = response.key_prefix
+        committed.set()
+        assert release.wait(timeout=2)
+        return agent, response
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        pause_after_commit,
+    )
+    if from_template:
+
+        class TemplateManagerStub:
+            async def get_template(self, template_id: str):  # type: ignore[no-untyped-def]
+                assert template_id == "runtime-key-template"
+                return {"name": "runtime key template", "agent_config": {}}
+
+        operation: asyncio.Task[object] = asyncio.create_task(
+            AgentManagementRuntime(
+                template_manager=TemplateManagerStub()
+            ).create_agent_from_template(
+                user_id=user_id,
+                is_admin=is_admin,
+                template_id="runtime-key-template",
+                name=None,
+                description=None,
+                instructions=None,
+                execution_mode=None,
+                models=None,
+                knowledge_bases=None,
+                skills=None,
+                tool_categories=None,
+                suggested_prompts=None,
+                generate_runtime_key=True,
+            )
+        )
+    else:
+        operation = asyncio.create_task(
+            AgentManagementRuntime().create_agent(
+                user_id=user_id,
+                is_admin=is_admin,
+                spec=_create_spec("cancel committed create"),
+            )
+        )
+
+    await _cancel_after_runtime_key_commit(operation, committed, release)
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == captured["agent_id"],
+                AgentApiKey.key_prefix == captured["prefix"],
+            )
+            .one()
+        )
+        assert row.revoked_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_committed_rotation_revokes_the_undelivered_exact_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    target = await runtime.create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("cancel committed rotation", generate_runtime_key=False),
+    )
+    committed = threading.Event()
+    release = threading.Event()
+    captured: dict[str, str] = {}
+    original_rotate = agent_management.AgentManagementService.generate_agent_runtime_key
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        response = original_rotate(service, *args, **kwargs)
+        assert response is not None
+        captured["prefix"] = response.key_prefix
+        committed.set()
+        assert release.wait(timeout=2)
+        return response
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "generate_agent_runtime_key",
+        pause_after_commit,
+    )
+    operation: asyncio.Task[object] = asyncio.create_task(
+        runtime.rotate_agent_runtime_key(user_id=user_id, agent_id=target.agent.id)
+    )
+    await _cancel_after_runtime_key_commit(operation, committed, release)
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == target.agent.id,
+                AgentApiKey.key_prefix == captured["prefix"],
+            )
+            .one()
+        )
+        assert row.revoked_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_exact_compensation_does_not_revoke_a_later_concurrent_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    committed = threading.Event()
+    release = threading.Event()
+    captured: dict[str, int | str] = {}
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        agent, response = original_create(service, *args, **kwargs)
+        assert response is not None
+        captured["agent_id"] = int(agent.id)
+        captured["prefix"] = response.key_prefix
+        committed.set()
+        assert release.wait(timeout=2)
+        return agent, response
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        pause_after_commit,
+    )
+    operation: asyncio.Task[object] = asyncio.create_task(
+        AgentManagementRuntime().create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("exact later key"),
+        )
+    )
+    assert await asyncio.to_thread(committed.wait, 2)
+
+    db = _direct_db_session()
+    try:
+        db.add(
+            AgentApiKey(
+                agent_id=int(captured["agent_id"]),
+                key_prefix="LATER1",
+                key_hash="later-key-hash",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    operation.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(operation, timeout=2)
+
+    db = _direct_db_session()
+    try:
+        rows = {
+            row.key_prefix: row
+            for row in db.query(AgentApiKey)
+            .filter(AgentApiKey.agent_id == captured["agent_id"])
+            .all()
+        }
+        assert rows[str(captured["prefix"])].revoked_at is not None
+        assert rows["LATER1"].revoked_at is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("persist_before_error", [True, False])
+async def test_commit_ambiguity_preserves_the_exact_receipt_for_compensation(
+    monkeypatch: pytest.MonkeyPatch,
+    persist_before_error: bool,
+) -> None:
+    user_id, is_admin = _admin_identity()
+    ambiguous = RuntimeError("commit response lost")
+    original_commit = Session.commit
+    commit_calls = 0
+
+    def commit_then_raise(session: Session) -> None:
+        nonlocal commit_calls
+        commit_calls += 1
+        if persist_before_error:
+            original_commit(session)
+        else:
+            session.rollback()
+        if commit_calls == 1:
+            raise ambiguous
+        original_commit(session)
+
+    monkeypatch.setattr(Session, "commit", commit_then_raise)
+    runtime = AgentManagementRuntime()
+    with pytest.raises(RuntimeError) as exc_info:
+        await runtime.create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec(f"ambiguous {persist_before_error}"),
+        )
+
+    assert exc_info.value is ambiguous
+    monkeypatch.undo()
+    db = _direct_db_session()
+    try:
+        rows = db.query(AgentApiKey).all()
+        if persist_before_error:
+            assert len(rows) == 1
+            assert rows[0].revoked_at is not None
+        else:
+            assert rows == []
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_commit_mapping_failure_revokes_the_runtime_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    captured: dict[str, int | str] = {}
+    mapping_error = RuntimeError("response mapping failed")
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def record_key(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        agent, response = original_create(service, *args, **kwargs)
+        assert response is not None
+        captured["agent_id"] = int(agent.id)
+        captured["prefix"] = response.key_prefix
+        return agent, response
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        record_key,
+    )
+    monkeypatch.setattr(
+        agent_management.AgentStore,
+        "agent_to_response_dict",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(mapping_error),
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        await AgentManagementRuntime().create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("mapping failure"),
+        )
+
+    assert exc_info.value is mapping_error
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == captured["agent_id"],
+                AgentApiKey.key_prefix == captured["prefix"],
+            )
+            .one()
+        )
+        assert row.revoked_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_commit_session_close_failure_revokes_the_runtime_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    captured: dict[str, int | str] = {}
+    close_error = RuntimeError("worker session close failed")
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+    original_close = Session.close
+    close_calls = 0
+
+    def record_key(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        agent, response = original_create(service, *args, **kwargs)
+        assert response is not None
+        captured["agent_id"] = int(agent.id)
+        captured["prefix"] = response.key_prefix
+        return agent, response
+
+    def close_once(session: Session) -> None:
+        nonlocal close_calls
+        original_close(session)
+        close_calls += 1
+        if close_calls == 1:
+            raise close_error
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        record_key,
+    )
+    monkeypatch.setattr(Session, "close", close_once)
+    with pytest.raises(RuntimeError) as exc_info:
+        await AgentManagementRuntime().create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("session close failure"),
+        )
+
+    assert exc_info.value is close_error
+    monkeypatch.undo()
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == captured["agent_id"],
+                AgentApiKey.key_prefix == captured["prefix"],
+            )
+            .one()
+        )
+        assert row.revoked_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation_kind", ["create", "rotate"])
+@pytest.mark.parametrize("failure_stage", ["commit", "refresh"])
+async def test_cancelled_receipt_failure_is_not_replaced_by_session_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    operation_kind: str,
+    failure_stage: str,
+) -> None:
+    """Keep post-commit delivery evidence through a failing Session.close()."""
+
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    agent_id: int | None = None
+    if operation_kind == "rotate":
+        created = await runtime.create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec(
+                "close failure rotate target", generate_runtime_key=False
+            ),
+        )
+        agent_id = created.agent.id
+
+    primary_error = RuntimeError(f"{operation_kind} {failure_stage} failed")
+    close_error = RuntimeError("worker session close failed")
+    original_commit = Session.commit
+    original_refresh = Session.refresh
+    original_close = Session.close
+    close_started = threading.Event()
+    release_close = threading.Event()
+    commit_calls = 0
+    refresh_calls = 0
+    close_calls = 0
+
+    def fail_after_commit(session: Session) -> None:
+        nonlocal commit_calls
+        commit_calls += 1
+        original_commit(session)
+        if failure_stage == "commit" and commit_calls == 1:
+            raise primary_error
+
+    def fail_after_commit_refresh(session: Session, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        nonlocal refresh_calls
+        refresh_calls += 1
+        if failure_stage == "refresh" and refresh_calls == 1:
+            raise primary_error
+        original_refresh(session, *args, **kwargs)
+
+    def close_after_primary_failure(session: Session) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        original_close(session)
+        if close_calls == 1:
+            close_started.set()
+            assert release_close.wait(timeout=2)
+            raise close_error
+
+    monkeypatch.setattr(Session, "commit", fail_after_commit)
+    monkeypatch.setattr(Session, "refresh", fail_after_commit_refresh)
+    monkeypatch.setattr(Session, "close", close_after_primary_failure)
+
+    if operation_kind == "create":
+        operation: asyncio.Task[object] = asyncio.create_task(
+            runtime.create_agent(
+                user_id=user_id,
+                is_admin=is_admin,
+                spec=_create_spec(f"close failure {failure_stage}"),
+            )
+        )
+    else:
+        assert agent_id is not None
+        operation = asyncio.create_task(
+            runtime.rotate_agent_runtime_key(user_id=user_id, agent_id=agent_id)
+        )
+
+    assert await asyncio.to_thread(close_started.wait, 2)
+    operation.cancel()
+    release_close.set()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(operation, timeout=2)
+
+    assert exc_info.value.__cause__ is primary_error
+    monkeypatch.undo()
+    db = _direct_db_session()
+    try:
+        if agent_id is None:
+            row = db.query(AgentApiKey).one()
+        else:
+            row = (
+                db.query(AgentApiKey)
+                .filter(AgentApiKey.agent_id == agent_id)
+                .order_by(AgentApiKey.id.desc())
+                .first()
+            )
+            assert row is not None
+        assert row.revoked_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_opt_out_and_not_found_rotation_need_no_compensation() -> (
+    None
+):
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+
+    created = await runtime.create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("no runtime key", generate_runtime_key=False),
+    )
+
+    assert created.api_key is None
+    assert (
+        await runtime.rotate_agent_runtime_key(user_id=user_id, agent_id=999999) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    engine = _install_one_slot_queue_pool(monkeypatch, pool_timeout=2)
+    committed = threading.Event()
+    release = threading.Event()
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        result = original_create(service, *args, **kwargs)
+        committed.set()
+        assert release.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        pause_after_commit,
+    )
+    operation: asyncio.Task[object] = asyncio.create_task(
+        AgentManagementRuntime().create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("pool compensation"),
+        )
+    )
+    assert await asyncio.to_thread(committed.wait, 2)
+    held_connection = engine.connect()
+    operation.cancel()
+    release.set()
+    try:
+        ticks = 0
+        for _ in range(4):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        assert ticks == 4
+        assert operation.done() is False
+    finally:
+        held_connection.close()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(operation, timeout=2)
+    assert engine.pool.checkedout() == 0
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_stays_primary_when_runtime_key_compensation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    committed = threading.Event()
+    release = threading.Event()
+    compensation_error = RuntimeError("revocation database unavailable")
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        result = original_create(service, *args, **kwargs)
+        committed.set()
+        assert release.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        pause_after_commit,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_revoke_runtime_key_sync",
+        lambda _receipt: (_ for _ in ()).throw(compensation_error),
+    )
+    operation: asyncio.Task[object] = asyncio.create_task(
+        runtime.create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("compensation failure"),
+        )
+    )
+    assert await asyncio.to_thread(committed.wait, 2)
+    operation.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(operation, timeout=2)
+
+    assert exc_info.value.__cause__ is compensation_error
+
+
+@pytest.mark.asyncio
+async def test_compensation_process_control_wins_over_caller_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import agent_management
+
+    class WorkerShutdown(BaseException):
+        pass
+
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    committed = threading.Event()
+    release = threading.Event()
+    shutdown = WorkerShutdown("controlled worker shutdown")
+    original_create = (
+        agent_management.AgentManagementService.create_agent_with_optional_key
+    )
+
+    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        result = original_create(service, *args, **kwargs)
+        committed.set()
+        assert release.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(
+        agent_management.AgentManagementService,
+        "create_agent_with_optional_key",
+        pause_after_commit,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_revoke_runtime_key_sync",
+        lambda _receipt: (_ for _ in ()).throw(shutdown),
+    )
+    operation: asyncio.Task[object] = asyncio.create_task(
+        runtime.create_agent(
+            user_id=user_id,
+            is_admin=is_admin,
+            spec=_create_spec("compensation shutdown"),
+        )
+    )
+    assert await asyncio.to_thread(committed.wait, 2)
+    operation.cancel()
+    release.set()
+
+    with pytest.raises(WorkerShutdown) as exc_info:
+        await asyncio.wait_for(operation, timeout=2)
+
+    assert exc_info.value is shutdown
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_agent_management_runtime.py
+++ b/tests/web/api/v1/test_agent_management_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import event, text
@@ -19,6 +20,7 @@ from xagent.web.services.agent_management import (
     _RuntimeKeyDeliveryOutcome,
 )
 from xagent.web.services.api_keys import (
+    AgentApiKeyService,
     RuntimeKeyReceipt,
 )
 
@@ -535,6 +537,136 @@ async def test_later_rotation_fence_prevents_stale_compensation_from_restoring_o
         assert rows[later.key_prefix].revoked_at is None
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_runtime_key_transition_fence_serializes_transactions() -> None:
+    """The transition fence must serialize writers before either snapshots keys."""
+
+    from xagent.web.models.database import get_session_local
+    from xagent.web.services.api_keys import acquire_runtime_key_transition_fence
+
+    user_id, is_admin = _admin_identity()
+    target = await AgentManagementRuntime().create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("sqlite transition fence", generate_runtime_key=False),
+    )
+    observer = _direct_db_session()
+    try:
+        original_updated_at = observer.get(Agent, target.agent.id).updated_at
+    finally:
+        observer.close()
+    SessionLocal = get_session_local()
+    first_acquired = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_acquired = threading.Event()
+
+    def hold_first_fence() -> None:
+        with SessionLocal() as db:
+            assert acquire_runtime_key_transition_fence(db, target.agent.id)
+            first_acquired.set()
+            assert release_first.wait(timeout=2)
+            db.commit()
+
+    def acquire_second_fence() -> None:
+        assert first_acquired.wait(timeout=2)
+        with SessionLocal() as db:
+            second_started.set()
+            assert acquire_runtime_key_transition_fence(db, target.agent.id)
+            second_acquired.set()
+            db.commit()
+
+    first = asyncio.create_task(asyncio.to_thread(hold_first_fence))
+    assert await asyncio.to_thread(first_acquired.wait, 2)
+    second = asyncio.create_task(asyncio.to_thread(acquire_second_fence))
+    assert await asyncio.to_thread(second_started.wait, 2)
+    try:
+        assert not await asyncio.to_thread(second_acquired.wait, 0.1)
+    finally:
+        release_first.set()
+
+    await asyncio.wait_for(first, timeout=2)
+    await asyncio.wait_for(second, timeout=2)
+    assert second_acquired.is_set()
+    observer = _direct_db_session()
+    try:
+        assert observer.get(Agent, target.agent.id).updated_at == original_updated_at
+    finally:
+        observer.close()
+
+
+@pytest.mark.asyncio
+async def test_paused_later_state_blocks_runtime_key_compensation() -> None:
+    """Compensation must not replace an operator's later pause decision."""
+
+    user_id, is_admin = _admin_identity()
+    target = await AgentManagementRuntime().create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("paused compensation fence"),
+    )
+
+    db = _direct_db_session()
+    try:
+        previous_key = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == target.agent.id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .one()
+        )
+        previous_key_id = int(previous_key.id)
+        key_service = AgentApiKeyService(db)
+        key_service.rotate_key_for_runtime_delivery(
+            target.agent.id,
+            candidate=("xag_PAUSED_" + "p" * 32, "PAUSED", "paused-hash"),
+        )
+        receipt = key_service.runtime_key_receipt
+        assert receipt is not None
+        paused_at = datetime.now(timezone.utc)
+        new_key = db.get(AgentApiKey, receipt.key_id)
+        assert new_key is not None
+        new_key.paused_at = paused_at
+        db.commit()
+    finally:
+        db.close()
+
+    result = AgentManagementRuntime._compensate_runtime_key_sync(receipt)
+
+    assert result.new_key_revoked == 0
+    assert result.prior_keys_restored == 0
+    db = _direct_db_session()
+    try:
+        previous_key = db.get(AgentApiKey, previous_key_id)
+        new_key = db.get(AgentApiKey, receipt.key_id)
+        assert previous_key is not None
+        assert new_key is not None
+        assert previous_key.revoked_at is not None
+        assert new_key.revoked_at is None
+        assert new_key.paused_at is not None
+    finally:
+        db.close()
+
+
+def test_runtime_key_session_operation_wraps_success_with_service_receipt() -> None:
+    """The Session boundary owns the common detached success envelope."""
+
+    expected = object()
+    receipt = RuntimeKeyReceipt(key_id=1, agent_id=2, key_prefix="ABC123")
+
+    def operation(service) -> object:  # type: ignore[no-untyped-def]
+        service.runtime_key_receipt = receipt
+        return expected
+
+    outcome = AgentManagementRuntime._run_runtime_key_session_operation(operation)
+
+    assert outcome.result is expected
+    assert outcome.receipt is receipt
+    assert outcome.error is None
+    assert outcome.traceback is None
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_agent_management_runtime.py
+++ b/tests/web/api/v1/test_agent_management_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 
 import pytest
@@ -15,6 +16,10 @@ from xagent.web.models.user import User
 from xagent.web.services.agent_management import (
     AgentCreateSpec,
     AgentManagementRuntime,
+    _RuntimeKeyDeliveryOutcome,
+)
+from xagent.web.services.api_keys import (
+    RuntimeKeyReceipt,
 )
 
 from ..conftest import (
@@ -384,8 +389,30 @@ async def test_cancel_after_committed_rotation_revokes_the_undelivered_exact_key
     target = await runtime.create_agent(
         user_id=user_id,
         is_admin=is_admin,
-        spec=_create_spec("cancel committed rotation", generate_runtime_key=False),
+        spec=_create_spec("cancel committed rotation"),
     )
+    db = _direct_db_session()
+    try:
+        db.add(
+            AgentApiKey(
+                agent_id=target.agent.id,
+                key_prefix="SECOND",
+                key_hash="second-active-key-hash",
+            )
+        )
+        db.commit()
+        previous_keys = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == target.agent.id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .all()
+        )
+        previous_key_ids = {int(row.id) for row in previous_keys}
+        assert len(previous_key_ids) == 2
+    finally:
+        db.close()
     committed = threading.Event()
     release = threading.Event()
     captured: dict[str, str] = {}
@@ -411,68 +438,83 @@ async def test_cancel_after_committed_rotation_revokes_the_undelivered_exact_key
 
     db = _direct_db_session()
     try:
-        row = (
-            db.query(AgentApiKey)
-            .filter(
-                AgentApiKey.agent_id == target.agent.id,
-                AgentApiKey.key_prefix == captured["prefix"],
-            )
-            .one()
+        rows = {
+            int(row.id): row
+            for row in db.query(AgentApiKey)
+            .filter(AgentApiKey.agent_id == target.agent.id)
+            .all()
+        }
+        assert all(rows[key_id].revoked_at is None for key_id in previous_key_ids)
+        undelivered = next(
+            row for row in rows.values() if row.key_prefix == captured["prefix"]
         )
-        assert row.revoked_at is not None
+        assert undelivered.revoked_at is not None
     finally:
         db.close()
 
 
 @pytest.mark.asyncio
-async def test_exact_compensation_does_not_revoke_a_later_concurrent_key(
+async def test_later_rotation_fence_prevents_stale_compensation_from_restoring_old_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from xagent.web.services import agent_management
 
     user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    target = await runtime.create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("later rotation fence"),
+    )
+    db = _direct_db_session()
+    try:
+        original_key = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == target.agent.id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .one()
+        )
+        original_key_id = int(original_key.id)
+    finally:
+        db.close()
+
     committed = threading.Event()
     release = threading.Event()
-    captured: dict[str, int | str] = {}
-    original_create = (
-        agent_management.AgentManagementService.create_agent_with_optional_key
-    )
+    captured: dict[str, str] = {}
+    original_rotate = agent_management.AgentManagementService.generate_agent_runtime_key
+    rotate_calls = 0
 
-    def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
-        agent, response = original_create(service, *args, **kwargs)
+    def pause_first_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal rotate_calls
+        rotate_calls += 1
+        response = original_rotate(service, *args, **kwargs)
         assert response is not None
-        captured["agent_id"] = int(agent.id)
-        captured["prefix"] = response.key_prefix
-        committed.set()
-        assert release.wait(timeout=2)
-        return agent, response
+        if rotate_calls == 1:
+            captured["first_prefix"] = response.key_prefix
+            committed.set()
+            assert release.wait(timeout=2)
+        return response
 
     monkeypatch.setattr(
         agent_management.AgentManagementService,
-        "create_agent_with_optional_key",
-        pause_after_commit,
+        "generate_agent_runtime_key",
+        pause_first_after_commit,
     )
     operation: asyncio.Task[object] = asyncio.create_task(
-        AgentManagementRuntime().create_agent(
+        runtime.rotate_agent_runtime_key(
             user_id=user_id,
-            is_admin=is_admin,
-            spec=_create_spec("exact later key"),
+            agent_id=target.agent.id,
         )
     )
     assert await asyncio.to_thread(committed.wait, 2)
 
-    db = _direct_db_session()
-    try:
-        db.add(
-            AgentApiKey(
-                agent_id=int(captured["agent_id"]),
-                key_prefix="LATER1",
-                key_hash="later-key-hash",
-            )
-        )
-        db.commit()
-    finally:
-        db.close()
+    later = await AgentManagementRuntime().rotate_agent_runtime_key(
+        user_id=user_id,
+        agent_id=target.agent.id,
+    )
+    assert later is not None
 
     operation.cancel()
     release.set()
@@ -484,13 +526,212 @@ async def test_exact_compensation_does_not_revoke_a_later_concurrent_key(
         rows = {
             row.key_prefix: row
             for row in db.query(AgentApiKey)
-            .filter(AgentApiKey.agent_id == captured["agent_id"])
+            .filter(AgentApiKey.agent_id == target.agent.id)
             .all()
         }
-        assert rows[str(captured["prefix"])].revoked_at is not None
-        assert rows["LATER1"].revoked_at is None
+        original = next(row for row in rows.values() if int(row.id) == original_key_id)
+        assert original.revoked_at is not None
+        assert rows[captured["first_prefix"]].revoked_at is not None
+        assert rows[later.key_prefix].revoked_at is None
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_rotation_mapping_failure_restores_the_previous_active_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-commit worker failure leaves the last delivered key usable."""
+
+    from xagent.web.services import agent_management
+
+    user_id, is_admin = _admin_identity()
+    runtime = AgentManagementRuntime()
+    target = await runtime.create_agent(
+        user_id=user_id,
+        is_admin=is_admin,
+        spec=_create_spec("rotation mapping restore"),
+    )
+    db = _direct_db_session()
+    try:
+        previous_key = (
+            db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == target.agent.id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .one()
+        )
+        previous_key_id = int(previous_key.id)
+    finally:
+        db.close()
+
+    mapping_error = RuntimeError("runtime key mapping failed")
+    monkeypatch.setattr(
+        agent_management,
+        "_runtime_key_snapshot",
+        lambda _response: (_ for _ in ()).throw(mapping_error),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await runtime.rotate_agent_runtime_key(
+            user_id=user_id,
+            agent_id=target.agent.id,
+        )
+    assert exc_info.value is mapping_error
+
+    db = _direct_db_session()
+    try:
+        rows = (
+            db.query(AgentApiKey)
+            .filter(AgentApiKey.agent_id == target.agent.id)
+            .order_by(AgentApiKey.id)
+            .all()
+        )
+        assert len(rows) == 2
+        assert (
+            next(row for row in rows if int(row.id) == previous_key_id).revoked_at
+            is None
+        )
+        assert (
+            next(row for row in rows if int(row.id) != previous_key_id).revoked_at
+            is not None
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_compensation_cancellation_is_not_swallowed_after_worker_settles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AgentManagementRuntime()
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed_compensation(_receipt: RuntimeKeyReceipt) -> None:
+        started.set()
+        assert release.wait(timeout=2)
+
+    monkeypatch.setattr(runtime, "_compensate_runtime_key_sync", delayed_compensation)
+    compensation = asyncio.create_task(
+        runtime._compensate_runtime_key(
+            RuntimeKeyReceipt(key_id=1, agent_id=2, key_prefix="ABC123")
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    compensation.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(compensation, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_delivery_error_keeps_its_existing_cause_when_compensation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AgentManagementRuntime()
+    upstream_error = ValueError("response mapper root cause")
+    delivery_error = RuntimeError("response mapping failed")
+    delivery_error.__cause__ = upstream_error
+    compensation_error = RuntimeError("compensation database unavailable")
+    receipt = RuntimeKeyReceipt(key_id=1, agent_id=2, key_prefix="ABC123")
+
+    async def fail_compensation(_receipt: RuntimeKeyReceipt) -> BaseException:
+        return compensation_error
+
+    monkeypatch.setattr(runtime, "_compensate_runtime_key", fail_compensation)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await runtime._run_runtime_key_delivery(
+            lambda: _RuntimeKeyDeliveryOutcome(
+                result=None,
+                receipt=receipt,
+                error=delivery_error,
+                traceback=delivery_error.__traceback__,
+            )
+        )
+
+    assert exc_info.value is delivery_error
+    assert exc_info.value.__cause__ is upstream_error
+    assert any(
+        "compensation database unavailable" in note for note in exc_info.value.__notes__
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_delivery_keeps_worker_error_as_cancellation_cause() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    worker_error = RuntimeError("post-commit mapper failed")
+
+    def operation() -> _RuntimeKeyDeliveryOutcome[object]:
+        started.set()
+        assert release.wait(timeout=2)
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=worker_error,
+            traceback=worker_error.__traceback__,
+        )
+
+    caller = asyncio.create_task(
+        AgentManagementRuntime()._run_runtime_key_delivery(operation)
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    caller.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+
+    assert exc_info.value.__cause__ is worker_error
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_delivery_keeps_process_control_over_cancellation() -> None:
+    class WorkerShutdown(BaseException):
+        pass
+
+    started = threading.Event()
+    release = threading.Event()
+    shutdown = WorkerShutdown("controlled worker shutdown")
+
+    def operation() -> _RuntimeKeyDeliveryOutcome[object]:
+        started.set()
+        assert release.wait(timeout=2)
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=shutdown,
+            traceback=shutdown.__traceback__,
+        )
+
+    caller = asyncio.create_task(
+        AgentManagementRuntime()._run_runtime_key_delivery(operation)
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    caller.cancel()
+    release.set()
+
+    with pytest.raises(WorkerShutdown) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+
+    assert exc_info.value is shutdown
+
+
+def test_already_revoked_runtime_key_compensation_is_an_audited_noop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="xagent.web.services.agent_management")
+    result = AgentManagementRuntime._compensate_runtime_key_sync(
+        RuntimeKeyReceipt(key_id=999999, agent_id=2, key_prefix="ABC123")
+    )
+
+    assert result.new_key_revoked == 0
+    assert result.prior_keys_restored == 0
+    assert "new_key_revoked=0" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -850,7 +1091,7 @@ async def test_cancellation_stays_primary_when_runtime_key_compensation_fails(
     )
     monkeypatch.setattr(
         runtime,
-        "_revoke_runtime_key_sync",
+        "_compensate_runtime_key_sync",
         lambda _receipt: (_ for _ in ()).throw(compensation_error),
     )
     operation: asyncio.Task[object] = asyncio.create_task(
@@ -901,7 +1142,7 @@ async def test_compensation_process_control_wins_over_caller_cancellation(
     )
     monkeypatch.setattr(
         runtime,
-        "_revoke_runtime_key_sync",
+        "_compensate_runtime_key_sync",
         lambda _receipt: (_ for _ in ()).throw(shutdown),
     )
     operation: asyncio.Task[object] = asyncio.create_task(

--- a/tests/web/services/test_db_runtime.py
+++ b/tests/web/services/test_db_runtime.py
@@ -8,6 +8,10 @@ import threading
 import pytest
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+from xagent.web.services.agent_management import (
+    AgentManagementRuntime,
+    _RuntimeKeyDeliveryOutcome,
+)
 from xagent.web.services.db_runtime import (
     await_task_settlement,
     drain_async_task_cancellation_safe,
@@ -185,6 +189,95 @@ async def test_await_task_settlement_returns_late_result_and_cancellation() -> N
 
     assert result == "settled"
     assert isinstance(cancellation, asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_await_task_settlement_preserves_child_process_control_after_caller_cancelled() -> (
+    None
+):
+    """A raw child control signal must not be rewritten as caller cancellation."""
+
+    class WorkerShutdown(BaseException):
+        pass
+
+    child: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    waiter = asyncio.create_task(await_task_settlement(child))  # type: ignore[arg-type]
+    await asyncio.sleep(0)
+    waiter.cancel()
+    await asyncio.sleep(0)
+
+    shutdown = WorkerShutdown("controlled test shutdown")
+    child.set_exception(shutdown)
+
+    with pytest.raises(WorkerShutdown) as exc_info:
+        await asyncio.wait_for(waiter, timeout=1)
+
+    assert exc_info.value is shutdown
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_delivery_keeps_worker_error_as_caller_cancellation_cause() -> (
+    None
+):
+    started = threading.Event()
+    release = threading.Event()
+    worker_error = RuntimeError("post-commit mapper failed")
+
+    def operation() -> _RuntimeKeyDeliveryOutcome:
+        started.set()
+        assert release.wait(timeout=2)
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=worker_error,
+            traceback=worker_error.__traceback__,
+        )
+
+    caller = asyncio.create_task(
+        AgentManagementRuntime()._run_runtime_key_delivery(operation)
+    )
+    await _wait_for_thread_event(started)
+    caller.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+
+    assert exc_info.value.__cause__ is worker_error
+
+
+@pytest.mark.asyncio
+async def test_runtime_key_delivery_keeps_worker_process_control_over_caller_cancel() -> (
+    None
+):
+    class WorkerShutdown(BaseException):
+        pass
+
+    started = threading.Event()
+    release = threading.Event()
+    shutdown = WorkerShutdown("controlled worker shutdown")
+
+    def operation() -> _RuntimeKeyDeliveryOutcome:
+        started.set()
+        assert release.wait(timeout=2)
+        return _RuntimeKeyDeliveryOutcome(
+            result=None,
+            receipt=None,
+            error=shutdown,
+            traceback=shutdown.__traceback__,
+        )
+
+    caller = asyncio.create_task(
+        AgentManagementRuntime()._run_runtime_key_delivery(operation)
+    )
+    await _wait_for_thread_event(started)
+    caller.cancel()
+    release.set()
+
+    with pytest.raises(WorkerShutdown) as exc_info:
+        await asyncio.wait_for(caller, timeout=1)
+
+    assert exc_info.value is shutdown
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_db_runtime.py
+++ b/tests/web/services/test_db_runtime.py
@@ -8,10 +8,6 @@ import threading
 import pytest
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
-from xagent.web.services.agent_management import (
-    AgentManagementRuntime,
-    _RuntimeKeyDeliveryOutcome,
-)
 from xagent.web.services.db_runtime import (
     await_task_settlement,
     drain_async_task_cancellation_safe,
@@ -211,71 +207,6 @@ async def test_await_task_settlement_preserves_child_process_control_after_calle
 
     with pytest.raises(WorkerShutdown) as exc_info:
         await asyncio.wait_for(waiter, timeout=1)
-
-    assert exc_info.value is shutdown
-
-
-@pytest.mark.asyncio
-async def test_runtime_key_delivery_keeps_worker_error_as_caller_cancellation_cause() -> (
-    None
-):
-    started = threading.Event()
-    release = threading.Event()
-    worker_error = RuntimeError("post-commit mapper failed")
-
-    def operation() -> _RuntimeKeyDeliveryOutcome:
-        started.set()
-        assert release.wait(timeout=2)
-        return _RuntimeKeyDeliveryOutcome(
-            result=None,
-            receipt=None,
-            error=worker_error,
-            traceback=worker_error.__traceback__,
-        )
-
-    caller = asyncio.create_task(
-        AgentManagementRuntime()._run_runtime_key_delivery(operation)
-    )
-    await _wait_for_thread_event(started)
-    caller.cancel()
-    release.set()
-
-    with pytest.raises(asyncio.CancelledError) as exc_info:
-        await asyncio.wait_for(caller, timeout=1)
-
-    assert exc_info.value.__cause__ is worker_error
-
-
-@pytest.mark.asyncio
-async def test_runtime_key_delivery_keeps_worker_process_control_over_caller_cancel() -> (
-    None
-):
-    class WorkerShutdown(BaseException):
-        pass
-
-    started = threading.Event()
-    release = threading.Event()
-    shutdown = WorkerShutdown("controlled worker shutdown")
-
-    def operation() -> _RuntimeKeyDeliveryOutcome:
-        started.set()
-        assert release.wait(timeout=2)
-        return _RuntimeKeyDeliveryOutcome(
-            result=None,
-            receipt=None,
-            error=shutdown,
-            traceback=shutdown.__traceback__,
-        )
-
-    caller = asyncio.create_task(
-        AgentManagementRuntime()._run_runtime_key_delivery(operation)
-    )
-    await _wait_for_thread_event(started)
-    caller.cancel()
-    release.set()
-
-    with pytest.raises(WorkerShutdown) as exc_info:
-        await asyncio.wait_for(caller, timeout=1)
 
     assert exc_info.value is shutdown
 

--- a/tests/web/services/test_runtime_key_transition_postgres.py
+++ b/tests/web/services/test_runtime_key_transition_postgres.py
@@ -1,0 +1,160 @@
+"""PostgreSQL concurrency coverage for runtime-key transition fencing."""
+
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+
+import pytest
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.agent_api_key import AgentApiKey
+from xagent.web.models.database import (
+    Base,
+    get_engine,
+    get_session_local,
+    init_db,
+)
+from xagent.web.models.user import User
+from xagent.web.services.agent_management import AgentManagementRuntime
+from xagent.web.services.api_keys import (
+    AgentApiKeyService,
+    RuntimeKeyReceipt,
+    acquire_runtime_key_transition_fence,
+)
+
+
+@pytest.fixture()
+def postgres_runtime_keys():
+    """Isolated runtime-key rows in a real PostgreSQL test database."""
+
+    url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    init_db(db_url=url)
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = get_session_local()
+    try:
+        with SessionLocal() as db:
+            user = User(
+                username="runtime-key-transition",
+                password_hash="hash",
+                is_admin=True,
+            )
+            db.add(user)
+            db.flush()
+            agent = Agent(
+                user_id=int(user.id),
+                name="runtime-key-transition",
+                instructions="test",
+            )
+            db.add(agent)
+            db.flush()
+            agent_id = int(agent.id)
+            db.add(
+                AgentApiKey(
+                    agent_id=agent_id,
+                    key_prefix="ORIGIN",
+                    key_hash="origin-hash",
+                )
+            )
+            db.commit()
+        yield SessionLocal, agent_id
+    finally:
+        Base.metadata.drop_all(bind=engine)
+
+
+def test_compensation_serializes_with_a_later_postgres_rotation(
+    postgres_runtime_keys,
+) -> None:
+    """A later rotation snapshot must commit before stale compensation runs."""
+
+    SessionLocal, agent_id = postgres_runtime_keys
+    with SessionLocal() as db:
+        service = AgentApiKeyService(db)
+        service.rotate_key_for_runtime_delivery(
+            agent_id,
+            candidate=("xag_FIRST1_" + "a" * 32, "FIRST1", "first-hash"),
+        )
+        receipt = service.runtime_key_receipt
+        assert isinstance(receipt, RuntimeKeyReceipt)
+
+    snapshot_taken = threading.Event()
+    release_rotation = threading.Event()
+    compensation_started = threading.Event()
+    compensation_finished = threading.Event()
+
+    def run_later_rotation() -> None:
+        with SessionLocal() as db:
+            assert acquire_runtime_key_transition_fence(db, agent_id)
+            replaced_key_ids = tuple(
+                row_id
+                for (row_id,) in (
+                    db.query(AgentApiKey.id)
+                    .filter(
+                        AgentApiKey.agent_id == agent_id,
+                        AgentApiKey.revoked_at.is_(None),
+                    )
+                    .all()
+                )
+            )
+            snapshot_taken.set()
+            assert release_rotation.wait(timeout=10)
+            now = datetime.now(timezone.utc)
+            revoked = (
+                db.query(AgentApiKey)
+                .filter(
+                    AgentApiKey.id.in_(replaced_key_ids),
+                    AgentApiKey.revoked_at.is_(None),
+                )
+                .update(
+                    {
+                        AgentApiKey.revoked_at: now,
+                        AgentApiKey.updated_at: now,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            assert revoked == 1
+            db.add(
+                AgentApiKey(
+                    agent_id=agent_id,
+                    key_prefix="SECOND",
+                    key_hash="second-hash",
+                )
+            )
+            db.commit()
+
+    def run_compensation():
+        compensation_started.set()
+        try:
+            return AgentManagementRuntime._compensate_runtime_key_sync(receipt)
+        finally:
+            compensation_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        rotation = executor.submit(run_later_rotation)
+        assert snapshot_taken.wait(timeout=10)
+        compensation = executor.submit(run_compensation)
+        assert compensation_started.wait(timeout=10)
+        try:
+            assert not compensation_finished.wait(timeout=0.2)
+        finally:
+            release_rotation.set()
+        rotation.result(timeout=10)
+        compensation_result = compensation.result(timeout=10)
+
+    assert compensation_result.new_key_revoked == 0
+    assert compensation_result.prior_keys_restored == 0
+    with SessionLocal() as db:
+        rows = (
+            db.query(AgentApiKey)
+            .filter(AgentApiKey.agent_id == agent_id)
+            .order_by(AgentApiKey.id)
+            .all()
+        )
+        assert [row.key_prefix for row in rows if row.revoked_at is None] == ["SECOND"]


### PR DESCRIPTION
## Summary

- keep V1 one-shot runtime API key creation cancellation-safe after commit
- retain a fenced transition receipt and compensate only the transition that failed delivery
- restore the previously delivered active keys when a new rotation is not delivered
- serialize rotation and compensation on the same cross-database transition fence
- preserve caller cancellation, original worker errors, and process-control exception precedence

## Root cause

V1 agent creation and runtime-key rotation can commit a new credential before the runtime returns the plaintext key to the route. If cancellation or post-commit response mapping fails, revoking only the new row prevents exposure of an undelivered secret but also leaves every previously delivered key revoked.

The original transition fence also had two concurrency gaps: compensation did not acquire the same agent-row lock as rotation, and SQLite ignores `FOR UPDATE`. Those gaps could let overlapping transitions retain more than one active replacement key. Compensation also needed to yield to a later administrative pause.

## What changed

- use one runtime-key transition fence in rotation and compensation:
  - PostgreSQL and MySQL use `SELECT ... FOR UPDATE` on the agent row
  - SQLite uses a no-op parent-row write before the key snapshot
  - the SQLite statement bypasses the ORM `updated_at` handler
- snapshot the exact active key ids replaced by each transition
- record the new key id, agent id, prefix, replaced key ids, and rotation timestamp in a detached receipt
- centralize staging, commit ambiguity handling, and post-commit response construction in one generic service boundary
- let the worker Session boundary build successful detached outcomes, removing duplicate create/rotate envelope construction
- compensate in a fresh worker-owned Session with three fences:
  - acquire the same per-agent transition fence used by rotation
  - revoke the new key only while its exact id, owner, prefix, active state, and unpaused state still match
  - restore only receipt-listed prior rows whose `revoked_at` still equals this transition timestamp, and only when the new-key CAS changed one row
- leave all prior rows untouched when a later rotation or pause superseded the receipt, so later state wins
- log new-key and restored-row counts for both successful and no-op compensation
- restore deferred cancellation after the compensation worker settles
- keep compensation failures as notes/log evidence without replacing an existing worker error cause
- share the process-control classifier and keep runtime-specific tests with the runtime owner

## Compatibility and scope

- no API response, database schema, or migration changes
- the legacy `/api/agents/{agent_id}/api-key` shares the serialized snapshot/revoke primitive, but its response contract is unchanged and it does not gain post-commit delivery compensation
- covered paths are `POST /v1/agents`, `POST /v1/agents/from-template`, and `POST /v1/agents/{agent_id}/api-key`
- the compensation boundary ends when `AgentManagementRuntime` returns its detached result to the route; it does not claim to observe a later HTTP transport failure
- these other one-shot credential paths remain outside this PR:
  - `POST /api/agents/{agent_id}/api-key`
  - `POST /api/agent-api-keys`
  - `POST /api/agent-api-keys/{key_id}/regenerate`
  - `POST /api/me/personal-keys`
- extending the contract to those endpoints requires a shared pending-delivery state spanning their different ownership and rotation semantics; this PR intentionally does not partially retrofit them
- compensation still uses the configured database pool and timeout. A separate compensation engine or background retry owner is not introduced because it would change deterministic cleanup and deployment configuration

## Verification

- `uv run pytest -q tests/web/api/v1/test_agent_management_runtime.py tests/web/api/test_agents_management.py`
- `uv run pytest -q tests/web/api/test_agent_api_keys.py tests/web/api/v1/test_auth.py`
- `XAGENT_TEST_POSTGRES_URL=... uv run pytest -q tests/web/services/test_runtime_key_transition_postgres.py`
- changed-file pre-commit checks passed, including Ruff, formatting, mypy, isort, and codespell
- `git diff --check` passed

This is V1 control-plane hardening related to #935; it does not close the task-runtime acceptance criteria in that issue.
