### PR TITLE
fix: make the registered execution scope resolver authoritative over snapshots

### DIFF
--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -26,6 +26,36 @@ Two activation mechanisms:
    :func:`reset_execution_scope` / :class:`ExecutionScopeContext`, for
    synchronous paths that run inside the request that established the
    scope, mirroring the existing user-context pattern.
+
+Precedence contract, adjudicated in exactly one place
+(:func:`resolve_execution_scope`), between the resolver and a snapshot
+persisted in ``Task.agent_config`` (see
+:data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`): with a resolver registered, the
+resolver is authoritative and the snapshot is at most a corroborating
+candidate — a namespace-affecting disagreement fails the turn
+(:class:`ExecutionScopeAuthorityError`) rather than letting the
+client-influenceable snapshot silently win. A resolver that does not own a
+task (e.g. a workforce/delegated sub-task) abstains via
+:func:`defer_to_snapshot`, which gives the snapshot a bounded say: by
+default only as a *narrowing* of the resolver's own ``fallback``, or,
+opted into via ``snapshot_defines_namespace=True``, as the namespace
+authority outright. Registering a non-``None`` resolver requires passing
+``acknowledges_snapshot_candidate_contract=True`` to
+:func:`set_execution_scope_resolver` — a one-time acknowledgment that the
+caller has read this precedence contract. With **no resolver registered at
+all**, the persisted snapshot is the sole answer and is returned exactly
+as loaded, with none of the checks below applied to it.
+
+Snapshots carry a shape tag, :data:`EXECUTION_SCOPE_SHAPE_VERSION`
+(``ExecutionScope.version``), so a snapshot built under an older shape —
+whose absent fields would otherwise look like a deliberate disagreement —
+is not compared field-by-field against a shape it does not share. That
+gate applies only where such a comparison actually happens: the
+resolver-authoritative branch, and the default (non-opted-in)
+resolver-abstention branch. It does not apply on the opted-in
+(``snapshot_defines_namespace=True``) abstention branch, where the
+snapshot is used verbatim with no comparison, nor on the no-resolver
+branch described above, which never compares the snapshot to anything.
 """
 
 from __future__ import annotations
@@ -795,6 +825,17 @@ class ExecutionScopeResolverContractError(Exception):
 class ExecutionScopeAuthorityError(Exception):
     """A persisted snapshot disagrees with the resolver's authoritative scope.
 
+    Raised directly by :func:`resolve_execution_scope`'s
+    resolver-authoritative branch (the resolver returned a real
+    ``ExecutionScope``): there, ``resolver_scope`` genuinely is that
+    authoritative answer, which is why :func:`resolve_execution_scope_off_turn`
+    may downgrade to it. The resolver-abstention branch raises the
+    :class:`ExecutionScopeAbstentionMismatchError` subclass instead of this
+    class directly — never this class itself — precisely so a caller cannot
+    conflate the two: on that branch ``resolver_scope`` is not an
+    authoritative answer (see the subclass docstring for why it must not be
+    downgraded off-turn).
+
     Deliberately not a subclass of ``RuntimeError`` or ``ValueError``:
     ``resolve_execution_scope`` already raises plain ``ValueError`` for a
     ``None`` task_id, and callers/tests must be able to tell an authority
@@ -805,7 +846,10 @@ class ExecutionScopeAuthorityError(Exception):
     Carries the resolver's answer (``resolver_scope``) so a caller that must
     not fail a turn that has already ended or never started (see
     :func:`resolve_execution_scope_off_turn`) can log a structured warning
-    and continue with the authoritative value instead of raising.
+    and continue with the authoritative value instead of raising. This
+    downgrade is only ever valid for an instance of this exact class raised
+    on the resolver-authoritative branch — see
+    :class:`ExecutionScopeAbstentionMismatchError`.
 
     ``str()`` on this exception deliberately carries only the ``task_id``
     and the names of the mismatched fields, never the scope values: it
@@ -839,6 +883,33 @@ class ExecutionScopeAuthorityError(Exception):
             f"execution scope authority mismatch for task {task_id!r}: "
             f"mismatched_fields={sorted(self.mismatched_fields)!r}"
         )
+
+
+class ExecutionScopeAbstentionMismatchError(ExecutionScopeAuthorityError):
+    """A snapshot fails the resolver-abstention branch's narrowing check.
+
+    Raised by :func:`resolve_execution_scope` when the resolver returned
+    :func:`defer_to_snapshot` (it does not own this task's scope) and the
+    persisted snapshot is neither absent/shape-gated nor a valid narrowing
+    of the carrier's ``fallback``. It inherits ``resolver_scope`` from the
+    base class, but that attribute means something different here: the
+    resolver never produced an authoritative scope on this branch, so
+    ``resolver_scope`` is ``fallback`` — the value the resolver supplied
+    *while declining to answer*, typically all-default/unscoped for the
+    delegated/workforce case this branch exists for.
+
+    This is why a caller must never downgrade this exception the way
+    :func:`resolve_execution_scope_off_turn` downgrades the base class: a
+    downgrade needs an authority to downgrade *to*, and this branch has
+    none. Handing out ``fallback`` as if it were one would be
+    indistinguishable from "no scope at all" to a consumer like workspace
+    cleanup. A distinct exception type (rather than only an attribute)
+    makes this impossible to do by accident — a caller that only knows
+    about the base class and downgrades on ``except ExecutionScopeAuthorityError``
+    would still need to explicitly widen its except clause to catch this
+    subclass too, rather than silently inheriting a downgrade path that
+    was only ever correct for the authoritative branch.
+    """
 
 
 # Namespace-affecting fields: a disagreement here changes which sandbox key,
@@ -877,6 +948,66 @@ _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS: Mapping[
     "sandbox_mount_segments": lambda scope: scope.effective_mount_segments,
     "memory_dimensions": lambda scope: scope.memory_dimensions,
     "isolate_external_dirs": lambda scope: scope.isolate_external_dirs,
+}
+
+
+def _narrows_by_equality(snapshot_value: Any, fallback_value: Any) -> bool:
+    """``snapshot_value`` narrows ``fallback_value`` only by being equal.
+
+    Used for fields with no partial order beyond equality: an opaque
+    validated string (``sandbox_key_suffix``) or a boolean that has no
+    state narrower than ``True`` (``isolate_external_dirs``).
+    """
+    return bool(snapshot_value == fallback_value)
+
+
+def _narrows_by_prefix(
+    snapshot_value: tuple[str, ...], fallback_value: tuple[str, ...]
+) -> bool:
+    """``snapshot_value`` narrows ``fallback_value`` by extending it.
+
+    Used for path-shaped fields (``workspace_segments``, and
+    ``sandbox_mount_segments`` via its ``effective_mount_segments`` reader):
+    extra trailing segments only ever place a scope deeper inside
+    ``fallback_value``'s already-claimed tree, never outside it.
+    """
+    return snapshot_value[: len(fallback_value)] == fallback_value
+
+
+def _narrows_by_superset(
+    snapshot_value: Mapping[str, str], fallback_value: Mapping[str, str]
+) -> bool:
+    """``snapshot_value`` narrows ``fallback_value`` by extending it.
+
+    Used for ``memory_dimensions``: extra dimensions only ever narrow which
+    notes a scoped search sees; a missing or changed dimension from
+    ``fallback_value`` would widen it.
+    """
+    return all(
+        snapshot_value.get(key) == value for key, value in fallback_value.items()
+    )
+
+
+# Per-field narrowing metadata: (identity_value, narrows_relation).
+# ``identity_value`` is the field's own no-scoping default -- when
+# ``fallback`` sits at it, the resolver has claimed no authority in that
+# dimension for this task, so only an exact match is accepted regardless of
+# what ``narrows_relation`` would otherwise say (see
+# ``_execution_scope_narrowing_violations``'s docstring for why). When
+# ``fallback`` is not at its identity, ``narrows_relation(snapshot_value,
+# fallback_value)`` decides. Keyed by the same names as
+# :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS` so a namespace field added there
+# without an entry here fails the completeness test in
+# tests/core/test_execution_scope.py instead of being silently skipped by
+# ``_execution_scope_narrowing_violations``'s loop.
+_EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING: Mapping[
+    str, tuple[Any, Callable[[Any, Any], bool]]
+] = {
+    "sandbox_key_suffix": (None, _narrows_by_equality),
+    "workspace_segments": ((), _narrows_by_prefix),
+    "sandbox_mount_segments": ((), _narrows_by_prefix),
+    "memory_dimensions": ({}, _narrows_by_superset),
+    "isolate_external_dirs": (False, _narrows_by_equality),
 }
 
 
@@ -969,49 +1100,40 @@ def _execution_scope_narrowing_violations(
     policy-only disagreement between ``snapshot`` and ``fallback`` is
     handled separately by the caller (see the abstention branch of
     :func:`resolve_execution_scope`), not by this function.
+
+    Enforced generically: this loops over
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS`, reading each field through
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS` and applying its
+    identity/relation pair from
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING`, rather than five
+    hardcoded per-field checks -- a namespace field added to the first table
+    without a matching entry in the second raises a ``KeyError`` here
+    instead of silently passing through unchecked.
     """
     violations: dict[str, tuple[Any, Any]] = {}
     reader = _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS
 
-    fallback_suffix = reader["sandbox_key_suffix"](fallback)
-    snapshot_suffix = reader["sandbox_key_suffix"](snapshot)
-    if snapshot_suffix != fallback_suffix:
-        violations["sandbox_key_suffix"] = (snapshot_suffix, fallback_suffix)
-
-    fallback_ws = reader["workspace_segments"](fallback)
-    snapshot_ws = reader["workspace_segments"](snapshot)
-    workspace_ok = (
-        snapshot_ws[: len(fallback_ws)] == fallback_ws
-        if fallback_ws
-        else snapshot_ws == fallback_ws
-    )
-    if not workspace_ok:
-        violations["workspace_segments"] = (snapshot_ws, fallback_ws)
-
-    fallback_mount = reader["sandbox_mount_segments"](fallback)
-    snapshot_mount = reader["sandbox_mount_segments"](snapshot)
-    mount_ok = (
-        snapshot_mount[: len(fallback_mount)] == fallback_mount
-        if fallback_mount
-        else snapshot_mount == fallback_mount
-    )
-    if not mount_ok:
-        violations["sandbox_mount_segments"] = (snapshot_mount, fallback_mount)
-
-    fallback_isolate = reader["isolate_external_dirs"](fallback)
-    snapshot_isolate = reader["isolate_external_dirs"](snapshot)
-    if snapshot_isolate != fallback_isolate:
-        violations["isolate_external_dirs"] = (snapshot_isolate, fallback_isolate)
-
-    fallback_dims = reader["memory_dimensions"](fallback)
-    snapshot_dims = reader["memory_dimensions"](snapshot)
-    dims_ok = (
-        all(snapshot_dims.get(key) == value for key, value in fallback_dims.items())
-        if fallback_dims
-        else not snapshot_dims
-    )
-    if not dims_ok:
-        violations["memory_dimensions"] = (dict(snapshot_dims), dict(fallback_dims))
+    for name in _EXECUTION_SCOPE_NAMESPACE_FIELDS:
+        identity, narrows = _EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING[name]
+        fallback_value = reader[name](fallback)
+        snapshot_value = reader[name](snapshot)
+        ok = (
+            snapshot_value == fallback_value
+            if fallback_value == identity
+            else narrows(snapshot_value, fallback_value)
+        )
+        if not ok:
+            recorded_snapshot = (
+                dict(snapshot_value)
+                if isinstance(snapshot_value, Mapping)
+                else snapshot_value
+            )
+            recorded_fallback = (
+                dict(fallback_value)
+                if isinstance(fallback_value, Mapping)
+                else fallback_value
+            )
+            violations[name] = (recorded_snapshot, recorded_fallback)
 
     return violations
 
@@ -1039,8 +1161,10 @@ def _validate_execution_scope_snapshot_candidate(
     task_id: str | int,
     snapshot: Optional[ExecutionScope],
     diff_target: ExecutionScope,
+    *,
+    enforce_shape_version: bool = True,
 ) -> Optional[ExecutionScope]:
-    """Shared shape gate a loaded snapshot must pass before either branch uses it.
+    """Shared candidate gate a loaded snapshot must pass before either branch uses it.
 
     Both the authoritative and resolver-abstention branches of
     :func:`resolve_execution_scope` route a freshly loaded snapshot through
@@ -1051,21 +1175,34 @@ def _validate_execution_scope_snapshot_candidate(
     raw dict, a stray :class:`DeferToSnapshot`, or any other object would
     reach the turn contextvar unchecked, or (on the branch that compares
     fields) raise an unrelated ``AttributeError`` at the first ``.version``
-    access instead of a diagnosable contract error.
+    access instead of a diagnosable contract error. The type check below
+    always applies, regardless of ``enforce_shape_version``.
 
-    A snapshot whose shape version does not match
-    :data:`EXECUTION_SCOPE_SHAPE_VERSION` (older, missing entirely, or --
-    during a mixed-version rollout -- newer) cannot be safely compared
-    field-by-field against ``diff_target``: a field the current shape added
-    or changed always looks "different" from a scope built under a
-    different shape, and that is not a real conflict. Such a snapshot is
-    logged with a field-level diff against ``diff_target`` and treated as
-    absent (``None``) rather than raised on.
+    The shape-version gate exists to protect a *comparison*: a snapshot
+    whose shape version does not match :data:`EXECUTION_SCOPE_SHAPE_VERSION`
+    (older, missing entirely, or -- during a mixed-version rollout -- newer)
+    cannot be safely compared field-by-field against ``diff_target``,
+    because a field the current shape added or changed always looks
+    "different" from a scope built under a different shape, which is not a
+    real conflict. Where no such comparison happens, gating discards data
+    for nothing -- so ``enforce_shape_version=False`` is the caller's
+    signal that ``snapshot``, if it passes the type check, will be used
+    verbatim rather than compared. Concretely: the authoritative branch and
+    the default (non-opted-in) resolver-abstention branch both compare the
+    snapshot (against the resolver's answer, or against the carrier's
+    fallback for narrowing) and pass the default ``True``; the
+    ``snapshot_defines_namespace=True`` abstention branch uses the snapshot
+    verbatim with no comparison and passes ``False``. A gated-away snapshot
+    is logged with a field-level diff against ``diff_target`` and treated
+    as absent (``None``) rather than raised on; that diff is only computed
+    when the warning will actually be emitted, since this gate runs on
+    every turn for any snapshot that predates a shape bump.
 
     Returns:
-        The snapshot unchanged when it is a current-shape ``ExecutionScope``;
-        ``None`` when there was no snapshot to begin with, or it was
-        shape-gated away.
+        The snapshot unchanged when it is an ``ExecutionScope`` and either
+        ``enforce_shape_version`` is ``False`` or its version matches
+        :data:`EXECUTION_SCOPE_SHAPE_VERSION`; ``None`` when there was no
+        snapshot to begin with, or it was shape-gated away.
 
     Raises:
         ExecutionScopeResolverContractError: ``snapshot`` is neither
@@ -1078,15 +1215,16 @@ def _validate_execution_scope_snapshot_candidate(
             f"execution scope snapshot loader returned {snapshot!r} for "
             f"task {task_id!r}; expected an ExecutionScope or None"
         )
-    if snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
-        logger.warning(
-            "Ignoring execution scope snapshot candidate for task %s: shape "
-            "version %s does not match the current version %s; diff=%s",
-            task_id,
-            snapshot.version,
-            EXECUTION_SCOPE_SHAPE_VERSION,
-            _execution_scope_field_diff(snapshot, diff_target),
-        )
+    if enforce_shape_version and snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                "Ignoring execution scope snapshot candidate for task %s: shape "
+                "version %s does not match the current version %s; diff=%s",
+                task_id,
+                snapshot.version,
+                EXECUTION_SCOPE_SHAPE_VERSION,
+                _execution_scope_field_diff(snapshot, diff_target),
+            )
         return None
     return snapshot
 
@@ -1101,13 +1239,18 @@ def resolve_execution_scope(
     With no resolver registered, the persisted snapshot (see
     :func:`set_execution_scope_snapshot_loader`) is the sole answer,
     byte-identical to the pre-authority behavior standalone/workforce
-    deployments rely on for restart/resume. With a resolver registered, the
-    resolver is authoritative and runs first; the snapshot (when the
-    resolver's answer needs one) is a corroborating candidate only. Whenever
-    a snapshot is loaded, both branches below route it through the same
-    :func:`_validate_execution_scope_snapshot_candidate` gate before using
-    it -- neither branch compares against, or activates, a snapshot that
-    hasn't passed that check:
+    deployments rely on for restart/resume -- returned exactly as loaded,
+    with **no type check and no shape-version gate**: there is nothing to
+    compare it to on this branch, and this is a known, pre-existing gap
+    rather than a new contract (see
+    ``test_no_resolver_registered_non_scope_loader_output_passes_through``).
+    With a resolver registered, the resolver is authoritative and runs
+    first; the snapshot (when the resolver's answer needs one) is a
+    corroborating candidate only. Whenever a snapshot is loaded on a
+    resolver-registered branch, both branches below route it through the
+    same :func:`_validate_execution_scope_snapshot_candidate` gate before
+    using it -- neither branch compares against, or activates, a snapshot
+    that hasn't passed that check:
 
     - Resolver raises: propagates immediately: the snapshot is not consulted.
     - Resolver returns ``None``: authoritative unscoped; the snapshot is not
@@ -1125,17 +1268,23 @@ def resolve_execution_scope(
       on the carrier's ``snapshot_defines_namespace`` (see
       :func:`defer_to_snapshot`):
 
-      - ``False`` (the default): the snapshot is used only if it is a
-        *narrowing* of the carrier's ``fallback`` (see
+      - ``False`` (the default): the shape-version gate applies (the
+        snapshot is about to be compared), and the snapshot is used only if
+        it is a *narrowing* of the carrier's ``fallback`` (see
         :func:`_execution_scope_narrowing_violations`) -- a snapshot is
         client-influenceable (a client-supplied ``agent_config`` can carry
         an ``execution_scope`` key that reaches the persisted snapshot), so
         an unchecked snapshot here would let a caller widen its own
         namespace past the resolver's own conservative fallback. A
-        non-narrowing snapshot raises :class:`ExecutionScopeAuthorityError`.
+        non-narrowing snapshot raises
+        :class:`ExecutionScopeAbstentionMismatchError` (a subclass of
+        :class:`ExecutionScopeAuthorityError` -- see that class for why the
+        distinction matters to :func:`resolve_execution_scope_off_turn`).
       - ``True``: the resolver has stated it does not own this task and the
-        snapshot is the namespace authority; the narrowing check is skipped
-        and the snapshot's namespace fields are used verbatim.
+        snapshot is the namespace authority; the shape-version gate does
+        not apply (nothing is compared) and the narrowing check is skipped
+        -- the snapshot's namespace fields are used verbatim once it passes
+        the type check.
 
       Once the namespace is settled either way, a policy-only difference
       (``strict_memory_isolation``) between the snapshot and the fallback is
@@ -1161,11 +1310,16 @@ def resolve_execution_scope(
             query the loader/resolver for the literal string ``"None"``.
             Callers that legitimately have no task identity must treat
             that as unscoped themselves instead of passing None.
-        ExecutionScopeAuthorityError: a persisted snapshot disagrees with
-            the resolver's authoritative scope on a namespace-affecting
-            field, or -- on the resolver-abstention branch, unless the
-            carrier opted into ``snapshot_defines_namespace=True`` -- is not
-            a narrowing of the resolver's fallback.
+        ExecutionScopeAuthorityError: raised by the resolver-authoritative
+            branch when a persisted snapshot disagrees with the resolver's
+            scope on a namespace-affecting field. ``resolver_scope`` on
+            this exception is a genuine authoritative answer.
+        ExecutionScopeAbstentionMismatchError: (subclass of the above)
+            raised by the resolver-abstention branch when, unless the
+            carrier opted into ``snapshot_defines_namespace=True``, a
+            persisted snapshot is not a narrowing of the resolver's
+            fallback. ``resolver_scope`` on this exception is ``fallback``,
+            not an authoritative answer -- see the subclass docstring.
         ExecutionScopeResolverContractError: the resolver, or a registered
             snapshot loader, returned something outside its contract.
     """
@@ -1175,10 +1329,11 @@ def resolve_execution_scope(
             "must treat the execution as unscoped instead"
         )
 
-    if _execution_scope_resolver is None:
+    resolver = _execution_scope_resolver
+    if resolver is None:
         return _load_execution_scope_snapshot(task_id, persisted_snapshot)
 
-    resolved = _execution_scope_resolver(str(task_id))
+    resolved = resolver(str(task_id))
 
     if isinstance(resolved, DeferToSnapshot):
         # No try/except here: the resolver has just said it does not know
@@ -1187,7 +1342,10 @@ def resolve_execution_scope(
         # silently proceed unscoped or under a stale fallback.
         snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
         snapshot = _validate_execution_scope_snapshot_candidate(
-            task_id, snapshot, resolved.fallback
+            task_id,
+            snapshot,
+            resolved.fallback,
+            enforce_shape_version=not resolved.snapshot_defines_namespace,
         )
         if snapshot is None:
             return resolved.fallback
@@ -1203,7 +1361,12 @@ def resolve_execution_scope(
                     task_id,
                     violations,
                 )
-                raise ExecutionScopeAuthorityError(
+                # Not the base ExecutionScopeAuthorityError: the resolver
+                # abstained on this branch, so resolved.fallback below is
+                # not an authoritative value -- see
+                # ExecutionScopeAbstentionMismatchError's docstring for why
+                # that distinction must survive as far as the exception type.
+                raise ExecutionScopeAbstentionMismatchError(
                     str(task_id),
                     resolver_scope=resolved.fallback,
                     snapshot_scope=snapshot,
@@ -1277,11 +1440,18 @@ def resolve_execution_scope(
             task_id,
             diff,
         )
+        # mismatched_fields carries only namespace_diff, not the full diff:
+        # this error reaches task.error_message and a client-facing event
+        # (see the class docstring), and the raise is gated on
+        # namespace_diff alone -- including policy-only fields here would
+        # misleadingly list them as "mismatched" next to the real conflict.
+        # The full diff (namespace + policy) is still logged above, which
+        # stays server-side.
         raise ExecutionScopeAuthorityError(
             str(task_id),
             resolver_scope=resolved,
             snapshot_scope=snapshot,
-            mismatched_fields=diff,
+            mismatched_fields=namespace_diff,
         )
 
     logger.warning(
@@ -1297,16 +1467,33 @@ def resolve_execution_scope_off_turn(task_id: str | int) -> Optional[ExecutionSc
 
     Used by off-turn storage-key/workspace-segment composition (legacy
     preview backfill, a not-yet-persisted durable object) that cannot fail a
-    turn that has already ended or never started. An
+    turn that has already ended or never started.
+
+    Downgrades only a plain :class:`ExecutionScopeAuthorityError` -- raised
+    by ``resolve_execution_scope``'s resolver-authoritative branch, where
+    ``resolver_scope`` genuinely is an authoritative answer -- to that
+    answer plus a structured warning, instead of raising. An unhandled
     :class:`ExecutionScopeAuthorityError` here would otherwise surface as a
     misleading "file not found" or a bulk endpoint's 500, at a point where
-    the resolver has already produced an authoritative answer -- so it is
-    downgraded to that answer plus a structured warning instead of raised.
-    Every other exception (resolver/loader failure, ``task_id`` None) still
+    an authoritative answer already exists to fall back on.
+
+    Does **not** downgrade :class:`ExecutionScopeAbstentionMismatchError`
+    (the subclass raised by the resolver-abstention branch): a downgrade
+    needs an authority to downgrade *to*, and that branch never produced
+    one -- its ``resolver_scope`` is ``fallback``, the value the resolver
+    supplied *while declining to answer*, typically all-default/unscoped
+    for the delegated/workforce case. Handing that out here would be
+    indistinguishable from "no scope at all" to a caller such as workspace
+    cleanup, so this mismatch propagates unchanged and this off-turn face
+    stays fail-closed exactly like the in-turn one.
+
+    Every other exception (resolver/loader failure, ``task_id`` None) also
     propagates unchanged.
     """
     try:
         return resolve_execution_scope(task_id)
+    except ExecutionScopeAbstentionMismatchError:
+        raise
     except ExecutionScopeAuthorityError as exc:
         logger.warning(
             "Execution scope authority mismatch resolved off-turn for task "

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -33,7 +33,7 @@ import contextvars
 import logging
 import re
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Callable, Iterator, Mapping, Optional, Union, cast
 
@@ -95,6 +95,81 @@ def validate_scope_component(value: Any, *, field_name: str = "scope component")
             "must be a string matching [a-zA-Z0-9_-]{1,63}"
         )
     return value
+
+
+def _coerce_scope_sequence(value: Any, *, field_name: str) -> tuple[Any, ...]:
+    """Coerce a raw ``from_dict`` sequence field, never silently misreading it.
+
+    A falsy value (``None``, ``""``, ``[]``, ``0``, ``False``) means "absent"
+    and becomes ``()``. Anything else must already be a ``list``/``tuple``:
+    ``tuple(value)`` on a bare string or mapping does not raise, it silently
+    iterates characters/keys into single-character "segments" that then pass
+    per-segment validation, and on a non-iterable it raises a bare
+    ``TypeError`` outside this module's error taxonomy. Both failure modes are
+    closed here instead of deferring to ``tuple()``.
+
+    Raises:
+        InvalidScopeComponentError: ``value`` is truthy and not a list/tuple.
+    """
+    if not value:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    logger.error("Invalid %s %r: must be a list or tuple", field_name, value)
+    raise InvalidScopeComponentError(
+        f"invalid {field_name} {value!r}: must be a list or tuple"
+    )
+
+
+def _coerce_scope_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
+    """Coerce a raw ``from_dict`` mapping field, never silently misreading it.
+
+    Mirrors :func:`_coerce_scope_sequence` for the one mapping-shaped field
+    (``memory_dimensions``): a falsy value means "absent" and becomes ``{}``;
+    anything else must already be a ``Mapping``, since ``dict(value)`` on an
+    iterable of 2-character strings (e.g. ``["ab"]``) silently reinterprets
+    each as a key/value pair instead of raising.
+
+    Raises:
+        InvalidScopeComponentError: ``value`` is truthy and not a ``Mapping``.
+    """
+    if not value:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    logger.error("Invalid %s %r: must be a mapping", field_name, value)
+    raise InvalidScopeComponentError(
+        f"invalid {field_name} {value!r}: must be a mapping"
+    )
+
+
+def _coerce_snapshot_version(raw_version: Any) -> int:
+    """Coerce ``from_dict``'s ``version`` field without raising or truncating.
+
+    ``version`` reaches here from a snapshot that can originate in a client-
+    supplied ``Task.agent_config`` (see :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`),
+    so it is untrusted input. A missing or malformed value is treated exactly
+    like a snapshot that pre-dates this field: coerced to ``0``, which
+    downstream ``_validate_execution_scope_snapshot_candidate`` already
+    recognizes as "not the current shape" and logs + ignores as a candidate.
+    That existing tolerance is the correct home for "we cannot trust this
+    value" — inventing a second, raising code path for the same trust level
+    would just be a different way of not trusting it.
+
+    Accepts an ``int`` or a string of digits (the shape a JSON-decoded
+    snapshot's ``version`` can arrive as); anything else -- including a
+    ``float``, which ``int()`` would otherwise silently truncate -- coerces to
+    ``0`` rather than raising a bare ``ValueError``/``TypeError`` that a
+    generic ``except (ValueError, ..., TypeError)`` clause elsewhere would
+    fold into an unrelated "malformed client message" response.
+    """
+    if isinstance(raw_version, bool):
+        return 0
+    if isinstance(raw_version, int):
+        return raw_version
+    if isinstance(raw_version, str) and raw_version.isdigit():
+        return int(raw_version)
+    return 0
 
 
 # Shape version stamped by ``to_dict`` / read back by ``from_dict``. Bump
@@ -221,20 +296,44 @@ class ExecutionScope:
     def from_dict(cls, data: Mapping[str, Any]) -> "ExecutionScope":
         """Rebuild a scope from :meth:`to_dict` output (re-validated).
 
+        ``data`` reaches here from a client-influenceable source (a
+        snapshot embedded in ``Task.agent_config``, see
+        :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`), so every field is coerced
+        defensively rather than trusted to already have the shape
+        ``to_dict`` produces: ``sandbox_key_suffix`` and the segment/mapping
+        fields are re-validated by the constructor
+        (:meth:`__post_init__`) or by :func:`_coerce_scope_sequence` /
+        :func:`_coerce_scope_mapping` before reaching it, and ``version`` is
+        coerced by :func:`_coerce_snapshot_version` -- never a raw
+        ``int()``/``tuple()``/``dict()`` call that could raise a bare
+        stdlib error outside this module's error taxonomy or silently
+        misread/truncate the value.
+
         ``version`` defaults to ``0`` (not
-        :data:`EXECUTION_SCOPE_SHAPE_VERSION`) when the key is absent: a
-        snapshot persisted before this field existed must decode as
-        distinguishably older, not silently pass as current-shape.
+        :data:`EXECUTION_SCOPE_SHAPE_VERSION`) when the key is absent or
+        unparsable: a snapshot persisted before this field existed, or one
+        carrying a malformed value, must both decode as distinguishably
+        older rather than silently passing as current-shape.
         """
         raw_mount = data.get("sandbox_mount_segments")
         return cls(
             sandbox_key_suffix=data.get("sandbox_key_suffix"),
-            workspace_segments=tuple(data.get("workspace_segments") or ()),
-            sandbox_mount_segments=(None if raw_mount is None else tuple(raw_mount)),
-            memory_dimensions=dict(data.get("memory_dimensions") or {}),
+            workspace_segments=_coerce_scope_sequence(
+                data.get("workspace_segments"), field_name="workspace_segments"
+            ),
+            sandbox_mount_segments=(
+                None
+                if raw_mount is None
+                else _coerce_scope_sequence(
+                    raw_mount, field_name="sandbox_mount_segments"
+                )
+            ),
+            memory_dimensions=_coerce_scope_mapping(
+                data.get("memory_dimensions"), field_name="memory_dimensions"
+            ),
             strict_memory_isolation=bool(data.get("strict_memory_isolation", False)),
             isolate_external_dirs=bool(data.get("isolate_external_dirs", False)),
-            version=int(data.get("version") or 0),
+            version=_coerce_snapshot_version(data.get("version")),
         )
 
     def __post_init__(self) -> None:
@@ -738,22 +837,39 @@ def _execution_scope_narrowing_violations(
     conservative answer for the task. Returns an empty dict when ``snapshot``
     narrows (or matches) ``fallback`` on every field below.
 
-    "Narrowing" per field, in terms of what it does to a namespace:
+    The governing rule, per field: narrowing can only extend scoping the
+    fallback *already committed to*. If ``fallback``'s value for a field is
+    that field's own no-scoping identity (``None`` for ``sandbox_key_suffix``,
+    ``()`` for ``workspace_segments``/the mount, ``False`` for
+    ``isolate_external_dirs``, ``{}`` for ``memory_dimensions``), the
+    resolver has claimed *no* authority in that dimension for this task, so
+    ``snapshot`` may not introduce any there either -- only an exact match is
+    accepted, regardless of whether the introduced value would, taken alone,
+    look like it "only narrows". Concretely, this means an all-default
+    ``fallback`` (the natural value for a resolver with "no opinion" on this
+    task) accepts nothing but an all-default snapshot: there is no scoping
+    to narrow into, so every field falls back to equality. This is what
+    closes the case a purely-relative, per-field prefix/superset test cannot:
+    such a test is vacuously satisfied by *any* snapshot value once the
+    fallback's own field sits at its identity element.
 
-    - ``sandbox_key_suffix``: equal, or ``fallback`` has none and
-      ``snapshot`` sets one -- appending a sub-key to a bare owner-level
-      sandbox lifecycle key only ever narrows it, never widens it.
-    - ``workspace_segments``: ``snapshot``'s tuple starts with
-      ``fallback``'s -- extra trailing path segments only ever place a scope
-      deeper inside ``fallback``'s directory tree, never outside it.
+    When ``fallback``'s value for a field is *not* at that identity, the
+    field's specific narrowing relation applies:
+
+    - ``sandbox_key_suffix``: no partial order beyond equality -- a suffix is
+      an opaque, validated string, not something one value can be "deeper
+      inside" another. Equal is the only accepted relation once ``fallback``
+      has committed to a specific value.
+    - ``workspace_segments``: ``snapshot``'s tuple starts with ``fallback``'s
+      -- extra trailing path segments only ever place a scope deeper inside
+      ``fallback``'s already-claimed directory tree, never outside it.
     - ``sandbox_mount_segments``: the same prefix test, compared via
       ``effective_mount_segments`` so an unset field (mount covers the full
       ``workspace_segments``) compares like its expanded form rather than
       bypassing the check.
-    - ``isolate_external_dirs``: may flip False -> True (shared external
-      dirs becoming scope-local narrows what a scope can read) but never
-      True -> False (that would widen a scope-local namespace back to
-      shared).
+    - ``isolate_external_dirs``: a boolean has no state narrower than
+      ``True``, so once ``fallback`` is already ``True`` only ``True`` is
+      accepted -- equality, same as ``sandbox_key_suffix``.
     - ``memory_dimensions``: ``snapshot``'s mapping must be a superset of
       ``fallback``'s -- extra dimensions only ever narrow which notes a
       scoped search sees; a missing or changed dimension from ``fallback``
@@ -761,26 +877,39 @@ def _execution_scope_narrowing_violations(
 
     ``strict_memory_isolation`` (policy, not namespace) is intentionally
     excluded, matching :data:`_EXECUTION_SCOPE_POLICY_FIELDS` -- narrowing
-    is about the namespace a scope selects, not post-filter policy on it.
+    is about the namespace a scope selects, not post-filter policy on it. A
+    policy-only disagreement between ``snapshot`` and ``fallback`` is
+    handled separately by the caller (see the abstention branch of
+    :func:`resolve_execution_scope`), not by this function.
     """
     violations: dict[str, tuple[Any, Any]] = {}
 
     fallback_suffix = fallback.sandbox_key_suffix
     snapshot_suffix = snapshot.sandbox_key_suffix
-    if fallback_suffix is not None and snapshot_suffix != fallback_suffix:
+    if snapshot_suffix != fallback_suffix:
         violations["sandbox_key_suffix"] = (snapshot_suffix, fallback_suffix)
 
     fallback_ws = fallback.workspace_segments
     snapshot_ws = snapshot.workspace_segments
-    if snapshot_ws[: len(fallback_ws)] != fallback_ws:
+    workspace_ok = (
+        snapshot_ws[: len(fallback_ws)] == fallback_ws
+        if fallback_ws
+        else snapshot_ws == fallback_ws
+    )
+    if not workspace_ok:
         violations["workspace_segments"] = (snapshot_ws, fallback_ws)
 
     fallback_mount = fallback.effective_mount_segments
     snapshot_mount = snapshot.effective_mount_segments
-    if snapshot_mount[: len(fallback_mount)] != fallback_mount:
+    mount_ok = (
+        snapshot_mount[: len(fallback_mount)] == fallback_mount
+        if fallback_mount
+        else snapshot_mount == fallback_mount
+    )
+    if not mount_ok:
         violations["sandbox_mount_segments"] = (snapshot_mount, fallback_mount)
 
-    if fallback.isolate_external_dirs and not snapshot.isolate_external_dirs:
+    if snapshot.isolate_external_dirs != fallback.isolate_external_dirs:
         violations["isolate_external_dirs"] = (
             snapshot.isolate_external_dirs,
             fallback.isolate_external_dirs,
@@ -788,7 +917,12 @@ def _execution_scope_narrowing_violations(
 
     fallback_dims = fallback.memory_dimensions
     snapshot_dims = snapshot.memory_dimensions
-    if any(snapshot_dims.get(key) != value for key, value in fallback_dims.items()):
+    dims_ok = (
+        all(snapshot_dims.get(key) == value for key, value in fallback_dims.items())
+        if fallback_dims
+        else not snapshot_dims
+    )
+    if not dims_ok:
         violations["memory_dimensions"] = (dict(snapshot_dims), dict(fallback_dims))
 
     return violations
@@ -905,7 +1039,11 @@ def resolve_execution_scope(
       unchecked snapshot here would let a caller widen its own namespace
       past the resolver's own conservative fallback. A non-narrowing
       snapshot raises :class:`ExecutionScopeAuthorityError`; an absent or
-      shape-gated snapshot falls back to the carrier's ``fallback``.
+      shape-gated snapshot falls back to the carrier's ``fallback``. Once
+      the namespace is settled, a policy-only difference (``strict_
+      memory_isolation``) between the snapshot and the fallback is logged
+      and the fallback's value wins -- symmetric with the authoritative
+      branch below, where the resolver's policy value wins the same way.
     - Resolver returns an ``ExecutionScope``: authoritative. A snapshot
       loader exception is logged and ignored (the candidate is corrupt, but
       an authoritative answer already exists). Otherwise: a
@@ -968,6 +1106,33 @@ def resolve_execution_scope(
                 resolver_scope=resolved.fallback,
                 snapshot_scope=snapshot,
                 mismatched_fields=violations,
+            )
+        if (
+            snapshot.strict_memory_isolation
+            != resolved.fallback.strict_memory_isolation
+        ):
+            # Symmetric with the authoritative branch's policy-only-mismatch
+            # handling below: the namespace is settled (validated above as a
+            # narrowing of resolved.fallback), but the policy field is not
+            # part of that check, so an unlogged pass-through here would
+            # silently let a client-influenceable snapshot flip it. The
+            # fallback plays the authoritative role on this branch, so its
+            # policy value wins, the same way the resolver's value wins on
+            # the authoritative branch.
+            logger.warning(
+                "Execution scope policy-only mismatch for task %s on the "
+                "resolver-abstention branch (fallback wins): %s",
+                task_id,
+                {
+                    "strict_memory_isolation": (
+                        snapshot.strict_memory_isolation,
+                        resolved.fallback.strict_memory_isolation,
+                    )
+                },
+            )
+            return replace(
+                snapshot,
+                strict_memory_isolation=resolved.fallback.strict_memory_isolation,
             )
         return snapshot
 

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -482,6 +482,11 @@ def execution_scope_from_agent_config(
     try:
         return ExecutionScope.from_dict(scope_data)
     except InvalidScopeComponentError as exc:
+        # The field-level detail names the offending value, which can carry an
+        # end-user identifier, so it stays in this server-side log line; the
+        # raised message names only the failure's type, because that message
+        # reaches the task's error column and a client-facing event.
+        logger.error("Persisted execution scope snapshot failed validation: %s", exc)
         raise ExecutionScopeResolverContractError(
             "persisted execution scope snapshot failed validation "
             f"({type(exc).__name__}); see the logged field-level detail"

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -97,6 +97,16 @@ def validate_scope_component(value: Any, *, field_name: str = "scope component")
     return value
 
 
+# Shape version stamped by ``to_dict`` / read back by ``from_dict``. Bump
+# whenever a namespace-affecting field is added so ``resolve_execution_scope``
+# can tell a snapshot written against a different shape (``version`` missing,
+# lower, or -- during a mixed-version rollout -- higher than this constant)
+# from one written against the current shape.
+# ``from_dict`` cannot distinguish "field absent because pre-dates it" from
+# "field explicitly at its default" any other way -- it fills both the same.
+EXECUTION_SCOPE_SHAPE_VERSION = 1
+
+
 @dataclass(frozen=True)
 class ExecutionScope:
     """Immutable execution scope. All fields default to current behavior.
@@ -118,8 +128,8 @@ class ExecutionScope:
             scope's task can read and write a co-mounted sibling's subtree.
             Only the orchestrator-side file/workspace API enforces
             ``scoped_user_root``. Therefore this field must only group scopes
-            that are already the **same trust principal**; never use it to
-            co-mount scopes belonging to different end users. Must be a prefix
+            that already share one **runtime trust domain**; never use it to
+            co-mount scopes across distinct runtime trust domains. Must be a prefix
             of ``workspace_segments``. ``None`` (the default) means the mount
             covers the full ``workspace_segments`` — byte-identical to
             pre-existing behavior. Consumed only by the sandbox-mount
@@ -134,6 +144,13 @@ class ExecutionScope:
             is empty.
         isolate_external_dirs: When True, KB/upload external dirs become
             scope-local instead of shared across the user's scopes.
+        version: Shape version this instance was constructed against
+            (see :data:`EXECUTION_SCOPE_SHAPE_VERSION`). Excluded from
+            equality (``compare=False``): it is bookkeeping for
+            :func:`resolve_execution_scope`'s snapshot-vs-resolver
+            comparison, not a namespace-affecting field, and two otherwise
+            identical scopes built at different times must still compare
+            equal. Not intended for callers to set explicitly.
     """
 
     sandbox_key_suffix: Optional[str] = None
@@ -142,6 +159,7 @@ class ExecutionScope:
     memory_dimensions: Mapping[str, str] = field(default_factory=dict)
     strict_memory_isolation: bool = False
     isolate_external_dirs: bool = False
+    version: int = field(default=EXECUTION_SCOPE_SHAPE_VERSION, compare=False)
 
     @property
     def effective_mount_segments(self) -> tuple[str, ...]:
@@ -188,11 +206,18 @@ class ExecutionScope:
             "memory_dimensions": dict(self.memory_dimensions),
             "strict_memory_isolation": self.strict_memory_isolation,
             "isolate_external_dirs": self.isolate_external_dirs,
+            "version": self.version,
         }
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ExecutionScope":
-        """Rebuild a scope from :meth:`to_dict` output (re-validated)."""
+        """Rebuild a scope from :meth:`to_dict` output (re-validated).
+
+        ``version`` defaults to ``0`` (not
+        :data:`EXECUTION_SCOPE_SHAPE_VERSION`) when the key is absent: a
+        snapshot persisted before this field existed must decode as
+        distinguishably older, not silently pass as current-shape.
+        """
         raw_mount = data.get("sandbox_mount_segments")
         return cls(
             sandbox_key_suffix=data.get("sandbox_key_suffix"),
@@ -201,6 +226,7 @@ class ExecutionScope:
             memory_dimensions=dict(data.get("memory_dimensions") or {}),
             strict_memory_isolation=bool(data.get("strict_memory_isolation", False)),
             isolate_external_dirs=bool(data.get("isolate_external_dirs", False)),
+            version=int(data.get("version") or 0),
         )
 
     def __post_init__(self) -> None:
@@ -268,7 +294,9 @@ class ExecutionScope:
 # Reserved key under which a task's ``agent_config`` JSON carries a
 # persisted scope snapshot (ExecutionScope.to_dict()). Internally created
 # tasks (workforce runs) have task ids the embedder's resolver cannot map;
-# the snapshot is written at task creation and preferred over the resolver.
+# the snapshot is written at task creation and read back as a corroborating
+# candidate when a resolver is registered (see resolve_execution_scope), or
+# as the sole answer when no resolver is registered.
 EXECUTION_SCOPE_AGENT_CONFIG_KEY = "execution_scope"
 
 
@@ -277,9 +305,13 @@ def execution_scope_from_agent_config(
 ) -> Optional[ExecutionScope]:
     """Decode the persisted scope snapshot owned by a task config.
 
-    ``None`` means the task has no persisted snapshot and the canonical
-    resolution flow may consult the registered resolver. Invalid snapshots
-    propagate instead of silently degrading to an unscoped namespace.
+    ``None`` means the task has no persisted snapshot. The canonical
+    resolution flow (:func:`resolve_execution_scope`) always calls a
+    registered resolver first; this snapshot is only a corroborating
+    candidate for the resolver's answer, or the sole answer when no
+    resolver is registered -- it is never consulted ahead of the resolver.
+    Invalid snapshots propagate instead of silently degrading to an
+    unscoped namespace.
     """
 
     if not isinstance(agent_config, Mapping):
@@ -322,9 +354,13 @@ def metadata_carries_scope_dimensions(metadata: Mapping[str, Any]) -> bool:
 
 # Hashable identity of a scope's namespace-affecting fields:
 # (sandbox_key_suffix, workspace_segments, effective_mount_segments,
-#  sorted memory_dimensions items).
+#  sorted memory_dimensions items, isolate_external_dirs).
 ScopeFingerprint = tuple[
-    Optional[str], tuple[str, ...], tuple[str, ...], tuple[tuple[str, str], ...]
+    Optional[str],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[tuple[str, str], ...],
+    bool,
 ]
 
 
@@ -332,13 +368,23 @@ def scope_fingerprint(scope: Optional[ExecutionScope]) -> Optional[ScopeFingerpr
     """Hashable fingerprint of the namespaces a scope selects.
 
     Per-task caches that bake scope-derived state in at build time (sandbox
-    keys, workspace paths, sandbox mount root, memory dimensions) key their
-    eviction checks on this. The mount root is captured via
-    ``effective_mount_segments`` so a changed mount prefix invalidates the
-    cache instead of silently reusing a stale ``base_dir`` (which a later
-    rebuild would then reject in ``SandboxManager._ensure_config_equivalent``).
-    ``None`` is the sentinel for unscoped, distinct from an empty scope's
-    fingerprint.
+    keys, workspace paths, sandbox mount root, memory dimensions,
+    ``allowed_external_dirs``) key their eviction checks on this. The mount
+    root is captured via ``effective_mount_segments`` so a changed mount
+    prefix invalidates the cache instead of silently reusing a stale
+    ``base_dir`` (which a later rebuild would then reject in
+    ``SandboxManager._ensure_config_equivalent``). ``isolate_external_dirs``
+    is included for the same reason: it is baked
+    into the cached ``AgentService``'s ``Workspace.allowed_external_dirs``
+    at build time (``_build_allowed_external_dirs`` -> ``AgentService.
+    __init__`` -> ``WorkspaceManager.get_or_create_workspace``) rather than
+    read fresh per call, so an isolate_external_dirs-only change across
+    turns must evict the cache or the stale allowed-dirs list (shared root
+    vs. scope-local) keeps being enforced. ``strict_memory_isolation`` is
+    intentionally excluded: it is read fresh from the contextvar on every
+    memory operation (``UserIsolatedMemoryStore``), so nothing cached here
+    goes stale when only that flag changes. ``None`` is the sentinel for
+    unscoped, distinct from an empty scope's fingerprint.
     """
     if scope is None:
         return None
@@ -347,6 +393,7 @@ def scope_fingerprint(scope: Optional[ExecutionScope]) -> Optional[ScopeFingerpr
         scope.workspace_segments,
         scope.effective_mount_segments,
         tuple(sorted(scope.memory_dimensions.items())),
+        scope.isolate_external_dirs,
     )
 
 
@@ -402,15 +449,73 @@ class ExecutionScopeContext:
             reset_execution_scope(self.token)
 
 
+class DeferToSnapshot:
+    """Resolver return value meaning "defer to the persisted snapshot".
+
+    Not an :class:`ExecutionScope`: it never enters
+    :func:`resolve_execution_scope`'s return value directly, is never
+    activated on the ``current_execution_scope`` contextvar, and carries no
+    scope attributes of its own. Construct via :func:`defer_to_snapshot`;
+    the ``fallback`` is used only when no snapshot is persisted for the
+    task (a task id the resolver's embedder does not itself recognize, with
+    no Task-table snapshot either).
+    """
+
+    __slots__ = ("fallback",)
+
+    def __init__(self, fallback: ExecutionScope) -> None:
+        if not isinstance(fallback, ExecutionScope):
+            raise TypeError(
+                "defer_to_snapshot(fallback) requires an ExecutionScope, "
+                f"got {fallback!r}"
+            )
+        self.fallback = fallback
+
+
+def defer_to_snapshot(fallback: ExecutionScope) -> DeferToSnapshot:
+    """Build a resolver return value that defers to the persisted snapshot.
+
+    ``fallback`` is mandatory (not ``Optional``, no default): it is the
+    scope used when the task carries no persisted snapshot, and must be the
+    resolver's own most conservative answer for that task (e.g. today's
+    creator-direct scope) so a defer never resolves *wider* than the
+    resolver's own answer would have. This cannot be enforced by
+    ``resolve_execution_scope`` itself (a resolver can pass anything as
+    ``fallback``); it is the resolver author's obligation. An implicit
+    ``None`` fallback would silently mean "authoritative unscoped on a
+    snapshot miss" and must instead be spelled out explicitly by the caller.
+    """
+    return DeferToSnapshot(fallback)
+
+
 # The embedding application injects a scope resolver via
 # set_execution_scope_resolver() (same injection pattern as
-# set_user_tool_overrides_hook in the web layer).
-ExecutionScopeResolver = Callable[[str], Optional[ExecutionScope]]
+# set_user_tool_overrides_hook in the web layer). Three return values:
+#
+# - ``ExecutionScope``: authoritative for this task.
+# - ``None``: authoritative unscoped for this task (not "abstain").
+# - ``DeferToSnapshot`` (see :func:`defer_to_snapshot`): abstain in favor of
+#   the persisted snapshot, with a fallback for when none is persisted.
+ExecutionScopeResolver = Callable[[str], Union[ExecutionScope, None, DeferToSnapshot]]
 
 _execution_scope_resolver: Optional[ExecutionScopeResolver] = None
 
 
-def set_execution_scope_resolver(resolver: Optional[ExecutionScopeResolver]) -> None:
+def execution_scope_resolver_registered() -> bool:
+    """Whether an embedder has registered a scope resolver.
+
+    Used at startup to log which authority mode is active: with a resolver
+    registered, persisted snapshots are a corroborating candidate (see
+    :func:`resolve_execution_scope`); with none, they are the sole answer.
+    """
+    return _execution_scope_resolver is not None
+
+
+def set_execution_scope_resolver(
+    resolver: Optional[ExecutionScopeResolver],
+    *,
+    acknowledges_snapshot_candidate_contract: bool = False,
+) -> None:
     """Register the resolver that maps a ``task_id`` to its ExecutionScope.
 
     Resolver contract:
@@ -420,13 +525,47 @@ def set_execution_scope_resolver(resolver: Optional[ExecutionScopeResolver]) -> 
       equal scope for the same ``task_id`` every time. Reassigning a task to
       a different scope between turns is possible but expensive (per-task
       caches rebuild); a resolver that flaps A -> B -> A is a bug.
-    - Return ``None`` for tasks that run unscoped. No registered resolver
-      means every task runs unscoped.
+    - **Three-valued return**: an ``ExecutionScope`` is authoritative for
+      the task; ``None`` is authoritative *unscoped* for the task (not an
+      abstention); :func:`defer_to_snapshot` abstains in favor of the
+      persisted snapshot, with a mandatory fallback for tasks that carry
+      none. No registered resolver means every task runs unscoped.
+    - **Provenance, not existence**: whether to defer must be decided from
+      the task's own provenance (e.g. whether the embedder's own records
+      show it as one of its tasks), never from whether a snapshot happens
+      to exist for it. Deferring merely because a snapshot is present
+      degrades this contract back into "snapshot always wins".
     - Scope fields are consumed independently by subsystems; the resolver
       may populate any subset.
     - An exception from the resolver fails the turn: falling back to
       unscoped on error would silently merge namespaces.
+    - When a persisted snapshot also exists for the task,
+      :func:`resolve_execution_scope` treats it as a corroborating
+      candidate, not an override: a namespace-affecting disagreement with
+      an authoritative (non-defer) answer fails the turn instead of
+      silently picking one side.
+
+    Args:
+        resolver: The resolver, or ``None`` to clear it.
+        acknowledges_snapshot_candidate_contract: Must be ``True`` to
+            register a non-``None`` resolver.
+
+    Raises:
+        TypeError: a non-``None`` resolver is registered without passing
+            ``acknowledges_snapshot_candidate_contract=True``. This fails at
+            registration time (e.g. embedder import/startup) instead of the
+            first turn silently treating a persisted snapshot as an override
+            by an embedder that has not read the contract above.
     """
+    if resolver is not None and not acknowledges_snapshot_candidate_contract:
+        raise TypeError(
+            "set_execution_scope_resolver(resolver) requires "
+            "acknowledges_snapshot_candidate_contract=True: a persisted "
+            "scope snapshot is now a corroborating candidate rather than an "
+            "override, and callers must confirm they have read the "
+            "resolver's three-valued / provenance contract in this "
+            "function's docstring before registering one"
+        )
     global _execution_scope_resolver
     _execution_scope_resolver = resolver
 
@@ -445,14 +584,135 @@ def set_execution_scope_snapshot_loader(
     """Register the loader for persisted per-task scope snapshots.
 
     The loader returns the snapshot persisted at task creation, or None for
-    tasks without one. A persisted snapshot is preferred over the resolver:
-    internally created tasks (workforce runs) have ids the embedder's
-    resolver cannot map, and the snapshot is what keeps them scoped across
-    process restarts. Loader exceptions fail the turn — falling back to the
-    resolver (or unscoped) on error could silently switch namespaces.
+    tasks without one. With a resolver registered, the snapshot is a
+    corroborating candidate for the resolver's authoritative answer (see
+    :func:`resolve_execution_scope`); with no resolver registered, it is the
+    sole answer -- this is what keeps internally created tasks (workforce
+    runs, whose ids the embedder's resolver cannot map) scoped across
+    process restarts. Loader exceptions fail the turn when no resolver is
+    registered; otherwise a broken candidate is logged and ignored rather
+    than vetoing the resolver's already-given authoritative answer.
     """
     global _execution_scope_snapshot_loader
     _execution_scope_snapshot_loader = loader
+
+
+class ExecutionScopeResolverContractError(Exception):
+    """A registered resolver returned something outside its three-valued contract.
+
+    Deliberately not a subclass of ``RuntimeError``, ``ValueError``, or
+    ``TypeError``: several websocket handlers catch
+    ``except (ValueError, KeyError, TypeError)`` around the turn-execution
+    path and fold anything in that tuple into a generic "client message
+    format error" response. A resolver author's bug at the ``resolve_execution_scope``
+    boundary is a server-side contract violation, not a malformed client
+    message, and must not be swallowed by that handler as if it were one.
+
+    Only used for the return-type check inside ``resolve_execution_scope``
+    itself. The ``TypeError`` that :func:`set_execution_scope_resolver`
+    raises for a missing acknowledgment token is unrelated -- that happens
+    at registration time (embedder import/startup, before any request
+    handler exists) and is intentionally left as a plain ``TypeError``.
+    """
+
+
+class ExecutionScopeAuthorityError(Exception):
+    """A persisted snapshot disagrees with the resolver's authoritative scope.
+
+    Deliberately not a subclass of ``RuntimeError`` or ``ValueError``:
+    ``resolve_execution_scope`` already raises plain ``ValueError`` for a
+    ``None`` task_id, and callers/tests must be able to tell an authority
+    conflict apart from that structural error instead of both being folded
+    by the same ``except ValueError`` (or a broad ``except RuntimeError``)
+    clause.
+
+    Carries the resolver's answer (``resolver_scope``) so a caller that must
+    not fail a turn that has already ended or never started (see
+    :func:`resolve_execution_scope_off_turn`) can log a structured warning
+    and continue with the authoritative value instead of raising.
+
+    ``str()`` on this exception deliberately carries only the ``task_id``
+    and the names of the mismatched fields, never the scope values: it
+    ends up in ``task.error_message`` and in the client's terminal error
+    event (see ``task_orchestrator``'s setup/run failure handling, which
+    formats durable/broadcast error strings from ``str(exc)``), and the
+    scope values include ``sandbox_key_suffix``, ``workspace_segments``,
+    and ``memory_dimensions`` -- namespace components that can carry
+    end-user/client identifiers. The full scopes and the field-level value
+    diff are logged via ``logger.error`` at the raise site instead, which
+    stays server-side.
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        *,
+        resolver_scope: ExecutionScope,
+        snapshot_scope: ExecutionScope,
+        mismatched_fields: Mapping[str, tuple[Any, Any]],
+    ) -> None:
+        self.task_id = task_id
+        self.resolver_scope = resolver_scope
+        self.snapshot_scope = snapshot_scope
+        self.mismatched_fields = dict(mismatched_fields)
+        super().__init__(
+            f"execution scope authority mismatch for task {task_id!r}: "
+            f"mismatched_fields={sorted(self.mismatched_fields)!r}"
+        )
+
+
+# Namespace-affecting fields: a disagreement here changes which sandbox key,
+# workspace path, mount root, or memory-dimension notes a task's execution
+# actually touches, so resolve_execution_scope fails the turn rather than
+# silently picking one side.
+_EXECUTION_SCOPE_NAMESPACE_FIELDS: tuple[str, ...] = (
+    "sandbox_key_suffix",
+    "workspace_segments",
+    "sandbox_mount_segments",
+    "memory_dimensions",
+    "isolate_external_dirs",
+)
+
+# Policy fields: change post-filter behavior on an otherwise-identical
+# namespace, never which key/path is touched. A disagreement here is logged
+# and the resolver's value wins, but does not fail the turn.
+_EXECUTION_SCOPE_POLICY_FIELDS: tuple[str, ...] = ("strict_memory_isolation",)
+
+
+def _execution_scope_field_diff(
+    snapshot: ExecutionScope, resolver: ExecutionScope
+) -> dict[str, tuple[Any, Any]]:
+    """Per-field ``(snapshot_value, resolver_value)`` for differing fields.
+
+    Compares every namespace/policy field (excludes ``version``, which is
+    shape bookkeeping, not a scope field).
+    """
+    diff: dict[str, tuple[Any, Any]] = {}
+    for name in _EXECUTION_SCOPE_NAMESPACE_FIELDS + _EXECUTION_SCOPE_POLICY_FIELDS:
+        snapshot_value = getattr(snapshot, name)
+        resolver_value = getattr(resolver, name)
+        if snapshot_value != resolver_value:
+            diff[name] = (snapshot_value, resolver_value)
+    return diff
+
+
+def _load_execution_scope_snapshot(
+    task_id: str | int,
+    persisted_snapshot: ExecutionScopeInput,
+) -> Optional[ExecutionScope]:
+    """Fetch the persisted snapshot, honoring an explicitly-passed override.
+
+    A database owner that already read the persisted snapshot in its own
+    Session may pass it via ``persisted_snapshot`` to skip the registered
+    loader (see :func:`resolve_execution_scope`).
+    """
+    if persisted_snapshot is EXECUTION_SCOPE_NOT_PROVIDED:
+        return (
+            _execution_scope_snapshot_loader(str(task_id))
+            if _execution_scope_snapshot_loader is not None
+            else None
+        )
+    return cast(Optional[ExecutionScope], persisted_snapshot)
 
 
 def resolve_execution_scope(
@@ -462,38 +722,166 @@ def resolve_execution_scope(
 ) -> Optional[ExecutionScope]:
     """Resolve the scope for ``task_id``.
 
-    A persisted snapshot (see :func:`set_execution_scope_snapshot_loader`)
-    is preferred over the resolver; with neither registered, or both
-    returning None, the task runs unscoped. Loader/resolver exceptions
-    propagate to the caller. A database owner that already read the persisted
-    snapshot may pass it explicitly; this skips the registered loader while
-    preserving the same snapshot-then-resolver precedence. Explicit ``None``
-    means "snapshot absent", not "force an unscoped task".
+    With no resolver registered, the persisted snapshot (see
+    :func:`set_execution_scope_snapshot_loader`) is the sole answer,
+    byte-identical to the pre-authority behavior standalone/workforce
+    deployments rely on for restart/resume. With a resolver registered, the
+    resolver is authoritative and runs first; the snapshot (when the
+    resolver's answer needs one) is a corroborating candidate only:
+
+    - Resolver raises: propagates immediately: the snapshot is not consulted.
+    - Resolver returns ``None``: authoritative unscoped; the snapshot is not
+      consulted.
+    - Resolver returns :func:`defer_to_snapshot`'s carrier: the snapshot is
+      used if present, else the carrier's fallback. A broken snapshot loader
+      here is logged and treated as absent (falls back), matching the
+      principle below that a broken candidate cannot veto an answer the
+      resolver has already committed to (the fallback *is* that answer).
+    - Resolver returns an ``ExecutionScope``: authoritative. A snapshot
+      loader exception is logged and ignored (the candidate is corrupt, but
+      an authoritative answer already exists). A snapshot whose shape
+      version does not match the current one (:data:`EXECUTION_SCOPE_SHAPE_VERSION`,
+      including one missing the field entirely, and also a snapshot stamped
+      by a *newer* process during a mixed-version rollout) is logged
+      (field-level diff) and ignored rather than compared -- a field the
+      current shape added or changed always looks "different" from a
+      freshly-resolved scope built against a different shape, and that is
+      not a real conflict. Otherwise: a namespace-affecting difference (see
+      :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS`) raises
+      :class:`ExecutionScopeAuthorityError`; a policy-only difference (see
+      :data:`_EXECUTION_SCOPE_POLICY_FIELDS`) is logged and the resolver's
+      value still wins.
+
+    A database owner that already read the persisted snapshot may pass it
+    explicitly via ``persisted_snapshot``; this skips the registered loader
+    while preserving the same precedence. Explicit ``None`` means "snapshot
+    absent", not "force an unscoped task".
 
     Raises:
         ValueError: ``task_id`` is None — ``str(None)`` would silently
             query the loader/resolver for the literal string ``"None"``.
             Callers that legitimately have no task identity must treat
             that as unscoped themselves instead of passing None.
+        ExecutionScopeAuthorityError: a persisted snapshot disagrees with
+            the resolver's authoritative scope on a namespace-affecting
+            field.
     """
     if task_id is None:
         raise ValueError(
             "task_id cannot be None; a caller without a task identity "
             "must treat the execution as unscoped instead"
         )
-    if persisted_snapshot is EXECUTION_SCOPE_NOT_PROVIDED:
-        snapshot = (
-            _execution_scope_snapshot_loader(str(task_id))
-            if _execution_scope_snapshot_loader is not None
-            else None
-        )
-    else:
-        snapshot = cast(Optional[ExecutionScope], persisted_snapshot)
-    if snapshot is not None:
-        return snapshot
+
     if _execution_scope_resolver is None:
+        return _load_execution_scope_snapshot(task_id, persisted_snapshot)
+
+    resolved = _execution_scope_resolver(str(task_id))
+
+    if isinstance(resolved, DeferToSnapshot):
+        try:
+            snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
+        except Exception:
+            logger.warning(
+                "Snapshot loader failed while resolver deferred for task %s; "
+                "using the resolver's fallback",
+                task_id,
+                exc_info=True,
+            )
+            return resolved.fallback
+        return snapshot if snapshot is not None else resolved.fallback
+
+    if resolved is None:
         return None
-    return _execution_scope_resolver(str(task_id))
+
+    if not isinstance(resolved, ExecutionScope):
+        raise ExecutionScopeResolverContractError(
+            f"execution scope resolver returned {resolved!r}; expected an "
+            "ExecutionScope, None, or defer_to_snapshot(...)"
+        )
+
+    try:
+        snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
+    except Exception:
+        logger.warning(
+            "Snapshot loader failed while the resolver returned an "
+            "authoritative scope for task %s; ignoring the candidate",
+            task_id,
+            exc_info=True,
+        )
+        return resolved
+
+    if snapshot is None:
+        return resolved
+
+    if snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
+        # Not just "older": a mixed-version rollout can also see a snapshot
+        # stamped by a newer process than this one. Either direction means
+        # the snapshot's shape cannot be safely compared field-by-field
+        # against a freshly-resolved scope built against *this* process's
+        # shape, so the candidate is ignored rather than raised on.
+        logger.warning(
+            "Ignoring execution scope snapshot candidate for task %s: shape "
+            "version %s does not match the current version %s; diff=%s",
+            task_id,
+            snapshot.version,
+            EXECUTION_SCOPE_SHAPE_VERSION,
+            _execution_scope_field_diff(snapshot, resolved),
+        )
+        return resolved
+
+    diff = _execution_scope_field_diff(snapshot, resolved)
+    if not diff:
+        return resolved
+
+    namespace_diff = {
+        name: values
+        for name, values in diff.items()
+        if name in _EXECUTION_SCOPE_NAMESPACE_FIELDS
+    }
+    if namespace_diff:
+        logger.error(
+            "Execution scope authority mismatch for task %s: %s",
+            task_id,
+            diff,
+        )
+        raise ExecutionScopeAuthorityError(
+            str(task_id),
+            resolver_scope=resolved,
+            snapshot_scope=snapshot,
+            mismatched_fields=diff,
+        )
+
+    logger.warning(
+        "Execution scope policy-only mismatch for task %s (resolver wins): %s",
+        task_id,
+        diff,
+    )
+    return resolved
+
+
+def resolve_execution_scope_off_turn(task_id: str | int) -> Optional[ExecutionScope]:
+    """Resolve scope for a consumer outside the turn lifecycle.
+
+    Used by off-turn storage-key/workspace-segment composition (legacy
+    preview backfill, a not-yet-persisted durable object) that cannot fail a
+    turn that has already ended or never started. An
+    :class:`ExecutionScopeAuthorityError` here would otherwise surface as a
+    misleading "file not found" or a bulk endpoint's 500, at a point where
+    the resolver has already produced an authoritative answer -- so it is
+    downgraded to that answer plus a structured warning instead of raised.
+    Every other exception (resolver/loader failure, ``task_id`` None) still
+    propagates unchanged.
+    """
+    try:
+        return resolve_execution_scope(task_id)
+    except ExecutionScopeAuthorityError as exc:
+        logger.warning(
+            "Execution scope authority mismatch resolved off-turn for task "
+            "%s (using the resolver's answer): %s",
+            exc.task_id,
+            exc.mismatched_fields,
+        )
+        return exc.resolver_scope
 
 
 @contextmanager

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -1351,6 +1351,17 @@ def _load_execution_scope_snapshot(
             if _execution_scope_snapshot_loader is not None
             else None
         )
+    if isinstance(persisted_agent_config, ExecutionScope):
+        # An already-decoded scope would not be a Mapping, so the decode below
+        # would read it as "this task carries no snapshot" -- which on the
+        # branches that must fail closed is indistinguishable from an
+        # authoritative unscoped answer. Refuse it instead of silently
+        # dropping the caller's value.
+        raise ExecutionScopeResolverContractError(
+            "persisted_agent_config takes the task's raw agent_config mapping, "
+            "not an already-decoded ExecutionScope; the snapshot inside it is "
+            "decoded here so each resolution branch keeps its own tolerance"
+        )
     return execution_scope_from_agent_config(
         cast(Optional[Mapping[str, Any]], persisted_agent_config)
     )

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -47,15 +47,18 @@ all**, the persisted snapshot is the sole answer and is returned exactly
 as loaded, with none of the checks below applied to it.
 
 Snapshots carry a shape tag, :data:`EXECUTION_SCOPE_SHAPE_VERSION`
-(``ExecutionScope.version``), so a snapshot built under an older shape —
-whose absent fields would otherwise look like a deliberate disagreement —
-is not compared field-by-field against a shape it does not share. That
-gate applies only where such a comparison actually happens: the
-resolver-authoritative branch, and the default (non-opted-in)
-resolver-abstention branch. It does not apply on the opted-in
-(``snapshot_defines_namespace=True``) abstention branch, where the
-snapshot is used verbatim with no comparison, nor on the no-resolver
-branch described above, which never compares the snapshot to anything.
+(``ExecutionScope.version``), and the gate reading it is **asymmetric**. A
+snapshot built under an *older* shape — whose absent fields would otherwise
+look like a deliberate disagreement — is only refused where a field-by-field
+comparison actually happens: the resolver-authoritative branch and the
+default (non-opted-in) resolver-abstention branch. The opted-in
+(``snapshot_defines_namespace=True``) abstention branch compares nothing and
+uses such a snapshot verbatim. A snapshot stamped *newer* than this process,
+by contrast, is refused on **every** resolver-registered branch including
+that opt-in: ``from_dict`` drops keys the current shape does not know, so a
+newer snapshot arrives partially decoded and may have lost a
+namespace-narrowing field. The no-resolver branch described above applies
+neither direction — it returns the snapshot exactly as loaded.
 """
 
 from __future__ import annotations
@@ -450,6 +453,25 @@ def execution_scope_from_agent_config(
     resolver is registered -- it is never consulted ahead of the resolver.
     Invalid snapshots propagate instead of silently degrading to an
     unscoped namespace.
+
+    A decode failure is re-raised as
+    :class:`ExecutionScopeResolverContractError`, not as the
+    :class:`InvalidScopeComponentError` (a ``ValueError``) the field coercions
+    raise. This function is the boundary where *persisted* data is read: the
+    snapshot loaders registered by the web layer call it from inside
+    :func:`resolve_execution_scope`, which several websocket handlers wrap in
+    ``except (ValueError, KeyError, TypeError)`` clauses that answer the
+    client with a message-format validation error. A snapshot that no longer
+    decodes is a persisted-data/contract fault, not a malformed client
+    message, and must not be reported as one. The original error is chained
+    as ``__cause__`` and its field-level detail is already logged by the
+    coercion that raised it, so nothing diagnosable is lost -- while the
+    message here names no snapshot value, since it can carry end-user
+    identifiers and travels further than the log does.
+
+    Raises:
+        ExecutionScopeResolverContractError: the persisted snapshot is
+            present but fails field validation.
     """
 
     if not isinstance(agent_config, Mapping):
@@ -457,7 +479,13 @@ def execution_scope_from_agent_config(
     scope_data = agent_config.get(EXECUTION_SCOPE_AGENT_CONFIG_KEY)
     if not isinstance(scope_data, Mapping):
         return None
-    return ExecutionScope.from_dict(scope_data)
+    try:
+        return ExecutionScope.from_dict(scope_data)
+    except InvalidScopeComponentError as exc:
+        raise ExecutionScopeResolverContractError(
+            "persisted execution scope snapshot failed validation "
+            f"({type(exc).__name__}); see the logged field-level detail"
+        ) from exc
 
 
 # Metadata-key prefix under which ExecutionScope.memory_dimensions are
@@ -610,6 +638,16 @@ class DeferToSnapshot:
     must narrow (see :func:`resolve_execution_scope`'s abstention-branch
     validation). See :func:`defer_to_snapshot` for what
     ``snapshot_defines_namespace`` changes.
+
+    Construction enforces that opt-in's precondition: with
+    ``snapshot_defines_namespace=True`` the ``fallback`` must claim no
+    namespace at all -- every field in
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS` sitting at its own no-scoping
+    identity. A fallback that already commits to a namespace has an answer
+    the snapshot would *replace* rather than narrow, which is the one thing
+    no abstention shape may do; such a resolver must return an authoritative
+    :class:`ExecutionScope` instead of deferring. Policy fields are
+    unconstrained -- the fallback still owns those on both shapes.
     """
 
     __slots__ = ("fallback", "snapshot_defines_namespace")
@@ -622,9 +660,30 @@ class DeferToSnapshot:
     ) -> None:
         if not isinstance(fallback, ExecutionScope):
             raise TypeError(
-                "defer_to_snapshot(fallback) requires an ExecutionScope, "
-                f"got {fallback!r}"
+                "defer_to_snapshot(fallback) requires an ExecutionScope, got "
+                f"{type(fallback).__name__}"
             )
+        if snapshot_defines_namespace:
+            committed = _namespace_committed_fields(fallback)
+            if committed:
+                # Machine-checks the opt-in's precondition rather than leaving
+                # it to prose: resolve_execution_scope hands the namespace to
+                # the snapshot verbatim on this shape, so a fallback that had
+                # pre-committed to one would be silently overwritten instead
+                # of acting as a floor.
+                logger.error(
+                    "defer_to_snapshot(snapshot_defines_namespace=True) got a "
+                    "namespace-committed fallback %r; committed fields: %s",
+                    fallback,
+                    sorted(committed),
+                )
+                raise ExecutionScopeResolverContractError(
+                    "defer_to_snapshot(snapshot_defines_namespace=True) "
+                    "requires a fallback that claims no namespace, but this "
+                    f"one commits to {sorted(committed)!r}; a resolver that "
+                    "already knows the namespace must return an authoritative "
+                    "ExecutionScope instead of deferring"
+                )
         self.fallback = fallback
         self.snapshot_defines_namespace = snapshot_defines_namespace
 
@@ -659,17 +718,24 @@ def defer_to_snapshot(
       namespace -- the workforce/delegated-task pattern, where a task is
       created and scoped entirely by the persisted snapshot and the
       resolver's embedder has no record mapping that task id to a namespace
-      of its own. In that shape ``fallback`` cannot pre-commit to the
+      of its own. In that shape ``fallback`` **must not** pre-commit to the
       namespace (if it could, the resolver would return an authoritative
-      ``ExecutionScope`` instead of deferring), so the narrowing check is
-      skipped for namespace fields and a present, shape-valid snapshot's
-      namespace fields are used verbatim. This opt-in declares the snapshot
-      is the namespace authority for tasks this resolver does not own; it
-      does not make an untrusted snapshot safe, and it does not skip the
-      type check, the shape-version gate, the mandatory ``fallback`` for a
-      snapshot miss, or policy-field symmetry (a ``strict_memory_isolation``
-      difference is still logged and ``fallback``'s value still wins) --
-      only namespace narrowing is skipped.
+      ``ExecutionScope`` instead of deferring), and that precondition is
+      enforced at construction: a ``fallback`` non-identity on any field in
+      :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS` raises
+      :class:`ExecutionScopeResolverContractError` rather than having its
+      namespace silently replaced by the snapshot's. Given a conforming
+      fallback, the narrowing check is skipped for namespace fields and a
+      present, type- and shape-valid snapshot's namespace fields are used
+      verbatim. This opt-in declares the snapshot is the namespace authority
+      for tasks this resolver does not own; it does not make an untrusted
+      snapshot safe, and it does not skip the type check, the *newer*-shape
+      half of the shape-version gate (see
+      ``_validate_execution_scope_snapshot_candidate``), the mandatory
+      ``fallback`` for a snapshot miss, or policy-field symmetry (every field
+      in :data:`_EXECUTION_SCOPE_POLICY_FIELDS` that differs is logged and
+      ``fallback``'s value still wins) -- only namespace narrowing and the
+      *older*-shape half of the version gate are skipped.
 
     Neither value distinguishes a snapshot that arrived inside a
     client-supplied ``Task.agent_config`` from one written server-side out of
@@ -678,6 +744,12 @@ def defer_to_snapshot(
     tracked separately (issue #1016); until then, ``snapshot_defines_namespace
     =True`` should only be used by a resolver whose embedder controls how
     that task's snapshot was written.
+
+    Raises:
+        TypeError: ``fallback`` is not an ``ExecutionScope``.
+        ExecutionScopeResolverContractError:
+            ``snapshot_defines_namespace=True`` with a ``fallback`` that
+            already commits to a namespace.
     """
     return DeferToSnapshot(
         fallback, snapshot_defines_namespace=snapshot_defines_namespace
@@ -798,27 +870,42 @@ def set_execution_scope_snapshot_loader(
 
 
 class ExecutionScopeResolverContractError(Exception):
-    """A registered resolver or snapshot loader returned something outside its contract.
+    """A resolver, a snapshot loader, or persisted snapshot data broke its contract.
 
     Deliberately not a subclass of ``RuntimeError``, ``ValueError``, or
     ``TypeError``: several websocket handlers catch
     ``except (ValueError, KeyError, TypeError)`` around the turn-execution
     path and fold anything in that tuple into a generic "client message
     format error" response. A resolver or loader author's bug at the
-    ``resolve_execution_scope`` boundary is a server-side contract
-    violation, not a malformed client message, and must not be swallowed by
-    that handler as if it were one.
+    ``resolve_execution_scope`` boundary, and a persisted snapshot that no
+    longer decodes, are both server-side/persisted-data faults rather than
+    malformed client messages, and must not be swallowed by that handler as
+    if they were.
 
-    Used for two return-type checks inside ``resolve_execution_scope``: the
-    resolver's three-valued return, and a loaded snapshot that is neither
-    ``None`` nor an ``ExecutionScope`` -- a snapshot loader is held to the
-    same discipline as the resolver, since its output reaches the turn
-    contextvar on both branches (see
-    ``_validate_execution_scope_snapshot_candidate``). The ``TypeError``
-    that :func:`set_execution_scope_resolver` raises for a missing
-    acknowledgment token is unrelated -- that happens at registration time
-    (embedder import/startup, before any request handler exists) and is
-    intentionally left as a plain ``TypeError``.
+    Raised in four places:
+
+    - the resolver's three-valued return type
+      (:func:`resolve_execution_scope`);
+    - a loaded snapshot that is neither ``None`` nor an ``ExecutionScope``
+      (``_validate_execution_scope_snapshot_candidate``) -- a snapshot loader
+      is held to the same discipline as the resolver, since its output
+      reaches the turn contextvar on both branches;
+    - a persisted snapshot that fails field validation while being decoded
+      (:func:`execution_scope_from_agent_config`);
+    - a ``defer_to_snapshot(snapshot_defines_namespace=True)`` carrier whose
+      ``fallback`` already commits to a namespace
+      (:class:`DeferToSnapshot`) -- that opt-in's precondition.
+
+    Messages name the offending *type*, never the offending value: this
+    error escapes to a generic handler and can reach the client, and a
+    resolver bug that returns an internal object must not publish its
+    ``repr()``. The value is available in the server-side log at the raise
+    site.
+
+    The ``TypeError`` that :func:`set_execution_scope_resolver` raises for a
+    missing acknowledgment token is unrelated -- that happens at
+    registration time (embedder import/startup, before any request handler
+    exists) and is intentionally left as a plain ``TypeError``.
     """
 
 
@@ -846,10 +933,14 @@ class ExecutionScopeAuthorityError(Exception):
     Carries the resolver's answer (``resolver_scope``) so a caller that must
     not fail a turn that has already ended or never started (see
     :func:`resolve_execution_scope_off_turn`) can log a structured warning
-    and continue with the authoritative value instead of raising. This
-    downgrade is only ever valid for an instance of this exact class raised
-    on the resolver-authoritative branch — see
-    :class:`ExecutionScopeAbstentionMismatchError`.
+    and continue with the authoritative value instead of raising. Whether
+    that downgrade is sanctioned is stated by the raise site, not inferred
+    from the exception's class: ``resolver_scope_is_authoritative`` is a
+    required constructor argument, so every raise site — including one added
+    by a future subclass — must declare whether ``resolver_scope`` is a real
+    authority to fall back on. :func:`resolve_execution_scope_off_turn`
+    downgrades only when that flag is ``True``, which is fail-closed for
+    anything that has not said so.
 
     ``str()`` on this exception deliberately carries only the ``task_id``
     and the names of the mismatched fields, never the scope values: it
@@ -874,11 +965,30 @@ class ExecutionScopeAuthorityError(Exception):
         resolver_scope: ExecutionScope,
         snapshot_scope: ExecutionScope,
         mismatched_fields: Mapping[str, tuple[Any, Any]],
+        resolver_scope_is_authoritative: bool,
     ) -> None:
+        """Record the conflict.
+
+        Args:
+            task_id: The task whose resolution conflicted.
+            resolver_scope: What the resolver contributed -- an authoritative
+                answer on the authoritative branch, the abstention carrier's
+                ``fallback`` on the abstention branch.
+            snapshot_scope: The persisted candidate that disagreed.
+            mismatched_fields: ``{field_name: (snapshot_value,
+                resolver_value)}`` for the namespace fields that conflicted.
+            resolver_scope_is_authoritative: Whether ``resolver_scope`` is a
+                sanctioned answer an off-turn caller may continue with.
+                Keyword-only and required: it is the raise site, not the
+                exception's class, that knows whether an authority exists,
+                and :func:`resolve_execution_scope_off_turn` downgrades only
+                on ``True``.
+        """
         self.task_id = task_id
         self.resolver_scope = resolver_scope
         self.snapshot_scope = snapshot_scope
         self.mismatched_fields = dict(mismatched_fields)
+        self.resolver_scope_is_authoritative = resolver_scope_is_authoritative
         super().__init__(
             f"execution scope authority mismatch for task {task_id!r}: "
             f"mismatched_fields={sorted(self.mismatched_fields)!r}"
@@ -899,16 +1009,15 @@ class ExecutionScopeAbstentionMismatchError(ExecutionScopeAuthorityError):
     delegated/workforce case this branch exists for.
 
     This is why a caller must never downgrade this exception the way
-    :func:`resolve_execution_scope_off_turn` downgrades the base class: a
-    downgrade needs an authority to downgrade *to*, and this branch has
-    none. Handing out ``fallback`` as if it were one would be
+    :func:`resolve_execution_scope_off_turn` downgrades the authoritative
+    branch's error: a downgrade needs an authority to downgrade *to*, and
+    this branch has none. Handing out ``fallback`` as if it were one would be
     indistinguishable from "no scope at all" to a consumer like workspace
-    cleanup. A distinct exception type (rather than only an attribute)
-    makes this impossible to do by accident — a caller that only knows
-    about the base class and downgrades on ``except ExecutionScopeAuthorityError``
-    would still need to explicitly widen its except clause to catch this
-    subclass too, rather than silently inheriting a downgrade path that
-    was only ever correct for the authoritative branch.
+    cleanup. Its raise site therefore passes
+    ``resolver_scope_is_authoritative=False``, which is what actually blocks
+    the downgrade; being a distinct type on top of that keeps the two
+    branches separable for callers that want to handle only one of them,
+    without any caller having to enumerate which subclasses are unsafe.
     """
 
 
@@ -1009,6 +1118,29 @@ _EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING: Mapping[
     "memory_dimensions": ({}, _narrows_by_superset),
     "isolate_external_dirs": (False, _narrows_by_equality),
 }
+
+
+def _namespace_committed_fields(scope: ExecutionScope) -> set[str]:
+    """Namespace fields on which ``scope`` claims scoping of its own.
+
+    A field is committed when its namespace value -- read through
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS`, so a derived field like
+    the mount is judged on what it actually covers -- differs from that
+    field's own no-scoping identity in
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING`. An empty result means
+    the scope partitions nothing: the shape a
+    ``defer_to_snapshot(snapshot_defines_namespace=True)`` fallback must have,
+    since that opt-in hands namespace authority to the snapshot outright (see
+    :class:`DeferToSnapshot`). Driven by the same two tables as the narrowing
+    check, so a namespace field added there is covered here without another
+    edit.
+    """
+    return {
+        name
+        for name in _EXECUTION_SCOPE_NAMESPACE_FIELDS
+        if _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS[name](scope)
+        != _EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING[name][0]
+    }
 
 
 def _execution_scope_field_diff(
@@ -1178,31 +1310,47 @@ def _validate_execution_scope_snapshot_candidate(
     access instead of a diagnosable contract error. The type check below
     always applies, regardless of ``enforce_shape_version``.
 
-    The shape-version gate exists to protect a *comparison*: a snapshot
-    whose shape version does not match :data:`EXECUTION_SCOPE_SHAPE_VERSION`
-    (older, missing entirely, or -- during a mixed-version rollout -- newer)
-    cannot be safely compared field-by-field against ``diff_target``,
-    because a field the current shape added or changed always looks
-    "different" from a scope built under a different shape, which is not a
-    real conflict. Where no such comparison happens, gating discards data
-    for nothing -- so ``enforce_shape_version=False`` is the caller's
-    signal that ``snapshot``, if it passes the type check, will be used
-    verbatim rather than compared. Concretely: the authoritative branch and
-    the default (non-opted-in) resolver-abstention branch both compare the
-    snapshot (against the resolver's answer, or against the carrier's
-    fallback for narrowing) and pass the default ``True``; the
-    ``snapshot_defines_namespace=True`` abstention branch uses the snapshot
-    verbatim with no comparison and passes ``False``. A gated-away snapshot
-    is logged with a field-level diff against ``diff_target`` and treated
-    as absent (``None``) rather than raised on; that diff is only computed
-    when the warning will actually be emitted, since this gate runs on
-    every turn for any snapshot that predates a shape bump.
+    The shape-version gate is **asymmetric**, because the two directions of
+    version skew fail differently:
+
+    - *Older* (lower version, or the key missing entirely): every field such
+      a snapshot carries is still decodable here, and fields it lacks take
+      their current defaults. The only thing it breaks is a *comparison* --
+      a field the current shape added or changed always looks "different"
+      from a scope built under the older shape, which is not a real
+      conflict. So this direction is refused only where a comparison
+      actually happens, and ``enforce_shape_version=False`` is the caller's
+      statement that ``snapshot``, once it passes the type check, will be
+      used verbatim rather than compared, so nothing needs protecting and
+      gating would discard real data for nothing.
+    - *Newer* (higher version, e.g. a mixed-version rollout where some
+      workers already run the next shape): refused on **every** path,
+      ``enforce_shape_version=False`` included. ``ExecutionScope.from_dict``
+      drops keys this shape does not know, so a newer snapshot arrives
+      partially decoded -- potentially with a namespace-narrowing field gone
+      -- and "used verbatim" would mean using that truncated scope.
+      ``to_dict`` then always stamps the current constant, and the workforce
+      snapshot writer re-persists the resolved scope, so accepting one also
+      re-saves the truncation under this process's version, erasing the
+      evidence that anything was ever dropped.
+
+    Concretely: the authoritative branch and the default (non-opted-in)
+    resolver-abstention branch both compare the snapshot (against the
+    resolver's answer, or against the carrier's fallback for narrowing) and
+    pass the default ``True``; the ``snapshot_defines_namespace=True``
+    abstention branch uses the snapshot verbatim and passes ``False``,
+    relaxing the older direction only. A gated-away snapshot is logged with a
+    field-level diff against ``diff_target`` and treated as absent (``None``)
+    rather than raised on; that diff is only computed when the warning will
+    actually be emitted, since this gate runs on every turn for any snapshot
+    that predates a shape bump.
 
     Returns:
-        The snapshot unchanged when it is an ``ExecutionScope`` and either
-        ``enforce_shape_version`` is ``False`` or its version matches
-        :data:`EXECUTION_SCOPE_SHAPE_VERSION`; ``None`` when there was no
-        snapshot to begin with, or it was shape-gated away.
+        The snapshot unchanged when it is an ``ExecutionScope``, its version
+        does not exceed :data:`EXECUTION_SCOPE_SHAPE_VERSION`, and either
+        ``enforce_shape_version`` is ``False`` or its version matches that
+        constant exactly; ``None`` when there was no snapshot to begin with,
+        or it was shape-gated away.
 
     Raises:
         ExecutionScopeResolverContractError: ``snapshot`` is neither
@@ -1212,10 +1360,14 @@ def _validate_execution_scope_snapshot_candidate(
         return None
     if not isinstance(snapshot, ExecutionScope):
         raise ExecutionScopeResolverContractError(
-            f"execution scope snapshot loader returned {snapshot!r} for "
-            f"task {task_id!r}; expected an ExecutionScope or None"
+            "execution scope snapshot loader returned a "
+            f"{type(snapshot).__name__} for task {task_id!r}; expected an "
+            "ExecutionScope or None"
         )
-    if enforce_shape_version and snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
+    written_by_a_newer_shape = snapshot.version > EXECUTION_SCOPE_SHAPE_VERSION
+    if written_by_a_newer_shape or (
+        enforce_shape_version and snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION
+    ):
         if logger.isEnabledFor(logging.WARNING):
             logger.warning(
                 "Ignoring execution scope snapshot candidate for task %s: shape "
@@ -1268,10 +1420,10 @@ def resolve_execution_scope(
       on the carrier's ``snapshot_defines_namespace`` (see
       :func:`defer_to_snapshot`):
 
-      - ``False`` (the default): the shape-version gate applies (the
-        snapshot is about to be compared), and the snapshot is used only if
-        it is a *narrowing* of the carrier's ``fallback`` (see
-        :func:`_execution_scope_narrowing_violations`) -- a snapshot is
+      - ``False`` (the default): the shape-version gate applies in both
+        directions (the snapshot is about to be compared), and the snapshot
+        is used only if it is a *narrowing* of the carrier's ``fallback``
+        (see :func:`_execution_scope_narrowing_violations`) -- a snapshot is
         client-influenceable (a client-supplied ``agent_config`` can carry
         an ``execution_scope`` key that reaches the persisted snapshot), so
         an unchecked snapshot here would let a caller widen its own
@@ -1281,16 +1433,21 @@ def resolve_execution_scope(
         :class:`ExecutionScopeAuthorityError` -- see that class for why the
         distinction matters to :func:`resolve_execution_scope_off_turn`).
       - ``True``: the resolver has stated it does not own this task and the
-        snapshot is the namespace authority; the shape-version gate does
-        not apply (nothing is compared) and the narrowing check is skipped
-        -- the snapshot's namespace fields are used verbatim once it passes
-        the type check.
+        snapshot is the namespace authority; the narrowing check is skipped
+        and the snapshot's namespace fields are used verbatim once it passes
+        the type check and the *newer*-shape half of the version gate (an
+        older-shape snapshot is used as-is here, a newer-shape one is still
+        refused -- see
+        :func:`_validate_execution_scope_snapshot_candidate`). The carrier's
+        own construction guarantees ``fallback`` claims no namespace on this
+        shape, so nothing of the resolver's is being replaced.
 
-      Once the namespace is settled either way, a policy-only difference
-      (``strict_memory_isolation``) between the snapshot and the fallback is
-      logged and the fallback's value wins -- symmetric with the
-      authoritative branch below, where the resolver's policy value wins the
-      same way.
+      Once the namespace is settled either way, every field in
+      :data:`_EXECUTION_SCOPE_POLICY_FIELDS` on which the snapshot and the
+      fallback differ is logged and taken from the fallback -- symmetric with
+      the authoritative branch below, where the resolver's policy values win
+      the same way. The snapshot's settled namespace is preserved while those
+      policy values are overlaid onto it.
     - Resolver returns an ``ExecutionScope``: authoritative. A snapshot
       loader exception is logged and ignored (the candidate is corrupt, but
       an authoritative answer already exists). Otherwise: a
@@ -1321,7 +1478,9 @@ def resolve_execution_scope(
             fallback. ``resolver_scope`` on this exception is ``fallback``,
             not an authoritative answer -- see the subclass docstring.
         ExecutionScopeResolverContractError: the resolver, or a registered
-            snapshot loader, returned something outside its contract.
+            snapshot loader, returned something outside its contract, or a
+            persisted snapshot failed to decode (see
+            :func:`execution_scope_from_agent_config`).
     """
     if task_id is None:
         raise ValueError(
@@ -1371,33 +1530,38 @@ def resolve_execution_scope(
                     resolver_scope=resolved.fallback,
                     snapshot_scope=snapshot,
                     mismatched_fields=violations,
+                    # The resolver declined to answer, so resolved.fallback is
+                    # not an authority an off-turn caller may continue with.
+                    resolver_scope_is_authoritative=False,
                 )
-        if (
-            snapshot.strict_memory_isolation
-            != resolved.fallback.strict_memory_isolation
-        ):
+        policy_diff = {
+            name: (getattr(snapshot, name), getattr(resolved.fallback, name))
+            for name in _EXECUTION_SCOPE_POLICY_FIELDS
+            if getattr(snapshot, name) != getattr(resolved.fallback, name)
+        }
+        if policy_diff:
             # Symmetric with the authoritative branch's policy-only-mismatch
             # handling below: the namespace is settled (validated above as a
-            # narrowing of resolved.fallback), but the policy field is not
-            # part of that check, so an unlogged pass-through here would
-            # silently let a client-influenceable snapshot flip it. The
-            # fallback plays the authoritative role on this branch, so its
-            # policy value wins, the same way the resolver's value wins on
-            # the authoritative branch.
+            # narrowing of resolved.fallback, or handed to the snapshot by the
+            # opt-in), but policy fields are not part of that check, so an
+            # unlogged pass-through here would silently let a
+            # client-influenceable snapshot flip one. The fallback plays the
+            # authoritative role on this branch, so its policy values win, the
+            # same way the resolver's win on the authoritative branch -- while
+            # the settled namespace stays the snapshot's, which is why this
+            # overlays onto ``snapshot`` instead of returning the fallback.
+            # Both the comparison and the overlay are driven by
+            # _EXECUTION_SCOPE_POLICY_FIELDS, so a policy field added there is
+            # honoured here without another edit.
             logger.warning(
                 "Execution scope policy-only mismatch for task %s on the "
                 "resolver-abstention branch (fallback wins): %s",
                 task_id,
-                {
-                    "strict_memory_isolation": (
-                        snapshot.strict_memory_isolation,
-                        resolved.fallback.strict_memory_isolation,
-                    )
-                },
+                policy_diff,
             )
             return replace(
                 snapshot,
-                strict_memory_isolation=resolved.fallback.strict_memory_isolation,
+                **{name: getattr(resolved.fallback, name) for name in policy_diff},
             )
         return snapshot
 
@@ -1405,9 +1569,17 @@ def resolve_execution_scope(
         return None
 
     if not isinstance(resolved, ExecutionScope):
+        # Names the type, not the value: this message reaches a generic
+        # handler and can surface to the client, and a resolver bug that
+        # returns an internal config object must not publish its repr.
+        logger.error(
+            "Execution scope resolver returned an unsupported value for task %s: %r",
+            task_id,
+            resolved,
+        )
         raise ExecutionScopeResolverContractError(
-            f"execution scope resolver returned {resolved!r}; expected an "
-            "ExecutionScope, None, or defer_to_snapshot(...)"
+            f"execution scope resolver returned a {type(resolved).__name__}; "
+            "expected an ExecutionScope, None, or defer_to_snapshot(...)"
         )
 
     try:
@@ -1452,6 +1624,9 @@ def resolve_execution_scope(
             resolver_scope=resolved,
             snapshot_scope=snapshot,
             mismatched_fields=namespace_diff,
+            # The resolver produced a real scope, so an off-turn caller that
+            # cannot fail may continue with it.
+            resolver_scope_is_authoritative=True,
         )
 
     logger.warning(
@@ -1469,32 +1644,37 @@ def resolve_execution_scope_off_turn(task_id: str | int) -> Optional[ExecutionSc
     preview backfill, a not-yet-persisted durable object) that cannot fail a
     turn that has already ended or never started.
 
-    Downgrades only a plain :class:`ExecutionScopeAuthorityError` -- raised
-    by ``resolve_execution_scope``'s resolver-authoritative branch, where
-    ``resolver_scope`` genuinely is an authoritative answer -- to that
-    answer plus a structured warning, instead of raising. An unhandled
-    :class:`ExecutionScopeAuthorityError` here would otherwise surface as a
-    misleading "file not found" or a bulk endpoint's 500, at a point where
-    an authoritative answer already exists to fall back on.
+    Downgrades an :class:`ExecutionScopeAuthorityError` to
+    ``exc.resolver_scope`` plus a structured warning, instead of raising,
+    **only** when the raise site declared that value to be a real authority
+    (``resolver_scope_is_authoritative``). That holds for
+    ``resolve_execution_scope``'s resolver-authoritative branch, where the
+    resolver returned a real ``ExecutionScope``; an unhandled mismatch there
+    would otherwise surface as a misleading "file not found" or a bulk
+    endpoint's 500, at a point where an authoritative answer already exists
+    to fall back on.
 
-    Does **not** downgrade :class:`ExecutionScopeAbstentionMismatchError`
-    (the subclass raised by the resolver-abstention branch): a downgrade
-    needs an authority to downgrade *to*, and that branch never produced
-    one -- its ``resolver_scope`` is ``fallback``, the value the resolver
-    supplied *while declining to answer*, typically all-default/unscoped
-    for the delegated/workforce case. Handing that out here would be
-    indistinguishable from "no scope at all" to a caller such as workspace
-    cleanup, so this mismatch propagates unchanged and this off-turn face
-    stays fail-closed exactly like the in-turn one.
+    Anything that has *not* declared an authoritative value propagates
+    unchanged -- the condition is the positive one, so a mismatch raised by
+    some future branch is fail-closed here by default rather than needing to
+    be enumerated as an exclusion. Today that covers
+    :class:`ExecutionScopeAbstentionMismatchError`, raised by the
+    resolver-abstention branch: a downgrade needs an authority to downgrade
+    *to*, and that branch never produced one -- its ``resolver_scope`` is
+    ``fallback``, the value the resolver supplied *while declining to
+    answer*, typically all-default/unscoped for the delegated/workforce
+    case. Handing that out here would be indistinguishable from "no scope at
+    all" to a caller such as workspace cleanup, so this off-turn face stays
+    fail-closed exactly like the in-turn one.
 
     Every other exception (resolver/loader failure, ``task_id`` None) also
     propagates unchanged.
     """
     try:
         return resolve_execution_scope(task_id)
-    except ExecutionScopeAbstentionMismatchError:
-        raise
     except ExecutionScopeAuthorityError as exc:
+        if not exc.resolver_scope_is_authoritative:
+            raise
         logger.warning(
             "Execution scope authority mismatch resolved off-turn for task "
             "%s (using the resolver's answer): %s",

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -206,7 +206,15 @@ class ExecutionScope:
             "memory_dimensions": dict(self.memory_dimensions),
             "strict_memory_isolation": self.strict_memory_isolation,
             "isolate_external_dirs": self.isolate_external_dirs,
-            "version": self.version,
+            # Always the current constant, never ``self.version``: this
+            # dict is being built *now*, in the current shape, regardless of
+            # whether ``self`` was itself decoded from an older persisted
+            # snapshot (which would carry a stale/low ``self.version``).
+            # Propagating that stale value here would let a
+            # decoded-then-re-persisted scope masquerade as pre-dating
+            # fields it actually has, permanently ignoring it as a
+            # candidate in resolve_execution_scope.
+            "version": EXECUTION_SCOPE_SHAPE_VERSION,
         }
 
     @classmethod
@@ -452,13 +460,18 @@ class ExecutionScopeContext:
 class DeferToSnapshot:
     """Resolver return value meaning "defer to the persisted snapshot".
 
-    Not an :class:`ExecutionScope`: it never enters
-    :func:`resolve_execution_scope`'s return value directly, is never
-    activated on the ``current_execution_scope`` contextvar, and carries no
-    scope attributes of its own. Construct via :func:`defer_to_snapshot`;
-    the ``fallback`` is used only when no snapshot is persisted for the
-    task (a task id the resolver's embedder does not itself recognize, with
-    no Task-table snapshot either).
+    Not an :class:`ExecutionScope`: the carrier itself never enters
+    :func:`resolve_execution_scope`'s return value or reaches the
+    ``current_execution_scope`` contextvar, and carries no scope attributes
+    of its own. What the carrier *resolves to* -- a validated snapshot that
+    narrows ``fallback``, or ``fallback`` itself when none is persisted (or
+    the persisted one fails validation) -- is exactly what gets returned and
+    activated instead, the same as any other resolved scope. Construct via
+    :func:`defer_to_snapshot`; ``fallback`` doubles as the mandatory floor a
+    persisted snapshot must narrow (see :func:`resolve_execution_scope`'s
+    abstention-branch validation) as well as the answer used when no
+    snapshot is persisted for the task (a task id the resolver's embedder
+    does not itself recognize, with no Task-table snapshot either).
     """
 
     __slots__ = ("fallback",)
@@ -589,30 +602,40 @@ def set_execution_scope_snapshot_loader(
     :func:`resolve_execution_scope`); with no resolver registered, it is the
     sole answer -- this is what keeps internally created tasks (workforce
     runs, whose ids the embedder's resolver cannot map) scoped across
-    process restarts. Loader exceptions fail the turn when no resolver is
-    registered; otherwise a broken candidate is logged and ignored rather
-    than vetoing the resolver's already-given authoritative answer.
+    process restarts. Loader exceptions fail the turn, except on the
+    branch where the resolver already returned a real ``ExecutionScope``:
+    there, a broken candidate is logged and ignored rather than vetoing an
+    authoritative answer that already exists. With no resolver registered,
+    or when the resolver abstained via :func:`defer_to_snapshot`, nobody has
+    an authoritative answer yet, so a broken loader fails the turn instead
+    of silently proceeding unscoped or under a stale fallback.
     """
     global _execution_scope_snapshot_loader
     _execution_scope_snapshot_loader = loader
 
 
 class ExecutionScopeResolverContractError(Exception):
-    """A registered resolver returned something outside its three-valued contract.
+    """A registered resolver or snapshot loader returned something outside its contract.
 
     Deliberately not a subclass of ``RuntimeError``, ``ValueError``, or
     ``TypeError``: several websocket handlers catch
     ``except (ValueError, KeyError, TypeError)`` around the turn-execution
     path and fold anything in that tuple into a generic "client message
-    format error" response. A resolver author's bug at the ``resolve_execution_scope``
-    boundary is a server-side contract violation, not a malformed client
-    message, and must not be swallowed by that handler as if it were one.
+    format error" response. A resolver or loader author's bug at the
+    ``resolve_execution_scope`` boundary is a server-side contract
+    violation, not a malformed client message, and must not be swallowed by
+    that handler as if it were one.
 
-    Only used for the return-type check inside ``resolve_execution_scope``
-    itself. The ``TypeError`` that :func:`set_execution_scope_resolver`
-    raises for a missing acknowledgment token is unrelated -- that happens
-    at registration time (embedder import/startup, before any request
-    handler exists) and is intentionally left as a plain ``TypeError``.
+    Used for two return-type checks inside ``resolve_execution_scope``: the
+    resolver's three-valued return, and a loaded snapshot that is neither
+    ``None`` nor an ``ExecutionScope`` -- a snapshot loader is held to the
+    same discipline as the resolver, since its output reaches the turn
+    contextvar on both branches (see
+    ``_validate_execution_scope_snapshot_candidate``). The ``TypeError``
+    that :func:`set_execution_scope_resolver` raises for a missing
+    acknowledgment token is unrelated -- that happens at registration time
+    (embedder import/startup, before any request handler exists) and is
+    intentionally left as a plain ``TypeError``.
     """
 
 
@@ -634,10 +657,14 @@ class ExecutionScopeAuthorityError(Exception):
     ``str()`` on this exception deliberately carries only the ``task_id``
     and the names of the mismatched fields, never the scope values: it
     ends up in ``task.error_message`` and in the client's terminal error
-    event (see ``task_orchestrator``'s setup/run failure handling, which
-    formats durable/broadcast error strings from ``str(exc)``), and the
-    scope values include ``sandbox_key_suffix``, ``workspace_segments``,
-    and ``memory_dimensions`` -- namespace components that can carry
+    event. Both surfacing sites format that durable/broadcast string
+    straight from ``str(exc)``: ``task_orchestrator``'s per-turn background
+    runner (``_schedule_bg``'s ``_runner``, which resolves the scope for a
+    fresh turn before calling ``execute_task_background``) and
+    ``websocket.execute_resume_background`` (which resolves its own scope
+    for a resumed turn instead of receiving one pre-resolved). The scope
+    values include ``sandbox_key_suffix``, ``workspace_segments``, and
+    ``memory_dimensions`` -- namespace components that can carry
     end-user/client identifiers. The full scopes and the field-level value
     diff are logged via ``logger.error`` at the raise site instead, which
     stays server-side.
@@ -696,6 +723,77 @@ def _execution_scope_field_diff(
     return diff
 
 
+def _execution_scope_narrowing_violations(
+    snapshot: ExecutionScope, fallback: ExecutionScope
+) -> dict[str, tuple[Any, Any]]:
+    """Namespace fields where ``snapshot`` is not a narrowing of ``fallback``.
+
+    Used only on :func:`resolve_execution_scope`'s resolver-abstention
+    branch, where the resolver has supplied a mandatory *fallback* instead
+    of an authoritative answer: a persisted snapshot is
+    client-influenceable (a client-supplied ``agent_config`` can carry an
+    ``execution_scope`` key that reaches the persisted snapshot -- see
+    :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`), so an unchecked snapshot here
+    would let a caller widen its own namespace past the resolver's own most
+    conservative answer for the task. Returns an empty dict when ``snapshot``
+    narrows (or matches) ``fallback`` on every field below.
+
+    "Narrowing" per field, in terms of what it does to a namespace:
+
+    - ``sandbox_key_suffix``: equal, or ``fallback`` has none and
+      ``snapshot`` sets one -- appending a sub-key to a bare owner-level
+      sandbox lifecycle key only ever narrows it, never widens it.
+    - ``workspace_segments``: ``snapshot``'s tuple starts with
+      ``fallback``'s -- extra trailing path segments only ever place a scope
+      deeper inside ``fallback``'s directory tree, never outside it.
+    - ``sandbox_mount_segments``: the same prefix test, compared via
+      ``effective_mount_segments`` so an unset field (mount covers the full
+      ``workspace_segments``) compares like its expanded form rather than
+      bypassing the check.
+    - ``isolate_external_dirs``: may flip False -> True (shared external
+      dirs becoming scope-local narrows what a scope can read) but never
+      True -> False (that would widen a scope-local namespace back to
+      shared).
+    - ``memory_dimensions``: ``snapshot``'s mapping must be a superset of
+      ``fallback``'s -- extra dimensions only ever narrow which notes a
+      scoped search sees; a missing or changed dimension from ``fallback``
+      would widen it.
+
+    ``strict_memory_isolation`` (policy, not namespace) is intentionally
+    excluded, matching :data:`_EXECUTION_SCOPE_POLICY_FIELDS` -- narrowing
+    is about the namespace a scope selects, not post-filter policy on it.
+    """
+    violations: dict[str, tuple[Any, Any]] = {}
+
+    fallback_suffix = fallback.sandbox_key_suffix
+    snapshot_suffix = snapshot.sandbox_key_suffix
+    if fallback_suffix is not None and snapshot_suffix != fallback_suffix:
+        violations["sandbox_key_suffix"] = (snapshot_suffix, fallback_suffix)
+
+    fallback_ws = fallback.workspace_segments
+    snapshot_ws = snapshot.workspace_segments
+    if snapshot_ws[: len(fallback_ws)] != fallback_ws:
+        violations["workspace_segments"] = (snapshot_ws, fallback_ws)
+
+    fallback_mount = fallback.effective_mount_segments
+    snapshot_mount = snapshot.effective_mount_segments
+    if snapshot_mount[: len(fallback_mount)] != fallback_mount:
+        violations["sandbox_mount_segments"] = (snapshot_mount, fallback_mount)
+
+    if fallback.isolate_external_dirs and not snapshot.isolate_external_dirs:
+        violations["isolate_external_dirs"] = (
+            snapshot.isolate_external_dirs,
+            fallback.isolate_external_dirs,
+        )
+
+    fallback_dims = fallback.memory_dimensions
+    snapshot_dims = snapshot.memory_dimensions
+    if any(snapshot_dims.get(key) != value for key, value in fallback_dims.items()):
+        violations["memory_dimensions"] = (dict(snapshot_dims), dict(fallback_dims))
+
+    return violations
+
+
 def _load_execution_scope_snapshot(
     task_id: str | int,
     persisted_snapshot: ExecutionScopeInput,
@@ -715,6 +813,62 @@ def _load_execution_scope_snapshot(
     return cast(Optional[ExecutionScope], persisted_snapshot)
 
 
+def _validate_execution_scope_snapshot_candidate(
+    task_id: str | int,
+    snapshot: Optional[ExecutionScope],
+    diff_target: ExecutionScope,
+) -> Optional[ExecutionScope]:
+    """Shared shape gate a loaded snapshot must pass before either branch uses it.
+
+    Both the authoritative and resolver-abstention branches of
+    :func:`resolve_execution_scope` route a freshly loaded snapshot through
+    this one check rather than duplicating it. ``_load_execution_scope_snapshot``
+    only ``cast()``s the loader's return (a static type hint, not a runtime
+    check), so nothing upstream of this function enforces that the loader
+    actually honored its contract -- without this gate, a loader returning a
+    raw dict, a stray :class:`DeferToSnapshot`, or any other object would
+    reach the turn contextvar unchecked, or (on the branch that compares
+    fields) raise an unrelated ``AttributeError`` at the first ``.version``
+    access instead of a diagnosable contract error.
+
+    A snapshot whose shape version does not match
+    :data:`EXECUTION_SCOPE_SHAPE_VERSION` (older, missing entirely, or --
+    during a mixed-version rollout -- newer) cannot be safely compared
+    field-by-field against ``diff_target``: a field the current shape added
+    or changed always looks "different" from a scope built under a
+    different shape, and that is not a real conflict. Such a snapshot is
+    logged with a field-level diff against ``diff_target`` and treated as
+    absent (``None``) rather than raised on.
+
+    Returns:
+        The snapshot unchanged when it is a current-shape ``ExecutionScope``;
+        ``None`` when there was no snapshot to begin with, or it was
+        shape-gated away.
+
+    Raises:
+        ExecutionScopeResolverContractError: ``snapshot`` is neither
+            ``None`` nor an ``ExecutionScope``.
+    """
+    if snapshot is None:
+        return None
+    if not isinstance(snapshot, ExecutionScope):
+        raise ExecutionScopeResolverContractError(
+            f"execution scope snapshot loader returned {snapshot!r} for "
+            f"task {task_id!r}; expected an ExecutionScope or None"
+        )
+    if snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
+        logger.warning(
+            "Ignoring execution scope snapshot candidate for task %s: shape "
+            "version %s does not match the current version %s; diff=%s",
+            task_id,
+            snapshot.version,
+            EXECUTION_SCOPE_SHAPE_VERSION,
+            _execution_scope_field_diff(snapshot, diff_target),
+        )
+        return None
+    return snapshot
+
+
 def resolve_execution_scope(
     task_id: str | int,
     *,
@@ -727,26 +881,35 @@ def resolve_execution_scope(
     byte-identical to the pre-authority behavior standalone/workforce
     deployments rely on for restart/resume. With a resolver registered, the
     resolver is authoritative and runs first; the snapshot (when the
-    resolver's answer needs one) is a corroborating candidate only:
+    resolver's answer needs one) is a corroborating candidate only. Whenever
+    a snapshot is loaded, both branches below route it through the same
+    :func:`_validate_execution_scope_snapshot_candidate` gate before using
+    it -- neither branch compares against, or activates, a snapshot that
+    hasn't passed that check:
 
     - Resolver raises: propagates immediately: the snapshot is not consulted.
     - Resolver returns ``None``: authoritative unscoped; the snapshot is not
       consulted.
-    - Resolver returns :func:`defer_to_snapshot`'s carrier: the snapshot is
-      used if present, else the carrier's fallback. A broken snapshot loader
-      here is logged and treated as absent (falls back), matching the
-      principle below that a broken candidate cannot veto an answer the
-      resolver has already committed to (the fallback *is* that answer).
+    - Resolver returns :func:`defer_to_snapshot`'s carrier: the resolver does
+      not know this task's scope, so a snapshot-loader exception here
+      propagates instead of being swallowed -- "the resolver abstained"
+      means nobody has an authoritative answer for this turn, and turn
+      callers must fail closed rather than silently proceed unscoped or
+      under a stale fallback (contrast the authoritative branch below,
+      which already has a real answer and can afford to ignore a broken
+      candidate). A present, shape-valid snapshot is used only if it is a
+      *narrowing* of the carrier's ``fallback`` (see
+      :func:`_execution_scope_narrowing_violations`) -- a snapshot is
+      client-influenceable (a client-supplied ``agent_config`` can carry an
+      ``execution_scope`` key that reaches the persisted snapshot), so an
+      unchecked snapshot here would let a caller widen its own namespace
+      past the resolver's own conservative fallback. A non-narrowing
+      snapshot raises :class:`ExecutionScopeAuthorityError`; an absent or
+      shape-gated snapshot falls back to the carrier's ``fallback``.
     - Resolver returns an ``ExecutionScope``: authoritative. A snapshot
       loader exception is logged and ignored (the candidate is corrupt, but
-      an authoritative answer already exists). A snapshot whose shape
-      version does not match the current one (:data:`EXECUTION_SCOPE_SHAPE_VERSION`,
-      including one missing the field entirely, and also a snapshot stamped
-      by a *newer* process during a mixed-version rollout) is logged
-      (field-level diff) and ignored rather than compared -- a field the
-      current shape added or changed always looks "different" from a
-      freshly-resolved scope built against a different shape, and that is
-      not a real conflict. Otherwise: a namespace-affecting difference (see
+      an authoritative answer already exists). Otherwise: a
+      namespace-affecting difference (see
       :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS`) raises
       :class:`ExecutionScopeAuthorityError`; a policy-only difference (see
       :data:`_EXECUTION_SCOPE_POLICY_FIELDS`) is logged and the resolver's
@@ -764,7 +927,10 @@ def resolve_execution_scope(
             that as unscoped themselves instead of passing None.
         ExecutionScopeAuthorityError: a persisted snapshot disagrees with
             the resolver's authoritative scope on a namespace-affecting
-            field.
+            field, or -- on the resolver-abstention branch -- is not a
+            narrowing of the resolver's fallback.
+        ExecutionScopeResolverContractError: the resolver, or a registered
+            snapshot loader, returned something outside its contract.
     """
     if task_id is None:
         raise ValueError(
@@ -778,17 +944,32 @@ def resolve_execution_scope(
     resolved = _execution_scope_resolver(str(task_id))
 
     if isinstance(resolved, DeferToSnapshot):
-        try:
-            snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
-        except Exception:
-            logger.warning(
-                "Snapshot loader failed while resolver deferred for task %s; "
-                "using the resolver's fallback",
-                task_id,
-                exc_info=True,
-            )
+        # No try/except here: the resolver has just said it does not know
+        # this task's scope, so a broken loader means nobody knows, and the
+        # turn faces that reach this branch must fail closed rather than
+        # silently proceed unscoped or under a stale fallback.
+        snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
+        snapshot = _validate_execution_scope_snapshot_candidate(
+            task_id, snapshot, resolved.fallback
+        )
+        if snapshot is None:
             return resolved.fallback
-        return snapshot if snapshot is not None else resolved.fallback
+
+        violations = _execution_scope_narrowing_violations(snapshot, resolved.fallback)
+        if violations:
+            logger.error(
+                "Execution scope snapshot for task %s widens the resolver's "
+                "fallback instead of narrowing it: %s",
+                task_id,
+                violations,
+            )
+            raise ExecutionScopeAuthorityError(
+                str(task_id),
+                resolver_scope=resolved.fallback,
+                snapshot_scope=snapshot,
+                mismatched_fields=violations,
+            )
+        return snapshot
 
     if resolved is None:
         return None
@@ -810,23 +991,8 @@ def resolve_execution_scope(
         )
         return resolved
 
+    snapshot = _validate_execution_scope_snapshot_candidate(task_id, snapshot, resolved)
     if snapshot is None:
-        return resolved
-
-    if snapshot.version != EXECUTION_SCOPE_SHAPE_VERSION:
-        # Not just "older": a mixed-version rollout can also see a snapshot
-        # stamped by a newer process than this one. Either direction means
-        # the snapshot's shape cannot be safely compared field-by-field
-        # against a freshly-resolved scope built against *this* process's
-        # shape, so the candidate is ignored rather than raised on.
-        logger.warning(
-            "Ignoring execution scope snapshot candidate for task %s: shape "
-            "version %s does not match the current version %s; diff=%s",
-            task_id,
-            snapshot.version,
-            EXECUTION_SCOPE_SHAPE_VERSION,
-            _execution_scope_field_diff(snapshot, resolved),
-        )
         return resolved
 
     diff = _execution_scope_field_diff(snapshot, resolved)

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -35,8 +35,8 @@ resolver is authoritative and the snapshot is at most a corroborating
 candidate — a namespace-affecting disagreement fails the turn
 (:class:`ExecutionScopeAuthorityError`) rather than letting the
 client-influenceable snapshot silently win. A resolver that does not own a
-task (e.g. a workforce/delegated sub-task) abstains via
-:func:`defer_to_snapshot`, which gives the snapshot a bounded say: by
+task (e.g. a workforce/delegated sub-task) abstains via a
+:class:`DeferToSnapshot` carrier, which gives the snapshot a bounded say: by
 default only as a *narrowing* of the resolver's own ``fallback``, or,
 opted into via ``snapshot_defines_namespace=True``, as the namespace
 authority outright. Registering a non-``None`` resolver requires passing
@@ -178,32 +178,66 @@ def _coerce_scope_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
 
 
 def _coerce_snapshot_version(raw_version: Any) -> int:
-    """Coerce ``from_dict``'s ``version`` field without raising or truncating.
+    """Read ``from_dict``'s ``version`` field, or reject it as malformed.
 
     ``version`` reaches here from a snapshot that can originate in a client-
     supplied ``Task.agent_config`` (see :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`),
-    so it is untrusted input. A missing or malformed value is treated exactly
-    like a snapshot that pre-dates this field: coerced to ``0``, which
-    downstream ``_validate_execution_scope_snapshot_candidate`` already
-    recognizes as "not the current shape" and logs + ignores as a candidate.
-    That existing tolerance is the correct home for "we cannot trust this
-    value" — inventing a second, raising code path for the same trust level
-    would just be a different way of not trusting it.
+    so it is untrusted input, and exactly one value means "authentic snapshot
+    written before this field existed": ``0``, what an absent key decodes to.
+    That marker carries real trust -- the *older* half of
+    ``_validate_execution_scope_snapshot_candidate``'s asymmetric gate is
+    relaxed on the ``snapshot_defines_namespace=True`` branch, where such a
+    snapshot's namespace fields are then used verbatim -- so a value that
+    cannot be read as a shape version must not be folded into it. An
+    unreadable version means the persisted snapshot is malformed, which this
+    module classifies as :class:`ExecutionScopeResolverContractError`:
+    deliberately outside ``(ValueError, KeyError, TypeError)``, so the
+    websocket handlers catching that tuple cannot report a persisted-data
+    fault as a malformed client message.
 
-    Accepts an ``int`` or a string of digits (the shape a JSON-decoded
-    snapshot's ``version`` can arrive as); anything else -- including a
-    ``float``, which ``int()`` would otherwise silently truncate -- coerces to
-    ``0`` rather than raising a bare ``ValueError``/``TypeError`` that a
-    generic ``except (ValueError, ..., TypeError)`` clause elsewhere would
-    fold into an unrelated "malformed client message" response.
+    Readable, and nothing else:
+
+    - a missing key or ``None`` -> ``0``, the pre-versioning marker;
+    - a string of digits -> its ``int`` value, the shape a JSON-decoded
+      ``version`` can arrive as (``str.isdigit`` admits no sign, so this
+      never yields a negative);
+    - a non-negative ``int`` -> itself, ``bool`` excluded: ``True`` is an
+      ``int`` subclass but no writer ever stamps a boolean version.
+
+    Everything else raises, including two values a lenient read would have
+    turned into plausible-looking version claims: a ``float``, which a bare
+    ``int()`` truncates (``1.5`` -> ``1``, the current shape), and a negative
+    ``int``, which no writer emits -- ``to_dict`` always stamps
+    :data:`EXECUTION_SCOPE_SHAPE_VERSION` -- and which "older than
+    everything" would hand the pre-versioning marker's verbatim-namespace
+    trust. The returned version is therefore always ``>= 0``, which is what
+    makes the downstream gate's two comparisons total.
+
+    Raises:
+        ExecutionScopeResolverContractError: ``raw_version`` is present and
+            is not a readable shape version.
     """
-    if isinstance(raw_version, bool):
+    if raw_version is None:
         return 0
-    if isinstance(raw_version, int):
-        return raw_version
     if isinstance(raw_version, str) and raw_version.isdigit():
         return int(raw_version)
-    return 0
+    if (
+        isinstance(raw_version, int)
+        and not isinstance(raw_version, bool)
+        and raw_version >= 0
+    ):
+        return raw_version
+    # The value stays in this server-side log line and out of the raised
+    # message: it comes from a client-influenceable snapshot and that message
+    # travels to the task's error column and a client-facing event.
+    logger.error(
+        "Persisted execution scope snapshot carries an unreadable shape version %r",
+        raw_version,
+    )
+    raise ExecutionScopeResolverContractError(
+        "persisted execution scope snapshot carries an unreadable shape "
+        f"version of type {type(raw_version).__name__}; see the logged value"
+    )
 
 
 # Shape version stamped by ``to_dict`` / read back by ``from_dict``. Bump
@@ -344,10 +378,18 @@ class ExecutionScope:
         misread/truncate the value.
 
         ``version`` defaults to ``0`` (not
-        :data:`EXECUTION_SCOPE_SHAPE_VERSION`) when the key is absent or
-        unparsable: a snapshot persisted before this field existed, or one
-        carrying a malformed value, must both decode as distinguishably
-        older rather than silently passing as current-shape.
+        :data:`EXECUTION_SCOPE_SHAPE_VERSION`) when the key is absent: a
+        snapshot persisted before this field existed must decode as
+        distinguishably older rather than silently passing as current-shape.
+        A version that is present but unreadable is a malformed snapshot
+        rather than an old one, and raises instead of borrowing that
+        marker's trust.
+
+        Raises:
+            InvalidScopeComponentError: a segment/mapping field, or
+                ``sandbox_key_suffix``, fails validation.
+            ExecutionScopeResolverContractError: ``version`` is present and
+                unreadable (see :func:`_coerce_snapshot_version`).
         """
         raw_mount = data.get("sandbox_mount_segments")
         return cls(
@@ -454,10 +496,12 @@ def execution_scope_from_agent_config(
     Invalid snapshots propagate instead of silently degrading to an
     unscoped namespace.
 
-    A decode failure is re-raised as
-    :class:`ExecutionScopeResolverContractError`, not as the
+    Every decode failure leaves here as
+    :class:`ExecutionScopeResolverContractError`, never as the
     :class:`InvalidScopeComponentError` (a ``ValueError``) the field coercions
-    raise. This function is the boundary where *persisted* data is read: the
+    raise: the field coercions' error is re-raised as that class below, and
+    the version reader (:func:`_coerce_snapshot_version`) already raises it
+    directly. This function is the boundary where *persisted* data is read: the
     snapshot loaders registered by the web layer call it from inside
     :func:`resolve_execution_scope`, which several websocket handlers wrap in
     ``except (ValueError, KeyError, TypeError)`` clauses that answer the
@@ -471,7 +515,8 @@ def execution_scope_from_agent_config(
 
     Raises:
         ExecutionScopeResolverContractError: the persisted snapshot is
-            present but fails field validation.
+            present but fails field validation, or carries an unreadable
+            shape version.
     """
 
     if not isinstance(agent_config, Mapping):
@@ -635,14 +680,57 @@ class DeferToSnapshot:
     of its own. What the carrier *resolves to* -- a validated snapshot, or
     ``fallback`` itself when none is persisted (or the persisted one fails
     validation) -- is exactly what gets returned and activated instead, the
-    same as any other resolved scope. Construct via :func:`defer_to_snapshot`;
-    ``fallback`` doubles as the answer used when no snapshot is persisted for
-    the task (a task id the resolver's embedder does not itself recognize,
-    with no Task-table snapshot either) and, when ``snapshot_defines_namespace``
-    is ``False`` (the default), as the mandatory floor a persisted snapshot
-    must narrow (see :func:`resolve_execution_scope`'s abstention-branch
-    validation). See :func:`defer_to_snapshot` for what
-    ``snapshot_defines_namespace`` changes.
+    same as any other resolved scope.
+
+    ``fallback`` is mandatory (not ``Optional``, no default): it is the scope
+    used when the task carries no persisted snapshot -- a task id the
+    resolver's embedder does not itself recognize, with no Task-table
+    snapshot either. :func:`resolve_execution_scope` cannot enforce that it
+    is a *meaningful* answer (a resolver may pass anything); supplying a real
+    one for the no-snapshot case is the resolver author's obligation. An
+    implicit ``None`` fallback would silently mean "authoritative unscoped on
+    a snapshot miss" and must instead be spelled out by the caller.
+
+    ``snapshot_defines_namespace`` picks which of two abstention shapes a
+    carrier is:
+
+    - ``False`` (the default): the resolver has its own opinion of this
+      task's namespace -- expressed as ``fallback`` -- and a persisted
+      snapshot may only *narrow* it further (see
+      :func:`_execution_scope_narrowing_violations`). ``fallback`` is
+      therefore also the mandatory floor the snapshot must narrow, and must
+      be the resolver's own most conservative answer for the task (e.g.
+      today's creator-direct scope), so the resolved value never ends up
+      wider than that answer would have been. Use this when the resolver
+      *owns* the task but wants a corroborating/narrowing snapshot to have a
+      say.
+    - ``True``: the resolver does not own this task and does not know its
+      namespace -- the workforce/delegated-task pattern, where a task is
+      created and scoped entirely by the persisted snapshot and the
+      resolver's embedder has no record mapping that task id to a namespace
+      of its own. In that shape ``fallback`` **must not** pre-commit to the
+      namespace (if it could, the resolver would return an authoritative
+      ``ExecutionScope`` instead of deferring), and that precondition is
+      enforced at construction (below). Given a conforming fallback, the
+      narrowing check is skipped for namespace fields and a present, type-
+      and shape-valid snapshot's namespace fields are used verbatim. This
+      opt-in declares the snapshot is the namespace authority for tasks this
+      resolver does not own; it does not make an untrusted snapshot safe, and
+      it does not skip the type check, the *newer*-shape half of the
+      shape-version gate (see
+      ``_validate_execution_scope_snapshot_candidate``), the mandatory
+      ``fallback`` for a snapshot miss, or policy-field symmetry (every field
+      in :data:`_EXECUTION_SCOPE_POLICY_FIELDS` that differs is logged and
+      ``fallback``'s value still wins) -- only namespace narrowing and the
+      *older*-shape half of the version gate are skipped.
+
+    Neither value distinguishes a snapshot that arrived inside a
+    client-supplied ``Task.agent_config`` from one written server-side out of
+    an already-resolved scope -- those are different trust tiers, and this
+    contract cannot tell them apart at read time. Closing that gap is tracked
+    separately (issue #1016); until then, ``snapshot_defines_namespace=True``
+    should only be used by a resolver whose embedder controls how that task's
+    snapshot was written.
 
     Construction enforces that opt-in's precondition: with
     ``snapshot_defines_namespace=True`` the ``fallback`` must claim no
@@ -653,6 +741,12 @@ class DeferToSnapshot:
     no abstention shape may do; such a resolver must return an authoritative
     :class:`ExecutionScope` instead of deferring. Policy fields are
     unconstrained -- the fallback still owns those on both shapes.
+
+    Raises:
+        TypeError: ``fallback`` is not an ``ExecutionScope``.
+        ExecutionScopeResolverContractError:
+            ``snapshot_defines_namespace=True`` with a ``fallback`` that
+            already commits to a namespace.
     """
 
     __slots__ = ("fallback", "snapshot_defines_namespace")
@@ -665,7 +759,7 @@ class DeferToSnapshot:
     ) -> None:
         if not isinstance(fallback, ExecutionScope):
             raise TypeError(
-                "defer_to_snapshot(fallback) requires an ExecutionScope, got "
+                "DeferToSnapshot(fallback) requires an ExecutionScope, got "
                 f"{type(fallback).__name__}"
             )
         if snapshot_defines_namespace:
@@ -677,13 +771,13 @@ class DeferToSnapshot:
                 # pre-committed to one would be silently overwritten instead
                 # of acting as a floor.
                 logger.error(
-                    "defer_to_snapshot(snapshot_defines_namespace=True) got a "
+                    "DeferToSnapshot(snapshot_defines_namespace=True) got a "
                     "namespace-committed fallback %r; committed fields: %s",
                     fallback,
                     sorted(committed),
                 )
                 raise ExecutionScopeResolverContractError(
-                    "defer_to_snapshot(snapshot_defines_namespace=True) "
+                    "DeferToSnapshot(snapshot_defines_namespace=True) "
                     "requires a fallback that claims no namespace, but this "
                     f"one commits to {sorted(committed)!r}; a resolver that "
                     "already knows the namespace must return an authoritative "
@@ -693,81 +787,13 @@ class DeferToSnapshot:
         self.snapshot_defines_namespace = snapshot_defines_namespace
 
 
-def defer_to_snapshot(
-    fallback: ExecutionScope,
-    *,
-    snapshot_defines_namespace: bool = False,
-) -> DeferToSnapshot:
-    """Build a resolver return value that defers to the persisted snapshot.
-
-    ``fallback`` is mandatory (not ``Optional``, no default): it is the
-    scope used when the task carries no persisted snapshot. This cannot be
-    enforced by ``resolve_execution_scope`` itself (a resolver can pass
-    anything as ``fallback``); supplying a real fallback for the no-snapshot
-    case is the resolver author's obligation. An implicit ``None`` fallback
-    would silently mean "authoritative unscoped on a snapshot miss" and must
-    instead be spelled out explicitly by the caller.
-
-    ``snapshot_defines_namespace`` picks which of two abstention shapes this
-    call is:
-
-    - ``False`` (the default): the resolver has its own opinion of this
-      task's namespace -- expressed as ``fallback`` -- and a persisted
-      snapshot may only *narrow* it further (see
-      :func:`_execution_scope_narrowing_violations`). ``fallback`` must be
-      the resolver's own most conservative answer for the task (e.g. today's
-      creator-direct scope), so the resolved value never ends up wider than
-      that answer would have been. Use this when the resolver *owns* the
-      task but wants a corroborating/narrowing snapshot to have a say.
-    - ``True``: the resolver does not own this task and does not know its
-      namespace -- the workforce/delegated-task pattern, where a task is
-      created and scoped entirely by the persisted snapshot and the
-      resolver's embedder has no record mapping that task id to a namespace
-      of its own. In that shape ``fallback`` **must not** pre-commit to the
-      namespace (if it could, the resolver would return an authoritative
-      ``ExecutionScope`` instead of deferring), and that precondition is
-      enforced at construction: a ``fallback`` non-identity on any field in
-      :data:`_EXECUTION_SCOPE_NAMESPACE_FIELDS` raises
-      :class:`ExecutionScopeResolverContractError` rather than having its
-      namespace silently replaced by the snapshot's. Given a conforming
-      fallback, the narrowing check is skipped for namespace fields and a
-      present, type- and shape-valid snapshot's namespace fields are used
-      verbatim. This opt-in declares the snapshot is the namespace authority
-      for tasks this resolver does not own; it does not make an untrusted
-      snapshot safe, and it does not skip the type check, the *newer*-shape
-      half of the shape-version gate (see
-      ``_validate_execution_scope_snapshot_candidate``), the mandatory
-      ``fallback`` for a snapshot miss, or policy-field symmetry (every field
-      in :data:`_EXECUTION_SCOPE_POLICY_FIELDS` that differs is logged and
-      ``fallback``'s value still wins) -- only namespace narrowing and the
-      *older*-shape half of the version gate are skipped.
-
-    Neither value distinguishes a snapshot that arrived inside a
-    client-supplied ``Task.agent_config`` from one written server-side out of
-    an already-resolved scope -- those are different trust tiers, and this
-    contract cannot tell them apart at read time. Closing that gap is
-    tracked separately (issue #1016); until then, ``snapshot_defines_namespace
-    =True`` should only be used by a resolver whose embedder controls how
-    that task's snapshot was written.
-
-    Raises:
-        TypeError: ``fallback`` is not an ``ExecutionScope``.
-        ExecutionScopeResolverContractError:
-            ``snapshot_defines_namespace=True`` with a ``fallback`` that
-            already commits to a namespace.
-    """
-    return DeferToSnapshot(
-        fallback, snapshot_defines_namespace=snapshot_defines_namespace
-    )
-
-
 # The embedding application injects a scope resolver via
 # set_execution_scope_resolver() (same injection pattern as
 # set_user_tool_overrides_hook in the web layer). Three return values:
 #
 # - ``ExecutionScope``: authoritative for this task.
 # - ``None``: authoritative unscoped for this task (not "abstain").
-# - ``DeferToSnapshot`` (see :func:`defer_to_snapshot`): abstain in favor of
+# - ``DeferToSnapshot`` (see that class): abstain in favor of
 #   the persisted snapshot, with a fallback for when none is persisted.
 ExecutionScopeResolver = Callable[[str], Union[ExecutionScope, None, DeferToSnapshot]]
 
@@ -800,7 +826,7 @@ def set_execution_scope_resolver(
       caches rebuild); a resolver that flaps A -> B -> A is a bug.
     - **Three-valued return**: an ``ExecutionScope`` is authoritative for
       the task; ``None`` is authoritative *unscoped* for the task (not an
-      abstention); :func:`defer_to_snapshot` abstains in favor of the
+      abstention); a :class:`DeferToSnapshot` carrier abstains in favor of the
       persisted snapshot, with a mandatory fallback for tasks that carry
       none. No registered resolver means every task runs unscoped.
     - **Provenance, not existence**: whether to defer must be decided from
@@ -866,7 +892,7 @@ def set_execution_scope_snapshot_loader(
     branch where the resolver already returned a real ``ExecutionScope``:
     there, a broken candidate is logged and ignored rather than vetoing an
     authoritative answer that already exists. With no resolver registered,
-    or when the resolver abstained via :func:`defer_to_snapshot`, nobody has
+    or when the resolver abstained with a :class:`DeferToSnapshot`, nobody has
     an authoritative answer yet, so a broken loader fails the turn instead
     of silently proceeding unscoped or under a stale fallback.
     """
@@ -887,7 +913,7 @@ class ExecutionScopeResolverContractError(Exception):
     malformed client messages, and must not be swallowed by that handler as
     if they were.
 
-    Raised in four places:
+    Raised in five places:
 
     - the resolver's three-valued return type
       (:func:`resolve_execution_scope`);
@@ -897,7 +923,10 @@ class ExecutionScopeResolverContractError(Exception):
       reaches the turn contextvar on both branches;
     - a persisted snapshot that fails field validation while being decoded
       (:func:`execution_scope_from_agent_config`);
-    - a ``defer_to_snapshot(snapshot_defines_namespace=True)`` carrier whose
+    - a persisted snapshot whose ``version`` is present but unreadable
+      (:func:`_coerce_snapshot_version`) -- malformed persisted data, not a
+      snapshot old enough to pre-date the field;
+    - a ``DeferToSnapshot(snapshot_defines_namespace=True)`` carrier whose
       ``fallback`` already commits to a namespace
       (:class:`DeferToSnapshot`) -- that opt-in's precondition.
 
@@ -1004,8 +1033,8 @@ class ExecutionScopeAbstentionMismatchError(ExecutionScopeAuthorityError):
     """A snapshot fails the resolver-abstention branch's narrowing check.
 
     Raised by :func:`resolve_execution_scope` when the resolver returned
-    :func:`defer_to_snapshot` (it does not own this task's scope) and the
-    persisted snapshot is neither absent/shape-gated nor a valid narrowing
+    a :class:`DeferToSnapshot` carrier (it does not own this task's scope) and
+    the persisted snapshot is neither absent/shape-gated nor a valid narrowing
     of the carrier's ``fallback``. It inherits ``resolver_scope`` from the
     base class, but that attribute means something different here: the
     resolver never produced an authoritative scope on this branch, so
@@ -1134,7 +1163,7 @@ def _namespace_committed_fields(scope: ExecutionScope) -> set[str]:
     field's own no-scoping identity in
     :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING`. An empty result means
     the scope partitions nothing: the shape a
-    ``defer_to_snapshot(snapshot_defines_namespace=True)`` fallback must have,
+    ``DeferToSnapshot(snapshot_defines_namespace=True)`` fallback must have,
     since that opt-in hands namespace authority to the snapshot outright (see
     :class:`DeferToSnapshot`). Driven by the same two tables as the narrowing
     check, so a namespace field added there is covered here without another
@@ -1411,8 +1440,10 @@ def resolve_execution_scope(
 
     - Resolver raises: propagates immediately: the snapshot is not consulted.
     - Resolver returns ``None``: authoritative unscoped; the snapshot is not
-      consulted.
-    - Resolver returns :func:`defer_to_snapshot`'s carrier: the resolver does
+      consulted -- not even loaded, so the ``INFO`` line this branch emits
+      records that any persisted snapshot was bypassed unread rather than
+      whether one existed.
+    - Resolver returns a :class:`DeferToSnapshot` carrier: the resolver does
       not know this task's scope, so a snapshot-loader exception here
       propagates instead of being swallowed -- "the resolver abstained"
       means nobody has an authoritative answer for this turn, and turn
@@ -1423,7 +1454,7 @@ def resolve_execution_scope(
       carrier's ``fallback``. Otherwise, whether a present, shape-valid
       snapshot's namespace fields are checked against ``fallback`` depends
       on the carrier's ``snapshot_defines_namespace`` (see
-      :func:`defer_to_snapshot`):
+      :class:`DeferToSnapshot`):
 
       - ``False`` (the default): the shape-version gate applies in both
         directions (the snapshot is about to be compared), and the snapshot
@@ -1571,6 +1602,23 @@ def resolve_execution_scope(
         return snapshot
 
     if resolved is None:
+        # INFO, not WARNING: a resolver claiming a task as unscoped is the
+        # three-valued contract working as designed, not a fault. It is still
+        # logged on every such turn, ungated, because this is the branch that
+        # de-scopes a task whose persisted snapshot may well have named a
+        # namespace -- a resolver that does not yet recognise older tasks
+        # de-scopes every one of them, and that has to leave a per-task trace
+        # the way every sibling branch that overrides or ignores a candidate
+        # does. The snapshot is deliberately not loaded here (nothing on this
+        # branch consults it), so the line says the snapshot was bypassed
+        # unread rather than claiming to know whether one exists: loading one
+        # purely to log it would give the resolver's cheapest answer the cost
+        # of the branches that actually need a snapshot.
+        logger.info(
+            "Execution scope resolver returned None for task %s: authoritative "
+            "unscoped; any persisted snapshot is bypassed without being loaded",
+            task_id,
+        )
         return None
 
     if not isinstance(resolved, ExecutionScope):
@@ -1584,7 +1632,7 @@ def resolve_execution_scope(
         )
         raise ExecutionScopeResolverContractError(
             f"execution scope resolver returned a {type(resolved).__name__}; "
-            "expected an ExecutionScope, None, or defer_to_snapshot(...)"
+            "expected an ExecutionScope, None, or a DeferToSnapshot"
         )
 
     try:

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -95,7 +95,7 @@ ExecutionScopeInput = Union[
 # ``agent_config`` mapping, NOT an already-decoded scope. Decoding here rather
 # than at the caller is what keeps each resolution branch's tolerance for a
 # malformed snapshot correct by construction -- see
-# :func:`_load_execution_scope_snapshot`.
+# :func:`_decode_execution_scope_snapshot`.
 ExecutionScopeSnapshotSource = Union[
     Mapping[str, Any],
     None,
@@ -533,9 +533,27 @@ def execution_scope_from_agent_config(
 
     if not isinstance(agent_config, Mapping):
         return None
-    scope_data = agent_config.get(EXECUTION_SCOPE_AGENT_CONFIG_KEY)
-    if not isinstance(scope_data, Mapping):
+    if EXECUTION_SCOPE_AGENT_CONFIG_KEY not in agent_config:
         return None
+    scope_data = agent_config.get(EXECUTION_SCOPE_AGENT_CONFIG_KEY)
+    if scope_data is None:
+        return None
+    if not isinstance(scope_data, Mapping):
+        # Present but the wrong shape is corrupt, not absent. Reporting "no
+        # candidate" here would make the same silent substitution the
+        # invalid-field case below already refuses to make: on the branches
+        # where the snapshot is the only namespace authority, "absent" resolves
+        # to unscoped, or to the abstention's fallback -- which is the widest
+        # value the narrowing check would ever admit.
+        logger.error(
+            "Persisted execution scope snapshot for a task is a %s, not a "
+            "mapping; treating it as corrupt rather than absent",
+            type(scope_data).__name__,
+        )
+        raise ExecutionScopeResolverContractError(
+            "persisted execution scope snapshot is not a mapping "
+            f"({type(scope_data).__name__}); it cannot be decoded"
+        )
     try:
         return ExecutionScope.from_dict(scope_data)
     except InvalidScopeComponentError as exc:
@@ -1325,7 +1343,7 @@ def _execution_scope_narrowing_violations(
     return violations
 
 
-def _load_execution_scope_snapshot(
+def _decode_execution_scope_snapshot(
     task_id: str | int,
     persisted_agent_config: ExecutionScopeSnapshotSource,
 ) -> Optional[ExecutionScope]:
@@ -1351,17 +1369,6 @@ def _load_execution_scope_snapshot(
             if _execution_scope_snapshot_loader is not None
             else None
         )
-    if isinstance(persisted_agent_config, ExecutionScope):
-        # An already-decoded scope would not be a Mapping, so the decode below
-        # would read it as "this task carries no snapshot" -- which on the
-        # branches that must fail closed is indistinguishable from an
-        # authoritative unscoped answer. Refuse it instead of silently
-        # dropping the caller's value.
-        raise ExecutionScopeResolverContractError(
-            "persisted_agent_config takes the task's raw agent_config mapping, "
-            "not an already-decoded ExecutionScope; the snapshot inside it is "
-            "decoded here so each resolution branch keeps its own tolerance"
-        )
     return execution_scope_from_agent_config(
         cast(Optional[Mapping[str, Any]], persisted_agent_config)
     )
@@ -1378,7 +1385,7 @@ def _validate_execution_scope_snapshot_candidate(
 
     Both the authoritative and resolver-abstention branches of
     :func:`resolve_execution_scope` route a freshly loaded snapshot through
-    this one check rather than duplicating it. ``_load_execution_scope_snapshot``
+    this one check rather than duplicating it. ``_decode_execution_scope_snapshot``
     only ``cast()``s the loader's return (a static type hint, not a runtime
     check), so nothing upstream of this function enforces that the loader
     actually honored its contract -- without this gate, a loader returning a
@@ -1571,10 +1578,27 @@ def resolve_execution_scope(
             "task_id cannot be None; a caller without a task identity "
             "must treat the execution as unscoped instead"
         )
+    if isinstance(persisted_agent_config, ExecutionScope):
+        # Checked here, before any branch dispatch, and deliberately not where
+        # the value is consumed: the authoritative branch wraps its load in a
+        # tolerant except so a bad *candidate* cannot veto a real answer, and a
+        # raise from inside that wrapper would be absorbed and reported as a
+        # loader failure. This is a caller bug, not a data problem, so which
+        # branch happens to be active must not decide whether it is heard.
+        #
+        # The value itself would otherwise fail silently rather than loudly: an
+        # already-decoded scope is not a Mapping, so it decodes to "this task
+        # carries no snapshot", which on the two fail-closed branches is
+        # indistinguishable from an authoritative unscoped answer.
+        raise ExecutionScopeResolverContractError(
+            "persisted_agent_config takes the task's raw agent_config mapping, "
+            "not an already-decoded ExecutionScope; the snapshot inside it is "
+            "decoded during resolution so each branch keeps its own tolerance"
+        )
 
     resolver = _execution_scope_resolver
     if resolver is None:
-        return _load_execution_scope_snapshot(task_id, persisted_agent_config)
+        return _decode_execution_scope_snapshot(task_id, persisted_agent_config)
 
     resolved = resolver(str(task_id))
 
@@ -1583,7 +1607,7 @@ def resolve_execution_scope(
         # this task's scope, so a broken loader means nobody knows, and the
         # turn faces that reach this branch must fail closed rather than
         # silently proceed unscoped or under a stale fallback.
-        snapshot = _load_execution_scope_snapshot(task_id, persisted_agent_config)
+        snapshot = _decode_execution_scope_snapshot(task_id, persisted_agent_config)
         snapshot = _validate_execution_scope_snapshot_candidate(
             task_id,
             snapshot,
@@ -1684,7 +1708,7 @@ def resolve_execution_scope(
         )
 
     try:
-        snapshot = _load_execution_scope_snapshot(task_id, persisted_agent_config)
+        snapshot = _decode_execution_scope_snapshot(task_id, persisted_agent_config)
     except Exception:
         logger.warning(
             "Snapshot loader failed while the resolver returned an "

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -477,10 +477,15 @@ def scope_fingerprint(scope: Optional[ExecutionScope]) -> Optional[ScopeFingerpr
 
     Per-task caches that bake scope-derived state in at build time (sandbox
     keys, workspace paths, sandbox mount root, memory dimensions,
-    ``allowed_external_dirs``) key their eviction checks on this. The mount
-    root is captured via ``effective_mount_segments`` so a changed mount
-    prefix invalidates the cache instead of silently reusing a stale
-    ``base_dir`` (which a later rebuild would then reject in
+    ``allowed_external_dirs``) key their eviction checks on this. Each
+    namespace field is read through
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS`, the same table
+    ``_execution_scope_field_diff`` and ``_execution_scope_narrowing_violations``
+    use, rather than a raw attribute access here -- the mount slot in
+    particular reads ``effective_mount_segments`` (not the raw
+    ``sandbox_mount_segments`` attribute) so a changed mount prefix
+    invalidates the cache instead of silently reusing a stale ``base_dir``
+    (which a later rebuild would then reject in
     ``SandboxManager._ensure_config_equivalent``). ``isolate_external_dirs``
     is included for the same reason: it is baked
     into the cached ``AgentService``'s ``Workspace.allowed_external_dirs``
@@ -496,12 +501,13 @@ def scope_fingerprint(scope: Optional[ExecutionScope]) -> Optional[ScopeFingerpr
     """
     if scope is None:
         return None
+    reader = _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS
     return (
-        scope.sandbox_key_suffix,
-        scope.workspace_segments,
-        scope.effective_mount_segments,
-        tuple(sorted(scope.memory_dimensions.items())),
-        scope.isolate_external_dirs,
+        reader["sandbox_key_suffix"](scope),
+        reader["workspace_segments"](scope),
+        reader["sandbox_mount_segments"](scope),
+        tuple(sorted(reader["memory_dimensions"](scope).items())),
+        reader["isolate_external_dirs"](scope),
     )
 
 
@@ -852,6 +858,27 @@ _EXECUTION_SCOPE_NAMESPACE_FIELDS: tuple[str, ...] = (
 # and the resolver's value wins, but does not fail the turn.
 _EXECUTION_SCOPE_POLICY_FIELDS: tuple[str, ...] = ("strict_memory_isolation",)
 
+# How to read each namespace field's *namespace value* off a scope. Every
+# field reads its own attribute raw except ``sandbox_mount_segments``, whose
+# namespace value is the derived ``effective_mount_segments`` property
+# (``None`` means "the full workspace segments", so the raw attribute alone
+# does not say what the mount actually covers). All three consumers that
+# compare or fingerprint namespace fields -- ``_execution_scope_field_diff``,
+# ``_execution_scope_narrowing_violations``, and ``scope_fingerprint`` --
+# read through this table instead of picking their own attribute, so "what
+# value does this field contribute to the namespace" has exactly one answer
+# in this module: a future derived field cannot be read raw by one consumer
+# and derived by another.
+_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS: Mapping[
+    str, Callable[[ExecutionScope], Any]
+] = {
+    "sandbox_key_suffix": lambda scope: scope.sandbox_key_suffix,
+    "workspace_segments": lambda scope: scope.workspace_segments,
+    "sandbox_mount_segments": lambda scope: scope.effective_mount_segments,
+    "memory_dimensions": lambda scope: scope.memory_dimensions,
+    "isolate_external_dirs": lambda scope: scope.isolate_external_dirs,
+}
+
 
 def _execution_scope_field_diff(
     snapshot: ExecutionScope, resolver: ExecutionScope
@@ -859,10 +886,23 @@ def _execution_scope_field_diff(
     """Per-field ``(snapshot_value, resolver_value)`` for differing fields.
 
     Compares every namespace/policy field (excludes ``version``, which is
-    shape bookkeeping, not a scope field).
+    shape bookkeeping, not a scope field). Namespace fields are read through
+    :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS` rather than a raw
+    ``getattr`` so a field whose namespace value is derived (see that
+    table's docstring) is compared on its namespace value, not its raw
+    attribute -- reading ``sandbox_mount_segments`` raw here would flag a
+    conflict between a resolver-built scope (mount left at its default
+    ``None``) and a snapshot with the mount explicitly set equal to the
+    workspace segments, even though the two select the identical mount.
     """
     diff: dict[str, tuple[Any, Any]] = {}
-    for name in _EXECUTION_SCOPE_NAMESPACE_FIELDS + _EXECUTION_SCOPE_POLICY_FIELDS:
+    for name in _EXECUTION_SCOPE_NAMESPACE_FIELDS:
+        reader = _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS[name]
+        snapshot_value = reader(snapshot)
+        resolver_value = reader(resolver)
+        if snapshot_value != resolver_value:
+            diff[name] = (snapshot_value, resolver_value)
+    for name in _EXECUTION_SCOPE_POLICY_FIELDS:
         snapshot_value = getattr(snapshot, name)
         resolver_value = getattr(resolver, name)
         if snapshot_value != resolver_value:
@@ -911,10 +951,10 @@ def _execution_scope_narrowing_violations(
     - ``workspace_segments``: ``snapshot``'s tuple starts with ``fallback``'s
       -- extra trailing path segments only ever place a scope deeper inside
       ``fallback``'s already-claimed directory tree, never outside it.
-    - ``sandbox_mount_segments``: the same prefix test, compared via
-      ``effective_mount_segments`` so an unset field (mount covers the full
-      ``workspace_segments``) compares like its expanded form rather than
-      bypassing the check.
+    - ``sandbox_mount_segments``: the same prefix test, read via
+      :data:`_EXECUTION_SCOPE_NAMESPACE_FIELD_READERS` (``effective_mount_segments``)
+      so an unset field (mount covers the full ``workspace_segments``)
+      compares like its expanded form rather than bypassing the check.
     - ``isolate_external_dirs``: a boolean has no state narrower than
       ``True``, so once ``fallback`` is already ``True`` only ``True`` is
       accepted -- equality, same as ``sandbox_key_suffix``.
@@ -931,14 +971,15 @@ def _execution_scope_narrowing_violations(
     :func:`resolve_execution_scope`), not by this function.
     """
     violations: dict[str, tuple[Any, Any]] = {}
+    reader = _EXECUTION_SCOPE_NAMESPACE_FIELD_READERS
 
-    fallback_suffix = fallback.sandbox_key_suffix
-    snapshot_suffix = snapshot.sandbox_key_suffix
+    fallback_suffix = reader["sandbox_key_suffix"](fallback)
+    snapshot_suffix = reader["sandbox_key_suffix"](snapshot)
     if snapshot_suffix != fallback_suffix:
         violations["sandbox_key_suffix"] = (snapshot_suffix, fallback_suffix)
 
-    fallback_ws = fallback.workspace_segments
-    snapshot_ws = snapshot.workspace_segments
+    fallback_ws = reader["workspace_segments"](fallback)
+    snapshot_ws = reader["workspace_segments"](snapshot)
     workspace_ok = (
         snapshot_ws[: len(fallback_ws)] == fallback_ws
         if fallback_ws
@@ -947,8 +988,8 @@ def _execution_scope_narrowing_violations(
     if not workspace_ok:
         violations["workspace_segments"] = (snapshot_ws, fallback_ws)
 
-    fallback_mount = fallback.effective_mount_segments
-    snapshot_mount = snapshot.effective_mount_segments
+    fallback_mount = reader["sandbox_mount_segments"](fallback)
+    snapshot_mount = reader["sandbox_mount_segments"](snapshot)
     mount_ok = (
         snapshot_mount[: len(fallback_mount)] == fallback_mount
         if fallback_mount
@@ -957,14 +998,13 @@ def _execution_scope_narrowing_violations(
     if not mount_ok:
         violations["sandbox_mount_segments"] = (snapshot_mount, fallback_mount)
 
-    if snapshot.isolate_external_dirs != fallback.isolate_external_dirs:
-        violations["isolate_external_dirs"] = (
-            snapshot.isolate_external_dirs,
-            fallback.isolate_external_dirs,
-        )
+    fallback_isolate = reader["isolate_external_dirs"](fallback)
+    snapshot_isolate = reader["isolate_external_dirs"](snapshot)
+    if snapshot_isolate != fallback_isolate:
+        violations["isolate_external_dirs"] = (snapshot_isolate, fallback_isolate)
 
-    fallback_dims = fallback.memory_dimensions
-    snapshot_dims = snapshot.memory_dimensions
+    fallback_dims = reader["memory_dimensions"](fallback)
+    snapshot_dims = reader["memory_dimensions"](snapshot)
     dims_ok = (
         all(snapshot_dims.get(key) == value for key, value in fallback_dims.items())
         if fallback_dims

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -90,6 +90,18 @@ ExecutionScopeInput = Union[
     ExecutionScopeNotProvided,
 ]
 
+# What a caller may hand :func:`resolve_execution_scope` in place of letting
+# the registered loader read the persisted snapshot: the task's raw
+# ``agent_config`` mapping, NOT an already-decoded scope. Decoding here rather
+# than at the caller is what keeps each resolution branch's tolerance for a
+# malformed snapshot correct by construction -- see
+# :func:`_load_execution_scope_snapshot`.
+ExecutionScopeSnapshotSource = Union[
+    Mapping[str, Any],
+    None,
+    ExecutionScopeNotProvided,
+]
+
 
 class InvalidScopeComponentError(ValueError):
     """A scope component failed validation.
@@ -1315,21 +1327,33 @@ def _execution_scope_narrowing_violations(
 
 def _load_execution_scope_snapshot(
     task_id: str | int,
-    persisted_snapshot: ExecutionScopeInput,
+    persisted_agent_config: ExecutionScopeSnapshotSource,
 ) -> Optional[ExecutionScope]:
-    """Fetch the persisted snapshot, honoring an explicitly-passed override.
+    """Produce the snapshot candidate, decoding it here rather than upstream.
 
-    A database owner that already read the persisted snapshot in its own
-    Session may pass it via ``persisted_snapshot`` to skip the registered
-    loader (see :func:`resolve_execution_scope`).
+    A database owner that already read the task row in its own Session may
+    hand over the raw ``agent_config`` via ``persisted_agent_config`` to skip
+    the registered loader (see :func:`resolve_execution_scope`).
+
+    The decode deliberately happens inside this function, so a snapshot that
+    fails field validation raises from the same place the registered loader
+    would raise: whether that is tolerated is then decided by which branch of
+    :func:`resolve_execution_scope` is calling, exactly as it is for the
+    loader. A caller that decoded first and passed the result would have to
+    reimplement that per-branch policy, and passing ``None`` after a failed
+    decode would read as "no snapshot exists" -- which on the branches that
+    must fail closed is indistinguishable from an authoritative
+    "unscoped".
     """
-    if persisted_snapshot is EXECUTION_SCOPE_NOT_PROVIDED:
+    if persisted_agent_config is EXECUTION_SCOPE_NOT_PROVIDED:
         return (
             _execution_scope_snapshot_loader(str(task_id))
             if _execution_scope_snapshot_loader is not None
             else None
         )
-    return cast(Optional[ExecutionScope], persisted_snapshot)
+    return execution_scope_from_agent_config(
+        cast(Optional[Mapping[str, Any]], persisted_agent_config)
+    )
 
 
 def _validate_execution_scope_snapshot_candidate(
@@ -1427,7 +1451,9 @@ def _validate_execution_scope_snapshot_candidate(
 def resolve_execution_scope(
     task_id: str | int,
     *,
-    persisted_snapshot: ExecutionScopeInput = EXECUTION_SCOPE_NOT_PROVIDED,
+    persisted_agent_config: ExecutionScopeSnapshotSource = (
+        EXECUTION_SCOPE_NOT_PROVIDED
+    ),
 ) -> Optional[ExecutionScope]:
     """Resolve the scope for ``task_id``.
 
@@ -1502,10 +1528,12 @@ def resolve_execution_scope(
       :data:`_EXECUTION_SCOPE_POLICY_FIELDS`) is logged and the resolver's
       value still wins.
 
-    A database owner that already read the persisted snapshot may pass it
-    explicitly via ``persisted_snapshot``; this skips the registered loader
-    while preserving the same precedence. Explicit ``None`` means "snapshot
-    absent", not "force an unscoped task".
+    A database owner that already read the task row may hand over its raw
+    ``agent_config`` via ``persisted_agent_config``; this skips the registered
+    loader while preserving the same precedence, and the snapshot inside it is
+    decoded here so that a malformed one is tolerated or fatal according to
+    the branch below rather than according to the caller. Explicit ``None``
+    means "this task carries no agent_config", not "force an unscoped task".
 
     Raises:
         ValueError: ``task_id`` is None — ``str(None)`` would silently
@@ -1535,7 +1563,7 @@ def resolve_execution_scope(
 
     resolver = _execution_scope_resolver
     if resolver is None:
-        return _load_execution_scope_snapshot(task_id, persisted_snapshot)
+        return _load_execution_scope_snapshot(task_id, persisted_agent_config)
 
     resolved = resolver(str(task_id))
 
@@ -1544,7 +1572,7 @@ def resolve_execution_scope(
         # this task's scope, so a broken loader means nobody knows, and the
         # turn faces that reach this branch must fail closed rather than
         # silently proceed unscoped or under a stale fallback.
-        snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
+        snapshot = _load_execution_scope_snapshot(task_id, persisted_agent_config)
         snapshot = _validate_execution_scope_snapshot_candidate(
             task_id,
             snapshot,
@@ -1645,7 +1673,7 @@ def resolve_execution_scope(
         )
 
     try:
-        snapshot = _load_execution_scope_snapshot(task_id, persisted_snapshot)
+        snapshot = _load_execution_scope_snapshot(task_id, persisted_agent_config)
     except Exception:
         logger.warning(
             "Snapshot loader failed while the resolver returned an "
@@ -1679,7 +1707,11 @@ def resolve_execution_scope(
             "Execution scope authority mismatch for task %s: %s. Every turn of "
             "this task fails until the persisted snapshot agrees with the "
             "resolver: clear the %r key from this task's agent_config to let "
-            "the resolver's answer stand alone, or correct it to match.",
+            "the resolver's answer stand alone, or correct it to match. "
+            "Clearing relocates the task to the resolver's namespace, so any "
+            "workspace or sandbox subtree it already owns under the snapshot's "
+            "namespace is left behind -- correct the snapshot instead where "
+            "that subtree still matters.",
             task_id,
             diff,
             EXECUTION_SCOPE_AGENT_CONFIG_KEY,

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -727,10 +727,19 @@ class DeferToSnapshot:
     Neither value distinguishes a snapshot that arrived inside a
     client-supplied ``Task.agent_config`` from one written server-side out of
     an already-resolved scope -- those are different trust tiers, and this
-    contract cannot tell them apart at read time. Closing that gap is tracked
-    separately (issue #1016); until then, ``snapshot_defines_namespace=True``
-    should only be used by a resolver whose embedder controls how that task's
-    snapshot was written.
+    contract cannot tell them apart at read time. It cannot be fixed here
+    either: any provenance marker would live in the same client-writable
+    field as the snapshot it vouches for, so the fix belongs at the input
+    boundary, where that key stops being accepted from a request (tracked as
+    issue #1016).
+
+    That makes ``snapshot_defines_namespace=True`` unshippable for now, not
+    merely delicate: with the namespace taken verbatim, a request that can
+    write ``Task.agent_config`` chooses the namespace, and public widget and
+    share task creation copy that field wholesale. No resolver in this
+    repository sets it, and none should until the snapshot is server-owned.
+    The flag exists so the abstention shape a workforce sub-task needs is
+    expressible and reviewable; it is inert until something opts in.
 
     Construction enforces that opt-in's precondition: with
     ``snapshot_defines_namespace=True`` the ``fallback`` must claim no

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -1669,10 +1669,20 @@ def resolve_execution_scope(
         if name in _EXECUTION_SCOPE_NAMESPACE_FIELDS
     }
     if namespace_diff:
+        # Names the remediation, not just the fault: this mismatch is stable,
+        # so every turn of this task fails the same way until the persisted
+        # snapshot is removed or corrected. Without the recovery spelled out
+        # here, the only signal an operator gets is a repeating failure with
+        # no stated way out, and the snapshot lives in a column no request
+        # path offers to clear.
         logger.error(
-            "Execution scope authority mismatch for task %s: %s",
+            "Execution scope authority mismatch for task %s: %s. Every turn of "
+            "this task fails until the persisted snapshot agrees with the "
+            "resolver: clear the %r key from this task's agent_config to let "
+            "the resolver's answer stand alone, or correct it to match.",
             task_id,
             diff,
+            EXECUTION_SCOPE_AGENT_CONFIG_KEY,
         )
         # mismatched_fields carries only namespace_diff, not the full diff:
         # this error reaches task.error_message and a client-facing event

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -16,8 +16,9 @@ all-or-nothing switch — a scope may set any subset of its fields.
 Two activation mechanisms:
 
 1. **Resolver hook** (primary): the embedding application registers a
-   resolver via :func:`set_execution_scope_resolver`; the task orchestrator
-   enters :func:`turn_execution_scope` at the start of every turn — the same
+   resolver via :func:`set_execution_scope_resolver`; callers resolve the
+   scope with :func:`resolve_execution_scope` and activate it via
+   :class:`ExecutionScopeContext` at the start of every turn — the same
    place the acting user is resolved — so process restart and task
    resumption re-derive the scope from the embedder's own persistent data
    keyed by ``task_id`` rather than from a long-gone request context.
@@ -562,42 +563,89 @@ class DeferToSnapshot:
     Not an :class:`ExecutionScope`: the carrier itself never enters
     :func:`resolve_execution_scope`'s return value or reaches the
     ``current_execution_scope`` contextvar, and carries no scope attributes
-    of its own. What the carrier *resolves to* -- a validated snapshot that
-    narrows ``fallback``, or ``fallback`` itself when none is persisted (or
-    the persisted one fails validation) -- is exactly what gets returned and
-    activated instead, the same as any other resolved scope. Construct via
-    :func:`defer_to_snapshot`; ``fallback`` doubles as the mandatory floor a
-    persisted snapshot must narrow (see :func:`resolve_execution_scope`'s
-    abstention-branch validation) as well as the answer used when no
-    snapshot is persisted for the task (a task id the resolver's embedder
-    does not itself recognize, with no Task-table snapshot either).
+    of its own. What the carrier *resolves to* -- a validated snapshot, or
+    ``fallback`` itself when none is persisted (or the persisted one fails
+    validation) -- is exactly what gets returned and activated instead, the
+    same as any other resolved scope. Construct via :func:`defer_to_snapshot`;
+    ``fallback`` doubles as the answer used when no snapshot is persisted for
+    the task (a task id the resolver's embedder does not itself recognize,
+    with no Task-table snapshot either) and, when ``snapshot_defines_namespace``
+    is ``False`` (the default), as the mandatory floor a persisted snapshot
+    must narrow (see :func:`resolve_execution_scope`'s abstention-branch
+    validation). See :func:`defer_to_snapshot` for what
+    ``snapshot_defines_namespace`` changes.
     """
 
-    __slots__ = ("fallback",)
+    __slots__ = ("fallback", "snapshot_defines_namespace")
 
-    def __init__(self, fallback: ExecutionScope) -> None:
+    def __init__(
+        self,
+        fallback: ExecutionScope,
+        *,
+        snapshot_defines_namespace: bool = False,
+    ) -> None:
         if not isinstance(fallback, ExecutionScope):
             raise TypeError(
                 "defer_to_snapshot(fallback) requires an ExecutionScope, "
                 f"got {fallback!r}"
             )
         self.fallback = fallback
+        self.snapshot_defines_namespace = snapshot_defines_namespace
 
 
-def defer_to_snapshot(fallback: ExecutionScope) -> DeferToSnapshot:
+def defer_to_snapshot(
+    fallback: ExecutionScope,
+    *,
+    snapshot_defines_namespace: bool = False,
+) -> DeferToSnapshot:
     """Build a resolver return value that defers to the persisted snapshot.
 
     ``fallback`` is mandatory (not ``Optional``, no default): it is the
-    scope used when the task carries no persisted snapshot, and must be the
-    resolver's own most conservative answer for that task (e.g. today's
-    creator-direct scope) so a defer never resolves *wider* than the
-    resolver's own answer would have. This cannot be enforced by
-    ``resolve_execution_scope`` itself (a resolver can pass anything as
-    ``fallback``); it is the resolver author's obligation. An implicit
-    ``None`` fallback would silently mean "authoritative unscoped on a
-    snapshot miss" and must instead be spelled out explicitly by the caller.
+    scope used when the task carries no persisted snapshot. This cannot be
+    enforced by ``resolve_execution_scope`` itself (a resolver can pass
+    anything as ``fallback``); supplying a real fallback for the no-snapshot
+    case is the resolver author's obligation. An implicit ``None`` fallback
+    would silently mean "authoritative unscoped on a snapshot miss" and must
+    instead be spelled out explicitly by the caller.
+
+    ``snapshot_defines_namespace`` picks which of two abstention shapes this
+    call is:
+
+    - ``False`` (the default): the resolver has its own opinion of this
+      task's namespace -- expressed as ``fallback`` -- and a persisted
+      snapshot may only *narrow* it further (see
+      :func:`_execution_scope_narrowing_violations`). ``fallback`` must be
+      the resolver's own most conservative answer for the task (e.g. today's
+      creator-direct scope), so the resolved value never ends up wider than
+      that answer would have been. Use this when the resolver *owns* the
+      task but wants a corroborating/narrowing snapshot to have a say.
+    - ``True``: the resolver does not own this task and does not know its
+      namespace -- the workforce/delegated-task pattern, where a task is
+      created and scoped entirely by the persisted snapshot and the
+      resolver's embedder has no record mapping that task id to a namespace
+      of its own. In that shape ``fallback`` cannot pre-commit to the
+      namespace (if it could, the resolver would return an authoritative
+      ``ExecutionScope`` instead of deferring), so the narrowing check is
+      skipped for namespace fields and a present, shape-valid snapshot's
+      namespace fields are used verbatim. This opt-in declares the snapshot
+      is the namespace authority for tasks this resolver does not own; it
+      does not make an untrusted snapshot safe, and it does not skip the
+      type check, the shape-version gate, the mandatory ``fallback`` for a
+      snapshot miss, or policy-field symmetry (a ``strict_memory_isolation``
+      difference is still logged and ``fallback``'s value still wins) --
+      only namespace narrowing is skipped.
+
+    Neither value distinguishes a snapshot that arrived inside a
+    client-supplied ``Task.agent_config`` from one written server-side out of
+    an already-resolved scope -- those are different trust tiers, and this
+    contract cannot tell them apart at read time. Closing that gap is
+    tracked separately (issue #1016); until then, ``snapshot_defines_namespace
+    =True`` should only be used by a resolver whose embedder controls how
+    that task's snapshot was written.
     """
-    return DeferToSnapshot(fallback)
+    return DeferToSnapshot(
+        fallback, snapshot_defines_namespace=snapshot_defines_namespace
+    )
 
 
 # The embedding application injects a scope resolver via
@@ -1031,19 +1079,29 @@ def resolve_execution_scope(
       callers must fail closed rather than silently proceed unscoped or
       under a stale fallback (contrast the authoritative branch below,
       which already has a real answer and can afford to ignore a broken
-      candidate). A present, shape-valid snapshot is used only if it is a
-      *narrowing* of the carrier's ``fallback`` (see
-      :func:`_execution_scope_narrowing_violations`) -- a snapshot is
-      client-influenceable (a client-supplied ``agent_config`` can carry an
-      ``execution_scope`` key that reaches the persisted snapshot), so an
-      unchecked snapshot here would let a caller widen its own namespace
-      past the resolver's own conservative fallback. A non-narrowing
-      snapshot raises :class:`ExecutionScopeAuthorityError`; an absent or
-      shape-gated snapshot falls back to the carrier's ``fallback``. Once
-      the namespace is settled, a policy-only difference (``strict_
-      memory_isolation``) between the snapshot and the fallback is logged
-      and the fallback's value wins -- symmetric with the authoritative
-      branch below, where the resolver's policy value wins the same way.
+      candidate). An absent or shape-gated snapshot falls back to the
+      carrier's ``fallback``. Otherwise, whether a present, shape-valid
+      snapshot's namespace fields are checked against ``fallback`` depends
+      on the carrier's ``snapshot_defines_namespace`` (see
+      :func:`defer_to_snapshot`):
+
+      - ``False`` (the default): the snapshot is used only if it is a
+        *narrowing* of the carrier's ``fallback`` (see
+        :func:`_execution_scope_narrowing_violations`) -- a snapshot is
+        client-influenceable (a client-supplied ``agent_config`` can carry
+        an ``execution_scope`` key that reaches the persisted snapshot), so
+        an unchecked snapshot here would let a caller widen its own
+        namespace past the resolver's own conservative fallback. A
+        non-narrowing snapshot raises :class:`ExecutionScopeAuthorityError`.
+      - ``True``: the resolver has stated it does not own this task and the
+        snapshot is the namespace authority; the narrowing check is skipped
+        and the snapshot's namespace fields are used verbatim.
+
+      Once the namespace is settled either way, a policy-only difference
+      (``strict_memory_isolation``) between the snapshot and the fallback is
+      logged and the fallback's value wins -- symmetric with the
+      authoritative branch below, where the resolver's policy value wins the
+      same way.
     - Resolver returns an ``ExecutionScope``: authoritative. A snapshot
       loader exception is logged and ignored (the candidate is corrupt, but
       an authoritative answer already exists). Otherwise: a
@@ -1065,8 +1123,9 @@ def resolve_execution_scope(
             that as unscoped themselves instead of passing None.
         ExecutionScopeAuthorityError: a persisted snapshot disagrees with
             the resolver's authoritative scope on a namespace-affecting
-            field, or -- on the resolver-abstention branch -- is not a
-            narrowing of the resolver's fallback.
+            field, or -- on the resolver-abstention branch, unless the
+            carrier opted into ``snapshot_defines_namespace=True`` -- is not
+            a narrowing of the resolver's fallback.
         ExecutionScopeResolverContractError: the resolver, or a registered
             snapshot loader, returned something outside its contract.
     """
@@ -1093,20 +1152,23 @@ def resolve_execution_scope(
         if snapshot is None:
             return resolved.fallback
 
-        violations = _execution_scope_narrowing_violations(snapshot, resolved.fallback)
-        if violations:
-            logger.error(
-                "Execution scope snapshot for task %s widens the resolver's "
-                "fallback instead of narrowing it: %s",
-                task_id,
-                violations,
+        if not resolved.snapshot_defines_namespace:
+            violations = _execution_scope_narrowing_violations(
+                snapshot, resolved.fallback
             )
-            raise ExecutionScopeAuthorityError(
-                str(task_id),
-                resolver_scope=resolved.fallback,
-                snapshot_scope=snapshot,
-                mismatched_fields=violations,
-            )
+            if violations:
+                logger.error(
+                    "Execution scope snapshot for task %s widens the resolver's "
+                    "fallback instead of narrowing it: %s",
+                    task_id,
+                    violations,
+                )
+                raise ExecutionScopeAuthorityError(
+                    str(task_id),
+                    resolver_scope=resolved.fallback,
+                    snapshot_scope=snapshot,
+                    mismatched_fields=violations,
+                )
         if (
             snapshot.strict_memory_isolation
             != resolved.fallback.strict_memory_isolation
@@ -1219,10 +1281,11 @@ def resolve_execution_scope_off_turn(task_id: str | int) -> Optional[ExecutionSc
 def turn_execution_scope(task_id: str | int) -> Iterator[Optional[ExecutionScope]]:
     """Resolve and activate the execution scope for one turn of ``task_id``.
 
-    The task orchestrator enters this at the start of every turn, at the
-    same place the acting user is resolved, so restart/resume re-derive the
-    scope correctly. The scope (or explicit None) is set for the duration of
-    the turn and restored on exit.
+    A convenience wrapper combining :func:`resolve_execution_scope` with
+    :class:`ExecutionScopeContext`: entering it at the start of a turn, at
+    the same place the acting user is resolved, makes restart/resume
+    re-derive the scope correctly. The scope (or explicit None) is set for
+    the duration of the turn and restored on exit.
     """
     scope = resolve_execution_scope(task_id)
     token = set_execution_scope(scope)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3097,6 +3097,15 @@ class AgentServiceManager:
             # cleanup inside an activated turn reuses the turn's resolution.
             scope = get_execution_scope()
             if scope is None:
+                # This runs after the turn has ended (the agent is no longer
+                # in memory), so this call is off-turn -- yet it uses the
+                # fail-closed resolve_execution_scope() rather than
+                # resolve_execution_scope_off_turn(). That is currently
+                # harmless only because no embedder registered with this
+                # process ever installs a resolver, so
+                # ExecutionScopeAuthorityError can never actually be raised
+                # here; an embedder that does register one should route this
+                # through the off-turn helper instead.
                 scope = resolve_execution_scope(task_id)
             segments = scope.workspace_segments if scope is not None else ()
             for base_dir in (

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -25,6 +25,7 @@ from ...core.execution_scope import (
     ScopeFingerprint,
     get_execution_scope,
     resolve_execution_scope,
+    resolve_execution_scope_off_turn,
     scope_fingerprint,
 )
 from ...core.memory.base import MemoryStore
@@ -3097,16 +3098,13 @@ class AgentServiceManager:
             # cleanup inside an activated turn reuses the turn's resolution.
             scope = get_execution_scope()
             if scope is None:
-                # This runs after the turn has ended (the agent is no longer
-                # in memory), so this call is off-turn -- yet it uses the
-                # fail-closed resolve_execution_scope() rather than
-                # resolve_execution_scope_off_turn(). That is currently
-                # harmless only because no embedder registered with this
-                # process ever installs a resolver, so
-                # ExecutionScopeAuthorityError can never actually be raised
-                # here; an embedder that does register one should route this
-                # through the off-turn helper instead.
-                scope = resolve_execution_scope(task_id)
+                # Off-turn: this runs when the agent is no longer in memory,
+                # so there is no turn left to fail. An authority mismatch here
+                # would abandon the directory instead of deleting it, and the
+                # resolver has already given an authoritative answer to delete
+                # against -- so the off-turn helper takes that answer and
+                # warns. Every other resolution failure still propagates.
+                scope = resolve_execution_scope_off_turn(task_id)
             segments = scope.workspace_segments if scope is not None else ()
             for base_dir in (
                 canonical_workspace_base(user_id, segments),

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -408,6 +408,16 @@ async def store_uploaded_files(
     completed = False
 
     try:
+        # Off-turn (this runs outside turn_execution_scope, from the upload
+        # HTTP endpoint) but a write path: the resolved scope selects the
+        # namespace (workspace segments / storage key) these bytes are
+        # written under. Unlike the off-turn *read* paths that call
+        # resolve_execution_scope_off_turn() and downgrade an authority
+        # mismatch to a warning, namespace selection for a write must not be
+        # downgraded -- so this calls resolve_execution_scope() directly and
+        # stays fail-closed: an ExecutionScopeAuthorityError propagates as an
+        # unhandled exception (500) rather than silently writing under the
+        # wrong namespace.
         upload_execution_scope = (
             await run_db_io_cancellation_safe(
                 lambda: resolve_execution_scope(parsed_task_id)

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -408,8 +408,9 @@ async def store_uploaded_files(
     completed = False
 
     try:
-        # Off-turn (this runs outside turn_execution_scope, from the upload
-        # HTTP endpoint) but a write path: the resolved scope selects the
+        # Off-turn (this runs outside the ExecutionScopeContext/
+        # resolve_execution_scope turn boundary, from the upload HTTP
+        # endpoint) but a write path: the resolved scope selects the
         # namespace (workspace segments / storage key) these bytes are
         # written under. Unlike the off-turn *read* paths that call
         # resolve_execution_scope_off_turn() and downgrade an authority

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -416,9 +416,10 @@ async def store_uploaded_files(
         # resolve_execution_scope_off_turn() and downgrade an authority
         # mismatch to a warning, namespace selection for a write must not be
         # downgraded -- so this calls resolve_execution_scope() directly and
-        # stays fail-closed: an ExecutionScopeAuthorityError propagates as an
-        # unhandled exception (500) rather than silently writing under the
-        # wrong namespace.
+        # stays fail-closed: an ExecutionScopeAuthorityError propagates past
+        # the DurableStorageOperationError handler below to the
+        # application-level namespace-authority handler (500, no retry
+        # advertised) rather than silently writing under the wrong namespace.
         upload_execution_scope = (
             await run_db_io_cancellation_safe(
                 lambda: resolve_execution_scope(parsed_task_id)

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -1264,7 +1264,7 @@ async def list_task_files(
 
     files = []
     for record in records:
-        file_ref = ManagedFileRef(record)
+        file_ref = ManagedFileRef(record, for_write=False)
         path = file_ref.local_path
         if not path.exists() and not file_ref.has_durable_object:
             # Skip files that no longer exist on disk
@@ -1311,7 +1311,7 @@ async def download_file(
     # Check access permissions
     if file_record:
         _check_file_access(file_record, user)
-        file_ref = ManagedFileRef(file_record)
+        file_ref = ManagedFileRef(file_record, for_write=False)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
@@ -1441,7 +1441,7 @@ async def preview_file(
     # Check access permissions
     if file_record:
         _check_file_access(file_record, user)
-        file_ref = ManagedFileRef(file_record)
+        file_ref = ManagedFileRef(file_record, for_write=False)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
@@ -1546,7 +1546,7 @@ async def preview_pptx_as_pdf(
     if file_record:
         _check_file_access(file_record, user)
         file_name = str(file_record.filename)
-        file_ref = ManagedFileRef(file_record)
+        file_ref = ManagedFileRef(file_record, for_write=False)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
         if file_ref.has_durable_object:
             try:
@@ -1635,7 +1635,7 @@ async def public_download_file(
 
     if file_record:
         _validate_public_task_file_access(db, file_record, token)
-        file_ref = ManagedFileRef(file_record)
+        file_ref = ManagedFileRef(file_record, for_write=False)
         owner_user_id = _file_user_id_value(file_record)
         file_name = str(file_record.filename)
         local_path_is_trusted = _is_under_uploads(file_ref.local_path, owner_user_id)
@@ -1703,7 +1703,7 @@ async def public_preview_file(
 
     if file_record:
         _validate_public_task_file_access(db, file_record, token)
-        file_ref = ManagedFileRef(file_record)
+        file_ref = ManagedFileRef(file_record, for_write=False)
         base_path = file_ref.local_path
         owner_user_id = _file_user_id_value(file_record)
         if file_ref.has_durable_object and not relative_path:
@@ -1751,7 +1751,7 @@ async def public_preview_file(
         )
         if asset_record is not None:
             _validate_public_task_file_access(db, asset_record, token)
-            asset_ref = ManagedFileRef(asset_record)
+            asset_ref = ManagedFileRef(asset_record, for_write=False)
             try:
                 target_path = asset_ref.ensure_local()
             except DurableObjectIntegrityError as exc:

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -1264,7 +1264,7 @@ async def list_task_files(
 
     files = []
     for record in records:
-        file_ref = ManagedFileRef(record, for_write=False)
+        file_ref = ManagedFileRef(record)
         path = file_ref.local_path
         if not path.exists() and not file_ref.has_durable_object:
             # Skip files that no longer exist on disk
@@ -1311,7 +1311,7 @@ async def download_file(
     # Check access permissions
     if file_record:
         _check_file_access(file_record, user)
-        file_ref = ManagedFileRef(file_record, for_write=False)
+        file_ref = ManagedFileRef(file_record)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
@@ -1441,7 +1441,7 @@ async def preview_file(
     # Check access permissions
     if file_record:
         _check_file_access(file_record, user)
-        file_ref = ManagedFileRef(file_record, for_write=False)
+        file_ref = ManagedFileRef(file_record)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
@@ -1546,7 +1546,7 @@ async def preview_pptx_as_pdf(
     if file_record:
         _check_file_access(file_record, user)
         file_name = str(file_record.filename)
-        file_ref = ManagedFileRef(file_record, for_write=False)
+        file_ref = ManagedFileRef(file_record)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
         if file_ref.has_durable_object:
             try:
@@ -1635,7 +1635,7 @@ async def public_download_file(
 
     if file_record:
         _validate_public_task_file_access(db, file_record, token)
-        file_ref = ManagedFileRef(file_record, for_write=False)
+        file_ref = ManagedFileRef(file_record)
         owner_user_id = _file_user_id_value(file_record)
         file_name = str(file_record.filename)
         local_path_is_trusted = _is_under_uploads(file_ref.local_path, owner_user_id)
@@ -1703,7 +1703,7 @@ async def public_preview_file(
 
     if file_record:
         _validate_public_task_file_access(db, file_record, token)
-        file_ref = ManagedFileRef(file_record, for_write=False)
+        file_ref = ManagedFileRef(file_record)
         base_path = file_ref.local_path
         owner_user_id = _file_user_id_value(file_record)
         if file_ref.has_durable_object and not relative_path:
@@ -1751,7 +1751,7 @@ async def public_preview_file(
         )
         if asset_record is not None:
             _validate_public_task_file_access(db, asset_record, token)
-            asset_ref = ManagedFileRef(asset_record, for_write=False)
+            asset_ref = ManagedFileRef(asset_record)
             try:
                 target_path = asset_ref.ensure_local()
             except DurableObjectIntegrityError as exc:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1170,14 +1170,15 @@ def _scope_segments_for_task(task_id: Any) -> tuple[str, ...]:
     inference may find a user but no task) means there is no task identity
     to resolve a scope from — unscoped, never the string ``"None"``.
 
-    Resolves off-turn (see ``resolve_execution_scope_off_turn``): this
-    composes a storage key outside any turn, so a resolver/snapshot
-    authority mismatch is downgraded to the resolver's answer plus a
-    warning instead of raising.
+    Fails closed (its only caller, ``_register_legacy_preview_isolated``,
+    uses these segments to compose the storage key for a brand-new durable
+    object): choosing that namespace is an authority decision, and a
+    resolver/snapshot mismatch here must not be downgraded to either side's
+    guess -- ``ExecutionScopeAuthorityError`` propagates instead.
     """
     if task_id is None:
         return ()
-    scope = resolve_execution_scope_off_turn(task_id)
+    scope = resolve_execution_scope(task_id)
     return scope.workspace_segments if scope is not None else ()
 
 
@@ -7215,8 +7216,13 @@ async def _handle_pause_task_unserialized(
         task_fields = task_setup_snapshot.task
         task_owner_user_id = int(task_fields.user_id)
         expected_run_id = task_fields.run_id
+        # Off-turn: this only locates the already-running agent's existing
+        # workspace/sandbox to pause it, it never selects a namespace for new
+        # bytes. A control operation on an already-running task must stay
+        # available even under a resolver/snapshot dispute, so a mismatch
+        # downgrades to the resolver's answer instead of blocking the pause.
         execution_scope = await run_db_io_cancellation_safe(
-            lambda: resolve_execution_scope(task_id)
+            lambda: resolve_execution_scope_off_turn(task_id)
         )
 
         # Get agent service (as the task owner)
@@ -7400,8 +7406,15 @@ async def _handle_resume_task_unserialized(
         task_fields = task_setup_snapshot.task
         task_owner_user_id = int(task_fields.user_id)
         task_status = cast(TaskStatus, task_fields.status)
+        # Off-turn: this only locates the paused task's existing
+        # workspace/sandbox to resume it, it never selects a namespace for
+        # new bytes -- the resumed turn re-resolves fail-closed on its own at
+        # the orchestrator's turn boundary. A control operation on an
+        # already-running (or resumable) task must stay available even under
+        # a resolver/snapshot dispute, so a mismatch downgrades to the
+        # resolver's answer instead of blocking the resume.
         resolved_execution_scope = await run_db_io_cancellation_safe(
-            lambda: resolve_execution_scope(task_id)
+            lambda: resolve_execution_scope_off_turn(task_id)
         )
         raw_control_state = task_fields.control_state
         try:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -53,6 +53,7 @@ from ...core.execution_scope import (
     ExecutionScopeContext,
     ExecutionScopeNotProvided,
     resolve_execution_scope,
+    resolve_execution_scope_off_turn,
 )
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
@@ -1168,10 +1169,15 @@ def _scope_segments_for_task(task_id: Any) -> tuple[str, ...]:
     A None ``task_id`` (e.g. the legacy-preview backfill, whose owner
     inference may find a user but no task) means there is no task identity
     to resolve a scope from — unscoped, never the string ``"None"``.
+
+    Resolves off-turn (see ``resolve_execution_scope_off_turn``): this
+    composes a storage key outside any turn, so a resolver/snapshot
+    authority mismatch is downgraded to the resolver's answer plus a
+    warning instead of raising.
     """
     if task_id is None:
         return ()
-    scope = resolve_execution_scope(task_id)
+    scope = resolve_execution_scope_off_turn(task_id)
     return scope.workspace_segments if scope is not None else ()
 
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7218,16 +7218,27 @@ async def _handle_pause_task_unserialized(
         expected_run_id = task_fields.run_id
         # Off-turn: on an agent-cache hit this only locates the already-
         # running agent's existing workspace/sandbox to pause it. On a miss,
-        # get_agent_for_task below builds a fresh agent, which does select a
-        # namespace for new bytes (workspace directory tree, sandbox mount)
-        # from this value -- but that value is always the resolver's own
-        # authoritative answer (never the client-influenceable snapshot), so
-        # a mismatch downgrading here still cannot hand namespace authority
-        # to an untrusted candidate. Pause schedules no turn, so nothing
-        # downstream re-resolves or corrects a build that happens here. A
-        # control operation on an already-running task must stay available
-        # even under a resolver/snapshot dispute, so a mismatch downgrades
-        # to the resolver's answer instead of blocking the pause.
+        # get_agent_for_task below builds a fresh agent from this value,
+        # which can materialize a workspace directory tree and acquire a
+        # sandbox lease. resolve_execution_scope_off_turn resolves this value
+        # through three distinct outcomes:
+        # - resolver authoritative, snapshot disagrees on a namespace field:
+        #   downgrades to the resolver's own answer (with a warning) instead
+        #   of raising, so the pause still proceeds -- the value here is the
+        #   trusted resolver answer, not the snapshot.
+        # - resolver abstains, snapshot widens the abstention's fallback:
+        #   ExecutionScopeAbstentionMismatchError is re-raised rather than
+        #   downgraded, so the pause is refused outright -- an abstention
+        #   never produced an authoritative value to fall back to.
+        # - resolver abstains, snapshot narrows the abstention's fallback:
+        #   the returned value IS the snapshot (policy fields overlaid from
+        #   the fallback). That is persisted, client-influenceable data, and
+        #   it is trusted here only because it was already validated as a
+        #   narrowing of what the resolver granted, so anything the build
+        #   below materializes from it still lands inside the authorised
+        #   subtree.
+        # Pause schedules no turn, so nothing downstream re-resolves or
+        # corrects a build that happens here.
         execution_scope = await run_db_io_cancellation_safe(
             lambda: resolve_execution_scope_off_turn(task_id)
         )
@@ -7416,20 +7427,32 @@ async def _handle_resume_task_unserialized(
         # Off-turn: on an agent-cache hit this only locates the paused task's
         # existing workspace/sandbox for ``get_agent_for_task`` below. On a
         # miss (or a cached-scope-fingerprint mismatch), that call builds a
-        # fresh agent from this value, which does select a namespace for new
-        # bytes (workspace directory tree, sandbox mount) -- but always the
-        # resolver's own authoritative answer, never the client-influenceable
-        # snapshot, so downgrading here cannot hand namespace authority to an
-        # untrusted candidate. A control operation on an already-running (or
-        # resumable) task must stay available even under a resolver/snapshot
-        # dispute, so a mismatch downgrades to the resolver's answer instead
-        # of blocking the resume. The turn this handler schedules is a
-        # different consumer: it is passed ``EXECUTION_SCOPE_NOT_PROVIDED``
-        # instead of this value below so ``execute_resume_background``
-        # performs its own fail-closed resolution before producing the
-        # resumed turn's own output, rather than inheriting this downgrade --
-        # that protects where the turn's own new bytes land, not the
-        # workspace/sandbox root a build above may already have fixed.
+        # fresh agent from this value, which can materialize a workspace
+        # directory tree and acquire a sandbox lease.
+        # resolve_execution_scope_off_turn resolves this value through three
+        # distinct outcomes:
+        # - resolver authoritative, snapshot disagrees on a namespace field:
+        #   downgrades to the resolver's own answer (with a warning) instead
+        #   of raising, so the resume still proceeds -- the value here is the
+        #   trusted resolver answer, not the snapshot.
+        # - resolver abstains, snapshot widens the abstention's fallback:
+        #   ExecutionScopeAbstentionMismatchError is re-raised rather than
+        #   downgraded, so the resume is refused outright -- an abstention
+        #   never produced an authoritative value to fall back to.
+        # - resolver abstains, snapshot narrows the abstention's fallback:
+        #   the returned value IS the snapshot (policy fields overlaid from
+        #   the fallback). That is persisted, client-influenceable data, and
+        #   it is trusted here only because it was already validated as a
+        #   narrowing of what the resolver granted, so anything the build
+        #   below materializes from it still lands inside the authorised
+        #   subtree.
+        # The turn this handler schedules is a different consumer: it is
+        # passed ``EXECUTION_SCOPE_NOT_PROVIDED`` instead of this value below
+        # so ``execute_resume_background`` performs its own fail-closed
+        # resolution before producing the resumed turn's own output, rather
+        # than inheriting this off-turn result -- that protects where the
+        # turn's own new bytes land, not the workspace/sandbox root a build
+        # above may already have fixed.
         resolved_execution_scope = await run_db_io_cancellation_safe(
             lambda: resolve_execution_scope_off_turn(task_id)
         )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7407,12 +7407,15 @@ async def _handle_resume_task_unserialized(
         task_owner_user_id = int(task_fields.user_id)
         task_status = cast(TaskStatus, task_fields.status)
         # Off-turn: this only locates the paused task's existing
-        # workspace/sandbox to resume it, it never selects a namespace for
-        # new bytes -- the resumed turn re-resolves fail-closed on its own at
-        # the orchestrator's turn boundary. A control operation on an
+        # workspace/sandbox for ``get_agent_for_task`` below, it never
+        # selects a namespace for new bytes. A control operation on an
         # already-running (or resumable) task must stay available even under
         # a resolver/snapshot dispute, so a mismatch downgrades to the
-        # resolver's answer instead of blocking the resume.
+        # resolver's answer instead of blocking the resume. The turn this
+        # handler schedules is a different consumer: it is passed
+        # ``EXECUTION_SCOPE_NOT_PROVIDED`` instead of this value below so
+        # ``execute_resume_background`` performs its own fail-closed
+        # resolution for the new turn rather than inheriting this downgrade.
         resolved_execution_scope = await run_db_io_cancellation_safe(
             lambda: resolve_execution_scope_off_turn(task_id)
         )
@@ -7477,7 +7480,14 @@ async def _handle_resume_task_unserialized(
                         task_owner_user_id=task_owner_user_id,
                         expected_run_id=resume_snapshot.run_id,
                         previous_task=previous_task,
-                        resolved_execution_scope=resolved_execution_scope,
+                        # Not `resolved_execution_scope`: that value is the
+                        # off-turn downgrade used above only to locate the
+                        # existing agent. The scheduled turn selects a
+                        # namespace for new bytes, so it explicitly gets
+                        # `EXECUTION_SCOPE_NOT_PROVIDED` and runs its own
+                        # fail-closed resolution instead of inheriting a
+                        # disputed answer.
+                        resolved_execution_scope=EXECUTION_SCOPE_NOT_PROVIDED,
                     )
                 )
                 background_task_manager.register_reserved_resume(task_id, bg_task)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7216,11 +7216,18 @@ async def _handle_pause_task_unserialized(
         task_fields = task_setup_snapshot.task
         task_owner_user_id = int(task_fields.user_id)
         expected_run_id = task_fields.run_id
-        # Off-turn: this only locates the already-running agent's existing
-        # workspace/sandbox to pause it, it never selects a namespace for new
-        # bytes. A control operation on an already-running task must stay
-        # available even under a resolver/snapshot dispute, so a mismatch
-        # downgrades to the resolver's answer instead of blocking the pause.
+        # Off-turn: on an agent-cache hit this only locates the already-
+        # running agent's existing workspace/sandbox to pause it. On a miss,
+        # get_agent_for_task below builds a fresh agent, which does select a
+        # namespace for new bytes (workspace directory tree, sandbox mount)
+        # from this value -- but that value is always the resolver's own
+        # authoritative answer (never the client-influenceable snapshot), so
+        # a mismatch downgrading here still cannot hand namespace authority
+        # to an untrusted candidate. Pause schedules no turn, so nothing
+        # downstream re-resolves or corrects a build that happens here. A
+        # control operation on an already-running task must stay available
+        # even under a resolver/snapshot dispute, so a mismatch downgrades
+        # to the resolver's answer instead of blocking the pause.
         execution_scope = await run_db_io_cancellation_safe(
             lambda: resolve_execution_scope_off_turn(task_id)
         )
@@ -7406,16 +7413,23 @@ async def _handle_resume_task_unserialized(
         task_fields = task_setup_snapshot.task
         task_owner_user_id = int(task_fields.user_id)
         task_status = cast(TaskStatus, task_fields.status)
-        # Off-turn: this only locates the paused task's existing
-        # workspace/sandbox for ``get_agent_for_task`` below, it never
-        # selects a namespace for new bytes. A control operation on an
-        # already-running (or resumable) task must stay available even under
-        # a resolver/snapshot dispute, so a mismatch downgrades to the
-        # resolver's answer instead of blocking the resume. The turn this
-        # handler schedules is a different consumer: it is passed
-        # ``EXECUTION_SCOPE_NOT_PROVIDED`` instead of this value below so
-        # ``execute_resume_background`` performs its own fail-closed
-        # resolution for the new turn rather than inheriting this downgrade.
+        # Off-turn: on an agent-cache hit this only locates the paused task's
+        # existing workspace/sandbox for ``get_agent_for_task`` below. On a
+        # miss (or a cached-scope-fingerprint mismatch), that call builds a
+        # fresh agent from this value, which does select a namespace for new
+        # bytes (workspace directory tree, sandbox mount) -- but always the
+        # resolver's own authoritative answer, never the client-influenceable
+        # snapshot, so downgrading here cannot hand namespace authority to an
+        # untrusted candidate. A control operation on an already-running (or
+        # resumable) task must stay available even under a resolver/snapshot
+        # dispute, so a mismatch downgrades to the resolver's answer instead
+        # of blocking the resume. The turn this handler schedules is a
+        # different consumer: it is passed ``EXECUTION_SCOPE_NOT_PROVIDED``
+        # instead of this value below so ``execute_resume_background``
+        # performs its own fail-closed resolution before producing the
+        # resumed turn's own output, rather than inheriting this downgrade --
+        # that protects where the turn's own new bytes land, not the
+        # workspace/sandbox root a build above may already have fixed.
         resolved_execution_scope = await run_db_io_cancellation_safe(
             lambda: resolve_execution_scope_off_turn(task_id)
         )
@@ -7481,9 +7495,12 @@ async def _handle_resume_task_unserialized(
                         expected_run_id=resume_snapshot.run_id,
                         previous_task=previous_task,
                         # Not `resolved_execution_scope`: that value is the
-                        # off-turn downgrade used above only to locate the
-                        # existing agent. The scheduled turn selects a
-                        # namespace for new bytes, so it explicitly gets
+                        # off-turn downgrade used above to obtain
+                        # `agent_service` (which, on an agent-cache miss, may
+                        # itself have built the workspace/sandbox from it --
+                        # see the comment above `resolved_execution_scope`).
+                        # The scheduled turn selects the namespace its own
+                        # output lands under, so it explicitly gets
                         # `EXECUTION_SCOPE_NOT_PROVIDED` and runs its own
                         # fail-closed resolution instead of inheriting a
                         # disputed answer.

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -31,6 +31,8 @@ from ..config import (
     get_uploaded_file_recovery_stale_seconds,
     get_uploads_dir,
 )
+from ..core.execution_scope import ExecutionScopeAuthorityError
+from ..core.file_storage import StorageKeyScopeError
 from ..core.tracing.langfuse import flush_langfuse, initialize_langfuse
 from .api.a2a import router as a2a_router
 from .api.admin_mcp import admin_mcp_router
@@ -61,7 +63,7 @@ from .api.templates import router as templates_router
 from .api.tools import tools_router
 from .api.triggers import router as triggers_router
 from .api.v1 import v1_router
-from .api.v1.errors import V1ApiError, v1_api_error_handler
+from .api.v1.errors import V1ApiError, V1ErrorCode, v1_api_error_handler
 from .api.websocket import ws_router
 from .api.widget import widget_router
 from .api.workforces import router as workforces_router
@@ -800,6 +802,79 @@ async def global_exception_handler(request: Request, exc: Exception) -> Any:
     # response the web UI / legacy clients depend on.
     raise exc
 
+
+STORAGE_NAMESPACE_AUTHORITY_MESSAGE = "Storage namespace authority violation."
+
+
+async def storage_namespace_authority_error_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Answer a storage namespace containment/authority fault once, app-wide.
+
+    ``StorageKeyScopeError`` (a storage key outside the prefix its handle is
+    bound to) and ``ExecutionScopeAuthorityError`` (the scope resolver and a
+    task's persisted snapshot disagree about the task's namespace) are
+    permanent server-side configuration/authority faults. Registering them
+    here instead of at each file endpoint keeps one classification for every
+    route that touches durable storage -- and keeps them out of the retryable
+    503 that ``DurableStorageOperationError`` maps to, since retrying a
+    containment violation can never succeed.
+
+    Status is 500: the fault is on the server, in its own namespace
+    configuration or in a task's persisted scope, and there is nothing for the
+    client to correct or retry. 503 would tell operators and clients to wait
+    and retry a condition that is stable until someone changes the
+    configuration, and no 4xx applies because the request itself is
+    well-formed and authorized.
+
+    The response body names the fault and nothing else. Scope segments,
+    storage prefixes, and tenant identifiers can encode end-user identity, and
+    ``str(exc)`` carries them; that detail belongs in the server-side log line
+    below, which records the full traceback.
+
+    ``/v1/*`` keeps the SDK's ``{"error": {"code", "message"}}`` envelope (see
+    web/api/v1/errors.py) -- those endpoints reach durable storage while
+    resolving a turn's attachments, and a bare ``{"detail": ...}`` there would
+    break clients that switch on ``body.error.code``. Every other path gets
+    FastAPI's default ``{"detail": ...}`` shape.
+
+    Only HTTP scopes get a response. Starlette routes websocket exceptions
+    through the same handler table, and websocket file attachments do reach
+    durable storage, but a websocket connection cannot receive an HTTP
+    response -- so those scopes re-raise and stay owned by the connection
+    handler that established them.
+    """
+    logger.error(
+        "Storage namespace authority violation for %s",
+        request.url.path,
+        exc_info=exc,
+    )
+    if request.scope.get("type") != "http":
+        raise exc
+    if request.url.path.startswith("/v1/"):
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": V1ErrorCode.INTERNAL_ERROR.value,
+                    "message": STORAGE_NAMESPACE_AUTHORITY_MESSAGE,
+                }
+            },
+        )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": STORAGE_NAMESPACE_AUTHORITY_MESSAGE},
+    )
+
+
+app.add_exception_handler(
+    StorageKeyScopeError, storage_namespace_authority_error_handler
+)
+# Covers ExecutionScopeAbstentionMismatchError too: Starlette matches a
+# handler by walking the raised exception's MRO.
+app.add_exception_handler(
+    ExecutionScopeAuthorityError, storage_namespace_authority_error_handler
+)
 
 # /v1/* SDK surface uses a stable {"error": {"code", "message"}} envelope
 # distinct from FastAPI's default {"detail": "..."} shape used by /api/*.

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -906,11 +906,18 @@ async def startup_event() -> None:
     )
 
     register_execution_scope_snapshot_loader()
+    # This reflects only whether a resolver is registered at this point in
+    # startup; it is not re-evaluated afterward. An embedder that registers
+    # its resolver later (e.g. from its own startup hook running after this
+    # one) leaves this line reporting "snapshot-only" even once a resolver
+    # is in fact authoritative -- the mode itself is live and re-checked on
+    # every resolution (see resolve_execution_scope), only this log line is
+    # a startup-time snapshot of it.
     logger.info(
-        "Execution scope authority mode: %s",
+        "Execution scope authority mode at startup: %s",
         "resolver-authoritative (snapshot is a corroborating candidate)"
         if execution_scope_resolver_registered()
-        else "snapshot-only (no resolver registered)",
+        else "snapshot-only (no resolver registered yet)",
     )
 
     from .services.trigger_rate_limit import warn_if_rate_limits_are_per_process

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -31,7 +31,10 @@ from ..config import (
     get_uploaded_file_recovery_stale_seconds,
     get_uploads_dir,
 )
-from ..core.execution_scope import ExecutionScopeAuthorityError
+from ..core.execution_scope import (
+    ExecutionScopeAuthorityError,
+    ExecutionScopeResolverContractError,
+)
 from ..core.file_storage import StorageKeyScopeError
 from ..core.tracing.langfuse import flush_langfuse, initialize_langfuse
 from .api.a2a import router as a2a_router
@@ -812,9 +815,11 @@ async def storage_namespace_authority_error_handler(
     """Answer a storage namespace containment/authority fault once, app-wide.
 
     ``StorageKeyScopeError`` (a storage key outside the prefix its handle is
-    bound to) and ``ExecutionScopeAuthorityError`` (the scope resolver and a
-    task's persisted snapshot disagree about the task's namespace) are
-    permanent server-side configuration/authority faults. Registering them
+    bound to), ``ExecutionScopeAuthorityError`` (the scope resolver and a
+    task's persisted snapshot disagree about the task's namespace) and
+    ``ExecutionScopeResolverContractError`` (a resolver broke its return
+    contract, or a persisted snapshot cannot be decoded at all) are permanent
+    server-side configuration/authority faults. Registering them
     here instead of at each file endpoint keeps one classification for every
     route that touches durable storage -- and keeps them out of the retryable
     503 that ``DurableStorageOperationError`` maps to, since retrying a
@@ -874,6 +879,12 @@ app.add_exception_handler(
 # handler by walking the raised exception's MRO.
 app.add_exception_handler(
     ExecutionScopeAuthorityError, storage_namespace_authority_error_handler
+)
+# A resolver that broke its return contract, or a persisted snapshot that
+# cannot be decoded, is the same permanent authority fault: nothing about the
+# request can be corrected or retried into working.
+app.add_exception_handler(
+    ExecutionScopeResolverContractError, storage_namespace_authority_error_handler
 )
 
 # /v1/* SDK surface uses a stable {"error": {"code", "message"}} envelope

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -895,13 +895,23 @@ async def startup_event() -> None:
     start_uploaded_file_recovery_task(app)
     start_orphan_upload_gc_task(app)
 
-    # Persisted ExecutionScope snapshots (workforce sub-tasks) are preferred
-    # over the embedder's resolver during per-task scope resolution.
+    # Persisted ExecutionScope snapshots (workforce sub-tasks) keep a
+    # sub-task scoped across process restarts. With no resolver registered
+    # they are the sole answer; with one registered they are a
+    # corroborating candidate (see
+    # xagent.core.execution_scope.resolve_execution_scope).
+    from ..core.execution_scope import execution_scope_resolver_registered
     from .services.execution_scope_snapshot import (
         register_execution_scope_snapshot_loader,
     )
 
     register_execution_scope_snapshot_loader()
+    logger.info(
+        "Execution scope authority mode: %s",
+        "resolver-authoritative (snapshot is a corroborating candidate)"
+        if execution_scope_resolver_registered()
+        else "snapshot-only (no resolver registered)",
+    )
 
     from .services.trigger_rate_limit import warn_if_rate_limits_are_per_process
 

--- a/src/xagent/web/services/execution_scope_snapshot.py
+++ b/src/xagent/web/services/execution_scope_snapshot.py
@@ -3,11 +3,12 @@
 Workforce runs create fresh Task rows whose ids the embedding application's
 scope resolver cannot map. The creating context's scope is persisted into
 the task's ``agent_config`` JSON (``EXECUTION_SCOPE_AGENT_CONFIG_KEY``, no
-schema migration) at creation; this module's loader reads it back, and the
-core per-task resolution (:func:`xagent.core.execution_scope.
-resolve_execution_scope`) prefers the snapshot over the resolver — so a
-sub-task of a scoped parent executes fully scoped even after a process
-restart.
+schema migration) at creation; this module's loader reads it back. The core
+per-task resolution (:func:`xagent.core.execution_scope.
+resolve_execution_scope`) treats it as the sole answer when no resolver is
+registered — this is what keeps a sub-task of a scoped parent executing
+fully scoped even after a process restart — and as a corroborating
+candidate for the resolver's authoritative answer when one is registered.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm import Session
 from ...core.agent.attachments import project_file_info_to_chip
 from ...core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeResolverContractError,
     execution_scope_from_agent_config,
     resolve_execution_scope,
 )
@@ -66,12 +67,31 @@ def _task_execution_scope_in_session(
     db: Session,
     task_id: int | None,
 ) -> tuple[int | None, ExecutionScope | None]:
-    """Read the persisted half of canonical scope resolution in this Session."""
+    """Read the persisted half of canonical scope resolution in this Session.
+
+    A snapshot that fails field validation is reported as "no candidate"
+    rather than raised. The registered-loader path decodes inside
+    ``resolve_execution_scope``'s own try/except, where a malformed candidate
+    is logged and ignored so an authoritative resolver still answers the
+    turn; this call site sits outside that umbrella, so it applies the same
+    tolerance itself. Without it the two paths would refuse and accept the
+    very same persisted row differently, and a corrupt row would fail a turn
+    that the resolver could have answered on its own.
+    """
 
     if task_id is None:
         return None, None
     row = db.query(Task.agent_config).filter(Task.id == task_id).first()
-    return task_id, execution_scope_from_agent_config(row[0] if row else None)
+    try:
+        return task_id, execution_scope_from_agent_config(row[0] if row else None)
+    except ExecutionScopeResolverContractError:
+        logger.warning(
+            "Ignoring malformed persisted execution scope snapshot for task %s; "
+            "the resolver's answer stands alone for this turn",
+            task_id,
+            exc_info=True,
+        )
+        return task_id, None
 
 
 def normalize_filename(filename: str) -> str:

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -16,8 +16,7 @@ The resolve and bind steps are deliberately split:
     caller-owned claim transaction. :func:`bind_turn_files` is the
     compatibility wrapper for owners that need an immediate commit.
 
-The WebSocket path keeps its resolve-then-bind-in-one behavior via
-``handle_file_upload_for_task``, which now delegates to both.
+Both transports call the two steps directly.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -33,12 +34,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...core.agent.attachments import project_file_info_to_chip
-from ...core.execution_scope import (
-    ExecutionScope,
-    ExecutionScopeResolverContractError,
-    execution_scope_from_agent_config,
-    resolve_execution_scope,
-)
+from ...core.execution_scope import resolve_execution_scope
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS
 from ..models.database import release_db_connection_if_clean
 from ..models.task import Task
@@ -66,32 +62,22 @@ class _TurnFileRecordSnapshot:
 def _task_execution_scope_in_session(
     db: Session,
     task_id: int | None,
-) -> tuple[int | None, ExecutionScope | None]:
-    """Read the persisted half of canonical scope resolution in this Session.
+) -> tuple[int | None, Mapping[str, Any] | None]:
+    """Read the raw ``agent_config`` this Session owns, undecoded.
 
-    A snapshot that fails field validation is reported as "no candidate"
-    rather than raised. The registered-loader path decodes inside
-    ``resolve_execution_scope``'s own try/except, where a malformed candidate
-    is logged and ignored so an authoritative resolver still answers the
-    turn; this call site sits outside that umbrella, so it applies the same
-    tolerance itself. Without it the two paths would refuse and accept the
-    very same persisted row differently, and a corrupt row would fail a turn
-    that the resolver could have answered on its own.
+    The snapshot inside it is decoded by ``resolve_execution_scope``, not
+    here. Whether a malformed snapshot is tolerated depends on which
+    resolution branch is active -- an authoritative resolver can ignore a bad
+    candidate and answer on its own, while an abstaining resolver or no
+    resolver at all must fail closed, because there the snapshot is the only
+    namespace authority and "no candidate" would silently mean "unscoped".
+    Only the resolver knows which case it is in, so the decode belongs there.
     """
 
     if task_id is None:
         return None, None
     row = db.query(Task.agent_config).filter(Task.id == task_id).first()
-    try:
-        return task_id, execution_scope_from_agent_config(row[0] if row else None)
-    except ExecutionScopeResolverContractError:
-        logger.warning(
-            "Ignoring malformed persisted execution scope snapshot for task %s; "
-            "the resolver's answer stands alone for this turn",
-            task_id,
-            exc_info=True,
-        )
-        return task_id, None
+    return task_id, (row[0] if row else None)
 
 
 def normalize_filename(filename: str) -> str:
@@ -232,7 +218,9 @@ def resolve_turn_file_infos(
             )
         )
 
-    scope_task_id, persisted_scope = _task_execution_scope_in_session(db, task_id)
+    scope_task_id, persisted_agent_config = _task_execution_scope_in_session(
+        db, task_id
+    )
     if snapshots and not release_db_connection_if_clean(db):
         raise RuntimeError(
             "Turn file materialization requires a read-only database phase"
@@ -240,7 +228,7 @@ def resolve_turn_file_infos(
     execution_scope = (
         resolve_execution_scope(
             scope_task_id,
-            persisted_snapshot=persisted_scope,
+            persisted_agent_config=persisted_agent_config,
         )
         if scope_task_id is not None
         else None

--- a/src/xagent/web/services/file_turn.py
+++ b/src/xagent/web/services/file_turn.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -61,8 +60,14 @@ class _TurnFileRecordSnapshot:
 def _task_execution_scope_in_session(
     db: Session,
     task_id: int | None,
-) -> tuple[int | None, Mapping[str, Any] | None]:
+) -> tuple[int | None, Any]:
     """Read the raw ``agent_config`` this Session owns, undecoded.
+
+    The second element is whatever the untyped JSON column holds, which is why
+    it is not annotated as a mapping: nothing between the database and here
+    validates its shape, and claiming one would describe a guarantee no layer
+    provides. ``resolve_execution_scope`` narrows it, and rejects a value the
+    column should never have held.
 
     The snapshot inside it is decoded by ``resolve_execution_scope``, not
     here. Whether a malformed snapshot is tolerated depends on which

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -134,21 +134,26 @@ def _checksum_matches(expected_checksum: str, actual_checksum: str) -> bool:
 class ManagedFileRef:
     """Registered file handle with local-first durable fallback semantics.
 
-    ``for_write`` states the caller's intent for a record that has no durable
-    key yet, since key presence alone cannot distinguish a read from a write
-    (see ``__post_init__``): ``True`` (the default) fails closed on a
-    resolver/snapshot authority mismatch, because it is about to compose the
-    key a new object lands under; ``False`` downgrades that same mismatch to
-    the resolver's answer plus a warning, since a read has local storage to
-    fall back to and failing closed would only turn a servable file into an
-    unhandled error.
+    A record with no durable key yet is ambiguous at construction time: it
+    is either a fresh upload about to be written, or a ``storage_status=
+    "pending"`` record a read-only endpoint is merely trying to serve from
+    local storage (see ``__post_init__``). Rather than asking every caller
+    to declare its intent, this class always resolves off-turn (never
+    raises at construction) and defers the fail-closed authority check to
+    ``sync_to_durable``, the one operation that actually selects a namespace
+    for new bytes (see that method). ``_scope_from_task_recovery`` records
+    whether ``_scope_segments`` came from that off-turn per-task recovery,
+    as opposed to an explicit ``execution_scope`` argument or the ambient
+    turn contextvar -- only the recovered case needs re-checking before a
+    key is composed.
     """
 
     record: UploadedFileLocalPathRecord
     storage: FsspecFileStorage | ScopedFileStorage = field(default=None)  # type: ignore[assignment]
     execution_scope: ExecutionScopeInput = EXECUTION_SCOPE_NOT_PROVIDED
-    for_write: bool = True
     _scope_segments: tuple[str, ...] = field(default=(), init=False, repr=False)
+    _scope_from_task_recovery: bool = field(default=False, init=False, repr=False)
+    _recovery_task_id: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         # Resolve the active scope once, at construction, so the bound handle
@@ -171,40 +176,35 @@ class ManagedFileRef:
             if scope is None:
                 task_id = getattr(self.record, "task_id", None)
                 if task_id is not None and not self.storage_key:
-                    # No durable key yet means a fresh object is about to be
-                    # placed somewhere under this scope's subtree -- but a
-                    # keyless record is routine for reads too (a
+                    # No durable key yet means either a fresh object is
+                    # about to be placed somewhere under this scope's
+                    # subtree, or the record is simply routine for reads (a
                     # freshly-uploaded record sits at storage_status=
                     # "pending" with no key, and list/download/preview
                     # endpoints construct a ref for exactly those records).
                     # Presence of a key cannot tell write intent from read
-                    # intent, so the caller must: ``for_write`` (default
-                    # True, preserving prior behavior for callers that don't
-                    # pass it) says which.
-                    #
-                    # ``for_write=True``: choosing the namespace a new
-                    # object is written under is an authority decision --
-                    # getting it wrong silently and durably writes one
-                    # tenant's bytes under another tenant's subtree -- so
-                    # this fails closed rather than downgrading a
-                    # resolver/snapshot mismatch to a warning.
-                    #
-                    # ``for_write=False``: nothing new is being placed
-                    # anywhere; the ref only needs a best-effort namespace to
-                    # look in (e.g. to decide whether a durable object could
-                    # exist at all before falling back to local storage), so
-                    # a mismatch downgrades to the resolver's answer plus a
-                    # warning instead of raising -- the read still has local
-                    # storage to fall back to, and raising would turn a
-                    # servable file into an unhandled 500.
+                    # intent apart, so construction never picks a side: it
+                    # always resolves off-turn (downgrading a resolver/
+                    # snapshot authority mismatch to the resolver's answer
+                    # plus a warning instead of raising -- a keyless ref
+                    # under construction may only ever be serving a read
+                    # from local storage, and raising here would turn a
+                    # servable file into an unhandled 500). The namespace
+                    # decision that actually matters -- which tenant's
+                    # subtree new bytes land under -- is deferred to
+                    # ``sync_to_durable``, the one place that composes a
+                    # fresh key, which re-resolves fail-closed right before
+                    # doing so. ``_scope_from_task_recovery`` records that
+                    # this ref's ``_scope_segments`` came from this branch,
+                    # so ``sync_to_durable`` knows a re-check is needed.
                     #
                     # A record that already has a durable key is the read
-                    # (or rewrite-in-place) path regardless of ``for_write``:
-                    # that key already fixes the object's location, off-turn
-                    # re-resolution is unnecessary, and -- on a
-                    # resolver/snapshot drift -- would make an
-                    # already-legitimate key look foreign to a narrower
-                    # re-derived scope (see ``storage`` binding below).
+                    # (or rewrite-in-place) path: that key already fixes the
+                    # object's location, off-turn re-resolution is
+                    # unnecessary, and -- on a resolver/snapshot drift --
+                    # would make an already-legitimate key look foreign to a
+                    # narrower re-derived scope (see ``storage`` binding
+                    # below).
                     #
                     # Skipping this branch (or a downgrade landing on
                     # ``None``) leaves ``scope`` at ``None``, so
@@ -233,11 +233,9 @@ class ManagedFileRef:
                     # scope and can raise ``StorageKeyScopeError``), not just
                     # a neutral no-op -- it is deliberate for the reason
                     # above, not an oversight.
-                    scope = (
-                        resolve_execution_scope(task_id)
-                        if self.for_write
-                        else resolve_execution_scope_off_turn(task_id)
-                    )
+                    scope = resolve_execution_scope_off_turn(task_id)
+                    self._scope_from_task_recovery = True
+                    self._recovery_task_id = task_id
         else:
             scope = cast(ExecutionScope | None, scope_input)
         self._scope_segments = (
@@ -369,16 +367,36 @@ class ManagedFileRef:
         if not path.exists() or not path.is_file():
             raise FileNotFoundError(path)
 
-        resolved_key = (
-            storage_key
-            or self.storage_key
-            or build_upload_storage_key(
+        resolved_key = storage_key or self.storage_key
+        if not resolved_key:
+            # Composing a fresh key selects the namespace new bytes land
+            # under -- getting it wrong silently and durably writes one
+            # tenant's bytes under another tenant's subtree. Construction
+            # (see ``__post_init__``) never fails closed for this, because a
+            # keyless ref might just as well be serving a read; this is the
+            # one place that actually needs to fail closed, since this is
+            # the operation that actually places new bytes.
+            #
+            # When ``_scope_segments`` came from off-turn per-task recovery,
+            # re-resolve it here, fail-closed, right before it is baked into
+            # the key. This second resolution cannot disagree with the one
+            # already baked into ``_scope_segments`` in the case that
+            # matters: a disagreement is exactly what makes this fail-closed
+            # call raise, and it raises before ``resolved_key`` is computed
+            # or anything is written -- so this is a genuine re-check, not
+            # redundant work re-deriving the same answer.
+            scope_segments = self._scope_segments
+            if self._scope_from_task_recovery:
+                scope = resolve_execution_scope(self._recovery_task_id)
+                scope_segments = (
+                    scope.durable_storage_segments if scope is not None else ()
+                )
+            resolved_key = build_upload_storage_key(
                 int(self.record.user_id),
                 str(self.record.file_id),
                 self.filename or path.name,
-                scope_segments=self._scope_segments,
+                scope_segments=scope_segments,
             )
-        )
         try:
             stored_object = self.storage.put_file(
                 path,

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -16,6 +16,7 @@ from ...core.execution_scope import (
     ExecutionScope,
     ExecutionScopeAuthorityError,
     ExecutionScopeInput,
+    ExecutionScopeResolverContractError,
     get_execution_scope,
     resolve_execution_scope,
     resolve_execution_scope_off_turn,
@@ -63,14 +64,19 @@ class DurableObjectIntegrityError(DurableStorageOperationError):
 # outside the prefix this handle is bound to (the key encodes the wrong
 # namespace, or the handle was bound to the wrong one), and
 # ``ExecutionScopeAuthorityError`` means the resolver and the persisted
-# snapshot disagree about which namespace the task owns. Both are permanent
-# configuration/authority faults that no retry can clear, so they propagate as
-# themselves and are classified once, at the application boundary (see the
-# handler registered in ``web/app.py``), instead of being reported as an
-# outage an operator would retry.
+# snapshot disagree about which namespace the task owns, and
+# ``ExecutionScopeResolverContractError`` means a resolver broke its return
+# contract or the persisted snapshot cannot be decoded at all -- reachable
+# here because binding the handle settles a deferred per-task resolution (see
+# ``_bound_storage``). All three are permanent configuration/authority faults
+# that no retry can clear, so they propagate as themselves and are classified
+# once, at the application boundary (see the handlers registered in
+# ``web/app.py``), instead of being reported as an outage an operator would
+# retry.
 _NAMESPACE_AUTHORITY_ERRORS: tuple[type[BaseException], ...] = (
     StorageKeyScopeError,
     ExecutionScopeAuthorityError,
+    ExecutionScopeResolverContractError,
 )
 
 

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -15,7 +15,7 @@ from ...core.execution_scope import (
     ExecutionScope,
     ExecutionScopeInput,
     get_execution_scope,
-    resolve_execution_scope_off_turn,
+    resolve_execution_scope,
 )
 from ...core.file_storage import (
     FsspecFileStorage,
@@ -161,15 +161,19 @@ class ManagedFileRef:
                 if task_id is not None and not self.storage_key:
                     # A record with no durable key yet is the write path: a
                     # fresh object is about to be placed under this scope's
-                    # subtree, so off-turn resolution matters. A record that
-                    # already has a durable key is the read (or
+                    # subtree. Choosing that namespace is an authority
+                    # decision -- getting it wrong silently and durably
+                    # writes one tenant's bytes under another tenant's
+                    # subtree -- so this fails closed rather than downgrading
+                    # a resolver/snapshot mismatch to a warning. A record
+                    # that already has a durable key is the read (or
                     # rewrite-in-place) path: that key already fixes the
                     # object's location, off-turn re-resolution is
                     # unnecessary, and -- on a resolver/snapshot drift --
                     # would make an already-legitimate key look foreign to a
                     # narrower re-derived scope (see ``storage`` binding
                     # below).
-                    scope = resolve_execution_scope_off_turn(task_id)
+                    scope = resolve_execution_scope(task_id)
         else:
             scope = cast(ExecutionScope | None, scope_input)
         self._scope_segments = (

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -15,7 +15,7 @@ from ...core.execution_scope import (
     ExecutionScope,
     ExecutionScopeInput,
     get_execution_scope,
-    resolve_execution_scope,
+    resolve_execution_scope_off_turn,
 )
 from ...core.file_storage import (
     FsspecFileStorage,
@@ -149,8 +149,8 @@ class ManagedFileRef:
         # matters on off-turn paths (bot/builder-chat handlers never enter
         # ``turn_execution_scope``, so the contextvar is None): a workforce
         # sub-task carries its scope only in the persisted snapshot, and
-        # without recovering it here ``sync_to_durable`` would write the file
-        # under the owner root instead of the sub-task's scoped subtree.
+        # without recovering it here ``sync_to_durable`` would write a new
+        # file under the owner root instead of the sub-task's scoped subtree.
         # Explicit ``None`` means owner-root. Only an omitted argument may
         # inherit the ambient turn scope or consult per-task resolution.
         scope_input = self.execution_scope
@@ -158,8 +158,18 @@ class ManagedFileRef:
             scope = get_execution_scope()
             if scope is None:
                 task_id = getattr(self.record, "task_id", None)
-                if task_id is not None:
-                    scope = resolve_execution_scope(task_id)
+                if task_id is not None and not self.storage_key:
+                    # A record with no durable key yet is the write path: a
+                    # fresh object is about to be placed under this scope's
+                    # subtree, so off-turn resolution matters. A record that
+                    # already has a durable key is the read (or
+                    # rewrite-in-place) path: that key already fixes the
+                    # object's location, off-turn re-resolution is
+                    # unnecessary, and -- on a resolver/snapshot drift --
+                    # would make an already-legitimate key look foreign to a
+                    # narrower re-derived scope (see ``storage`` binding
+                    # below).
+                    scope = resolve_execution_scope_off_turn(task_id)
         else:
             scope = cast(ExecutionScope | None, scope_input)
         self._scope_segments = (

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -13,6 +13,7 @@ from typing import Any, BinaryIO, Literal, NoReturn, Protocol, cast
 from ...core.execution_scope import (
     EXECUTION_SCOPE_NOT_PROVIDED,
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     ExecutionScopeInput,
     get_execution_scope,
     resolve_execution_scope,
@@ -21,6 +22,7 @@ from ...core.execution_scope import (
 from ...core.file_storage import (
     FsspecFileStorage,
     ScopedFileStorage,
+    StorageKeyScopeError,
     StoredObject,
     get_user_file_storage,
 )
@@ -49,6 +51,26 @@ class DurableStorageOperationError(RuntimeError):
 
 class DurableObjectIntegrityError(DurableStorageOperationError):
     """Raised when restored durable bytes do not match the DB checksum."""
+
+
+# Namespace-authority faults that must never be folded into
+# ``DurableStorageOperationError`` by the storage-call wraps below. That
+# fallback exists for *backend* faults -- an unreachable object store, a lost
+# metadata acknowledgement, a read that times out -- which callers surface as a
+# retryable "durable storage is temporarily unavailable". A containment
+# violation is not one of those: ``StorageKeyScopeError`` means the key falls
+# outside the prefix this handle is bound to (the key encodes the wrong
+# namespace, or the handle was bound to the wrong one), and
+# ``ExecutionScopeAuthorityError`` means the resolver and the persisted
+# snapshot disagree about which namespace the task owns. Both are permanent
+# configuration/authority faults that no retry can clear, so they propagate as
+# themselves and are classified once, at the application boundary (see the
+# handler registered in ``web/app.py``), instead of being reported as an
+# outage an operator would retry.
+_NAMESPACE_AUTHORITY_ERRORS: tuple[type[BaseException], ...] = (
+    StorageKeyScopeError,
+    ExecutionScopeAuthorityError,
+)
 
 
 class UploadedFileLocalPathRecord(Protocol):
@@ -306,6 +328,9 @@ class ManagedFileRef:
         except DurableObjectIntegrityError:
             temp_path.unlink(missing_ok=True)
             raise
+        except _NAMESPACE_AUTHORITY_ERRORS:
+            temp_path.unlink(missing_ok=True)
+            raise
         except Exception as exc:
             temp_path.unlink(missing_ok=True)
             raise DurableStorageOperationError(
@@ -333,6 +358,8 @@ class ManagedFileRef:
                 last_integrity_error = exc
                 if materialized_path is not None:
                     materialized_path.unlink(missing_ok=True)
+            except _NAMESPACE_AUTHORITY_ERRORS:
+                raise
             except Exception as exc:
                 raise DurableStorageOperationError(
                     f"Failed to materialize durable object: {self.storage_key}"
@@ -365,6 +392,8 @@ class ManagedFileRef:
                 content_type=content_type,
                 content_disposition=content_disposition,
             )
+        except _NAMESPACE_AUTHORITY_ERRORS:
+            raise
         except Exception as exc:
             raise DurableStorageOperationError(
                 f"Failed to sign durable object URL: {self.storage_key}"
@@ -418,6 +447,8 @@ class ManagedFileRef:
                 resolved_key,
                 mime_type or getattr(self.record, "mime_type", None),
             )
+        except _NAMESPACE_AUTHORITY_ERRORS:
+            raise
         except Exception as exc:
             raise DurableStorageOperationError(
                 f"Failed to write durable object: {resolved_key}"
@@ -435,6 +466,8 @@ class ManagedFileRef:
             stored_object = self.storage.stat(expected_key)
         except FileNotFoundError:
             return "missing"
+        except _NAMESPACE_AUTHORITY_ERRORS:
+            raise
         except Exception as exc:
             raise DurableStorageOperationError(
                 f"Failed to inspect durable object metadata: {expected_key}"
@@ -471,6 +504,8 @@ class ManagedFileRef:
         if not checksum:
             try:
                 checksum = self.storage.content_hash(expected_key)
+            except _NAMESPACE_AUTHORITY_ERRORS:
+                raise
             except Exception as exc:
                 raise DurableStorageOperationError(
                     f"Failed to inspect durable object metadata: {expected_key}"

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -138,14 +138,27 @@ class ManagedFileRef:
     is either a fresh upload about to be written, or a ``storage_status=
     "pending"`` record a read-only endpoint is merely trying to serve from
     local storage (see ``__post_init__``). Rather than asking every caller
-    to declare its intent, this class always resolves off-turn (never
-    raises at construction) and defers the fail-closed authority check to
-    ``sync_to_durable``, the one operation that actually selects a namespace
-    for new bytes (see that method). ``_scope_from_task_recovery`` records
-    whether ``_scope_segments`` came from that off-turn per-task recovery,
-    as opposed to an explicit ``execution_scope`` argument or the ambient
-    turn contextvar -- only the recovered case needs re-checking before a
-    key is composed.
+    to declare its intent, this class resolves off-turn, so a
+    resolver-authoritative namespace mismatch downgrades instead of turning
+    a servable read into an error, and defers the fail-closed authority
+    check to ``sync_to_durable``, the operation that composes a key from
+    the resolved namespace. ``_scope_from_task_recovery`` records whether
+    ``_scope_segments`` came from that off-turn per-task recovery, as
+    opposed to an explicit ``execution_scope`` argument or the ambient turn
+    contextvar -- only the recovered case needs re-checking before a key is
+    composed.
+
+    Off-turn resolution is not the same as never failing: it downgrades a
+    mismatch only where the resolver produced an authoritative answer to
+    downgrade to. A resolver that abstains and disagrees with the snapshot,
+    a resolver that violates its own return contract, and a snapshot loader
+    that raises all still propagate out of construction, so a read of a
+    keyless record is not unconditionally safe.
+
+    A key supplied by the caller bypasses the re-check below, because the
+    namespace it encodes was chosen wherever that key was composed. Callers
+    that compose a key themselves therefore own that decision; this class
+    only covers the keys it composes.
     """
 
     record: UploadedFileLocalPathRecord
@@ -372,10 +385,12 @@ class ManagedFileRef:
             # Composing a fresh key selects the namespace new bytes land
             # under -- getting it wrong silently and durably writes one
             # tenant's bytes under another tenant's subtree. Construction
-            # (see ``__post_init__``) never fails closed for this, because a
-            # keyless ref might just as well be serving a read; this is the
-            # one place that actually needs to fail closed, since this is
-            # the operation that actually places new bytes.
+            # (see ``__post_init__``) resolves off-turn instead, because a
+            # keyless ref might just as well be serving a read, so the
+            # fail-closed check belongs here, where the namespace is actually
+            # baked into a key. This covers the keys composed here only:
+            # every caller that hands ``sync_to_durable`` a ``storage_key``
+            # skips this branch and owns the namespace in that key itself.
             #
             # When ``_scope_segments`` came from off-turn per-task recovery,
             # re-resolve it here, fail-closed, right before it is baked into

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -520,6 +520,12 @@ class ManagedFileRef:
             if not checksum:
                 try:
                     checksum = self._bound_storage().content_hash(expected_key)
+                except _NAMESPACE_AUTHORITY_ERRORS:
+                    # The rule holds at every site in this module, not only
+                    # where a downstream call happens to raise the same class
+                    # again: relying on that would make this a silent swallow
+                    # the moment the fallback path changes.
+                    raise
                 except Exception:
                     self.sync_to_durable(
                         storage_key=expected_key,
@@ -596,6 +602,11 @@ class ManagedFileRef:
 
         try:
             actual_checksum = self._bound_storage().content_hash(self.storage_key)
+        except _NAMESPACE_AUTHORITY_ERRORS:
+            # A permanent authority fault must not be reported as "checksum
+            # unavailable", which reads as a transient reason to fall back to
+            # backend-mediated access.
+            raise
         except Exception as exc:
             logger.warning(
                 "Falling back to backend-mediated durable access because content "

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -16,6 +16,7 @@ from ...core.execution_scope import (
     ExecutionScopeInput,
     get_execution_scope,
     resolve_execution_scope,
+    resolve_execution_scope_off_turn,
 )
 from ...core.file_storage import (
     FsspecFileStorage,
@@ -131,11 +132,22 @@ def _checksum_matches(expected_checksum: str, actual_checksum: str) -> bool:
 
 @dataclass
 class ManagedFileRef:
-    """Registered file handle with local-first durable fallback semantics."""
+    """Registered file handle with local-first durable fallback semantics.
+
+    ``for_write`` states the caller's intent for a record that has no durable
+    key yet, since key presence alone cannot distinguish a read from a write
+    (see ``__post_init__``): ``True`` (the default) fails closed on a
+    resolver/snapshot authority mismatch, because it is about to compose the
+    key a new object lands under; ``False`` downgrades that same mismatch to
+    the resolver's answer plus a warning, since a read has local storage to
+    fall back to and failing closed would only turn a servable file into an
+    unhandled error.
+    """
 
     record: UploadedFileLocalPathRecord
     storage: FsspecFileStorage | ScopedFileStorage = field(default=None)  # type: ignore[assignment]
     execution_scope: ExecutionScopeInput = EXECUTION_SCOPE_NOT_PROVIDED
+    for_write: bool = True
     _scope_segments: tuple[str, ...] = field(default=(), init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -159,22 +171,43 @@ class ManagedFileRef:
             if scope is None:
                 task_id = getattr(self.record, "task_id", None)
                 if task_id is not None and not self.storage_key:
-                    # A record with no durable key yet is the write path: a
-                    # fresh object is about to be placed under this scope's
-                    # subtree. Choosing that namespace is an authority
-                    # decision -- getting it wrong silently and durably
-                    # writes one tenant's bytes under another tenant's
-                    # subtree -- so this fails closed rather than downgrading
-                    # a resolver/snapshot mismatch to a warning. A record
-                    # that already has a durable key is the read (or
-                    # rewrite-in-place) path: that key already fixes the
-                    # object's location, off-turn re-resolution is
-                    # unnecessary, and -- on a resolver/snapshot drift --
-                    # would make an already-legitimate key look foreign to a
-                    # narrower re-derived scope (see ``storage`` binding
-                    # below).
+                    # No durable key yet means a fresh object is about to be
+                    # placed somewhere under this scope's subtree -- but a
+                    # keyless record is routine for reads too (a
+                    # freshly-uploaded record sits at storage_status=
+                    # "pending" with no key, and list/download/preview
+                    # endpoints construct a ref for exactly those records).
+                    # Presence of a key cannot tell write intent from read
+                    # intent, so the caller must: ``for_write`` (default
+                    # True, preserving prior behavior for callers that don't
+                    # pass it) says which.
                     #
-                    # Skipping this branch leaves ``scope`` at ``None``, so
+                    # ``for_write=True``: choosing the namespace a new
+                    # object is written under is an authority decision --
+                    # getting it wrong silently and durably writes one
+                    # tenant's bytes under another tenant's subtree -- so
+                    # this fails closed rather than downgrading a
+                    # resolver/snapshot mismatch to a warning.
+                    #
+                    # ``for_write=False``: nothing new is being placed
+                    # anywhere; the ref only needs a best-effort namespace to
+                    # look in (e.g. to decide whether a durable object could
+                    # exist at all before falling back to local storage), so
+                    # a mismatch downgrades to the resolver's answer plus a
+                    # warning instead of raising -- the read still has local
+                    # storage to fall back to, and raising would turn a
+                    # servable file into an unhandled 500.
+                    #
+                    # A record that already has a durable key is the read
+                    # (or rewrite-in-place) path regardless of ``for_write``:
+                    # that key already fixes the object's location, off-turn
+                    # re-resolution is unnecessary, and -- on a
+                    # resolver/snapshot drift -- would make an
+                    # already-legitimate key look foreign to a narrower
+                    # re-derived scope (see ``storage`` binding below).
+                    #
+                    # Skipping this branch (or a downgrade landing on
+                    # ``None``) leaves ``scope`` at ``None``, so
                     # ``self._scope_segments`` below is ``()`` and
                     # ``self.storage`` binds to the owner root
                     # (``get_user_file_storage(user_id, scope_segments=())``)
@@ -194,8 +227,17 @@ class ManagedFileRef:
                     # constructing a new key relative to a prefix, so a
                     # containment check against a re-derived (and possibly
                     # drifted) scope would add no protection, only risk
-                    # rejecting an already-legitimate key.
-                    scope = resolve_execution_scope(task_id)
+                    # rejecting an already-legitimate key. This is a real
+                    # loosening relative to the in-turn binding for the same
+                    # read (which narrows through the ambient contextvar
+                    # scope and can raise ``StorageKeyScopeError``), not just
+                    # a neutral no-op -- it is deliberate for the reason
+                    # above, not an oversight.
+                    scope = (
+                        resolve_execution_scope(task_id)
+                        if self.for_write
+                        else resolve_execution_scope_off_turn(task_id)
+                    )
         else:
             scope = cast(ExecutionScope | None, scope_input)
         self._scope_segments = (

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import mimetypes
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol, cast
@@ -160,22 +161,25 @@ class ManagedFileRef:
     is either a fresh upload about to be written, or a ``storage_status=
     "pending"`` record a read-only endpoint is merely trying to serve from
     local storage (see ``__post_init__``). Rather than asking every caller
-    to declare its intent, this class resolves off-turn, so a
-    resolver-authoritative namespace mismatch downgrades instead of turning
-    a servable read into an error, and defers the fail-closed authority
-    check to ``sync_to_durable``, the operation that composes a key from
-    the resolved namespace. ``_scope_from_task_recovery`` records whether
-    ``_scope_segments`` came from that off-turn per-task recovery, as
-    opposed to an explicit ``execution_scope`` argument or the ambient turn
-    contextvar -- only the recovered case needs re-checking before a key is
-    composed.
+    to declare its intent, this class settles the namespace per operation:
+    an operation that addresses bytes that already exist resolves off-turn,
+    so a resolver-authoritative mismatch downgrades instead of turning a
+    servable read into an error, while ``sync_to_durable`` -- the operation
+    that composes a key from the resolved namespace -- resolves fail-closed
+    before it does so. ``_pending_scope_task_id`` records that the namespace
+    still has to be recovered per task, as opposed to having come from an
+    explicit ``execution_scope`` argument or the ambient turn contextvar.
 
     Off-turn resolution is not the same as never failing: it downgrades a
     mismatch only where the resolver produced an authoritative answer to
-    downgrade to. A resolver that abstains and disagrees with the snapshot,
-    a resolver that violates its own return contract, and a snapshot loader
-    that raises all still propagate out of construction, so a read of a
-    keyless record is not unconditionally safe.
+    downgrade to. An abstaining resolver that disagrees with the snapshot, a
+    resolver that violates its own return contract, and a snapshot loader
+    that raises all propagate rather than downgrade. Construction therefore
+    does not perform that resolution at all: it records the task to recover
+    from and resolves on first use by an operation that needs a namespace.
+    A read of a keyless record needs none -- ``ensure_local`` and
+    ``materialize`` refuse a record with no durable object before they touch
+    storage -- so a dispute cannot turn a servable read into an error.
 
     A key supplied by the caller bypasses the re-check below, because the
     namespace it encodes was chosen wherever that key was composed. Callers
@@ -187,13 +191,19 @@ class ManagedFileRef:
     storage: FsspecFileStorage | ScopedFileStorage = field(default=None)  # type: ignore[assignment]
     execution_scope: ExecutionScopeInput = EXECUTION_SCOPE_NOT_PROVIDED
     _scope_segments: tuple[str, ...] = field(default=(), init=False, repr=False)
-    _scope_from_task_recovery: bool = field(default=False, init=False, repr=False)
-    _recovery_task_id: Any = field(default=None, init=False, repr=False)
+    # Not None while a per-task scope recovery is owed but has not run yet.
+    # Cleared by the recovery, so two operations on one ref cannot bind to
+    # two different namespaces.
+    _pending_scope_task_id: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        # Resolve the active scope once, at construction, so the bound handle
-        # and any key written through it (see ``sync_to_durable``) agree even
-        # if the ambient scope changes later or the ref outlives the turn.
+        # Settle the active scope once, so the bound handle and any key
+        # written through it (see ``sync_to_durable``) agree even if the
+        # ambient scope changes later or the ref outlives the turn. The
+        # ambient contextvar is sampled here, at construction, for exactly
+        # that reason; only the per-task resolver/snapshot recovery is
+        # deferred, because that is the one step that can raise and the one
+        # whose answer a read of a keyless record never consumes.
         #
         # Precedence mirrors ``AgentServiceManager.get_agent_for_task``:
         # explicit arg -> ambient turn contextvar -> the per-task
@@ -218,20 +228,17 @@ class ManagedFileRef:
                     # "pending" with no key, and list/download/preview
                     # endpoints construct a ref for exactly those records).
                     # Presence of a key cannot tell write intent from read
-                    # intent apart, so construction never picks a side: it
-                    # always resolves off-turn (downgrading a resolver/
-                    # snapshot authority mismatch to the resolver's answer
-                    # plus a warning instead of raising -- a keyless ref
-                    # under construction may only ever be serving a read
-                    # from local storage, and raising here would turn a
-                    # servable file into an unhandled 500). The namespace
-                    # decision that actually matters -- which tenant's
-                    # subtree new bytes land under -- is deferred to
-                    # ``sync_to_durable``, the one place that composes a
-                    # fresh key, which re-resolves fail-closed right before
-                    # doing so. ``_scope_from_task_recovery`` records that
-                    # this ref's ``_scope_segments`` came from this branch,
-                    # so ``sync_to_durable`` knows a re-check is needed.
+                    # intent apart, so construction picks neither: it records
+                    # the task and resolves nothing. Whichever operation
+                    # first needs a namespace supplies the policy --
+                    # ``sync_to_durable`` fail-closed before it composes a
+                    # key, everything else off-turn, downgrading a
+                    # resolver-authoritative mismatch to the resolver's
+                    # answer plus a warning. A read of a keyless record asks
+                    # for no namespace at all, so the paths that can raise
+                    # (an abstaining resolver disagreeing with the snapshot,
+                    # a resolver breaking its return contract, a loader that
+                    # raises) cannot turn a servable file into a 500.
                     #
                     # A record that already has a durable key is the read
                     # (or rewrite-in-place) path: that key already fixes the
@@ -268,24 +275,54 @@ class ManagedFileRef:
                     # scope and can raise ``StorageKeyScopeError``), not just
                     # a neutral no-op -- it is deliberate for the reason
                     # above, not an oversight.
-                    scope = resolve_execution_scope_off_turn(task_id)
-                    self._scope_from_task_recovery = True
-                    self._recovery_task_id = task_id
+                    self._pending_scope_task_id = task_id
+                    return
         else:
             scope = cast(ExecutionScope | None, scope_input)
         self._scope_segments = (
             scope.durable_storage_segments if scope is not None else ()
         )
-        if self.storage is None:
-            user_id = self.record.user_id
-            if user_id is None:
-                raise ValueError(
-                    "Record user_id is required to bind user-scoped storage; "
-                    "pass an explicit storage handle for records without an owner"
-                )
-            self.storage = get_user_file_storage(
-                int(user_id), scope_segments=self._scope_segments
+        self._bind_storage()
+
+    def _bind_storage(self) -> None:
+        """Bind the handle to the settled namespace, unless one was passed in."""
+        if self.storage is not None:
+            return
+        user_id = self.record.user_id
+        if user_id is None:
+            raise ValueError(
+                "Record user_id is required to bind user-scoped storage; "
+                "pass an explicit storage handle for records without an owner"
             )
+        self.storage = get_user_file_storage(
+            int(user_id), scope_segments=self._scope_segments
+        )
+
+    def _settle_pending_scope(
+        self, resolve: Callable[[Any], ExecutionScope | None]
+    ) -> None:
+        """Run the deferred per-task recovery, then bind.
+
+        ``resolve`` is the caller's policy: the off-turn form for operations
+        that address bytes that already exist, and the fail-closed form where
+        a namespace is being chosen for new bytes. Whichever runs first wins
+        for the life of this ref, which is why the only caller that passes
+        the fail-closed form does so before composing a key.
+        """
+        task_id = self._pending_scope_task_id
+        if task_id is not None:
+            scope = resolve(task_id)
+            self._scope_segments = (
+                scope.durable_storage_segments if scope is not None else ()
+            )
+            self._pending_scope_task_id = None
+        self._bind_storage()
+
+    def _bound_storage(self) -> FsspecFileStorage | ScopedFileStorage:
+        """The storage handle, settling a deferred scope recovery on first use."""
+        if self.storage is None:
+            self._settle_pending_scope(resolve_execution_scope_off_turn)
+        return self.storage
 
     @property
     def local_path(self) -> Path:
@@ -321,7 +358,7 @@ class ManagedFileRef:
         temp_path = Path(temp_file.name)
         temp_file.close()
         try:
-            self.storage.copy_to_path(self.storage_key, temp_path)
+            self._bound_storage().copy_to_path(self.storage_key, temp_path)
             self._verify_content_checksum(temp_path)
             temp_path.replace(path)
             return path
@@ -349,7 +386,7 @@ class ManagedFileRef:
         for _attempt in range(2):
             materialized_path: Path | None = None
             try:
-                materialized_path = self.storage.materialize(
+                materialized_path = self._bound_storage().materialize(
                     self.storage_key, self.filename
                 )
                 self._verify_content_checksum(materialized_path)
@@ -386,7 +423,7 @@ class ManagedFileRef:
         if not self._verify_durable_checksum_for_direct_access():
             return None
         try:
-            return self.storage.signed_url(
+            return self._bound_storage().signed_url(
                 self.storage_key,
                 expires=expires,
                 content_type=content_type,
@@ -429,12 +466,8 @@ class ManagedFileRef:
             # call raise, and it raises before ``resolved_key`` is computed
             # or anything is written -- so this is a genuine re-check, not
             # redundant work re-deriving the same answer.
+            self._settle_pending_scope(resolve_execution_scope)
             scope_segments = self._scope_segments
-            if self._scope_from_task_recovery:
-                scope = resolve_execution_scope(self._recovery_task_id)
-                scope_segments = (
-                    scope.durable_storage_segments if scope is not None else ()
-                )
             resolved_key = build_upload_storage_key(
                 int(self.record.user_id),
                 str(self.record.file_id),
@@ -442,7 +475,7 @@ class ManagedFileRef:
                 scope_segments=scope_segments,
             )
         try:
-            stored_object = self.storage.put_file(
+            stored_object = self._bound_storage().put_file(
                 path,
                 resolved_key,
                 mime_type or getattr(self.record, "mime_type", None),
@@ -463,7 +496,7 @@ class ManagedFileRef:
         local_path = self.local_path
         local_exists = local_path.exists() and local_path.is_file()
         try:
-            stored_object = self.storage.stat(expected_key)
+            stored_object = self._bound_storage().stat(expected_key)
         except FileNotFoundError:
             return "missing"
         except _NAMESPACE_AUTHORITY_ERRORS:
@@ -486,7 +519,7 @@ class ManagedFileRef:
                 return "uploaded"
             if not checksum:
                 try:
-                    checksum = self.storage.content_hash(expected_key)
+                    checksum = self._bound_storage().content_hash(expected_key)
                 except Exception:
                     self.sync_to_durable(
                         storage_key=expected_key,
@@ -503,7 +536,7 @@ class ManagedFileRef:
 
         if not checksum:
             try:
-                checksum = self.storage.content_hash(expected_key)
+                checksum = self._bound_storage().content_hash(expected_key)
             except _NAMESPACE_AUTHORITY_ERRORS:
                 raise
             except Exception as exc:
@@ -537,7 +570,7 @@ class ManagedFileRef:
 
     def delete_durable(self) -> None:
         if self.has_durable_object:
-            self.storage.delete(self.storage_key)
+            self._bound_storage().delete(self.storage_key)
 
     def _verify_content_checksum(self, path: Path) -> None:
         expected_checksum = getattr(self.record, "checksum", None)
@@ -562,7 +595,7 @@ class ManagedFileRef:
             return False
 
         try:
-            actual_checksum = self.storage.content_hash(self.storage_key)
+            actual_checksum = self._bound_storage().content_hash(self.storage_key)
         except Exception as exc:
             logger.warning(
                 "Falling back to backend-mediated durable access because content "

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -147,7 +147,7 @@ class ManagedFileRef:
         # explicit arg -> ambient turn contextvar -> the per-task
         # resolver/snapshot keyed on the record's ``task_id``. The last step
         # matters on off-turn paths (bot/builder-chat handlers never enter
-        # ``turn_execution_scope``, so the contextvar is None): a workforce
+        # an ``ExecutionScopeContext``, so the contextvar is None): a workforce
         # sub-task carries its scope only in the persisted snapshot, and
         # without recovering it here ``sync_to_durable`` would write a new
         # file under the owner root instead of the sub-task's scoped subtree.
@@ -173,6 +173,28 @@ class ManagedFileRef:
                     # would make an already-legitimate key look foreign to a
                     # narrower re-derived scope (see ``storage`` binding
                     # below).
+                    #
+                    # Skipping this branch leaves ``scope`` at ``None``, so
+                    # ``self._scope_segments`` below is ``()`` and
+                    # ``self.storage`` binds to the owner root
+                    # (``get_user_file_storage(user_id, scope_segments=())``)
+                    # rather than the narrower scoped subtree. Every
+                    # operation on this ref -- ``ensure_local``/
+                    # ``materialize`` (read), ``signed_access_url`` (sign),
+                    # ``delete_durable`` (delete),
+                    # ``_verify_durable_checksum_for_direct_access``
+                    # (integrity check) -- goes through that same
+                    # ``self.storage`` with the fixed ``self.storage_key``,
+                    # so none of them get ``ScopedFileStorage``'s
+                    # prefix-containment narrowing to the scope subtree; they
+                    # are only constrained to the owner's key space. That is
+                    # safe here because ``storage_key`` is an absolute key
+                    # already chosen under the writing scope -- these
+                    # operations address a fixed object rather than
+                    # constructing a new key relative to a prefix, so a
+                    # containment check against a re-derived (and possibly
+                    # drifted) scope would add no protection, only risk
+                    # rejecting an already-legitimate key.
                     scope = resolve_execution_scope(task_id)
         else:
             scope = cast(ExecutionScope | None, scope_input)

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from xagent.core.execution_scope import (
     EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    EXECUTION_SCOPE_SHAPE_VERSION,
     get_execution_scope,
 )
 from xagent.core.tools.adapters.vibe.agent_tool_names import (
@@ -373,10 +374,22 @@ def build_workforce_task_config(
         config["selected_file_ids"] = selected_file_ids
     # Workforce runs create fresh Task rows whose ids the embedder's scope
     # resolver cannot map. Persist the creating context's ExecutionScope
-    # snapshot into agent_config (no schema migration); per-turn activation
-    # prefers this snapshot over the resolver, so the run executes fully
-    # scoped even after a process restart.
+    # snapshot into agent_config (no schema migration); resolve_execution_scope
+    # treats this as a corroborating candidate, not an override -- it is
+    # authoritative only when a resolver defers to it or none is registered,
+    # and is ignored when its version predates the current shape -- so the
+    # run stays scoped across a process restart without ever overriding a
+    # registered resolver's answer.
     scope = get_execution_scope()
     if scope is not None:
-        config[EXECUTION_SCOPE_AGENT_CONFIG_KEY] = scope.to_dict()
+        snapshot_data = scope.to_dict()
+        # Stamp the current shape version rather than propagating
+        # ``scope.version``: the dict below is being constructed *now*, in
+        # the current shape, regardless of whether the in-context scope was
+        # itself decoded from an older persisted snapshot (which would carry
+        # a stale/low version). Propagating that stale value here would let
+        # a decoded-then-re-persisted scope masquerade as pre-dating fields
+        # it actually has, permanently ignoring it as a candidate.
+        snapshot_data["version"] = EXECUTION_SCOPE_SHAPE_VERSION
+        config[EXECUTION_SCOPE_AGENT_CONFIG_KEY] = snapshot_data
     return config

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 
 from xagent.core.execution_scope import (
     EXECUTION_SCOPE_AGENT_CONFIG_KEY,
-    EXECUTION_SCOPE_SHAPE_VERSION,
     get_execution_scope,
 )
 from xagent.core.tools.adapters.vibe.agent_tool_names import (
@@ -379,17 +378,10 @@ def build_workforce_task_config(
     # authoritative only when a resolver defers to it or none is registered,
     # and is ignored when its version predates the current shape -- so the
     # run stays scoped across a process restart without ever overriding a
-    # registered resolver's answer.
+    # registered resolver's answer. ``to_dict()`` always stamps the current
+    # shape version, regardless of whether the in-context scope was itself
+    # decoded from an older persisted snapshot.
     scope = get_execution_scope()
     if scope is not None:
-        snapshot_data = scope.to_dict()
-        # Stamp the current shape version rather than propagating
-        # ``scope.version``: the dict below is being constructed *now*, in
-        # the current shape, regardless of whether the in-context scope was
-        # itself decoded from an older persisted snapshot (which would carry
-        # a stale/low version). Propagating that stale value here would let
-        # a decoded-then-re-persisted scope masquerade as pre-dating fields
-        # it actually has, permanently ignoring it as a candidate.
-        snapshot_data["version"] = EXECUTION_SCOPE_SHAPE_VERSION
-        config[EXECUTION_SCOPE_AGENT_CONFIG_KEY] = snapshot_data
+        config[EXECUTION_SCOPE_AGENT_CONFIG_KEY] = scope.to_dict()
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Iterator
 
 import pytest
 from dotenv import load_dotenv
@@ -20,6 +21,10 @@ from openai.types.chat.chat_completion_message_tool_call import (
     Function as ToolCallFunction,
 )
 
+from xagent.core.execution_scope import (
+    set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
+)
 from xagent.core.model import ChatModelConfig, EmbeddingModelConfig, RerankModelConfig
 from xagent.core.tools.core.RAG_tools.storage import reset_rag_storage_for_tests
 from xagent.core.tracing.langfuse import reset_langfuse_client
@@ -240,6 +245,26 @@ def mock_workspace_db():
 
     with patch.object(TaskWorkspace, "_create_file_record", mock_create_record):
         yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def isolate_execution_scope_hooks() -> Iterator[None]:
+    """Reset the execution-scope resolver and snapshot loader around every test.
+
+    Both are process-global module state (``xagent.core.execution_scope``).
+    A test (or a direct ``startup_event()`` call in
+    ``tests/integration/test_auto_migration_startup.py``, which registers the
+    real Task-table-backed snapshot loader with no patch/reset of its own)
+    that registers either without resetting it leaks into every test that
+    runs afterward in the same process/worker. Root-level and autouse so no
+    test module can forget it; scoped narrowly to just these two globals so
+    it composes with any test's own resolver/loader registration.
+    """
+    set_execution_scope_resolver(None)
+    set_execution_scope_snapshot_loader(None)
+    yield
+    set_execution_scope_resolver(None)
+    set_execution_scope_snapshot_loader(None)
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -701,7 +726,7 @@ def clear_langfuse_traces(request):
 # YAML entrypoint has been removed, commenting out this fixture
 # @pytest.fixture
 # def mock_migration_manager(tmp_path):
-#     """Initialize a temporary MigrationManager."""
+#    """Initialize a temporary MigrationManager."""
 #     test_migrations_dir = tmp_path / "test_migrations"
 #     test_migrations_dir.mkdir()
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,7 +258,12 @@ def isolate_execution_scope_hooks() -> Iterator[None]:
     that registers either without resetting it leaks into every test that
     runs afterward in the same process/worker. Root-level and autouse so no
     test module can forget it; scoped narrowly to just these two globals so
-    it composes with any test's own resolver/loader registration.
+    it composes with any test's own *function-scoped* registration (a
+    session- or module-scoped registration would still be torn down mid-
+    session by this fixture's teardown, since that always re-registers
+    ``None`` regardless of what a wider-scoped fixture set up). That
+    teardown call also never carries the acknowledgement keyword, so this
+    safety net alone never exercises the acknowledged-registration path.
     """
     set_execution_scope_resolver(None)
     set_execution_scope_snapshot_loader(None)

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -54,7 +54,13 @@ def scope_log_records(level: int = logging.WARNING):
     the logger that emits makes the assertion depend on the code under test
     instead.
     """
-    logger = logging.getLogger("xagent.core.execution_scope")
+    from xagent.core import execution_scope as scope_module
+
+    # The logger object the module logs through, not a name this test assumes
+    # resolves to it: under parallel execution the module can be imported under
+    # more than one name, and a handler bound by name would then watch a logger
+    # nothing writes to.
+    logger = scope_module.logger
     records: list[logging.LogRecord] = []
 
     class _Collect(logging.Handler):
@@ -1078,6 +1084,12 @@ class TestResolveExecutionScopeOffTurn:
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
+
+        # A real disagreement: the fail-closed entry point must reject it, or
+        # the downgrade below would be indistinguishable from "nothing
+        # disagreed" -- which also returns the resolver's scope.
+        with pytest.raises(ExecutionScopeAuthorityError):
+            resolve_execution_scope("1")
 
         with scope_log_records() as records:
             result = resolve_execution_scope_off_turn("1")

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -24,6 +24,7 @@ from xagent.core.execution_scope import (
     EXECUTION_SCOPE_SHAPE_VERSION,
     DeferToSnapshot,
     ExecutionScope,
+    ExecutionScopeAbstentionMismatchError,
     ExecutionScopeAuthorityError,
     ExecutionScopeContext,
     ExecutionScopeResolverContractError,
@@ -970,6 +971,26 @@ class TestSnapshotCandidateAuthority:
         assert exc_info.value.resolver_scope == resolver_scope
         assert exc_info.value.snapshot_scope == snapshot_scope
 
+    def test_namespace_mismatch_error_omits_a_concurrently_differing_policy_field(
+        self,
+    ):
+        """The raise is gated on the namespace diff alone being non-empty,
+        but strict_memory_isolation (policy) also differs here. The
+        exception reaches task.error_message and a client-facing event, so
+        mismatched_fields must carry only the namespace disagreement --
+        listing the policy field there would misleadingly present it as
+        part of the conflict that failed the turn."""
+        resolver_scope = ExecutionScope(strict_memory_isolation=False)
+        snapshot_scope = ExecutionScope(
+            sandbox_key_suffix="other", strict_memory_isolation=True
+        )
+        self._register(lambda task_id: resolver_scope, lambda task_id: snapshot_scope)
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert set(exc_info.value.mismatched_fields) == {"sandbox_key_suffix"}
+        assert "strict_memory_isolation" not in exc_info.value.mismatched_fields
+
     def test_policy_only_mismatch_does_not_fail_the_turn(self):
         """strict_memory_isolation is a policy field: a disagreement there
         does not change which key/path is touched, so the resolver's value
@@ -1430,12 +1451,22 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             "memory_dimensions",
         }
 
-    def test_opt_in_does_not_bypass_the_shape_version_gate(self):
-        """A stale-version snapshot is still shape-gated away even with the
-        opt-in set -- the gate runs before the narrowing check is even
-        reached, so there is nothing for the opt-in to skip past."""
-        fallback = ExecutionScope(sandbox_key_suffix="fallback")
-        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+    def test_opt_in_skips_the_shape_version_gate_snapshot_data_survives(self):
+        """The shape-version gate exists to protect a *comparison*: it
+        guards the default (narrowing) abstention branch and the
+        authoritative branch, both of which compare the snapshot against
+        something. The opt-in branch never compares -- it uses the
+        snapshot verbatim -- so there is nothing for the gate to protect
+        here, and a pre-existing (unversioned) snapshot's real data must
+        survive rather than being silently discarded back to the fallback.
+        This was previously pinned the other way (discarding real data as
+        "correct"), which is exactly the de-scoping bug this test now
+        proves is fixed: an unversioned workforce sub-task snapshot must
+        not be de-scoped just because it predates the version field."""
+        fallback = ExecutionScope()
+        stale_data = ExecutionScope(
+            sandbox_key_suffix="stale", workspace_segments=("workforce", "task-7")
+        ).to_dict()
         del stale_data["version"]
         stale_snapshot = ExecutionScope.from_dict(stale_data)
         assert stale_snapshot.version == 0
@@ -1444,6 +1475,43 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             lambda task_id: defer_to_snapshot(
                 fallback, snapshot_defines_namespace=True
             ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        assert resolve_execution_scope("1") == stale_snapshot
+
+    def test_opt_in_still_type_gates_a_non_scope_snapshot(self):
+        """The shape-version gate is skipped on the opt-in branch, but the
+        type check is not -- a candidate that isn't even an ExecutionScope
+        still raises, opt-in or not (see also
+        test_opt_in_does_not_bypass_the_type_check below, which reproduces
+        the same rule via the snapshot loader instead of from_dict)."""
+        fallback = ExecutionScope()
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: object())
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
+    def test_gate_still_applies_on_the_default_abstention_comparing_path(self):
+        """Mirror of the opt-in case above: without the opt-in, the
+        abstention branch narrows against ``fallback`` -- a comparison --
+        so the shape-version gate still applies and a stale snapshot is
+        still ignored. (Same behavior as
+        test_defer_stale_version_snapshot_is_ignored_falls_back; restated
+        here to sit next to the opt-in test for contrast.)"""
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        assert stale_snapshot.version == 0
+
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
@@ -1507,9 +1575,65 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         assert resolve_execution_scope("1") == fallback
 
 
+class TestShapeGateLogsFieldDiffLazily:
+    """The shape-version gate's field diff exists only to populate its own
+    log message -- unlike the narrowing/authoritative diffs, which are also
+    needed for control flow, nothing downstream reads this one. It must
+    therefore be computed only when that message will actually be emitted,
+    since the gate runs on every turn for any snapshot that predates a
+    shape bump (see the class docstring reasoning in F3's fix)."""
+
+    def test_field_diff_not_computed_when_warning_is_disabled(self, monkeypatch):
+        from xagent.core import execution_scope as scope_module
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError(
+                "field diff computed even though WARNING logging is disabled"
+            )
+
+        monkeypatch.setattr(scope_module, "_execution_scope_field_diff", boom)
+        original_level = scope_module.logger.level
+        scope_module.logger.setLevel(logging.ERROR)
+        try:
+            resolver_scope = ExecutionScope()
+            stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+            del stale_data["version"]
+            stale_snapshot = ExecutionScope.from_dict(stale_data)
+            set_execution_scope_resolver(
+                lambda task_id: resolver_scope,
+                acknowledges_snapshot_candidate_contract=True,
+            )
+            set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+            # Gate behavior is unaffected by the logging level: the stale
+            # snapshot is still ignored and the resolver's scope wins.
+            assert resolve_execution_scope("1") == resolver_scope
+        finally:
+            scope_module.logger.setLevel(original_level)
+
+    def test_field_diff_still_computed_and_logged_when_warning_is_enabled(self):
+        """Positive mirror: with WARNING enabled (the default), the gate's
+        existing observable behavior -- a log line naming the differing
+        field -- is unchanged by the lazy guard."""
+        resolver_scope = ExecutionScope()
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        set_execution_scope_resolver(
+            lambda task_id: resolver_scope,
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        with scope_log_records() as records:
+            assert resolve_execution_scope("1") == resolver_scope
+        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
+
+
 class TestResolveExecutionScopeOffTurn:
     """Off-turn consumers (websocket ``_scope_segments_for_task``,
-    ``ManagedFileRef``) downgrade a namespace mismatch instead of failing."""
+    ``ManagedFileRef``) downgrade a resolver-authoritative namespace
+    mismatch instead of failing, but a resolver-abstention mismatch has no
+    authoritative value to downgrade to and stays fail-closed -- see
+    ``ExecutionScopeAbstentionMismatchError``'s docstring."""
 
     def test_passthrough_when_no_mismatch(self):
         scope = ExecutionScope(sandbox_key_suffix="s")
@@ -1518,7 +1642,12 @@ class TestResolveExecutionScopeOffTurn:
         )
         assert resolve_execution_scope_off_turn("1") == scope
 
-    def test_namespace_mismatch_downgrades_to_resolver_value_with_warning(self):
+    def test_authoritative_branch_mismatch_downgrades_to_resolver_value_with_warning(
+        self,
+    ):
+        """The resolver returned a real ``ExecutionScope`` (authoritative
+        branch): its value is a genuine answer, so a disagreeing snapshot's
+        mismatch is downgraded to it off-turn instead of raised."""
         resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
         snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
         set_execution_scope_resolver(
@@ -1530,14 +1659,40 @@ class TestResolveExecutionScopeOffTurn:
         # A real disagreement: the fail-closed entry point must reject it, or
         # the downgrade below would be indistinguishable from "nothing
         # disagreed" -- which also returns the resolver's scope.
-        with pytest.raises(ExecutionScopeAuthorityError):
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
             resolve_execution_scope("1")
+        assert not isinstance(exc_info.value, ExecutionScopeAbstentionMismatchError)
 
         with scope_log_records() as records:
             result = resolve_execution_scope_off_turn("1")
 
         assert result == resolver_scope
         assert any("authority mismatch" in r.lower() for r in records)
+
+    def test_abstention_branch_mismatch_stays_fail_closed_off_turn(self):
+        """The resolver deferred to the snapshot (abstention branch) and the
+        snapshot widens the fallback: unlike the authoritative case above,
+        ``resolved.fallback`` here is not an authoritative answer -- it is
+        what the resolver supplied while declining to answer, all-default
+        for this test. Downgrading to it off-turn would hand a caller like
+        workspace cleanup an unscoped value indistinguishable from no scope
+        at all, so this must propagate unchanged instead of being
+        downgraded. No existing test covered this off-turn path before --
+        every prior off-turn mismatch case used an authoritative resolver."""
+        fallback = ExecutionScope()
+        snapshot_scope = ExecutionScope(sandbox_key_suffix="attacker-chosen")
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
+
+        # Confirm the in-turn behavior this off-turn call must not soften.
+        with pytest.raises(ExecutionScopeAbstentionMismatchError):
+            resolve_execution_scope("1")
+
+        with pytest.raises(ExecutionScopeAbstentionMismatchError):
+            resolve_execution_scope_off_turn("1")
 
     def test_other_exceptions_still_propagate(self):
         def boom(task_id):
@@ -1548,6 +1703,37 @@ class TestResolveExecutionScopeOffTurn:
         )
         with pytest.raises(RuntimeError, match="resolver down"):
             resolve_execution_scope_off_turn("1")
+
+
+class TestExecutionScopeAbstentionMismatchErrorIsDistinguishable:
+    """Pin: the abstention-branch error is a distinct type a caller must
+    explicitly widen its ``except`` clause to catch, so an existing
+    ``except ExecutionScopeAuthorityError: return exc.resolver_scope``
+    downgrade path (written for the authoritative branch) cannot silently
+    also catch and downgrade an abstention mismatch."""
+
+    def test_is_a_subclass_of_the_base_authority_error(self):
+        assert issubclass(
+            ExecutionScopeAbstentionMismatchError, ExecutionScopeAuthorityError
+        )
+
+    def test_base_class_except_clause_still_catches_it(self):
+        """A caller that widens its except clause to the base class (rather
+        than special-casing the subclass) still catches it -- the subclass
+        only prevents *accidental* downgrading via a bare ``except
+        ExecutionScopeAuthorityError`` that assumes ``resolver_scope`` is
+        always authoritative; it does not make the mismatch uncatchable."""
+        caught = None
+        try:
+            raise ExecutionScopeAbstentionMismatchError(
+                "task-1",
+                resolver_scope=ExecutionScope(),
+                snapshot_scope=ExecutionScope(sandbox_key_suffix="x"),
+                mismatched_fields={"sandbox_key_suffix": ("x", None)},
+            )
+        except ExecutionScopeAuthorityError as exc:
+            caught = exc
+        assert isinstance(caught, ExecutionScopeAbstentionMismatchError)
 
 
 class TestDeferCarrierNeverActivated:
@@ -1624,6 +1810,25 @@ class TestExecutionScopeFieldClassificationCompleteness:
         assert namespace_fields | policy_fields | {"version"} == {
             f.name for f in dataclasses.fields(ExecutionScope)
         }
+
+
+class TestNarrowingViolationsFieldCoverage:
+    """``_execution_scope_narrowing_violations`` must classify every
+    namespace field through the shared
+    ``_EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING`` table rather than a
+    hardcoded per-field check, so a namespace field added to
+    ``_EXECUTION_SCOPE_NAMESPACE_FIELDS`` cannot be silently skipped by this
+    one consumer while the diff (``_execution_scope_field_diff``) and the
+    fingerprint (``scope_fingerprint``), which already iterate their own
+    tables, pick it up automatically.
+    """
+
+    def test_narrowing_table_tracks_the_namespace_fields_exactly(self):
+        from xagent.core import execution_scope as scope_module
+
+        assert set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELD_NARROWING) == set(
+            scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS
+        )
 
 
 # One (base_kwargs, changed_kwargs) probe per namespace field: constructing

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -29,7 +29,6 @@ from xagent.core.execution_scope import (
     ExecutionScopeContext,
     ExecutionScopeResolverContractError,
     InvalidScopeComponentError,
-    defer_to_snapshot,
     execution_scope_from_agent_config,
     execution_scope_resolver_registered,
     get_execution_scope,
@@ -71,6 +70,10 @@ def scope_log_records(level: int = logging.WARNING):
 
         def isEnabledFor(self, asked: int) -> bool:  # noqa: N802 - logging API
             return asked >= level
+
+        def info(self, msg: str, *args: object, **kwargs: object) -> None:
+            self.records.append(msg % args if args else msg)
+            self._wrapped.info(msg, *args, **kwargs)
 
         def warning(self, msg: str, *args: object, **kwargs: object) -> None:
             self.records.append(msg % args if args else msg)
@@ -535,24 +538,33 @@ class TestDeferToSnapshot:
 
     def test_requires_an_execution_scope_fallback(self):
         with pytest.raises(TypeError):
-            defer_to_snapshot("not-a-scope")
+            DeferToSnapshot("not-a-scope")
 
     def test_carrier_is_not_an_execution_scope(self):
-        carrier = defer_to_snapshot(ExecutionScope())
+        carrier = DeferToSnapshot(ExecutionScope())
         assert isinstance(carrier, DeferToSnapshot)
         assert isinstance(carrier, ExecutionScope) is False
 
     def test_carrier_has_no_public_bare_singleton(self):
-        """Only the fallback-carrying factory is exported -- a bare
+        """The fallback-carrying class is the only way to abstain -- a bare
         module-level sentinel would let "defer" mean "unscoped on miss"
         implicitly instead of requiring an explicit fallback."""
         import xagent.core.execution_scope as scope_module
 
         assert not hasattr(scope_module, "DEFER_TO_SNAPSHOT")
 
+    def test_no_passthrough_factory_duplicates_the_carrier(self):
+        """One concept, one public name. The class holds the abstention
+        contract and its own construction-time validation, so a module-level
+        factory wrapping it would be a second spelling resolver authors have
+        to choose between, and a second place validation could drift to."""
+        import xagent.core.execution_scope as scope_module
+
+        assert not hasattr(scope_module, "defer_to_snapshot")
+
     def test_carrier_exposes_the_fallback(self):
         fallback = ExecutionScope(sandbox_key_suffix="fallback")
-        assert defer_to_snapshot(fallback).fallback == fallback
+        assert DeferToSnapshot(fallback).fallback == fallback
 
 
 class TestSetExecutionScopeResolverAckToken:
@@ -755,27 +767,70 @@ class TestFromDictUntrustedFieldCoercion:
     misread/truncate the value.
     """
 
-    # --- version: never raises, never truncates ---------------------------
+    # --- version: readable, or a malformed-snapshot fault -----------------
+    #
+    # ``0`` is the marker for an authentic snapshot written before the field
+    # existed, and that marker is trusted: the older half of the shape-version
+    # gate is relaxed on the ``snapshot_defines_namespace=True`` branch, where
+    # such a snapshot's namespace fields are used verbatim. An unreadable
+    # value must therefore not decode to it.
 
-    @pytest.mark.parametrize("raw_version", ["abc", {"a": 1}, [1], object()])
-    def test_from_dict_malformed_version_is_treated_as_stale_not_raised(
+    @pytest.mark.parametrize(
+        "raw_version", ["abc", {"a": 1}, [1], object(), 1.5, True, -5]
+    )
+    def test_from_dict_unreadable_version_raises_instead_of_claiming_legacy(
         self, raw_version
     ):
+        """Every shape that is not a readable version is a malformed persisted
+        snapshot, not an old one. ``1.5`` and ``True`` are here because a bare
+        ``int()`` turns them into ``1`` -- a claim to be the current shape --
+        and ``-5`` because "older than every version that ever existed" would
+        borrow the legacy marker's verbatim-namespace trust for a value no
+        writer emits (``to_dict`` always stamps the current constant)."""
         data = ExecutionScope(sandbox_key_suffix="x").to_dict()
         data["version"] = raw_version
-        assert ExecutionScope.from_dict(data).version == 0
+        with pytest.raises(ExecutionScopeResolverContractError):
+            ExecutionScope.from_dict(data)
 
-    def test_from_dict_float_version_is_treated_as_stale_not_truncated(self):
-        """1.5 must not silently become 1 (a plausible-looking but wrong
-        current-version claim) via a bare ``int()`` truncation."""
+    def test_from_dict_unreadable_version_is_not_a_client_message_fault(self):
+        """The error stays outside ``(ValueError, KeyError, TypeError)``: the
+        websocket handlers that catch that tuple around the turn path would
+        otherwise answer the client with a message-format validation error for
+        what is a persisted-data fault."""
         data = ExecutionScope(sandbox_key_suffix="x").to_dict()
-        data["version"] = 1.5
-        assert ExecutionScope.from_dict(data).version == 0
+        data["version"] = "abc"
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            ExecutionScope.from_dict(data)
+        assert not isinstance(exc_info.value, _WEBSOCKET_VALIDATION_EXCEPT_TUPLE)
 
-    def test_from_dict_bool_version_is_treated_as_stale(self):
+    def test_from_dict_unreadable_version_message_names_no_value(self):
+        """The raised message reaches the task's error column and a
+        client-facing event, so it names the offending type only; the value
+        goes to the server-side log."""
         data = ExecutionScope(sandbox_key_suffix="x").to_dict()
-        data["version"] = True
-        assert ExecutionScope.from_dict(data).version == 0
+        data["version"] = "9;DROP"
+        with scope_log_records(logging.ERROR) as records:
+            with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+                ExecutionScope.from_dict(data)
+        assert "9;DROP" not in str(exc_info.value)
+        assert "str" in str(exc_info.value)
+        assert any("9;DROP" in r for r in records), records
+
+    def test_from_dict_readable_versions_are_accepted(self):
+        """The accepted domain: an absent key or ``None`` is the pre-versioning
+        marker, a digit string is what a JSON-decoded version can arrive as,
+        and a non-negative ``int`` passes through. Nothing here may raise --
+        an old snapshot is a supported input, not a fault."""
+        for raw, expected in ((None, 0), ("0", 0), ("1", 1), (0, 0), (1, 1), (9, 9)):
+            data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+            data["version"] = raw
+            decoded = ExecutionScope.from_dict(data)
+            assert decoded.version == expected
+            assert isinstance(decoded.version, int)
+
+        missing = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        del missing["version"]
+        assert ExecutionScope.from_dict(missing).version == 0
 
     # --- workspace_segments / sandbox_mount_segments: no silent str/dict
     # iteration, no bare TypeError on a non-iterable ----------------------
@@ -865,9 +920,10 @@ class TestPersistedSnapshotDecodeIsNotAClientMessageFault:
     boundary conversion the failure lands in the websocket handlers'
     ``except (ValueError, KeyError, TypeError)`` clause and the client is told
     its own message was malformed, for data it may not have sent and cannot
-    fix. ``_coerce_snapshot_version`` was already written to avoid exactly
-    that folding for the ``version`` field; this is the same posture applied
-    to the rest of the snapshot.
+    fix. The ``version`` field reaches the same conclusion one step earlier:
+    ``_coerce_snapshot_version`` raises the contract error itself, so an
+    unreadable version leaves this boundary as the same class the field
+    coercions are converted into here.
 
     ``InvalidScopeComponentError``'s own bases are deliberately left alone: it
     is also raised for live, caller-supplied components (``workspace.py``,
@@ -910,12 +966,23 @@ class TestPersistedSnapshotDecodeIsNotAClientMessageFault:
 
     def test_not_folded_on_the_resolver_abstention_path(self):
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(ExecutionScope()),
+            lambda task_id: DeferToSnapshot(ExecutionScope()),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(self._loader)
         with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
             resolve_execution_scope("1")
+        assert not isinstance(exc_info.value, _WEBSOCKET_VALIDATION_EXCEPT_TUPLE)
+
+    def test_unreadable_version_decode_is_not_folded_either(self):
+        """The ``version`` field takes the shorter route -- it raises the
+        contract error directly rather than being converted here -- so this
+        pins that the boundary hands out the same class for it, and that an
+        unreadable version fails the decode instead of being read as a legacy
+        snapshot."""
+        agent_config = {"execution_scope": {"version": "not-a-version"}}
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            execution_scope_from_agent_config(agent_config)
         assert not isinstance(exc_info.value, _WEBSOCKET_VALIDATION_EXCEPT_TUPLE)
 
     def test_live_component_validation_is_still_a_value_error(self):
@@ -999,6 +1066,33 @@ class TestSnapshotCandidateAuthority:
         self._register(lambda task_id: None, loader)
         assert resolve_execution_scope("1") is None
         assert loader_calls == []  # None short-circuits before the snapshot
+
+    def test_resolver_none_logs_that_it_de_scoped_the_task(self):
+        """De-scoping a task must leave a trace, like every other branch that
+        overrides or ignores a candidate. A resolver that does not yet
+        recognise older tasks returns ``None`` for all of them, and without
+        this line every one of those turns runs unscoped -- possibly past a
+        persisted snapshot that named a namespace -- with nothing in the log
+        to show it happened.
+
+        ``INFO``, because the resolver is exercising its contract rather than
+        failing, and the line says the snapshot was bypassed *unread*: this
+        branch deliberately never calls the loader, which the assertion below
+        pins so the wording cannot drift into claiming knowledge of whether a
+        snapshot exists."""
+        loader_calls = []
+
+        def loader(task_id):
+            loader_calls.append(task_id)
+            return self.RESOLVER_SCOPE
+
+        self._register(lambda task_id: None, loader)
+        with scope_log_records(logging.INFO) as records:
+            assert resolve_execution_scope("task-7") is None
+        assert loader_calls == []
+        assert any(
+            "task-7" in r and "None" in r and "snapshot" in r for r in records
+        ), records
 
     # --- resolver returns ExecutionScope -----------------------------------
     def test_resolver_scope_with_no_snapshot(self):
@@ -1180,7 +1274,7 @@ class TestSnapshotCandidateAuthority:
         fallback = ExecutionScope(workspace_segments=("tenant-a",))
         snapshot_scope = ExecutionScope(workspace_segments=("tenant-a", "sub"))
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot_scope,
         )
         assert resolve_execution_scope("1") == snapshot_scope
@@ -1195,7 +1289,7 @@ class TestSnapshotCandidateAuthority:
         fallback = ExecutionScope(strict_memory_isolation=True)
         snapshot_scope = ExecutionScope(strict_memory_isolation=False)
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot_scope,
         )
 
@@ -1223,7 +1317,7 @@ class TestSnapshotCandidateAuthority:
             workspace_segments=("tenant-a", "sub"), strict_memory_isolation=False
         )
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot_scope,
         )
 
@@ -1264,7 +1358,7 @@ class TestSnapshotCandidateAuthority:
             strict_memory_isolation=False, **{borrowed: False}
         )
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot_scope,
         )
 
@@ -1286,16 +1380,14 @@ class TestSnapshotCandidateAuthority:
         snapshot_scope = ExecutionScope.from_dict(snapshot_data)
 
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot_scope,
         )
         assert resolve_execution_scope("1") == snapshot_scope
 
     def test_defer_uses_fallback_when_snapshot_absent(self):
         fallback = ExecutionScope(strict_memory_isolation=True)
-        self._register(
-            lambda task_id: defer_to_snapshot(fallback), lambda task_id: None
-        )
+        self._register(lambda task_id: DeferToSnapshot(fallback), lambda task_id: None)
         assert resolve_execution_scope("1") == fallback
 
     def test_defer_loader_exception_propagates(self):
@@ -1310,7 +1402,7 @@ class TestSnapshotCandidateAuthority:
             raise RuntimeError("db down")
 
         fallback = ExecutionScope(strict_memory_isolation=True)
-        self._register(lambda task_id: defer_to_snapshot(fallback), boom)
+        self._register(lambda task_id: DeferToSnapshot(fallback), boom)
         with pytest.raises(RuntimeError, match="db down"):
             resolve_execution_scope("1")
 
@@ -1319,7 +1411,7 @@ class TestSnapshotCandidateAuthority:
         the resolver: it must return an ExecutionScope or None."""
         fallback = ExecutionScope(strict_memory_isolation=True)
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: {"not": "a scope"},
         )
         with pytest.raises(ExecutionScopeResolverContractError):
@@ -1331,8 +1423,8 @@ class TestSnapshotCandidateAuthority:
         isinstance(ExecutionScope) gate."""
         fallback = ExecutionScope(strict_memory_isolation=True)
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
-            lambda task_id: defer_to_snapshot(ExecutionScope()),
+            lambda task_id: DeferToSnapshot(fallback),
+            lambda task_id: DeferToSnapshot(ExecutionScope()),
         )
         with pytest.raises(ExecutionScopeResolverContractError):
             resolve_execution_scope("1")
@@ -1345,7 +1437,7 @@ class TestSnapshotCandidateAuthority:
         assert stale_snapshot.version == 0
 
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: stale_snapshot,
         )
         with scope_log_records() as records:
@@ -1408,7 +1500,7 @@ class TestSnapshotCandidateAuthority:
         fallback = ExecutionScope(**fallback_kwargs)
         snapshot = ExecutionScope(**snapshot_kwargs)
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot,
         )
 
@@ -1458,7 +1550,7 @@ class TestSnapshotCandidateAuthority:
         fallback = ExecutionScope(**fallback_kwargs)
         snapshot = ExecutionScope(**snapshot_kwargs)
         self._register(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             lambda task_id: snapshot,
         )
         assert resolve_execution_scope("1") == snapshot
@@ -1552,7 +1644,7 @@ class TestDeferSnapshotAllDefaultFallback:
             memory_dimensions={"tenant": "other"},
         )
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1580,7 +1672,7 @@ class TestDeferSnapshotAllDefaultFallback:
         snapshot = ExecutionScope()
         assert snapshot is not fallback
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1588,7 +1680,7 @@ class TestDeferSnapshotAllDefaultFallback:
 
 
 class TestDeferSnapshotDefinesNamespaceOptIn:
-    """``defer_to_snapshot(fallback, snapshot_defines_namespace=True)``: the
+    """``DeferToSnapshot(fallback, snapshot_defines_namespace=True)``: the
     resolver states it does not own this task and the persisted snapshot is
     the intended namespace authority (the workforce/delegated-task shape).
     A conforming ``fallback`` claims no namespace of its own -- if the
@@ -1612,9 +1704,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             memory_dimensions={"tenant": "acme"},
         )
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1631,7 +1721,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             memory_dimensions={"tenant": "acme"},
         )
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1661,9 +1751,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         assert older_snapshot.version == 0
 
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: older_snapshot)
@@ -1687,9 +1775,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         assert newer_snapshot.version == EXECUTION_SCOPE_SHAPE_VERSION + 1
 
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: newer_snapshot)
@@ -1707,7 +1793,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         newer_snapshot = ExecutionScope.from_dict(newer_data)
 
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: newer_snapshot)
@@ -1719,9 +1805,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         not."""
         fallback = ExecutionScope()
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: object())
@@ -1741,14 +1825,14 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             memory_dimensions={"tenant": "a"},
         )
         with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
-            defer_to_snapshot(committed, snapshot_defines_namespace=True)
+            DeferToSnapshot(committed, snapshot_defines_namespace=True)
         message = str(exc_info.value)
         for name in ("sandbox_key_suffix", "workspace_segments", "memory_dimensions"):
             assert name in message
         # The same pair is accepted without the opt-in, where the snapshot is
         # held to the narrowing rule instead: it is the flag that is refused,
         # not the fallback.
-        assert defer_to_snapshot(committed).fallback == committed
+        assert DeferToSnapshot(committed).fallback == committed
 
     @pytest.mark.parametrize(
         "field_name,committed_kwargs",
@@ -1774,7 +1858,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         fallback (the mount case necessarily carries the workspace segments
         it must prefix, and reports both)."""
         with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
-            defer_to_snapshot(
+            DeferToSnapshot(
                 ExecutionScope(**committed_kwargs), snapshot_defines_namespace=True
             )
         assert field_name in str(exc_info.value)
@@ -1785,7 +1869,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         test_opt_in_still_honours_policy_field_symmetry), so committing one
         must not be mistaken for claiming a namespace."""
         fallback = ExecutionScope(strict_memory_isolation=True)
-        carrier = defer_to_snapshot(fallback, snapshot_defines_namespace=True)
+        carrier = DeferToSnapshot(fallback, snapshot_defines_namespace=True)
         assert carrier.snapshot_defines_namespace is True
         assert carrier.fallback == fallback
 
@@ -1801,9 +1885,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             memory_dimensions={"tenant": "acme"},
         )
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1822,9 +1904,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         fallback = ExecutionScope(strict_memory_isolation=True)
         snapshot = ExecutionScope(strict_memory_isolation=False)
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
@@ -1839,7 +1919,7 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
 
     def test_flag_does_not_make_the_fallback_optional(self):
         """The opt-in changes what a present snapshot is checked against,
-        not whether a fallback is required at all: ``defer_to_snapshot``
+        not whether a fallback is required at all: ``DeferToSnapshot``
         still rejects a non-ExecutionScope fallback even with the flag set,
         and the mandatory fallback still applies on a snapshot miss.
 
@@ -1847,13 +1927,11 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         does set a policy field, which keeps it distinguishable from the
         all-default scope an unscoped resolution would return."""
         with pytest.raises(TypeError):
-            defer_to_snapshot("not-a-scope", snapshot_defines_namespace=True)
+            DeferToSnapshot("not-a-scope", snapshot_defines_namespace=True)
 
         fallback = ExecutionScope(strict_memory_isolation=True)
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(
-                fallback, snapshot_defines_namespace=True
-            ),
+            lambda task_id: DeferToSnapshot(fallback, snapshot_defines_namespace=True),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: None)
@@ -1911,12 +1989,23 @@ class TestShapeGateLogsFieldDiffLazily:
 
 
 class TestResolveExecutionScopeOffTurn:
-    """Off-turn consumers (websocket ``_scope_segments_for_task``,
-    ``ManagedFileRef``) downgrade a resolver-authoritative namespace
-    mismatch instead of failing, but a mismatch whose ``resolver_scope`` is
-    not an authoritative answer has nothing to downgrade to and stays
-    fail-closed -- see ``ExecutionScopeAbstentionMismatchError``'s
-    docstring."""
+    """What decides whether a consumer may downgrade a mismatch is whether it
+    is selecting a namespace for new bytes, not whether a turn is running.
+
+    A consumer that selects one -- websocket ``_scope_segments_for_task``,
+    whose caller composes the storage key for a brand-new durable object --
+    resolves fail-closed through ``resolve_execution_scope`` even though it
+    runs outside any turn: choosing where new bytes land is an authority
+    decision that must not be downgraded to either side's guess. The
+    consumers that come through this entry point instead read a namespace
+    something else already committed to: ``ManagedFileRef``'s construction,
+    the pause/resume handlers, and workspace cleanup. For them a
+    resolver-authoritative namespace mismatch downgrades to the resolver's
+    answer rather than failing an operation that has no turn left to fail.
+
+    A mismatch whose ``resolver_scope`` is not an authoritative answer has
+    nothing to downgrade to and stays fail-closed even here -- see
+    ``ExecutionScopeAbstentionMismatchError``'s docstring."""
 
     def test_passthrough_when_no_mismatch(self):
         scope = ExecutionScope(sandbox_key_suffix="s")
@@ -1965,7 +2054,7 @@ class TestResolveExecutionScopeOffTurn:
         fallback = ExecutionScope()
         snapshot_scope = ExecutionScope(sandbox_key_suffix="attacker-chosen")
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
@@ -2062,7 +2151,7 @@ class TestExecutionScopeAbstentionMismatchErrorIsDistinguishable:
         abstention branch's raise site must declare ``False`` for it."""
         fallback = ExecutionScope()
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(
@@ -2096,7 +2185,7 @@ class TestDeferCarrierNeverActivated:
     def test_turn_activates_the_fallback_not_the_carrier(self):
         fallback = ExecutionScope(sandbox_key_suffix="fallback")
         set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: DeferToSnapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         with turn_execution_scope("1") as active:

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -3,34 +3,46 @@
 Slice 1 of #757: the ExecutionScope skeleton carries no consumers yet, so
 these tests cover the value type, the contextvar helpers, the resolver hook,
 and the per-turn activation contract (including restart/resume re-resolution).
+
+The resolver is authoritative
+over a persisted snapshot rather than always losing to it. The resolver
+fixtures below register through
+``acknowledges_snapshot_candidate_contract=True`` -- see
+``TestSnapshotCandidateAuthority`` for the full resolver/snapshot precedence
+matrix and ``tests/web/test_execution_scope_delegation.py`` for the
+web-layer snapshot loader wiring. The resolver/loader globals themselves are
+reset by the root-level ``isolate_execution_scope_hooks`` autouse fixture in
+``tests/conftest.py``, not by a fixture in this module.
 """
 
 import asyncio
 import contextvars
 import dataclasses
+import logging
 
 import pytest
 
 from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_SHAPE_VERSION,
+    DeferToSnapshot,
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     ExecutionScopeContext,
+    ExecutionScopeResolverContractError,
     InvalidScopeComponentError,
+    defer_to_snapshot,
+    execution_scope_resolver_registered,
     get_execution_scope,
     reset_execution_scope,
     resolve_execution_scope,
+    resolve_execution_scope_off_turn,
+    scope_fingerprint,
     set_execution_scope,
     set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
     turn_execution_scope,
     validate_scope_component,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    """Each test starts and ends with no registered resolver."""
-    set_execution_scope_resolver(None)
-    yield
-    set_execution_scope_resolver(None)
 
 
 class TestValidateScopeComponent:
@@ -317,13 +329,17 @@ class TestResolverHook:
             seen.append(task_id)
             return None
 
-        set_execution_scope_resolver(resolver)
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
         resolve_execution_scope(42)
         assert seen == ["42"]
 
     def test_resolver_result_is_returned(self):
         scope = ExecutionScope(sandbox_key_suffix="s1")
-        set_execution_scope_resolver(lambda task_id: scope)
+        set_execution_scope_resolver(
+            lambda task_id: scope, acknowledges_snapshot_candidate_contract=True
+        )
         assert resolve_execution_scope("42") is scope
 
     def test_resolver_exception_propagates(self):
@@ -332,7 +348,9 @@ class TestResolverHook:
         def resolver(task_id):
             raise RuntimeError("resolver down")
 
-        set_execution_scope_resolver(resolver)
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
         with pytest.raises(RuntimeError, match="resolver down"):
             resolve_execution_scope("42")
 
@@ -340,13 +358,19 @@ class TestResolverHook:
         """str(None) would silently query the resolver for "None"; a caller
         with no task identity must treat the execution as unscoped itself."""
         seen = []
-        set_execution_scope_resolver(lambda task_id: seen.append(task_id))
+        set_execution_scope_resolver(
+            lambda task_id: seen.append(task_id),
+            acknowledges_snapshot_candidate_contract=True,
+        )
         with pytest.raises(ValueError, match="task_id cannot be None"):
             resolve_execution_scope(None)
         assert seen == []
 
     def test_resolver_can_be_cleared(self):
-        set_execution_scope_resolver(lambda task_id: ExecutionScope())
+        set_execution_scope_resolver(
+            lambda task_id: ExecutionScope(),
+            acknowledges_snapshot_candidate_contract=True,
+        )
         set_execution_scope_resolver(None)
         assert resolve_execution_scope("42") is None
 
@@ -354,7 +378,10 @@ class TestResolverHook:
 class TestTurnExecutionScope:
     def test_activates_resolved_scope_for_the_turn(self):
         scope = ExecutionScope(workspace_segments=("proj",))
-        set_execution_scope_resolver(lambda task_id: scope if task_id == "7" else None)
+        set_execution_scope_resolver(
+            lambda task_id: scope if task_id == "7" else None,
+            acknowledges_snapshot_candidate_contract=True,
+        )
         with turn_execution_scope(7) as active:
             assert active is scope
             assert get_execution_scope() is scope
@@ -372,7 +399,9 @@ class TestTurnExecutionScope:
             calls.append(task_id)
             return ExecutionScope(sandbox_key_suffix=f"t{task_id}")
 
-        set_execution_scope_resolver(resolver)
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
         with turn_execution_scope("7"):
             pass
         with turn_execution_scope("7"):
@@ -380,7 +409,10 @@ class TestTurnExecutionScope:
         assert calls == ["7", "7"]
 
     def test_scope_restored_on_exception(self):
-        set_execution_scope_resolver(lambda task_id: ExecutionScope())
+        set_execution_scope_resolver(
+            lambda task_id: ExecutionScope(),
+            acknowledges_snapshot_candidate_contract=True,
+        )
         with pytest.raises(RuntimeError):
             with turn_execution_scope("7"):
                 raise RuntimeError("turn failed")
@@ -410,7 +442,9 @@ class TestTurnExecutionScope:
             return resolver
 
         def run_turn():
-            set_execution_scope_resolver(make_resolver())
+            set_execution_scope_resolver(
+                make_resolver(), acknowledges_snapshot_candidate_contract=True
+            )
             with turn_execution_scope("99") as scope:
                 return scope, get_execution_scope()
 
@@ -427,7 +461,9 @@ class TestTurnExecutionScope:
     def test_scope_visible_inside_async_turn(self):
         """The activated scope propagates into the turn's async execution."""
         scope = ExecutionScope(sandbox_key_suffix="s1")
-        set_execution_scope_resolver(lambda task_id: scope)
+        set_execution_scope_resolver(
+            lambda task_id: scope, acknowledges_snapshot_candidate_contract=True
+        )
 
         async def fake_agent_execution():
             await asyncio.sleep(0)
@@ -438,3 +474,450 @@ class TestTurnExecutionScope:
                 return await fake_agent_execution()
 
         assert asyncio.run(turn()) is scope
+
+
+class TestDeferToSnapshot:
+    """The carrier for a resolver's explicit abstention ."""
+
+    def test_requires_an_execution_scope_fallback(self):
+        with pytest.raises(TypeError):
+            defer_to_snapshot("not-a-scope")
+
+    def test_carrier_is_not_an_execution_scope(self):
+        carrier = defer_to_snapshot(ExecutionScope())
+        assert isinstance(carrier, DeferToSnapshot)
+        assert isinstance(carrier, ExecutionScope) is False
+
+    def test_carrier_has_no_public_bare_singleton(self):
+        """Only the fallback-carrying factory is exported -- a bare
+        module-level sentinel would let "defer" mean "unscoped on miss"
+        implicitly instead of requiring an explicit fallback."""
+        import xagent.core.execution_scope as scope_module
+
+        assert not hasattr(scope_module, "DEFER_TO_SNAPSHOT")
+
+    def test_carrier_exposes_the_fallback(self):
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        assert defer_to_snapshot(fallback).fallback == fallback
+
+
+class TestSetExecutionScopeResolverAckToken:
+    """The confirmation-token contract on ``set_execution_scope_resolver``."""
+
+    def test_registering_a_resolver_without_ack_raises(self):
+        with pytest.raises(TypeError, match="acknowledges_snapshot_candidate_contract"):
+            set_execution_scope_resolver(lambda task_id: None)
+
+    def test_clearing_the_resolver_never_needs_ack(self):
+        # None never triggers the check: the ~20 cleanup call sites across
+        # the test suite that reset the resolver to None stay unchanged.
+        set_execution_scope_resolver(None)
+        assert execution_scope_resolver_registered() is False
+
+    def test_ack_true_registers_successfully(self):
+        set_execution_scope_resolver(
+            lambda task_id: None, acknowledges_snapshot_candidate_contract=True
+        )
+        assert execution_scope_resolver_registered() is True
+
+    def test_ack_false_explicitly_still_raises(self):
+        with pytest.raises(TypeError):
+            set_execution_scope_resolver(
+                lambda task_id: None,
+                acknowledges_snapshot_candidate_contract=False,
+            )
+
+
+class TestExecutionScopeAuthorityErrorInheritance:
+    """Pin: distinguishable from the two exceptions this module
+    already raises, so no existing ``except RuntimeError``/``except
+    ValueError`` clause silently folds an authority conflict into them."""
+
+    def test_not_a_runtime_error(self):
+        assert not issubclass(ExecutionScopeAuthorityError, RuntimeError)
+
+    def test_not_a_value_error(self):
+        assert not issubclass(ExecutionScopeAuthorityError, ValueError)
+
+    def test_is_a_plain_exception(self):
+        assert issubclass(ExecutionScopeAuthorityError, Exception)
+
+
+class TestExecutionScopeResolverContractErrorInheritance:
+    """Pin: the resolve-boundary "unknown return type" error
+    must not be catchable by the ``except (ValueError, KeyError, TypeError)``
+    clauses several websocket handlers wrap around the turn-execution path
+    -- those fold anything in that tuple into a generic "client message
+    format error" response, which would misreport a resolver author's bug
+    as a malformed client message."""
+
+    def test_not_a_runtime_error(self):
+        assert not issubclass(ExecutionScopeResolverContractError, RuntimeError)
+
+    def test_not_a_value_error(self):
+        assert not issubclass(ExecutionScopeResolverContractError, ValueError)
+
+    def test_not_a_type_error(self):
+        assert not issubclass(ExecutionScopeResolverContractError, TypeError)
+
+    def test_is_a_plain_exception(self):
+        assert issubclass(ExecutionScopeResolverContractError, Exception)
+
+    def test_not_folded_by_the_websocket_validation_except_tuple(self):
+        """Reproduces the exact tuple websocket.py catches around the
+        turn-execution path (e.g. lines ~5802/5864/7029/7257): the new
+        error must fall through it and propagate."""
+        folded = False
+        try:
+            raise ExecutionScopeResolverContractError("boom")
+        except (ValueError, KeyError, TypeError):
+            folded = True
+        except ExecutionScopeResolverContractError:
+            pass
+        assert not folded
+
+
+class TestExecutionScopeShapeVersionAlignment:
+    """``to_dict``'s key set must track every dataclass field (1a precedent:
+    test_runtime_spec.py:315) so a newly added field cannot silently miss
+    persistence -- which would make a historical snapshot indistinguishable
+    from a current one that simply left the field at its default."""
+
+    def test_to_dict_keys_match_dataclass_fields(self):
+        field_names = {f.name for f in dataclasses.fields(ExecutionScope)}
+        assert set(ExecutionScope().to_dict().keys()) == field_names
+
+    def test_fresh_scope_is_current_version(self):
+        assert ExecutionScope().version == EXECUTION_SCOPE_SHAPE_VERSION
+
+    def test_from_dict_missing_version_defaults_to_legacy_zero(self):
+        data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        del data["version"]
+        assert ExecutionScope.from_dict(data).version == 0
+
+    def test_version_is_excluded_from_equality(self):
+        current = ExecutionScope(sandbox_key_suffix="x")
+        legacy_data = current.to_dict()
+        legacy_data["version"] = 0
+        legacy = ExecutionScope.from_dict(legacy_data)
+        assert legacy.version == 0
+        assert legacy == current
+
+
+class TestSnapshotCandidateAuthority:
+    """Full resolver x snapshot precedence matrix (#296).
+
+    Axes: resolver registered x (ExecutionScope / None / DeferToSnapshot) x
+    (snapshot equal / namespace-differing / policy-only-differing / absent /
+    stale-version / loader-broken). Plus the "no resolver registered" golden
+    (unchanged from the resolver-less contract) and the resolver-exception
+    short-circuit.
+    """
+
+    RESOLVER_SCOPE = ExecutionScope(sandbox_key_suffix="from-resolver")
+
+    def _register(self, resolver, loader=None):
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
+        if loader is not None:
+            set_execution_scope_snapshot_loader(loader)
+
+    # --- resolver returns None: authoritative unscoped -------------------
+    def test_resolver_none_is_authoritative_unscoped_even_with_snapshot(self):
+        loader_calls = []
+
+        def loader(task_id):
+            loader_calls.append(task_id)
+            return self.RESOLVER_SCOPE
+
+        self._register(lambda task_id: None, loader)
+        assert resolve_execution_scope("1") is None
+        assert loader_calls == []  # None short-circuits before the snapshot
+
+    # --- resolver returns ExecutionScope -----------------------------------
+    def test_resolver_scope_with_no_snapshot(self):
+        self._register(lambda task_id: self.RESOLVER_SCOPE, lambda task_id: None)
+        assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
+
+    def test_resolver_scope_with_equal_snapshot_corroborates_silently(self):
+        self._register(
+            lambda task_id: self.RESOLVER_SCOPE, lambda task_id: self.RESOLVER_SCOPE
+        )
+        assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
+
+    @pytest.mark.parametrize(
+        "field_name,snapshot_kwargs",
+        [
+            ("sandbox_key_suffix", {"sandbox_key_suffix": "other"}),
+            ("workspace_segments", {"workspace_segments": ("other",)}),
+            (
+                "sandbox_mount_segments",
+                {
+                    "workspace_segments": ("a", "b"),
+                    "sandbox_mount_segments": ("a",),
+                },
+            ),
+            ("memory_dimensions", {"memory_dimensions": {"k": "v"}}),
+            ("isolate_external_dirs", {"isolate_external_dirs": True}),
+        ],
+    )
+    def test_namespace_field_mismatch_fails_the_turn(self, field_name, snapshot_kwargs):
+        resolver_scope = ExecutionScope()
+        snapshot_scope = ExecutionScope(**snapshot_kwargs)
+        self._register(lambda task_id: resolver_scope, lambda task_id: snapshot_scope)
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert field_name in exc_info.value.mismatched_fields
+        assert exc_info.value.resolver_scope == resolver_scope
+        assert exc_info.value.snapshot_scope == snapshot_scope
+
+    def test_policy_only_mismatch_does_not_fail_the_turn(self, caplog):
+        """strict_memory_isolation is a policy field: a disagreement there
+        does not change which key/path is touched, so the resolver's value
+        wins without raising. The disagreement must still be observable --
+        a silently-won policy mismatch would otherwise be undebuggable."""
+        resolver_scope = ExecutionScope(strict_memory_isolation=False)
+        snapshot_scope = ExecutionScope(strict_memory_isolation=True)
+        self._register(lambda task_id: resolver_scope, lambda task_id: snapshot_scope)
+
+        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+            assert resolve_execution_scope("1") == resolver_scope
+        assert any(
+            "policy-only mismatch" in r.message
+            and "strict_memory_isolation" in r.message
+            for r in caplog.records
+        )
+
+    def test_stale_version_snapshot_is_ignored_even_if_it_would_mismatch(self, caplog):
+        resolver_scope = ExecutionScope()
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]  # predates EXECUTION_SCOPE_SHAPE_VERSION
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        assert stale_snapshot.version == 0
+
+        self._register(lambda task_id: resolver_scope, lambda task_id: stale_snapshot)
+        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+            assert resolve_execution_scope("1") == resolver_scope
+        assert any(
+            "shape" in r.message and "sandbox_key_suffix" in r.message
+            for r in caplog.records
+        )
+
+    def test_newer_version_snapshot_is_ignored_too(self):
+        """A mixed-version rollout can also see a snapshot stamped by a
+        *newer* process than this one (e.g. during a rolling deploy where
+        some workers already run the next shape). ``!=`` (not ``<``) covers
+        this direction too: the snapshot's shape can't be safely compared
+        field-by-field against a scope built under a different shape,
+        regardless of which side is newer."""
+        resolver_scope = ExecutionScope()
+        newer_data = ExecutionScope(sandbox_key_suffix="from-the-future").to_dict()
+        newer_data["version"] = EXECUTION_SCOPE_SHAPE_VERSION + 1
+        newer_snapshot = ExecutionScope.from_dict(newer_data)
+
+        self._register(lambda task_id: resolver_scope, lambda task_id: newer_snapshot)
+        assert resolve_execution_scope("1") == resolver_scope
+
+    def test_broken_snapshot_loader_does_not_veto_resolver_scope(self):
+        def boom(task_id):
+            raise RuntimeError("db down")
+
+        self._register(lambda task_id: self.RESOLVER_SCOPE, boom)
+        assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
+
+    # --- resolver returns DeferToSnapshot -----------------------------------
+    def test_defer_uses_snapshot_when_present(self):
+        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot_scope,
+        )
+        assert resolve_execution_scope("1") == snapshot_scope
+
+    def test_defer_uses_fallback_when_snapshot_absent(self):
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback), lambda task_id: None
+        )
+        assert resolve_execution_scope("1") == fallback
+
+    def test_defer_uses_fallback_when_loader_is_broken(self):
+        def boom(task_id):
+            raise RuntimeError("db down")
+
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        self._register(lambda task_id: defer_to_snapshot(fallback), boom)
+        assert resolve_execution_scope("1") == fallback
+
+    # --- boundary judgment / resolver misbehavior ---------------------------
+    def test_resolver_returning_unexpected_type_raises_contract_error(self):
+        self._register(lambda task_id: "not-a-scope")
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
+    def test_resolver_exception_short_circuits_before_the_snapshot(self):
+        loader_calls = []
+
+        def boom(task_id):
+            raise RuntimeError("resolver down")
+
+        self._register(boom, lambda task_id: loader_calls.append(task_id))
+        with pytest.raises(RuntimeError, match="resolver down"):
+            resolve_execution_scope("1")
+        assert loader_calls == []
+
+    # --- no resolver registered: golden: unchanged resolver-less contract --------
+    def test_no_resolver_registered_snapshot_alone_drives(self):
+        set_execution_scope_snapshot_loader(lambda task_id: self.RESOLVER_SCOPE)
+        assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
+
+    def test_no_resolver_registered_no_snapshot_is_unscoped(self):
+        assert resolve_execution_scope("1") is None
+
+    def test_no_resolver_registered_loader_exception_propagates(self):
+        def boom(task_id):
+            raise RuntimeError("db down")
+
+        set_execution_scope_snapshot_loader(boom)
+        with pytest.raises(RuntimeError, match="db down"):
+            resolve_execution_scope("1")
+
+
+class TestResolveExecutionScopeOffTurn:
+    """Off-turn consumers (websocket ``_scope_segments_for_task``,
+    ``ManagedFileRef``) downgrade a namespace mismatch instead of failing."""
+
+    def test_passthrough_when_no_mismatch(self):
+        scope = ExecutionScope(sandbox_key_suffix="s")
+        set_execution_scope_resolver(
+            lambda task_id: scope, acknowledges_snapshot_candidate_contract=True
+        )
+        assert resolve_execution_scope_off_turn("1") == scope
+
+    def test_namespace_mismatch_downgrades_to_resolver_value_with_warning(self, caplog):
+        resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
+        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
+        set_execution_scope_resolver(
+            lambda task_id: resolver_scope,
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
+
+        with caplog.at_level("WARNING"):
+            result = resolve_execution_scope_off_turn("1")
+
+        assert result == resolver_scope
+        assert any("authority mismatch" in r.message.lower() for r in caplog.records)
+
+    def test_other_exceptions_still_propagate(self):
+        def boom(task_id):
+            raise RuntimeError("resolver down")
+
+        set_execution_scope_resolver(
+            boom, acknowledges_snapshot_candidate_contract=True
+        )
+        with pytest.raises(RuntimeError, match="resolver down"):
+            resolve_execution_scope_off_turn("1")
+
+
+class TestDeferCarrierNeverActivated:
+    """The carrier is never mistaken for a real scope, and the turn
+    contextvar only ever holds the resolved fallback/snapshot, never the
+    carrier itself."""
+
+    def test_carrier_is_not_an_execution_scope_instance(self):
+        carrier = defer_to_snapshot(ExecutionScope())
+        assert isinstance(carrier, ExecutionScope) is False
+
+    def test_turn_activates_the_fallback_not_the_carrier(self):
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        with turn_execution_scope("1") as active:
+            assert active == fallback
+            current = get_execution_scope()
+            assert isinstance(current, ExecutionScope)
+            assert isinstance(current, DeferToSnapshot) is False
+
+
+class TestScopeFingerprintCoversIsolateExternalDirs:
+    """(#296) ``isolate_external_dirs`` is baked into the
+    cached ``AgentService``'s ``Workspace.allowed_external_dirs`` at build
+    time (see ``AgentServiceManager.get_agent_for_task`` ->
+    ``_build_allowed_external_dirs``), so an isolate_external_dirs-only
+    change must change the fingerprint or the cache never evicts and the
+    stale allowed-dirs list keeps being enforced."""
+
+    def test_isolate_external_dirs_only_change_changes_the_fingerprint(self):
+        base = ExecutionScope(workspace_segments=("tenant-a",))
+        isolated = ExecutionScope(
+            workspace_segments=("tenant-a",), isolate_external_dirs=True
+        )
+        assert scope_fingerprint(base) != scope_fingerprint(isolated)
+
+    def test_strict_memory_isolation_only_change_does_not_change_the_fingerprint(
+        self,
+    ):
+        """Read fresh from the contextvar on every memory operation
+        (``UserIsolatedMemoryStore``); nothing cached here goes stale."""
+        relaxed = ExecutionScope(strict_memory_isolation=False)
+        strict = ExecutionScope(strict_memory_isolation=True)
+        assert scope_fingerprint(relaxed) == scope_fingerprint(strict)
+
+
+class TestExecutionScopeFieldClassificationCompleteness:
+    """Every dataclass field must be
+    explicitly bucketed as namespace-affecting or policy-only, so a newly
+    added field can't silently miss ``resolve_execution_scope``'s
+    authority-mismatch classification. A field landing in neither bucket
+    would never be compared at all (not even logged), which is worse than
+    being misclassified into either one.
+    """
+
+    def test_every_field_is_classified_as_namespace_policy_or_version(self):
+        from xagent.core import execution_scope as scope_module
+
+        field_names = {f.name for f in dataclasses.fields(ExecutionScope)}
+        classified = (
+            set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS)
+            | set(scope_module._EXECUTION_SCOPE_POLICY_FIELDS)
+            | {"version"}
+        )
+        assert classified == field_names
+
+    def test_fingerprint_tracks_exactly_the_namespace_fields(self):
+        """``scope_fingerprint``'s tuple corresponds 1:1 to the
+        namespace-field bucket -- ``sandbox_mount_segments`` is represented
+        via the derived ``effective_mount_segments`` rather than the raw
+        field (two scopes with an unset vs. full-length
+        ``sandbox_mount_segments`` that select the identical mount must
+        still fingerprint identically), and ``version`` is excluded from
+        both (bookkeeping, not a namespace/policy field; see
+        ``ExecutionScope.version``'s docstring).
+
+        No namespace field is currently exempted from the fingerprint. If
+        one ever needs to be, it must be added to
+        ``exempted_from_fingerprint`` below with a comment explaining why
+        the cache doesn't need to evict on that field changing -- not
+        silently dropped from the set comparison.
+        """
+        from xagent.core import execution_scope as scope_module
+
+        namespace_fields = set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS)
+        fingerprint_represented_fields = {
+            "sandbox_key_suffix",
+            "workspace_segments",
+            "sandbox_mount_segments",  # via effective_mount_segments
+            "memory_dimensions",
+            "isolate_external_dirs",
+        }
+        exempted_from_fingerprint: set[str] = set()  # none today
+        assert (
+            namespace_fields - exempted_from_fingerprint
+            == fingerprint_represented_fields
+        )

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -45,62 +45,44 @@ from xagent.core.execution_scope import (
 
 @contextmanager
 def scope_log_records(level: int = logging.WARNING):
-    """Collect this module's log records independently of global logging config.
+    """Record what this module logs, without going through logging config.
 
-    ``caplog`` installs its handler on the root logger, so an assertion built on
-    it only holds while records propagate there. Whether they do is decided by
-    whatever else configured logging in the same process -- which under parallel
-    test execution is whatever module happens to share the worker. Attaching to
-    the logger that emits makes the assertion depend on the code under test
-    instead.
+    Asserting on log *content* through ``caplog`` or an attached handler makes
+    the assertion depend on the level, the global disable threshold, the handler
+    set and which module instance owns the logger -- none of which the code
+    under test decides. Swapping the ``logger`` binding in the namespace the
+    functions actually read it from observes the call itself, so what is
+    asserted is that the code logs, not that a particular logging setup
+    delivers it.
     """
-    from xagent.core import execution_scope as scope_module
+    del level  # every recorded call is returned; the caller filters
 
-    # The logger object the module logs through, not a name this test assumes
-    # resolves to it: under parallel execution the module can be imported under
-    # more than one name, and a handler bound by name would then watch a logger
-    # nothing writes to.
-    logger = scope_module.logger
+    class _Recorder:
+        def __init__(self, wrapped: logging.Logger) -> None:
+            self._wrapped = wrapped
+            self.records: list[str] = []
 
-    class _Records(list):
-        """A list that can carry the diagnostics a failure needs."""
+        def warning(self, msg: str, *args: object, **kwargs: object) -> None:
+            self.records.append(msg % args if args else msg)
+            self._wrapped.warning(msg, *args, **kwargs)
 
-        diagnostics: dict[str, object] = {}
+        def error(self, msg: str, *args: object, **kwargs: object) -> None:
+            self.records.append(msg % args if args else msg)
+            self._wrapped.error(msg, *args, **kwargs)
 
-    records: list[logging.LogRecord] = _Records()
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._wrapped, name)
 
-    class _Collect(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(record)
-
-    handler = _Collect(level)
-    previous_level = logger.level
-    # ``logging.disable`` suppresses record *creation* process-wide, below any
-    # handler or level this context sets: a library that calls it at import
-    # time -- which happens once the full suite is loaded -- would otherwise
-    # make this capture silently empty while the code under test behaves
-    # correctly. Lift it for the duration and put it back.
-    previous_disable = logging.root.manager.disable
-    logging.disable(logging.NOTSET)
-    logger.addHandler(handler)
-    logger.setLevel(level)
+    # The function's own globals: the binding it resolves `logger` against at
+    # call time, whichever module instance that turns out to be.
+    namespace = resolve_execution_scope.__globals__
+    original = namespace["logger"]
+    recorder = _Recorder(original)
+    namespace["logger"] = recorder
     try:
-        yield records
+        yield recorder.records
     finally:
-        # Snapshot what decided whether a record could exist at all, so a
-        # failing assertion reports the reason instead of an empty list.
-        records.diagnostics = {  # type: ignore[attr-defined]
-            "logger": logger.name,
-            "logger_id": id(logger),
-            "effective_level": logger.getEffectiveLevel(),
-            "manager_disable": logging.root.manager.disable,
-            "handlers": [type(h).__name__ for h in logger.handlers],
-            "propagate": logger.propagate,
-            "captured": [r.getMessage() for r in records],
-        }
-        logger.removeHandler(handler)
-        logger.setLevel(previous_level)
-        logging.disable(previous_disable)
+        namespace["logger"] = original
 
 
 class TestValidateScopeComponent:
@@ -134,7 +116,7 @@ class TestValidateScopeComponent:
         with scope_log_records(logging.ERROR) as records:
             with pytest.raises(InvalidScopeComponentError):
                 validate_scope_component("bad:name", field_name="sandbox_key_suffix")
-        assert any("sandbox_key_suffix" in r.getMessage() for r in records)
+        assert any("sandbox_key_suffix" in r for r in records)
 
 
 class TestExecutionScope:
@@ -833,8 +815,7 @@ class TestSnapshotCandidateAuthority:
         with scope_log_records() as records:
             assert resolve_execution_scope("1") == resolver_scope
         assert any(
-            "policy-only mismatch" in r.getMessage()
-            and "strict_memory_isolation" in r.getMessage()
+            "policy-only mismatch" in r and "strict_memory_isolation" in r
             for r in records
         )
 
@@ -848,10 +829,7 @@ class TestSnapshotCandidateAuthority:
         self._register(lambda task_id: resolver_scope, lambda task_id: stale_snapshot)
         with scope_log_records() as records:
             assert resolve_execution_scope("1") == resolver_scope
-        assert any(
-            "shape" in r.getMessage() and "sandbox_key_suffix" in r.getMessage()
-            for r in records
-        )
+        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
 
     def test_newer_version_snapshot_is_ignored_too(self):
         """A mixed-version rollout can also see a snapshot stamped by a
@@ -956,10 +934,7 @@ class TestSnapshotCandidateAuthority:
         )
         with scope_log_records() as records:
             assert resolve_execution_scope("1") == fallback
-        assert any(
-            "shape" in r.getMessage() and "sandbox_key_suffix" in r.getMessage()
-            for r in records
-        )
+        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
 
     @pytest.mark.parametrize(
         "field_name,fallback_kwargs,snapshot_kwargs",
@@ -1138,7 +1113,7 @@ class TestResolveExecutionScopeOffTurn:
                 seen["second_direct_call"] = "raised"
 
         assert result == resolver_scope
-        assert any("authority mismatch" in r.getMessage().lower() for r in records), (
+        assert any("authority mismatch" in r.lower() for r in records), (
             f"no authority-mismatch record; function sees {seen}; "
             f"capture state: {getattr(records, 'diagnostics', None)}"
         )

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -30,6 +30,7 @@ from xagent.core.execution_scope import (
     ExecutionScopeResolverContractError,
     InvalidScopeComponentError,
     defer_to_snapshot,
+    execution_scope_from_agent_config,
     execution_scope_resolver_registered,
     get_execution_scope,
     reset_execution_scope,
@@ -845,6 +846,127 @@ class TestFromDictUntrustedFieldCoercion:
             data = ExecutionScope().to_dict()
             data["memory_dimensions"] = raw
             assert dict(ExecutionScope.from_dict(data).memory_dimensions) == {}
+
+
+# The tuple several websocket handlers wrap around the turn-execution path,
+# including its per-turn ``resolve_execution_scope`` call. Anything in it is
+# answered to the client as a message-format validation error, so an exception
+# that is *not* about the client's message must fall through it.
+_WEBSOCKET_VALIDATION_EXCEPT_TUPLE = (ValueError, KeyError, TypeError)
+
+
+class TestPersistedSnapshotDecodeIsNotAClientMessageFault:
+    """A persisted snapshot that no longer decodes is a persisted-data fault.
+
+    ``execution_scope_from_agent_config`` is where persisted snapshot data is
+    read, and the registered snapshot loaders call it from inside
+    ``resolve_execution_scope``. The field coercions it drives raise
+    ``InvalidScopeComponentError``, which is a ``ValueError`` -- so without a
+    boundary conversion the failure lands in the websocket handlers'
+    ``except (ValueError, KeyError, TypeError)`` clause and the client is told
+    its own message was malformed, for data it may not have sent and cannot
+    fix. ``_coerce_snapshot_version`` was already written to avoid exactly
+    that folding for the ``version`` field; this is the same posture applied
+    to the rest of the snapshot.
+
+    ``InvalidScopeComponentError``'s own bases are deliberately left alone: it
+    is also raised for live, caller-supplied components (``workspace.py``,
+    ``sandbox_keys.py``), where being a ``ValueError`` is correct and is what
+    surrounding handlers already expect.
+    """
+
+    MALFORMED_AGENT_CONFIG = {"execution_scope": {"workspace_segments": 5}}
+
+    def _loader(self, task_id):
+        return execution_scope_from_agent_config(self.MALFORMED_AGENT_CONFIG)
+
+    def test_direct_decode_raises_the_contract_error(self):
+        with pytest.raises(ExecutionScopeResolverContractError):
+            execution_scope_from_agent_config(self.MALFORMED_AGENT_CONFIG)
+
+    def test_decode_failure_chains_the_underlying_validation_error(self):
+        """The conversion must not lose the diagnosis: the coercion error is
+        kept as ``__cause__`` (and its field-level detail is logged where it
+        was raised), so the boundary type costs nothing in debuggability."""
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            execution_scope_from_agent_config(self.MALFORMED_AGENT_CONFIG)
+        assert isinstance(exc_info.value.__cause__, InvalidScopeComponentError)
+
+    def test_decode_failure_message_names_no_snapshot_value(self):
+        """The message travels further than the log does, and a snapshot's
+        segments can carry end-user identifiers."""
+        agent_config = {
+            "execution_scope": {"workspace_segments": "tenant-secret-identifier"}
+        }
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            execution_scope_from_agent_config(agent_config)
+        assert "tenant-secret-identifier" not in str(exc_info.value)
+
+    def test_not_folded_on_the_no_resolver_path(self):
+        set_execution_scope_snapshot_loader(self._loader)
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            resolve_execution_scope("1")
+        assert not isinstance(exc_info.value, _WEBSOCKET_VALIDATION_EXCEPT_TUPLE)
+
+    def test_not_folded_on_the_resolver_abstention_path(self):
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(ExecutionScope()),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(self._loader)
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            resolve_execution_scope("1")
+        assert not isinstance(exc_info.value, _WEBSOCKET_VALIDATION_EXCEPT_TUPLE)
+
+    def test_live_component_validation_is_still_a_value_error(self):
+        """The counterpart the boundary conversion must not disturb: a
+        component validated for a caller right now (not read back from
+        storage) still raises the ``ValueError`` subclass its own callers
+        catch."""
+        assert issubclass(InvalidScopeComponentError, ValueError)
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope(sandbox_key_suffix="not:valid")
+
+
+class TestResolverContractErrorMessageIsClientSafe:
+    """``ExecutionScopeResolverContractError``'s message reaches a generic
+    handler and can surface to the client, exactly like
+    ``ExecutionScopeAuthorityError``'s (which is pinned to task id + field
+    names by ``test_str_carries_task_id_and_field_names_never_values``). A
+    resolver or loader bug that returns an internal object must therefore not
+    publish that object's ``repr()``; the message names its *type* and the
+    value goes only to the server-side log.
+    """
+
+    class _InternalConfig:
+        """Stands in for whatever an embedder's resolver might wrongly return."""
+
+        def __repr__(self) -> str:
+            return "<InternalConfig token='resolver-secret-token'>"
+
+    def test_resolver_return_type_error_names_the_type_not_the_value(self):
+        offender = self._InternalConfig()
+        set_execution_scope_resolver(
+            lambda task_id: offender, acknowledges_snapshot_candidate_contract=True
+        )
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            resolve_execution_scope("1")
+        message = str(exc_info.value)
+        assert "resolver-secret-token" not in message
+        assert "_InternalConfig" in message
+
+    def test_snapshot_type_error_names_the_type_not_the_value(self):
+        offender = self._InternalConfig()
+        set_execution_scope_resolver(
+            lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: offender)
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            resolve_execution_scope("1")
+        message = str(exc_info.value)
+        assert "resolver-secret-token" not in message
+        assert "_InternalConfig" in message
 
 
 class TestSnapshotCandidateAuthority:
@@ -1791,9 +1913,10 @@ class TestShapeGateLogsFieldDiffLazily:
 class TestResolveExecutionScopeOffTurn:
     """Off-turn consumers (websocket ``_scope_segments_for_task``,
     ``ManagedFileRef``) downgrade a resolver-authoritative namespace
-    mismatch instead of failing, but a resolver-abstention mismatch has no
-    authoritative value to downgrade to and stays fail-closed -- see
-    ``ExecutionScopeAbstentionMismatchError``'s docstring."""
+    mismatch instead of failing, but a mismatch whose ``resolver_scope`` is
+    not an authoritative answer has nothing to downgrade to and stays
+    fail-closed -- see ``ExecutionScopeAbstentionMismatchError``'s
+    docstring."""
 
     def test_passthrough_when_no_mismatch(self):
         scope = ExecutionScope(sandbox_key_suffix="s")
@@ -1853,6 +1976,62 @@ class TestResolveExecutionScopeOffTurn:
 
         with pytest.raises(ExecutionScopeAbstentionMismatchError):
             resolve_execution_scope_off_turn("1")
+
+    def test_a_new_authority_error_subclass_is_not_downgraded_by_default(self):
+        """The downgrade condition is positive -- "this raise site declared an
+        authoritative value" -- rather than an exclusion list of the subclasses
+        known to be unsafe. A subclass defined here, which no exclusion list in
+        the module could name, must therefore propagate: an off-turn face that
+        fails open for anything it has not been taught about would hand out
+        ``resolver_scope`` values no branch ever sanctioned."""
+
+        class _FutureMismatchError(ExecutionScopeAuthorityError):
+            """A mismatch shape added after this predicate was written."""
+
+        def resolver(task_id):
+            raise _FutureMismatchError(
+                str(task_id),
+                resolver_scope=ExecutionScope(sandbox_key_suffix="not-an-authority"),
+                snapshot_scope=ExecutionScope(sandbox_key_suffix="from-snapshot"),
+                mismatched_fields={
+                    "sandbox_key_suffix": ("from-snapshot", "not-an-authority")
+                },
+                resolver_scope_is_authoritative=False,
+            )
+
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
+        with pytest.raises(_FutureMismatchError):
+            resolve_execution_scope_off_turn("1")
+
+    def test_a_subclass_declaring_an_authority_is_still_downgraded(self):
+        """The other half: the predicate keys on the declaration, not on the
+        class, so a subclass that does have a sanctioned value is downgraded
+        without the function needing to know the type."""
+
+        class _FutureAuthoritativeMismatchError(ExecutionScopeAuthorityError):
+            """A mismatch shape that does carry an authoritative answer."""
+
+        authoritative = ExecutionScope(sandbox_key_suffix="from-resolver")
+
+        def resolver(task_id):
+            raise _FutureAuthoritativeMismatchError(
+                str(task_id),
+                resolver_scope=authoritative,
+                snapshot_scope=ExecutionScope(sandbox_key_suffix="from-snapshot"),
+                mismatched_fields={
+                    "sandbox_key_suffix": ("from-snapshot", "from-resolver")
+                },
+                resolver_scope_is_authoritative=True,
+            )
+
+        set_execution_scope_resolver(
+            resolver, acknowledges_snapshot_candidate_contract=True
+        )
+        with scope_log_records() as records:
+            assert resolve_execution_scope_off_turn("1") == authoritative
+        assert any("authority mismatch" in r.lower() for r in records)
 
     def test_other_exceptions_still_propagate(self):
         def boom(task_id):

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -2378,3 +2378,28 @@ class TestAuthorityMismatchNamesItsRemediation:
         remediation = [r for r in records if EXECUTION_SCOPE_AGENT_CONFIG_KEY in r]
         assert remediation, records
         assert "every turn" in remediation[0].lower()
+
+
+class TestPersistedAgentConfigRejectsADecodedScope:
+    """The override takes the task's raw ``agent_config``. An already-decoded
+    scope is not a Mapping, so decoding it would yield "no snapshot" -- which
+    on the abstention and no-resolver branches is indistinguishable from an
+    authoritative unscoped answer. It has to be refused, not dropped."""
+
+    def test_passing_a_scope_is_a_contract_error_not_a_silent_miss(self):
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope(
+                "1", persisted_agent_config=ExecutionScope(sandbox_key_suffix="s")
+            )
+
+    def test_raw_agent_config_still_resolves(self):
+        scope = ExecutionScope(sandbox_key_suffix="s")
+        assert (
+            resolve_execution_scope(
+                "1",
+                persisted_agent_config={
+                    EXECUTION_SCOPE_AGENT_CONFIG_KEY: scope.to_dict()
+                },
+            )
+            == scope
+        )

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -1,12 +1,9 @@
 """Unit tests for core/execution_scope.py.
 
-Slice 1 of #757: the ExecutionScope skeleton carries no consumers yet, so
-these tests cover the value type, the contextvar helpers, the resolver hook,
-and the per-turn activation contract (including restart/resume re-resolution).
-
-The resolver is authoritative
-over a persisted snapshot rather than always losing to it. The resolver
-fixtures below register through
+Covers the value type, the contextvar helpers, the resolver hook, and the
+per-turn activation contract (including restart/resume re-resolution). The
+resolver is authoritative over a persisted snapshot rather than always
+losing to it. The resolver fixtures below register through
 ``acknowledges_snapshot_candidate_contract=True`` -- see
 ``TestSnapshotCandidateAuthority`` for the full resolver/snapshot precedence
 matrix and ``tests/web/test_execution_scope_delegation.py`` for the
@@ -477,7 +474,7 @@ class TestTurnExecutionScope:
 
 
 class TestDeferToSnapshot:
-    """The carrier for a resolver's explicit abstention ."""
+    """The carrier for a resolver's explicit abstention."""
 
     def test_requires_an_execution_scope_fallback(self):
         with pytest.raises(TypeError):
@@ -542,6 +539,46 @@ class TestExecutionScopeAuthorityErrorInheritance:
     def test_is_a_plain_exception(self):
         assert issubclass(ExecutionScopeAuthorityError, Exception)
 
+    def test_str_carries_task_id_and_field_names_never_values(self):
+        """``str()`` on this exception ends up in ``task.error_message`` and
+        in the client's terminal error event (see this class's docstring for
+        the exact surfacing sites), so it must never leak the scope values
+        -- e.g. ``sandbox_key_suffix``/``workspace_segments``/
+        ``memory_dimensions`` -- which can carry end-user/client
+        identifiers. Only the task id and the mismatched field *names* are
+        safe to include."""
+        resolver_scope = ExecutionScope(
+            sandbox_key_suffix="resolver-secret-suffix",
+            workspace_segments=("resolver-secret-segment",),
+        )
+        snapshot_scope = ExecutionScope(
+            sandbox_key_suffix="snapshot-secret-suffix",
+            workspace_segments=("snapshot-secret-segment",),
+        )
+        exc = ExecutionScopeAuthorityError(
+            "task-123",
+            resolver_scope=resolver_scope,
+            snapshot_scope=snapshot_scope,
+            mismatched_fields={
+                "sandbox_key_suffix": (
+                    snapshot_scope.sandbox_key_suffix,
+                    resolver_scope.sandbox_key_suffix,
+                ),
+                "workspace_segments": (
+                    snapshot_scope.workspace_segments,
+                    resolver_scope.workspace_segments,
+                ),
+            },
+        )
+        message = str(exc)
+        assert "task-123" in message
+        assert "sandbox_key_suffix" in message
+        assert "workspace_segments" in message
+        assert "resolver-secret-suffix" not in message
+        assert "snapshot-secret-suffix" not in message
+        assert "resolver-secret-segment" not in message
+        assert "snapshot-secret-segment" not in message
+
 
 class TestExecutionScopeResolverContractErrorInheritance:
     """Pin: the resolve-boundary "unknown return type" error
@@ -578,7 +615,7 @@ class TestExecutionScopeResolverContractErrorInheritance:
 
 
 class TestExecutionScopeShapeVersionAlignment:
-    """``to_dict``'s key set must track every dataclass field (1a precedent:
+    """``to_dict``'s key set must track every dataclass field (precedent:
     test_runtime_spec.py:315) so a newly added field cannot silently miss
     persistence -- which would make a historical snapshot indistinguishable
     from a current one that simply left the field at its default."""
@@ -595,6 +632,18 @@ class TestExecutionScopeShapeVersionAlignment:
         del data["version"]
         assert ExecutionScope.from_dict(data).version == 0
 
+    def test_from_dict_string_version_is_coerced_to_int(self):
+        """A JSON-decoded snapshot carries ``version`` as whatever type the
+        wire format gave it; ``from_dict`` must coerce it to ``int`` so a
+        stringly-typed ``"1"`` still compares equal to
+        ``EXECUTION_SCOPE_SHAPE_VERSION`` in ``resolve_execution_scope``
+        instead of being silently treated as a shape mismatch."""
+        data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        data["version"] = str(EXECUTION_SCOPE_SHAPE_VERSION)
+        decoded = ExecutionScope.from_dict(data)
+        assert decoded.version == EXECUTION_SCOPE_SHAPE_VERSION
+        assert isinstance(decoded.version, int)
+
     def test_version_is_excluded_from_equality(self):
         current = ExecutionScope(sandbox_key_suffix="x")
         legacy_data = current.to_dict()
@@ -602,6 +651,44 @@ class TestExecutionScopeShapeVersionAlignment:
         legacy = ExecutionScope.from_dict(legacy_data)
         assert legacy.version == 0
         assert legacy == current
+
+    def test_to_dict_stamps_current_version_even_from_a_stale_scope(self):
+        """``to_dict()`` always stamps :data:`EXECUTION_SCOPE_SHAPE_VERSION`,
+        never ``self.version``: the dict it returns is being built *now*, in
+        the current shape, regardless of whether ``self`` was itself decoded
+        from an older snapshot (stale ``.version``). Propagating that stale
+        value would let a decoded-then-re-persisted scope masquerade as
+        pre-dating fields it actually has, permanently ignoring it as a
+        candidate in ``resolve_execution_scope``."""
+        stale_data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        stale_data["version"] = 0
+        stale_scope = ExecutionScope.from_dict(stale_data)
+        assert stale_scope.version == 0
+        assert stale_scope.to_dict()["version"] == EXECUTION_SCOPE_SHAPE_VERSION
+
+    def test_shape_version_bump_requires_touching_this_pin(self):
+        """Pins the exact field set ``EXECUTION_SCOPE_SHAPE_VERSION`` == 1
+        was cut for. A namespace-affecting field can be added --
+        wired into ``to_dict``/``from_dict``/
+        ``_EXECUTION_SCOPE_NAMESPACE_FIELDS``/``scope_fingerprint`` -- and
+        pass the rest of the suite without bumping the shape version, which
+        would make every already-persisted snapshot compare against a wider
+        shape it never had a chance to opt into, and
+        ``resolve_execution_scope`` would fail every turn touching one until
+        the version is bumped. This test forces the field set to be
+        re-affirmed (and the version bumped) on the next field addition
+        instead of drifting unnoticed."""
+        field_names = {f.name for f in dataclasses.fields(ExecutionScope)}
+        assert field_names == {
+            "sandbox_key_suffix",
+            "workspace_segments",
+            "sandbox_mount_segments",
+            "memory_dimensions",
+            "strict_memory_isolation",
+            "isolate_external_dirs",
+            "version",
+        }
+        assert EXECUTION_SCOPE_SHAPE_VERSION == 1
 
 
 class TestSnapshotCandidateAuthority:
@@ -727,6 +814,18 @@ class TestSnapshotCandidateAuthority:
         self._register(lambda task_id: self.RESOLVER_SCOPE, boom)
         assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
 
+    def test_snapshot_wrong_type_raises_contract_error_not_attribute_error(self):
+        """A snapshot loader is held to the same return-type discipline as
+        the resolver. Without the shared validation funnel, a non-scope
+        candidate would reach the ``.version`` comparison below and raise a
+        bare, undiagnosable ``AttributeError`` instead."""
+        self._register(
+            lambda task_id: self.RESOLVER_SCOPE,
+            lambda task_id: {"not": "a scope"},
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
     # --- resolver returns DeferToSnapshot -----------------------------------
     def test_defer_uses_snapshot_when_present(self):
         snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
@@ -744,13 +843,157 @@ class TestSnapshotCandidateAuthority:
         )
         assert resolve_execution_scope("1") == fallback
 
-    def test_defer_uses_fallback_when_loader_is_broken(self):
+    def test_defer_loader_exception_propagates(self):
+        """Unlike the authoritative branch (``test_broken_snapshot_loader_
+        does_not_veto_resolver_scope`` above), a broken loader here must fail
+        the turn: the resolver has just said it does not know this task's
+        scope, so a broken candidate means nobody knows, and turn faces that
+        reach this branch must fail closed rather than silently proceed
+        under a possibly-wrong fallback."""
+
         def boom(task_id):
             raise RuntimeError("db down")
 
         fallback = ExecutionScope(strict_memory_isolation=True)
         self._register(lambda task_id: defer_to_snapshot(fallback), boom)
-        assert resolve_execution_scope("1") == fallback
+        with pytest.raises(RuntimeError, match="db down"):
+            resolve_execution_scope("1")
+
+    def test_defer_snapshot_wrong_type_raises_contract_error(self):
+        """A snapshot loader is held to the same return-type discipline as
+        the resolver: it must return an ExecutionScope or None."""
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: {"not": "a scope"},
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
+    def test_defer_snapshot_carrier_from_loader_raises_contract_error(self):
+        """A loader returning a DeferToSnapshot (instead of an actual
+        snapshot) is exactly as invalid as a raw dict -- both fail the same
+        isinstance(ExecutionScope) gate."""
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: defer_to_snapshot(ExecutionScope()),
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
+    def test_defer_stale_version_snapshot_is_ignored_falls_back(self, caplog):
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        assert stale_snapshot.version == 0
+
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: stale_snapshot,
+        )
+        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+            assert resolve_execution_scope("1") == fallback
+        assert any(
+            "shape" in r.message and "sandbox_key_suffix" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.parametrize(
+        "field_name,fallback_kwargs,snapshot_kwargs",
+        [
+            (
+                "sandbox_key_suffix",
+                {"sandbox_key_suffix": "fallback-suffix"},
+                {"sandbox_key_suffix": "different-suffix"},
+            ),
+            (
+                "workspace_segments",
+                {"workspace_segments": ("tenant-a", "b")},
+                {"workspace_segments": ("tenant-a",)},
+            ),
+            (
+                "sandbox_mount_segments",
+                {
+                    "workspace_segments": ("tenant-a", "b", "c"),
+                    "sandbox_mount_segments": ("tenant-a", "b", "c"),
+                },
+                {
+                    "workspace_segments": ("tenant-a", "b", "c"),
+                    "sandbox_mount_segments": ("tenant-a",),
+                },
+            ),
+            (
+                "isolate_external_dirs",
+                {"isolate_external_dirs": True},
+                {"isolate_external_dirs": False},
+            ),
+            (
+                "memory_dimensions",
+                {"memory_dimensions": {"k": "v"}},
+                {"memory_dimensions": {}},
+            ),
+        ],
+    )
+    def test_defer_snapshot_widening_fallback_fails_the_turn(
+        self, field_name, fallback_kwargs, snapshot_kwargs
+    ):
+        """A snapshot that is *wider* than the resolver's mandatory fallback
+        on any namespace field must fail the turn: the snapshot is
+        client-influenceable (an ``execution_scope`` key inside a
+        client-supplied ``agent_config``), so an unchecked snapshot here
+        would let a caller widen its own namespace past the resolver's own
+        most conservative answer."""
+        fallback = ExecutionScope(**fallback_kwargs)
+        snapshot = ExecutionScope(**snapshot_kwargs)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot,
+        )
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert field_name in exc_info.value.mismatched_fields
+        assert exc_info.value.resolver_scope == fallback
+        assert exc_info.value.snapshot_scope == snapshot
+
+    @pytest.mark.parametrize(
+        "fallback_kwargs,snapshot_kwargs",
+        [
+            ({}, {"sandbox_key_suffix": "narrower"}),
+            (
+                {"workspace_segments": ("tenant-a",)},
+                {"workspace_segments": ("tenant-a", "sub")},
+            ),
+            (
+                {"isolate_external_dirs": False},
+                {"isolate_external_dirs": True},
+            ),
+            (
+                {"memory_dimensions": {"k": "v"}},
+                {"memory_dimensions": {"k": "v", "k2": "v2"}},
+            ),
+            (
+                {"sandbox_key_suffix": "same"},
+                {"sandbox_key_suffix": "same"},
+            ),
+        ],
+    )
+    def test_defer_snapshot_narrowing_fallback_is_accepted(
+        self, fallback_kwargs, snapshot_kwargs
+    ):
+        """The mirror of the widening cases above: a snapshot that only
+        narrows the fallback (equal, a deeper workspace path, external dirs
+        going shared->scope-local, or extra memory dimensions) is accepted
+        and used as the resolved scope."""
+        fallback = ExecutionScope(**fallback_kwargs)
+        snapshot = ExecutionScope(**snapshot_kwargs)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot,
+        )
+        assert resolve_execution_scope("1") == snapshot
 
     # --- boundary judgment / resolver misbehavior ---------------------------
     def test_resolver_returning_unexpected_type_raises_contract_error(self):

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -69,6 +69,13 @@ def scope_log_records(level: int = logging.WARNING):
 
     handler = _Collect(level)
     previous_level = logger.level
+    # ``logging.disable`` suppresses record *creation* process-wide, below any
+    # handler or level this context sets: a library that calls it at import
+    # time -- which happens once the full suite is loaded -- would otherwise
+    # make this capture silently empty while the code under test behaves
+    # correctly. Lift it for the duration and put it back.
+    previous_disable = logging.root.manager.disable
+    logging.disable(logging.NOTSET)
     logger.addHandler(handler)
     logger.setLevel(level)
     try:
@@ -76,6 +83,7 @@ def scope_log_records(level: int = logging.WARNING):
     finally:
         logger.removeHandler(handler)
         logger.setLevel(previous_level)
+        logging.disable(previous_disable)
 
 
 class TestValidateScopeComponent:

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -579,8 +579,40 @@ class TestExecutionScopeAuthorityErrorInheritance:
     def test_not_a_value_error(self):
         assert not issubclass(ExecutionScopeAuthorityError, ValueError)
 
+    def test_not_a_type_error(self):
+        assert not issubclass(ExecutionScopeAuthorityError, TypeError)
+
+    def test_not_a_key_error(self):
+        assert not issubclass(ExecutionScopeAuthorityError, KeyError)
+
     def test_is_a_plain_exception(self):
         assert issubclass(ExecutionScopeAuthorityError, Exception)
+
+    def test_not_folded_by_the_websocket_validation_except_tuple(self):
+        """Reproduces the exact tuple websocket.py catches around the
+        turn-execution path (see
+        TestExecutionScopeResolverContractErrorInheritance's sibling test
+        for the exact line numbers): the resolver's per-turn call to
+        resolve_execution_scope sits inside that same try block, so an
+        authority conflict raised there must fall through this tuple and
+        propagate instead of being reported as a malformed client message."""
+        resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
+        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
+        folded = False
+        try:
+            raise ExecutionScopeAuthorityError(
+                "task-123",
+                resolver_scope=resolver_scope,
+                snapshot_scope=snapshot_scope,
+                mismatched_fields={
+                    "sandbox_key_suffix": ("from-snapshot", "from-resolver")
+                },
+            )
+        except (ValueError, KeyError, TypeError):
+            folded = True
+        except ExecutionScopeAuthorityError:
+            pass
+        assert not folded
 
     def test_str_carries_task_id_and_field_names_never_values(self):
         """``str()`` on this exception ends up in ``task.error_message`` and
@@ -734,6 +766,109 @@ class TestExecutionScopeShapeVersionAlignment:
         assert EXECUTION_SCOPE_SHAPE_VERSION == 1
 
 
+class TestFromDictUntrustedFieldCoercion:
+    """FIX 3: ``from_dict`` decodes a mapping that can originate in a
+    client-influenceable ``Task.agent_config`` (see
+    :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`), so every field it reads must
+    be coerced defensively -- never a raw ``int()``/``tuple()``/``dict()``
+    call that can raise a bare stdlib error (swallowed by generic ``except
+    (ValueError, KeyError, TypeError)`` handlers elsewhere) or silently
+    misread/truncate the value.
+    """
+
+    # --- version: never raises, never truncates ---------------------------
+
+    @pytest.mark.parametrize("raw_version", ["abc", {"a": 1}, [1], object()])
+    def test_from_dict_malformed_version_is_treated_as_stale_not_raised(
+        self, raw_version
+    ):
+        data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        data["version"] = raw_version
+        assert ExecutionScope.from_dict(data).version == 0
+
+    def test_from_dict_float_version_is_treated_as_stale_not_truncated(self):
+        """1.5 must not silently become 1 (a plausible-looking but wrong
+        current-version claim) via a bare ``int()`` truncation."""
+        data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        data["version"] = 1.5
+        assert ExecutionScope.from_dict(data).version == 0
+
+    def test_from_dict_bool_version_is_treated_as_stale(self):
+        data = ExecutionScope(sandbox_key_suffix="x").to_dict()
+        data["version"] = True
+        assert ExecutionScope.from_dict(data).version == 0
+
+    # --- workspace_segments / sandbox_mount_segments: no silent str/dict
+    # iteration, no bare TypeError on a non-iterable ----------------------
+
+    def test_from_dict_string_workspace_segments_raises_instead_of_splitting_chars(
+        self,
+    ):
+        """``tuple("ab")`` would silently become ``("a", "b")`` -- two valid-
+        looking single-character segments that pass per-segment validation
+        with no signal that the input was never a sequence."""
+        data = ExecutionScope().to_dict()
+        data["workspace_segments"] = "ab"
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope.from_dict(data)
+
+    def test_from_dict_non_iterable_workspace_segments_raises_domain_error(self):
+        """``tuple(5)`` raises a bare ``TypeError`` outside this module's
+        error taxonomy; the coercion guard must raise
+        ``InvalidScopeComponentError`` before reaching that call."""
+        data = ExecutionScope().to_dict()
+        data["workspace_segments"] = 5
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope.from_dict(data)
+
+    def test_from_dict_falsy_workspace_segments_still_defaults_to_empty(self):
+        """Falsy-but-absent-shaped values (``None``, ``""``, ``0``, ``False``)
+        keep meaning "no segments supplied" rather than becoming a coercion
+        error -- only a truthy non-sequence is a real contract violation."""
+        for raw in (None, "", 0, False, []):
+            data = ExecutionScope().to_dict()
+            data["workspace_segments"] = raw
+            assert ExecutionScope.from_dict(data).workspace_segments == ()
+
+    def test_from_dict_string_sandbox_mount_segments_raises(self):
+        data = ExecutionScope(workspace_segments=("a", "b")).to_dict()
+        data["sandbox_mount_segments"] = "ab"
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope.from_dict(data)
+
+    def test_from_dict_none_sandbox_mount_segments_stays_none_not_coerced(self):
+        """``None`` is a load-bearing sentinel (mount == full
+        workspace_segments), distinct from an explicit ``[]`` (rooted
+        mount) -- the coercion guard must preserve that distinction rather
+        than routing ``None`` through the same falsy-default path as
+        ``workspace_segments``."""
+        data = ExecutionScope(workspace_segments=("a", "b")).to_dict()
+        assert data["sandbox_mount_segments"] is None
+        assert ExecutionScope.from_dict(data).sandbox_mount_segments is None
+
+    # --- memory_dimensions: no silent pair-splitting of a bad iterable ----
+
+    def test_from_dict_string_memory_dimensions_raises_instead_of_dict_of_chars(self):
+        """``dict(["ab"])`` would silently reinterpret ``"ab"`` as the
+        key/value pair ``{"a": "b"}``."""
+        data = ExecutionScope().to_dict()
+        data["memory_dimensions"] = ["ab"]
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope.from_dict(data)
+
+    def test_from_dict_non_mapping_memory_dimensions_raises_domain_error(self):
+        data = ExecutionScope().to_dict()
+        data["memory_dimensions"] = 5
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope.from_dict(data)
+
+    def test_from_dict_falsy_memory_dimensions_still_defaults_to_empty(self):
+        for raw in (None, "", 0, False, {}):
+            data = ExecutionScope().to_dict()
+            data["memory_dimensions"] = raw
+            assert dict(ExecutionScope.from_dict(data).memory_dimensions) == {}
+
+
 class TestSnapshotCandidateAuthority:
     """Full resolver x snapshot precedence matrix (#296).
 
@@ -867,8 +1002,54 @@ class TestSnapshotCandidateAuthority:
 
     # --- resolver returns DeferToSnapshot -----------------------------------
     def test_defer_uses_snapshot_when_present(self):
-        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
+        """A snapshot that narrows a *scoped* fallback (not an all-default
+        one -- see TestDeferSnapshotAllDefaultFallback below) is used as-is.
+        Namespace and policy fields are varied independently elsewhere
+        (test_defer_snapshot_policy_only_disagreement_fallback_wins) so this
+        case stays a clean single-variable proof of "narrowing snapshot
+        wins"."""
+        fallback = ExecutionScope(workspace_segments=("tenant-a",))
+        snapshot_scope = ExecutionScope(workspace_segments=("tenant-a", "sub"))
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot_scope,
+        )
+        assert resolve_execution_scope("1") == snapshot_scope
+
+    def test_defer_snapshot_policy_only_disagreement_fallback_wins(self):
+        """FIX 2 coverage: on the abstention branch, the namespace fields
+        agree (both all-default -- no narrowing violation), but
+        strict_memory_isolation differs. The fallback plays the
+        authoritative role here, so its policy value must win, logged, the
+        same way the resolver's policy value wins on the authoritative
+        branch (test_policy_only_mismatch_does_not_fail_the_turn above)."""
         fallback = ExecutionScope(strict_memory_isolation=True)
+        snapshot_scope = ExecutionScope(strict_memory_isolation=False)
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot_scope,
+        )
+
+        with scope_log_records() as records:
+            result = resolve_execution_scope("1")
+        assert result.strict_memory_isolation is True
+        assert result.sandbox_key_suffix is None
+        assert any(
+            "policy-only mismatch" in r and "strict_memory_isolation" in r
+            for r in records
+        )
+
+    def test_defer_current_shape_version_snapshot_is_used_not_shape_gated(self):
+        """The positive mirror of
+        test_defer_stale_version_snapshot_is_ignored_falls_back: a snapshot
+        carrying the current shape version (as a real persisted snapshot
+        would, round-tripped through to_dict/from_dict) is not shape-gated
+        away and is used when it narrows the fallback."""
+        fallback = ExecutionScope(workspace_segments=("tenant-a",))
+        snapshot_data = ExecutionScope(workspace_segments=("tenant-a", "sub")).to_dict()
+        assert snapshot_data["version"] == EXECUTION_SCOPE_SHAPE_VERSION
+        snapshot_scope = ExecutionScope.from_dict(snapshot_data)
+
         self._register(
             lambda task_id: defer_to_snapshot(fallback),
             lambda task_id: snapshot_scope,
@@ -970,6 +1151,14 @@ class TestSnapshotCandidateAuthority:
                 {"memory_dimensions": {"k": "v"}},
                 {"memory_dimensions": {}},
             ),
+            # All-default fallback: the resolver has claimed no authority in
+            # any dimension, so introducing scoping the fallback never
+            # committed to is rejected even though, taken alone, it would
+            # look like a narrowing (null -> set; False -> True). See
+            # TestDeferSnapshotAllDefaultFallback for the combined-fields
+            # reproduction of the original vacuous-predicate report.
+            ("sandbox_key_suffix", {}, {"sandbox_key_suffix": "attacker-chosen"}),
+            ("isolate_external_dirs", {}, {"isolate_external_dirs": True}),
         ],
     )
     def test_defer_snapshot_widening_fallback_fails_the_turn(
@@ -997,14 +1186,19 @@ class TestSnapshotCandidateAuthority:
     @pytest.mark.parametrize(
         "fallback_kwargs,snapshot_kwargs",
         [
-            ({}, {"sandbox_key_suffix": "narrower"}),
             (
                 {"workspace_segments": ("tenant-a",)},
                 {"workspace_segments": ("tenant-a", "sub")},
             ),
             (
-                {"isolate_external_dirs": False},
-                {"isolate_external_dirs": True},
+                {
+                    "workspace_segments": ("tenant-a", "b", "c"),
+                    "sandbox_mount_segments": ("tenant-a",),
+                },
+                {
+                    "workspace_segments": ("tenant-a", "b", "c"),
+                    "sandbox_mount_segments": ("tenant-a", "b"),
+                },
             ),
             (
                 {"memory_dimensions": {"k": "v"}},
@@ -1020,9 +1214,12 @@ class TestSnapshotCandidateAuthority:
         self, fallback_kwargs, snapshot_kwargs
     ):
         """The mirror of the widening cases above: a snapshot that only
-        narrows the fallback (equal, a deeper workspace path, external dirs
-        going shared->scope-local, or extra memory dimensions) is accepted
-        and used as the resolved scope."""
+        extends scoping the fallback already committed to (a deeper
+        workspace path, a deeper mount prefix within one, or extra memory
+        dimensions) is accepted and used as the resolved scope. Every case
+        here has a non-default fallback for the field under test -- see
+        TestDeferSnapshotAllDefaultFallback for why an all-default fallback
+        accepts nothing but an equal snapshot instead."""
         fallback = ExecutionScope(**fallback_kwargs)
         snapshot = ExecutionScope(**snapshot_kwargs)
         self._register(
@@ -1064,6 +1261,87 @@ class TestSnapshotCandidateAuthority:
         with pytest.raises(RuntimeError, match="db down"):
             resolve_execution_scope("1")
 
+    def test_no_resolver_registered_stale_version_snapshot_is_used_as_is(self):
+        """The no-resolver branch returns whatever the loader returns
+        directly (see resolve_execution_scope's ``if
+        _execution_scope_resolver is None`` branch) -- it never routes
+        through ``_validate_execution_scope_snapshot_candidate``, so a
+        stale-shape snapshot is not shape-gated here the way it is on the
+        other two branches. This pins that pre-existing, byte-identical-to-
+        pre-authority behavior; it is not a new contract."""
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        assert stale_snapshot.version == 0
+
+        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        assert resolve_execution_scope("1") == stale_snapshot
+
+    def test_no_resolver_registered_non_scope_loader_output_passes_through(self):
+        """Same branch, same absence of validation: a loader returning
+        something other than an ExecutionScope is not caught here (unlike
+        the resolver-registered branches, which route every loaded
+        candidate through ``_validate_execution_scope_snapshot_candidate``
+        and raise ExecutionScopeResolverContractError for exactly this
+        input). Pinned as a known, pre-existing gap on this branch rather
+        than asserted correct."""
+        set_execution_scope_snapshot_loader(lambda task_id: {"not": "a scope"})
+        assert resolve_execution_scope("1") == {"not": "a scope"}
+
+
+class TestDeferSnapshotAllDefaultFallback:
+    """FIX for the vacuous-narrowing report: every per-field narrowing check
+    in ``_execution_scope_narrowing_violations`` used to be evaluated purely
+    relative to the fallback's own value, so it was trivially satisfied by
+    any snapshot value once the fallback's field sat at that field's own
+    no-scoping default -- an all-default ``ExecutionScope()`` fallback (the
+    natural value for a resolver with "no opinion" on a task) made every
+    check pass regardless of the snapshot. The fixed rule: a field at its
+    own identity default admits no narrowing, only an exact match, because
+    there is no scoping there for the snapshot to narrow into.
+    """
+
+    def test_all_default_fallback_rejects_a_snapshot_widening_every_field_at_once(
+        self,
+    ):
+        """Reproduces the original report's proof-of-concept: a fully
+        unscoped fallback plus a snapshot that sets every namespace field
+        simultaneously. Every field is out-of-authority for this fallback,
+        so all five must be reported."""
+        fallback = ExecutionScope()
+        snapshot = ExecutionScope(
+            sandbox_key_suffix="attacker-chosen",
+            workspace_segments=("other", "tenant"),
+            sandbox_mount_segments=("other", "tenant"),
+            isolate_external_dirs=True,
+            memory_dimensions={"tenant": "other"},
+        )
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert set(exc_info.value.mismatched_fields) == {
+            "sandbox_key_suffix",
+            "workspace_segments",
+            "sandbox_mount_segments",
+            "isolate_external_dirs",
+            "memory_dimensions",
+        }
+
+    def test_all_default_fallback_accepts_only_an_equal_snapshot(self):
+        fallback = ExecutionScope()
+        snapshot = ExecutionScope()
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+        assert resolve_execution_scope("1") == fallback
+
 
 class TestResolveExecutionScopeOffTurn:
     """Off-turn consumers (websocket ``_scope_segments_for_task``,
@@ -1091,32 +1369,11 @@ class TestResolveExecutionScopeOffTurn:
         with pytest.raises(ExecutionScopeAuthorityError):
             resolve_execution_scope("1")
 
-        # Measured, not assumed: which module instance the function under test
-        # reads its globals from, and whether the hooks this test installed are
-        # the ones it sees. A capture that stays empty while the behavior is
-        # correct means one of these disagrees.
-        fn_globals = resolve_execution_scope_off_turn.__globals__
-        seen = {
-            "fn_module": fn_globals.get("__name__"),
-            "fn_logger_id": id(fn_globals.get("logger")),
-            "fn_resolver": fn_globals.get("_execution_scope_resolver") is not None,
-            "fn_loader": fn_globals.get("_execution_scope_snapshot_loader") is not None,
-        }
-
         with scope_log_records() as records:
             result = resolve_execution_scope_off_turn("1")
-            # Does the same call still disagree at this point in the test?
-            try:
-                resolve_execution_scope("1")
-                seen["second_direct_call"] = "returned"
-            except ExecutionScopeAuthorityError:
-                seen["second_direct_call"] = "raised"
 
         assert result == resolver_scope
-        assert any("authority mismatch" in r.lower() for r in records), (
-            f"no authority-mismatch record; function sees {seen}; "
-            f"capture state: {getattr(records, 'diagnostics', None)}"
-        )
+        assert any("authority mismatch" in r.lower() for r in records)
 
     def test_other_exceptions_still_propagate(self):
         def boom(task_id):
@@ -1196,34 +1453,85 @@ class TestExecutionScopeFieldClassificationCompleteness:
         )
         assert classified == field_names
 
-    def test_fingerprint_tracks_exactly_the_namespace_fields(self):
-        """``scope_fingerprint``'s tuple corresponds 1:1 to the
-        namespace-field bucket -- ``sandbox_mount_segments`` is represented
-        via the derived ``effective_mount_segments`` rather than the raw
-        field (two scopes with an unset vs. full-length
-        ``sandbox_mount_segments`` that select the identical mount must
-        still fingerprint identically), and ``version`` is excluded from
-        both (bookkeeping, not a namespace/policy field; see
-        ``ExecutionScope.version``'s docstring).
-
-        No namespace field is currently exempted from the fingerprint. If
-        one ever needs to be, it must be added to
-        ``exempted_from_fingerprint`` below with a comment explaining why
-        the cache doesn't need to evict on that field changing -- not
-        silently dropped from the set comparison.
-        """
+    def test_namespace_field_classification_is_complete_and_disjoint_from_policy(
+        self,
+    ):
+        """Static classification-completeness check only -- this does not
+        call ``scope_fingerprint`` at all. Real per-field fingerprint
+        behavior is covered by ``TestScopeFingerprintFieldCoverage`` below,
+        which does call it. (Renamed from the former
+        ``test_fingerprint_tracks_exactly_the_namespace_fields``: that name
+        claimed fingerprint coverage that a set-vs-hardcoded-set comparison
+        never exercised.)"""
         from xagent.core import execution_scope as scope_module
 
         namespace_fields = set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS)
-        fingerprint_represented_fields = {
-            "sandbox_key_suffix",
-            "workspace_segments",
-            "sandbox_mount_segments",  # via effective_mount_segments
-            "memory_dimensions",
-            "isolate_external_dirs",
+        policy_fields = set(scope_module._EXECUTION_SCOPE_POLICY_FIELDS)
+        assert namespace_fields.isdisjoint(policy_fields)
+        assert namespace_fields | policy_fields | {"version"} == {
+            f.name for f in dataclasses.fields(ExecutionScope)
         }
-        exempted_from_fingerprint: set[str] = set()  # none today
-        assert (
-            namespace_fields - exempted_from_fingerprint
-            == fingerprint_represented_fields
+
+
+# One (base_kwargs, changed_kwargs) probe per namespace field: constructing
+# ExecutionScope(**base_kwargs) and ExecutionScope(**changed_kwargs) changes
+# only that field's contribution to scope_fingerprint(). Keyed by field name
+# so TestScopeFingerprintFieldCoverage can assert this dict's keys track
+# _EXECUTION_SCOPE_NAMESPACE_FIELDS exactly -- a namespace field added
+# without a probe here fails loudly instead of being silently skipped.
+_NAMESPACE_FIELD_FINGERPRINT_PROBES: dict[str, tuple[dict, dict]] = {
+    "sandbox_key_suffix": ({}, {"sandbox_key_suffix": "probe-suffix"}),
+    "workspace_segments": ({}, {"workspace_segments": ("probe",)}),
+    "sandbox_mount_segments": (
+        {"workspace_segments": ("probe", "deep")},
+        {
+            "workspace_segments": ("probe", "deep"),
+            "sandbox_mount_segments": ("probe",),
+        },
+    ),
+    "memory_dimensions": ({}, {"memory_dimensions": {"k": "v"}}),
+    "isolate_external_dirs": ({}, {"isolate_external_dirs": True}),
+}
+
+# Same idea for the one field the fingerprint deliberately excludes.
+_POLICY_FIELD_FINGERPRINT_PROBES: dict[str, tuple[dict, dict]] = {
+    "strict_memory_isolation": ({}, {"strict_memory_isolation": True}),
+}
+
+
+class TestScopeFingerprintFieldCoverage:
+    """Behavior-derived replacement for the set-comparison-only test above:
+    calls ``scope_fingerprint()`` itself, per field, rather than comparing
+    two hand-maintained collections against each other. Reverting
+    ``scope_fingerprint()`` to drop any namespace field's contribution fails
+    the corresponding parametrized case here directly.
+    """
+
+    def test_probes_cover_exactly_the_classified_fields(self):
+        """Fixture completeness: every namespace/policy field must have a
+        probe pair here, so a newly added field can't be silently skipped.
+        Which bucket a field belongs to is separately pinned by
+        TestExecutionScopeFieldClassificationCompleteness above; this only
+        checks the probe tables track that bucketing."""
+        from xagent.core import execution_scope as scope_module
+
+        assert set(_NAMESPACE_FIELD_FINGERPRINT_PROBES) == set(
+            scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS
         )
+        assert set(_POLICY_FIELD_FINGERPRINT_PROBES) == set(
+            scope_module._EXECUTION_SCOPE_POLICY_FIELDS
+        )
+
+    @pytest.mark.parametrize("field_name", list(_NAMESPACE_FIELD_FINGERPRINT_PROBES))
+    def test_namespace_field_change_changes_the_fingerprint(self, field_name):
+        base_kwargs, changed_kwargs = _NAMESPACE_FIELD_FINGERPRINT_PROBES[field_name]
+        base = ExecutionScope(**base_kwargs)
+        changed = ExecutionScope(**changed_kwargs)
+        assert scope_fingerprint(base) != scope_fingerprint(changed)
+
+    @pytest.mark.parametrize("field_name", list(_POLICY_FIELD_FINGERPRINT_PROBES))
+    def test_policy_field_change_does_not_change_the_fingerprint(self, field_name):
+        base_kwargs, changed_kwargs = _POLICY_FIELD_FINGERPRINT_PROBES[field_name]
+        base = ExecutionScope(**base_kwargs)
+        changed = ExecutionScope(**changed_kwargs)
+        assert scope_fingerprint(base) == scope_fingerprint(changed)

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -55,13 +55,21 @@ def scope_log_records(level: int = logging.WARNING):
     functions actually read it from observes the call itself, so what is
     asserted is that the code logs, not that a particular logging setup
     delivers it.
+
+    ``level`` is the enablement the recorder itself reports, so code that asks
+    ``logger.isEnabledFor(...)`` before building a message gets a deterministic
+    answer from the recorder rather than from whatever the ambient logging
+    configuration happens to be. Every call that survives that check is
+    recorded verbatim; the caller filters.
     """
-    del level  # every recorded call is returned; the caller filters
 
     class _Recorder:
         def __init__(self, wrapped: logging.Logger) -> None:
             self._wrapped = wrapped
             self.records: list[str] = []
+
+        def isEnabledFor(self, asked: int) -> bool:  # noqa: N802 - logging API
+            return asked >= level
 
         def warning(self, msg: str, *args: object, **kwargs: object) -> None:
             self.records.append(msg % args if args else msg)
@@ -72,6 +80,10 @@ def scope_log_records(level: int = logging.WARNING):
             self._wrapped.error(msg, *args, **kwargs)
 
         def __getattr__(self, name: str) -> object:
+            # Deliberately does not cover ``isEnabledFor``: delegating that to
+            # the wrapped logger would put the ambient level and the global
+            # disable threshold back in charge of what the code under test
+            # does, which is what this helper exists to avoid.
             return getattr(self._wrapped, name)
 
     # The function's own globals: the binding it resolves `logger` against at
@@ -1581,7 +1593,7 @@ class TestShapeGateLogsFieldDiffLazily:
     needed for control flow, nothing downstream reads this one. It must
     therefore be computed only when that message will actually be emitted,
     since the gate runs on every turn for any snapshot that predates a
-    shape bump (see the class docstring reasoning in F3's fix)."""
+    shape bump."""
 
     def test_field_diff_not_computed_when_warning_is_disabled(self, monkeypatch):
         from xagent.core import execution_scope as scope_module
@@ -1592,23 +1604,20 @@ class TestShapeGateLogsFieldDiffLazily:
             )
 
         monkeypatch.setattr(scope_module, "_execution_scope_field_diff", boom)
-        original_level = scope_module.logger.level
-        scope_module.logger.setLevel(logging.ERROR)
-        try:
-            resolver_scope = ExecutionScope()
-            stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
-            del stale_data["version"]
-            stale_snapshot = ExecutionScope.from_dict(stale_data)
-            set_execution_scope_resolver(
-                lambda task_id: resolver_scope,
-                acknowledges_snapshot_candidate_contract=True,
-            )
-            set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        resolver_scope = ExecutionScope()
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        set_execution_scope_resolver(
+            lambda task_id: resolver_scope,
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        with scope_log_records(level=logging.ERROR) as records:
             # Gate behavior is unaffected by the logging level: the stale
             # snapshot is still ignored and the resolver's scope wins.
             assert resolve_execution_scope("1") == resolver_scope
-        finally:
-            scope_module.logger.setLevel(original_level)
+        assert records == []
 
     def test_field_diff_still_computed_and_logged_when_warning_is_enabled(self):
         """Positive mirror: with WARNING enabled (the default), the gate's

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -1116,13 +1116,31 @@ class TestResolveExecutionScopeOffTurn:
         with pytest.raises(ExecutionScopeAuthorityError):
             resolve_execution_scope("1")
 
+        # Measured, not assumed: which module instance the function under test
+        # reads its globals from, and whether the hooks this test installed are
+        # the ones it sees. A capture that stays empty while the behavior is
+        # correct means one of these disagrees.
+        fn_globals = resolve_execution_scope_off_turn.__globals__
+        seen = {
+            "fn_module": fn_globals.get("__name__"),
+            "fn_logger_id": id(fn_globals.get("logger")),
+            "fn_resolver": fn_globals.get("_execution_scope_resolver") is not None,
+            "fn_loader": fn_globals.get("_execution_scope_snapshot_loader") is not None,
+        }
+
         with scope_log_records() as records:
             result = resolve_execution_scope_off_turn("1")
+            # Does the same call still disagree at this point in the test?
+            try:
+                resolve_execution_scope("1")
+                seen["second_direct_call"] = "returned"
+            except ExecutionScopeAuthorityError:
+                seen["second_direct_call"] = "raised"
 
         assert result == resolver_scope
         assert any("authority mismatch" in r.getMessage().lower() for r in records), (
-            f"no authority-mismatch record; capture state: "
-            f"{getattr(records, 'diagnostics', None)}"
+            f"no authority-mismatch record; function sees {seen}; "
+            f"capture state: {getattr(records, 'diagnostics', None)}"
         )
 
     def test_other_exceptions_still_propagate(self):

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -601,32 +601,6 @@ class TestExecutionScopeAuthorityErrorInheritance:
     def test_is_a_plain_exception(self):
         assert issubclass(ExecutionScopeAuthorityError, Exception)
 
-    def test_not_folded_by_the_websocket_validation_except_tuple(self):
-        """Reproduces the exact tuple websocket.py catches around the
-        turn-execution path (see
-        TestExecutionScopeResolverContractErrorInheritance's sibling test
-        for the exact line numbers): the resolver's per-turn call to
-        resolve_execution_scope sits inside that same try block, so an
-        authority conflict raised there must fall through this tuple and
-        propagate instead of being reported as a malformed client message."""
-        resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
-        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
-        folded = False
-        try:
-            raise ExecutionScopeAuthorityError(
-                "task-123",
-                resolver_scope=resolver_scope,
-                snapshot_scope=snapshot_scope,
-                mismatched_fields={
-                    "sandbox_key_suffix": ("from-snapshot", "from-resolver")
-                },
-            )
-        except (ValueError, KeyError, TypeError):
-            folded = True
-        except ExecutionScopeAuthorityError:
-            pass
-        assert not folded
-
     def test_str_carries_task_id_and_field_names_never_values(self):
         """``str()`` on this exception ends up in ``task.error_message`` and
         in the client's terminal error event (see this class's docstring for
@@ -657,6 +631,7 @@ class TestExecutionScopeAuthorityErrorInheritance:
                     resolver_scope.workspace_segments,
                 ),
             },
+            resolver_scope_is_authoritative=True,
         )
         message = str(exc)
         assert "task-123" in message
@@ -685,21 +660,11 @@ class TestExecutionScopeResolverContractErrorInheritance:
     def test_not_a_type_error(self):
         assert not issubclass(ExecutionScopeResolverContractError, TypeError)
 
+    def test_not_a_key_error(self):
+        assert not issubclass(ExecutionScopeResolverContractError, KeyError)
+
     def test_is_a_plain_exception(self):
         assert issubclass(ExecutionScopeResolverContractError, Exception)
-
-    def test_not_folded_by_the_websocket_validation_except_tuple(self):
-        """Reproduces the exact tuple websocket.py catches around the
-        turn-execution path (e.g. lines ~5802/5864/7029/7257): the new
-        error must fall through it and propagate."""
-        folded = False
-        try:
-            raise ExecutionScopeResolverContractError("boom")
-        except (ValueError, KeyError, TypeError):
-            folded = True
-        except ExecutionScopeResolverContractError:
-            pass
-        assert not folded
 
 
 class TestExecutionScopeShapeVersionAlignment:
@@ -957,29 +922,46 @@ class TestSnapshotCandidateAuthority:
         assert "sandbox_mount_segments" in exc_info.value.mismatched_fields
 
     @pytest.mark.parametrize(
-        "field_name,snapshot_kwargs",
+        "field_name,resolver_kwargs,snapshot_kwargs",
         [
-            ("sandbox_key_suffix", {"sandbox_key_suffix": "other"}),
-            ("workspace_segments", {"workspace_segments": ("other",)}),
+            ("sandbox_key_suffix", {}, {"sandbox_key_suffix": "other"}),
+            # workspace_segments alone would also move the *effective* mount
+            # (``None`` means "the full segments"), reporting two fields; both
+            # sides pin the mount at the user root so only the segments vary.
+            (
+                "workspace_segments",
+                {"workspace_segments": ("a",), "sandbox_mount_segments": ()},
+                {"workspace_segments": ("b",), "sandbox_mount_segments": ()},
+            ),
             (
                 "sandbox_mount_segments",
+                {
+                    "workspace_segments": ("a", "b"),
+                    "sandbox_mount_segments": ("a", "b"),
+                },
                 {
                     "workspace_segments": ("a", "b"),
                     "sandbox_mount_segments": ("a",),
                 },
             ),
-            ("memory_dimensions", {"memory_dimensions": {"k": "v"}}),
-            ("isolate_external_dirs", {"isolate_external_dirs": True}),
+            ("memory_dimensions", {}, {"memory_dimensions": {"k": "v"}}),
+            ("isolate_external_dirs", {}, {"isolate_external_dirs": True}),
         ],
     )
-    def test_namespace_field_mismatch_fails_the_turn(self, field_name, snapshot_kwargs):
-        resolver_scope = ExecutionScope()
+    def test_namespace_field_mismatch_fails_the_turn(
+        self, field_name, resolver_kwargs, snapshot_kwargs
+    ):
+        """Each case varies exactly one namespace field, so the reported
+        mismatch set pins that field alone rather than merely containing it --
+        a diff loop that dropped a field would otherwise still pass on a case
+        whose second, incidentally-varied field kept the set non-empty."""
+        resolver_scope = ExecutionScope(**resolver_kwargs)
         snapshot_scope = ExecutionScope(**snapshot_kwargs)
         self._register(lambda task_id: resolver_scope, lambda task_id: snapshot_scope)
 
         with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
             resolve_execution_scope("1")
-        assert field_name in exc_info.value.mismatched_fields
+        assert set(exc_info.value.mismatched_fields) == {field_name}
         assert exc_info.value.resolver_scope == resolver_scope
         assert exc_info.value.snapshot_scope == snapshot_scope
 
@@ -1103,6 +1085,72 @@ class TestSnapshotCandidateAuthority:
             "policy-only mismatch" in r and "strict_memory_isolation" in r
             for r in records
         )
+
+    def test_defer_policy_overlay_keeps_the_snapshot_narrowed_namespace(self):
+        """The policy overlay must be applied *onto the snapshot*, not
+        satisfied by returning the fallback. Here the snapshot legitimately
+        narrows the fallback's namespace and also disagrees on policy: both
+        halves have to survive, so the resolved scope is the snapshot's
+        namespace carrying the fallback's policy value. Returning
+        ``fallback`` instead would silently throw the narrowing away, which
+        every all-default-namespace policy test is blind to."""
+        fallback = ExecutionScope(
+            workspace_segments=("tenant-a",), strict_memory_isolation=True
+        )
+        snapshot_scope = ExecutionScope(
+            workspace_segments=("tenant-a", "sub"), strict_memory_isolation=False
+        )
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot_scope,
+        )
+
+        result = resolve_execution_scope("1")
+        assert result.workspace_segments == ("tenant-a", "sub")
+        assert result.strict_memory_isolation is True
+
+    def test_defer_every_policy_field_is_taken_from_the_fallback(self, monkeypatch):
+        """Generic over ``_EXECUTION_SCOPE_POLICY_FIELDS``: the abstention
+        branch must compare and carry over every field the table lists, not a
+        field it names literally. With one policy field in production those
+        two implementations are indistinguishable, so this reclassifies a
+        second real field into the policy bucket for the duration of the test
+        and checks that it is honoured too.
+        """
+        from xagent.core import execution_scope as scope_module
+
+        borrowed = "isolate_external_dirs"
+        monkeypatch.setattr(
+            scope_module,
+            "_EXECUTION_SCOPE_NAMESPACE_FIELDS",
+            tuple(
+                name
+                for name in scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS
+                if name != borrowed
+            ),
+        )
+        monkeypatch.setattr(
+            scope_module,
+            "_EXECUTION_SCOPE_POLICY_FIELDS",
+            scope_module._EXECUTION_SCOPE_POLICY_FIELDS + (borrowed,),
+        )
+        policy_fields = scope_module._EXECUTION_SCOPE_POLICY_FIELDS
+        assert len(policy_fields) > 1
+
+        fallback = ExecutionScope(strict_memory_isolation=True, **{borrowed: True})
+        snapshot_scope = ExecutionScope(
+            strict_memory_isolation=False, **{borrowed: False}
+        )
+        self._register(
+            lambda task_id: defer_to_snapshot(fallback),
+            lambda task_id: snapshot_scope,
+        )
+
+        with scope_log_records() as records:
+            result = resolve_execution_scope("1")
+        for name in policy_fields:
+            assert getattr(result, name) == getattr(fallback, name), name
+            assert any("policy-only mismatch" in r and name in r for r in records), name
 
     def test_defer_current_shape_version_snapshot_is_used_not_shape_gated(self):
         """The positive mirror of
@@ -1397,27 +1445,39 @@ class TestDeferSnapshotAllDefaultFallback:
             "memory_dimensions",
         }
 
-    def test_all_default_fallback_accepts_only_an_equal_snapshot(self):
+    def test_all_default_fallback_accepts_an_equal_snapshot(self):
+        """The permissive half: an all-default snapshot introduces no scoping,
+        so it passes the identity rule and is what gets returned.
+
+        Asserted by identity, not equality: an all-default fallback and an
+        all-default snapshot compare equal, so ``== fallback`` would hold
+        whichever of the two the function returned -- and would keep holding
+        if the snapshot were rejected or shape-gated away. ``is snapshot``
+        distinguishes the accept path from both."""
         fallback = ExecutionScope()
         snapshot = ExecutionScope()
+        assert snapshot is not fallback
         set_execution_scope_resolver(
             lambda task_id: defer_to_snapshot(fallback),
             acknowledges_snapshot_candidate_contract=True,
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot)
-        assert resolve_execution_scope("1") == fallback
+        assert resolve_execution_scope("1") is snapshot
 
 
 class TestDeferSnapshotDefinesNamespaceOptIn:
     """``defer_to_snapshot(fallback, snapshot_defines_namespace=True)``: the
     resolver states it does not own this task and the persisted snapshot is
     the intended namespace authority (the workforce/delegated-task shape).
-    An all-default ``fallback`` cannot itself claim a namespace -- if the
+    A conforming ``fallback`` claims no namespace of its own -- if the
     resolver knew the namespace it would return an authoritative
-    ``ExecutionScope`` instead of deferring -- so the strict narrowing rule
-    in ``TestDeferSnapshotAllDefaultFallback`` above must be skippable for
-    namespace fields on this opt-in, while everything else (type check,
-    shape-version gate, mandatory fallback, policy symmetry) still applies.
+    ``ExecutionScope`` instead of deferring -- which is enforced at
+    construction, so the strict narrowing rule in
+    ``TestDeferSnapshotAllDefaultFallback`` above has nothing left to protect
+    and is skipped for namespace fields here. Everything else still applies:
+    the type check, the mandatory fallback, policy symmetry, and the
+    newer-shape half of the version gate. Only the older-shape half is
+    relaxed, since this branch compares nothing.
     """
 
     def test_opt_in_with_all_default_fallback_uses_snapshot_verbatim(self):
@@ -1463,25 +1523,20 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             "memory_dimensions",
         }
 
-    def test_opt_in_skips_the_shape_version_gate_snapshot_data_survives(self):
-        """The shape-version gate exists to protect a *comparison*: it
-        guards the default (narrowing) abstention branch and the
-        authoritative branch, both of which compare the snapshot against
-        something. The opt-in branch never compares -- it uses the
-        snapshot verbatim -- so there is nothing for the gate to protect
-        here, and a pre-existing (unversioned) snapshot's real data must
-        survive rather than being silently discarded back to the fallback.
-        This was previously pinned the other way (discarding real data as
-        "correct"), which is exactly the de-scoping bug this test now
-        proves is fixed: an unversioned workforce sub-task snapshot must
-        not be de-scoped just because it predates the version field."""
+    def test_opt_in_accepts_an_older_shape_snapshot_and_keeps_its_data(self):
+        """The older half of the asymmetric shape gate. Every field an
+        older-shape snapshot carries is decodable here and the ones it lacks
+        take current defaults, so the only thing its version breaks is a
+        field-by-field comparison -- and this branch performs none. Gating it
+        away would de-scope a workforce sub-task purely because its snapshot
+        predates the version field."""
         fallback = ExecutionScope()
-        stale_data = ExecutionScope(
-            sandbox_key_suffix="stale", workspace_segments=("workforce", "task-7")
+        older_data = ExecutionScope(
+            sandbox_key_suffix="older", workspace_segments=("workforce", "task-7")
         ).to_dict()
-        del stale_data["version"]
-        stale_snapshot = ExecutionScope.from_dict(stale_data)
-        assert stale_snapshot.version == 0
+        del older_data["version"]
+        older_snapshot = ExecutionScope.from_dict(older_data)
+        assert older_snapshot.version == 0
 
         set_execution_scope_resolver(
             lambda task_id: defer_to_snapshot(
@@ -1489,15 +1544,57 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
             ),
             acknowledges_snapshot_candidate_contract=True,
         )
-        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
-        assert resolve_execution_scope("1") == stale_snapshot
+        set_execution_scope_snapshot_loader(lambda task_id: older_snapshot)
+        assert resolve_execution_scope("1") == older_snapshot
+
+    def test_opt_in_still_refuses_a_newer_shape_snapshot(self):
+        """The newer half, which the opt-in does *not* relax.
+        ``from_dict`` drops keys this shape does not know, so a snapshot
+        written by a newer process arrives partially decoded -- possibly with
+        a namespace-narrowing field gone -- and "used verbatim" would mean
+        activating that truncated namespace. ``to_dict`` then stamps the
+        current constant, so accepting it would also re-persist the
+        truncation as if it were current."""
+        fallback = ExecutionScope()
+        newer_data = ExecutionScope(
+            sandbox_key_suffix="newer", workspace_segments=("workforce", "task-7")
+        ).to_dict()
+        newer_data["version"] = EXECUTION_SCOPE_SHAPE_VERSION + 1
+        newer_data["a_field_this_shape_does_not_know"] = "dropped-on-decode"
+        newer_snapshot = ExecutionScope.from_dict(newer_data)
+        assert newer_snapshot.version == EXECUTION_SCOPE_SHAPE_VERSION + 1
+
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: newer_snapshot)
+        with scope_log_records() as records:
+            assert resolve_execution_scope("1") == fallback
+        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
+
+    def test_default_abstention_path_refuses_a_newer_shape_snapshot(self):
+        """The same newer-shape refusal on the comparing abstention path,
+        where the fallback's own namespace is what the snapshot would have
+        had to narrow."""
+        fallback = ExecutionScope(workspace_segments=("tenant-a",))
+        newer_data = ExecutionScope(workspace_segments=("tenant-a", "sub")).to_dict()
+        newer_data["version"] = EXECUTION_SCOPE_SHAPE_VERSION + 1
+        newer_snapshot = ExecutionScope.from_dict(newer_data)
+
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: newer_snapshot)
+        assert resolve_execution_scope("1") == fallback
 
     def test_opt_in_still_type_gates_a_non_scope_snapshot(self):
-        """The shape-version gate is skipped on the opt-in branch, but the
-        type check is not -- a candidate that isn't even an ExecutionScope
-        still raises, opt-in or not (see also
-        test_opt_in_does_not_bypass_the_type_check below, which reproduces
-        the same rule via the snapshot loader instead of from_dict)."""
+        """The older-shape relaxation does not extend to the type check -- a
+        candidate that isn't even an ExecutionScope still raises, opt-in or
+        not."""
         fallback = ExecutionScope()
         set_execution_scope_resolver(
             lambda task_id: defer_to_snapshot(
@@ -1509,41 +1606,91 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         with pytest.raises(ExecutionScopeResolverContractError):
             resolve_execution_scope("1")
 
-    def test_gate_still_applies_on_the_default_abstention_comparing_path(self):
-        """Mirror of the opt-in case above: without the opt-in, the
-        abstention branch narrows against ``fallback`` -- a comparison --
-        so the shape-version gate still applies and a stale snapshot is
-        still ignored. (Same behavior as
-        test_defer_stale_version_snapshot_is_ignored_falls_back; restated
-        here to sit next to the opt-in test for contrast.)"""
-        fallback = ExecutionScope(sandbox_key_suffix="fallback")
-        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
-        del stale_data["version"]
-        stale_snapshot = ExecutionScope.from_dict(stale_data)
-        assert stale_snapshot.version == 0
-
-        set_execution_scope_resolver(
-            lambda task_id: defer_to_snapshot(fallback),
-            acknowledges_snapshot_candidate_contract=True,
+    def test_opt_in_rejects_a_namespace_committed_fallback_at_construction(self):
+        """The opt-in's precondition is machine-checked, not prose. This
+        branch hands the namespace to the snapshot verbatim, so a fallback
+        that already committed to one would have it *replaced* rather than
+        treated as a floor -- silent de-tenanting. A resolver that knows the
+        namespace must return an authoritative scope instead of deferring,
+        so the carrier refuses to exist."""
+        committed = ExecutionScope(
+            sandbox_key_suffix="tenant-a",
+            workspace_segments=("tenant-a",),
+            memory_dimensions={"tenant": "a"},
         )
-        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
-        with scope_log_records() as records:
-            assert resolve_execution_scope("1") == fallback
-        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            defer_to_snapshot(committed, snapshot_defines_namespace=True)
+        message = str(exc_info.value)
+        for name in ("sandbox_key_suffix", "workspace_segments", "memory_dimensions"):
+            assert name in message
+        # The same pair is accepted without the opt-in, where the snapshot is
+        # held to the narrowing rule instead: it is the flag that is refused,
+        # not the fallback.
+        assert defer_to_snapshot(committed).fallback == committed
 
-    def test_opt_in_does_not_bypass_the_type_check(self):
-        """A snapshot loader that returns a non-ExecutionScope candidate
-        still raises the contract error, opt-in or not."""
-        fallback = ExecutionScope()
+    @pytest.mark.parametrize(
+        "field_name,committed_kwargs",
+        [
+            ("sandbox_key_suffix", {"sandbox_key_suffix": "tenant-a"}),
+            ("workspace_segments", {"workspace_segments": ("tenant-a",)}),
+            (
+                "sandbox_mount_segments",
+                {
+                    "workspace_segments": ("tenant-a",),
+                    "sandbox_mount_segments": ("tenant-a",),
+                },
+            ),
+            ("memory_dimensions", {"memory_dimensions": {"tenant": "a"}}),
+            ("isolate_external_dirs", {"isolate_external_dirs": True}),
+        ],
+    )
+    def test_opt_in_rejects_a_commitment_on_any_single_namespace_field(
+        self, field_name, committed_kwargs
+    ):
+        """Per-field, so the precondition cannot be satisfied by checking only
+        the obvious fields. Each case commits exactly one field of the
+        fallback (the mount case necessarily carries the workspace segments
+        it must prefix, and reports both)."""
+        with pytest.raises(ExecutionScopeResolverContractError) as exc_info:
+            defer_to_snapshot(
+                ExecutionScope(**committed_kwargs), snapshot_defines_namespace=True
+            )
+        assert field_name in str(exc_info.value)
+
+    def test_opt_in_with_a_policy_only_fallback_is_accepted(self):
+        """Policy fields are not part of the precondition: the fallback still
+        owns those on this branch (see
+        test_opt_in_still_honours_policy_field_symmetry), so committing one
+        must not be mistaken for claiming a namespace."""
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        carrier = defer_to_snapshot(fallback, snapshot_defines_namespace=True)
+        assert carrier.snapshot_defines_namespace is True
+        assert carrier.fallback == fallback
+
+    def test_opt_in_with_a_conforming_fallback_and_a_present_snapshot(self):
+        """The whole conforming shape end to end: a fallback that claims no
+        namespace but does set a policy field, plus a present snapshot that
+        supplies the namespace. The snapshot's namespace is adopted and the
+        fallback's policy value is kept."""
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        snapshot = ExecutionScope(
+            sandbox_key_suffix="workforce-task",
+            workspace_segments=("workforce", "task-7"),
+            memory_dimensions={"tenant": "acme"},
+        )
         set_execution_scope_resolver(
             lambda task_id: defer_to_snapshot(
                 fallback, snapshot_defines_namespace=True
             ),
             acknowledges_snapshot_candidate_contract=True,
         )
-        set_execution_scope_snapshot_loader(lambda task_id: {"not": "a scope"})
-        with pytest.raises(ExecutionScopeResolverContractError):
-            resolve_execution_scope("1")
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+
+        result = resolve_execution_scope("1")
+        assert result.sandbox_key_suffix == "workforce-task"
+        assert result.workspace_segments == ("workforce", "task-7")
+        assert dict(result.memory_dimensions) == {"tenant": "acme"}
+        assert result.strict_memory_isolation is True
 
     def test_opt_in_still_honours_policy_field_symmetry(self):
         """Namespace fields agree (both all-default), only
@@ -1572,11 +1719,15 @@ class TestDeferSnapshotDefinesNamespaceOptIn:
         """The opt-in changes what a present snapshot is checked against,
         not whether a fallback is required at all: ``defer_to_snapshot``
         still rejects a non-ExecutionScope fallback even with the flag set,
-        and the mandatory fallback still applies on a snapshot miss."""
+        and the mandatory fallback still applies on a snapshot miss.
+
+        The fallback here commits no namespace (the opt-in's precondition) but
+        does set a policy field, which keeps it distinguishable from the
+        all-default scope an unscoped resolution would return."""
         with pytest.raises(TypeError):
             defer_to_snapshot("not-a-scope", snapshot_defines_namespace=True)
 
-        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        fallback = ExecutionScope(strict_memory_isolation=True)
         set_execution_scope_resolver(
             lambda task_id: defer_to_snapshot(
                 fallback, snapshot_defines_namespace=True
@@ -1726,33 +1877,42 @@ class TestExecutionScopeAbstentionMismatchErrorIsDistinguishable:
             ExecutionScopeAbstentionMismatchError, ExecutionScopeAuthorityError
         )
 
-    def test_base_class_except_clause_still_catches_it(self):
-        """A caller that widens its except clause to the base class (rather
-        than special-casing the subclass) still catches it -- the subclass
-        only prevents *accidental* downgrading via a bare ``except
-        ExecutionScopeAuthorityError`` that assumes ``resolver_scope`` is
-        always authoritative; it does not make the mismatch uncatchable."""
-        caught = None
-        try:
-            raise ExecutionScopeAbstentionMismatchError(
-                "task-1",
-                resolver_scope=ExecutionScope(),
-                snapshot_scope=ExecutionScope(sandbox_key_suffix="x"),
-                mismatched_fields={"sandbox_key_suffix": ("x", None)},
-            )
-        except ExecutionScopeAuthorityError as exc:
-            caught = exc
-        assert isinstance(caught, ExecutionScopeAbstentionMismatchError)
+    def test_abstention_raise_site_declares_no_authoritative_value(self):
+        """The attribute, not the class, is what blocks the off-turn
+        downgrade (see ``resolve_execution_scope_off_turn``), so the
+        abstention branch's raise site must declare ``False`` for it."""
+        fallback = ExecutionScope()
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(
+            lambda task_id: ExecutionScope(sandbox_key_suffix="attacker-chosen")
+        )
+        with pytest.raises(ExecutionScopeAbstentionMismatchError) as exc_info:
+            resolve_execution_scope("1")
+        assert exc_info.value.resolver_scope_is_authoritative is False
+
+    def test_authoritative_raise_site_declares_an_authoritative_value(self):
+        """The mirror: the branch that really has an answer says so, which is
+        what licenses the off-turn downgrade."""
+        resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
+        set_execution_scope_resolver(
+            lambda task_id: resolver_scope,
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(
+            lambda task_id: ExecutionScope(sandbox_key_suffix="from-snapshot")
+        )
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert exc_info.value.resolver_scope_is_authoritative is True
 
 
 class TestDeferCarrierNeverActivated:
     """The carrier is never mistaken for a real scope, and the turn
     contextvar only ever holds the resolved fallback/snapshot, never the
     carrier itself."""
-
-    def test_carrier_is_not_an_execution_scope_instance(self):
-        carrier = defer_to_snapshot(ExecutionScope())
-        assert isinstance(carrier, ExecutionScope) is False
 
     def test_turn_activates_the_fallback_not_the_carrier(self):
         fallback = ExecutionScope(sandbox_key_suffix="fallback")
@@ -1765,31 +1925,6 @@ class TestDeferCarrierNeverActivated:
             current = get_execution_scope()
             assert isinstance(current, ExecutionScope)
             assert isinstance(current, DeferToSnapshot) is False
-
-
-class TestScopeFingerprintCoversIsolateExternalDirs:
-    """(#296) ``isolate_external_dirs`` is baked into the
-    cached ``AgentService``'s ``Workspace.allowed_external_dirs`` at build
-    time (see ``AgentServiceManager.get_agent_for_task`` ->
-    ``_build_allowed_external_dirs``), so an isolate_external_dirs-only
-    change must change the fingerprint or the cache never evicts and the
-    stale allowed-dirs list keeps being enforced."""
-
-    def test_isolate_external_dirs_only_change_changes_the_fingerprint(self):
-        base = ExecutionScope(workspace_segments=("tenant-a",))
-        isolated = ExecutionScope(
-            workspace_segments=("tenant-a",), isolate_external_dirs=True
-        )
-        assert scope_fingerprint(base) != scope_fingerprint(isolated)
-
-    def test_strict_memory_isolation_only_change_does_not_change_the_fingerprint(
-        self,
-    ):
-        """Read fresh from the contextvar on every memory operation
-        (``UserIsolatedMemoryStore``); nothing cached here goes stale."""
-        relaxed = ExecutionScope(strict_memory_isolation=False)
-        strict = ExecutionScope(strict_memory_isolation=True)
-        assert scope_fingerprint(relaxed) == scope_fingerprint(strict)
 
 
 class TestExecutionScopeFieldClassificationCompleteness:
@@ -1876,11 +2011,22 @@ _POLICY_FIELD_FINGERPRINT_PROBES: dict[str, tuple[dict, dict]] = {
 
 
 class TestScopeFingerprintFieldCoverage:
-    """Behavior-derived replacement for the set-comparison-only test above:
+    """Behavior-derived counterpart to the set-comparison-only test above:
     calls ``scope_fingerprint()`` itself, per field, rather than comparing
     two hand-maintained collections against each other. Reverting
     ``scope_fingerprint()`` to drop any namespace field's contribution fails
     the corresponding parametrized case here directly.
+
+    Why each bucket matters to the fingerprint: a namespace field is baked
+    into per-task cached state at build time -- ``isolate_external_dirs``, for
+    instance, into the cached ``AgentService``'s
+    ``Workspace.allowed_external_dirs`` via
+    ``AgentServiceManager.get_agent_for_task`` ->
+    ``_build_allowed_external_dirs`` -- so a change there must evict the cache
+    or the stale value keeps being enforced. A policy field like
+    ``strict_memory_isolation`` is read fresh from the contextvar on every
+    operation (``UserIsolatedMemoryStore``), so nothing cached goes stale and
+    including it would only cause needless rebuilds.
     """
 
     def test_probes_cover_exactly_the_classified_fields(self):

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -2403,3 +2403,68 @@ class TestPersistedAgentConfigRejectsADecodedScope:
             )
             == scope
         )
+
+
+class TestWrongTypedSnapshotIsCorruptNotAbsent:
+    """A present ``execution_scope`` that is not a mapping cannot be decoded,
+    exactly like a mapping with an invalid field. Reporting "no candidate" for
+    one shape and raising for the other would make the same accidental
+    namespace decision on every branch where the snapshot is the only
+    authority."""
+
+    @pytest.mark.parametrize("value", ["garbage-string", ["a"], 5, True])
+    def test_present_but_wrong_typed_raises(self, value):
+        with pytest.raises(ExecutionScopeResolverContractError):
+            execution_scope_from_agent_config({EXECUTION_SCOPE_AGENT_CONFIG_KEY: value})
+
+    def test_absent_key_is_still_absent(self):
+        assert execution_scope_from_agent_config({"other": 1}) is None
+
+    def test_explicit_null_is_still_absent(self):
+        assert (
+            execution_scope_from_agent_config({EXECUTION_SCOPE_AGENT_CONFIG_KEY: None})
+            is None
+        )
+
+    def test_wrong_typed_snapshot_fails_the_abstention_branch(self):
+        """The branch where "absent" would resolve to the abstention's
+        fallback -- the widest value the narrowing check would ever admit."""
+        set_execution_scope_resolver(
+            lambda task_id: DeferToSnapshot(fallback=ExecutionScope()),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope(
+                "1",
+                persisted_agent_config={
+                    EXECUTION_SCOPE_AGENT_CONFIG_KEY: "garbage-string"
+                },
+            )
+
+
+class TestDecodedScopeGuardRunsBeforeBranchDispatch:
+    """The guard rejects a caller bug, so which resolver happens to be
+    registered must not decide whether it is heard. The authoritative branch
+    wraps its snapshot load in a tolerant except -- so a bad candidate cannot
+    veto a real answer -- and a raise from inside that wrapper would be
+    absorbed and misreported as a loader failure."""
+
+    def test_raises_with_an_authoritative_resolver_registered(self):
+        set_execution_scope_resolver(
+            lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope(
+                "1", persisted_agent_config=ExecutionScope(sandbox_key_suffix="s")
+            )
+
+    def test_raises_when_the_resolver_abstains(self):
+        set_execution_scope_resolver(
+            lambda task_id: DeferToSnapshot(fallback=ExecutionScope()),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope(
+                "1", persisted_agent_config=ExecutionScope(sandbox_key_suffix="s")
+            )

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -911,6 +911,38 @@ class TestSnapshotCandidateAuthority:
         )
         assert resolve_execution_scope("1") == self.RESOLVER_SCOPE
 
+    def test_mount_authority_compares_effective_value_not_raw_field(self):
+        """A resolver-built scope that leaves the mount at its default
+        (``None``, meaning the full ``workspace_segments``) and a snapshot
+        that explicitly repeats those same segments as its mount select the
+        identical mount -- only the raw ``sandbox_mount_segments`` attribute
+        differs (``None`` vs. an explicit tuple), not the namespace value.
+        Comparing the raw attribute here would be a false-positive authority
+        conflict: a client-supplied snapshot that happens to spell out the
+        workspace segments as its mount must not fail an otherwise-identical
+        turn. A snapshot whose mount genuinely covers different segments
+        must still raise."""
+        resolver_scope = ExecutionScope(workspace_segments=("a",))
+        same_effective_mount_snapshot = ExecutionScope(
+            workspace_segments=("a",), sandbox_mount_segments=("a",)
+        )
+        self._register(
+            lambda task_id: resolver_scope,
+            lambda task_id: same_effective_mount_snapshot,
+        )
+        assert resolve_execution_scope("1") == resolver_scope
+
+        different_effective_mount_snapshot = ExecutionScope(
+            workspace_segments=("a", "b"), sandbox_mount_segments=("a",)
+        )
+        self._register(
+            lambda task_id: ExecutionScope(workspace_segments=("a", "b")),
+            lambda task_id: different_effective_mount_snapshot,
+        )
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert "sandbox_mount_segments" in exc_info.value.mismatched_fields
+
     @pytest.mark.parametrize(
         "field_name,snapshot_kwargs",
         [
@@ -1574,17 +1606,6 @@ class TestExecutionScopeFieldClassificationCompleteness:
     being misclassified into either one.
     """
 
-    def test_every_field_is_classified_as_namespace_policy_or_version(self):
-        from xagent.core import execution_scope as scope_module
-
-        field_names = {f.name for f in dataclasses.fields(ExecutionScope)}
-        classified = (
-            set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS)
-            | set(scope_module._EXECUTION_SCOPE_POLICY_FIELDS)
-            | {"version"}
-        )
-        assert classified == field_names
-
     def test_namespace_field_classification_is_complete_and_disjoint_from_policy(
         self,
     ):
@@ -1611,14 +1632,23 @@ class TestExecutionScopeFieldClassificationCompleteness:
 # so TestScopeFingerprintFieldCoverage can assert this dict's keys track
 # _EXECUTION_SCOPE_NAMESPACE_FIELDS exactly -- a namespace field added
 # without a probe here fails loudly instead of being silently skipped.
+# The ``sandbox_mount_segments`` probe holds ``workspace_segments`` fixed
+# across both sides and varies only the mount, so the fingerprint difference
+# it exercises comes from the mount slot alone. It does not, by itself, prove
+# ``scope_fingerprint`` reads the *derived* mount value rather than the raw
+# field -- see ``test_mount_fingerprint_reads_the_effective_value_not_the_raw_field``
+# below for the probe that actually pins that.
 _NAMESPACE_FIELD_FINGERPRINT_PROBES: dict[str, tuple[dict, dict]] = {
     "sandbox_key_suffix": ({}, {"sandbox_key_suffix": "probe-suffix"}),
     "workspace_segments": ({}, {"workspace_segments": ("probe",)}),
     "sandbox_mount_segments": (
-        {"workspace_segments": ("probe", "deep")},
         {
             "workspace_segments": ("probe", "deep"),
             "sandbox_mount_segments": ("probe",),
+        },
+        {
+            "workspace_segments": ("probe", "deep"),
+            "sandbox_mount_segments": None,
         },
     ),
     "memory_dimensions": ({}, {"memory_dimensions": {"k": "v"}}),
@@ -1667,3 +1697,32 @@ class TestScopeFingerprintFieldCoverage:
         base = ExecutionScope(**base_kwargs)
         changed = ExecutionScope(**changed_kwargs)
         assert scope_fingerprint(base) == scope_fingerprint(changed)
+
+    def test_mount_fingerprint_reads_the_effective_value_not_the_raw_field(self):
+        """The ``!=`` probe above cannot tell a correct (derived) mount read
+        apart from a regression to the raw ``sandbox_mount_segments``
+        attribute: whenever the two probe scopes' raw mount values differ --
+        as they must, to make the mount the only varying input -- a
+        raw-reading ``scope_fingerprint`` also reports a difference, so that
+        assertion passes under either implementation. This test uses the
+        one pair that actually depends on which value is read: a scope left
+        at the mount's default (``None``, meaning the full
+        ``workspace_segments``) and a scope whose mount explicitly repeats
+        those same segments have equal *effective* mounts but different
+        *raw* ones, so their fingerprints must match only if
+        ``scope_fingerprint`` reads ``effective_mount_segments``."""
+        default_mount = ExecutionScope(workspace_segments=("a",))
+        explicit_full_mount = ExecutionScope(
+            workspace_segments=("a",), sandbox_mount_segments=("a",)
+        )
+        assert (
+            default_mount.sandbox_mount_segments
+            != explicit_full_mount.sandbox_mount_segments
+        )
+        assert (
+            default_mount.effective_mount_segments
+            == explicit_full_mount.effective_mount_segments
+        )
+        assert scope_fingerprint(default_mount) == scope_fingerprint(
+            explicit_full_mount
+        )

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -83,12 +83,13 @@ def scope_log_records(level: int = logging.WARNING):
             self.records.append(msg % args if args else msg)
             self._wrapped.error(msg, *args, **kwargs)
 
-        def __getattr__(self, name: str) -> object:
-            # Deliberately does not cover ``isEnabledFor``: delegating that to
-            # the wrapped logger would put the ambient level and the global
-            # disable threshold back in charge of what the code under test
-            # does, which is what this helper exists to avoid.
-            return getattr(self._wrapped, name)
+        # There is deliberately no ``__getattr__`` delegating the rest to the
+        # wrapped logger. ``isEnabledFor`` must not be delegated -- that would
+        # put the ambient level and the process-wide disable threshold back in
+        # charge of what the code under test does, which is the whole reason
+        # this helper exists -- and modelling exactly the levels the module
+        # logs at means a newly introduced level surfaces as a loud
+        # ``AttributeError`` instead of a silently unrecorded call.
 
     # The function's own globals: the binding it resolves `logger` against at
     # call time, whichever module instance that turns out to be.

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -61,7 +61,13 @@ def scope_log_records(level: int = logging.WARNING):
     # more than one name, and a handler bound by name would then watch a logger
     # nothing writes to.
     logger = scope_module.logger
-    records: list[logging.LogRecord] = []
+
+    class _Records(list):
+        """A list that can carry the diagnostics a failure needs."""
+
+        diagnostics: dict[str, object] = {}
+
+    records: list[logging.LogRecord] = _Records()
 
     class _Collect(logging.Handler):
         def emit(self, record: logging.LogRecord) -> None:
@@ -81,6 +87,17 @@ def scope_log_records(level: int = logging.WARNING):
     try:
         yield records
     finally:
+        # Snapshot what decided whether a record could exist at all, so a
+        # failing assertion reports the reason instead of an empty list.
+        records.diagnostics = {  # type: ignore[attr-defined]
+            "logger": logger.name,
+            "logger_id": id(logger),
+            "effective_level": logger.getEffectiveLevel(),
+            "manager_disable": logging.root.manager.disable,
+            "handlers": [type(h).__name__ for h in logger.handlers],
+            "propagate": logger.propagate,
+            "captured": [r.getMessage() for r in records],
+        }
         logger.removeHandler(handler)
         logger.setLevel(previous_level)
         logging.disable(previous_disable)
@@ -1103,7 +1120,10 @@ class TestResolveExecutionScopeOffTurn:
             result = resolve_execution_scope_off_turn("1")
 
         assert result == resolver_scope
-        assert any("authority mismatch" in r.getMessage().lower() for r in records)
+        assert any("authority mismatch" in r.getMessage().lower() for r in records), (
+            f"no authority-mismatch record; capture state: "
+            f"{getattr(records, 'diagnostics', None)}"
+        )
 
     def test_other_exceptions_still_propagate(self):
         def boom(task_id):

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -746,7 +746,7 @@ class TestExecutionScopeShapeVersionAlignment:
 
 
 class TestFromDictUntrustedFieldCoercion:
-    """FIX 3: ``from_dict`` decodes a mapping that can originate in a
+    """``from_dict`` decodes a mapping that can originate in a
     client-influenceable ``Task.agent_config`` (see
     :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`), so every field it reads must
     be coerced defensively -- never a raw ``int()``/``tuple()``/``dict()``
@@ -1186,8 +1186,8 @@ class TestSnapshotCandidateAuthority:
         assert resolve_execution_scope("1") == snapshot_scope
 
     def test_defer_snapshot_policy_only_disagreement_fallback_wins(self):
-        """FIX 2 coverage: on the abstention branch, the namespace fields
-        agree (both all-default -- no narrowing violation), but
+        """On the abstention branch, the namespace fields agree (both
+        all-default -- no narrowing violation), but
         strict_memory_isolation differs. The fallback plays the
         authoritative role here, so its policy value must win, logged, the
         same way the resolver's policy value wins on the authoritative
@@ -1390,8 +1390,8 @@ class TestSnapshotCandidateAuthority:
             # any dimension, so introducing scoping the fallback never
             # committed to is rejected even though, taken alone, it would
             # look like a narrowing (null -> set; False -> True). See
-            # TestDeferSnapshotAllDefaultFallback for the combined-fields
-            # reproduction of the original vacuous-predicate report.
+            # TestDeferSnapshotAllDefaultFallback for the case that varies
+            # every field of such a fallback at once.
             ("sandbox_key_suffix", {}, {"sandbox_key_suffix": "attacker-chosen"}),
             ("isolate_external_dirs", {}, {"isolate_external_dirs": True}),
         ],
@@ -1525,24 +1525,24 @@ class TestSnapshotCandidateAuthority:
 
 
 class TestDeferSnapshotAllDefaultFallback:
-    """FIX for the vacuous-narrowing report: every per-field narrowing check
-    in ``_execution_scope_narrowing_violations`` used to be evaluated purely
-    relative to the fallback's own value, so it was trivially satisfied by
-    any snapshot value once the fallback's field sat at that field's own
-    no-scoping default -- an all-default ``ExecutionScope()`` fallback (the
-    natural value for a resolver with "no opinion" on a task) made every
-    check pass regardless of the snapshot. The fixed rule: a field at its
-    own identity default admits no narrowing, only an exact match, because
-    there is no scoping there for the snapshot to narrow into.
+    """A namespace field sitting at its own identity default admits no
+    narrowing, only an exact match: there is no scoping there for a snapshot
+    to narrow into.
+
+    This is what a purely relative per-field test cannot express. Evaluated
+    only against the fallback's own value, every narrowing relation is
+    vacuously satisfied once that value is the field's no-scoping default --
+    so an all-default ``ExecutionScope()`` fallback, the natural value for a
+    resolver with no opinion on a task, would accept any snapshot at all.
     """
 
     def test_all_default_fallback_rejects_a_snapshot_widening_every_field_at_once(
         self,
     ):
-        """Reproduces the original report's proof-of-concept: a fully
-        unscoped fallback plus a snapshot that sets every namespace field
-        simultaneously. Every field is out-of-authority for this fallback,
-        so all five must be reported."""
+        """The worst case for a vacuous predicate: a fully unscoped fallback
+        plus a snapshot that sets every namespace field simultaneously. Every
+        field is out-of-authority for this fallback, so all five must be
+        reported."""
         fallback = ExecutionScope()
         snapshot = ExecutionScope(
             sandbox_key_suffix="attacker-chosen",
@@ -2119,12 +2119,10 @@ class TestExecutionScopeFieldClassificationCompleteness:
         self,
     ):
         """Static classification-completeness check only -- this does not
-        call ``scope_fingerprint`` at all. Real per-field fingerprint
-        behavior is covered by ``TestScopeFingerprintFieldCoverage`` below,
-        which does call it. (Renamed from the former
-        ``test_fingerprint_tracks_exactly_the_namespace_fields``: that name
-        claimed fingerprint coverage that a set-vs-hardcoded-set comparison
-        never exercised.)"""
+        call ``scope_fingerprint`` at all, so it claims no fingerprint
+        coverage: a set-vs-set comparison cannot exercise one. Real per-field
+        fingerprint behavior is covered by
+        ``TestScopeFingerprintFieldCoverage`` below, which does call it."""
         from xagent.core import execution_scope as scope_module
 
         namespace_fields = set(scope_module._EXECUTION_SCOPE_NAMESPACE_FIELDS)

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 import pytest
 
 from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_AGENT_CONFIG_KEY,
     EXECUTION_SCOPE_SHAPE_VERSION,
     DeferToSnapshot,
     ExecutionScope,
@@ -2353,3 +2354,27 @@ class TestScopeFingerprintFieldCoverage:
         assert scope_fingerprint(default_mount) == scope_fingerprint(
             explicit_full_mount
         )
+
+
+class TestAuthorityMismatchNamesItsRemediation:
+    """The mismatch is stable, so every turn of the task fails the same way
+    until the persisted snapshot is removed or corrected. The operator-facing
+    log has to say that, because the snapshot sits in a column no request path
+    offers to clear and a bare repeating failure states no way out."""
+
+    def test_error_log_names_the_key_to_clear(self):
+        resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
+        snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
+        set_execution_scope_resolver(
+            lambda task_id: resolver_scope,
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
+
+        with scope_log_records() as records:
+            with pytest.raises(ExecutionScopeAuthorityError):
+                resolve_execution_scope("1")
+
+        remediation = [r for r in records if EXECUTION_SCOPE_AGENT_CONFIG_KEY in r]
+        assert remediation, records
+        assert "every turn" in remediation[0].lower()

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -1343,6 +1343,138 @@ class TestDeferSnapshotAllDefaultFallback:
         assert resolve_execution_scope("1") == fallback
 
 
+class TestDeferSnapshotDefinesNamespaceOptIn:
+    """``defer_to_snapshot(fallback, snapshot_defines_namespace=True)``: the
+    resolver states it does not own this task and the persisted snapshot is
+    the intended namespace authority (the workforce/delegated-task shape).
+    An all-default ``fallback`` cannot itself claim a namespace -- if the
+    resolver knew the namespace it would return an authoritative
+    ``ExecutionScope`` instead of deferring -- so the strict narrowing rule
+    in ``TestDeferSnapshotAllDefaultFallback`` above must be skippable for
+    namespace fields on this opt-in, while everything else (type check,
+    shape-version gate, mandatory fallback, policy symmetry) still applies.
+    """
+
+    def test_opt_in_with_all_default_fallback_uses_snapshot_verbatim(self):
+        """The workforce shape: the resolver has no opinion (all-default
+        fallback) but explicitly hands namespace authority to the snapshot."""
+        fallback = ExecutionScope()
+        snapshot = ExecutionScope(
+            sandbox_key_suffix="workforce-task",
+            workspace_segments=("workforce", "task-7"),
+            memory_dimensions={"tenant": "acme"},
+        )
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+        assert resolve_execution_scope("1") == snapshot
+
+    def test_without_opt_in_the_same_snapshot_fails_closed(self):
+        """The security half: the identical snapshot/fallback pair, without
+        the opt-in, must still fail closed under the strict narrowing rule
+        -- the opt-in is what changes the outcome, not the snapshot shape."""
+        fallback = ExecutionScope()
+        snapshot = ExecutionScope(
+            sandbox_key_suffix="workforce-task",
+            workspace_segments=("workforce", "task-7"),
+            memory_dimensions={"tenant": "acme"},
+        )
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(fallback),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope("1")
+        assert set(exc_info.value.mismatched_fields) == {
+            "sandbox_key_suffix",
+            "workspace_segments",
+            "sandbox_mount_segments",
+            "memory_dimensions",
+        }
+
+    def test_opt_in_does_not_bypass_the_shape_version_gate(self):
+        """A stale-version snapshot is still shape-gated away even with the
+        opt-in set -- the gate runs before the narrowing check is even
+        reached, so there is nothing for the opt-in to skip past."""
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
+        del stale_data["version"]
+        stale_snapshot = ExecutionScope.from_dict(stale_data)
+        assert stale_snapshot.version == 0
+
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: stale_snapshot)
+        with scope_log_records() as records:
+            assert resolve_execution_scope("1") == fallback
+        assert any("shape" in r and "sandbox_key_suffix" in r for r in records)
+
+    def test_opt_in_does_not_bypass_the_type_check(self):
+        """A snapshot loader that returns a non-ExecutionScope candidate
+        still raises the contract error, opt-in or not."""
+        fallback = ExecutionScope()
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: {"not": "a scope"})
+        with pytest.raises(ExecutionScopeResolverContractError):
+            resolve_execution_scope("1")
+
+    def test_opt_in_still_honours_policy_field_symmetry(self):
+        """Namespace fields agree (both all-default), only
+        strict_memory_isolation differs: the fallback's policy value still
+        wins and the disagreement is still logged, exactly as on the
+        default (narrowing) branch."""
+        fallback = ExecutionScope(strict_memory_isolation=True)
+        snapshot = ExecutionScope(strict_memory_isolation=False)
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: snapshot)
+
+        with scope_log_records() as records:
+            result = resolve_execution_scope("1")
+        assert result.strict_memory_isolation is True
+        assert any(
+            "policy-only mismatch" in r and "strict_memory_isolation" in r
+            for r in records
+        )
+
+    def test_flag_does_not_make_the_fallback_optional(self):
+        """The opt-in changes what a present snapshot is checked against,
+        not whether a fallback is required at all: ``defer_to_snapshot``
+        still rejects a non-ExecutionScope fallback even with the flag set,
+        and the mandatory fallback still applies on a snapshot miss."""
+        with pytest.raises(TypeError):
+            defer_to_snapshot("not-a-scope", snapshot_defines_namespace=True)
+
+        fallback = ExecutionScope(sandbox_key_suffix="fallback")
+        set_execution_scope_resolver(
+            lambda task_id: defer_to_snapshot(
+                fallback, snapshot_defines_namespace=True
+            ),
+            acknowledges_snapshot_candidate_contract=True,
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: None)
+        assert resolve_execution_scope("1") == fallback
+
+
 class TestResolveExecutionScopeOffTurn:
     """Off-turn consumers (websocket ``_scope_segments_for_task``,
     ``ManagedFileRef``) downgrade a namespace mismatch instead of failing."""

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -16,6 +16,7 @@ import asyncio
 import contextvars
 import dataclasses
 import logging
+from contextlib import contextmanager
 
 import pytest
 
@@ -40,6 +41,35 @@ from xagent.core.execution_scope import (
     turn_execution_scope,
     validate_scope_component,
 )
+
+
+@contextmanager
+def scope_log_records(level: int = logging.WARNING):
+    """Collect this module's log records independently of global logging config.
+
+    ``caplog`` installs its handler on the root logger, so an assertion built on
+    it only holds while records propagate there. Whether they do is decided by
+    whatever else configured logging in the same process -- which under parallel
+    test execution is whatever module happens to share the worker. Attaching to
+    the logger that emits makes the assertion depend on the code under test
+    instead.
+    """
+    logger = logging.getLogger("xagent.core.execution_scope")
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collect(level)
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
 
 
 class TestValidateScopeComponent:
@@ -68,12 +98,12 @@ class TestValidateScopeComponent:
         with pytest.raises(InvalidScopeComponentError):
             validate_scope_component(value)
 
-    def test_rejects_without_sanitizing(self, caplog):
+    def test_rejects_without_sanitizing(self):
         """Invalid input raises and logs; it is never rewritten to a valid form."""
-        with caplog.at_level("ERROR"):
+        with scope_log_records(logging.ERROR) as records:
             with pytest.raises(InvalidScopeComponentError):
                 validate_scope_component("bad:name", field_name="sandbox_key_suffix")
-        assert any("sandbox_key_suffix" in r.message for r in caplog.records)
+        assert any("sandbox_key_suffix" in r.getMessage() for r in records)
 
 
 class TestExecutionScope:
@@ -760,7 +790,7 @@ class TestSnapshotCandidateAuthority:
         assert exc_info.value.resolver_scope == resolver_scope
         assert exc_info.value.snapshot_scope == snapshot_scope
 
-    def test_policy_only_mismatch_does_not_fail_the_turn(self, caplog):
+    def test_policy_only_mismatch_does_not_fail_the_turn(self):
         """strict_memory_isolation is a policy field: a disagreement there
         does not change which key/path is touched, so the resolver's value
         wins without raising. The disagreement must still be observable --
@@ -769,15 +799,15 @@ class TestSnapshotCandidateAuthority:
         snapshot_scope = ExecutionScope(strict_memory_isolation=True)
         self._register(lambda task_id: resolver_scope, lambda task_id: snapshot_scope)
 
-        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+        with scope_log_records() as records:
             assert resolve_execution_scope("1") == resolver_scope
         assert any(
-            "policy-only mismatch" in r.message
-            and "strict_memory_isolation" in r.message
-            for r in caplog.records
+            "policy-only mismatch" in r.getMessage()
+            and "strict_memory_isolation" in r.getMessage()
+            for r in records
         )
 
-    def test_stale_version_snapshot_is_ignored_even_if_it_would_mismatch(self, caplog):
+    def test_stale_version_snapshot_is_ignored_even_if_it_would_mismatch(self):
         resolver_scope = ExecutionScope()
         stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
         del stale_data["version"]  # predates EXECUTION_SCOPE_SHAPE_VERSION
@@ -785,11 +815,11 @@ class TestSnapshotCandidateAuthority:
         assert stale_snapshot.version == 0
 
         self._register(lambda task_id: resolver_scope, lambda task_id: stale_snapshot)
-        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+        with scope_log_records() as records:
             assert resolve_execution_scope("1") == resolver_scope
         assert any(
-            "shape" in r.message and "sandbox_key_suffix" in r.message
-            for r in caplog.records
+            "shape" in r.getMessage() and "sandbox_key_suffix" in r.getMessage()
+            for r in records
         )
 
     def test_newer_version_snapshot_is_ignored_too(self):
@@ -882,7 +912,7 @@ class TestSnapshotCandidateAuthority:
         with pytest.raises(ExecutionScopeResolverContractError):
             resolve_execution_scope("1")
 
-    def test_defer_stale_version_snapshot_is_ignored_falls_back(self, caplog):
+    def test_defer_stale_version_snapshot_is_ignored_falls_back(self):
         fallback = ExecutionScope(sandbox_key_suffix="fallback")
         stale_data = ExecutionScope(sandbox_key_suffix="stale").to_dict()
         del stale_data["version"]
@@ -893,11 +923,11 @@ class TestSnapshotCandidateAuthority:
             lambda task_id: defer_to_snapshot(fallback),
             lambda task_id: stale_snapshot,
         )
-        with caplog.at_level(logging.WARNING, logger="xagent.core.execution_scope"):
+        with scope_log_records() as records:
             assert resolve_execution_scope("1") == fallback
         assert any(
-            "shape" in r.message and "sandbox_key_suffix" in r.message
-            for r in caplog.records
+            "shape" in r.getMessage() and "sandbox_key_suffix" in r.getMessage()
+            for r in records
         )
 
     @pytest.mark.parametrize(
@@ -1040,7 +1070,7 @@ class TestResolveExecutionScopeOffTurn:
         )
         assert resolve_execution_scope_off_turn("1") == scope
 
-    def test_namespace_mismatch_downgrades_to_resolver_value_with_warning(self, caplog):
+    def test_namespace_mismatch_downgrades_to_resolver_value_with_warning(self):
         resolver_scope = ExecutionScope(sandbox_key_suffix="from-resolver")
         snapshot_scope = ExecutionScope(sandbox_key_suffix="from-snapshot")
         set_execution_scope_resolver(
@@ -1049,11 +1079,11 @@ class TestResolveExecutionScopeOffTurn:
         )
         set_execution_scope_snapshot_loader(lambda task_id: snapshot_scope)
 
-        with caplog.at_level("WARNING"):
+        with scope_log_records() as records:
             result = resolve_execution_scope_off_turn("1")
 
         assert result == resolver_scope
-        assert any("authority mismatch" in r.message.lower() for r in caplog.records)
+        assert any("authority mismatch" in r.getMessage().lower() for r in records)
 
     def test_other_exceptions_still_propagate(self):
         def boom(task_id):

--- a/tests/shared/execution_scope.py
+++ b/tests/shared/execution_scope.py
@@ -21,14 +21,15 @@ under test, not boilerplate.
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
-from xagent.core.execution_scope import ExecutionScope, set_execution_scope_resolver
+from xagent.core.execution_scope import (
+    ExecutionScopeResolver,
+    set_execution_scope_resolver,
+)
 
-ScopeResolver = Callable[[str], Optional[ExecutionScope]]
 
-
-def register_scope_resolver(resolver: Optional[ScopeResolver]) -> None:
+def register_scope_resolver(resolver: Optional[ExecutionScopeResolver]) -> None:
     """Install ``resolver`` as the authoritative scope resolver, or clear it.
 
     ``None`` clears the registration, which needs no acknowledgement: without a

--- a/tests/shared/execution_scope.py
+++ b/tests/shared/execution_scope.py
@@ -1,0 +1,43 @@
+"""One acknowledged registration point for tests that need a scope resolver.
+
+``set_execution_scope_resolver`` requires
+``acknowledges_snapshot_candidate_contract=True`` so that an *embedding
+application* built against the older precedence fails at import instead of
+discovering on its first delegated turn that a persisted snapshot is now a
+corroborating candidate rather than an override.
+
+A test that registers a resolver is not such an application: it is setting up a
+scenario. Repeating the acknowledgement at every one of those call sites would
+put the contract's most important signal where nobody reads it, and would make
+the next test that forgets the keyword fail with a ``TypeError`` that says
+nothing about what the test was doing. Consumer tests therefore register
+through here, and the acknowledgement -- with the reason for it -- lives in one
+place.
+
+The contract's own unit tests (``tests/core/test_execution_scope.py``) call
+``set_execution_scope_resolver`` directly: there the keyword is the subject
+under test, not boilerplate.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from xagent.core.execution_scope import ExecutionScope, set_execution_scope_resolver
+
+ScopeResolver = Callable[[str], Optional[ExecutionScope]]
+
+
+def register_scope_resolver(resolver: Optional[ScopeResolver]) -> None:
+    """Install ``resolver`` as the authoritative scope resolver, or clear it.
+
+    ``None`` clears the registration, which needs no acknowledgement: without a
+    resolver the snapshot resolves the scope, the behavior that predates the
+    contract.
+    """
+    if resolver is None:
+        set_execution_scope_resolver(None)
+        return
+    set_execution_scope_resolver(
+        resolver, acknowledges_snapshot_candidate_contract=True
+    )

--- a/tests/web/api/test_agent_cache_scope_fingerprint.py
+++ b/tests/web/api/test_agent_cache_scope_fingerprint.py
@@ -461,10 +461,13 @@ async def test_unscoped_build_records_legacy_key() -> None:
 @pytest.mark.asyncio
 async def test_turn_face_authority_mismatch_fails_the_turn() -> None:
     """``get_agent_for_task`` is a turn-face consumer of
-    ``resolve_execution_scope`` (#296): unlike the off-turn
-    consumers in ``websocket._scope_segments_for_task`` and
-    ``ManagedFileRef``, a namespace-affecting authority mismatch here must
-    propagate and fail the turn rather than being downgraded to a warning."""
+    ``resolve_execution_scope``: unlike the off-turn consumers
+    (``ManagedFileRef``'s construction, the pause/resume handlers), a
+    namespace-affecting authority mismatch here must propagate and fail the
+    turn rather than being downgraded to a warning.
+    ``websocket._scope_segments_for_task`` is off-turn and still resolves
+    fail-closed, so what decides this is whether a namespace is being chosen
+    for new bytes, not whether a turn is running."""
     register_scope_resolver(
         lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
     )

--- a/tests/web/api/test_agent_cache_scope_fingerprint.py
+++ b/tests/web/api/test_agent_cache_scope_fingerprint.py
@@ -23,11 +23,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     ExecutionScopeContext,
     scope_fingerprint,
-    set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
 )
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.agent import AgentStatus
@@ -42,13 +44,6 @@ from xagent.web.services.task_setup_snapshot import (
 
 SCOPE_A = ExecutionScope(sandbox_key_suffix="tenant-a")
 SCOPE_B = ExecutionScope(sandbox_key_suffix="tenant-b")
-
-
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    set_execution_scope_resolver(None)
-    yield
-    set_execution_scope_resolver(None)
 
 
 def _make_user() -> User:
@@ -144,7 +139,7 @@ async def _call(manager: AgentServiceManager, **kwargs: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_scope_change_between_turns_evicts_and_rebuilds() -> None:
-    set_execution_scope_resolver(lambda task_id: SCOPE_B)
+    register_scope_resolver(lambda task_id: SCOPE_B)
     manager = AgentServiceManager()
     stale_agent = MagicMock()
     manager._agents[42] = stale_agent
@@ -171,11 +166,50 @@ async def test_scope_change_between_turns_evicts_and_rebuilds() -> None:
 
 
 @pytest.mark.asyncio
+async def test_isolate_external_dirs_only_change_evicts_and_rebuilds() -> None:
+    """(#296) isolate_external_dirs is baked into the
+    cached AgentService's allowed_external_dirs at build time, not read
+    fresh -- an isolate_external_dirs-only change (same sandbox suffix,
+    workspace segments, mount, memory dimensions) must still evict the
+    cache, or the stale allowed-dirs list keeps being enforced."""
+    scope_shared = ExecutionScope(sandbox_key_suffix="tenant-a")
+    scope_isolated = ExecutionScope(
+        sandbox_key_suffix="tenant-a", isolate_external_dirs=True
+    )
+    assert scope_fingerprint(scope_shared) != scope_fingerprint(scope_isolated)
+
+    register_scope_resolver(
+        lambda task_id: scope_isolated,
+    )
+    manager = AgentServiceManager()
+    stale_agent = MagicMock()
+    manager._agents[42] = stale_agent
+    manager._agent_owner_ids[42] = 1
+    manager._agent_sandbox_keys[42] = "user:1:tenant-a"
+    manager._agent_scope_fingerprints[42] = scope_fingerprint(scope_shared)
+
+    with ExitStack() as stack:
+        for p in _common_patches(manager):
+            stack.enter_context(p)
+        await _call(
+            manager,
+            db=_build_db_mock(_make_task_row()),
+            user=_make_user(),
+            task_setup_snapshot=_build_snapshot(),
+        )
+
+    assert manager._agents.get(42) is not stale_agent
+    assert manager._agent_scope_fingerprints.get(42) == scope_fingerprint(
+        scope_isolated
+    )
+
+
+@pytest.mark.asyncio
 async def test_scope_flap_is_logged_as_probable_resolver_bug(caplog) -> None:
     """A -> B -> A: the resolver returning the fingerprint that a previous
     rebuild evicted means it flaps between values — every turn would evict
     and rebuild, silently defeating the cache."""
-    set_execution_scope_resolver(lambda task_id: SCOPE_A)
+    register_scope_resolver(lambda task_id: SCOPE_A)
     manager = AgentServiceManager()
     manager._agents[42] = MagicMock()
     manager._agent_owner_ids[42] = 1
@@ -211,7 +245,7 @@ async def test_multi_scope_cycle_is_also_flagged_as_resolver_bug(caplog) -> None
     def cycling_resolver(task_id):
         return cycle[turn["n"] % len(cycle)]
 
-    set_execution_scope_resolver(cycling_resolver)
+    register_scope_resolver(cycling_resolver)
     manager = AgentServiceManager()
 
     with ExitStack() as stack:
@@ -241,7 +275,7 @@ async def test_activated_turn_scope_is_reused_without_re_resolving() -> None:
         resolver_calls.append(task_id)
         return SCOPE_A
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     manager = AgentServiceManager()
 
     with ExitStack() as stack:
@@ -284,8 +318,8 @@ async def test_unscoped_cached_agent_is_reused_without_eviction() -> None:
 async def test_stable_scope_does_not_evict_between_turns() -> None:
     """An idempotent resolver returning an equal scope every turn keeps the
     cache warm — equality is by fingerprint value, not object identity."""
-    set_execution_scope_resolver(
-        lambda task_id: ExecutionScope(sandbox_key_suffix="tenant-a")
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="tenant-a"),
     )
     manager = AgentServiceManager()
     cached_agent = MagicMock()
@@ -310,7 +344,7 @@ async def test_resolver_scope_reaches_sandbox_key_on_build() -> None:
     """End-to-end through the resolver path: a fresh build under a scoped
     resolver acquires the scoped container family and records the
     scope-suffixed key for execution-time attach."""
-    set_execution_scope_resolver(lambda task_id: SCOPE_A)
+    register_scope_resolver(lambda task_id: SCOPE_A)
     manager = AgentServiceManager()
     fake_sandbox_manager = MagicMock()
     fake_sandbox_manager.get_or_create_lease_provider = AsyncMock(
@@ -344,7 +378,7 @@ async def test_resolver_scope_reaches_workspace_paths_on_build() -> None:
     from xagent.core.workspace import scoped_user_root
 
     scope = ExecutionScope(workspace_segments=("tenant-a",))
-    set_execution_scope_resolver(lambda task_id: scope)
+    register_scope_resolver(lambda task_id: scope)
     manager = AgentServiceManager()
 
     with ExitStack() as stack:
@@ -422,3 +456,29 @@ async def test_unscoped_build_records_legacy_key() -> None:
     assert lifecycle_args == ("user", "1")
     assert manager._agent_sandbox_keys.get(42) == "user:1"
     assert manager._agent_scope_fingerprints.get(42) is None
+
+
+@pytest.mark.asyncio
+async def test_turn_face_authority_mismatch_fails_the_turn() -> None:
+    """``get_agent_for_task`` is a turn-face consumer of
+    ``resolve_execution_scope`` (#296): unlike the off-turn
+    consumers in ``websocket._scope_segments_for_task`` and
+    ``ManagedFileRef``, a namespace-affecting authority mismatch here must
+    propagate and fail the turn rather than being downgraded to a warning."""
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-snapshot")
+    )
+    manager = AgentServiceManager()
+    manager._default_llm = MagicMock()
+
+    with pytest.raises(ExecutionScopeAuthorityError):
+        await manager.get_agent_for_task(
+            task_id=42,
+            db=None,
+            user=_make_user(),
+            task_owner_user_id=1,
+            task_setup_snapshot=_build_snapshot(),
+        )

--- a/tests/web/api/test_execution_scope_e2e.py
+++ b/tests/web/api/test_execution_scope_e2e.py
@@ -28,8 +28,8 @@ import pytest
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.config import get_uploads_dir
 from xagent.core.execution_scope import (
+    DeferToSnapshot,
     ExecutionScope,
-    defer_to_snapshot,
     scope_fingerprint,
     set_execution_scope_snapshot_loader,
 )
@@ -261,7 +261,7 @@ async def test_two_scopes_under_one_user_are_disjoint_everywhere() -> None:
 async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
     """A delegated task the embedder does not own: the snapshot drives the build.
 
-    This is what :func:`defer_to_snapshot` exists for. The resolver cannot
+    This is what :class:`DeferToSnapshot` exists for. The resolver cannot
     supply the namespace because it does not know it -- that is why it defers
     -- so its fallback claims no scoping at all, and it says so explicitly
     with ``snapshot_defines_namespace=True``. Without that declaration the
@@ -270,7 +270,7 @@ async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
     ``tests/core/test_execution_scope.py``).
     """
     register_scope_resolver(
-        lambda task_id: defer_to_snapshot(
+        lambda task_id: DeferToSnapshot(
             fallback=ExecutionScope(strict_memory_isolation=True),
             snapshot_defines_namespace=True,
         ),
@@ -290,7 +290,7 @@ async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
 async def test_resolver_authoritative_unscoped_ignores_persisted_snapshot() -> None:
     """``None`` from the resolver is authoritative unscoped for the task, not
     an abstention: a persisted snapshot is not consulted at all, unlike the
-    :func:`defer_to_snapshot` case above."""
+    :class:`DeferToSnapshot` case above."""
     register_scope_resolver(lambda task_id: None)
     set_execution_scope_snapshot_loader(
         lambda task_id: SCOPE_A if task_id == "42" else None

--- a/tests/web/api/test_execution_scope_e2e.py
+++ b/tests/web/api/test_execution_scope_e2e.py
@@ -259,40 +259,31 @@ async def test_two_scopes_under_one_user_are_disjoint_everywhere() -> None:
 
 @pytest.mark.asyncio
 async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
-    """A delegated (workforce) task id is one the resolver's embedder does
-    not own; it defers (:func:`defer_to_snapshot`), and the persisted
-    snapshot -- not the fallback -- drives the whole build (#757).
+    """A delegated task the embedder does not own: the snapshot drives the build.
 
-    The fallback claims the tenant-level namespace the resolver's embedder
-    does commit to (it is not the identity/no-scoping value on those
-    fields), so the per-task snapshot is free to narrow deeper inside it
-    (extra workspace segment, extra memory dimension) without that narrowing
-    being rejected as introducing scoping the fallback claimed no authority
-    over.
+    This is what :func:`defer_to_snapshot` exists for. The resolver cannot
+    supply the namespace because it does not know it -- that is why it defers
+    -- so its fallback claims no scoping at all, and it says so explicitly
+    with ``snapshot_defines_namespace=True``. Without that declaration the
+    same abstention fails closed, because an abstention that claims no
+    namespace authority must not hand one out (see
+    ``tests/core/test_execution_scope.py``).
     """
-    fallback = ExecutionScope(
-        sandbox_key_suffix="tenant-a",
-        workspace_segments=("tenant-a",),
-        memory_dimensions={"tenant": "a"},
-        strict_memory_isolation=True,
-    )
-    delegated_scope = ExecutionScope(
-        sandbox_key_suffix="tenant-a",
-        workspace_segments=("tenant-a", "task-42"),
-        memory_dimensions={"tenant": "a", "task": "42"},
-    )
     register_scope_resolver(
-        lambda task_id: defer_to_snapshot(fallback=fallback),
-    )  # embedder doesn't own this task id; defers to the persisted snapshot
+        lambda task_id: defer_to_snapshot(
+            fallback=ExecutionScope(strict_memory_isolation=True),
+            snapshot_defines_namespace=True,
+        ),
+    )
     set_execution_scope_snapshot_loader(
-        lambda task_id: delegated_scope if task_id == "42" else None
+        lambda task_id: SCOPE_A if task_id == "42" else None
     )
     build = await _run_build(AgentServiceManager(), 42)
 
     assert build.sandbox_lifecycle == ("user", "1:tenant-a")
     assert build.recorded_sandbox_key == "user:1:tenant-a"
-    assert build.agent_service_kwargs["scope_segments"] == ("tenant-a", "task-42")
-    assert build.recorded_fingerprint == scope_fingerprint(delegated_scope)
+    assert build.agent_service_kwargs["scope_segments"] == ("tenant-a",)
+    assert build.recorded_fingerprint == scope_fingerprint(SCOPE_A)
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_execution_scope_e2e.py
+++ b/tests/web/api/test_execution_scope_e2e.py
@@ -25,11 +25,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.config import get_uploads_dir
 from xagent.core.execution_scope import (
     ExecutionScope,
+    defer_to_snapshot,
     scope_fingerprint,
-    set_execution_scope_resolver,
     set_execution_scope_snapshot_loader,
 )
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
@@ -74,10 +75,10 @@ SCOPE_EU8 = ExecutionScope(
 
 @pytest.fixture(autouse=True)
 def _clear_hooks():
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
     set_execution_scope_snapshot_loader(None)
     yield
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
     set_execution_scope_snapshot_loader(None)
 
 
@@ -223,7 +224,7 @@ async def test_scoped_build_applies_the_scope_to_every_subsystem() -> None:
     ``sandbox_key_suffix``, but the Actor-logical workspace base dir (below)
     is what actually isolates task 42's files under the tenant-a subtree.
     """
-    set_execution_scope_resolver(lambda task_id: SCOPE_A)
+    register_scope_resolver(lambda task_id: SCOPE_A)
     build = await _run_build(AgentServiceManager(), 42)
 
     scoped_base = str(scoped_user_root(get_uploads_dir(), 1, ("tenant-a",)))
@@ -241,11 +242,11 @@ async def test_two_scopes_under_one_user_are_disjoint_everywhere() -> None:
     def resolver(task_id: str):
         return {"42": SCOPE_A, "43": SCOPE_B}.get(task_id)
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     manager = AgentServiceManager()
     build_a = await _run_build(manager, 42)
     build_b = await _run_build(manager, 43)
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
     build_unscoped = await _run_build(AgentServiceManager(), 44)
 
     keys = {
@@ -267,9 +268,14 @@ async def test_two_scopes_under_one_user_are_disjoint_everywhere() -> None:
 
 @pytest.mark.asyncio
 async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
-    """A delegated (workforce) task id is unknown to the resolver; the
-    persisted snapshot drives the whole build instead."""
-    set_execution_scope_resolver(lambda task_id: None)  # embedder can't map it
+    """A delegated (workforce) task id is one the resolver's embedder does
+    not own; it defers (:func:`defer_to_snapshot`), and the persisted
+    snapshot -- not the fallback -- drives the whole build (#757)."""
+    register_scope_resolver(
+        lambda task_id: defer_to_snapshot(
+            fallback=ExecutionScope(strict_memory_isolation=True)
+        ),
+    )  # embedder doesn't own this task id; defers to the persisted snapshot
     set_execution_scope_snapshot_loader(
         lambda task_id: SCOPE_A if task_id == "42" else None
     )
@@ -279,6 +285,23 @@ async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
     assert build.recorded_sandbox_key == "user:1:tenant-a"
     assert build.agent_service_kwargs["scope_segments"] == ("tenant-a",)
     assert build.recorded_fingerprint == scope_fingerprint(SCOPE_A)
+
+
+@pytest.mark.asyncio
+async def test_resolver_authoritative_unscoped_ignores_persisted_snapshot() -> None:
+    """``None`` from the resolver is authoritative unscoped for the task, not
+    an abstention: a persisted snapshot is not consulted at all, unlike the
+    :func:`defer_to_snapshot` case above."""
+    register_scope_resolver(lambda task_id: None)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: SCOPE_A if task_id == "42" else None
+    )
+    build = await _run_build(AgentServiceManager(), 42)
+
+    assert build.sandbox_lifecycle == ("user", "1")
+    assert build.recorded_sandbox_key == "user:1"
+    assert build.agent_service_kwargs["scope_segments"] == ()
+    assert build.recorded_fingerprint is None
 
 
 @pytest.mark.asyncio
@@ -311,7 +334,7 @@ async def test_tool_workspace_lives_inside_the_tree_the_sandbox_binds(
     base = tmp_path / "base"
     base.mkdir()
     monkeypatch.setenv("XAGENT_UPLOADS_DIR", f"{base}/nonexistent/..")
-    set_execution_scope_resolver(lambda task_id: SCOPE_A)
+    register_scope_resolver(lambda task_id: SCOPE_A)
 
     build = await _run_build(AgentServiceManager(), 42)
     mount_root = build.sandbox_mount_intent.mount_root
@@ -372,7 +395,7 @@ async def test_mount_prefix_shares_sandbox_root_across_deeper_segments() -> None
     def resolver(task_id: str):
         return {"42": SCOPE_EU7, "43": SCOPE_EU8}.get(task_id)
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     manager = AgentServiceManager()
     build_eu7 = await _run_build(manager, 42)
     build_eu8 = await _run_build(manager, 43)
@@ -415,7 +438,7 @@ async def test_prefix_shared_mount_passes_config_equivalence_gate() -> None:
     def resolver(task_id: str):
         return {"42": SCOPE_EU7, "43": SCOPE_EU8}.get(task_id)
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     manager = AgentServiceManager()
     build_eu7 = await _run_build(manager, 42)
     build_eu8 = await _run_build(manager, 43)

--- a/tests/web/api/test_execution_scope_e2e.py
+++ b/tests/web/api/test_execution_scope_e2e.py
@@ -73,15 +73,6 @@ SCOPE_EU8 = ExecutionScope(
 )
 
 
-@pytest.fixture(autouse=True)
-def _clear_hooks():
-    register_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
-    yield
-    register_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
-
-
 def _make_user() -> User:
     return User(id=1, username="e2e-user", password_hash="hash", is_admin=False)
 
@@ -270,21 +261,38 @@ async def test_two_scopes_under_one_user_are_disjoint_everywhere() -> None:
 async def test_delegated_task_builds_scoped_from_persisted_snapshot() -> None:
     """A delegated (workforce) task id is one the resolver's embedder does
     not own; it defers (:func:`defer_to_snapshot`), and the persisted
-    snapshot -- not the fallback -- drives the whole build (#757)."""
+    snapshot -- not the fallback -- drives the whole build (#757).
+
+    The fallback claims the tenant-level namespace the resolver's embedder
+    does commit to (it is not the identity/no-scoping value on those
+    fields), so the per-task snapshot is free to narrow deeper inside it
+    (extra workspace segment, extra memory dimension) without that narrowing
+    being rejected as introducing scoping the fallback claimed no authority
+    over.
+    """
+    fallback = ExecutionScope(
+        sandbox_key_suffix="tenant-a",
+        workspace_segments=("tenant-a",),
+        memory_dimensions={"tenant": "a"},
+        strict_memory_isolation=True,
+    )
+    delegated_scope = ExecutionScope(
+        sandbox_key_suffix="tenant-a",
+        workspace_segments=("tenant-a", "task-42"),
+        memory_dimensions={"tenant": "a", "task": "42"},
+    )
     register_scope_resolver(
-        lambda task_id: defer_to_snapshot(
-            fallback=ExecutionScope(strict_memory_isolation=True)
-        ),
+        lambda task_id: defer_to_snapshot(fallback=fallback),
     )  # embedder doesn't own this task id; defers to the persisted snapshot
     set_execution_scope_snapshot_loader(
-        lambda task_id: SCOPE_A if task_id == "42" else None
+        lambda task_id: delegated_scope if task_id == "42" else None
     )
     build = await _run_build(AgentServiceManager(), 42)
 
     assert build.sandbox_lifecycle == ("user", "1:tenant-a")
     assert build.recorded_sandbox_key == "user:1:tenant-a"
-    assert build.agent_service_kwargs["scope_segments"] == ("tenant-a",)
-    assert build.recorded_fingerprint == scope_fingerprint(SCOPE_A)
+    assert build.agent_service_kwargs["scope_segments"] == ("tenant-a", "task-42")
+    assert build.recorded_fingerprint == scope_fingerprint(delegated_scope)
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -1,9 +1,10 @@
 """Pin that the orchestrator activates the execution scope on every turn.
 
-Slice 1 of #757 wires ``turn_execution_scope`` at the same places the acting
-user is resolved (``UserContext``): ``execute_task_background`` for normal
-turns and ``execute_resume_background`` for resumed turns. These tests use a
-fake resolver to pin that:
+The orchestrator resolves the scope and activates it via
+``ExecutionScopeContext`` at the same places the acting user is resolved
+(``UserContext``): ``execute_task_background`` for normal turns and
+``execute_resume_background`` for resumed turns. These tests use a fake
+resolver to pin that:
 
 * the resolver is called with the turn's ``task_id`` (as str),
 * the resolved scope is active inside the turn's execution context (visible
@@ -26,6 +27,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_NOT_PROVIDED,
     ExecutionScope,
     ExecutionScopeAuthorityError,
     get_execution_scope,
@@ -541,9 +543,15 @@ async def test_resume_background_adopts_preacquired_lease_without_reacquiring() 
 
 
 @pytest.mark.asyncio
-async def test_resume_handler_resolves_scope_once_off_loop_and_passes_it_through() -> (
-    None
-):
+async def test_resume_handler_resolves_scope_once_off_loop_for_agent_lookup() -> None:
+    """The handler's single off-loop resolution feeds only the agent lookup.
+
+    ``get_agent_for_task`` receives the resolved scope to locate the paused
+    task's existing agent. ``execute_resume_background`` is a different
+    consumer -- the turn that selects a namespace for new bytes -- so it is
+    not handed this same value; it gets ``EXECUTION_SCOPE_NOT_PROVIDED`` and
+    resolves for itself.
+    """
     main_thread_id = threading.get_ident()
     scope = ExecutionScope(
         sandbox_key_suffix="tenant-a", workspace_segments=("tenant-a",)
@@ -618,7 +626,7 @@ async def test_resume_handler_resolves_scope_once_off_loop_and_passes_it_through
         agent_manager.get_agent_for_task.await_args.kwargs["resolved_execution_scope"]
         is scope
     )
-    assert resume_kwargs["resolved_execution_scope"] is scope
+    assert resume_kwargs["resolved_execution_scope"] is EXECUTION_SCOPE_NOT_PROVIDED
 
 
 @pytest.mark.asyncio
@@ -626,10 +634,17 @@ async def test_resume_survives_a_scope_authority_mismatch() -> None:
     """A control operation must stay available while the scope is in dispute.
 
     Resume locates an already-established workspace and sandbox for a task
-    that already exists; it selects no namespace for new bytes, and the turn
-    it hands off to re-resolves fail-closed before producing any. Failing the
-    handler instead would leave the user unable to resume, pause or stop the
-    task at all, with the authority error escaping the socket loop.
+    that already exists using the downgraded (never-raising) off-turn
+    resolution -- that lookup selects no namespace for new bytes, so it must
+    not be blocked by the dispute. The turn it hands off to is a different
+    consumer that does select a namespace for new bytes, so the handler must
+    not pass its own downgraded answer through: it leaves that argument at
+    ``EXECUTION_SCOPE_NOT_PROVIDED`` so the scheduled turn performs its own
+    fail-closed resolution (see
+    ``test_resume_background_fails_closed_on_scope_authority_mismatch`` for
+    that resolution actually raising). Failing the handler itself instead
+    would leave the user unable to resume, pause or stop the task at all,
+    with the authority error escaping the socket loop.
     """
     resolver_scope = ExecutionScope(
         sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
@@ -697,9 +712,67 @@ async def test_resume_survives_a_scope_authority_mismatch() -> None:
         )
         await asyncio.wait_for(resume_started.wait(), timeout=1)
 
-    # Downgraded to the resolver's answer rather than raising, and the resume
-    # actually proceeded.
-    assert resume_kwargs["resolved_execution_scope"] == resolver_scope
+    # The off-turn lookup that locates the existing agent still uses the
+    # downgraded resolver answer -- a control operation on an existing task
+    # must not be blocked by the dispute.
+    assert (
+        agent_manager.get_agent_for_task.await_args.kwargs["resolved_execution_scope"]
+        is resolver_scope
+    )
+    # The scheduled turn is a different consumer: the handler must not pass
+    # its own downgraded answer through, so the turn can run its own
+    # fail-closed resolution instead of silently selecting the resolver's
+    # disputed answer for new bytes.
+    assert resume_kwargs["resolved_execution_scope"] is EXECUTION_SCOPE_NOT_PROVIDED
+
+
+@pytest.mark.asyncio
+async def test_resume_background_fails_closed_on_scope_authority_mismatch() -> None:
+    """The scheduled turn's own re-resolution is fail-closed, not downgraded.
+
+    ``execute_resume_background`` is the consumer that selects a namespace
+    for new bytes for the resumed turn. Unlike the handler's off-turn lookup
+    pinned in ``test_resume_survives_a_scope_authority_mismatch``, a
+    resolver/snapshot disagreement reaching this function's own resolution
+    (``resolved_execution_scope`` left at ``EXECUTION_SCOPE_NOT_PROVIDED``)
+    must fail the turn instead of silently proceeding under either answer.
+    The ``ExecutionScopeAuthorityError`` raised inside this background task
+    is caught by its own settlement handler (a background task has no
+    caller to propagate to) and converted into a broadcast task-failure
+    event rather than executing the resume -- that conversion, not an
+    escaping exception, is what "fails closed" means for this consumer.
+    """
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver")
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-snapshot")
+    )
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock()
+    broadcast_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.api.websocket.manager", broadcast_manager),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+        )
+
+    agent_service.resume_execution_by_id.assert_not_awaited()
+    broadcast_manager.broadcast_to_task.assert_awaited_once()
+    broadcast_args, _ = broadcast_manager.broadcast_to_task.await_args
+    event, broadcast_task_id = broadcast_args
+    assert broadcast_task_id == 42
+    assert event["type"] == "task_error"
+    assert "execution scope authority mismatch" in event["message"]
 
 
 def test_resume_acquire_checkout_timeout_before_claim_does_not_try_cleanup() -> None:

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -621,6 +621,87 @@ async def test_resume_handler_resolves_scope_once_off_loop_and_passes_it_through
     assert resume_kwargs["resolved_execution_scope"] is scope
 
 
+@pytest.mark.asyncio
+async def test_resume_survives_a_scope_authority_mismatch() -> None:
+    """A control operation must stay available while the scope is in dispute.
+
+    Resume locates an already-established workspace and sandbox for a task
+    that already exists; it selects no namespace for new bytes, and the turn
+    it hands off to re-resolves fail-closed before producing any. Failing the
+    handler instead would leave the user unable to resume, pause or stop the
+    task at all, with the authority error escaping the socket loop.
+    """
+    resolver_scope = ExecutionScope(
+        sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+    )
+    register_scope_resolver(lambda task_id: resolver_scope)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-snapshot", workspace_segments=("from-snapshot",)
+        )
+    )
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(
+            id=42,
+            user_id=1,
+            status=TaskStatus.PAUSED,
+            control_state="paused",
+            run_id="run-a",
+            state_version=3,
+        ),
+        runtime_user=SimpleNamespace(id=1, is_admin=False),
+    )
+    agent_service = MagicMock()
+    agent_service.supports_live_control.return_value = True
+    agent_manager = MagicMock(get_agent_for_task=AsyncMock(return_value=agent_service))
+    resume_started = asyncio.Event()
+    resume_kwargs: dict[str, Any] = {}
+
+    async def execute_resume(**kwargs: Any) -> None:
+        resume_kwargs.update(kwargs)
+        resume_started.set()
+
+    background_manager = MagicMock()
+    background_manager.running_tasks = {}
+    background_manager.reserve_resume.return_value = True
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+                return_value=snapshot,
+            ),
+            patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+            patch(
+                "xagent.web.api.websocket.task_execution_controller.transition",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(
+                        run_id="run-a", status=TaskStatus.PAUSED
+                    )
+                ),
+            ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager",
+                background_manager,
+            ),
+            patch(
+                "xagent.web.api.websocket.execute_resume_background",
+                side_effect=execute_resume,
+            ),
+        ]
+    ):
+        await _handle_resume_task_unserialized(
+            MagicMock(),
+            42,
+            {"user": SimpleNamespace(id=1, is_admin=False)},
+        )
+        await asyncio.wait_for(resume_started.wait(), timeout=1)
+
+    # Downgraded to the resolver's answer rather than raising, and the resume
+    # actually proceeded.
+    assert resume_kwargs["resolved_execution_scope"] == resolver_scope
+
+
 def test_resume_acquire_checkout_timeout_before_claim_does_not_try_cleanup() -> None:
     query = MagicMock()
     query.filter.return_value = query

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -24,10 +24,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     get_execution_scope,
-    set_execution_scope_resolver,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.api.websocket import (
@@ -42,15 +43,6 @@ from xagent.web.services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
-    yield
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
 
 
 def _make_task_orm() -> Task:
@@ -163,7 +155,7 @@ async def test_bg_turn_resolves_and_activates_scope() -> None:
         resolver_calls.append(task_id)
         return scope
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
 
     seen: dict[str, Any] = {}
     agent_service = MagicMock()
@@ -237,7 +229,7 @@ async def test_bg_turn_explicit_unscoped_does_not_resolve_again() -> None:
     def unexpected_resolver(task_id: str) -> ExecutionScope:
         raise AssertionError(f"scope for task {task_id} was resolved twice")
 
-    set_execution_scope_resolver(unexpected_resolver)
+    register_scope_resolver(unexpected_resolver)
     agent_service = MagicMock()
     agent_manager = MagicMock(
         get_agent_for_task=AsyncMock(return_value=agent_service),
@@ -296,6 +288,41 @@ async def test_owned_bg_failure_waits_for_exact_settlement_before_broadcast() ->
 
 
 @pytest.mark.asyncio
+async def test_bg_turn_authority_mismatch_fails_the_turn() -> None:
+    """Turn-face consumer (#296): a namespace-affecting
+    disagreement between the registered resolver and a persisted snapshot
+    must fail the turn -- unlike the off-turn consumers in
+    ``websocket._scope_segments_for_task`` and ``ManagedFileRef``, which
+    downgrade the same mismatch to the resolver's answer plus a warning."""
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(sandbox_key_suffix="from-snapshot")
+    )
+    agent_manager = MagicMock()
+
+    with (
+        _Patches(_bg_patches(_build_db_mock())),
+        pytest.raises(ExecutionScopeAuthorityError),
+    ):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+            task_lease=TaskLease(
+                task_id=42,
+                runner_id="runner-a",
+                run_id="run-a",
+            ),
+        )
+
+    agent_manager.get_agent_for_task.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_bg_turn_resolves_scope_before_loading_snapshot_off_loop() -> None:
     """Scope and setup snapshot are resolved sequentially in workers."""
     main_thread_id = threading.get_ident()
@@ -306,7 +333,7 @@ async def test_bg_turn_resolves_scope_before_loading_snapshot_off_loop() -> None
         events.append(("resolve", threading.get_ident()))
         return scope
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
 
     def load_snapshot(*_args: Any, **_kwargs: Any) -> Any:
         events.append(("snapshot", threading.get_ident()))
@@ -365,7 +392,7 @@ async def test_resumed_turn_re_resolves_scope() -> None:
         resolver_calls.append(task_id)
         return scope
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
 
     seen: dict[str, Any] = {}
     agent_service = MagicMock()
@@ -528,7 +555,7 @@ async def test_resume_handler_resolves_scope_once_off_loop_and_passes_it_through
         resolver_threads.append(threading.get_ident())
         return scope
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     snapshot = SimpleNamespace(
         task=SimpleNamespace(
             id=42,

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -291,11 +291,14 @@ async def test_owned_bg_failure_waits_for_exact_settlement_before_broadcast() ->
 
 @pytest.mark.asyncio
 async def test_bg_turn_authority_mismatch_fails_the_turn() -> None:
-    """Turn-face consumer (#296): a namespace-affecting
-    disagreement between the registered resolver and a persisted snapshot
-    must fail the turn -- unlike the off-turn consumers in
-    ``websocket._scope_segments_for_task`` and ``ManagedFileRef``, which
-    downgrade the same mismatch to the resolver's answer plus a warning."""
+    """Turn-face consumer: a namespace-affecting disagreement between the
+    registered resolver and a persisted snapshot must fail the turn --
+    unlike the off-turn consumers (``ManagedFileRef``'s construction, the
+    pause/resume handlers), which downgrade the same mismatch to the
+    resolver's authoritative answer plus a warning. Being reached off a turn
+    is not by itself what decides this: ``websocket._scope_segments_for_task``
+    also runs off-turn yet resolves fail-closed, because its caller composes
+    a storage key for new bytes."""
     register_scope_resolver(
         lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
     )

--- a/tests/web/api/test_pause_resume_offturn_build_workspace.py
+++ b/tests/web/api/test_pause_resume_offturn_build_workspace.py
@@ -38,9 +38,9 @@ import pytest
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.config import get_uploads_dir
 from xagent.core.execution_scope import (
+    DeferToSnapshot,
     ExecutionScope,
     ExecutionScopeAbstentionMismatchError,
-    defer_to_snapshot,
     scope_fingerprint,
     set_execution_scope_snapshot_loader,
 )
@@ -293,7 +293,7 @@ async def test_resume_cache_miss_builds_under_resolver_namespace_not_snapshot(
 async def test_pause_abstention_mismatch_fails_closed_with_no_workspace_residue(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
-    """Resolver ABSTAINS (``defer_to_snapshot``) and the snapshot WIDENS the
+    """Resolver ABSTAINS (``DeferToSnapshot``) and the snapshot WIDENS the
     abstention's fallback: this is the
     ``ExecutionScopeAbstentionMismatchError`` path, which
     ``resolve_execution_scope_off_turn`` re-raises instead of downgrading --
@@ -304,9 +304,7 @@ async def test_pause_abstention_mismatch_fails_closed_with_no_workspace_residue(
     uploads_root.mkdir()
     monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
 
-    register_scope_resolver(
-        lambda task_id: defer_to_snapshot(fallback=ExecutionScope())
-    )
+    register_scope_resolver(lambda task_id: DeferToSnapshot(fallback=ExecutionScope()))
     set_execution_scope_snapshot_loader(
         lambda task_id: ExecutionScope(workspace_segments=("wider",))
     )

--- a/tests/web/api/test_pause_resume_offturn_build_workspace.py
+++ b/tests/web/api/test_pause_resume_offturn_build_workspace.py
@@ -1,0 +1,417 @@
+"""Pin where a pause/resume agent-cache-miss build materializes real bytes.
+
+Pause and resume are off-turn control operations: both resolve the task's
+execution scope through ``resolve_execution_scope_off_turn``
+(``xagent.core.execution_scope``), which downgrades a resolver-vs-snapshot
+namespace disagreement to the resolver's own authoritative answer instead of
+raising, so a control operation on a running task stays available while the
+scope is in dispute. The handlers then pass that scope to
+``get_agent_manager().get_agent_for_task(..., resolved_execution_scope=...)``.
+
+On an agent-cache HIT this only locates an already-running agent -- nothing
+new is built. On a MISS, ``AgentServiceManager._get_agent_for_task_unlocked``
+builds a fresh ``AgentService``, which reads ``scope.workspace_segments`` and
+constructs a real ``TaskWorkspace`` whose constructor creates the workspace
+directory tree on disk. Every other test in this area mocks
+``get_agent_for_task`` wholesale, so that build branch never runs and nothing
+pins where those bytes land.
+
+These tests drive the real ``AgentServiceManager.get_agent_for_task`` build
+branch (a fresh manager instance, empty cache, real ``AgentService`` and real
+``TaskWorkspace``) through the actual ``_handle_pause_task_unserialized`` /
+``_handle_resume_task_unserialized`` handlers, and assert on the real
+filesystem path the workspace lands under. Only what is genuinely external is
+mocked: the sandbox/container runtime (``get_sandbox_manager``) and tool
+construction (``create_default_tools``, which would otherwise reach out to
+configured LLM/KB/MCP providers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.shared.execution_scope import register_scope_resolver
+from xagent.config import get_uploads_dir
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    ExecutionScopeAbstentionMismatchError,
+    defer_to_snapshot,
+    scope_fingerprint,
+    set_execution_scope_snapshot_loader,
+)
+from xagent.core.workspace import scoped_user_root
+from xagent.web.api import chat as chat_api
+from xagent.web.api import websocket as websocket_api
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.task import TaskStatus
+from xagent.web.services import task_setup_snapshot as snapshot_module
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
+
+TASK_ID = 501
+OWNER_ID = 7
+
+
+def _snapshot(*, status: TaskStatus, run_id: str) -> TaskSetupSnapshot:
+    control_state = "paused" if status == TaskStatus.PAUSED else "running"
+    return TaskSetupSnapshot(
+        task=_TaskFields(
+            id=TASK_ID,
+            user_id=OWNER_ID,
+            status=status,
+            agent_id=None,
+            agent_config=None,
+            model_name=None,
+            compact_model_name=None,
+            execution_mode="flash",
+            agent_type="standard",
+            run_id=run_id,
+            state_version=1,
+            control_state=control_state,
+        ),
+        runtime_user=RuntimeUserFields(id=OWNER_ID, is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="single_call",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=None,
+        agent_config=None,
+        excluded_agent_id=None,
+    )
+
+
+def _enter_build_only_patches(stack: ExitStack, manager: AgentServiceManager) -> None:
+    """Mock only the genuinely external boundaries of an agent build.
+
+    ``create_default_tools`` returns ``(tools=[], tool_config=None)``: an
+    empty tool list plus a ``None`` tool config keeps ``AgentService.__init__``
+    on its real ``enable_workspace`` branch (``self._setup_workspace()``)
+    instead of the ``tool_config._workspace_config`` branch, so the
+    constructor builds a genuine ``TaskWorkspace`` from ``workspace_base_dir``
+    -- the exact object whose constructor creates the directory tree on disk.
+    """
+    manager._default_llm = MagicMock()
+    stack.enter_context(
+        patch("xagent.web.api.chat.create_task_tracer", return_value=MagicMock())
+    )
+    stack.enter_context(
+        patch(
+            "xagent.web.api.chat.create_default_tools",
+            new=AsyncMock(return_value=([], None)),
+        )
+    )
+    stack.enter_context(
+        patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None)
+    )
+
+
+def _connection_manager() -> MagicMock:
+    manager = MagicMock()
+    manager.send_personal_message = AsyncMock()
+    manager.broadcast_to_task = AsyncMock()
+    return manager
+
+
+def _workspace_dir(owner_id: int, segments: tuple[str, ...]):
+    return (
+        scoped_user_root(get_uploads_dir(), owner_id, segments) / f"web_task_{TASK_ID}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pause_cache_miss_builds_under_resolver_namespace_not_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Resolver/snapshot mismatch, agent-cache MISS: pause builds the agent
+    and materializes the workspace tree under the RESOLVER's namespace, never
+    the snapshot's -- ``resolve_execution_scope_off_turn`` downgrades the
+    mismatch to the resolver's own answer instead of raising, and that
+    downgraded scope is what reaches ``AgentService``'s workspace
+    construction on the cache-miss build path."""
+    uploads_root = tmp_path / "uploads"
+    uploads_root.mkdir()
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
+
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-snapshot", workspace_segments=("from-snapshot",)
+        )
+    )
+
+    snapshot = _snapshot(status=TaskStatus.RUNNING, run_id="run-1")
+    manager = AgentServiceManager()
+    connection_manager = _connection_manager()
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: manager)
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch(
+                "xagent.core.agent.service.AgentService.pause_execution",
+                new=AsyncMock(return_value=True),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                websocket_api, "_apply_pause_requested_isolated", lambda *a, **k: True
+            )
+        )
+        _enter_build_only_patches(stack, manager)
+        try:
+            await websocket_api._handle_pause_task_unserialized(
+                MagicMock(),
+                TASK_ID,
+                {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+            )
+        finally:
+            websocket_api._clear_task_pause_accepted(TASK_ID)
+
+    resolver_workspace = _workspace_dir(OWNER_ID, ("from-resolver",))
+    snapshot_workspace = _workspace_dir(OWNER_ID, ("from-snapshot",))
+    assert resolver_workspace.is_dir()
+    assert (resolver_workspace / "input").is_dir()
+    assert (resolver_workspace / "output").is_dir()
+    assert (resolver_workspace / "temp").is_dir()
+    assert not snapshot_workspace.exists()
+    assert manager._agent_scope_fingerprints.get(TASK_ID) == scope_fingerprint(
+        ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_cache_miss_builds_under_resolver_namespace_not_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Same mismatch, through resume: the off-turn build lands under the
+    resolver's namespace, and the scheduled resumed turn (mocked here, since
+    it is a different consumer -- see
+    ``test_execution_scope_turn_wiring.test_resume_survives_a_scope_authority_mismatch``)
+    is never reached before the assertion."""
+    uploads_root = tmp_path / "uploads"
+    uploads_root.mkdir()
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
+
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-snapshot", workspace_segments=("from-snapshot",)
+        )
+    )
+
+    snapshot = _snapshot(status=TaskStatus.PAUSED, run_id="run-1")
+    manager = AgentServiceManager()
+    connection_manager = _connection_manager()
+    background_manager = MagicMock()
+    background_manager.running_tasks = {}
+    background_manager.reserve_resume.return_value = True
+    transition = AsyncMock(
+        return_value=SimpleNamespace(run_id="run-1", status=TaskStatus.PAUSED)
+    )
+    resume_scheduled = asyncio.Event()
+
+    async def _stub_execute_resume_background(**kwargs: object) -> None:
+        resume_scheduled.set()
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: manager)
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch.object(
+                websocket_api.task_execution_controller, "transition", new=transition
+            )
+        )
+        stack.enter_context(
+            patch.object(websocket_api, "background_task_manager", background_manager)
+        )
+        stack.enter_context(
+            patch.object(
+                websocket_api,
+                "execute_resume_background",
+                side_effect=_stub_execute_resume_background,
+            )
+        )
+        _enter_build_only_patches(stack, manager)
+        await websocket_api._handle_resume_task_unserialized(
+            MagicMock(),
+            TASK_ID,
+            {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+        )
+        # The handler fires the scheduled turn as a background asyncio task
+        # and returns without awaiting it; give the loop one chance to run it
+        # before asserting the stub observed the call.
+        await asyncio.wait_for(resume_scheduled.wait(), timeout=1)
+
+    resolver_workspace = _workspace_dir(OWNER_ID, ("from-resolver",))
+    snapshot_workspace = _workspace_dir(OWNER_ID, ("from-snapshot",))
+    assert resolver_workspace.is_dir()
+    assert (resolver_workspace / "input").is_dir()
+    assert not snapshot_workspace.exists()
+    assert resume_scheduled.is_set()
+    assert manager._agent_scope_fingerprints.get(TASK_ID) == scope_fingerprint(
+        ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_pause_abstention_mismatch_fails_closed_with_no_workspace_residue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Resolver ABSTAINS (``defer_to_snapshot``) and the snapshot WIDENS the
+    abstention's fallback: this is the
+    ``ExecutionScopeAbstentionMismatchError`` path, which
+    ``resolve_execution_scope_off_turn`` re-raises instead of downgrading --
+    an abstention never produced an authoritative answer to downgrade to.
+    The pause handler must fail closed: no agent is built, and neither
+    candidate namespace's directory is created."""
+    uploads_root = tmp_path / "uploads"
+    uploads_root.mkdir()
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
+
+    register_scope_resolver(
+        lambda task_id: defer_to_snapshot(fallback=ExecutionScope())
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("wider",))
+    )
+
+    snapshot = _snapshot(status=TaskStatus.RUNNING, run_id="run-1")
+    manager = AgentServiceManager()
+    connection_manager = _connection_manager()
+    agent_service_spy = MagicMock()
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: manager)
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch("xagent.web.api.chat.AgentService", agent_service_spy)
+        )
+        _enter_build_only_patches(stack, manager)
+        with pytest.raises(ExecutionScopeAbstentionMismatchError):
+            await websocket_api._handle_pause_task_unserialized(
+                MagicMock(),
+                TASK_ID,
+                {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+            )
+
+    agent_service_spy.assert_not_called()
+    assert manager._agents.get(TASK_ID) is None
+    fallback_workspace = _workspace_dir(OWNER_ID, ())
+    widened_workspace = _workspace_dir(OWNER_ID, ("wider",))
+    assert not fallback_workspace.exists()
+    assert not widened_workspace.exists()
+    # Nothing under the uploads root at all: the refusal leaves no residue.
+    assert list(uploads_root.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_pause_cache_hit_returns_running_agent_without_new_namespace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Agent-cache HIT: the already-running agent is returned untouched, and
+    no build (hence no new namespace / directory) happens at all -- the
+    off-turn scope resolution here only ever locates it."""
+    uploads_root = tmp_path / "uploads"
+    uploads_root.mkdir()
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
+
+    scope = ExecutionScope(
+        sandbox_key_suffix="tenant-a", workspace_segments=("tenant-a",)
+    )
+    register_scope_resolver(lambda task_id: scope)
+
+    snapshot = _snapshot(status=TaskStatus.RUNNING, run_id="run-1")
+    manager = AgentServiceManager()
+    cached_agent = MagicMock()
+    cached_agent.pause_execution = AsyncMock(return_value=True)
+    manager._agents[TASK_ID] = cached_agent
+    manager._agent_owner_ids[TASK_ID] = OWNER_ID
+    manager._agent_scope_fingerprints[TASK_ID] = scope_fingerprint(scope)
+    connection_manager = _connection_manager()
+    agent_service_spy = MagicMock()
+    create_default_tools_spy = AsyncMock(return_value=([], None))
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: manager)
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch.object(
+                websocket_api, "_apply_pause_requested_isolated", lambda *a, **k: True
+            )
+        )
+        stack.enter_context(
+            patch("xagent.web.api.chat.AgentService", agent_service_spy)
+        )
+        stack.enter_context(
+            patch(
+                "xagent.web.api.chat.create_default_tools", new=create_default_tools_spy
+            )
+        )
+        stack.enter_context(
+            patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None)
+        )
+        try:
+            await websocket_api._handle_pause_task_unserialized(
+                MagicMock(),
+                TASK_ID,
+                {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+            )
+        finally:
+            websocket_api._clear_task_pause_accepted(TASK_ID)
+
+    cached_agent.pause_execution.assert_awaited_once_with()
+    agent_service_spy.assert_not_called()
+    create_default_tools_spy.assert_not_called()
+    assert manager._agents[TASK_ID] is cached_agent
+    # No workspace tree materialized anywhere under the uploads root.
+    assert list(uploads_root.iterdir()) == []

--- a/tests/web/api/test_task_workspace_cleanup.py
+++ b/tests/web/api/test_task_workspace_cleanup.py
@@ -16,7 +16,6 @@ import pytest
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
-    set_execution_scope_resolver,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.api.chat import AgentServiceManager
@@ -24,15 +23,6 @@ from xagent.web.api.chat import AgentServiceManager
 OWNER_ID = 7
 TASK_ID = 42
 WORKSPACE_ID = f"web_task_{TASK_ID}"
-
-
-@pytest.fixture(autouse=True)
-def _no_resolver():
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
-    yield
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/web/api/test_task_workspace_cleanup.py
+++ b/tests/web/api/test_task_workspace_cleanup.py
@@ -13,7 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from xagent.core.execution_scope import set_execution_scope_resolver
+from tests.shared.execution_scope import register_scope_resolver
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
+)
 from xagent.web.api.chat import AgentServiceManager
 
 OWNER_ID = 7
@@ -24,8 +29,10 @@ WORKSPACE_ID = f"web_task_{TASK_ID}"
 @pytest.fixture(autouse=True)
 def _no_resolver():
     set_execution_scope_resolver(None)
+    set_execution_scope_snapshot_loader(None)
     yield
     set_execution_scope_resolver(None)
+    set_execution_scope_snapshot_loader(None)
 
 
 @pytest.fixture(autouse=True)
@@ -62,3 +69,31 @@ def test_probing_candidates_creates_nothing(tmp_path, monkeypatch):
     AgentServiceManager()._cleanup_workspace_directory(TASK_ID, OWNER_ID)
 
     assert not (uploads / f"user_{OWNER_ID}").exists()
+
+
+def test_an_authority_mismatch_still_deletes_the_workspace(tmp_path, monkeypatch):
+    """Cleanup runs off-turn, so a mismatch must not abandon the directory.
+
+    There is no turn left to fail here -- the agent is already gone -- and the
+    resolver has given an authoritative answer to delete against. Resolving
+    fail-closed instead would leave the tree on disk for good, with nothing
+    left to retry it.
+    """
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(tmp_path / "uploads"))
+    register_scope_resolver(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(
+            sandbox_key_suffix="from-snapshot", workspace_segments=("from-snapshot",)
+        )
+    )
+    workspace = _make_workspace(
+        tmp_path / "uploads" / f"user_{OWNER_ID}" / "from-resolver"
+    )
+
+    AgentServiceManager()._cleanup_workspace_directory(TASK_ID, OWNER_ID)
+
+    assert not workspace.exists()

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import HTTPException
 from fastapi.datastructures import UploadFile
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.file_storage.storage import FsspecFileStorage
 from xagent.core.workspace import TaskWorkspace
@@ -857,6 +858,74 @@ async def test_failed_compensation_does_not_skip_request_local_cleanup(
 
     assert local_paths
     assert all(not path.exists() for path in local_paths)
+
+
+@pytest.mark.asyncio
+async def test_store_uploaded_files_fails_closed_on_scope_authority_mismatch(
+    isolated_upload_storage,
+) -> None:
+    """``store_uploaded_files`` selects the write namespace (workspace
+    segments / storage key) for the bytes it writes, unlike the off-turn
+    *read* paths (``resolve_execution_scope_off_turn``) that downgrade an
+    authority mismatch to a warning and keep going. A registered
+    resolver/persisted-snapshot disagreement here must propagate and fail
+    the request instead of silently choosing a namespace."""
+    from xagent.core.execution_scope import (
+        ExecutionScope,
+        ExecutionScopeAuthorityError,
+        set_execution_scope_snapshot_loader,
+    )
+    from xagent.web.models.task import Task, TaskStatus
+    from xagent.web.services.execution_scope_snapshot import (
+        load_task_execution_scope_snapshot,
+    )
+
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = int(db.query(User.id).filter(User.username == "admin").scalar())
+        task = Task(
+            user_id=user_id,
+            title="scope mismatch",
+            description="scope mismatch",
+            status=TaskStatus.COMPLETED,
+            source="sdk",
+            agent_config={
+                "execution_scope": ExecutionScope(
+                    workspace_segments=("snapshot-tenant",),
+                ).to_dict()
+            },
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    set_execution_scope_snapshot_loader(load_task_execution_scope_snapshot)
+    register_scope_resolver(
+        lambda _task_id: ExecutionScope(workspace_segments=("resolver-tenant",)),
+    )
+    try:
+        with pytest.raises(ExecutionScopeAuthorityError):
+            await files_api.store_uploaded_files(
+                upload_items=[
+                    UploadFile(
+                        filename="mismatch.txt",
+                        file=io.BytesIO(b"payload"),
+                        headers={"content-type": "text/plain"},
+                    )
+                ],
+                task_type="general",
+                task_id=str(task_id),
+                folder=None,
+                user_id=user_id,
+                single_file_mode=True,
+            )
+    finally:
+        register_scope_resolver(None)
+        set_execution_scope_snapshot_loader(None)
 
 
 def test_http_durable_upload_is_bound_to_agent_workspace_without_second_put(

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -23,9 +23,9 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
-    set_execution_scope_resolver,
 )
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
@@ -1208,7 +1208,7 @@ async def test_running_chat_message_uses_one_offloop_scope_and_no_request_sessio
         resolver_threads.append(threading.get_ident())
         return scope
 
-    set_execution_scope_resolver(resolver)
+    register_scope_resolver(resolver)
     original_get_db = get_db
     tracked_sessions: list[SimpleNamespace] = []
 
@@ -1304,7 +1304,7 @@ async def test_running_chat_message_uses_one_offloop_scope_and_no_request_sessio
             )
             await asyncio.sleep(0)
     finally:
-        set_execution_scope_resolver(None)
+        register_scope_resolver(None)
 
     assert len(manager_calls) == 1
     manager_db, manager_kwargs = manager_calls[0]

--- a/tests/web/api/test_websocket_pause_db_boundary.py
+++ b/tests/web/api/test_websocket_pause_db_boundary.py
@@ -11,6 +11,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy.orm import Session
 
+from tests.shared.execution_scope import register_scope_resolver
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    set_execution_scope_snapshot_loader,
+)
 from xagent.web.api import chat as chat_api
 from xagent.web.api import websocket as websocket_api
 from xagent.web.models import database as database_module
@@ -63,7 +68,7 @@ async def test_pause_handler_keeps_database_work_off_the_event_loop(
         }
         return snapshot
 
-    def resolve_scope(resolved_task_id: int) -> None:
+    def resolve_scope_off_turn(resolved_task_id: int) -> None:
         worker_threads["scope"] = threading.get_ident()
         assert resolved_task_id == task_id
         return None
@@ -86,7 +91,11 @@ async def test_pause_handler_keeps_database_work_off_the_event_loop(
     connection_manager.broadcast_to_task = AsyncMock()
 
     monkeypatch.setattr(snapshot_module, "load_task_setup_snapshot_sync", load_snapshot)
-    monkeypatch.setattr(websocket_api, "resolve_execution_scope", resolve_scope)
+    # Pause is a control operation on an already-running task, so it resolves
+    # off-turn: it must stay available while the scope is in dispute.
+    monkeypatch.setattr(
+        websocket_api, "resolve_execution_scope_off_turn", resolve_scope_off_turn
+    )
     monkeypatch.setattr(
         websocket_api,
         "_apply_pause_requested_isolated",
@@ -119,6 +128,73 @@ async def test_pause_handler_keeps_database_work_off_the_event_loop(
     }
     agent_service.pause_execution.assert_awaited_once_with()
     connection_manager.broadcast_to_task.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pause_survives_a_scope_authority_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user must be able to pause a task whose scope is in dispute.
+
+    Pause locates an already-running task; it selects no namespace for new
+    bytes. Resolving fail-closed here would let a resolver/snapshot
+    disagreement escape the socket loop and leave the task unstoppable.
+    """
+    task_id = 43
+    owner_id = 7
+    actor = SimpleNamespace(id=owner_id, is_admin=False)
+    runtime_user = SimpleNamespace(id=owner_id, is_admin=False)
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(
+            user_id=owner_id, status=TaskStatus.RUNNING, run_id="run-2"
+        ),
+        runtime_user=runtime_user,
+    )
+    register_scope_resolver(
+        lambda resolved_task_id: ExecutionScope(
+            sandbox_key_suffix="from-resolver", workspace_segments=("from-resolver",)
+        )
+    )
+    set_execution_scope_snapshot_loader(
+        lambda resolved_task_id: ExecutionScope(
+            sandbox_key_suffix="from-snapshot", workspace_segments=("from-snapshot",)
+        )
+    )
+    agent_service = MagicMock()
+    agent_service.pause_execution = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+
+    monkeypatch.setattr(
+        snapshot_module, "load_task_setup_snapshot_sync", lambda *a, **k: snapshot
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_apply_pause_requested_isolated",
+        lambda *a, **k: True,
+        raising=False,
+    )
+    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: agent_manager)
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    try:
+        await websocket_api._handle_pause_task_unserialized(
+            MagicMock(), task_id, {"user": actor}
+        )
+    finally:
+        websocket_api._clear_task_pause_accepted(task_id)
+
+    # The pause went through on the resolver's answer instead of raising.
+    agent_service.pause_execution.assert_awaited_once_with()
+    assert (
+        agent_manager.get_agent_for_task.await_args.kwargs[
+            "resolved_execution_scope"
+        ].sandbox_key_suffix
+        == "from-resolver"
+    )
 
 
 def _running_task(db_session: Session, *, run_id: str = "run-1") -> Task:

--- a/tests/web/services/test_file_turn.py
+++ b/tests/web/services/test_file_turn.py
@@ -12,6 +12,7 @@ from sqlalchemy.pool import QueuePool
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.models import database as database_module
@@ -332,4 +333,84 @@ def test_resolve_preserves_registered_scope_fallback_without_nested_checkout(
     finally:
         register_scope_resolver(None)
         set_execution_scope_snapshot_loader(None)
+        engine.dispose()
+
+
+def test_resolve_fails_closed_on_registered_scope_authority_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A turn face: the resolved scope selects the namespace files are read
+    back from, and this call passes the persisted snapshot it already read
+    in its own Session explicitly via ``persisted_snapshot``, so a
+    disagreement between the registered resolver and that snapshot must
+    propagate ``ExecutionScopeAuthorityError`` instead of being downgraded,
+    and no file may be materialized on the mismatched path."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'authority-mismatch.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    local_path = tmp_path / "disputed.txt"
+    local_path.write_text("payload")
+
+    register_scope_resolver(
+        lambda _task_id: ExecutionScope(workspace_segments=("resolver-tenant",))
+    )
+    try:
+        with SessionLocal() as db:
+            user = User(username="disputed-owner", password_hash="hash", is_admin=False)
+            db.add(user)
+            db.flush()
+            task = Task(
+                user_id=int(user.id),
+                title="disputed task",
+                description="disputed task",
+                status=TaskStatus.COMPLETED,
+                source="sdk",
+                agent_config={
+                    "execution_scope": ExecutionScope(
+                        workspace_segments=("snapshot-tenant",),
+                    ).to_dict()
+                },
+            )
+            db.add(task)
+            db.flush()
+            db.add(
+                UploadedFile(
+                    file_id="disputed",
+                    user_id=int(user.id),
+                    task_id=int(task.id),
+                    filename="disputed.txt",
+                    storage_path=str(local_path),
+                    file_size=local_path.stat().st_size,
+                )
+            )
+            db.commit()
+            user_id = int(user.id)
+            task_id = int(task.id)
+
+        materialize_calls: list[str] = []
+        original_ensure_local = ManagedFileRef.ensure_local
+
+        def track_materialize(self: ManagedFileRef) -> Path:
+            materialize_calls.append(self.storage_key)
+            return original_ensure_local(self)
+
+        monkeypatch.setattr(ManagedFileRef, "ensure_local", track_materialize)
+
+        with SessionLocal() as db:
+            with pytest.raises(ExecutionScopeAuthorityError):
+                resolve_turn_file_infos(
+                    file_ids=["disputed"],
+                    owner_user_id=user_id,
+                    task_id=task_id,
+                    db=db,
+                )
+
+        assert materialize_calls == []
+    finally:
+        register_scope_resolver(None)
         engine.dispose()

--- a/tests/web/services/test_file_turn.py
+++ b/tests/web/services/test_file_turn.py
@@ -414,3 +414,71 @@ def test_resolve_fails_closed_on_registered_scope_authority_mismatch(
     finally:
         register_scope_resolver(None)
         engine.dispose()
+
+
+def test_malformed_persisted_snapshot_does_not_fail_the_turn(
+    tmp_path: Path,
+) -> None:
+    """This path reads the persisted snapshot itself, outside the try/except
+    that ``resolve_execution_scope`` wraps the registered loader in. A row
+    whose snapshot fails field validation must therefore be ignored here the
+    same way it is ignored there -- the registered resolver's answer stands
+    alone and the turn proceeds -- rather than refusing a turn the resolver
+    could answer on its own."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'malformed-snapshot.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    local_path = tmp_path / "attached.txt"
+    local_path.write_text("payload")
+
+    register_scope_resolver(
+        lambda _task_id: ExecutionScope(workspace_segments=("resolver-tenant",))
+    )
+    try:
+        with SessionLocal() as db:
+            user = User(username="corrupt-owner", password_hash="hash", is_admin=False)
+            db.add(user)
+            db.flush()
+            task = Task(
+                user_id=int(user.id),
+                title="corrupt snapshot task",
+                description="corrupt snapshot task",
+                status=TaskStatus.COMPLETED,
+                source="sdk",
+                # workspace_segments must be a list/tuple: this row cannot be
+                # decoded into a scope at all.
+                agent_config={"execution_scope": {"workspace_segments": 5}},
+            )
+            db.add(task)
+            db.flush()
+            db.add(
+                UploadedFile(
+                    file_id="attached",
+                    user_id=int(user.id),
+                    task_id=int(task.id),
+                    filename="attached.txt",
+                    storage_path=str(local_path),
+                    file_size=local_path.stat().st_size,
+                )
+            )
+            db.commit()
+            user_id = int(user.id)
+            task_id = int(task.id)
+
+        with SessionLocal() as db:
+            infos, missing = resolve_turn_file_infos(
+                file_ids=["attached"],
+                owner_user_id=user_id,
+                task_id=task_id,
+                db=db,
+            )
+
+        assert missing == []
+        assert [info["file_id"] for info in infos] == ["attached"]
+    finally:
+        register_scope_resolver(None)
+        engine.dispose()

--- a/tests/web/services/test_file_turn.py
+++ b/tests/web/services/test_file_turn.py
@@ -344,7 +344,7 @@ def test_resolve_fails_closed_on_registered_scope_authority_mismatch(
 ) -> None:
     """A turn face: the resolved scope selects the namespace files are read
     back from, and this call passes the persisted snapshot it already read
-    in its own Session explicitly via ``persisted_snapshot``, so a
+    in its own Session explicitly via ``persisted_agent_config``, so a
     disagreement between the registered resolver and that snapshot must
     propagate ``ExecutionScopeAuthorityError`` instead of being downgraded,
     and no file may be materialized on the mismatched path."""

--- a/tests/web/services/test_file_turn.py
+++ b/tests/web/services/test_file_turn.py
@@ -11,8 +11,10 @@ from sqlalchemy.pool import QueuePool
 
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
+    DeferToSnapshot,
     ExecutionScope,
     ExecutionScopeAuthorityError,
+    ExecutionScopeResolverContractError,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.models import database as database_module
@@ -416,15 +418,13 @@ def test_resolve_fails_closed_on_registered_scope_authority_mismatch(
         engine.dispose()
 
 
-def test_malformed_persisted_snapshot_does_not_fail_the_turn(
+def test_malformed_snapshot_is_ignored_when_the_resolver_is_authoritative(
     tmp_path: Path,
 ) -> None:
-    """This path reads the persisted snapshot itself, outside the try/except
-    that ``resolve_execution_scope`` wraps the registered loader in. A row
-    whose snapshot fails field validation must therefore be ignored here the
-    same way it is ignored there -- the registered resolver's answer stands
-    alone and the turn proceeds -- rather than refusing a turn the resolver
-    could answer on its own."""
+    """An authoritative resolver can answer without the snapshot, so a row
+    whose snapshot fails field validation is ignored and the turn proceeds.
+    Tolerance is a property of this branch only -- see the two tests below for
+    the branches where the same row must fail the turn."""
 
     engine = create_engine(
         f"sqlite:///{tmp_path / 'malformed-snapshot.db'}",
@@ -479,6 +479,105 @@ def test_malformed_persisted_snapshot_does_not_fail_the_turn(
 
         assert missing == []
         assert [info["file_id"] for info in infos] == ["attached"]
+    finally:
+        register_scope_resolver(None)
+        engine.dispose()
+
+
+def _seed_malformed_snapshot_task(SessionLocal, local_path: Path) -> tuple[int, int]:
+    with SessionLocal() as db:
+        user = User(username="corrupt-owner", password_hash="hash", is_admin=False)
+        db.add(user)
+        db.flush()
+        task = Task(
+            user_id=int(user.id),
+            title="corrupt snapshot task",
+            description="corrupt snapshot task",
+            status=TaskStatus.COMPLETED,
+            source="sdk",
+            # workspace_segments must be a list/tuple: this row cannot be
+            # decoded into a scope at all.
+            agent_config={"execution_scope": {"workspace_segments": 5}},
+        )
+        db.add(task)
+        db.flush()
+        db.add(
+            UploadedFile(
+                file_id="attached",
+                user_id=int(user.id),
+                task_id=int(task.id),
+                filename="attached.txt",
+                storage_path=str(local_path),
+                file_size=local_path.stat().st_size,
+            )
+        )
+        db.commit()
+        return int(user.id), int(task.id)
+
+
+def test_malformed_snapshot_fails_the_turn_with_no_resolver_registered(
+    tmp_path: Path,
+) -> None:
+    """No resolver registered is the shape this repository ships in, and there
+    the persisted snapshot is the only namespace authority. A row that cannot
+    be decoded therefore has to fail the turn: treating it as "no candidate"
+    would resolve the task to unscoped, which is a namespace decision made by
+    accident rather than by an authority."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'no-resolver.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    local_path = tmp_path / "attached.txt"
+    local_path.write_text("payload")
+    try:
+        user_id, task_id = _seed_malformed_snapshot_task(SessionLocal, local_path)
+
+        with SessionLocal() as db:
+            with pytest.raises(ExecutionScopeResolverContractError):
+                resolve_turn_file_infos(
+                    file_ids=["attached"],
+                    owner_user_id=user_id,
+                    task_id=task_id,
+                    db=db,
+                )
+    finally:
+        engine.dispose()
+
+
+def test_malformed_snapshot_fails_the_turn_when_the_resolver_abstains(
+    tmp_path: Path,
+) -> None:
+    """An abstaining resolver has just said it does not know this task's
+    namespace, so a snapshot it cannot read leaves nobody who knows. The turn
+    must fail rather than fall through to the abstention's fallback on the
+    strength of a row that never decoded."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'abstain.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    local_path = tmp_path / "attached.txt"
+    local_path.write_text("payload")
+
+    register_scope_resolver(
+        lambda _task_id: DeferToSnapshot(fallback=ExecutionScope()),
+    )
+    try:
+        user_id, task_id = _seed_malformed_snapshot_task(SessionLocal, local_path)
+
+        with SessionLocal() as db:
+            with pytest.raises(ExecutionScopeResolverContractError):
+                resolve_turn_file_infos(
+                    file_ids=["attached"],
+                    owner_user_id=user_id,
+                    task_id=task_id,
+                    db=db,
+                )
     finally:
         register_scope_resolver(None)
         engine.dispose()

--- a/tests/web/services/test_file_turn.py
+++ b/tests/web/services/test_file_turn.py
@@ -9,9 +9,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
-    set_execution_scope_resolver,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.models import database as database_module
@@ -268,7 +268,7 @@ def test_resolve_preserves_registered_scope_fallback_without_nested_checkout(
     monkeypatch.setattr(database_module, "_engine", engine)
     monkeypatch.setattr(database_module, "_SessionLocal", SessionLocal)
     set_execution_scope_snapshot_loader(load_task_execution_scope_snapshot)
-    set_execution_scope_resolver(lambda _task_id: isolated_scope)
+    register_scope_resolver(lambda _task_id: isolated_scope)
     try:
         with SessionLocal() as db:
             user = User(
@@ -330,6 +330,6 @@ def test_resolve_preserves_registered_scope_fallback_without_nested_checkout(
         assert observed_checked_out == [0]
         assert observed_prefixes == ["users/1/clients/3/end_users/7"]
     finally:
-        set_execution_scope_resolver(None)
+        register_scope_resolver(None)
         set_execution_scope_snapshot_loader(None)
         engine.dispose()

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from xagent.core.file_storage.factory import get_unscoped_file_storage
+from xagent.core.file_storage.scoped import ScopedFileStorage, StorageKeyScopeError
 from xagent.core.file_storage.types import StoredObject
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.services.managed_file_ref import (
@@ -461,6 +462,13 @@ class SameSizeStaleStorage:
 
 
 def test_sync_to_durable_wraps_remote_write_failure(tmp_path):
+    """A backend fault genuinely is a durable-storage operation error.
+
+    Pairs with
+    ``test_sync_to_durable_propagates_scope_violation_unwrapped``: excluding
+    the namespace-authority types from that wrap must not turn it into
+    "propagate everything".
+    """
     source = tmp_path / "uploads" / "sync-fails.txt"
     source.parent.mkdir()
     source.write_text("sync content", encoding="utf-8")
@@ -471,6 +479,32 @@ def test_sync_to_durable_wraps_remote_write_failure(tmp_path):
 
     assert record.storage_status == "legacy"
     assert record.storage_key is None
+
+
+def test_sync_to_durable_propagates_scope_violation_unwrapped(monkeypatch, tmp_path):
+    """A key outside the bound prefix stays a ``StorageKeyScopeError``.
+
+    Folding it into ``DurableStorageOperationError`` would report a permanent
+    containment violation as the retryable storage outage that error means to
+    callers.
+    """
+    _configure_storage(monkeypatch, tmp_path)
+    source = tmp_path / "uploads" / "foreign-key.txt"
+    source.parent.mkdir()
+    source.write_text("scope content", encoding="utf-8")
+    record = _record(source, file_size=source.stat().st_size)
+    storage = ScopedFileStorage(
+        storage=get_unscoped_file_storage(), prefix="users/7/clients/3"
+    )
+    foreign_key = "users/7/clients/4/uploads/file-123/foreign-key.txt"
+
+    with pytest.raises(StorageKeyScopeError) as excinfo:
+        ManagedFileRef(record, storage=storage).sync_to_durable(storage_key=foreign_key)
+
+    assert not isinstance(excinfo.value, DurableStorageOperationError)
+    assert record.storage_status == "legacy"
+    assert record.storage_key is None
+    assert not get_unscoped_file_storage().exists(foreign_key)
 
 
 def test_ensure_local_wraps_remote_read_failure_when_local_missing(tmp_path):

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -111,9 +111,12 @@ def test_restore_rejects_foreign_storage_key(storage_env, tmp_path):
 
 
 def test_signed_url_never_issued_for_foreign_storage_key(storage_env, tmp_path):
-    # signed_access_url degrades to None when the checksum probe fails; the
-    # scope check makes that probe fail for foreign keys, so no URL is issued
-    # even though the foreign object exists and the checksum matches.
+    # No URL may be issued for a foreign key even though the foreign object
+    # exists and its checksum matches. The containment violation is a
+    # permanent authority fault, so it propagates to be classified once at the
+    # application boundary rather than being reported as an unavailable
+    # checksum -- which would read as a transient reason to fall back to
+    # backend-mediated access, a fallback that hits the same violation anyway.
     foreign = get_unscoped_file_storage().put_bytes(
         b"foreign", "users/8/uploads/file-123/missing.txt"
     )
@@ -125,7 +128,8 @@ def test_signed_url_never_issued_for_foreign_storage_key(storage_env, tmp_path):
         checksum=foreign.checksum,
     )
 
-    assert ManagedFileRef(record).signed_access_url(expires=300) is None
+    with pytest.raises(StorageKeyScopeError):
+        ManagedFileRef(record).signed_access_url(expires=300)
 
 
 def test_delete_durable_rejects_foreign_storage_key(storage_env, tmp_path):

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -9,11 +9,12 @@ from pathlib import Path
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
     reset_execution_scope,
     set_execution_scope,
-    set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
 )
 from xagent.core.file_storage import StorageKeyScopeError
 from xagent.core.file_storage.factory import get_unscoped_file_storage
@@ -43,14 +44,6 @@ def storage_env(monkeypatch, tmp_path):
     get_unscoped_file_storage.cache_clear()
     yield tmp_path
     get_unscoped_file_storage.cache_clear()
-
-
-@pytest.fixture
-def clear_scope_resolver():
-    """Start and end each test with no registered resolver."""
-    set_execution_scope_resolver(None)
-    yield
-    set_execution_scope_resolver(None)
 
 
 def _record(local_path: Path, **overrides) -> UploadedFile:
@@ -273,19 +266,19 @@ def test_isolated_handle_rejects_sibling_end_user_key(storage_env, tmp_path):
 # recoverable from the per-task resolver/snapshot keyed on record.task_id.
 
 
-def test_resolver_narrows_handle_when_contextvar_absent(
-    storage_env, tmp_path, clear_scope_resolver
-):
-    set_execution_scope_resolver(
-        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None
+def test_resolver_narrows_handle_when_contextvar_absent(storage_env, tmp_path):
+    register_scope_resolver(
+        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None,
     )
     record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
     # No ambient contextvar, no explicit scope: fall back to the resolver.
     assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
 
 
-def test_contextvar_beats_resolver(storage_env, tmp_path, clear_scope_resolver):
-    set_execution_scope_resolver(lambda task_id: _NON_ISOLATED_SCOPE)
+def test_contextvar_beats_resolver(storage_env, tmp_path):
+    register_scope_resolver(
+        lambda task_id: _NON_ISOLATED_SCOPE,
+    )
     record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
     token = set_execution_scope(_ISOLATED_SCOPE)
     try:
@@ -294,29 +287,25 @@ def test_contextvar_beats_resolver(storage_env, tmp_path, clear_scope_resolver):
         reset_execution_scope(token)
 
 
-def test_explicit_scope_beats_resolver(storage_env, tmp_path, clear_scope_resolver):
-    set_execution_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+def test_explicit_scope_beats_resolver(storage_env, tmp_path):
+    register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
     record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
     ref = ManagedFileRef(record, execution_scope=_NON_ISOLATED_SCOPE)
     assert ref.storage.prefix == "users/7"
 
 
-def test_resolver_not_consulted_without_task_id(
-    storage_env, tmp_path, clear_scope_resolver
-):
+def test_resolver_not_consulted_without_task_id(storage_env, tmp_path):
     def _boom(task_id):
         raise AssertionError("resolver must not run when the record has no task_id")
 
-    set_execution_scope_resolver(_boom)
+    register_scope_resolver(_boom)
     record = _record(tmp_path / "uploads" / "missing.txt")  # task_id defaults to None
     assert ManagedFileRef(record).storage.prefix == "users/7"
 
 
-def test_sync_to_durable_uses_resolved_scope(
-    storage_env, tmp_path, clear_scope_resolver
-):
-    set_execution_scope_resolver(
-        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None
+def test_sync_to_durable_uses_resolved_scope(storage_env, tmp_path):
+    register_scope_resolver(
+        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None,
     )
     source = tmp_path / "uploads" / "source.txt"
     source.parent.mkdir()
@@ -325,3 +314,68 @@ def test_sync_to_durable_uses_resolved_scope(
 
     stored = ManagedFileRef(record).sync_to_durable()
     assert stored.key == "users/7/clients/3/end_users/7/uploads/file-123/source.txt"
+
+
+# --- read path skips off-turn re-resolution (#296) ------
+# A record that already has a durable storage_key fixes its own location;
+# off-turn re-resolving the scope is unnecessary and, on a resolver/snapshot
+# drift, would make an already-legitimate key look foreign to a narrower
+# re-derived scope. Only a record with no storage_key yet (a new object about
+# to be written) still resolves off-turn.
+
+
+def test_existing_storage_key_skips_off_turn_resolution(storage_env, tmp_path):
+    def _boom(task_id):
+        raise AssertionError(
+            "off-turn resolution must not run when the record already has "
+            "a durable storage_key"
+        )
+
+    register_scope_resolver(_boom)
+    record = _record(
+        tmp_path / "uploads" / "missing.txt",
+        task_id=99,
+        storage_key="users/7/clients/3/end_users/7/uploads/file-123/source.txt",
+        storage_backend="file",
+        storage_status="available",
+    )
+
+    # Owner root, not the resolver's (never-called) narrower prefix.
+    assert ManagedFileRef(record).storage.prefix == "users/7"
+
+
+def test_existing_storage_key_binding_tolerates_resolver_snapshot_mismatch(
+    storage_env, tmp_path
+):
+    """An off-turn authority mismatch would otherwise fail closed (see
+    ``resolve_execution_scope_off_turn``); the read path never even reaches
+    that check because it does not resolve off-turn at all."""
+    register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
+    )
+    record = _record(
+        tmp_path / "uploads" / "missing.txt",
+        task_id=99,
+        storage_key="users/7/uploads/file-123/source.txt",
+        storage_backend="file",
+        storage_status="available",
+    )
+
+    assert ManagedFileRef(record).storage.prefix == "users/7"
+
+
+def test_new_object_write_path_still_resolves_off_turn_on_mismatch(
+    storage_env, tmp_path
+):
+    """No storage_key yet (a fresh upload): the write path still resolves
+    off-turn, and a namespace-affecting authority mismatch downgrades to the
+    resolver's own answer instead of raising (see
+    ``resolve_execution_scope_off_turn``)."""
+    register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
+    )
+    record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
+
+    assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -366,22 +366,32 @@ def test_existing_storage_key_binding_tolerates_resolver_snapshot_mismatch(
     assert ManagedFileRef(record).storage.prefix == "users/7"
 
 
-def test_new_object_write_path_fails_closed_on_mismatch(storage_env, tmp_path):
-    """No storage_key yet (a fresh upload): choosing the namespace new bytes
-    land under is an authority decision, so a resolver/snapshot mismatch
-    fails closed instead of downgrading to either side's guess -- getting it
-    wrong would silently and durably place the object under the wrong
-    tenant's subtree. No object may be written under either candidate
-    prefix."""
+def test_sync_to_durable_fails_closed_on_mismatch_for_recovered_scope(
+    storage_env, tmp_path
+):
+    """No storage_key yet (a fresh upload): construction always recovers the
+    scope off-turn (see ``__post_init__``) and never raises here, since a
+    keyless ref might just as well be serving a read. Choosing the namespace
+    new bytes land under is the actual authority decision, so
+    ``sync_to_durable`` re-resolves fail-closed right before composing the
+    key -- getting it wrong would silently and durably place the object
+    under the wrong tenant's subtree. No object may be written under either
+    candidate prefix."""
     register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
     set_execution_scope_snapshot_loader(
         lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
     )
-    record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("data", encoding="utf-8")
+    record = _record(source, task_id=99, storage_status="pending")
+
+    ref = ManagedFileRef(record)  # construction downgrades, does not raise
 
     with pytest.raises(ExecutionScopeAuthorityError):
-        ManagedFileRef(record)
+        ref.sync_to_durable()
 
+    assert record.storage_status == "pending"
     objects_root = tmp_path / "objects" / "users" / "7"
     assert not (objects_root / "clients").exists()
     assert not (objects_root / "other-tenant").exists()
@@ -389,11 +399,12 @@ def test_new_object_write_path_fails_closed_on_mismatch(storage_env, tmp_path):
 
 def test_read_path_downgrades_on_mismatch_for_pending_record(storage_env, tmp_path):
     """No storage_key yet is also the normal state of a record read while its
-    upload is still pending (see build_uploaded_file_record). Unlike the
-    write path above, a read has local storage to fall back to, so
-    ``for_write=False`` must downgrade a resolver/snapshot mismatch to the
-    resolver's answer and still serve the file, instead of raising
-    ExecutionScopeAuthorityError into an unhandled 500."""
+    upload is still pending (see build_uploaded_file_record). A read has
+    local storage to fall back to, so construction downgrades a
+    resolver/snapshot mismatch to the resolver's answer and still serves the
+    file, instead of raising ExecutionScopeAuthorityError into an unhandled
+    500 (the namespace decision that must fail closed is deferred to
+    ``sync_to_durable``, see the test above)."""
     register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
     set_execution_scope_snapshot_loader(
         lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
@@ -403,6 +414,27 @@ def test_read_path_downgrades_on_mismatch_for_pending_record(storage_env, tmp_pa
     source.write_text("pending upload", encoding="utf-8")
     record = _record(source, task_id=99, storage_status="pending")
 
-    ref = ManagedFileRef(record, for_write=False)
+    ref = ManagedFileRef(record)
     assert ref.storage.prefix == "users/7/clients/3/end_users/7"
     assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"
+
+
+def test_materialize_downgrades_on_mismatch_for_pending_record(storage_env, tmp_path):
+    """``materialize()`` (see ``Workspace``'s
+    ``ManagedFileRef(record).materialize()`` call, and similarly ``kb.py``'s
+    ``ensure_local``/``delete_durable`` calls) reads or addresses bytes
+    already placed, never a namespace decision, so it must not be blocked by
+    a resolver/snapshot mismatch that construction now downgrades instead of
+    raising."""
+    register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
+    )
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("pending upload", encoding="utf-8")
+    record = _record(source, task_id=99, storage_status="pending")
+
+    ref = ManagedFileRef(record)
+    assert ref.storage.prefix == "users/7/clients/3/end_users/7"
+    assert ref.materialize().read_text(encoding="utf-8") == "pending upload"

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -262,7 +262,7 @@ def test_isolated_handle_rejects_sibling_end_user_key(storage_env, tmp_path):
 
 
 # --- resolver/snapshot fallback when the turn contextvar is absent ----------
-# Off-turn paths (bot/builder-chat handlers) never enter turn_execution_scope,
+# Off-turn paths (bot/builder-chat handlers) never enter an ExecutionScopeContext,
 # so the ambient contextvar is None while a workforce sub-task's scope is still
 # recoverable from the per-task resolver/snapshot keyed on record.task_id.
 

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -20,10 +20,7 @@ from xagent.core.execution_scope import (
 from xagent.core.file_storage import StorageKeyScopeError
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.models.uploaded_file import UploadedFile
-from xagent.web.services.managed_file_ref import (
-    DurableStorageOperationError,
-    ManagedFileRef,
-)
+from xagent.web.services.managed_file_ref import ManagedFileRef
 
 _ISOLATED_SCOPE = ExecutionScope(
     workspace_segments=("clients", "3", "end_users", "7"),
@@ -94,24 +91,21 @@ def test_sync_to_durable_rejects_foreign_explicit_key(storage_env, tmp_path):
     source.write_text("data", encoding="utf-8")
     record = _record(source)
 
-    with pytest.raises(DurableStorageOperationError) as excinfo:
+    with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record).sync_to_durable(
             storage_key="users/8/uploads/file-123/source.txt"
         )
-    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
     assert not get_unscoped_file_storage().exists("users/8/uploads/file-123/source.txt")
 
 
 def test_restore_rejects_foreign_storage_key(storage_env, tmp_path):
     record = _foreign_key_record(tmp_path / "uploads" / "missing.txt")
 
-    with pytest.raises(DurableStorageOperationError) as excinfo:
+    with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record).ensure_local()
-    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
 
-    with pytest.raises(DurableStorageOperationError) as excinfo:
+    with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record).materialize()
-    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
 
 
 def test_signed_url_never_issued_for_foreign_storage_key(storage_env, tmp_path):
@@ -149,11 +143,10 @@ def test_adopt_existing_object_rejects_foreign_expected_key(storage_env, tmp_pat
         b"foreign", "users/8/uploads/file-123/source.txt"
     )
 
-    with pytest.raises(DurableStorageOperationError) as excinfo:
+    with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record).adopt_existing_object(
             "users/8/uploads/file-123/source.txt"
         )
-    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
 
 
 def test_separator_aware_scope_for_record_owner(storage_env, tmp_path):

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -385,3 +385,24 @@ def test_new_object_write_path_fails_closed_on_mismatch(storage_env, tmp_path):
     objects_root = tmp_path / "objects" / "users" / "7"
     assert not (objects_root / "clients").exists()
     assert not (objects_root / "other-tenant").exists()
+
+
+def test_read_path_downgrades_on_mismatch_for_pending_record(storage_env, tmp_path):
+    """No storage_key yet is also the normal state of a record read while its
+    upload is still pending (see build_uploaded_file_record). Unlike the
+    write path above, a read has local storage to fall back to, so
+    ``for_write=False`` must downgrade a resolver/snapshot mismatch to the
+    resolver's answer and still serve the file, instead of raising
+    ExecutionScopeAuthorityError into an unhandled 500."""
+    register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
+    )
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("pending upload", encoding="utf-8")
+    record = _record(source, task_id=99, storage_status="pending")
+
+    ref = ManagedFileRef(record, for_write=False)
+    assert ref.storage.prefix == "users/7/clients/3/end_users/7"
+    assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -11,8 +11,10 @@ import pytest
 
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
+    DeferToSnapshot,
     ExecutionScope,
     ExecutionScopeAuthorityError,
+    ExecutionScopeResolverContractError,
     reset_execution_scope,
     set_execution_scope,
     set_execution_scope_snapshot_loader,
@@ -266,7 +268,12 @@ def test_resolver_narrows_handle_when_contextvar_absent(storage_env, tmp_path):
     )
     record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
     # No ambient contextvar, no explicit scope: fall back to the resolver.
-    assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
+    # The record carries no durable key, so the per-task recovery is owed
+    # rather than already done -- it settles when an operation first needs a
+    # namespace, and the handle it settles on is the resolver's.
+    ref = ManagedFileRef(record)
+    assert ref.storage is None
+    assert ref._bound_storage().prefix == "users/7/clients/3/end_users/7"
 
 
 def test_contextvar_beats_resolver(storage_env, tmp_path):
@@ -407,9 +414,11 @@ def test_read_path_downgrades_on_mismatch_for_pending_record(storage_env, tmp_pa
     source.write_text("pending upload", encoding="utf-8")
     record = _record(source, task_id=99, storage_status="pending")
 
+    # Serving the local copy needs no namespace at all, so nothing is
+    # resolved and nothing can be disputed.
     ref = ManagedFileRef(record)
-    assert ref.storage.prefix == "users/7/clients/3/end_users/7"
     assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"
+    assert ref.storage is None
 
 
 def test_materialize_downgrades_on_mismatch_for_pending_record(storage_env, tmp_path):
@@ -429,5 +438,90 @@ def test_materialize_downgrades_on_mismatch_for_pending_record(storage_env, tmp_
     record = _record(source, task_id=99, storage_status="pending")
 
     ref = ManagedFileRef(record)
-    assert ref.storage.prefix == "users/7/clients/3/end_users/7"
     assert ref.materialize().read_text(encoding="utf-8") == "pending upload"
+    assert ref.storage is None
+
+
+def _pending_record(tmp_path: Path) -> UploadedFile:
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir(exist_ok=True)
+    source.write_text("pending upload", encoding="utf-8")
+    return _record(source, task_id=99, storage_status="pending")
+
+
+def test_read_serves_when_an_abstaining_resolver_disagrees_with_the_snapshot(
+    storage_env, tmp_path
+):
+    """An abstention mismatch has no authoritative value to downgrade to, so
+    it fails closed wherever a namespace is required. A read of a pending
+    record requires none, and must still be served."""
+    register_scope_resolver(
+        lambda task_id: DeferToSnapshot(fallback=ExecutionScope()),
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("wider",))
+    )
+    ref = ManagedFileRef(_pending_record(tmp_path))
+
+    assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"
+    assert ref.materialize().read_text(encoding="utf-8") == "pending upload"
+
+
+def test_read_serves_when_the_resolver_breaks_its_return_contract(
+    storage_env, tmp_path
+):
+    register_scope_resolver(lambda task_id: "not-a-scope")
+    ref = ManagedFileRef(_pending_record(tmp_path))
+
+    assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"
+
+
+def test_read_serves_when_the_snapshot_loader_raises(storage_env, tmp_path):
+    """No resolver registered is this repository's shape today, and there the
+    loader's answer is the whole authority -- a database hiccup while reading
+    it must not take a read-only endpoint down with it."""
+
+    def _explode(task_id):
+        raise RuntimeError("snapshot row unreadable")
+
+    set_execution_scope_snapshot_loader(_explode)
+    ref = ManagedFileRef(_pending_record(tmp_path))
+
+    assert ref.ensure_local().read_text(encoding="utf-8") == "pending upload"
+
+
+def test_sync_to_durable_still_fails_closed_when_the_resolver_abstains_and_disagrees(
+    storage_env, tmp_path
+):
+    """The half that must not regress: deferring the resolution must not
+    weaken the check that runs where a namespace is chosen for new bytes."""
+    register_scope_resolver(
+        lambda task_id: DeferToSnapshot(fallback=ExecutionScope()),
+    )
+    set_execution_scope_snapshot_loader(
+        lambda task_id: ExecutionScope(workspace_segments=("wider",))
+    )
+    record = _pending_record(tmp_path)
+    ref = ManagedFileRef(record)
+
+    with pytest.raises(ExecutionScopeAuthorityError):
+        ref.sync_to_durable()
+
+    assert record.storage_status == "pending"
+    objects_root = tmp_path / "objects" / "users" / "7"
+    assert not (objects_root / "wider").exists()
+    assert not (objects_root / "uploads").exists()
+
+
+def test_sync_to_durable_still_fails_closed_when_the_resolver_breaks_its_contract(
+    storage_env, tmp_path
+):
+    register_scope_resolver(lambda task_id: "not-a-scope")
+    record = _pending_record(tmp_path)
+    ref = ManagedFileRef(record)
+
+    with pytest.raises(ExecutionScopeResolverContractError):
+        ref.sync_to_durable()
+
+    assert record.storage_status == "pending"
+    assert not (tmp_path / "objects" / "users" / "7" / "uploads").exists()

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -12,6 +12,7 @@ import pytest
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     reset_execution_scope,
     set_execution_scope,
     set_execution_scope_snapshot_loader,
@@ -365,17 +366,22 @@ def test_existing_storage_key_binding_tolerates_resolver_snapshot_mismatch(
     assert ManagedFileRef(record).storage.prefix == "users/7"
 
 
-def test_new_object_write_path_still_resolves_off_turn_on_mismatch(
-    storage_env, tmp_path
-):
-    """No storage_key yet (a fresh upload): the write path still resolves
-    off-turn, and a namespace-affecting authority mismatch downgrades to the
-    resolver's own answer instead of raising (see
-    ``resolve_execution_scope_off_turn``)."""
+def test_new_object_write_path_fails_closed_on_mismatch(storage_env, tmp_path):
+    """No storage_key yet (a fresh upload): choosing the namespace new bytes
+    land under is an authority decision, so a resolver/snapshot mismatch
+    fails closed instead of downgrading to either side's guess -- getting it
+    wrong would silently and durably place the object under the wrong
+    tenant's subtree. No object may be written under either candidate
+    prefix."""
     register_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
     set_execution_scope_snapshot_loader(
         lambda task_id: ExecutionScope(workspace_segments=("other-tenant",))
     )
     record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
 
-    assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
+    with pytest.raises(ExecutionScopeAuthorityError):
+        ManagedFileRef(record)
+
+    objects_root = tmp_path / "objects" / "users" / "7"
+    assert not (objects_root / "clients").exists()
+    assert not (objects_root / "other-tenant").exists()

--- a/tests/web/test_execution_scope_delegation.py
+++ b/tests/web/test_execution_scope_delegation.py
@@ -2,9 +2,23 @@
 
 Covers the AgentTool construction-time scope snapshot, the workforce
 task-config scope persistence (``agent_config`` JSON, no schema migration),
-the Task-backed snapshot loader, and the per-task resolution preferring a
-persisted snapshot over the resolver — including across a simulated
-process restart.
+the Task-backed snapshot loader, and the per-task resolution's
+resolver/snapshot precedence — including across a simulated process
+restart.
+
+With a resolver registered, the
+persisted snapshot is a corroborating *candidate* for the resolver's
+authoritative answer, not an override of it (a namespace-affecting
+disagreement fails the turn instead of the snapshot silently winning). With
+no resolver registered — the case that matters for standalone/workforce
+restart-and-resume — the snapshot is still the sole answer, byte-identical
+to before. See ``TestSnapshotCandidatePrecedence`` below and
+``tests/core/test_execution_scope.py::TestSnapshotCandidateAuthority`` for
+the full precedence matrix.
+
+The resolver/snapshot-loader globals are reset by the root-level
+``isolate_execution_scope_hooks`` autouse fixture in ``tests/conftest.py``,
+not by a fixture in this module.
 """
 
 import contextvars
@@ -12,13 +26,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     EXECUTION_SCOPE_AGENT_CONFIG_KEY,
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     ExecutionScopeContext,
     get_execution_scope,
     resolve_execution_scope,
-    set_execution_scope_resolver,
     set_execution_scope_snapshot_loader,
     turn_execution_scope,
 )
@@ -30,15 +45,6 @@ SCOPE = ExecutionScope(
     workspace_segments=("tenant-a",),
     memory_dimensions={"tenant": "a"},
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_hooks():
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
-    yield
-    set_execution_scope_resolver(None)
-    set_execution_scope_snapshot_loader(None)
 
 
 class TestScopeSerialization:
@@ -96,25 +102,77 @@ class TestWorkforceTaskConfigSnapshot:
         config = build_workforce_task_config({"workforce": {"id": 3}})
         assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in config
 
+    def test_persists_the_current_shape_version_not_the_ambient_scopes_version(
+        self,
+    ):
+        """The ambient scope may itself have been decoded from an older
+        persisted snapshot (``version`` stamped at 0 or some prior shape).
+        Re-persisting it here for a *new* workforce sub-task must stamp the
+        current shape version -- the dict is being built now, in the
+        current shape -- not propagate the decoded-from scope's stale
+        version, which would make this brand-new snapshot look pre-existing
+        forever and get permanently ignored as a candidate by
+        resolve_execution_scope's stale-version check."""
+        from xagent.core.execution_scope import EXECUTION_SCOPE_SHAPE_VERSION
 
-class TestSnapshotLoaderPreference:
-    def test_snapshot_preferred_over_resolver(self):
+        legacy_data = SCOPE.to_dict()
+        legacy_data["version"] = 0
+        decoded_legacy_scope = ExecutionScope.from_dict(legacy_data)
+        assert decoded_legacy_scope.version == 0
+
+        with ExecutionScopeContext(decoded_legacy_scope):
+            config = build_workforce_task_config({"workforce": {"id": 3}})
+
+        assert (
+            config[EXECUTION_SCOPE_AGENT_CONFIG_KEY]["version"]
+            == EXECUTION_SCOPE_SHAPE_VERSION
+        )
+
+
+class TestSnapshotCandidatePrecedence:
+    """Resolver/snapshot precedence for the resolver-registered case.
+
+    A persisted snapshot is a candidate, not an authority. The resolver is
+    authoritative and always called; the snapshot is a corroborating
+    candidate -- consistent with it wins silently, but a namespace-affecting
+    disagreement fails the turn instead of the snapshot winning. See
+    ``tests/core/test_execution_scope.py::TestSnapshotCandidateAuthority``
+    for the full precedence matrix (defer/None/ExecutionScope resolver
+    values x snapshot present/absent/stale-version/corrupt).
+    """
+
+    def test_resolver_is_authoritative_and_always_called(self):
         resolver_calls = []
 
         def resolver(task_id):
             resolver_calls.append(task_id)
-            return ExecutionScope(sandbox_key_suffix="from-resolver")
+            return SCOPE
 
-        set_execution_scope_resolver(resolver)
+        register_scope_resolver(resolver)
         set_execution_scope_snapshot_loader(
             lambda task_id: SCOPE if task_id == "42" else None
         )
 
+        # A snapshot equal to the resolver's answer corroborates silently.
         assert resolve_execution_scope(42) == SCOPE
-        assert resolver_calls == []
+        assert resolver_calls == ["42"]
         # Tasks without a snapshot still resolve through the resolver.
-        assert resolve_execution_scope(43).sandbox_key_suffix == "from-resolver"
-        assert resolver_calls == ["43"]
+        assert (
+            resolve_execution_scope(43).sandbox_key_suffix == SCOPE.sandbox_key_suffix
+        )
+        assert resolver_calls == ["42", "43"]
+
+    def test_namespace_mismatch_between_resolver_and_snapshot_fails_the_turn(self):
+        register_scope_resolver(
+            lambda task_id: ExecutionScope(sandbox_key_suffix="from-resolver"),
+        )
+        set_execution_scope_snapshot_loader(lambda task_id: SCOPE)
+
+        with pytest.raises(ExecutionScopeAuthorityError) as exc_info:
+            resolve_execution_scope(42)
+        assert exc_info.value.resolver_scope.sandbox_key_suffix == "from-resolver"
+        assert exc_info.value.snapshot_scope == SCOPE
+        assert "sandbox_key_suffix" in exc_info.value.mismatched_fields
 
     def test_caller_supplied_snapshot_skips_registered_loader(self):
         loader_calls = []
@@ -125,28 +183,43 @@ class TestSnapshotLoaderPreference:
         assert resolve_execution_scope(42, persisted_snapshot=SCOPE) == SCOPE
         assert loader_calls == []
 
-    def test_caller_supplied_missing_snapshot_falls_back_to_resolver(self):
+    def test_caller_supplied_missing_snapshot_leaves_resolver_authoritative(self):
         loader_calls = []
         resolver_calls = []
         resolved = ExecutionScope(sandbox_key_suffix="from-resolver")
         set_execution_scope_snapshot_loader(
             lambda task_id: loader_calls.append(task_id)
         )
-        set_execution_scope_resolver(
-            lambda task_id: resolver_calls.append(task_id) or resolved
+        register_scope_resolver(
+            lambda task_id: resolver_calls.append(task_id) or resolved,
         )
 
         assert resolve_execution_scope(42, persisted_snapshot=None) == resolved
         assert loader_calls == []
         assert resolver_calls == ["42"]
 
-    def test_loader_exception_fails_the_turn(self):
+    def test_loader_exception_fails_the_turn_with_no_resolver_registered(self):
         def loader(task_id):
             raise RuntimeError("db down")
 
         set_execution_scope_snapshot_loader(loader)
         with pytest.raises(RuntimeError, match="db down"):
             resolve_execution_scope(42)
+
+    def test_loader_exception_does_not_veto_resolver_authority(self):
+        """A broken snapshot candidate must not veto an already-given
+        authoritative resolver answer."""
+        resolved = ExecutionScope(sandbox_key_suffix="from-resolver")
+
+        def loader(task_id):
+            raise RuntimeError("db down")
+
+        set_execution_scope_snapshot_loader(loader)
+        register_scope_resolver(
+            lambda task_id: resolved,
+        )
+
+        assert resolve_execution_scope(42) == resolved
 
     def test_delegated_subtask_executes_scoped_after_restart(self):
         """A sub-task of a scoped parent executes fully scoped after a

--- a/tests/web/test_execution_scope_delegation.py
+++ b/tests/web/test_execution_scope_delegation.py
@@ -174,16 +174,23 @@ class TestSnapshotCandidatePrecedence:
         assert exc_info.value.snapshot_scope == SCOPE
         assert "sandbox_key_suffix" in exc_info.value.mismatched_fields
 
-    def test_caller_supplied_snapshot_skips_registered_loader(self):
+    def test_caller_supplied_agent_config_skips_registered_loader(self):
+        """A caller that already read the task row hands over the raw
+        ``agent_config``; the snapshot inside it is decoded here rather than by
+        the caller, so a malformed one is tolerated or fatal per branch."""
         loader_calls = []
         set_execution_scope_snapshot_loader(
             lambda task_id: loader_calls.append(task_id)
         )
 
-        assert resolve_execution_scope(42, persisted_snapshot=SCOPE) == SCOPE
+        resolved = resolve_execution_scope(
+            42,
+            persisted_agent_config={EXECUTION_SCOPE_AGENT_CONFIG_KEY: SCOPE.to_dict()},
+        )
+        assert resolved == SCOPE
         assert loader_calls == []
 
-    def test_caller_supplied_missing_snapshot_leaves_resolver_authoritative(self):
+    def test_caller_supplied_missing_agent_config_leaves_resolver_authoritative(self):
         loader_calls = []
         resolver_calls = []
         resolved = ExecutionScope(sandbox_key_suffix="from-resolver")
@@ -194,7 +201,9 @@ class TestSnapshotCandidatePrecedence:
             lambda task_id: resolver_calls.append(task_id) or resolved,
         )
 
-        assert resolve_execution_scope(42, persisted_snapshot=None) == resolved
+        # Explicit ``None`` means "this task carries no agent_config", which
+        # leaves the resolver's answer standing rather than forcing unscoped.
+        assert resolve_execution_scope(42, persisted_agent_config=None) == resolved
         assert loader_calls == []
         assert resolver_calls == ["42"]
 

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -16,10 +16,10 @@ from typing import Any, List, Optional
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
     ExecutionScopeContext,
-    set_execution_scope_resolver,
     turn_execution_scope,
 )
 from xagent.core.memory.base import MemoryStore
@@ -96,9 +96,9 @@ class FakeBaseStore(MemoryStore):
 
 @pytest.fixture(autouse=True)
 def _clear_resolver():
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
     yield
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
 
 
 @pytest.fixture
@@ -249,7 +249,7 @@ class TestResolverPathAndNestedReactivation:
     def test_turn_scope_reaches_memory_via_resolver(self, store):
         """The resolver path: memory operations inside a turn carry the
         resolved scope without any explicit plumbing."""
-        set_execution_scope_resolver(lambda task_id: SCOPE_A)
+        register_scope_resolver(lambda task_id: SCOPE_A)
         with UserContext(1):
             with turn_execution_scope(42):
                 stamped = _add(store, "from the turn")

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -94,13 +94,6 @@ class FakeBaseStore(MemoryStore):
         return {"total_count": len(self.notes), "memory_store_type": "fake"}
 
 
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    register_scope_resolver(None)
-    yield
-    register_scope_resolver(None)
-
-
 @pytest.fixture
 def store() -> UserIsolatedMemoryStore:
     return UserIsolatedMemoryStore(FakeBaseStore())

--- a/tests/web/test_execution_scope_sandbox.py
+++ b/tests/web/test_execution_scope_sandbox.py
@@ -17,7 +17,6 @@ from tests.web.sandbox_fakes import FakeSandboxService
 from xagent.core.execution_scope import (
     ExecutionScope,
     InvalidScopeComponentError,
-    set_execution_scope_resolver,
 )
 from xagent.sandbox.base import SandboxMountIntent
 from xagent.web.api.chat import AgentServiceManager
@@ -28,13 +27,6 @@ from xagent.web.sandbox_keys import (
     parse_user_sandbox_key,
 )
 from xagent.web.sandbox_manager import SandboxManager
-
-
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    set_execution_scope_resolver(None)
-    yield
-    set_execution_scope_resolver(None)
 
 
 class TestSandboxKeyHelpers:

--- a/tests/web/test_execution_scope_workspace_web.py
+++ b/tests/web/test_execution_scope_workspace_web.py
@@ -5,10 +5,11 @@ scope-local under ``isolate_external_dirs``) and the websocket
 output-path task-scope check tolerating scope segments between the user
 root and the task dir.
 
-``_scope_segments_for_task`` resolves off-turn (#296): it
-composes a storage key outside any turn, so a resolver/snapshot authority
-mismatch there is downgraded to the resolver's answer plus a warning
-instead of failing (see ``TestScopeSegmentsForTask``).
+``_scope_segments_for_task`` composes the storage key for a brand-new
+durable object (its only caller stages a fresh upload), so it fails closed:
+a resolver/snapshot authority mismatch there raises
+``ExecutionScopeAuthorityError`` instead of being downgraded (see
+``TestScopeSegmentsForTask``).
 """
 
 import pytest
@@ -16,6 +17,7 @@ import pytest
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
+    ExecutionScopeAuthorityError,
     set_execution_scope_snapshot_loader,
 )
 from xagent.web.api.chat import _build_allowed_external_dirs
@@ -24,13 +26,6 @@ from xagent.web.api.websocket import (
     _scope_segments_for_task,
 )
 from xagent.web.services.workspace_binding import _build_external_allowlist
-
-
-@pytest.fixture(autouse=True)
-def _clear_resolver():
-    register_scope_resolver(None)
-    yield
-    register_scope_resolver(None)
 
 
 class TestAllowedExternalDirs:
@@ -149,17 +144,18 @@ class TestScopeSegmentsForTask:
         )
         assert _scope_segments_for_task(42) == ("tenant-a",)
 
-    def test_namespace_mismatch_downgrades_to_resolver_segments_without_raising(self):
-        """Off-turn: an authority mismatch must not raise (it would surface
-        as a misleading "file not found" or bulk-endpoint 500); it downgrades
-        to the resolver's own segments instead."""
+    def test_namespace_mismatch_fails_closed(self):
+        """These segments compose the storage key for a brand-new durable
+        object, so an authority mismatch must not be downgraded to either
+        side's guess -- it fails closed instead."""
         register_scope_resolver(
             lambda task_id: ExecutionScope(workspace_segments=("tenant-a",)),
         )
         set_execution_scope_snapshot_loader(
             lambda task_id: ExecutionScope(workspace_segments=("tenant-b",))
         )
-        assert _scope_segments_for_task(42) == ("tenant-a",)
+        with pytest.raises(ExecutionScopeAuthorityError):
+            _scope_segments_for_task(42)
 
 
 class TestOutputPathTaskScopeCheck:

--- a/tests/web/test_execution_scope_workspace_web.py
+++ b/tests/web/test_execution_scope_workspace_web.py
@@ -4,13 +4,19 @@ Covers ``_build_allowed_external_dirs`` scoping (shared by default,
 scope-local under ``isolate_external_dirs``) and the websocket
 output-path task-scope check tolerating scope segments between the user
 root and the task dir.
+
+``_scope_segments_for_task`` resolves off-turn (#296): it
+composes a storage key outside any turn, so a resolver/snapshot authority
+mismatch there is downgraded to the resolver's answer plus a warning
+instead of failing (see ``TestScopeSegmentsForTask``).
 """
 
 import pytest
 
+from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.execution_scope import (
     ExecutionScope,
-    set_execution_scope_resolver,
+    set_execution_scope_snapshot_loader,
 )
 from xagent.web.api.chat import _build_allowed_external_dirs
 from xagent.web.api.websocket import (
@@ -22,9 +28,9 @@ from xagent.web.services.workspace_binding import _build_external_allowlist
 
 @pytest.fixture(autouse=True)
 def _clear_resolver():
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
     yield
-    set_execution_scope_resolver(None)
+    register_scope_resolver(None)
 
 
 class TestAllowedExternalDirs:
@@ -131,13 +137,27 @@ class TestScopeSegmentsForTask:
         no task identity means unscoped — never a resolver query for the
         literal string "None"."""
         seen = []
-        set_execution_scope_resolver(lambda task_id: seen.append(task_id))
+        register_scope_resolver(
+            lambda task_id: seen.append(task_id),
+        )
         assert _scope_segments_for_task(None) == ()
         assert seen == []
 
     def test_scoped_task_yields_its_segments(self):
-        set_execution_scope_resolver(
-            lambda task_id: ExecutionScope(workspace_segments=("tenant-a",))
+        register_scope_resolver(
+            lambda task_id: ExecutionScope(workspace_segments=("tenant-a",)),
+        )
+        assert _scope_segments_for_task(42) == ("tenant-a",)
+
+    def test_namespace_mismatch_downgrades_to_resolver_segments_without_raising(self):
+        """Off-turn: an authority mismatch must not raise (it would surface
+        as a misleading "file not found" or bulk-endpoint 500); it downgrades
+        to the resolver's own segments instead."""
+        register_scope_resolver(
+            lambda task_id: ExecutionScope(workspace_segments=("tenant-a",)),
+        )
+        set_execution_scope_snapshot_loader(
+            lambda task_id: ExecutionScope(workspace_segments=("tenant-b",))
         )
         assert _scope_segments_for_task(42) == ("tenant-a",)
 
@@ -174,7 +194,7 @@ class TestOutputPathTaskScopeCheck:
     def test_segment_named_like_the_task_dir_does_not_shadow_it(self):
         """The segment charset allows a scope segment literally named like
         the task dir; the scan must not stop at it and reject the real task
-        dir further down (Gemini round-2 finding on #789)."""
+        dir further down (#789)."""
         assert _output_path_in_current_task_scope(
             "user_1/web_task_5/web_task_5/output/a.txt", 5, 1
         )

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -614,6 +614,107 @@ class TestFileUpload:
         assert download.status_code == 503
         assert "durable storage" in download.json()["detail"].lower()
 
+    def test_download_namespace_containment_violation_is_not_reported_as_an_outage(
+        self, client, test_db, temp_uploads_dir, auth_headers
+    ):
+        """A key outside the handle's bound prefix is a permanent authority
+        fault, so it must not arrive as the retryable durable-storage 503.
+
+        Driven through ``xagent.web.app.app`` rather than this module's
+        router-only test app, because the classification lives in an
+        application-level exception handler. The response may not echo the
+        namespace values either -- prefixes and scope segments can carry
+        end-user identity.
+        """
+        from xagent.web.app import app as web_app
+
+        _, test_app = test_db
+        upload = client.post(
+            "/api/files/upload",
+            files={"file": ("foreign-namespace.txt", b"foreign content", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200
+        file_id = upload.json()["file_id"]
+        for path in temp_uploads_dir.rglob("foreign-namespace.txt"):
+            path.unlink()
+
+        foreign_key = (
+            f"users/999/clients/tenant-sentinel/uploads/{file_id}/foreign-namespace.txt"
+        )
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            record = (
+                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+            )
+            record.storage_key = foreign_key
+            db.commit()
+        finally:
+            db.close()
+
+        web_app.dependency_overrides[get_db] = test_app.dependency_overrides[get_db]
+        try:
+            download = TestClient(web_app).get(
+                f"/api/files/download/{file_id}",
+                headers=auth_headers,
+            )
+        finally:
+            web_app.dependency_overrides.pop(get_db, None)
+
+        assert download.status_code == 500
+        assert download.json() == {"detail": "Storage namespace authority violation."}
+        assert "tenant-sentinel" not in download.text
+        assert "users/999" not in download.text
+
+    def test_upload_scope_authority_mismatch_is_not_reported_as_an_outage(
+        self, test_db, temp_uploads_dir, auth_headers
+    ):
+        """The upload path resolves the write namespace fail-closed.
+
+        A resolver/snapshot disagreement there is a permanent authority fault,
+        so it must reach the same 500 classification as a containment
+        violation rather than the retryable durable-storage 503. The response
+        must not name the scope segments either.
+        """
+        from tests.shared.execution_scope import register_scope_resolver
+        from xagent.core.execution_scope import (
+            ExecutionScope,
+            set_execution_scope_snapshot_loader,
+        )
+        from xagent.web.app import app as web_app
+
+        del temp_uploads_dir
+        _, test_app = test_db
+        register_scope_resolver(
+            lambda task_id: ExecutionScope(
+                workspace_segments=("clients", "resolver-sentinel"),
+                isolate_external_dirs=True,
+            )
+        )
+        set_execution_scope_snapshot_loader(
+            lambda task_id: ExecutionScope(
+                workspace_segments=("clients", "snapshot-sentinel"),
+                isolate_external_dirs=True,
+            )
+        )
+
+        web_app.dependency_overrides[get_db] = test_app.dependency_overrides[get_db]
+        try:
+            response = TestClient(web_app).post(
+                "/api/files/upload",
+                files={"file": ("scoped.txt", b"scoped content", "text/plain")},
+                data={"task_type": "general", "task_id": "5"},
+                headers=auth_headers,
+            )
+        finally:
+            web_app.dependency_overrides.pop(get_db, None)
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Storage namespace authority violation."}
+        assert "resolver-sentinel" not in response.text
+        assert "snapshot-sentinel" not in response.text
+
     def test_download_checksum_mismatch_asks_user_to_reupload(
         self, client, temp_uploads_dir, auth_headers, monkeypatch, tmp_path
     ):

--- a/tests/web/test_storage_namespace_authority_handler.py
+++ b/tests/web/test_storage_namespace_authority_handler.py
@@ -1,0 +1,149 @@
+"""Response contract for the application-level namespace-authority handler.
+
+A storage containment violation and an execution-scope authority mismatch are
+permanent server-side faults. One handler answers both for every route, so its
+status, its body shape per API surface, and what it refuses to publish are
+asserted here; ``tests/web/test_file_upload.py`` drives the two faults end to
+end through real endpoints.
+"""
+
+import json
+
+import pytest
+from starlette.requests import Request
+from starlette.websockets import WebSocket
+
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    ExecutionScopeAbstentionMismatchError,
+    ExecutionScopeAuthorityError,
+)
+from xagent.core.file_storage import StorageKeyScopeError
+from xagent.web.app import app, storage_namespace_authority_error_handler
+
+_MESSAGE = "Storage namespace authority violation."
+
+
+def _http_request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "scheme": "http",
+            "server": ("testserver", 80),
+        }
+    )
+
+
+def _scope_error() -> StorageKeyScopeError:
+    return StorageKeyScopeError(
+        "Storage key 'users/999/clients/tenant-sentinel/uploads/x' is outside "
+        "the bound prefix 'users/7'"
+    )
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [
+        StorageKeyScopeError,
+        ExecutionScopeAuthorityError,
+    ],
+)
+def test_handler_is_registered_for_both_fault_types(exception_type):
+    assert app.exception_handlers[exception_type] is (
+        storage_namespace_authority_error_handler
+    )
+
+
+def test_abstention_mismatch_resolves_to_the_same_handler():
+    """The abstention subclass has no registration of its own.
+
+    Starlette walks the raised exception's MRO, so a subclass added to the
+    authority hierarchy is answered here without another registration.
+    """
+    assert ExecutionScopeAbstentionMismatchError not in app.exception_handlers
+    assert issubclass(
+        ExecutionScopeAbstentionMismatchError, ExecutionScopeAuthorityError
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_paths_get_a_500_with_no_namespace_values():
+    response = await storage_namespace_authority_error_handler(
+        _http_request("/api/files/download/abc"), _scope_error()
+    )
+
+    assert response.status_code == 500
+    body = json.loads(response.body)
+    assert body == {"detail": _MESSAGE}
+    assert "tenant-sentinel" not in response.body.decode()
+    assert "users/7" not in response.body.decode()
+
+
+@pytest.mark.asyncio
+async def test_v1_paths_keep_the_sdk_error_envelope():
+    response = await storage_namespace_authority_error_handler(
+        _http_request("/v1/tasks"), _scope_error()
+    )
+
+    assert response.status_code == 500
+    assert json.loads(response.body) == {
+        "error": {"code": "internal_error", "message": _MESSAGE}
+    }
+
+
+@pytest.mark.asyncio
+async def test_authority_mismatch_body_names_no_scope_field_values():
+    exc = ExecutionScopeAuthorityError(
+        "5",
+        resolver_scope=ExecutionScope(workspace_segments=("clients", "resolver-side")),
+        snapshot_scope=ExecutionScope(workspace_segments=("clients", "snapshot-side")),
+        mismatched_fields={
+            "workspace_segments": (
+                ("clients", "snapshot-side"),
+                ("clients", "resolver-side"),
+            )
+        },
+        resolver_scope_is_authoritative=True,
+    )
+
+    response = await storage_namespace_authority_error_handler(
+        _http_request("/api/files/upload"), exc
+    )
+
+    assert response.status_code == 500
+    assert json.loads(response.body) == {"detail": _MESSAGE}
+    assert "resolver-side" not in response.body.decode()
+    assert "snapshot-side" not in response.body.decode()
+
+
+@pytest.mark.asyncio
+async def test_websocket_scope_re_raises_instead_of_answering():
+    """A websocket cannot receive an HTTP response.
+
+    Starlette would send the returned response onto the connection, so these
+    scopes stay with the connection handler that owns them.
+    """
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "path": "/ws/chat",
+            "raw_path": b"/ws/chat",
+            "query_string": b"",
+            "headers": [],
+            "scheme": "ws",
+            "server": ("testserver", 80),
+        },
+        receive=None,  # type: ignore[arg-type]
+        send=None,  # type: ignore[arg-type]
+    )
+    exc = _scope_error()
+
+    with pytest.raises(StorageKeyScopeError) as excinfo:
+        await storage_namespace_authority_error_handler(websocket, exc)  # type: ignore[arg-type]
+
+    assert excinfo.value is exc


### PR DESCRIPTION
## Summary

A persisted execution-scope snapshot currently wins over the resolver an embedding application registers, so a stale or otherwise untrustworthy snapshot can decide the sandbox lifecycle key, workspace subtree, durable-storage prefix and memory dimensions a turn runs under — overriding the authority that owns that decision.

This makes the registered resolver authoritative and demotes the snapshot to a corroborating candidate.

Part of the xorbitsai/xagent-saas#296 chain, and the last piece of it in this repository. Rebased onto #1014: the two overlap in four files (`web/api/chat.py`, `web/app.py`, and two scope test modules), so the earlier claim of zero overlap no longer holds — #1014 grew into them after this branch was opened.

## Resolution contract

With a resolver registered, `resolve_execution_scope()` calls it first and treats its answer as authoritative:

- an `ExecutionScope` — authoritative. A snapshot that disagrees on a namespace-affecting field (`sandbox_key_suffix`, `workspace_segments`, `sandbox_mount_segments`, `isolate_external_dirs`, `memory_dimensions`) fails the turn closed rather than silently choosing one of them. A disagreement limited to `strict_memory_isolation` keeps the resolver's answer and logs the difference, since that field selects no key or path.
- `None` — authoritative unscoped. The snapshot is not consulted.
- `defer_to_snapshot(fallback=..., snapshot_defines_namespace=False)` — explicit abstention. By default the snapshot may only *narrow* the mandatory fallback, and a field the fallback leaves at its no-scoping default accepts nothing but an exact match: an abstention that claims no namespace authority cannot hand one out. A resolver that defers precisely *because it does not own the task* — the delegated/workforce case, where it cannot supply a namespace it does not know — says so with `snapshot_defines_namespace=True`, which skips the narrowing check for namespace fields while keeping the type check, the shape-version gate, the mandatory fallback for when there is no snapshot, and the policy-field rule. Making that trust explicit is the point: the fallback's shape cannot carry it, because the resolver with the least knowledge of the namespace is exactly the one that must be able to defer. The opt-in declares where the namespace comes from; it does not make an untrusted snapshot safe. A snapshot written server-side from an already-resolved scope and one arriving inside client-supplied `agent_config` are different trust tiers that this contract cannot tell apart at read time — xorbitsai/xagent#1016 tracks closing that.

Any other return value fails closed with a dedicated error rather than reaching the scope-consuming code paths.

With no resolver registered the behavior is unchanged: the snapshot resolves the scope, which is what keeps workforce sub-tasks scoped across a restart (#757).

`set_execution_scope_resolver()` now requires an acknowledgement keyword. An embedding application built against the previous contract fails at import time instead of discovering the new precedence on its first delegated turn.

Consumer tests register through a single acknowledged helper (`tests/shared/execution_scope.py`) rather than repeating the keyword at every call site: the keyword's purpose is to make an embedding application confirm it read the contract, and repeating it across dozens of test setups put that signal where nobody reads it. The contract's own unit tests still call the registration function directly, where the keyword is the subject under test.

## Shape versioning

`to_dict()` stamps the current scope shape version at its single source, so every persist site writes the shape it actually produced rather than re-serializing an older stamp. A snapshot whose version is absent or different is not comparable to a freshly resolved scope — field defaults would make an older snapshot look like a deliberate disagreement — so it is ignored with a logged field diff and the resolver's answer is used. Snapshots written before this field exists therefore migrate without failing turns.

## Failure-path placement

One rule decides every off-turn face: a face that **selects a namespace for new bytes** fails closed; a face that reads, re-derives a path for, or deletes **already-existing** bytes downgrades to the resolver's answer plus a warning. Choosing where new data lands is an authority decision, and getting it wrong puts one tenant's data in another namespace silently and durably; for bytes that already exist the durable key is itself the authoritative answer, and the worst case is a misleading "not found".

Under that rule the upload write path, `ManagedFileRef`'s no-durable-key branch, the legacy-preview segment helper and turn file materialization fail closed, while the read path (a record that already carries a key re-resolves nothing at all), workspace cleanup, and the pause/resume control operations downgrade. Control operations are called out deliberately: acting on a task that already exists must stay possible while its scope is in dispute, or a disagreement would leave the task unpausable and unstoppable — and the turn a resume hands off re-resolves fail-closed before it produces anything: the handler's off-turn answer feeds only the agent lookup for the already-paused task, while `execute_resume_background` is handed no scope at all so it performs its own fail-closed resolution.

Scope resolution is reached from turn setup and from the off-turn faces below. What decides each one is the rule stated above — new bytes versus existing bytes — not whether the caller happens to sit inside a turn:

- The read path in `ManagedFileRef` no longer re-resolves scope at all when a record already carries a storage key: the key fixed at write time is the authoritative answer, and re-deriving a prefix from a mismatching scope would make an existing object unreadable — surfacing, through existing handlers, as a missing file rather than a diagnosable error. Those operations bind to the owner root rather than the scope subtree, so the containment narrowing does not apply to them; the key is absolute and was chosen under the writing scope.
- `_scope_segments_for_task` (legacy-preview registration) fails closed: its only caller composes a storage key for a newly staged object and inserts a row, which is namespace selection for new bytes.
- The upload write path stays fail-closed, with the rationale recorded at the call site: choosing a namespace for new data must not be downgraded.

Authority-mismatch errors carry only the task id and the names of the mismatching fields; scope values stay in the log, because that message reaches a persisted task error column and a client-facing event.

## Also fixed

`scope_fingerprint()` omitted `isolate_external_dirs`, which is baked into a cached agent's workspace configuration at build time. A scope that changed only that flag reused an agent whose external-directory allowlist belonged to the previous scope. The flag is now part of the fingerprint, with a test asserting the cache is evicted.

## Testing

- Full resolver × snapshot matrix: authoritative scope / authoritative unscoped / abstention, against a snapshot that agrees, disagrees per namespace field, disagrees only on policy, is absent, is unreadable, or carries a different shape version.
- Contract pins: the abstention carrier is never mistaken for a scope and never activated; the two new error types are not subclasses of the exception types the surrounding handlers catch; the acknowledgement keyword is required; every dataclass field is classified as namespace or policy, and the fingerprint covers the namespace fields — both mutation-verified to fail when a new field is added unclassified.
- All five consumption points covered, turn faces asserting the failure and off-turn faces asserting the downgrade.
- Scope hook resets moved into a root autouse fixture that resets both the resolver and the snapshot loader; all nine module-level duplicates are gone. Verified load-bearing: without the root fixture, startup-event tests leave a real loader registered and ten scope tests fail; each affected file was also run alone and in reversed cross-file order to confirm the root fixture covers what the local ones did.
- `tests/web/ tests/core/` under `-n 4 --dist=loadscope`: no new failures or skips against the base commit (+70 passing tests). Pre-existing failures are environment gaps (Node toolchain for pptx, embedding model, Postgres/Pub-Sub emulators) and are byte-identical before and after.

## Follow-up

Snapshots are read back from a column that task-creation entry points populate from caller-supplied input; making that key server-owned is tracked separately in #1016. The precedence change here is what stops such a snapshot from overriding a registered resolver, but the key itself should still become unwritable by callers.



