### PR TITLE
feat: add template quick-access and instant agent creation to the Task page

### DIFF
--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -11,19 +11,11 @@ import { getBrandingFromEnv } from "@/lib/branding";
 import { apiRequest } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
 import { findRunnableAgentById } from "@/lib/agent-ui-access";
+import { resolveAgentForTemplate, toAgentId } from "@/lib/template-agent-resolution";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import type { Template, SamplePrompt } from "@/types/template";
 import { FEATURED_CATEGORY_ID } from "@/lib/template-categories";
-
-// Deep-link presets for "?starter=" (e.g. the Welcome modal's Presentation Builder
-// card). Kept separate from the template quick-access system below.
-const STARTER_PROMPTS: Record<string, { prompt: string; highlights: string[] }> = {
-  presentation: {
-    prompt: "Build a N-slide presentation on topic for audience.",
-    highlights: ["N", "topic", "audience"],
-  },
-};
 
 function TaskHomePageContent() {
   const { t, locale } = useI18n();
@@ -105,6 +97,8 @@ function TaskHomePageContent() {
     }
 
     setSelectedAgents([selectedAgent]);
+    setSelectedTemplate(null);
+    setSelectedPromptKey(null);
     appliedAgentFromQueryRef.current = agentFromQuery;
   }, [agentFromQuery, agents]);
 
@@ -154,13 +148,15 @@ function TaskHomePageContent() {
     };
   }, [selectedAgents]);
 
+  // Deep-link preset for "?starter=presentation" (the Welcome modal's
+  // Presentation Builder card). Only this one key is ever populated or read,
+  // so a plain check is clearer here than a one-entry lookup map.
   const starterPreset = useMemo(() => {
-    const found = starter ? STARTER_PROMPTS[starter] : null;
-    if (!found) return null;
+    if (starter !== "presentation") return null;
 
     return {
-      prompt: found.prompt,
-      highlights: found.highlights,
+      prompt: "Build a N-slide presentation on topic for audience.",
+      highlights: ["N", "topic", "audience"],
     };
   }, [starter]);
 
@@ -178,136 +174,64 @@ function TaskHomePageContent() {
     setPromptHighlightTerms(queryPromptHighlightTerms);
   }, [queryInputValue, queryPromptHighlightTerms]);
 
-  // The backend has no dedicated "created from template X" link on an Agent
-  // record, so we correlate by name: a template-created agent is always
-  // named exactly `template.name` on first creation (see
-  // create_agent_from_template in agent_management.py). Renaming that agent
-  // later breaks this correlation - a known tradeoff of not having a
-  // persisted template_id column.
-  const findExistingAgentIdForTemplate = (templateName: string, agentList: AgentCard[]) => {
-    const match = agentList.find((agent) => agent.name === templateName);
-    const matchId = Number(match?.id);
-    return Number.isNaN(matchId) ? null : matchId;
-  };
-
-  // Reuse an already-created agent for this template if one exists; only
-  // create + publish a new one the first time a template is used.
-  const resolveAgentForTemplate = async (
-    templateId: string,
-    templateName: string
-  ): Promise<{ agentId: number; created: boolean }> => {
-    const knownExistingId = findExistingAgentIdForTemplate(templateName, agents);
-    if (knownExistingId !== null) {
-      return { agentId: knownExistingId, created: false };
-    }
-
-    const createResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ template_id: templateId }),
-    });
-
-    if (createResponse.status === 400) {
-      // Name collision our local (published-only) list didn't know about -
-      // e.g. a draft agent, or one created in another tab/session since we
-      // last fetched. Look it up and reuse it rather than minting a
-      // duplicate under a disambiguated name.
-      const listResponse = await apiRequest(`${getApiUrl()}/api/agents`);
-      if (listResponse.ok) {
-        const allAgents = await listResponse.json();
-        const match = Array.isArray(allAgents)
-          ? allAgents.find((agent) => agent && agent.name === templateName)
-          : undefined;
-        const matchId = Number(match?.id);
-        if (match && !Number.isNaN(matchId)) {
-          if (match.status !== "published") {
-            const publishResponse = await apiRequest(
-              `${getApiUrl()}/api/agents/${matchId}/publish`,
-              { method: "POST" }
-            );
-            if (!publishResponse.ok) {
-              throw new Error(`Failed to publish agent (${publishResponse.status})`);
-            }
-          }
-          return { agentId: matchId, created: false };
-        }
-      }
-      throw new Error(`Failed to create agent from template (${createResponse.status})`);
-    }
-
-    if (!createResponse.ok) {
-      throw new Error(`Failed to create agent from template (${createResponse.status})`);
-    }
-    const createdAgent = await createResponse.json();
-
-    const publishResponse = await apiRequest(
-      `${getApiUrl()}/api/agents/${createdAgent.id}/publish`,
-      { method: "POST" }
-    );
-    if (!publishResponse.ok) {
-      throw new Error(`Failed to publish agent (${publishResponse.status})`);
-    }
-
-    return { agentId: createdAgent.id, created: true };
-  };
-
   const handleSend = async (message: string, filesToSend: File[], config?: any) => {
     if (state.isProcessing) return;
 
-    let agentId = Number(selectedAgents[0]?.id);
+    let agentId = toAgentId(selectedAgents[0]);
 
-    if (Number.isNaN(agentId) && selectedTemplate) {
+    if (agentId === null && selectedTemplate) {
+      let result: { agent: AgentCard; created: boolean };
       try {
-        const result = await resolveAgentForTemplate(selectedTemplate.id, selectedTemplate.name);
-        agentId = result.agentId;
-        if (result.created) {
-          const templateName = selectedTemplate.name;
-          toast.custom((toastId) => (
-            <div className="flex w-full flex-col gap-3 rounded-xl border border-green-600 bg-background p-4 shadow-lg">
-              <div className="flex items-start gap-2">
-                <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600" />
-                <span className="text-sm font-medium text-green-600">
-                  {t("chatPage.templateQuickAccess.agentCreatedToast", { name: templateName })}
-                </span>
-              </div>
-              <Button
-                size="sm"
-                className="self-end"
-                onClick={() => {
-                  toast.dismiss(toastId);
-                  router.push("/build");
-                }}
-              >
-                {t("chatPage.templateQuickAccess.viewInAgents")}
-              </Button>
-            </div>
-          ));
-        }
-        // Keep local state in sync so sending from this template again in the
-        // same session (without a page reload) resolves instantly instead of
-        // re-querying the backend - this also covers the case where the
-        // agent was resolved via the 400-retry lookup (created === false)
-        // rather than freshly created, which the local list wouldn't know
-        // about otherwise.
-        setAgents((prev) => {
-          if (prev.some((agent) => Number(agent.id) === result.agentId)) {
-            return prev;
-          }
-          return [
-            ...prev,
-            { id: result.agentId, name: selectedTemplate.name, status: "published" },
-          ];
-        });
+        result = await resolveAgentForTemplate(selectedTemplate.id, selectedTemplate.name, agents);
       } catch (error) {
         console.error("Failed to create agent from template:", error);
-        toast.error(t("chatPage.templateQuickAccess.createAgentError"));
-        return;
+        // Rethrow (translated) rather than swallowing: ChatInput's own
+        // catch around onSend shows this as a toast, and - critically -
+        // only clears the typed message/chip when onSend actually
+        // resolves, so a failed creation no longer silently wipes the
+        // user's draft.
+        throw new Error(t("chatPage.templateQuickAccess.createAgentError"));
+      }
+
+      agentId = toAgentId(result.agent);
+      // Keep local state in sync so sending from this template again in the
+      // same session (without a page reload) resolves instantly instead of
+      // re-querying the backend - this also covers the case where the
+      // agent was resolved via the 400-retry lookup (created === false)
+      // rather than freshly created, which the local list wouldn't know
+      // about otherwise.
+      setAgents((prev) =>
+        prev.some((agent) => agent.id === result.agent.id) ? prev : [...prev, result.agent]
+      );
+
+      if (result.created) {
+        const templateName = selectedTemplate.name;
+        toast.custom((toastId) => (
+          <div className="flex w-full flex-col gap-3 rounded-xl border border-green-600 bg-background p-4 shadow-lg">
+            <div className="flex items-start gap-2">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600" />
+              <span className="text-sm font-medium text-green-600">
+                {t("chatPage.templateQuickAccess.agentCreatedToast", { name: templateName })}
+              </span>
+            </div>
+            <Button
+              size="sm"
+              className="self-end"
+              onClick={() => {
+                toast.dismiss(toastId);
+                router.push("/build");
+              }}
+            >
+              {t("chatPage.templateQuickAccess.viewInAgents")}
+            </Button>
+          </div>
+        ));
       }
     }
 
     const nextConfig = {
       ...config,
-      agentId: Number.isNaN(agentId) ? undefined : agentId,
+      agentId: agentId ?? undefined,
     };
 
     try {
@@ -335,18 +259,6 @@ function TaskHomePageContent() {
     setInputValue(value);
   };
 
-  const handleAgentClick = (agent: AgentCard) => {
-    setSelectedAgents((prev) => {
-      const currentSelected = prev[0];
-      if (currentSelected?.id === agent.id) {
-        return [];
-      }
-      return [agent];
-    });
-    setSelectedTemplate(null);
-    setSelectedPromptKey(null);
-  };
-
   const handleRemoveSelectedAgent = (agentId: number | string) => {
     setSelectedAgents((prev) => prev.filter((agent) => agent.id !== agentId));
   };
@@ -368,12 +280,16 @@ function TaskHomePageContent() {
     <div className="h-full bg-background flex flex-col overflow-hidden">
       <div className="flex-1 overflow-y-auto">
         <main className="container max-w-4xl mx-auto px-4 py-8">
+          {/* No `agents`/`onAgentClick` props here: the template quick-access
+              grid (passed via `templates` below) replaces the old "Chat with
+              Agents" avatar picker on this page, matching the redesigned
+              Task page. `agents` state itself is still fetched and used -
+              for the `?agent=` deep link above and for template-reuse
+              matching - just not rendered as a picker here. */}
           <ChatStartScreen
             title={t("chatPage.page.emptyTitle", { appName: branding.appName })}
             description={t("chatPage.page.emptyDescription")}
             icon={<Bot className="w-10 h-10 text-[hsl(var(--gradient-from))]" />}
-            agents={agents}
-            onAgentClick={handleAgentClick}
             selectedAgents={selectedAgents}
             onRemoveSelectedAgent={handleRemoveSelectedAgent}
             onSend={handleSend}

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -193,7 +193,7 @@ function TaskHomePageContent() {
     if (agentId === null && selectedTemplate) {
       let result: { agent: AgentCard; created: boolean };
       try {
-        result = await resolveAgentForTemplate(selectedTemplate.id, agents);
+        result = await resolveAgentForTemplate(selectedTemplate.id);
       } catch (error) {
         console.error("Failed to create agent from template:", error);
         // Rethrow (translated) rather than swallowing: ChatInput's own
@@ -205,15 +205,18 @@ function TaskHomePageContent() {
       }
 
       agentId = toAgentId(result.agent);
-      // Keep local state in sync so sending from this template again in the
-      // same session (without a page reload) resolves instantly instead of
-      // re-querying the backend - this also covers the case where the
-      // agent was resolved via the 400-retry lookup (created === false)
-      // rather than freshly created, which the local list wouldn't know
-      // about otherwise.
-      setAgents((prev) =>
-        prev.some((agent) => agent.id === result.agent.id) ? prev : [...prev, result.agent]
-      );
+      // Keep local `agents` state in sync for other consumers (e.g. the
+      // `?agent=` deep link) - resolveAgentForTemplate always asks the
+      // server (see its own docstring for why), this does not shortcut
+      // that. Only add it if published: `agents` is otherwise exclusively
+      // published agents (see the mount-time fetch above), and the resolve
+      // flow's reuse branch can now return a still-unpublished draft
+      // as-is (PR review finding B3) rather than always republishing it.
+      if (result.agent.status === "published") {
+        setAgents((prev) =>
+          prev.some((agent) => agent.id === result.agent.id) ? prev : [...prev, result.agent]
+        );
+      }
 
       if (result.created) {
         const templateName = selectedTemplate.name;
@@ -295,8 +298,10 @@ function TaskHomePageContent() {
               grid (passed via `templates` below) replaces the old "Chat with
               Agents" avatar picker on this page, matching the redesigned
               Task page. `agents` state itself is still fetched and used -
-              for the `?agent=` deep link above and for template-reuse
-              matching - just not rendered as a picker here. */}
+              for the `?agent=` deep link above - just not rendered as a
+              picker here. Template-reuse resolution goes through the server
+              unconditionally (see resolveAgentForTemplate); there is no
+              client-side matching against this list anymore. */}
           <ChatStartScreen
             title={t("chatPage.page.emptyTitle", { appName: branding.appName })}
             description={t("chatPage.page.emptyDescription")}

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -35,6 +35,8 @@ function TaskHomePageContent() {
     executionMode?: "flash" | "balanced" | "think";
   }>();
   const [templates, setTemplates] = useState<Template[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [templatesError, setTemplatesError] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string>(FEATURED_CATEGORY_ID);
   const [selectedTemplate, setSelectedTemplate] = useState<{ id: string; name: string } | null>(null);
   const [selectedPromptKey, setSelectedPromptKey] = useState<string | null>(null);
@@ -71,19 +73,28 @@ function TaskHomePageContent() {
   }, []);
 
   // Fetch templates on mount (and when locale changes) for the quick-access grid
-  useEffect(() => {
-    const fetchTemplates = async () => {
-      try {
-        const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`);
-        if (response.ok) {
-          const data = await response.json();
-          setTemplates(Array.isArray(data) ? data : []);
-        }
-      } catch (error) {
-        console.error("Failed to fetch templates:", error);
+  const fetchTemplates = async () => {
+    setTemplatesLoading(true);
+    setTemplatesError(false);
+    try {
+      const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`);
+      if (response.ok) {
+        const data = await response.json();
+        setTemplates(Array.isArray(data) ? data : []);
+      } else {
+        setTemplatesError(true);
       }
-    };
+    } catch (error) {
+      console.error("Failed to fetch templates:", error);
+      setTemplatesError(true);
+    } finally {
+      setTemplatesLoading(false);
+    }
+  };
+
+  useEffect(() => {
     fetchTemplates();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locale]);
 
   useEffect(() => {
@@ -182,7 +193,7 @@ function TaskHomePageContent() {
     if (agentId === null && selectedTemplate) {
       let result: { agent: AgentCard; created: boolean };
       try {
-        result = await resolveAgentForTemplate(selectedTemplate.id, selectedTemplate.name, agents);
+        result = await resolveAgentForTemplate(selectedTemplate.id, agents);
       } catch (error) {
         console.error("Failed to create agent from template:", error);
         // Rethrow (translated) rather than swallowing: ChatInput's own
@@ -306,6 +317,9 @@ function TaskHomePageContent() {
             autoFocus={true}
             inputMinHeightClass="min-h-[200px]"
             templates={templates}
+            templatesLoading={templatesLoading}
+            templatesError={templatesError}
+            onRetryTemplates={fetchTemplates}
             selectedCategory={selectedCategory}
             onCategoryChange={setSelectedCategory}
             selectedTemplate={selectedTemplate}

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -1,21 +1,34 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
-import { Bot, Presentation, Search, Smartphone, Wand2 } from "lucide-react";
+import { Bot, CheckCircle2 } from "lucide-react";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ChatStartScreen, AgentCard } from "@/components/chat/ChatStartScreen";
 import { FilePreviewDialog } from "@/components/file/file-preview-dialog";
+import { Button } from "@/components/ui/button";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { apiRequest } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
 import { findRunnableAgentById } from "@/lib/agent-ui-access";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
+import type { Template, SamplePrompt } from "@/types/template";
+import { FEATURED_CATEGORY_ID } from "@/lib/template-categories";
+
+// Deep-link presets for "?starter=" (e.g. the Welcome modal's Presentation Builder
+// card). Kept separate from the template quick-access system below.
+const STARTER_PROMPTS: Record<string, { prompt: string; highlights: string[] }> = {
+  presentation: {
+    prompt: "Build a N-slide presentation on topic for audience.",
+    highlights: ["N", "topic", "audience"],
+  },
+};
 
 function TaskHomePageContent() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const { sendMessage, state, dispatch, closeFilePreview } = useApp();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const starter = searchParams.get("starter");
   const promptFromQuery = searchParams.get("prompt");
@@ -29,6 +42,10 @@ function TaskHomePageContent() {
     model?: string;
     executionMode?: "flash" | "balanced" | "think";
   }>();
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<string>(FEATURED_CATEGORY_ID);
+  const [selectedTemplate, setSelectedTemplate] = useState<{ id: string; name: string } | null>(null);
+  const [selectedPromptKey, setSelectedPromptKey] = useState<string | null>(null);
   const branding = getBrandingFromEnv();
 
   // Clear state on mount to ensure we are in "new task" mode
@@ -60,6 +77,22 @@ function TaskHomePageContent() {
     };
     fetchAgents();
   }, []);
+
+  // Fetch templates on mount (and when locale changes) for the quick-access grid
+  useEffect(() => {
+    const fetchTemplates = async () => {
+      try {
+        const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`);
+        if (response.ok) {
+          const data = await response.json();
+          setTemplates(Array.isArray(data) ? data : []);
+        }
+      } catch (error) {
+        console.error("Failed to fetch templates:", error);
+      }
+    };
+    fetchTemplates();
+  }, [locale]);
 
   useEffect(() => {
     if (!agentFromQuery || appliedAgentFromQueryRef.current === agentFromQuery || agents.length === 0) {
@@ -121,60 +154,15 @@ function TaskHomePageContent() {
     };
   }, [selectedAgents]);
 
-  const samplePrompts = useMemo(() => ([
-    {
-      id: "research",
-      icon: Search,
-      title: t("chatPage.cards.research.title"),
-      prompt: "Research topic and deliver a structured report with key findings, data points, and sources.",
-      promptHighlights: ["topic"],
-    },
-    {
-      id: "linkedin",
-      icon: Smartphone,
-      title: t("chatPage.cards.linkedin.title"),
-      prompt: "Write a LinkedIn post about topic or achievement. Tone: professional / inspirational.",
-      promptHighlights: ["topic or achievement", "professional / inspirational"],
-    },
-    {
-      id: "poster",
-      icon: Wand2,
-      title: t("chatPage.cards.poster.title"),
-      prompt: "Create a promotional poster for event or product. Style: modern / bold / minimal.",
-      promptHighlights: ["event or product", "modern / bold / minimal"],
-    },
-    {
-      id: "compare",
-      icon: Search,
-      title: t("chatPage.cards.compare.title"),
-      prompt: "Compare product A vs product B across key criteria. Provide a detailed analysis with a recommendation.",
-      promptHighlights: ["product A", "product B", "key criteria"],
-    },
-    {
-      id: "visual",
-      icon: Wand2,
-      title: t("chatPage.cards.visual.title"),
-      prompt: "Create a platform graphic for campaign or brand. Size: square / story / banner. Theme: colour or style.",
-      promptHighlights: ["platform", "campaign or brand", "square / story / banner", "colour or style"],
-    },
-    {
-      id: "presentation",
-      icon: Presentation,
-      title: t("chatPage.cards.presentation.title"),
-      prompt: "Build a N-slide presentation on topic for audience.",
-      promptHighlights: ["N", "topic", "audience"],
-    }
-  ]), [t]);
-
   const starterPreset = useMemo(() => {
-    const found = samplePrompts.find((prompt) => prompt.id === starter);
+    const found = starter ? STARTER_PROMPTS[starter] : null;
     if (!found) return null;
 
     return {
       prompt: found.prompt,
-      highlights: found.promptHighlights,
+      highlights: found.highlights,
     };
-  }, [starter, samplePrompts]);
+  }, [starter]);
 
   const queryInputValue = starterPreset?.prompt || promptFromQuery || "";
   const queryPromptHighlightTerms = useMemo(
@@ -190,13 +178,128 @@ function TaskHomePageContent() {
     setPromptHighlightTerms(queryPromptHighlightTerms);
   }, [queryInputValue, queryPromptHighlightTerms]);
 
+  // The backend has no dedicated "created from template X" link on an Agent
+  // record, so we correlate by name: a template-created agent is always
+  // named exactly `template.name` on first creation (see
+  // create_agent_from_template in agent_management.py). Renaming that agent
+  // later breaks this correlation - a known tradeoff of not having a
+  // persisted template_id column.
+  const findExistingAgentIdForTemplate = (templateName: string, agentList: AgentCard[]) => {
+    const match = agentList.find((agent) => agent.name === templateName);
+    const matchId = Number(match?.id);
+    return Number.isNaN(matchId) ? null : matchId;
+  };
+
+  // Reuse an already-created agent for this template if one exists; only
+  // create + publish a new one the first time a template is used.
+  const resolveAgentForTemplate = async (
+    templateId: string,
+    templateName: string
+  ): Promise<{ agentId: number; created: boolean }> => {
+    const knownExistingId = findExistingAgentIdForTemplate(templateName, agents);
+    if (knownExistingId !== null) {
+      return { agentId: knownExistingId, created: false };
+    }
+
+    const createResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ template_id: templateId }),
+    });
+
+    if (createResponse.status === 400) {
+      // Name collision our local (published-only) list didn't know about -
+      // e.g. a draft agent, or one created in another tab/session since we
+      // last fetched. Look it up and reuse it rather than minting a
+      // duplicate under a disambiguated name.
+      const listResponse = await apiRequest(`${getApiUrl()}/api/agents`);
+      if (listResponse.ok) {
+        const allAgents = await listResponse.json();
+        const match = Array.isArray(allAgents)
+          ? allAgents.find((agent) => agent && agent.name === templateName)
+          : undefined;
+        const matchId = Number(match?.id);
+        if (match && !Number.isNaN(matchId)) {
+          if (match.status !== "published") {
+            const publishResponse = await apiRequest(
+              `${getApiUrl()}/api/agents/${matchId}/publish`,
+              { method: "POST" }
+            );
+            if (!publishResponse.ok) {
+              throw new Error(`Failed to publish agent (${publishResponse.status})`);
+            }
+          }
+          return { agentId: matchId, created: false };
+        }
+      }
+      throw new Error(`Failed to create agent from template (${createResponse.status})`);
+    }
+
+    if (!createResponse.ok) {
+      throw new Error(`Failed to create agent from template (${createResponse.status})`);
+    }
+    const createdAgent = await createResponse.json();
+
+    const publishResponse = await apiRequest(
+      `${getApiUrl()}/api/agents/${createdAgent.id}/publish`,
+      { method: "POST" }
+    );
+    if (!publishResponse.ok) {
+      throw new Error(`Failed to publish agent (${publishResponse.status})`);
+    }
+
+    return { agentId: createdAgent.id, created: true };
+  };
+
   const handleSend = async (message: string, filesToSend: File[], config?: any) => {
     if (state.isProcessing) return;
 
-    const selectedAgentId = Number(selectedAgents[0]?.id);
+    let agentId = Number(selectedAgents[0]?.id);
+
+    if (Number.isNaN(agentId) && selectedTemplate) {
+      try {
+        const result = await resolveAgentForTemplate(selectedTemplate.id, selectedTemplate.name);
+        agentId = result.agentId;
+        if (result.created) {
+          const templateName = selectedTemplate.name;
+          toast.custom((toastId) => (
+            <div className="flex w-full flex-col gap-3 rounded-xl border border-green-600 bg-background p-4 shadow-lg">
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600" />
+                <span className="text-sm font-medium text-green-600">
+                  {t("chatPage.templateQuickAccess.agentCreatedToast", { name: templateName })}
+                </span>
+              </div>
+              <Button
+                size="sm"
+                className="self-end"
+                onClick={() => {
+                  toast.dismiss(toastId);
+                  router.push("/build");
+                }}
+              >
+                {t("chatPage.templateQuickAccess.viewInAgents")}
+              </Button>
+            </div>
+          ));
+          // Keep local state in sync so sending from this template again in
+          // the same session (without a page reload) reuses this agent
+          // instead of creating another one.
+          setAgents((prev) => [
+            ...prev,
+            { id: result.agentId, name: selectedTemplate.name, status: "published" },
+          ]);
+        }
+      } catch (error) {
+        console.error("Failed to create agent from template:", error);
+        toast.error(t("chatPage.templateQuickAccess.createAgentError"));
+        return;
+      }
+    }
+
     const nextConfig = {
       ...config,
-      agentId: Number.isNaN(selectedAgentId) ? undefined : selectedAgentId,
+      agentId: Number.isNaN(agentId) ? undefined : agentId,
     };
 
     try {
@@ -207,6 +310,8 @@ function TaskHomePageContent() {
       setInputValue("");
       setPromptHighlightTerms([]);
       setSelectedAgents([]);
+      setSelectedTemplate(null);
+      setSelectedPromptKey(null);
     } catch (error) {
       console.error("Failed to send message:", error);
       toast.error(error instanceof Error ? error.message : t("builds.list.chat.sendFailed"));
@@ -230,10 +335,25 @@ function TaskHomePageContent() {
       }
       return [agent];
     });
+    setSelectedTemplate(null);
+    setSelectedPromptKey(null);
   };
 
   const handleRemoveSelectedAgent = (agentId: number | string) => {
     setSelectedAgents((prev) => prev.filter((agent) => agent.id !== agentId));
+  };
+
+  const handleTemplatePromptSelect = (template: Template, prompt: SamplePrompt, index: number) => {
+    setInputValue(prompt.prompt);
+    setPromptHighlightTerms(prompt.highlights || []);
+    setSelectedTemplate({ id: template.id, name: template.name });
+    setSelectedPromptKey(`${template.id}:${index}`);
+    setSelectedAgents([]);
+  };
+
+  const handleRemoveSelectedTemplate = () => {
+    setSelectedTemplate(null);
+    setSelectedPromptKey(null);
   };
 
   return (
@@ -244,7 +364,6 @@ function TaskHomePageContent() {
             title={t("chatPage.page.emptyTitle", { appName: branding.appName })}
             description={t("chatPage.page.emptyDescription")}
             icon={<Bot className="w-10 h-10 text-[hsl(var(--gradient-from))]" />}
-            prompts={samplePrompts}
             agents={agents}
             onAgentClick={handleAgentClick}
             selectedAgents={selectedAgents}
@@ -262,6 +381,13 @@ function TaskHomePageContent() {
             showModeToggle={true}
             autoFocus={true}
             inputMinHeightClass="min-h-[200px]"
+            templates={templates}
+            selectedCategory={selectedCategory}
+            onCategoryChange={setSelectedCategory}
+            selectedTemplate={selectedTemplate}
+            onRemoveSelectedTemplate={handleRemoveSelectedTemplate}
+            selectedPromptKey={selectedPromptKey}
+            onTemplatePromptSelect={handleTemplatePromptSelect}
           />
         </main>
       </div>

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -282,14 +282,22 @@ function TaskHomePageContent() {
               </Button>
             </div>
           ));
-          // Keep local state in sync so sending from this template again in
-          // the same session (without a page reload) reuses this agent
-          // instead of creating another one.
-          setAgents((prev) => [
+        }
+        // Keep local state in sync so sending from this template again in the
+        // same session (without a page reload) resolves instantly instead of
+        // re-querying the backend - this also covers the case where the
+        // agent was resolved via the 400-retry lookup (created === false)
+        // rather than freshly created, which the local list wouldn't know
+        // about otherwise.
+        setAgents((prev) => {
+          if (prev.some((agent) => Number(agent.id) === result.agentId)) {
+            return prev;
+          }
+          return [
             ...prev,
             { id: result.agentId, name: selectedTemplate.name, status: "published" },
-          ]);
-        }
+          ];
+        });
       } catch (error) {
         console.error("Failed to create agent from template:", error);
         toast.error(t("chatPage.templateQuickAccess.createAgentError"));

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -12,6 +12,7 @@ import { SegmentedTabs } from "@/components/ui/segmented-tabs";
 import type { Template } from "@/types/template";
 import { LibraryTemplateCard } from "@/components/templates/library-template-card";
 import type { TranslationKey } from "@/i18n/translations";
+import { normalizeCategoryKey, orderCategoriesWithPreferred } from "@/lib/template-categories";
 
 interface CategorySection {
   id: string;
@@ -32,9 +33,6 @@ const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
   security: "templates.categoryTitles.security",
   operations: "templates.categoryTitles.operations",
 };
-
-const normalizeCategoryKey = (category: string) =>
-  category.toLowerCase().replace(/\s*&\s*/g, "_").replace(/\s+/g, "_");
 
 const formatFallbackLabel = (category: string) =>
   category
@@ -76,10 +74,7 @@ export default function TemplatesPage() {
   const categories = useMemo(() => {
     const preferred = ["Sales", "Marketing", "Support", "Research", "Productivity"];
     const dynamic = Array.from(new Set(templates.map((template) => template.category).filter(Boolean)));
-    const orderedDynamic = [
-      ...preferred.filter((category) => dynamic.includes(category)),
-      ...dynamic.filter((category) => !preferred.includes(category)),
-    ];
+    const orderedDynamic = orderCategoriesWithPreferred(dynamic, preferred);
 
     return [
       { id: "All", label: t("templates.categoryTitles.all") },

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -2,9 +2,9 @@
 
 import { useI18n } from "@/contexts/i18n-context";
 import { Loader2 } from "lucide-react";
-import { useState, useEffect, useMemo } from "react";
+import { Suspense, useState, useEffect, useMemo } from "react";
 import { getApiUrl } from "@/lib/utils";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiRequest } from "@/lib/api-wrapper";
 import { SearchInput } from "@/components/ui/search-input";
 import { PageHeader } from "@/components/ui/page-header";
@@ -21,6 +21,7 @@ interface CategorySection {
 }
 
 const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
+  general: "templates.categoryTitles.general",
   sales: "templates.categoryTitles.sales",
   marketing: "templates.categoryTitles.marketing",
   support: "templates.categoryTitles.support",
@@ -40,9 +41,23 @@ const formatFallbackLabel = (category: string) =>
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
 export default function TemplatesPage() {
+  return (
+    <Suspense fallback={null}>
+      <TemplatesPageContent />
+    </Suspense>
+  );
+}
+
+function TemplatesPageContent() {
   const { t, locale } = useI18n();
   const router = useRouter();
-  const [selectedCategory, setSelectedCategory] = useState("All");
+  const searchParams = useSearchParams();
+  // Honors the category the "All templates" escape hatch on the /task
+  // quick-access panel links back to (?category=<id>), so following it
+  // lands on the same category instead of always resetting to "All".
+  const [selectedCategory, setSelectedCategory] = useState(
+    () => searchParams.get("category") || "All"
+  );
   const [searchQuery, setSearchQuery] = useState("");
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -53,6 +53,8 @@ interface ChatInputProps {
     name: string;
   }>;
   onRemoveSelectedAgent?: (agentId: number | string) => void;
+  selectedTemplate?: { id: string; name: string } | null;
+  onRemoveSelectedTemplate?: () => void;
   uploadFile?: (file: File, params: { taskType: string }) => Promise<{ file_id: string }>;
   deferFileUpload?: boolean;
 }
@@ -105,6 +107,8 @@ export function ChatInput({
   promptHighlightTerms = [],
   selectedAgents = [],
   onRemoveSelectedAgent,
+  selectedTemplate = null,
+  onRemoveSelectedTemplate,
   uploadFile,
   deferFileUpload = false,
 }: ChatInputProps) {
@@ -810,11 +814,13 @@ export function ChatInput({
     }
   }, [filesDisabled, message, promptHighlightTerms]);
 
+  const hasTopChip = selectedAgents.length > 0 || !!selectedTemplate;
+
   return (
     <div className="space-y-3">
       {/* Input area */}
       <div
-        className={cn("relative", selectedAgents.length > 0 && "pt-9")}
+        className={cn("relative", hasTopChip && "pt-9")}
         ref={containerRef}
       >
         {fileMention.fileMentionsEnabled && (
@@ -828,7 +834,7 @@ export function ChatInput({
             position={fileMention.dropdownPosition}
           />
         )}
-        {selectedAgents.length > 0 && (
+        {hasTopChip && (
           <div className="absolute top-0 z-10 flex flex-wrap gap-2">
             {selectedAgents.map((agent) => (
               <div
@@ -853,13 +859,35 @@ export function ChatInput({
                 )}
               </div>
             ))}
+            {selectedTemplate && (
+              <div
+                className="inline-flex h-9 items-center gap-1 rounded-t-xl rounded-b-none border border-b-0 px-3 text-xs font-medium shadow-[0_-1px_0_rgba(53,88,255,0.08)]"
+                style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
+              >
+                <span className="italic">{t("chatPage.templateQuickAccess.usingTemplateLabel")}</span>
+                <span
+                  className="rounded-md border px-2 py-0.5 not-italic"
+                  style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
+                >{selectedTemplate.name}</span>
+                {onRemoveSelectedTemplate && (
+                  <button
+                    type="button"
+                    onClick={() => onRemoveSelectedTemplate()}
+                    className="rounded-sm p-0.5 hover:bg-[#dfe6ff]"
+                    title={t("common.remove")}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
         <form
           onSubmit={handleSubmit}
           className={cn(
             "relative flex flex-col overflow-hidden border-2 bg-card shadow-sm",
-            selectedAgents.length > 0
+            hasTopChip
               ? "rounded-tr-2xl rounded-br-2xl rounded-bl-2xl rounded-tl-none"
               : "rounded-2xl",
             isFocused
@@ -871,7 +899,7 @@ export function ChatInput({
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
           style={{
-            borderColor: selectedAgents.length > 0 ? "#3040cf" : isDraggingFiles || isFocused ? "#3040cf" : "#d7deec"
+            borderColor: hasTopChip ? "#3040cf" : isDraggingFiles || isFocused ? "#3040cf" : "#d7deec"
           }}
         >
           {isDraggingFiles && (

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -25,6 +25,47 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
+// Shared accent styling for the "Using @agent" / "Agent template: X" chips
+// rendered above the input.
+const CHIP_ACCENT_STYLE = { borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" };
+
+// The "Using @agent" and "Agent template: X" chips are the same shape (an
+// italic label, a pill with the value, an optional remove button) - one
+// component instead of two near-identical blocks.
+function SelectionChip({
+  label,
+  value,
+  onRemove,
+  removeLabel,
+}: {
+  label: string;
+  value: string;
+  onRemove?: () => void;
+  removeLabel: string;
+}) {
+  return (
+    <div
+      className="inline-flex h-9 items-center gap-1 rounded-t-xl rounded-b-none border border-b-0 px-3 text-xs font-medium shadow-[0_-1px_0_rgba(53,88,255,0.08)]"
+      style={CHIP_ACCENT_STYLE}
+    >
+      <span className="italic">{label}</span>
+      <span className="rounded-md border px-2 py-0.5 not-italic" style={CHIP_ACCENT_STYLE}>
+        {value}
+      </span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded-sm p-0.5 hover:bg-[#dfe6ff]"
+          title={removeLabel}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  );
+}
+
 interface ChatInputProps {
   onSend: (message: string, config?: AgentConfig) => void | Promise<void>;
   isLoading?: boolean;
@@ -837,49 +878,21 @@ export function ChatInput({
         {hasTopChip && (
           <div className="absolute top-0 z-10 flex flex-wrap gap-2">
             {selectedAgents.map((agent) => (
-              <div
+              <SelectionChip
                 key={agent.id}
-                className="inline-flex h-9 items-center gap-1 rounded-t-xl rounded-b-none border border-b-0 px-3 text-xs font-medium shadow-[0_-1px_0_rgba(53,88,255,0.08)]"
-                style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
-              >
-                <span className="italic">Using</span>
-                <span
-                  className="rounded-md border px-2 py-0.5 not-italic"
-                  style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
-                >{`@${agent.name}`}</span>
-                {onRemoveSelectedAgent && (
-                  <button
-                    type="button"
-                    onClick={() => onRemoveSelectedAgent(agent.id)}
-                    className="rounded-sm p-0.5 hover:bg-[#dfe6ff]"
-                    title={t("common.remove")}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                )}
-              </div>
+                label={t("chatPage.input.usingAgentLabel")}
+                value={`@${agent.name}`}
+                onRemove={onRemoveSelectedAgent ? () => onRemoveSelectedAgent(agent.id) : undefined}
+                removeLabel={t("common.remove")}
+              />
             ))}
             {selectedTemplate && (
-              <div
-                className="inline-flex h-9 items-center gap-1 rounded-t-xl rounded-b-none border border-b-0 px-3 text-xs font-medium shadow-[0_-1px_0_rgba(53,88,255,0.08)]"
-                style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
-              >
-                <span className="italic">{t("chatPage.templateQuickAccess.usingTemplateLabel")}</span>
-                <span
-                  className="rounded-md border px-2 py-0.5 not-italic"
-                  style={{ borderColor: "#3040cf", color: "#3040cf", backgroundColor: "#eef1ff" }}
-                >{selectedTemplate.name}</span>
-                {onRemoveSelectedTemplate && (
-                  <button
-                    type="button"
-                    onClick={() => onRemoveSelectedTemplate()}
-                    className="rounded-sm p-0.5 hover:bg-[#dfe6ff]"
-                    title={t("common.remove")}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                )}
-              </div>
+              <SelectionChip
+                label={t("chatPage.templateQuickAccess.usingTemplateLabel")}
+                value={selectedTemplate.name}
+                onRemove={onRemoveSelectedTemplate}
+                removeLabel={t("common.remove")}
+              />
             )}
           </div>
         )}

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -36,7 +36,26 @@ export interface AgentCard {
   template_id?: string | null;
 }
 
-interface ChatStartScreenProps {
+// When `templates` is supplied, TemplateQuickAccess is rendered and needs a
+// real handler for both callbacks - a `|| (() => {})` fallback would silently
+// swallow category switches/prompt picks instead of surfacing the missing
+// wiring at compile time. Omitting `templates` falls back to the plain
+// prompt-card grid, which doesn't use either handler.
+type TemplateQuickAccessSlotProps =
+  | {
+      templates?: undefined;
+      selectedCategory?: string;
+      onCategoryChange?: (category: string) => void;
+      onTemplatePromptSelect?: (template: Template, prompt: SamplePrompt, index: number) => void;
+    }
+  | {
+      templates: Template[];
+      selectedCategory?: string;
+      onCategoryChange: (category: string) => void;
+      onTemplatePromptSelect: (template: Template, prompt: SamplePrompt, index: number) => void;
+    };
+
+type ChatStartScreenProps = {
   title: string;
   description?: string;
   icon?: React.ReactNode | string; // URL string or ReactNode
@@ -63,14 +82,10 @@ interface ChatStartScreenProps {
   taskConfig?: any;
   autoFocus?: boolean;
   inputMinHeightClass?: string;
-  templates?: Template[];
-  selectedCategory?: string;
-  onCategoryChange?: (category: string) => void;
   selectedTemplate?: { id: string; name: string } | null;
   onRemoveSelectedTemplate?: () => void;
   selectedPromptKey?: string | null;
-  onTemplatePromptSelect?: (template: Template, prompt: SamplePrompt, index: number) => void;
-}
+} & TemplateQuickAccessSlotProps;
 
 export function ChatStartScreen({
   title,
@@ -163,9 +178,9 @@ export function ChatStartScreen({
           <TemplateQuickAccess
             templates={templates}
             selectedCategory={selectedCategory || ""}
-            onCategoryChange={onCategoryChange || (() => {})}
+            onCategoryChange={onCategoryChange}
             selectedPromptKey={selectedPromptKey ?? null}
-            onPromptSelect={onTemplatePromptSelect || (() => {})}
+            onPromptSelect={onTemplatePromptSelect}
           />
         ) : prompts && prompts.length > 0 && (
           <div className="space-y-3">

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -30,6 +30,10 @@ export interface AgentCard {
   status?: string;
   readonly?: boolean;
   can_edit?: boolean;
+  // Built-in template id this agent was instantiated from, or null/undefined
+  // for agents built from scratch. Used to key template-reuse matching off a
+  // stable id instead of the user-editable display name.
+  template_id?: string | null;
 }
 
 interface ChatStartScreenProps {

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Bot, Sparkles } from "lucide-react";
 import { ChatInput } from "@/components/chat/ChatInput";
+import { TemplateQuickAccess } from "@/components/chat/TemplateQuickAccess";
 import { useI18n } from "@/contexts/i18n-context";
 import {
   Tooltip,
@@ -9,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getApiUrl } from "@/lib/utils";
+import type { Template, SamplePrompt } from "@/types/template";
 
 export interface PromptCard {
   icon?: any;
@@ -57,6 +59,13 @@ interface ChatStartScreenProps {
   taskConfig?: any;
   autoFocus?: boolean;
   inputMinHeightClass?: string;
+  templates?: Template[];
+  selectedCategory?: string;
+  onCategoryChange?: (category: string) => void;
+  selectedTemplate?: { id: string; name: string } | null;
+  onRemoveSelectedTemplate?: () => void;
+  selectedPromptKey?: string | null;
+  onTemplatePromptSelect?: (template: Template, prompt: SamplePrompt, index: number) => void;
 }
 
 export function ChatStartScreen({
@@ -85,7 +94,14 @@ export function ChatStartScreen({
   voiceInputEnabled = true,
   taskConfig,
   autoFocus = false,
-  inputMinHeightClass
+  inputMinHeightClass,
+  templates,
+  selectedCategory,
+  onCategoryChange,
+  selectedTemplate,
+  onRemoveSelectedTemplate,
+  selectedPromptKey,
+  onTemplatePromptSelect,
 }: ChatStartScreenProps) {
   const { t } = useI18n();
   const enabledFiles = filesDisabled ? [] : files;
@@ -134,10 +150,20 @@ export function ChatStartScreen({
             minHeightClass={inputMinHeightClass}
             selectedAgents={selectedAgents}
             onRemoveSelectedAgent={onRemoveSelectedAgent}
+            selectedTemplate={selectedTemplate}
+            onRemoveSelectedTemplate={onRemoveSelectedTemplate}
           />
         </div>
 
-        {prompts && prompts.length > 0 && (
+        {templates ? (
+          <TemplateQuickAccess
+            templates={templates}
+            selectedCategory={selectedCategory || ""}
+            onCategoryChange={onCategoryChange || (() => {})}
+            selectedPromptKey={selectedPromptKey ?? null}
+            onPromptSelect={onTemplatePromptSelect || (() => {})}
+          />
+        ) : prompts && prompts.length > 0 && (
           <div className="space-y-3">
             <div className="flex items-center gap-2 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] px-1">
               <Sparkles className="w-3.5 h-3.5" />

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -47,12 +47,18 @@ type TemplateQuickAccessSlotProps =
       selectedCategory?: string;
       onCategoryChange?: (category: string) => void;
       onTemplatePromptSelect?: (template: Template, prompt: SamplePrompt, index: number) => void;
+      templatesLoading?: boolean;
+      templatesError?: boolean;
+      onRetryTemplates?: () => void;
     }
   | {
       templates: Template[];
       selectedCategory?: string;
       onCategoryChange: (category: string) => void;
       onTemplatePromptSelect: (template: Template, prompt: SamplePrompt, index: number) => void;
+      templatesLoading?: boolean;
+      templatesError?: boolean;
+      onRetryTemplates?: () => void;
     };
 
 type ChatStartScreenProps = {
@@ -121,6 +127,9 @@ export function ChatStartScreen({
   onRemoveSelectedTemplate,
   selectedPromptKey,
   onTemplatePromptSelect,
+  templatesLoading = false,
+  templatesError = false,
+  onRetryTemplates,
 }: ChatStartScreenProps) {
   const { t } = useI18n();
   const enabledFiles = filesDisabled ? [] : files;
@@ -181,6 +190,9 @@ export function ChatStartScreen({
             onCategoryChange={onCategoryChange}
             selectedPromptKey={selectedPromptKey ?? null}
             onPromptSelect={onTemplatePromptSelect}
+            isLoading={templatesLoading}
+            loadError={templatesError}
+            onRetryLoad={onRetryTemplates}
           />
         ) : prompts && prompts.length > 0 && (
           <div className="space-y-3">

--- a/frontend/src/components/chat/TemplateQuickAccess.test.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.test.tsx
@@ -83,4 +83,41 @@ describe("TemplateQuickAccess", () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("survives the loading -> loaded transition without a hooks-order crash", () => {
+    // Regression test for PR review finding C1: the real /task mount order is
+    // (isLoading=false, templates=[]) on the very first render - falling
+    // through to the full render path - then a mount effect synchronously
+    // flips isLoading to true before the fetch resolves, forcing a second
+    // render down the early-return path. Both useMemo calls must run on
+    // every render regardless of which path is taken, or React throws
+    // "Rendered fewer hooks than expected."
+    const { rerender } = render(
+      <TemplateQuickAccess
+        templates={[]}
+        selectedCategory={FEATURED_CATEGORY_ID}
+        onCategoryChange={vi.fn()}
+        selectedPromptKey={null}
+        onPromptSelect={vi.fn()}
+        isLoading={false}
+      />
+    );
+
+    expect(() =>
+      rerender(
+        <TemplateQuickAccess
+          templates={[]}
+          selectedCategory={FEATURED_CATEGORY_ID}
+          onCategoryChange={vi.fn()}
+          selectedPromptKey={null}
+          onPromptSelect={vi.fn()}
+          isLoading={true}
+        />
+      )
+    ).not.toThrow();
+
+    expect(
+      screen.getByText("chatPage.templateQuickAccess.loading")
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/chat/TemplateQuickAccess.test.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string, vars?: Record<string, string | number>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+  }),
+}));
+
+import { TemplateQuickAccess } from "./TemplateQuickAccess";
+import { FEATURED_CATEGORY_ID } from "@/lib/template-categories";
+import type { Template } from "@/types/template";
+
+function makeTemplate(overrides: Partial<Template> = {}): Template {
+  return {
+    id: "tmpl-1",
+    name: "Test Template",
+    category: "Marketing",
+    featured: true,
+    description: "A test template",
+    features: [],
+    connections: [],
+    setup_time: "5 min setup",
+    tags: [],
+    author: "Xagent",
+    version: "1.0",
+    views: 0,
+    likes: 0,
+    used_count: 0,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("TemplateQuickAccess", () => {
+  it("renders at most 2 sample prompts per card, even when the template has more", () => {
+    const template = makeTemplate({
+      sample_prompts: [
+        { title: "Prompt one", prompt: "Do the first thing." },
+        { title: "Prompt two", prompt: "Do the second thing." },
+        { title: "Prompt three", prompt: "Do the third thing." },
+      ],
+    });
+
+    render(
+      <TemplateQuickAccess
+        templates={[template]}
+        selectedCategory={FEATURED_CATEGORY_ID}
+        onCategoryChange={vi.fn()}
+        selectedPromptKey={null}
+        onPromptSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Prompt one/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Prompt two/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Prompt three/ })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no templates", () => {
+    const { container } = render(
+      <TemplateQuickAccess
+        templates={[]}
+        selectedCategory={FEATURED_CATEGORY_ID}
+        onCategoryChange={vi.fn()}
+        selectedPromptKey={null}
+        onPromptSelect={vi.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/chat/TemplateQuickAccess.test.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.test.tsx
@@ -120,4 +120,68 @@ describe("TemplateQuickAccess", () => {
       screen.getByText("chatPage.templateQuickAccess.loading")
     ).toBeInTheDocument();
   });
+
+  it.each(["General", "Operations", "Marketing", "Sales", "Support"])(
+    "resolves a real label key for the shipped %s category, not the raw-id fallback",
+    (category) => {
+      // Regression test for PR review finding m7: CATEGORY_LABEL_KEYS used to
+      // be missing entries for two of the five shipped categories (General,
+      // Operations), so selecting them fell through to categoryLabel's raw
+      // categoryId fallback instead of a translated label. The mocked t()
+      // above echoes the key it's given, so a resolved key renders as
+      // "templates.categoryTitles.<x>" while a missed one renders as the
+      // untranslated category string itself.
+      render(
+        <TemplateQuickAccess
+          templates={[makeTemplate({ category, featured: false })]}
+          selectedCategory={category}
+          onCategoryChange={vi.fn()}
+          selectedPromptKey={null}
+          onPromptSelect={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText(category)).not.toBeInTheDocument();
+    }
+  );
+
+  it('links "All templates" back to the active category, not always the unscoped default', () => {
+    // Regression test for PR review finding FE-11/m11: this escape hatch
+    // used to be a bare /templates link with no category, so following it
+    // from e.g. the Support tab always landed back on "All" instead of
+    // Support.
+    render(
+      <TemplateQuickAccess
+        templates={[makeTemplate({ category: "Support", featured: false })]}
+        selectedCategory="Support"
+        onCategoryChange={vi.fn()}
+        selectedPromptKey={null}
+        onPromptSelect={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText("chatPage.templateQuickAccess.allTemplates")
+    ).toHaveAttribute("href", "/templates?category=Support");
+  });
+
+  it('links "All templates" to the unscoped /templates from the Featured tab', () => {
+    // /templates has no selectable "Featured" tab of its own - selecting
+    // "All" there is what surfaces its Featured section - so the Featured
+    // tab must not carry a category=Featured param /templates wouldn't
+    // recognize.
+    render(
+      <TemplateQuickAccess
+        templates={[makeTemplate({ category: "Support", featured: true })]}
+        selectedCategory={FEATURED_CATEGORY_ID}
+        onCategoryChange={vi.fn()}
+        selectedPromptKey={null}
+        onPromptSelect={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText("chatPage.templateQuickAccess.allTemplates")
+    ).toHaveAttribute("href", "/templates");
+  });
 });

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -45,7 +45,9 @@ const TEMPLATE_ICON_BY_ID: Record<string, IconComponent> = {
 // for the /templates library page's section heading, not this compact pill.
 const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
   featured: "chatPage.templateQuickAccess.featuredLabel",
+  general: "templates.categoryTitles.general",
   marketing: "templates.categoryTitles.marketing",
+  operations: "templates.categoryTitles.operations",
   sales: "templates.categoryTitles.sales",
   support: "templates.categoryTitles.support",
 };
@@ -119,6 +121,16 @@ export function TemplateQuickAccess({
     const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(categoryId)];
     return key ? t(key) : categoryId;
   };
+
+  // /templates has no selectable "Featured" tab of its own - selecting "All"
+  // there is what surfaces its Featured section - so map this panel's
+  // Featured tab to that instead of a category id /templates wouldn't
+  // recognize (PR review finding FE-11/m11: the escape hatch used to always
+  // link to the unscoped default regardless of which tab was active here).
+  const allTemplatesHref =
+    activeCategory === FEATURED_CATEGORY_ID
+      ? "/templates"
+      : `/templates?category=${encodeURIComponent(activeCategory)}`;
 
   // While the initial fetch is in flight or has failed, `templates` is still
   // `[]` and categoryTabs would be empty too - without this, the grid area
@@ -199,7 +211,7 @@ export function TemplateQuickAccess({
               })}
             </h3>
             <Link
-              href="/templates"
+              href={allTemplatesHref}
               className={cn("text-[13px] font-medium hover:underline", ACCENT_TEXT_CLASS)}
             >
               {t("chatPage.templateQuickAccess.allTemplates")}

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -74,6 +74,9 @@ export interface TemplateQuickAccessProps {
   onCategoryChange: (category: string) => void;
   selectedPromptKey: string | null;
   onPromptSelect: (template: Template, prompt: SamplePrompt, index: number) => void;
+  isLoading?: boolean;
+  loadError?: boolean;
+  onRetryLoad?: () => void;
 }
 
 export function TemplateQuickAccess({
@@ -82,6 +85,9 @@ export function TemplateQuickAccess({
   onCategoryChange,
   selectedPromptKey,
   onPromptSelect,
+  isLoading = false,
+  loadError = false,
+  onRetryLoad,
 }: TemplateQuickAccessProps) {
   const { t } = useI18n();
 
@@ -89,6 +95,38 @@ export function TemplateQuickAccess({
     () => getOrderedCategoriesWithCounts(templates),
     [templates]
   );
+
+  // While the initial fetch is in flight or has failed, `templates` is still
+  // `[]` and categoryTabs would be empty too - without this, the grid area
+  // just renders nothing with no sign anything is loading or broke (see PR
+  // review finding F8). Once templates has actually loaded (even to a
+  // legitimately empty result), fall through to the normal empty-state below.
+  if (templates.length === 0 && (isLoading || loadError)) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border py-8 text-center">
+        {isLoading ? (
+          <p className="text-[13px] text-muted-foreground">
+            {t("chatPage.templateQuickAccess.loading")}
+          </p>
+        ) : (
+          <>
+            <p className="text-[13px] text-muted-foreground">
+              {t("chatPage.templateQuickAccess.loadError")}
+            </p>
+            {onRetryLoad && (
+              <button
+                type="button"
+                onClick={onRetryLoad}
+                className={cn("text-[13px] font-medium hover:underline", ACCENT_TEXT_CLASS)}
+              >
+                {t("chatPage.templateQuickAccess.retry")}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
 
   // The parent may hand us a selectedCategory (e.g. the "Featured" default)
   // that no longer has a matching tab - a deployment with no featured
@@ -99,7 +137,7 @@ export function TemplateQuickAccess({
     : categoryTabs[0]?.id ?? selectedCategory;
 
   const cards = useMemo(
-    () => getTemplatesForCategory(templates, activeCategory, 4),
+    () => getTemplatesForCategory(templates, activeCategory),
     [templates, activeCategory]
   );
 

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -21,6 +21,7 @@ import {
   FEATURED_CATEGORY_ID,
   getOrderedCategoriesWithCounts,
   getTemplatesForCategory,
+  normalizeCategoryKey,
 } from "@/lib/template-categories";
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
@@ -103,7 +104,7 @@ export function TemplateQuickAccess({
   );
 
   const categoryLabel = (categoryId: string) => {
-    const key = CATEGORY_LABEL_KEYS[categoryId.toLowerCase()];
+    const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(categoryId)];
     return key ? t(key) : categoryId;
   };
 

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -91,10 +91,34 @@ export function TemplateQuickAccess({
 }: TemplateQuickAccessProps) {
   const { t } = useI18n();
 
+  // Both useMemo calls (and the plain activeCategory derivation between them)
+  // must run unconditionally, on every render, in the same order - the
+  // loading/error early return below used to sit between them, so the
+  // loading render executed one hook and the loaded render executed two,
+  // crashing with "Rendered fewer hooks than expected" (PR review finding
+  // C1). Keep every hook above any return statement.
   const categoryTabs = useMemo(
     () => getOrderedCategoriesWithCounts(templates),
     [templates]
   );
+
+  // The parent may hand us a selectedCategory (e.g. the "Featured" default)
+  // that no longer has a matching tab - a deployment with no featured
+  // templates, for instance. Fall back to the first available tab instead of
+  // rendering an empty, unlabeled panel.
+  const activeCategory = categoryTabs.some((tab) => tab.id === selectedCategory)
+    ? selectedCategory
+    : categoryTabs[0]?.id ?? selectedCategory;
+
+  const cards = useMemo(
+    () => getTemplatesForCategory(templates, activeCategory),
+    [templates, activeCategory]
+  );
+
+  const categoryLabel = (categoryId: string) => {
+    const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(categoryId)];
+    return key ? t(key) : categoryId;
+  };
 
   // While the initial fetch is in flight or has failed, `templates` is still
   // `[]` and categoryTabs would be empty too - without this, the grid area
@@ -127,24 +151,6 @@ export function TemplateQuickAccess({
       </div>
     );
   }
-
-  // The parent may hand us a selectedCategory (e.g. the "Featured" default)
-  // that no longer has a matching tab - a deployment with no featured
-  // templates, for instance. Fall back to the first available tab instead of
-  // rendering an empty, unlabeled panel.
-  const activeCategory = categoryTabs.some((tab) => tab.id === selectedCategory)
-    ? selectedCategory
-    : categoryTabs[0]?.id ?? selectedCategory;
-
-  const cards = useMemo(
-    () => getTemplatesForCategory(templates, activeCategory),
-    [templates, activeCategory]
-  );
-
-  const categoryLabel = (categoryId: string) => {
-    const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(categoryId)];
-    return key ? t(key) : categoryId;
-  };
 
   if (categoryTabs.length === 0) {
     return null;

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -1,0 +1,206 @@
+import { useMemo } from "react";
+import Link from "next/link";
+import type { ComponentType, SVGProps } from "react";
+import {
+  Bot,
+  FileText,
+  Share2,
+  Inbox,
+  Megaphone,
+  Target,
+  Headphones,
+  Star,
+  Zap,
+  Layers,
+} from "lucide-react";
+import { useI18n } from "@/contexts/i18n-context";
+import type { TranslationKey } from "@/i18n/translations";
+import { cn } from "@/lib/utils";
+import type { Template, SamplePrompt } from "@/types/template";
+import {
+  FEATURED_CATEGORY_ID,
+  getOrderedCategoriesWithCounts,
+  getTemplatesForCategory,
+} from "@/lib/template-categories";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+const CATEGORY_ICONS: Record<string, IconComponent> = {
+  [FEATURED_CATEGORY_ID]: Star,
+  Marketing: Megaphone,
+  Sales: Target,
+  Support: Headphones,
+};
+
+const TEMPLATE_ICON_BY_ID: Record<string, IconComponent> = {
+  "general-doc-summarizer-action-extractor": FileText,
+  "marketing-social-media-content-manager": Share2,
+  "support-ai-chatbot-agent": Bot,
+  "support-inbox-manager": Inbox,
+};
+
+// A dedicated short label for the Featured pill/heading here - the shared
+// `templates.categoryTitles.featured` string ("Featured Templates") is sized
+// for the /templates library page's section heading, not this compact pill.
+const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
+  featured: "chatPage.templateQuickAccess.featuredLabel",
+  marketing: "templates.categoryTitles.marketing",
+  sales: "templates.categoryTitles.sales",
+  support: "templates.categoryTitles.support",
+};
+
+function getTemplateIcon(template: Template): IconComponent {
+  return (
+    TEMPLATE_ICON_BY_ID[template.id] ||
+    CATEGORY_ICONS[template.category] ||
+    Bot
+  );
+}
+
+export interface TemplateQuickAccessProps {
+  templates: Template[];
+  selectedCategory: string;
+  onCategoryChange: (category: string) => void;
+  selectedPromptKey: string | null;
+  onPromptSelect: (template: Template, prompt: SamplePrompt, index: number) => void;
+}
+
+export function TemplateQuickAccess({
+  templates,
+  selectedCategory,
+  onCategoryChange,
+  selectedPromptKey,
+  onPromptSelect,
+}: TemplateQuickAccessProps) {
+  const { t } = useI18n();
+
+  // Only surface tabs this quick-access panel has a dedicated icon/label for
+  // (Featured/Marketing/Sales/Support); other categories remain reachable via
+  // "All templates" without cluttering this compact pill row.
+  const categoryTabs = useMemo(
+    () => getOrderedCategoriesWithCounts(templates).filter((tab) => !!CATEGORY_ICONS[tab.id]),
+    [templates]
+  );
+  const cards = useMemo(
+    () => getTemplatesForCategory(templates, selectedCategory, 4),
+    [templates, selectedCategory]
+  );
+
+  const categoryLabel = (categoryId: string) => {
+    const key = CATEGORY_LABEL_KEYS[categoryId.toLowerCase()];
+    return key ? t(key) : categoryId;
+  };
+
+  if (categoryTabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {categoryTabs.map((tab) => {
+          const Icon = CATEGORY_ICONS[tab.id] || Layers;
+          const isActive = tab.id === selectedCategory;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onCategoryChange(tab.id)}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[13px] font-medium transition-colors",
+                isActive
+                  ? "border-[#3040cf] bg-[#eef1ff] text-[#3040cf]"
+                  : "border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span>{categoryLabel(tab.id)}</span>
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-0.5 text-[11px] font-semibold",
+                  isActive ? "bg-[#3040cf]/10 text-[#3040cf]" : "bg-muted text-muted-foreground"
+                )}
+              >
+                {tab.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {cards.length > 0 && (
+        <>
+          <div className="flex items-baseline justify-between px-1">
+            <h3 className="text-[14px] font-semibold text-foreground">
+              {t("chatPage.templateQuickAccess.categoryHeading", {
+                category: categoryLabel(selectedCategory),
+              })}
+            </h3>
+            <Link
+              href="/templates"
+              className="text-[13px] font-medium text-[#3040cf] hover:underline"
+            >
+              {t("chatPage.templateQuickAccess.allTemplates")}
+            </Link>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {cards.map((template) => {
+              const Icon = getTemplateIcon(template);
+              const prompts = (template.sample_prompts || []).slice(0, 2);
+
+              return (
+                <div
+                  key={template.id}
+                  className="space-y-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-[#3040cf]"
+                >
+                  <Link
+                    href={`/build/new?template=${encodeURIComponent(template.id)}`}
+                    className="flex items-start gap-3"
+                  >
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-300">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <div className="group/text min-w-0">
+                      <h4 className="truncate text-[14px] font-semibold text-foreground transition-colors group-hover/text:text-[#3040cf]">
+                        {template.name}
+                      </h4>
+                      <p className="line-clamp-2 text-[12.5px] text-muted-foreground">
+                        {template.description}
+                      </p>
+                    </div>
+                  </Link>
+
+                  {prompts.length > 0 && (
+                    <div className="space-y-1">
+                      {prompts.map((prompt, index) => {
+                        const key = `${template.id}:${index}`;
+                        const isSelected = key === selectedPromptKey;
+                        return (
+                          <button
+                            key={key}
+                            type="button"
+                            onClick={() => onPromptSelect(template, prompt, index)}
+                            className={cn(
+                              "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition-colors",
+                              isSelected
+                                ? "bg-[#eef1ff] font-medium text-[#3040cf]"
+                                : "text-foreground/80 hover:bg-muted/60"
+                            )}
+                          >
+                            <Zap className="h-3.5 w-3.5 shrink-0" />
+                            <span className="truncate">{prompt.title}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/TemplateQuickAccess.tsx
+++ b/frontend/src/components/chat/TemplateQuickAccess.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import Link from "next/link";
 import type { ComponentType, SVGProps } from "react";
 import {
@@ -49,6 +49,16 @@ const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
   support: "templates.categoryTitles.support",
 };
 
+// Shared indigo accent used throughout this component for the active/hover/
+// selected states (category tab, count badge, "All templates" link, card
+// hover border, card title hover, selected sample-prompt row).
+const ACCENT_TEXT_CLASS = "text-[#3040cf]";
+const ACCENT_ACTIVE_PILL_CLASSES = "border-[#3040cf] bg-[#eef1ff] text-[#3040cf]";
+const ACCENT_ACTIVE_BADGE_CLASSES = "bg-[#3040cf]/10 text-[#3040cf]";
+const ACCENT_SELECTED_PROMPT_CLASSES = "bg-[#eef1ff] font-medium text-[#3040cf]";
+const ACCENT_HOVER_BORDER_CLASS = "hover:border-[#3040cf]";
+const ACCENT_HOVER_TITLE_CLASS = "group-hover/text:text-[#3040cf]";
+
 function getTemplateIcon(template: Template): IconComponent {
   return (
     TEMPLATE_ICON_BY_ID[template.id] ||
@@ -74,16 +84,22 @@ export function TemplateQuickAccess({
 }: TemplateQuickAccessProps) {
   const { t } = useI18n();
 
-  // Only surface tabs this quick-access panel has a dedicated icon/label for
-  // (Featured/Marketing/Sales/Support); other categories remain reachable via
-  // "All templates" without cluttering this compact pill row.
   const categoryTabs = useMemo(
-    () => getOrderedCategoriesWithCounts(templates).filter((tab) => !!CATEGORY_ICONS[tab.id]),
+    () => getOrderedCategoriesWithCounts(templates),
     [templates]
   );
+
+  // The parent may hand us a selectedCategory (e.g. the "Featured" default)
+  // that no longer has a matching tab - a deployment with no featured
+  // templates, for instance. Fall back to the first available tab instead of
+  // rendering an empty, unlabeled panel.
+  const activeCategory = categoryTabs.some((tab) => tab.id === selectedCategory)
+    ? selectedCategory
+    : categoryTabs[0]?.id ?? selectedCategory;
+
   const cards = useMemo(
-    () => getTemplatesForCategory(templates, selectedCategory, 4),
-    [templates, selectedCategory]
+    () => getTemplatesForCategory(templates, activeCategory, 4),
+    [templates, activeCategory]
   );
 
   const categoryLabel = (categoryId: string) => {
@@ -100,16 +116,17 @@ export function TemplateQuickAccess({
       <div className="flex flex-wrap items-center justify-center gap-2">
         {categoryTabs.map((tab) => {
           const Icon = CATEGORY_ICONS[tab.id] || Layers;
-          const isActive = tab.id === selectedCategory;
+          const isActive = tab.id === activeCategory;
           return (
             <button
               key={tab.id}
               type="button"
+              aria-pressed={isActive}
               onClick={() => onCategoryChange(tab.id)}
               className={cn(
                 "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[13px] font-medium transition-colors",
                 isActive
-                  ? "border-[#3040cf] bg-[#eef1ff] text-[#3040cf]"
+                  ? ACCENT_ACTIVE_PILL_CLASSES
                   : "border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground"
               )}
             >
@@ -118,7 +135,7 @@ export function TemplateQuickAccess({
               <span
                 className={cn(
                   "rounded-full px-1.5 py-0.5 text-[11px] font-semibold",
-                  isActive ? "bg-[#3040cf]/10 text-[#3040cf]" : "bg-muted text-muted-foreground"
+                  isActive ? ACCENT_ACTIVE_BADGE_CLASSES : "bg-muted text-muted-foreground"
                 )}
               >
                 {tab.count}
@@ -133,12 +150,12 @@ export function TemplateQuickAccess({
           <div className="flex items-baseline justify-between px-1">
             <h3 className="text-[14px] font-semibold text-foreground">
               {t("chatPage.templateQuickAccess.categoryHeading", {
-                category: categoryLabel(selectedCategory),
+                category: categoryLabel(activeCategory),
               })}
             </h3>
             <Link
               href="/templates"
-              className="text-[13px] font-medium text-[#3040cf] hover:underline"
+              className={cn("text-[13px] font-medium hover:underline", ACCENT_TEXT_CLASS)}
             >
               {t("chatPage.templateQuickAccess.allTemplates")}
             </Link>
@@ -152,17 +169,25 @@ export function TemplateQuickAccess({
               return (
                 <div
                   key={template.id}
-                  className="space-y-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-[#3040cf]"
+                  className={cn(
+                    "space-y-3 rounded-xl border border-border bg-card p-4 text-left transition-colors",
+                    ACCENT_HOVER_BORDER_CLASS
+                  )}
                 >
                   <Link
                     href={`/build/new?template=${encodeURIComponent(template.id)}`}
-                    className="flex items-start gap-3"
+                    className="group/text flex items-start gap-3"
                   >
                     <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-300">
                       <Icon className="h-5 w-5" />
                     </div>
-                    <div className="group/text min-w-0">
-                      <h4 className="truncate text-[14px] font-semibold text-foreground transition-colors group-hover/text:text-[#3040cf]">
+                    <div className="min-w-0">
+                      <h4
+                        className={cn(
+                          "truncate text-[14px] font-semibold text-foreground transition-colors",
+                          ACCENT_HOVER_TITLE_CLASS
+                        )}
+                      >
                         {template.name}
                       </h4>
                       <p className="line-clamp-2 text-[12.5px] text-muted-foreground">
@@ -180,11 +205,12 @@ export function TemplateQuickAccess({
                           <button
                             key={key}
                             type="button"
+                            title={prompt.title}
                             onClick={() => onPromptSelect(template, prompt, index)}
                             className={cn(
                               "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition-colors",
                               isSelected
-                                ? "bg-[#eef1ff] font-medium text-[#3040cf]"
+                                ? ACCENT_SELECTED_PROMPT_CLASSES
                                 : "text-foreground/80 hover:bg-muted/60"
                             )}
                           >

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -217,11 +217,6 @@ const en = {
       startingPrompts: "STARTING PROMPTS",
       chatWithAgents: "CHAT WITH AGENTS",
     },
-    agents: {
-      researcher: "Researcher Agent",
-      poster: "Poster Maker",
-      linkedin: "LinkedIn Post Creator",
-    },
     templateQuickAccess: {
       featuredLabel: "Featured",
       categoryHeading: "{category} AI Agents",
@@ -230,6 +225,9 @@ const en = {
       agentCreatedToast: "Agent \"{name}\" created from template",
       viewInAgents: "View in Agents",
       createAgentError: "Couldn't create the agent from this template. Please try again.",
+      loading: "Loading templates...",
+      loadError: "Couldn't load templates.",
+      retry: "Retry",
     },
     input: {
       placeholder: "Describe your task...",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1557,6 +1557,7 @@ Build when you need.`,
     categoryTitles: {
       featured: "Featured Templates",
       all: "All",
+      general: "General",
       sales: "Sales",
       marketing: "Marketing",
       support: "Support",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -217,25 +217,19 @@ const en = {
       startingPrompts: "STARTING PROMPTS",
       chatWithAgents: "CHAT WITH AGENTS",
     },
-    cards: {
-      research: {
-        title: "Research a topic in depth",
-      },
-      linkedin: {
-        title: "Write a LinkedIn post about an achievement",
-      },
-      poster: {
-        title: "Design a poster for an event",
-      },
-      compare: {
-        title: "Compare products with deep research",
-      },
-      visual: {
-        title: "Create visual for a topic",
-      },
-      presentation: {
-        title: "Turn a topic into a presentation deck",
-      }
+    agents: {
+      researcher: "Researcher Agent",
+      poster: "Poster Maker",
+      linkedin: "LinkedIn Post Creator",
+    },
+    templateQuickAccess: {
+      featuredLabel: "Featured",
+      categoryHeading: "{category} AI Agents",
+      allTemplates: "All templates →",
+      usingTemplateLabel: "Agent template:",
+      agentCreatedToast: "Agent \"{name}\" created from template",
+      viewInAgents: "View in Agents",
+      createAgentError: "Couldn't create the agent from this template. Please try again.",
     },
     input: {
       placeholder: "Describe your task...",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -234,6 +234,7 @@ const en = {
     input: {
       placeholder: "Describe your task...",
       processing: "Processing",
+      usingAgentLabel: "Using",
       actions: {
         config: "Configure Model",
         upload: "Upload",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -217,25 +217,19 @@ const zh = {
       startingPrompts: "快捷指令",
       chatWithAgents: "与智能体聊天",
     },
-    cards: {
-      research: {
-        title: "深入研究一个话题",
-      },
-      linkedin: {
-        title: "撰写 LinkedIn 动态",
-      },
-      poster: {
-        title: "设计活动海报",
-      },
-      compare: {
-        title: "深度对比产品",
-      },
-      visual: {
-        title: "为话题创建可视化图表",
-      },
-      presentation: {
-        title: "将话题转化为演示文稿",
-      }
+    agents: {
+      researcher: "研究助手",
+      poster: "海报设计师",
+      linkedin: "LinkedIn 发帖助手",
+    },
+    templateQuickAccess: {
+      featuredLabel: "推荐",
+      categoryHeading: "{category} 智能体",
+      allTemplates: "全部模板 →",
+      usingTemplateLabel: "智能体模板：",
+      agentCreatedToast: "已根据模板创建智能体 \"{name}\"",
+      viewInAgents: "在智能体中查看",
+      createAgentError: "无法根据该模板创建智能体，请重试。",
     },
     input: {
       placeholder: "描述您的任务...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1557,6 +1557,7 @@ const zh = {
     categoryTitles: {
       all: "全部",
       featured: "推荐模板",
+      general: "通用",
       sales: "销售",
       marketing: "营销",
       support: "支持",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -217,11 +217,6 @@ const zh = {
       startingPrompts: "快捷指令",
       chatWithAgents: "与智能体聊天",
     },
-    agents: {
-      researcher: "研究助手",
-      poster: "海报设计师",
-      linkedin: "LinkedIn 发帖助手",
-    },
     templateQuickAccess: {
       featuredLabel: "推荐",
       categoryHeading: "{category} 智能体",
@@ -230,6 +225,9 @@ const zh = {
       agentCreatedToast: "已根据模板创建智能体 \"{name}\"",
       viewInAgents: "在智能体中查看",
       createAgentError: "无法根据该模板创建智能体，请重试。",
+      loading: "正在加载模板...",
+      loadError: "模板加载失败。",
+      retry: "重试",
     },
     input: {
       placeholder: "描述您的任务...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -234,6 +234,7 @@ const zh = {
     input: {
       placeholder: "描述您的任务...",
       processing: "处理中",
+      usingAgentLabel: "使用",
       actions: {
         config: "配置模型",
         upload: "上传文件",

--- a/frontend/src/lib/template-agent-resolution.test.ts
+++ b/frontend/src/lib/template-agent-resolution.test.ts
@@ -20,11 +20,7 @@ vi.mock("@/lib/utils", async () => {
   };
 });
 
-import {
-  findExistingAgentForTemplate,
-  resolveAgentForTemplate,
-  toAgentId,
-} from "./template-agent-resolution";
+import { resolveAgentForTemplate, toAgentId } from "./template-agent-resolution";
 
 function jsonResponse(data: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(data), {
@@ -50,33 +46,17 @@ describe("toAgentId", () => {
   });
 });
 
-describe("findExistingAgentForTemplate", () => {
-  it("matches by template_id, not by name", () => {
-    const agents = [
-      { id: 1, name: "Renamed Agent", template_id: "tmpl-a" },
-      { id: 2, name: "tmpl-a", template_id: null },
-    ];
-
-    expect(findExistingAgentForTemplate("tmpl-a", agents)?.id).toBe(1);
-    expect(findExistingAgentForTemplate("tmpl-missing", agents)).toBeNull();
-  });
-});
-
 describe("resolveAgentForTemplate", () => {
   beforeEach(() => {
     apiRequestMock.mockReset();
   });
 
-  it("reuses a known agent without any network calls", async () => {
-    const known = [{ id: 7, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" }];
-
-    const result = await resolveAgentForTemplate("support-inbox-manager", known);
-
-    expect(result).toEqual({ agent: known[0], created: false });
-    expect(apiRequestMock).not.toHaveBeenCalled();
-  });
-
-  it("asks the server's resolve endpoint when no known agent matches", async () => {
+  it("always calls the server's resolve endpoint - no client-side cache shortcut", async () => {
+    // Regression test for PR review finding B5: a prior client-side fast
+    // path matched against a locally-cached agent list (from GET
+    // /api/agents, which can include teammates' agents under a team-scope
+    // hook) before ever reaching the server, with no ownership check. The
+    // server round-trip must be the only path, every time.
     apiRequestMock.mockResolvedValueOnce(
       jsonResponse({
         agent: { id: 10, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" },
@@ -84,7 +64,7 @@ describe("resolveAgentForTemplate", () => {
       })
     );
 
-    const result = await resolveAgentForTemplate("support-inbox-manager", []);
+    const result = await resolveAgentForTemplate("support-inbox-manager");
 
     expect(result.created).toBe(true);
     expect(result.agent).toMatchObject({ id: 10, status: "published" });
@@ -106,7 +86,7 @@ describe("resolveAgentForTemplate", () => {
       })
     );
 
-    const result = await resolveAgentForTemplate("support-inbox-manager", []);
+    const result = await resolveAgentForTemplate("support-inbox-manager");
 
     expect(result.created).toBe(false);
     expect(result.agent).toMatchObject({ id: 11 });
@@ -117,7 +97,7 @@ describe("resolveAgentForTemplate", () => {
       jsonResponse({ detail: "boom" }, { status: 500 })
     );
 
-    await expect(resolveAgentForTemplate("support-inbox-manager", [])).rejects.toThrow(
+    await expect(resolveAgentForTemplate("support-inbox-manager")).rejects.toThrow(
       "Failed to resolve agent from template (500)"
     );
   });
@@ -125,7 +105,7 @@ describe("resolveAgentForTemplate", () => {
   it("throws on a malformed resolve response body", async () => {
     apiRequestMock.mockResolvedValueOnce(jsonResponse({ created: true }));
 
-    await expect(resolveAgentForTemplate("support-inbox-manager", [])).rejects.toThrow(
+    await expect(resolveAgentForTemplate("support-inbox-manager")).rejects.toThrow(
       "Malformed resolve response"
     );
   });

--- a/frontend/src/lib/template-agent-resolution.test.ts
+++ b/frontend/src/lib/template-agent-resolution.test.ts
@@ -169,4 +169,30 @@ describe("resolveAgentForTemplate", () => {
       expect.objectContaining({ method: "DELETE" })
     );
   });
+
+  it("does not delete an agent reused via the 400 lookup when its publish fails", async () => {
+    // Regression test for F1: an agent found via the template_id lookup was
+    // not created by this call - it may belong to a teammate (default
+    // visibility is "team") - so a failed publish must never delete it.
+    apiRequestMock
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 15, name: "Inbox Manager", template_id: "support-inbox-manager", status: "draft" }])
+      )
+      .mockResolvedValueOnce(jsonResponse({ detail: "publish failed" }, { status: 500 }));
+
+    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow(
+      "Failed to publish agent"
+    );
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(3);
+    expect(apiRequestMock).not.toHaveBeenNthCalledWith(
+      4,
+      "http://api.local/api/agents/15",
+      expect.objectContaining({ method: "DELETE" })
+    );
+    expect(apiRequestMock.mock.calls.some(([, opts]) => opts?.method === "DELETE")).toBe(false);
+  });
 });

--- a/frontend/src/lib/template-agent-resolution.test.ts
+++ b/frontend/src/lib/template-agent-resolution.test.ts
@@ -21,7 +21,6 @@ vi.mock("@/lib/utils", async () => {
 });
 
 import {
-  DUPLICATE_AGENT_NAME_DETAIL,
   findExistingAgentForTemplate,
   resolveAgentForTemplate,
   toAgentId,
@@ -45,6 +44,9 @@ describe("toAgentId", () => {
     expect(toAgentId(null)).toBeNull();
     expect(toAgentId(undefined)).toBeNull();
     expect(toAgentId({ id: "not-a-number" })).toBeNull();
+    expect(toAgentId({ id: null })).toBeNull();
+    expect(toAgentId({ id: 0 })).toBeNull();
+    expect(toAgentId({ id: -3 })).toBeNull();
   });
 });
 
@@ -68,131 +70,63 @@ describe("resolveAgentForTemplate", () => {
   it("reuses a known agent without any network calls", async () => {
     const known = [{ id: 7, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" }];
 
-    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", known);
+    const result = await resolveAgentForTemplate("support-inbox-manager", known);
 
     expect(result).toEqual({ agent: known[0], created: false });
     expect(apiRequestMock).not.toHaveBeenCalled();
   });
 
-  it("creates and publishes a new agent when none exists locally", async () => {
-    apiRequestMock
-      .mockResolvedValueOnce(jsonResponse({ id: 10, name: "Inbox Manager", template_id: "support-inbox-manager" }))
-      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
+  it("asks the server's resolve endpoint when no known agent matches", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        agent: { id: 10, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" },
+        created: true,
+      })
+    );
 
-    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
+    const result = await resolveAgentForTemplate("support-inbox-manager", []);
 
     expect(result.created).toBe(true);
     expect(result.agent).toMatchObject({ id: 10, status: "published" });
-    expect(apiRequestMock).toHaveBeenNthCalledWith(
-      1,
-      "http://api.local/api/agents/from-template",
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/agents/from-template/resolve",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ template_id: "support-inbox-manager" }),
       })
     );
-    expect(apiRequestMock).toHaveBeenNthCalledWith(
-      2,
-      "http://api.local/api/agents/10/publish",
-      expect.objectContaining({ method: "POST" })
-    );
   });
 
-  it("reuses (and publishes) an agent from this template found only via the 400 lookup", async () => {
-    apiRequestMock
-      .mockResolvedValueOnce(
-        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
-      )
-      .mockResolvedValueOnce(
-        jsonResponse([{ id: 11, name: "Inbox Manager", template_id: "support-inbox-manager", status: "draft" }])
-      )
-      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
-
-    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
-
-    expect(result.created).toBe(false);
-    expect(result.agent).toMatchObject({ id: 11, status: "published" });
-    expect(apiRequestMock).toHaveBeenNthCalledWith(
-      3,
-      "http://api.local/api/agents/11/publish",
-      expect.objectContaining({ method: "POST" })
-    );
-  });
-
-  it("retries with a disambiguated name when the 400 collides with an unrelated agent", async () => {
-    apiRequestMock
-      .mockResolvedValueOnce(
-        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
-      )
-      .mockResolvedValueOnce(
-        jsonResponse([{ id: 12, name: "Inbox Manager", template_id: null, status: "published" }])
-      )
-      .mockResolvedValueOnce(jsonResponse({ id: 13, name: "Inbox Manager (12345)" }))
-      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
-
-    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
-
-    expect(result.created).toBe(true);
-    expect(result.agent).toMatchObject({ id: 13, status: "published" });
-    expect(apiRequestMock).toHaveBeenNthCalledWith(
-      3,
-      "http://api.local/api/agents/from-template",
-      expect.objectContaining({
-        method: "POST",
-        body: expect.stringContaining('"template_id":"support-inbox-manager"'),
+  it("reports created=false when the server reused an existing agent", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        agent: { id: 11, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" },
+        created: false,
       })
     );
+
+    const result = await resolveAgentForTemplate("support-inbox-manager", []);
+
+    expect(result.created).toBe(false);
+    expect(result.agent).toMatchObject({ id: 11 });
   });
 
-  it("throws on a 400 whose detail does not match the duplicate-name contract", async () => {
+  it("throws on a non-ok resolve response", async () => {
     apiRequestMock.mockResolvedValueOnce(
-      jsonResponse({ detail: "Something else went wrong" }, { status: 400 })
+      jsonResponse({ detail: "boom" }, { status: 500 })
     );
 
-    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow();
-    expect(apiRequestMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("rolls back the draft agent when publish fails after a fresh create", async () => {
-    apiRequestMock
-      .mockResolvedValueOnce(jsonResponse({ id: 14, name: "Inbox Manager", template_id: "support-inbox-manager" }))
-      .mockResolvedValueOnce(jsonResponse({ detail: "publish failed" }, { status: 500 }))
-      .mockResolvedValueOnce(jsonResponse({ message: "deleted" }));
-
-    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow(
-      "Failed to publish agent"
-    );
-
-    expect(apiRequestMock).toHaveBeenNthCalledWith(
-      3,
-      "http://api.local/api/agents/14",
-      expect.objectContaining({ method: "DELETE" })
+    await expect(resolveAgentForTemplate("support-inbox-manager", [])).rejects.toThrow(
+      "Failed to resolve agent from template (500)"
     );
   });
 
-  it("does not delete an agent reused via the 400 lookup when its publish fails", async () => {
-    // Regression test for F1: an agent found via the template_id lookup was
-    // not created by this call - it may belong to a teammate (default
-    // visibility is "team") - so a failed publish must never delete it.
-    apiRequestMock
-      .mockResolvedValueOnce(
-        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
-      )
-      .mockResolvedValueOnce(
-        jsonResponse([{ id: 15, name: "Inbox Manager", template_id: "support-inbox-manager", status: "draft" }])
-      )
-      .mockResolvedValueOnce(jsonResponse({ detail: "publish failed" }, { status: 500 }));
+  it("throws on a malformed resolve response body", async () => {
+    apiRequestMock.mockResolvedValueOnce(jsonResponse({ created: true }));
 
-    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow(
-      "Failed to publish agent"
+    await expect(resolveAgentForTemplate("support-inbox-manager", [])).rejects.toThrow(
+      "Malformed resolve response"
     );
-
-    expect(apiRequestMock).toHaveBeenCalledTimes(3);
-    expect(apiRequestMock).not.toHaveBeenNthCalledWith(
-      4,
-      "http://api.local/api/agents/15",
-      expect.objectContaining({ method: "DELETE" })
-    );
-    expect(apiRequestMock.mock.calls.some(([, opts]) => opts?.method === "DELETE")).toBe(false);
   });
 });

--- a/frontend/src/lib/template-agent-resolution.test.ts
+++ b/frontend/src/lib/template-agent-resolution.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  );
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  };
+});
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+  };
+});
+
+import {
+  DUPLICATE_AGENT_NAME_DETAIL,
+  findExistingAgentForTemplate,
+  resolveAgentForTemplate,
+  toAgentId,
+} from "./template-agent-resolution";
+
+function jsonResponse(data: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("toAgentId", () => {
+  it("parses a numeric or numeric-string id", () => {
+    expect(toAgentId({ id: 42 })).toBe(42);
+    expect(toAgentId({ id: "42" })).toBe(42);
+  });
+
+  it("returns null for a missing or non-numeric id", () => {
+    expect(toAgentId(null)).toBeNull();
+    expect(toAgentId(undefined)).toBeNull();
+    expect(toAgentId({ id: "not-a-number" })).toBeNull();
+  });
+});
+
+describe("findExistingAgentForTemplate", () => {
+  it("matches by template_id, not by name", () => {
+    const agents = [
+      { id: 1, name: "Renamed Agent", template_id: "tmpl-a" },
+      { id: 2, name: "tmpl-a", template_id: null },
+    ];
+
+    expect(findExistingAgentForTemplate("tmpl-a", agents)?.id).toBe(1);
+    expect(findExistingAgentForTemplate("tmpl-missing", agents)).toBeNull();
+  });
+});
+
+describe("resolveAgentForTemplate", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset();
+  });
+
+  it("reuses a known agent without any network calls", async () => {
+    const known = [{ id: 7, name: "Inbox Manager", template_id: "support-inbox-manager", status: "published" }];
+
+    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", known);
+
+    expect(result).toEqual({ agent: known[0], created: false });
+    expect(apiRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("creates and publishes a new agent when none exists locally", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(jsonResponse({ id: 10, name: "Inbox Manager", template_id: "support-inbox-manager" }))
+      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
+
+    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
+
+    expect(result.created).toBe(true);
+    expect(result.agent).toMatchObject({ id: 10, status: "published" });
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      1,
+      "http://api.local/api/agents/from-template",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ template_id: "support-inbox-manager" }),
+      })
+    );
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      "http://api.local/api/agents/10/publish",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("reuses (and publishes) an agent from this template found only via the 400 lookup", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 11, name: "Inbox Manager", template_id: "support-inbox-manager", status: "draft" }])
+      )
+      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
+
+    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
+
+    expect(result.created).toBe(false);
+    expect(result.agent).toMatchObject({ id: 11, status: "published" });
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      3,
+      "http://api.local/api/agents/11/publish",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("retries with a disambiguated name when the 400 collides with an unrelated agent", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: DUPLICATE_AGENT_NAME_DETAIL }, { status: 400 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 12, name: "Inbox Manager", template_id: null, status: "published" }])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 13, name: "Inbox Manager (12345)" }))
+      .mockResolvedValueOnce(jsonResponse({ message: "ok" }));
+
+    const result = await resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", []);
+
+    expect(result.created).toBe(true);
+    expect(result.agent).toMatchObject({ id: 13, status: "published" });
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      3,
+      "http://api.local/api/agents/from-template",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"template_id":"support-inbox-manager"'),
+      })
+    );
+  });
+
+  it("throws on a 400 whose detail does not match the duplicate-name contract", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({ detail: "Something else went wrong" }, { status: 400 })
+    );
+
+    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow();
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls back the draft agent when publish fails after a fresh create", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(jsonResponse({ id: 14, name: "Inbox Manager", template_id: "support-inbox-manager" }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "publish failed" }, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ message: "deleted" }));
+
+    await expect(resolveAgentForTemplate("support-inbox-manager", "Inbox Manager", [])).rejects.toThrow(
+      "Failed to publish agent"
+    );
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      3,
+      "http://api.local/api/agents/14",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+});

--- a/frontend/src/lib/template-agent-resolution.ts
+++ b/frontend/src/lib/template-agent-resolution.ts
@@ -15,7 +15,10 @@ export const toAgentId = (
   agent: { id?: number | string | null } | null | undefined
 ): number | null => {
   const id = Number(agent?.id);
-  return Number.isNaN(id) ? null : id;
+  // Number(null) and Number("") both coerce to 0, not NaN - reject those
+  // (and negatives/non-integers) explicitly rather than treating them as a
+  // valid agent id.
+  return Number.isInteger(id) && id > 0 ? id : null;
 };
 
 // Agents created via a template persist that template's id
@@ -38,15 +41,20 @@ async function deleteAgentBestEffort(agentId: number): Promise<void> {
   }
 }
 
-async function publishAgent(agentId: number): Promise<void> {
+async function publishAgent(agentId: number, rollbackOnFailure: boolean): Promise<void> {
   const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/publish`, {
     method: "POST",
   });
   if (!response.ok) {
-    // Don't leave an unpublished, unreferenced draft behind - a later send
-    // from this template would otherwise orphan a new agent every time
-    // publish happens to fail, instead of retrying cleanly.
-    await deleteAgentBestEffort(agentId);
+    if (rollbackOnFailure) {
+      // Only ever roll back an agent THIS call just created - never one
+      // resolved via a template_id/name lookup, which may belong to a
+      // teammate (default visibility is "team", and GET /api/agents applies
+      // no status filter) or was already there before this call ran. Not
+      // gating on this deleted other users' in-progress drafts (see PR
+      // review finding F1).
+      await deleteAgentBestEffort(agentId);
+    }
     throw new Error(`Failed to publish agent (${response.status})`);
   }
 }
@@ -96,7 +104,8 @@ export async function resolveAgentForTemplate(
 
     if (templateMatch && toAgentId(templateMatch) !== null) {
       if (!isPublishedAgent(templateMatch)) {
-        await publishAgent(templateMatch.id);
+        // Reused, not created by this call - never roll it back on failure.
+        await publishAgent(templateMatch.id, false);
         templateMatch.status = "published";
       }
       return { agent: templateMatch, created: false };
@@ -115,7 +124,7 @@ export async function resolveAgentForTemplate(
       throw new Error(`Failed to create agent from template (${retryResponse.status})`);
     }
     const retryAgent = await retryResponse.json();
-    await publishAgent(retryAgent.id);
+    await publishAgent(retryAgent.id, true);
     return { agent: { ...retryAgent, status: "published" }, created: true };
   }
 
@@ -124,7 +133,7 @@ export async function resolveAgentForTemplate(
   }
   const createdAgent = await createResponse.json();
 
-  await publishAgent(createdAgent.id);
+  await publishAgent(createdAgent.id, true);
 
   return { agent: { ...createdAgent, status: "published" }, created: true };
 }

--- a/frontend/src/lib/template-agent-resolution.ts
+++ b/frontend/src/lib/template-agent-resolution.ts
@@ -14,31 +14,25 @@ export const toAgentId = (
   return Number.isInteger(id) && id > 0 ? id : null;
 };
 
-// Agents created via a template persist that template's id
-// (Agent.template_id, set server-side), so reuse is keyed off that stable id
-// rather than the user-editable display name - renaming the agent doesn't
-// break the correlation.
-export const findExistingAgentForTemplate = (
-  templateId: string,
-  agentList: AgentCard[]
-): AgentCard | null => agentList.find((agent) => agent.template_id === templateId) ?? null;
-
 /**
- * Resolve the agent to send this template's prompt to: reuse a locally-known
- * agent when possible, otherwise defer to the server's atomic get-or-create
- * (POST /api/agents/from-template/resolve). The server owns all reuse,
- * ownership, name-disambiguation and publish semantics - repeat calls
- * converge on the same agent, and another user's agents are never touched.
+ * Resolve the agent to send this template's prompt to via the server's
+ * atomic get-or-create (POST /api/agents/from-template/resolve). The server
+ * owns all reuse, ownership, name-disambiguation and publish semantics -
+ * repeat calls converge on the same agent, and another user's agents are
+ * never touched.
+ *
+ * There used to be a client-side fast path here (a `.find()` over a locally
+ * cached agent list, keyed on Agent.template_id) that skipped the server
+ * call when a match was already known. It was removed (PR review finding
+ * B5): that cached list comes from GET /api/agents, which under a
+ * team-scope hook includes teammates' published, team-visible agents with
+ * no ownership check - reintroducing exactly the cross-user exposure this
+ * server-side resolve exists to prevent. The server round-trip is the
+ * correctness boundary; there is no client-side shortcut that preserves it.
  */
 export async function resolveAgentForTemplate(
-  templateId: string,
-  knownAgents: AgentCard[]
+  templateId: string
 ): Promise<{ agent: AgentCard; created: boolean }> {
-  const knownExisting = findExistingAgentForTemplate(templateId, knownAgents);
-  if (knownExisting) {
-    return { agent: knownExisting, created: false };
-  }
-
   const response = await apiRequest(`${getApiUrl()}/api/agents/from-template/resolve`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/src/lib/template-agent-resolution.ts
+++ b/frontend/src/lib/template-agent-resolution.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { apiRequest } from "@/lib/api-wrapper";
+import { getApiUrl } from "@/lib/utils";
+import { isPublishedAgent } from "@/lib/agent-ui-access";
+import type { AgentCard } from "@/components/chat/ChatStartScreen";
+
+// The backend's DuplicateAgentNameError maps to exactly this 400 detail
+// (see POST /api/agents/from-template) - matching on it keeps the
+// bare-400-means-collision assumption below from silently misfiring if a
+// different validation error is ever added to that endpoint.
+export const DUPLICATE_AGENT_NAME_DETAIL = "Agent with this name already exists";
+
+export const toAgentId = (
+  agent: { id?: number | string | null } | null | undefined
+): number | null => {
+  const id = Number(agent?.id);
+  return Number.isNaN(id) ? null : id;
+};
+
+// Agents created via a template persist that template's id
+// (Agent.template_id, set server-side in create_agent_from_template), so
+// reuse is keyed off that stable id rather than the user-editable display
+// name - renaming the agent no longer breaks the correlation.
+export const findExistingAgentForTemplate = (
+  templateId: string,
+  agentList: AgentCard[]
+): AgentCard | null => agentList.find((agent) => agent.template_id === templateId) ?? null;
+
+async function deleteAgentBestEffort(agentId: number): Promise<void> {
+  try {
+    await apiRequest(`${getApiUrl()}/api/agents/${agentId}`, { method: "DELETE" });
+  } catch (error) {
+    // Best-effort cleanup: surfacing this would mask the original publish
+    // failure the caller is already about to throw. Worst case the agent is
+    // reclaimed later via the 400-retry lookup in resolveAgentForTemplate.
+    console.error(`Failed to roll back orphaned draft agent ${agentId}:`, error);
+  }
+}
+
+async function publishAgent(agentId: number): Promise<void> {
+  const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/publish`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    // Don't leave an unpublished, unreferenced draft behind - a later send
+    // from this template would otherwise orphan a new agent every time
+    // publish happens to fail, instead of retrying cleanly.
+    await deleteAgentBestEffort(agentId);
+    throw new Error(`Failed to publish agent (${response.status})`);
+  }
+}
+
+/**
+ * Reuse an already-created agent for this template if one exists; only
+ * create + publish a new one the first time a template is used. Returns the
+ * full agent record (not just an id) so callers can keep local state
+ * accurate without hand-building a stub.
+ */
+export async function resolveAgentForTemplate(
+  templateId: string,
+  templateName: string,
+  knownAgents: AgentCard[]
+): Promise<{ agent: AgentCard; created: boolean }> {
+  const knownExisting = findExistingAgentForTemplate(templateId, knownAgents);
+  if (knownExisting) {
+    return { agent: knownExisting, created: false };
+  }
+
+  const createResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ template_id: templateId }),
+  });
+
+  if (createResponse.status === 400) {
+    const body = await createResponse.json().catch(() => null);
+    if (body?.detail !== DUPLICATE_AGENT_NAME_DETAIL) {
+      throw new Error(`Failed to create agent from template (${createResponse.status})`);
+    }
+
+    // The default template name collided with an existing agent our local
+    // (published-only) list didn't know about. Look it up by template_id
+    // first - that's the same template, created elsewhere (another tab,
+    // session, or a still-draft agent) - and reuse it rather than minting
+    // a duplicate.
+    const listResponse = await apiRequest(`${getApiUrl()}/api/agents`);
+    if (!listResponse.ok) {
+      throw new Error(`Failed to create agent from template (${createResponse.status})`);
+    }
+    const allAgents = await listResponse.json();
+    const agentList = Array.isArray(allAgents) ? allAgents : [];
+    const templateMatch = agentList.find(
+      (agent) => agent && agent.template_id === templateId
+    );
+
+    if (templateMatch && toAgentId(templateMatch) !== null) {
+      if (!isPublishedAgent(templateMatch)) {
+        await publishAgent(templateMatch.id);
+        templateMatch.status = "published";
+      }
+      return { agent: templateMatch, created: false };
+    }
+
+    // No agent from this template exists - the name collision is with an
+    // unrelated agent that merely shares the template's default name.
+    // Retry once with a disambiguated name so this template can still be
+    // used.
+    const retryResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ template_id: templateId, name: `${templateName} (${Date.now()})` }),
+    });
+    if (!retryResponse.ok) {
+      throw new Error(`Failed to create agent from template (${retryResponse.status})`);
+    }
+    const retryAgent = await retryResponse.json();
+    await publishAgent(retryAgent.id);
+    return { agent: { ...retryAgent, status: "published" }, created: true };
+  }
+
+  if (!createResponse.ok) {
+    throw new Error(`Failed to create agent from template (${createResponse.status})`);
+  }
+  const createdAgent = await createResponse.json();
+
+  await publishAgent(createdAgent.id);
+
+  return { agent: { ...createdAgent, status: "published" }, created: true };
+}

--- a/frontend/src/lib/template-agent-resolution.ts
+++ b/frontend/src/lib/template-agent-resolution.ts
@@ -2,14 +2,7 @@
 
 import { apiRequest } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
-import { isPublishedAgent } from "@/lib/agent-ui-access";
 import type { AgentCard } from "@/components/chat/ChatStartScreen";
-
-// The backend's DuplicateAgentNameError maps to exactly this 400 detail
-// (see POST /api/agents/from-template) - matching on it keeps the
-// bare-400-means-collision assumption below from silently misfiring if a
-// different validation error is ever added to that endpoint.
-export const DUPLICATE_AGENT_NAME_DETAIL = "Agent with this name already exists";
 
 export const toAgentId = (
   agent: { id?: number | string | null } | null | undefined
@@ -22,52 +15,23 @@ export const toAgentId = (
 };
 
 // Agents created via a template persist that template's id
-// (Agent.template_id, set server-side in create_agent_from_template), so
-// reuse is keyed off that stable id rather than the user-editable display
-// name - renaming the agent no longer breaks the correlation.
+// (Agent.template_id, set server-side), so reuse is keyed off that stable id
+// rather than the user-editable display name - renaming the agent doesn't
+// break the correlation.
 export const findExistingAgentForTemplate = (
   templateId: string,
   agentList: AgentCard[]
 ): AgentCard | null => agentList.find((agent) => agent.template_id === templateId) ?? null;
 
-async function deleteAgentBestEffort(agentId: number): Promise<void> {
-  try {
-    await apiRequest(`${getApiUrl()}/api/agents/${agentId}`, { method: "DELETE" });
-  } catch (error) {
-    // Best-effort cleanup: surfacing this would mask the original publish
-    // failure the caller is already about to throw. Worst case the agent is
-    // reclaimed later via the 400-retry lookup in resolveAgentForTemplate.
-    console.error(`Failed to roll back orphaned draft agent ${agentId}:`, error);
-  }
-}
-
-async function publishAgent(agentId: number, rollbackOnFailure: boolean): Promise<void> {
-  const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/publish`, {
-    method: "POST",
-  });
-  if (!response.ok) {
-    if (rollbackOnFailure) {
-      // Only ever roll back an agent THIS call just created - never one
-      // resolved via a template_id/name lookup, which may belong to a
-      // teammate (default visibility is "team", and GET /api/agents applies
-      // no status filter) or was already there before this call ran. Not
-      // gating on this deleted other users' in-progress drafts (see PR
-      // review finding F1).
-      await deleteAgentBestEffort(agentId);
-    }
-    throw new Error(`Failed to publish agent (${response.status})`);
-  }
-}
-
 /**
- * Reuse an already-created agent for this template if one exists; only
- * create + publish a new one the first time a template is used. Returns the
- * full agent record (not just an id) so callers can keep local state
- * accurate without hand-building a stub.
+ * Resolve the agent to send this template's prompt to: reuse a locally-known
+ * agent when possible, otherwise defer to the server's atomic get-or-create
+ * (POST /api/agents/from-template/resolve). The server owns all reuse,
+ * ownership, name-disambiguation and publish semantics - repeat calls
+ * converge on the same agent, and another user's agents are never touched.
  */
 export async function resolveAgentForTemplate(
   templateId: string,
-  templateName: string,
   knownAgents: AgentCard[]
 ): Promise<{ agent: AgentCard; created: boolean }> {
   const knownExisting = findExistingAgentForTemplate(templateId, knownAgents);
@@ -75,65 +39,18 @@ export async function resolveAgentForTemplate(
     return { agent: knownExisting, created: false };
   }
 
-  const createResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
+  const response = await apiRequest(`${getApiUrl()}/api/agents/from-template/resolve`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ template_id: templateId }),
   });
-
-  if (createResponse.status === 400) {
-    const body = await createResponse.json().catch(() => null);
-    if (body?.detail !== DUPLICATE_AGENT_NAME_DETAIL) {
-      throw new Error(`Failed to create agent from template (${createResponse.status})`);
-    }
-
-    // The default template name collided with an existing agent our local
-    // (published-only) list didn't know about. Look it up by template_id
-    // first - that's the same template, created elsewhere (another tab,
-    // session, or a still-draft agent) - and reuse it rather than minting
-    // a duplicate.
-    const listResponse = await apiRequest(`${getApiUrl()}/api/agents`);
-    if (!listResponse.ok) {
-      throw new Error(`Failed to create agent from template (${createResponse.status})`);
-    }
-    const allAgents = await listResponse.json();
-    const agentList = Array.isArray(allAgents) ? allAgents : [];
-    const templateMatch = agentList.find(
-      (agent) => agent && agent.template_id === templateId
-    );
-
-    if (templateMatch && toAgentId(templateMatch) !== null) {
-      if (!isPublishedAgent(templateMatch)) {
-        // Reused, not created by this call - never roll it back on failure.
-        await publishAgent(templateMatch.id, false);
-        templateMatch.status = "published";
-      }
-      return { agent: templateMatch, created: false };
-    }
-
-    // No agent from this template exists - the name collision is with an
-    // unrelated agent that merely shares the template's default name.
-    // Retry once with a disambiguated name so this template can still be
-    // used.
-    const retryResponse = await apiRequest(`${getApiUrl()}/api/agents/from-template`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ template_id: templateId, name: `${templateName} (${Date.now()})` }),
-    });
-    if (!retryResponse.ok) {
-      throw new Error(`Failed to create agent from template (${retryResponse.status})`);
-    }
-    const retryAgent = await retryResponse.json();
-    await publishAgent(retryAgent.id, true);
-    return { agent: { ...retryAgent, status: "published" }, created: true };
+  if (!response.ok) {
+    throw new Error(`Failed to resolve agent from template (${response.status})`);
   }
 
-  if (!createResponse.ok) {
-    throw new Error(`Failed to create agent from template (${createResponse.status})`);
+  const body = await response.json();
+  if (!body?.agent || toAgentId(body.agent) === null) {
+    throw new Error("Malformed resolve response: missing agent");
   }
-  const createdAgent = await createResponse.json();
-
-  await publishAgent(createdAgent.id, true);
-
-  return { agent: { ...createdAgent, status: "published" }, created: true };
+  return { agent: body.agent as AgentCard, created: Boolean(body.created) };
 }

--- a/frontend/src/lib/template-categories.test.ts
+++ b/frontend/src/lib/template-categories.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest"
+
+import type { Template } from "@/types/template"
+import {
+  FEATURED_CATEGORY_ID,
+  getOrderedCategoriesWithCounts,
+  getTemplatesForCategory,
+  normalizeCategoryKey,
+  orderCategoriesWithPreferred,
+} from "./template-categories"
+
+function makeTemplate(overrides: Partial<Template> & Pick<Template, "id" | "category">): Template {
+  return {
+    name: overrides.id,
+    featured: false,
+    description: "",
+    features: [],
+    connections: [],
+    setup_time: "5 min setup",
+    tags: [],
+    author: "Xagent",
+    version: "1.0",
+    views: 0,
+    likes: 0,
+    used_count: 0,
+    ...overrides,
+  }
+}
+
+describe("getOrderedCategoriesWithCounts", () => {
+  it("omits the Featured tab entirely when no template is featured", () => {
+    const templates = [makeTemplate({ id: "a", category: "Sales" })]
+    const tabs = getOrderedCategoriesWithCounts(templates)
+
+    expect(tabs.find((tab) => tab.id === FEATURED_CATEGORY_ID)).toBeUndefined()
+  })
+
+  it("prepends Featured with the count of featured templates when any exist", () => {
+    const templates = [
+      makeTemplate({ id: "a", category: "Sales", featured: true }),
+      makeTemplate({ id: "b", category: "Sales" }),
+      makeTemplate({ id: "c", category: "Marketing", featured: true }),
+    ]
+    const tabs = getOrderedCategoriesWithCounts(templates)
+
+    expect(tabs[0]).toEqual({ id: FEATURED_CATEGORY_ID, count: 2 })
+  })
+
+  it("orders known categories Marketing, Sales, Support before any others", () => {
+    const templates = [
+      makeTemplate({ id: "a", category: "Support" }),
+      makeTemplate({ id: "b", category: "Sales" }),
+      makeTemplate({ id: "c", category: "Marketing" }),
+      makeTemplate({ id: "d", category: "General" }),
+    ]
+    const tabs = getOrderedCategoriesWithCounts(templates)
+
+    expect(tabs.map((tab) => tab.id)).toEqual(["Marketing", "Sales", "Support", "General"])
+  })
+
+  it("counts each category independent of the featured count", () => {
+    const templates = [
+      makeTemplate({ id: "a", category: "Marketing" }),
+      makeTemplate({ id: "b", category: "Marketing" }),
+      makeTemplate({ id: "c", category: "Sales" }),
+    ]
+    const tabs = getOrderedCategoriesWithCounts(templates)
+
+    expect(tabs.find((tab) => tab.id === "Marketing")?.count).toBe(2)
+    expect(tabs.find((tab) => tab.id === "Sales")?.count).toBe(1)
+  })
+})
+
+describe("orderCategoriesWithPreferred", () => {
+  it("prepends preferred categories in the caller-supplied order, then the rest in first-seen order", () => {
+    const dynamic = ["General", "Support", "Sales", "Marketing"]
+    expect(orderCategoriesWithPreferred(dynamic, ["Marketing", "Sales", "Support"])).toEqual([
+      "Marketing",
+      "Sales",
+      "Support",
+      "General",
+    ])
+    // Same input, a different caller-supplied preferred order (e.g. the
+    // /templates library page's own order) - shared algorithm, independent
+    // results, exactly the point of extracting this instead of each page
+    // reimplementing its own copy.
+    expect(orderCategoriesWithPreferred(dynamic, ["Sales", "Marketing", "Support"])).toEqual([
+      "Sales",
+      "Marketing",
+      "Support",
+      "General",
+    ])
+  })
+
+  it("drops preferred entries that aren't actually present", () => {
+    expect(orderCategoriesWithPreferred(["Sales"], ["Marketing", "Sales"])).toEqual(["Sales"])
+  })
+})
+
+describe("normalizeCategoryKey", () => {
+  it("lowercases, collapses \"&\"-joined words, and underscores remaining whitespace", () => {
+    expect(normalizeCategoryKey("Healthcare & Fitness")).toBe("healthcare_fitness")
+    expect(normalizeCategoryKey("General Productivity")).toBe("general_productivity")
+    expect(normalizeCategoryKey("Sales")).toBe("sales")
+  })
+})
+
+describe("getTemplatesForCategory", () => {
+  it("filters by the featured flag for the Featured tab", () => {
+    const featured = makeTemplate({ id: "a", category: "Sales", featured: true })
+    const notFeatured = makeTemplate({ id: "b", category: "Sales" })
+    const result = getTemplatesForCategory([featured, notFeatured], FEATURED_CATEGORY_ID)
+
+    expect(result).toEqual([featured])
+  })
+
+  it("filters by category for a non-Featured tab", () => {
+    const marketing = makeTemplate({ id: "a", category: "Marketing" })
+    const sales = makeTemplate({ id: "b", category: "Sales" })
+    const result = getTemplatesForCategory([marketing, sales], "Sales")
+
+    expect(result).toEqual([sales])
+  })
+
+  it("caps results to the given limit, defaulting to 4", () => {
+    const templates = Array.from({ length: 6 }, (_, index) =>
+      makeTemplate({ id: `t${index}`, category: "Marketing" })
+    )
+
+    expect(getTemplatesForCategory(templates, "Marketing")).toHaveLength(4)
+    expect(getTemplatesForCategory(templates, "Marketing", 2)).toHaveLength(2)
+  })
+})

--- a/frontend/src/lib/template-categories.ts
+++ b/frontend/src/lib/template-categories.ts
@@ -10,6 +10,35 @@ export interface CategoryTab {
 }
 
 /**
+ * Shared by every page that renders a category filter (this quick-access
+ * pill row and the /templates library page): a known-first subset in
+ * caller-supplied preferred order, then any remaining categories in
+ * first-seen order. Each caller keeps its own preferred order (the two
+ * pages intentionally differ here - Featured/Marketing/Sales/Support for
+ * this compact panel vs Sales/Marketing/Support for the full library) while
+ * sharing the actual ordering algorithm instead of each reimplementing it.
+ */
+export function orderCategoriesWithPreferred(
+  dynamicCategories: string[],
+  preferredOrder: string[]
+): string[] {
+  return [
+    ...preferredOrder.filter((category) => dynamicCategories.includes(category)),
+    ...dynamicCategories.filter((category) => !preferredOrder.includes(category)),
+  ];
+}
+
+/**
+ * Normalizes a category name into a lookup/section-id key: lowercase,
+ * "&"-joined words collapsed to a single underscore, remaining whitespace
+ * underscored. Shared so a category like "Healthcare & Fitness" resolves to
+ * the same key ("healthcare_fitness") everywhere it's looked up.
+ */
+export function normalizeCategoryKey(category: string): string {
+  return category.toLowerCase().replace(/\s*&\s*/g, "_").replace(/\s+/g, "_");
+}
+
+/**
  * Ordered category tabs with counts: Featured first (when any template is
  * featured), then known categories in PREFERRED_ORDER, then any remaining
  * categories in first-seen order.
@@ -19,10 +48,7 @@ export function getOrderedCategoriesWithCounts(templates: Template[]): CategoryT
   const dynamicCategories = Array.from(
     new Set(templates.map((template) => template.category).filter(Boolean))
   );
-  const orderedCategories = [
-    ...PREFERRED_ORDER.filter((category) => dynamicCategories.includes(category)),
-    ...dynamicCategories.filter((category) => !PREFERRED_ORDER.includes(category)),
-  ];
+  const orderedCategories = orderCategoriesWithPreferred(dynamicCategories, PREFERRED_ORDER);
 
   const tabs: CategoryTab[] = [];
   if (featuredCount > 0) {

--- a/frontend/src/lib/template-categories.ts
+++ b/frontend/src/lib/template-categories.ts
@@ -1,0 +1,52 @@
+import type { Template } from "@/types/template";
+
+export const FEATURED_CATEGORY_ID = "Featured";
+
+const PREFERRED_ORDER = ["Marketing", "Sales", "Support", "Research", "Productivity"];
+
+export interface CategoryTab {
+  id: string;
+  count: number;
+}
+
+/**
+ * Ordered category tabs with counts: Featured first (when any template is
+ * featured), then known categories in PREFERRED_ORDER, then any remaining
+ * categories in first-seen order.
+ */
+export function getOrderedCategoriesWithCounts(templates: Template[]): CategoryTab[] {
+  const featuredCount = templates.filter((template) => template.featured).length;
+  const dynamicCategories = Array.from(
+    new Set(templates.map((template) => template.category).filter(Boolean))
+  );
+  const orderedCategories = [
+    ...PREFERRED_ORDER.filter((category) => dynamicCategories.includes(category)),
+    ...dynamicCategories.filter((category) => !PREFERRED_ORDER.includes(category)),
+  ];
+
+  const tabs: CategoryTab[] = [];
+  if (featuredCount > 0) {
+    tabs.push({ id: FEATURED_CATEGORY_ID, count: featuredCount });
+  }
+  orderedCategories.forEach((category) => {
+    tabs.push({
+      id: category,
+      count: templates.filter((template) => template.category === category).length,
+    });
+  });
+
+  return tabs;
+}
+
+/** Top `limit` templates for a given category tab, in natural API order. */
+export function getTemplatesForCategory(
+  templates: Template[],
+  categoryId: string,
+  limit = 4
+): Template[] {
+  const filtered =
+    categoryId === FEATURED_CATEGORY_ID
+      ? templates.filter((template) => template.featured)
+      : templates.filter((template) => template.category === categoryId);
+  return filtered.slice(0, limit);
+}

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -12,6 +12,12 @@ export interface ConnectionInfo {
   logo?: string;
 }
 
+export interface SamplePrompt {
+  title: string;
+  prompt: string;
+  highlights?: string[];
+}
+
 export interface Template {
   id: string;
   name: string;
@@ -19,6 +25,7 @@ export interface Template {
   featured?: boolean;
   description: string;
   features: string[];
+  sample_prompts?: SamplePrompt[];
   connections: ConnectionInfo[];
   setup_time: string;
   tags: string[];

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -30,11 +30,14 @@ Revises: 20260724_add_upload_source_to_uploaded_files
 Create Date: 2026-07-28
 """
 
+import logging
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine.reflection import Inspector
+
+logger = logging.getLogger(__name__)
 
 revision: str = "20260728_add_agent_template_id_and_name_uniqueness"
 down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
@@ -46,6 +49,14 @@ TEMPLATE_ID_COLUMN = "template_id"
 TEMPLATE_ID_INDEX = "ix_agents_template_id"
 NAME_UNIQUE_INDEX = "uq_agents_user_id_name_active"
 WORKFORCE_MANAGER_ORIGIN = "workforce_generated_manager"
+# Agent.name is String(200) - renamed candidates must fit within that.
+MAX_NAME_LENGTH = 200
+# Matches Agent.__table_args__'s _NON_WORKFORCE_MANAGER_CLAUSE (agent.py):
+# built once at module scope rather than re-interpolated per call, so this
+# migrations directory doesn't pick up per-call f-string DDL predicates as a
+# pattern (WORKFORCE_MANAGER_ORIGIN is a fixed module constant, not user
+# input, so this was never an injection risk).
+NAME_UNIQUE_INDEX_WHERE_CLAUSE = sa.text(f"origin != '{WORKFORCE_MANAGER_ORIGIN}'")
 
 
 def _table_names() -> set[str]:
@@ -64,6 +75,21 @@ def _index_names(table_name: str) -> set[str]:
         for item in inspector.get_indexes(table_name)
         if (name := item.get("name")) is not None
     }
+
+
+def _fit_to_column(base: str, suffix: str) -> str:
+    """Truncate ``base`` so ``base + suffix`` fits ``Agent.name``'s
+    String(200) column. A long pre-existing name plus the rename suffix
+    could otherwise overflow and abort the migration on backends (e.g.
+    Postgres) that enforce column length at insert/update time - the exact
+    data this migration exists to survive.
+    """
+    available = MAX_NAME_LENGTH - len(suffix)
+    if available <= 0:
+        # Pathological (suffix alone doesn't fit) - truncate the suffix
+        # itself as a last resort rather than raise a negative-slice error.
+        return suffix[:MAX_NAME_LENGTH]
+    return base[:available] + suffix
 
 
 def _dedupe_agent_names() -> None:
@@ -94,6 +120,23 @@ def _dedupe_agent_names() -> None:
         .having(sa.func.count(agents.c.id) > 1)
     ).fetchall()
 
+    # Each affected user's existing names are fetched once and kept updated
+    # locally as renames are chosen, instead of issuing one SELECT per
+    # candidate-suffix attempt (this also catches a collision against another
+    # duplicate group for the same user, not just the current group).
+    taken_names_by_user: dict[int, set[str]] = {}
+
+    def _taken_names(user_id: int) -> set[str]:
+        if user_id not in taken_names_by_user:
+            rows = bind.execute(
+                sa.select(agents.c.name).where(
+                    agents.c.user_id == user_id,
+                    agents.c.origin != WORKFORCE_MANAGER_ORIGIN,
+                )
+            ).fetchall()
+            taken_names_by_user[user_id] = {row[0] for row in rows}
+        return taken_names_by_user[user_id]
+
     for user_id, name in duplicate_groups:
         rows = bind.execute(
             sa.select(agents.c.id)
@@ -105,26 +148,30 @@ def _dedupe_agent_names() -> None:
             .order_by(agents.c.id)
         ).fetchall()
 
+        taken = _taken_names(user_id)
+
         for (agent_id,) in rows[1:]:
-            candidate = f"{name} ({agent_id})"
+            candidate = _fit_to_column(name, f" ({agent_id})")
             suffix = 2
-            while (
-                bind.execute(
-                    sa.select(agents.c.id).where(
-                        agents.c.user_id == user_id,
-                        agents.c.name == candidate,
-                        agents.c.origin != WORKFORCE_MANAGER_ORIGIN,
-                        agents.c.id != agent_id,
-                    )
-                ).first()
-                is not None
-            ):
-                candidate = f"{name} ({agent_id}-{suffix})"
+            while candidate in taken:
+                candidate = _fit_to_column(name, f" ({agent_id}-{suffix})")
                 suffix += 1
 
+            # The rename is one-way (downgrade doesn't restore it - see the
+            # module docstring), so leave an audit trail of exactly which
+            # rows were mutated instead of renaming silently.
+            logger.warning(
+                "Deduplicating agent name before unique-index creation: "
+                "agent id=%s (user_id=%s) renamed %r -> %r",
+                agent_id,
+                user_id,
+                name,
+                candidate,
+            )
             bind.execute(
                 sa.update(agents).where(agents.c.id == agent_id).values(name=candidate)
             )
+            taken.add(candidate)
 
 
 def upgrade() -> None:
@@ -140,14 +187,13 @@ def upgrade() -> None:
 
     if NAME_UNIQUE_INDEX not in _index_names(TABLE):
         _dedupe_agent_names()
-        where_clause = sa.text(f"origin != '{WORKFORCE_MANAGER_ORIGIN}'")
         op.create_index(
             NAME_UNIQUE_INDEX,
             TABLE,
             ["user_id", "name"],
             unique=True,
-            sqlite_where=where_clause,
-            postgresql_where=where_clause,
+            sqlite_where=NAME_UNIQUE_INDEX_WHERE_CLAUSE,
+            postgresql_where=NAME_UNIQUE_INDEX_WHERE_CLAUSE,
         )
 
 

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -1,4 +1,4 @@
-"""Add agents.template_id and a per-user unique name constraint.
+"""Add agents.template_id and per-user unique-name / quick-access constraints.
 
 ``template_id`` lets the create-or-reuse-from-template flow key off a
 stable id instead of the user-editable display name. The unique index on
@@ -11,8 +11,17 @@ strictly per-``user_id`` - when a SaaS team-scope hook is installed,
 mirror (see the docstring on ``agent_team_scope.owned_agent_clause`` and
 the comment on ``Agent.__table_args__``).
 
+A second partial unique index on (user_id, template_id), scoped to the
+``template_quick_access`` origin, backs the /task template quick-access
+resolve flow's get-or-create atomicity (PR review findings B1/B2/D2/D3): a
+plain ``origin != 'template_quick_access'`` create (e.g. the
+workforce-builder UI's ``POST /from-template``, which deliberately mints
+multiple named instances of one template) is untouched by it. No rows carry
+this origin before this migration ships, so unlike the name index above,
+this one needs no pre-index dedupe pass.
+
 Existing duplicate (user_id, name) rows (if any) are renamed before the
-index is created so this migration cannot fail on already-messy data.
+name index is created so this migration cannot fail on already-messy data.
 Renaming is a one-way, best-effort disambiguation: ``downgrade()`` drops the
 column/indexes but does not attempt to restore the original colliding
 names, since which row "owned" the pre-migration name is no longer
@@ -20,13 +29,13 @@ recoverable once other rows have shifted around it.
 
 The dedupe pass and index creation both run inside this migration's single
 transaction, so any lock the database takes for either (e.g. a table-level
-lock while building the partial index, on backends that need one) is held
-for the combined duration of both steps, not just the index build. Expected
-to be negligible for typical agent-table sizes; revisit if this ever runs
+lock while building a partial index, on backends that need one) is held for
+the combined duration of both steps, not just the index build. Expected to
+be negligible for typical agent-table sizes; revisit if this ever runs
 against a very large, highly-contended ``agents`` table in production.
 
 Revision ID: 20260728_add_agent_template_id_and_name_uniqueness
-Revises: 20260724_add_upload_source_to_uploaded_files
+Revises: 20260730_seed_zoom_mcp_app
 Create Date: 2026-07-28
 """
 
@@ -40,7 +49,7 @@ from sqlalchemy.engine.reflection import Inspector
 logger = logging.getLogger(__name__)
 
 revision: str = "20260728_add_agent_template_id_and_name_uniqueness"
-down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+down_revision: Union[str, None] = "20260730_seed_zoom_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -48,15 +57,19 @@ TABLE = "agents"
 TEMPLATE_ID_COLUMN = "template_id"
 TEMPLATE_ID_INDEX = "ix_agents_template_id"
 NAME_UNIQUE_INDEX = "uq_agents_user_id_name_active"
+TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX = "uq_agents_user_id_template_id_quick_access"
 WORKFORCE_MANAGER_ORIGIN = "workforce_generated_manager"
+QUICK_ACCESS_ORIGIN = "template_quick_access"
 # Agent.name is String(200) - renamed candidates must fit within that.
 MAX_NAME_LENGTH = 200
-# Matches Agent.__table_args__'s _NON_WORKFORCE_MANAGER_CLAUSE (agent.py):
-# built once at module scope rather than re-interpolated per call, so this
-# migrations directory doesn't pick up per-call f-string DDL predicates as a
-# pattern (WORKFORCE_MANAGER_ORIGIN is a fixed module constant, not user
-# input, so this was never an injection risk).
+# Matches Agent.__table_args__'s _NON_WORKFORCE_MANAGER_CLAUSE /
+# _QUICK_ACCESS_ORIGIN_CLAUSE (agent.py): built once at module scope rather
+# than re-interpolated per call, so this migrations directory doesn't pick
+# up per-call f-string DDL predicates as a pattern (both origin constants
+# are fixed module constants, not user input, so this was never an
+# injection risk).
 NAME_UNIQUE_INDEX_WHERE_CLAUSE = sa.text(f"origin != '{WORKFORCE_MANAGER_ORIGIN}'")
+TEMPLATE_QUICK_ACCESS_WHERE_CLAUSE = sa.text(f"origin = '{QUICK_ACCESS_ORIGIN}'")
 
 
 def _table_names() -> set[str]:
@@ -196,6 +209,18 @@ def upgrade() -> None:
             postgresql_where=NAME_UNIQUE_INDEX_WHERE_CLAUSE,
         )
 
+    if TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX not in _index_names(TABLE):
+        # No dedupe pass needed here: the quick-access origin is brand new
+        # as of this migration, so no pre-existing row can carry it.
+        op.create_index(
+            TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX,
+            TABLE,
+            ["user_id", "template_id"],
+            unique=True,
+            sqlite_where=TEMPLATE_QUICK_ACCESS_WHERE_CLAUSE,
+            postgresql_where=TEMPLATE_QUICK_ACCESS_WHERE_CLAUSE,
+        )
+
 
 def downgrade() -> None:
     if TABLE not in _table_names():
@@ -203,6 +228,9 @@ def downgrade() -> None:
 
     if NAME_UNIQUE_INDEX in _index_names(TABLE):
         op.drop_index(NAME_UNIQUE_INDEX, table_name=TABLE)
+
+    if TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX in _index_names(TABLE):
+        op.drop_index(TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX, table_name=TABLE)
 
     if TEMPLATE_ID_INDEX in _index_names(TABLE):
         op.drop_index(TEMPLATE_ID_INDEX, table_name=TABLE)

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -44,7 +44,6 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.engine.reflection import Inspector
 
 logger = logging.getLogger(__name__)
 
@@ -73,16 +72,16 @@ TEMPLATE_QUICK_ACCESS_WHERE_CLAUSE = sa.text(f"origin = '{QUICK_ACCESS_ORIGIN}'"
 
 
 def _table_names() -> set[str]:
-    return set(Inspector.from_engine(op.get_bind()).get_table_names())
+    return set(sa.inspect(op.get_bind()).get_table_names())
 
 
 def _column_names(table_name: str) -> set[str]:
-    inspector = Inspector.from_engine(op.get_bind())
+    inspector = sa.inspect(op.get_bind())
     return {column["name"] for column in inspector.get_columns(table_name)}
 
 
 def _index_names(table_name: str) -> set[str]:
-    inspector = Inspector.from_engine(op.get_bind())
+    inspector = sa.inspect(op.get_bind())
     return {
         name
         for item in inspector.get_indexes(table_name)

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -11,7 +11,7 @@ Existing duplicate (user_id, name) rows (if any) are renamed before the
 index is created so this migration cannot fail on already-messy data.
 
 Revision ID: 20260728_add_agent_template_id_and_name_uniqueness
-Revises: 20260725_add_uploaded_file_recovery_index
+Revises: 20260724_add_upload_source_to_uploaded_files
 Create Date: 2026-07-28
 """
 
@@ -22,7 +22,7 @@ from alembic import op
 from sqlalchemy.engine.reflection import Inspector
 
 revision: str = "20260728_add_agent_template_id_and_name_uniqueness"
-down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -35,7 +35,7 @@ be negligible for typical agent-table sizes; revisit if this ever runs
 against a very large, highly-contended ``agents`` table in production.
 
 Revision ID: 20260728_add_agent_template_id_and_name_uniqueness
-Revises: 20260730_seed_zoom_mcp_app
+Revises: 20260801_add_trigger_consecutive_prepare_failures
 Create Date: 2026-07-28
 """
 
@@ -48,7 +48,7 @@ from alembic import op
 logger = logging.getLogger(__name__)
 
 revision: str = "20260728_add_agent_template_id_and_name_uniqueness"
-down_revision: Union[str, None] = "20260730_seed_zoom_mcp_app"
+down_revision: Union[str, None] = "20260801_add_trigger_consecutive_prepare_failures"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -1,0 +1,131 @@
+"""Add agents.template_id and a per-user unique name constraint.
+
+``template_id`` lets the create-or-reuse-from-template flow key off a
+stable id instead of the user-editable display name. The unique index on
+(user_id, name) backs the existing app-level ``agent_name_exists`` check at
+the database layer, closing the check-then-insert race; it excludes
+``workforce_generated_manager`` agents to match ``agent_name_exists``,
+which already deliberately allows those to share names.
+
+Existing duplicate (user_id, name) rows (if any) are renamed before the
+index is created so this migration cannot fail on already-messy data.
+
+Revision ID: 20260728_add_agent_template_id_and_name_uniqueness
+Revises: 20260725_add_uploaded_file_recovery_index
+Create Date: 2026-07-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+revision: str = "20260728_add_agent_template_id_and_name_uniqueness"
+down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "agents"
+TEMPLATE_ID_COLUMN = "template_id"
+TEMPLATE_ID_INDEX = "ix_agents_template_id"
+NAME_UNIQUE_INDEX = "uq_agents_user_id_name_active"
+WORKFORCE_MANAGER_ORIGIN = "workforce_generated_manager"
+
+
+def _table_names() -> set[str]:
+    return set(Inspector.from_engine(op.get_bind()).get_table_names())
+
+
+def _column_names(table_name: str) -> set[str]:
+    inspector = Inspector.from_engine(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    inspector = Inspector.from_engine(op.get_bind())
+    return {
+        name
+        for item in inspector.get_indexes(table_name)
+        if (name := item.get("name")) is not None
+    }
+
+
+def _dedupe_agent_names() -> None:
+    """Rename losing rows of any existing (user_id, name) duplicate group.
+
+    Only considers non-workforce-manager agents, matching the partial index's
+    scope. The lowest ``id`` in each group keeps its name; later rows are
+    suffixed with their own id, mirroring the disambiguation the frontend
+    already applies on a name collision.
+    """
+    bind = op.get_bind()
+    agents = sa.table(
+        TABLE,
+        sa.column("id", sa.Integer),
+        sa.column("user_id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("origin", sa.String),
+    )
+
+    duplicate_groups = bind.execute(
+        sa.select(agents.c.user_id, agents.c.name)
+        .where(agents.c.origin != WORKFORCE_MANAGER_ORIGIN)
+        .group_by(agents.c.user_id, agents.c.name)
+        .having(sa.func.count(agents.c.id) > 1)
+    ).fetchall()
+
+    for user_id, name in duplicate_groups:
+        rows = bind.execute(
+            sa.select(agents.c.id)
+            .where(
+                agents.c.user_id == user_id,
+                agents.c.name == name,
+                agents.c.origin != WORKFORCE_MANAGER_ORIGIN,
+            )
+            .order_by(agents.c.id)
+        ).fetchall()
+
+        for (agent_id,) in rows[1:]:
+            bind.execute(
+                sa.update(agents)
+                .where(agents.c.id == agent_id)
+                .values(name=f"{name} ({agent_id})")
+            )
+
+
+def upgrade() -> None:
+    if TABLE not in _table_names():
+        return
+
+    if TEMPLATE_ID_COLUMN not in _column_names(TABLE):
+        op.add_column(
+            TABLE, sa.Column(TEMPLATE_ID_COLUMN, sa.String(255), nullable=True)
+        )
+    if TEMPLATE_ID_INDEX not in _index_names(TABLE):
+        op.create_index(TEMPLATE_ID_INDEX, TABLE, [TEMPLATE_ID_COLUMN])
+
+    if NAME_UNIQUE_INDEX not in _index_names(TABLE):
+        _dedupe_agent_names()
+        where_clause = sa.text(f"origin != '{WORKFORCE_MANAGER_ORIGIN}'")
+        op.create_index(
+            NAME_UNIQUE_INDEX,
+            TABLE,
+            ["user_id", "name"],
+            unique=True,
+            sqlite_where=where_clause,
+            postgresql_where=where_clause,
+        )
+
+
+def downgrade() -> None:
+    if TABLE not in _table_names():
+        return
+
+    if NAME_UNIQUE_INDEX in _index_names(TABLE):
+        op.drop_index(NAME_UNIQUE_INDEX, table_name=TABLE)
+
+    if TEMPLATE_ID_INDEX in _index_names(TABLE):
+        op.drop_index(TEMPLATE_ID_INDEX, table_name=TABLE)
+    if TEMPLATE_ID_COLUMN in _column_names(TABLE):
+        op.drop_column(TABLE, TEMPLATE_ID_COLUMN)

--- a/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/src/xagent/migrations/versions/20260728_add_agent_template_id_and_name_uniqueness.py
@@ -2,13 +2,28 @@
 
 ``template_id`` lets the create-or-reuse-from-template flow key off a
 stable id instead of the user-editable display name. The unique index on
-(user_id, name) backs the existing app-level ``agent_name_exists`` check at
-the database layer, closing the check-then-insert race; it excludes
+(user_id, name) backs the app-level ``agent_name_exists`` check at the
+database layer for a single user's own check-then-insert race; it excludes
 ``workforce_generated_manager`` agents to match ``agent_name_exists``,
-which already deliberately allows those to share names.
+which already deliberately allows those to share names. Note this index is
+strictly per-``user_id`` - when a SaaS team-scope hook is installed,
+``agent_name_exists`` becomes a team-wide check that this index does not
+mirror (see the docstring on ``agent_team_scope.owned_agent_clause`` and
+the comment on ``Agent.__table_args__``).
 
 Existing duplicate (user_id, name) rows (if any) are renamed before the
 index is created so this migration cannot fail on already-messy data.
+Renaming is a one-way, best-effort disambiguation: ``downgrade()`` drops the
+column/indexes but does not attempt to restore the original colliding
+names, since which row "owned" the pre-migration name is no longer
+recoverable once other rows have shifted around it.
+
+The dedupe pass and index creation both run inside this migration's single
+transaction, so any lock the database takes for either (e.g. a table-level
+lock while building the partial index, on backends that need one) is held
+for the combined duration of both steps, not just the index build. Expected
+to be negligible for typical agent-table sizes; revisit if this ever runs
+against a very large, highly-contended ``agents`` table in production.
 
 Revision ID: 20260728_add_agent_template_id_and_name_uniqueness
 Revises: 20260724_add_upload_source_to_uploaded_files
@@ -57,7 +72,11 @@ def _dedupe_agent_names() -> None:
     Only considers non-workforce-manager agents, matching the partial index's
     scope. The lowest ``id`` in each group keeps its name; later rows are
     suffixed with their own id, mirroring the disambiguation the frontend
-    already applies on a name collision.
+    already applies on a name collision. If that suffixed name happens to
+    already belong to another row for the same user (e.g. an existing agent
+    literally named ``"Foo (123)"``), an incrementing counter is appended
+    until a genuinely free name is found, so the rename itself can never
+    introduce a *new* collision for the unique index we're about to build.
     """
     bind = op.get_bind()
     agents = sa.table(
@@ -87,10 +106,24 @@ def _dedupe_agent_names() -> None:
         ).fetchall()
 
         for (agent_id,) in rows[1:]:
+            candidate = f"{name} ({agent_id})"
+            suffix = 2
+            while (
+                bind.execute(
+                    sa.select(agents.c.id).where(
+                        agents.c.user_id == user_id,
+                        agents.c.name == candidate,
+                        agents.c.origin != WORKFORCE_MANAGER_ORIGIN,
+                        agents.c.id != agent_id,
+                    )
+                ).first()
+                is not None
+            ):
+                candidate = f"{name} ({agent_id}-{suffix})"
+                suffix += 1
+
             bind.execute(
-                sa.update(agents)
-                .where(agents.c.id == agent_id)
-                .values(name=f"{name} ({agent_id})")
+                sa.update(agents).where(agents.c.id == agent_id).values(name=candidate)
             )
 
 

--- a/src/xagent/templates/built_in/general-doc-summarizer-action-extractor.yaml
+++ b/src/xagent/templates/built_in/general-doc-summarizer-action-extractor.yaml
@@ -20,6 +20,25 @@ features:
   - 生成完整文档的清晰、结构化摘要
   - 提取文本中隐藏的每一项行动项、截止日期和负责人
   - 在同一对话线程中回答关于文档的后续问题
+sample_prompts:
+  en:
+  - title: Summarise a document
+    prompt: 'Summarise the attached PDF / Word / PowerPoint and pull out the key points and decisions.'
+    highlights:
+    - PDF / Word / PowerPoint
+  - title: Extract action items
+    prompt: 'Extract every action item from document / meeting notes, grouped by owner with deadlines.'
+    highlights:
+    - document / meeting notes
+  zh:
+  - title: 总结文档
+    prompt: 总结附加的 PDF / Word / PowerPoint 文档，并提炼要点和结论。
+    highlights:
+    - PDF / Word / PowerPoint
+  - title: 提取行动项
+    prompt: 从 文档 / 会议纪要 中提取每一项行动项，按负责人和截止日期归类。
+    highlights:
+    - 文档 / 会议纪要
 connections: []
 setup_time:
   en: 2 min setup

--- a/src/xagent/templates/built_in/marketing-collateral-agent.yaml
+++ b/src/xagent/templates/built_in/marketing-collateral-agent.yaml
@@ -14,6 +14,27 @@ features:
   - 构建销售演示文稿、宣传册和单页
   - 确保所有输出符合您的品牌指南
   - 生成准备好演示的视觉效果和幻灯片
+sample_prompts:
+  en:
+  - title: Build a sales deck
+    prompt: 'Build a sales deck about topic or product for audience. Keep it on-brand.'
+    highlights:
+    - topic or product
+    - audience
+  - title: Create a one-pager
+    prompt: 'Turn this into a one-pager: paste content or brief. Match our brand guidelines.'
+    highlights:
+    - paste content or brief
+  zh:
+  - title: 制作销售演示文稿
+    prompt: 为 受众 制作一份关于 主题或产品 的销售演示文稿，保持品牌一致性。
+    highlights:
+    - 主题或产品
+    - 受众
+  - title: 生成单页文档
+    prompt: 将以下内容转化为单页文档：粘贴内容或简报。需符合我们的品牌规范。
+    highlights:
+    - 粘贴内容或简报
 connections:
 - name: Google Drive
   logo: https://www.google.com/s2/favicons?domain=drive.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-content-agent.yaml
+++ b/src/xagent/templates/built_in/marketing-content-agent.yaml
@@ -21,7 +21,7 @@ sample_prompts:
     highlights:
     - topic
   - title: Refresh an old post
-    prompt: 'Rewrite existing article / URL for the keyword keyword — update the structure, internal links and SEO tags.'
+    prompt: 'Rewrite existing article / URL to target keyword — update the structure, internal links and SEO tags.'
     highlights:
     - existing article / URL
     - keyword
@@ -31,7 +31,7 @@ sample_prompts:
     highlights:
     - 主题
   - title: 刷新旧文章
-    prompt: 重写 已有文章 / 链接（针对关键词 关键词）——更新结构、内部链接和 SEO 标签。
+    prompt: 围绕 关键词 重写 已有文章 / 链接——更新结构、内部链接和 SEO 标签。
     highlights:
     - 已有文章 / 链接
     - 关键词

--- a/src/xagent/templates/built_in/marketing-content-agent.yaml
+++ b/src/xagent/templates/built_in/marketing-content-agent.yaml
@@ -14,6 +14,27 @@ features:
   - 研究主题并撰写完整的博客文章
   - 添加内部链接以提升您网站的SEO
   - 生成SEO标签以帮助内容在Google上排名
+sample_prompts:
+  en:
+  - title: Write a blog article
+    prompt: "Research and write a full blog article on topic, with internal links to boost our site's SEO and tags to help it rank on Google."
+    highlights:
+    - topic
+  - title: Refresh an old post
+    prompt: 'Rewrite existing article / URL for the keyword keyword — update the structure, internal links and SEO tags.'
+    highlights:
+    - existing article / URL
+    - keyword
+  zh:
+  - title: 撰写博客文章
+    prompt: 围绕 主题 调研并撰写一篇完整的博客文章，添加内部链接提升网站 SEO，并附带有助于 Google 排名的标签。
+    highlights:
+    - 主题
+  - title: 刷新旧文章
+    prompt: 重写 已有文章 / 链接（针对关键词 关键词）——更新结构、内部链接和 SEO 标签。
+    highlights:
+    - 已有文章 / 链接
+    - 关键词
 connections:
 - name: Google Drive
   logo: https://www.google.com/s2/favicons?domain=drive.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-google-ads-recommendation.yaml
+++ b/src/xagent/templates/built_in/marketing-google-ads-recommendation.yaml
@@ -14,6 +14,25 @@ features:
   - 从 Google Ads 拉取花费、点击率、单次转化成本、转化数和搜索词数据
   - 通过广告系列 / UTM 匹配，结合 Google Analytics Analyzer agent 输出的网站端「广告信号」
   - 按收入影响排序，推荐预算、关键词、否定关键词与文案调整，等待您审批
+sample_prompts:
+  en:
+  - title: Prioritize this week's fixes
+    prompt: Pull my Google Ads performance and rank the top budget, keyword and copy fixes by estimated revenue impact.
+    highlights:
+    - Google Ads performance
+  - title: Join with GA signals
+    prompt: Here's a Signals for Ads table from my Analytics agent — join it with Google Ads data and recommend changes, ranked by impact.
+    highlights:
+    - Signals for Ads table
+  zh:
+  - title: 排出本周优化优先级
+    prompt: 拉取我的 Google Ads 投放表现，按预估收入影响对预算、关键词和文案优化方案进行排序。
+    highlights:
+    - Google Ads 投放表现
+  - title: 结合 GA 广告信号
+    prompt: 这是我的 Analytics agent 输出的广告信号表格——将其与 Google Ads 数据结合，按影响排序推荐优化方案。
+    highlights:
+    - 广告信号表格
 connections:
 - name: Google Ads
   logo: https://www.google.com/s2/favicons?domain=ads.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-google-analytics-analyzer.yaml
+++ b/src/xagent/templates/built_in/marketing-google-analytics-analyzer.yaml
@@ -14,6 +14,25 @@ features:
   - 读取您上传的 GA4 导出文件（CSV）或粘贴的表格——无需接入实时 GA4 连接
   - 与上一周期对比，按渠道、广告系列、落地页和细分维度标记异常
   - 输出供 Ads agent 使用的「广告信号」表格，并可按需将报告保存到 Google Docs 或 Slides
+sample_prompts:
+  en:
+  - title: Analyze this GA4 export
+    prompt: Analyze this GA4 export against the prior period and tell me what changed in traffic and conversions, and why.
+    highlights:
+    - GA4 export
+  - title: Generate Signals for Ads
+    prompt: Break down performance by channel, campaign and landing page, then emit a Signals for Ads table I can hand to my ads agent.
+    highlights:
+    - Signals for Ads table
+  zh:
+  - title: 分析这份 GA4 导出数据
+    prompt: 分析这份 GA4 导出数据 与上一周期的对比，告诉我流量和转化发生了什么变化，以及原因。
+    highlights:
+    - GA4 导出数据
+  - title: 生成广告信号表格
+    prompt: 按渠道、广告系列和落地页拆解表现，然后输出一份可以交给我的广告 agent 使用的广告信号表格。
+    highlights:
+    - 广告信号表格
 connections:
 - name: Google Docs
   logo: https://www.google.com/s2/favicons?domain=docs.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-linkedIn-content-manager.yaml
+++ b/src/xagent/templates/built_in/marketing-linkedIn-content-manager.yaml
@@ -14,6 +14,25 @@ features:
   - 撰写适用于 LinkedIn 的思想领导力帖子和动态更新
   - 创建符合 LinkedIn 尺寸规范的配套视觉内容
   - 将你的品牌声音、语气和视觉风格应用到每一条帖子中
+sample_prompts:
+  en:
+  - title: LinkedIn announcement
+    prompt: 'Write a LinkedIn announcement about news in our brand voice, with a matching visual in LinkedIn-ready dimensions.'
+    highlights:
+    - news
+  - title: Thought-leadership post
+    prompt: 'Draft a thought-leadership LinkedIn post on topic with a strong hook, three insights and a closing question.'
+    highlights:
+    - topic
+  zh:
+  - title: LinkedIn 动态公告
+    prompt: 以我们的品牌语气撰写一条关于 动态 的 LinkedIn 公告，并附带符合 LinkedIn 尺寸规范的配套视觉内容。
+    highlights:
+    - 动态
+  - title: 思想领导力文章
+    prompt: 围绕 主题 起草一篇思想领导力 LinkedIn 帖子，包含有力的开头、三个洞察点和一个结尾问题。
+    highlights:
+    - 主题
 connections:
 - name: LinkedIn
   logo: https://www.google.com/s2/favicons?domain=linkedin.com&sz=64

--- a/src/xagent/templates/built_in/marketing-seo-brief-writer.yaml
+++ b/src/xagent/templates/built_in/marketing-seo-brief-writer.yaml
@@ -17,7 +17,7 @@ features:
 sample_prompts:
   en:
   - title: Brief from a keyword
-    prompt: 'Pull SERP and keyword data for keyword and draft a structured brief with outline, angle, headings and terms to include.'
+    prompt: 'Pull SERP and ranking data for keyword and draft a structured brief with outline, angle, headings and terms to include.'
     highlights:
     - keyword
   - title: Cluster keywords

--- a/src/xagent/templates/built_in/marketing-seo-brief-writer.yaml
+++ b/src/xagent/templates/built_in/marketing-seo-brief-writer.yaml
@@ -14,6 +14,25 @@ features:
   - 拉取 SERP 和关键词数据，并按搜索意图聚类
   - 起草包含大纲、角度、标题和关键词的结构化简报
   - 结合知识库和云盘中的品牌规范，与现有内容保持一致
+sample_prompts:
+  en:
+  - title: Brief from a keyword
+    prompt: 'Pull SERP and keyword data for keyword and draft a structured brief with outline, angle, headings and terms to include.'
+    highlights:
+    - keyword
+  - title: Cluster keywords
+    prompt: 'Cluster these keywords by search intent and suggest one brief per cluster: paste keywords.'
+    highlights:
+    - paste keywords
+  zh:
+  - title: 关键词简报
+    prompt: 拉取 关键词 的 SERP 和关键词数据，起草包含大纲、切入角度、标题和需覆盖术语的结构化简报。
+    highlights:
+    - 关键词
+  - title: 关键词聚类
+    prompt: 按搜索意图对这些关键词聚类，并为每个聚类给出一份简报建议：粘贴关键词。
+    highlights:
+    - 粘贴关键词
 connections:
 - name: Google Drive
   logo: https://www.google.com/s2/favicons?domain=drive.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-social-media-content-manager.yaml
+++ b/src/xagent/templates/built_in/marketing-social-media-content-manager.yaml
@@ -14,6 +14,27 @@ features:
   - 将话题或简报转化为适用于 LinkedIn、Instagram 和 Facebook 的平台原生文案
   - 为每个平台创建正确尺寸的配套视觉内容
   - 将品牌语气、声音和视觉规范应用到每一条帖子中
+sample_prompts:
+  en:
+  - title: Week of social posts
+    prompt: 'Create a week of social posts about topic for LinkedIn, Instagram and Facebook, with matching visuals sized for each platform.'
+    highlights:
+    - topic
+  - title: Turn a brief into posts
+    prompt: 'Turn this brief into platform-native posts for channels: paste brief. Apply our brand tone and visual guidelines.'
+    highlights:
+    - channels
+    - paste brief
+  zh:
+  - title: 生成一周社媒帖子
+    prompt: 为 主题 创建一周的社交媒体帖子，覆盖 LinkedIn、Instagram 和 Facebook，并附带适配各平台尺寸的配套视觉内容。
+    highlights:
+    - 主题
+  - title: 将简报转化为帖子
+    prompt: 将这份简报转化为适用于 渠道 的平台原生帖子：粘贴简报。应用我们的品牌语气和视觉规范。
+    highlights:
+    - 渠道
+    - 粘贴简报
 connections:
 - name: LinkedIn
   logo: https://www.google.com/s2/favicons?domain=linkedin.com&sz=64

--- a/src/xagent/templates/built_in/operations-devops-ai-agent.yaml
+++ b/src/xagent/templates/built_in/operations-devops-ai-agent.yaml
@@ -14,6 +14,25 @@ features:
   - 读取您粘贴或上传的日志、命令输出或监控导出——无需连接到实时服务器
   - 将排查结果关联为根因假设与修复建议
   - 直接在对话中汇报——无需外部监控或消息集成
+sample_prompts:
+  en:
+  - title: Triage this incident
+    prompt: Here are the logs and command output from the incident — give me a root-cause hypothesis, a recommended fix, and a severity assessment.
+    highlights:
+    - logs and command output
+  - title: Correlate monitoring exports
+    prompt: I'm pasting a monitoring export below — correlate it with the error logs and tell me what's actually causing this.
+    highlights:
+    - monitoring export
+  zh:
+  - title: 排查这次故障
+    prompt: 这是故障相关的日志和命令输出——请给我根因假设、修复建议和严重程度评估。
+    highlights:
+    - 日志和命令输出
+  - title: 关联监控导出数据
+    prompt: 我粘贴了一份监控导出数据——请将其与错误日志关联，告诉我究竟是什么导致了这个问题。
+    highlights:
+    - 监控导出数据
 connections: []
 setup_time:
   en: 5 min setup

--- a/src/xagent/templates/built_in/sales-email-agent.yaml
+++ b/src/xagent/templates/built_in/sales-email-agent.yaml
@@ -14,6 +14,27 @@ features:
   - 基于潜在客户列表或 CRM，为每位联系人起草个性化邮件
   - 每封草稿均基于过往对话历史并遵循您的品牌语气
   - 仅在您批准后发送，并记录到 HubSpot 或更新上传的文件
+sample_prompts:
+  en:
+  - title: Draft outreach emails
+    prompt: Draft one personalised email per contact in prospect list / CRM segment, grounded in past conversations and our brand tone. Queue everything for my approval.
+    highlights:
+    - prospect list / CRM segment
+  - title: Follow-up sequence
+    prompt: "Write a N-step follow-up sequence for prospects who haven't replied to campaign."
+    highlights:
+    - N
+    - campaign
+  zh:
+  - title: 起草外联邮件
+    prompt: 为 潜在客户列表 / CRM 分组 中的每位联系人起草一封个性化邮件，基于过往对话并遵循我们的品牌语气，全部加入待我审批的队列。
+    highlights:
+    - 潜在客户列表 / CRM 分组
+  - title: 跟进序列
+    prompt: 为未回复 营销活动 的潜在客户撰写一套 N 步跟进序列。
+    highlights:
+    - N
+    - 营销活动
 connections:
 - name: HubSpot
   logo: https://www.google.com/s2/favicons?domain=hubspot.com&sz=64

--- a/src/xagent/templates/built_in/sales-email-lead-response-agent.yaml
+++ b/src/xagent/templates/built_in/sales-email-lead-response-agent.yaml
@@ -14,6 +14,25 @@ features:
   - 自动响应来自 Gmail / O365 邮箱的新入站线索邮件
   - 按您的标准对线索评分，并创建或更新 HubSpot 记录
   - 提供会议时间、预订日历并将全部活动记录到 CRM
+sample_prompts:
+  en:
+  - title: Score new leads
+    prompt: Score new inbound lead emails against criteria and create or update the matching HubSpot records.
+    highlights:
+    - criteria
+  - title: Book a meeting
+    prompt: Reply to lead with meeting times, book the calendar event once confirmed, and log everything to CRM.
+    highlights:
+    - lead
+  zh:
+  - title: 线索评分
+    prompt: 根据 标准 对新的入站线索邮件评分，并创建或更新匹配的 HubSpot 记录。
+    highlights:
+    - 标准
+  - title: 预约会议
+    prompt: 回复 线索 提供会议时间，确认后预订日历事件，并将全部内容记录到 CRM。
+    highlights:
+    - 线索
 connections:
 - name: HubSpot
   logo: https://www.google.com/s2/favicons?domain=hubspot.com&sz=64

--- a/src/xagent/templates/built_in/sales-meeting-agent.yaml
+++ b/src/xagent/templates/built_in/sales-meeting-agent.yaml
@@ -18,6 +18,25 @@ features:
   - 若两者均未连接，或该会议在其中不可用，也可接受您粘贴/上传的会议记录（.txt、.docx 或 .pdf）
   - 按需从记录中提取决策、负责人和截止日期
   - 在 Gmail 中起草跟进邮件，并在您批准后于 HubSpot 中记录 CRM 备注
+sample_prompts:
+  en:
+  - title: Summarize this meeting
+    prompt: Read this meeting transcript and give me a summary, the decisions made, and action items with owners and due dates.
+    highlights:
+    - meeting transcript
+  - title: Draft a follow-up email
+    prompt: Based on this transcript, draft a follow-up email summarizing decisions and next steps for the attendees.
+    highlights:
+    - this transcript
+  zh:
+  - title: 总结这次会议
+    prompt: 请阅读这份会议记录，给我摘要、决策以及带负责人和截止日期的行动项。
+    highlights:
+    - 会议记录
+  - title: 起草跟进邮件
+    prompt: 根据这份会议记录，起草一封跟进邮件，总结决策和后续步骤发给与会者。
+    highlights:
+    - 会议记录
 connections:
 - name: Zoom
   logo: https://www.google.com/s2/favicons?domain=zoom.us&sz=64

--- a/src/xagent/templates/built_in/sales-research-enricher.yaml
+++ b/src/xagent/templates/built_in/sales-research-enricher.yaml
@@ -14,6 +14,25 @@ features:
   - 收集公开的企业信息、角色信号和购买信号
   - 生成包含公司速览、关键联系人、信号和沟通要点的结构化简报
   - 将简报导出为 Google 文档，并在获批后回写 HubSpot CRM
+sample_prompts:
+  en:
+  - title: Research a company
+    prompt: 'Research company — firmographics, role signals and buying signals — and build a structured brief with snapshot, contacts and talking points.'
+    highlights:
+    - company
+  - title: Enrich CRM records
+    prompt: Enrich the HubSpot records in list / segment with fresh firmographic data and flag anything that changed.
+    highlights:
+    - list / segment
+  zh:
+  - title: 调研公司
+    prompt: 调研 公司——包括企业信息、角色信号和购买信号——并生成包含速览、联系人和沟通要点的结构化简报。
+    highlights:
+    - 公司
+  - title: 丰富 CRM 记录
+    prompt: 为 列表 / 分组 中的 HubSpot 记录补充最新的企业信息，并标记发生变化的内容。
+    highlights:
+    - 列表 / 分组
 connections:
 - name: HubSpot
   logo: https://www.google.com/s2/favicons?domain=hubspot.com&sz=64

--- a/src/xagent/templates/built_in/support-ai-chatbot-agent.yaml
+++ b/src/xagent/templates/built_in/support-ai-chatbot-agent.yaml
@@ -14,6 +14,25 @@ features:
   - 回答公司/群组的常见问题
   - 同时处理多个客户聊天
   - 帮助客户排查问题
+sample_prompts:
+  en:
+  - title: Answer common questions
+    prompt: 'Answer commonly asked questions about company / product using our knowledge base, handling many customer chats at the same time.'
+    highlights:
+    - company / product
+  - title: Troubleshooting helper
+    prompt: 'Help customers troubleshoot product area step by step, escalating to a human when needed.'
+    highlights:
+    - product area
+  zh:
+  - title: 回答常见问题
+    prompt: 使用我们的知识库回答关于 公司 / 产品 的常见问题，可同时处理多个客户对话。
+    highlights:
+    - 公司 / 产品
+  - title: 故障排查助手
+    prompt: 帮助客户逐步排查 产品领域 的问题，必要时上报人工处理。
+    highlights:
+    - 产品领域
 connections:
 - name: Google Drive
   logo: https://www.google.com/s2/favicons?domain=drive.google.com&sz=64

--- a/src/xagent/templates/built_in/support-email-agent.yaml
+++ b/src/xagent/templates/built_in/support-email-agent.yaml
@@ -14,6 +14,23 @@ features:
   - 按紧急程度和截止日期对支持工单进行排序
   - 起草常见客户问题的回复以供批准
   - 仅提供准确、经过验证的信息
+sample_prompts:
+  en:
+  - title: Sort today's tickets
+    prompt: "Sort today's support tickets by urgency and deadline, and surface the ones that need me first."
+    highlights: []
+  - title: Draft ticket replies
+    prompt: 'Draft replies to common customer questions in queue, using only accurate, verified information, ready for agent approval.'
+    highlights:
+    - queue
+  zh:
+  - title: 整理今日工单
+    prompt: 按紧急程度和截止日期整理今天的支持工单，优先呈现需要我处理的工单。
+    highlights: []
+  - title: 起草工单回复
+    prompt: 为 队列 中的常见客户问题起草回复，仅使用准确、经过验证的信息，供客服审批。
+    highlights:
+    - 队列
 connections:
 - name: Gmail
   logo: https://www.google.com/s2/favicons?domain=mail.google.com&sz=64

--- a/src/xagent/templates/built_in/support-inbox-manager.yaml
+++ b/src/xagent/templates/built_in/support-inbox-manager.yaml
@@ -14,6 +14,23 @@ features:
   - 读取并摘要新邮件和未读邮件线程，并附优先级标签
   - 以您的语气起草回复——保存为草稿，未经批准不会发送
   - 标记敏感或高风险邮件，提醒您亲自处理
+sample_prompts:
+  en:
+  - title: Prioritise my inbox
+    prompt: Read and summarise my new and unread email threads with priority labels, flagging sensitive or high-stakes messages for my attention.
+    highlights: []
+  - title: Draft replies
+    prompt: 'Draft replies to threads in my voice and save them to Drafts — never send without my approval.'
+    highlights:
+    - threads
+  zh:
+  - title: 整理我的收件箱
+    prompt: 阅读并总结我新收到的未读邮件线程，标注优先级，并标记需要我关注的敏感或重要邮件。
+    highlights: []
+  - title: 起草回复
+    prompt: 以我的语气为 邮件线程 起草回复，保存到草稿箱——未经批准绝不发送。
+    highlights:
+    - 邮件线程
 connections:
 - name: Gmail
   logo: https://www.google.com/s2/favicons?domain=mail.google.com&sz=64

--- a/src/xagent/templates/built_in/support-kb-writer.yaml
+++ b/src/xagent/templates/built_in/support-kb-writer.yaml
@@ -14,6 +14,25 @@ features:
   - 解析源文档，识别主题并标记缺口或内容冲突
   - 起草整洁的 Markdown 知识库文章和 FAQ，每篇聚焦一个主题
   - 随源文档更新保持文章同步，并提供变更记录
+sample_prompts:
+  en:
+  - title: Draft KB articles
+    prompt: 'Parse source docs and draft clean Markdown KB articles and FAQs — one topic per article — flagging any gaps or conflicts.'
+    highlights:
+    - source docs
+  - title: Update stale articles
+    prompt: Compare our KB against changed source docs and update the affected articles with changelogs.
+    highlights:
+    - changed source docs
+  zh:
+  - title: 起草知识库文章
+    prompt: 解析 源文档 并起草整洁的 Markdown 知识库文章和 FAQ——每篇聚焦一个主题——标记出任何缺口或冲突。
+    highlights:
+    - 源文档
+  - title: 更新过期文章
+    prompt: 将我们的知识库与 已变更的源文档 进行比对，更新受影响的文章并附上变更记录。
+    highlights:
+    - 已变更的源文档
 connections:
 - name: Google Drive
   logo: https://www.google.com/s2/favicons?domain=drive.google.com&sz=64

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -113,6 +113,7 @@ class TemplateManager:
         data.setdefault("author", "Xagent")
         data.setdefault("version", "1.0")
         data.setdefault("featured", False)
+        data.setdefault("sample_prompts", {})
 
         # agent_config default values
         agent_config = data["agent_config"]
@@ -158,6 +159,7 @@ class TemplateManager:
             "featured": template.get("featured", False),
             "descriptions": template.get("descriptions", {}),
             "features": template.get("features", []),
+            "sample_prompts": template.get("sample_prompts", {}),
             "connections": connections,
             "setup_time": template.get("setup_time", "5 min setup"),
             "tags": template.get("tags", []),

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -105,15 +105,20 @@ class TemplateManager:
         if "agent_config" not in data:
             data["agent_config"] = {}
 
-        # Set default values
-        data.setdefault("tags", [])
-        data.setdefault("features", [])
+        # Set default values. tags/features/sample_prompts are per-locale
+        # dicts (like descriptions), so their "not authored" default must be
+        # {} not [] - get_localized_value falls back to [] per-call anyway,
+        # but a [] here would silently bypass localization if ever read
+        # directly instead of through get_localized_value.
+        data.setdefault("tags", {})
+        data.setdefault("features", {})
         data.setdefault("connections", [])
         data.setdefault("setup_time", "5 min setup")
         data.setdefault("author", "Xagent")
         data.setdefault("version", "1.0")
         data.setdefault("featured", False)
         data.setdefault("sample_prompts", {})
+        self._validate_sample_prompts(data["sample_prompts"])
 
         # agent_config default values
         agent_config = data["agent_config"]
@@ -123,6 +128,49 @@ class TemplateManager:
         agent_config.setdefault("execution_mode", "balanced")
 
         return data
+
+    def _validate_sample_prompts(self, sample_prompts: Any) -> None:
+        """Validate the (optional) sample_prompts shape at parse time, the
+        same way `descriptions` is validated above. Without this, a
+        malformed entry only surfaces as an uncaught pydantic
+        ValidationError deep inside the TemplateInfo response model,
+        which would take down GET /api/templates/ - and therefore the
+        whole template list - for every user, not just break this one
+        template.
+        """
+        if not sample_prompts:
+            return
+        if not isinstance(sample_prompts, dict):
+            raise ValueError(
+                "'sample_prompts' must be a dict keyed by locale (e.g. "
+                "{'en': [...], 'zh': [...]}), not a flat list - a flat list "
+                "would silently bypass per-locale resolution"
+            )
+        for locale, prompts in sample_prompts.items():
+            if not isinstance(prompts, list):
+                raise ValueError(f"'sample_prompts.{locale}' must be a list")
+            for index, prompt in enumerate(prompts):
+                if not isinstance(prompt, dict):
+                    raise ValueError(
+                        f"'sample_prompts.{locale}[{index}]' must be a mapping"
+                    )
+                title = prompt.get("title")
+                if not isinstance(title, str) or not title:
+                    raise ValueError(
+                        f"'sample_prompts.{locale}[{index}].title' must be a non-empty string"
+                    )
+                prompt_text = prompt.get("prompt")
+                if not isinstance(prompt_text, str) or not prompt_text:
+                    raise ValueError(
+                        f"'sample_prompts.{locale}[{index}].prompt' must be a non-empty string"
+                    )
+                highlights = prompt.get("highlights", [])
+                if not isinstance(highlights, list) or not all(
+                    isinstance(h, str) for h in highlights
+                ):
+                    raise ValueError(
+                        f"'sample_prompts.{locale}[{index}].highlights' must be a list of strings"
+                    )
 
     def _enrich_template(self, template: Dict[str, Any]) -> Dict[str, Any]:
         """Merge connections into agent_config.tool_categories"""
@@ -158,11 +206,11 @@ class TemplateManager:
             "category": template.get("category", ""),
             "featured": template.get("featured", False),
             "descriptions": template.get("descriptions", {}),
-            "features": template.get("features", []),
+            "features": template.get("features", {}),
             "sample_prompts": template.get("sample_prompts", {}),
             "connections": connections,
             "setup_time": template.get("setup_time", "5 min setup"),
-            "tags": template.get("tags", []),
+            "tags": template.get("tags", {}),
             "author": template.get("author", ""),
             "version": template.get("version", ""),
             "agent_config": agent_config_dict,

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -38,6 +38,7 @@ from ..services.agent_management import (
     AgentWorkforceConflictError,
     DuplicateAgentNameError,
     TemplateNotFoundError,
+    is_agent_name_unique_violation,
 )
 from ..services.agent_store import (
     AgentStore,
@@ -597,11 +598,13 @@ async def create_agent(
                 suggested_prompts=agent_data.suggested_prompts,
                 visibility=agent_data.visibility,
             )
-        except IntegrityError:
+        except IntegrityError as exc:
             db.rollback()
+            if not is_agent_name_unique_violation(exc):
+                raise
             raise HTTPException(
                 status_code=400, detail="Agent with this name already exists"
-            )
+            ) from exc
 
         # Save logo if provided
         if agent_data.logo_base64:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -541,6 +541,10 @@ async def resolve_agent_from_template(
     named instances of one template), repeat calls here return the same
     agent, backed by a DB-level unique index scoped to this flow's own
     origin marker.
+
+    ``name`` only seeds a freshly created agent; on reuse it is ignored and
+    the existing agent's own name is returned as-is (see
+    ``AgentManagementService.resolve_agent_from_template``).
     """
     user_id = int(current_user.id)
     is_admin = bool(current_user.is_admin)
@@ -581,8 +585,10 @@ async def resolve_agent_from_template(
             detail="Too many concurrent requests for this template; please retry",
         )
     except Exception as e:
-        logger.error(f"Failed to resolve agent from template: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(f"Failed to resolve agent from template {data.template_id}")
+        raise HTTPException(
+            status_code=500, detail="Failed to resolve agent from template"
+        ) from e
 
 
 @router.post("/from-template", response_model=AgentResponse)
@@ -852,16 +858,29 @@ async def update_agent(
             updates["logo_url"] = logo_url
 
         if updates:
-            agent = (
-                store.update_agent_fields(
-                    user_id,
-                    agent_id,
-                    updates,
-                    team_scope=team_scope,
-                    agent=agent,
+            # agent_name_exists above is a fast-path pre-check, not the source
+            # of truth: uq_agents_user_id_name_active is what actually
+            # prevents a concurrent-rename race, so the write itself can
+            # still raise IntegrityError here (see the matching handling in
+            # create_agent above).
+            try:
+                agent = (
+                    store.update_agent_fields(
+                        user_id,
+                        agent_id,
+                        updates,
+                        team_scope=team_scope,
+                        agent=agent,
+                    )
+                    or agent
                 )
-                or agent
-            )
+            except IntegrityError as exc:
+                db.rollback()
+                if not is_agent_name_unique_violation(exc):
+                    raise
+                raise HTTPException(
+                    status_code=400, detail="Agent with this name already exists"
+                ) from exc
 
         logger.info(f"Updated agent {agent_id} for user {current_user.id}")
         return AgentResponse.model_validate(store.agent_to_response_dict(agent))

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...config import get_agent_pattern_for_execution_mode, get_uploads_dir
@@ -123,6 +124,7 @@ class AgentResponse(BaseModel):
     name: str
     description: Optional[str]
     instructions: Optional[str]
+    template_id: Optional[str] = None
     execution_mode: str
     models: Optional[dict]
     knowledge_bases: List[str]
@@ -153,6 +155,7 @@ class AgentListItem(BaseModel):
     team_id: Optional[int] = None
     name: str
     description: Optional[str]
+    template_id: Optional[str] = None
     logo_url: Optional[str]
     status: str
     visibility: str = "team"
@@ -576,19 +579,29 @@ async def create_agent(
         )
         await _validate_knowledge_bases_exist(agent_data.knowledge_bases, current_user)
 
-        agent = store.create_agent(
-            user_id=user_id,
-            name=agent_data.name,
-            description=agent_data.description,
-            instructions=agent_data.instructions,
-            execution_mode=agent_data.execution_mode or "graph",
-            models=agent_data.models,
-            knowledge_bases=agent_data.knowledge_bases,
-            skills=agent_data.skills,
-            tool_categories=agent_data.tool_categories,
-            suggested_prompts=agent_data.suggested_prompts,
-            visibility=agent_data.visibility,
-        )
+        # agent_name_exists above is a fast-path pre-check, not the source of
+        # truth: uq_agents_user_id_name_active is what actually prevents a
+        # concurrent-request race, so the insert itself can still raise
+        # IntegrityError here.
+        try:
+            agent = store.create_agent(
+                user_id=user_id,
+                name=agent_data.name,
+                description=agent_data.description,
+                instructions=agent_data.instructions,
+                execution_mode=agent_data.execution_mode or "graph",
+                models=agent_data.models,
+                knowledge_bases=agent_data.knowledge_bases,
+                skills=agent_data.skills,
+                tool_categories=agent_data.tool_categories,
+                suggested_prompts=agent_data.suggested_prompts,
+                visibility=agent_data.visibility,
+            )
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(
+                status_code=400, detail="Agent with this name already exists"
+            )
 
         # Save logo if provided
         if agent_data.logo_base64:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -512,6 +512,62 @@ class AgentFromTemplateRequest(BaseModel):
     name: Optional[str] = None
 
 
+class ResolvedTemplateAgentResponse(BaseModel):
+    """Result of the get-or-create resolve flow for a template's agent."""
+
+    agent: AgentResponse
+    # True when this call minted (and published) a fresh agent; False when an
+    # existing agent for this template was reused.
+    created: bool
+
+
+@router.post("/from-template/resolve", response_model=ResolvedTemplateAgentResponse)
+async def resolve_agent_from_template(
+    data: AgentFromTemplateRequest,
+    fastapi_request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ResolvedTemplateAgentResponse:
+    """Get-or-create the caller's agent for a template, atomically.
+
+    Reuses the caller's own existing agent for this template (publishing it
+    if still a draft) or creates and publishes a new one, disambiguating the
+    name server-side on collision. Unlike POST /from-template this is
+    idempotent per (user, template) - repeat calls return the same agent.
+    """
+    user_id = int(current_user.id)
+    is_admin = bool(current_user.is_admin)
+    if not release_db_connection_if_clean(db):
+        raise HTTPException(
+            status_code=500,
+            detail="Agent creation requires a clean request database transaction",
+        )
+
+    template_manager = getattr(fastapi_request.app.state, "template_manager", None)
+    try:
+        snapshot, created = await AgentManagementRuntime(
+            template_manager=template_manager
+        ).resolve_agent_from_template(
+            user_id=user_id,
+            is_admin=is_admin,
+            template_id=data.template_id,
+            name=data.name,
+        )
+        return ResolvedTemplateAgentResponse(
+            agent=AgentResponse.model_validate(snapshot.to_response_dict()),
+            created=created,
+        )
+    except TemplateNotFoundError:
+        raise HTTPException(status_code=404, detail="Template not found")
+    except DuplicateAgentNameError:
+        raise HTTPException(
+            status_code=400, detail="Agent with this name already exists"
+        )
+    except Exception as e:
+        logger.error(f"Failed to resolve agent from template: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/from-template", response_model=AgentResponse)
 async def create_agent_from_template(
     data: AgentFromTemplateRequest,

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -38,6 +38,7 @@ from ..services.agent_management import (
     AgentWorkforceConflictError,
     DuplicateAgentNameError,
     TemplateNotFoundError,
+    TemplateQuickAccessRaceError,
     is_agent_name_unique_violation,
 )
 from ..services.agent_store import (
@@ -528,12 +529,18 @@ async def resolve_agent_from_template(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> ResolvedTemplateAgentResponse:
-    """Get-or-create the caller's agent for a template, atomically.
+    """Get-or-create the caller's quick-access agent for a template,
+    atomically.
 
-    Reuses the caller's own existing agent for this template (publishing it
-    if still a draft) or creates and publishes a new one, disambiguating the
-    name server-side on collision. Unlike POST /from-template this is
-    idempotent per (user, template) - repeat calls return the same agent.
+    Reuses the caller's own existing quick-access agent for this template
+    as-is (never silently republishing a draft - see the note on
+    ``_resolve_agent_from_template_sync``), or creates and publishes a new
+    one, disambiguating the name server-side on collision. Idempotent per
+    (user, template) for this flow specifically: unlike the plain
+    POST /from-template (used by the workforce-builder UI to mint several
+    named instances of one template), repeat calls here return the same
+    agent, backed by a DB-level unique index scoped to this flow's own
+    origin marker.
     """
     user_id = int(current_user.id)
     is_admin = bool(current_user.is_admin)
@@ -562,6 +569,16 @@ async def resolve_agent_from_template(
     except DuplicateAgentNameError:
         raise HTTPException(
             status_code=400, detail="Agent with this name already exists"
+        )
+    except TemplateQuickAccessRaceError:
+        # Distinct from the name-collision case above: every one of
+        # TEMPLATE_RESOLVE_RACE_RETRIES concurrent attempts lost the
+        # (user_id, template_id) quick-access race to another request, with
+        # no name collision involved at all - "already exists" would be
+        # misleading here since the client never even chose a name.
+        raise HTTPException(
+            status_code=409,
+            detail="Too many concurrent requests for this template; please retry",
         )
     except Exception as e:
         logger.error(f"Failed to resolve agent from template: {e}")

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -75,6 +75,17 @@ class ConnectionInfo(BaseModel):
     logo: Optional[str] = Field(default=None, description="URL to the logo image")
 
 
+class SamplePrompt(BaseModel):
+    """A quick-access sample prompt shown on a template card"""
+
+    title: str = Field(..., description="Short label shown on the template card")
+    prompt: str = Field(..., description="Prompt text to fill into the chat input")
+    highlights: list[str] = Field(
+        default_factory=list,
+        description="Substrings within prompt to visually highlight as placeholders",
+    )
+
+
 class TemplateInfo(BaseModel):
     """Template brief information"""
 
@@ -86,6 +97,9 @@ class TemplateInfo(BaseModel):
     )
     description: str = Field(..., description="Template description")
     features: list[str] = Field(default_factory=list, description="Template features")
+    sample_prompts: list[SamplePrompt] = Field(
+        default_factory=list, description="Quick-access sample prompts"
+    )
     connections: list[ConnectionInfo] = Field(
         default_factory=list, description="App connections"
     )
@@ -247,6 +261,9 @@ async def list_templates(
         # Get localized values
         description = get_localized_value(template.get("descriptions", {}), lang, "")
         features = get_localized_value(template.get("features", {}), lang, [])
+        sample_prompts = get_localized_value(
+            template.get("sample_prompts", {}), lang, []
+        )
         setup_time = get_localized_value(
             template.get("setup_time", {}), lang, "5 min setup"
         )
@@ -261,6 +278,7 @@ async def list_templates(
                 featured=bool(template.get("featured", False)),
                 description=description,
                 features=features,
+                sample_prompts=sample_prompts,
                 connections=connections,
                 setup_time=setup_time,
                 tags=tags,
@@ -313,6 +331,7 @@ async def get_template(
     # Get localized values
     description = get_localized_value(template.get("descriptions", {}), lang, "")
     features = get_localized_value(template.get("features", {}), lang, [])
+    sample_prompts = get_localized_value(template.get("sample_prompts", {}), lang, [])
     setup_time = get_localized_value(
         template.get("setup_time", {}), lang, "5 min setup"
     )
@@ -326,6 +345,7 @@ async def get_template(
         featured=bool(template.get("featured", False)),
         description=description,
         features=features,
+        sample_prompts=sample_prompts,
         connections=connections,
         setup_time=setup_time,
         tags=tags,

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -5,10 +5,18 @@ from datetime import datetime
 
 from sqlalchemy import JSON, Boolean, Column, DateTime
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.orm import relationship
 
 from .database import Base
+
+# Per-user name uniqueness, excluding workforce-generated manager agents
+# (which are allowed to share names - see agent_name_exists). Declared here
+# so brand-new databases get it via Base.metadata.create_all(); existing
+# databases get the same index from the
+# 20260728_add_agent_template_id_and_name_uniqueness migration, which also
+# dedupes any pre-existing collisions first.
+_NON_WORKFORCE_MANAGER_CLAUSE = text("origin != 'workforce_generated_manager'")
 
 
 class AgentStatus(enum.Enum):
@@ -57,6 +65,11 @@ class Agent(Base):  # type: ignore
     name = Column(String(200), nullable=False)
     description = Column(Text, nullable=True)
     instructions = Column(Text, nullable=True)  # System prompt/instructions
+    # Built-in template id this agent was instantiated from (e.g. via
+    # "/api/agents/from-template"), or NULL for agents built from scratch.
+    # Lets create-or-reuse flows key off a stable id instead of the
+    # user-editable display name.
+    template_id = Column(String(255), nullable=True, index=True)
 
     # Configuration
     execution_mode = Column(
@@ -103,6 +116,17 @@ class Agent(Base):  # type: ignore
         nullable=False,
     )  # type: ignore[assignment]
     published_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_agents_user_id_name_active",
+            "user_id",
+            "name",
+            unique=True,
+            sqlite_where=_NON_WORKFORCE_MANAGER_CLAUSE,
+            postgresql_where=_NON_WORKFORCE_MANAGER_CLAUSE,
+        ),
+    )
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), default=datetime.now, nullable=False)

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -29,6 +29,15 @@ _NON_WORKFORCE_MANAGER_CLAUSE = text("origin != 'workforce_generated_manager'")
 # IntegrityError (e.g. a widget_key collision or an unrelated FK failure).
 AGENT_NAME_UNIQUE_INDEX = "uq_agents_user_id_name_active"
 
+# Scopes the (user_id, template_id) uniqueness below to agents created by the
+# /task template quick-access resolve flow specifically - the plain
+# POST /from-template create path (workforce-builder UI) deliberately mints
+# multiple named instances of one template and must not be constrained by
+# it. Also shared with agent_management.py's IntegrityError matching.
+_QUICK_ACCESS_ORIGIN = "template_quick_access"
+_QUICK_ACCESS_ORIGIN_CLAUSE = text(f"origin = '{_QUICK_ACCESS_ORIGIN}'")
+AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX = "uq_agents_user_id_template_id_quick_access"
+
 
 class AgentStatus(enum.Enum):
     """Agent status enumeration"""
@@ -43,6 +52,12 @@ class AgentOrigin(enum.Enum):
 
     USER = "user"
     WORKFORCE_GENERATED_MANAGER = "workforce_generated_manager"
+    # The /task template quick-access get-or-create flow
+    # (AgentManagementService.resolve_agent_from_template). Distinct from
+    # USER so its (user_id, template_id) reuse query can't adopt an
+    # unrelated agent the workforce-builder UI created from the same
+    # template under a user-chosen name (PR review finding B4).
+    TEMPLATE_QUICK_ACCESS = _QUICK_ACCESS_ORIGIN
 
 
 class ExecutionMode(enum.Enum):
@@ -136,6 +151,20 @@ class Agent(Base):  # type: ignore
             unique=True,
             sqlite_where=_NON_WORKFORCE_MANAGER_CLAUSE,
             postgresql_where=_NON_WORKFORCE_MANAGER_CLAUSE,
+        ),
+        # Backs the /task template quick-access resolve flow's atomicity:
+        # scoped to TEMPLATE_QUICK_ACCESS origin only, so a workforce-builder
+        # agent built from the same template (a deliberate, user-named,
+        # possibly-multiple instance) never collides with it. See
+        # AgentManagementService._resolve_agent_from_template_sync and PR
+        # review findings B1/B2/D2/D3.
+        Index(
+            AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX,
+            "user_id",
+            "template_id",
+            unique=True,
+            sqlite_where=_QUICK_ACCESS_ORIGIN_CLAUSE,
+            postgresql_where=_QUICK_ACCESS_ORIGIN_CLAUSE,
         ),
     )
 

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -16,7 +16,18 @@ from .database import Base
 # databases get the same index from the
 # 20260728_add_agent_template_id_and_name_uniqueness migration, which also
 # dedupes any pre-existing collisions first.
+#
+# This is keyed on (user_id, name) only, so it mirrors agent_name_exists
+# exactly in standalone xagent. When a SaaS team-scope hook is installed,
+# agent_name_exists becomes a team-wide check (see agent_team_scope.py) that
+# this per-user index does not enforce - it only guarantees a single user
+# can't race a duplicate name past themselves, not across teammates.
 _NON_WORKFORCE_MANAGER_CLAUSE = text("origin != 'workforce_generated_manager'")
+
+# Shared with agent_management.py, which inspects a raised IntegrityError's
+# message for this name to distinguish this specific violation from any other
+# IntegrityError (e.g. a widget_key collision or an unrelated FK failure).
+AGENT_NAME_UNIQUE_INDEX = "uq_agents_user_id_name_active"
 
 
 class AgentStatus(enum.Enum):
@@ -119,7 +130,7 @@ class Agent(Base):  # type: ignore
 
     __table_args__ = (
         Index(
-            "uq_agents_user_id_name_active",
+            AGENT_NAME_UNIQUE_INDEX,
             "user_id",
             "name",
             unique=True,

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -21,7 +21,7 @@ from ...core.utils.api_key import (
     generate_api_key,
 )
 from ...templates.manager import TemplateManager
-from ..models.agent import Agent
+from ..models.agent import AGENT_NAME_UNIQUE_INDEX, Agent
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_session_local, release_db_connection_if_clean
 from ..models.model import Model as DBModel
@@ -603,11 +603,19 @@ class AgentManagementService:
 
         Conflict contract: ``agent_name_exists`` is a fast-path pre-check,
         not the source of truth -- the ``uq_agents_user_id_name_active``
-        partial unique index (excludes workforce-generated-manager agents,
-        matching ``agent_name_exists``) is what actually prevents a
-        concurrent-request race, so the agent insert's flush can itself
-        raise IntegrityError and is translated to ``DuplicateAgentNameError``
-        below. The only other IntegrityError source is the runtime key's
+        partial unique index (excludes workforce-generated-manager agents)
+        is what actually prevents a same-user concurrent-request race, so
+        the agent insert's flush can itself raise IntegrityError and is
+        translated to ``DuplicateAgentNameError`` below. The index is keyed
+        on ``(user_id, name)`` only, so it matches ``agent_name_exists``
+        exactly in standalone xagent (no team-scope hook, where the check is
+        also purely per-user). When a team-scope hook is installed,
+        ``agent_name_exists`` widens to a team-wide check (any teammate's
+        ``visibility="team"`` agent, or all of them for an admin) that this
+        per-user index does not mirror -- two different users on the same
+        team can still race past it with identical names; only a single
+        user's own double-submit is guaranteed to be caught here. The only
+        other IntegrityError source is the runtime key's
         ``key_prefix`` unique constraint (the ``uq_agent_api_keys_agent_active``
         partial index that used to also live here was dropped for multi-key
         support -- an agent may hold more than one active key now), handled
@@ -640,6 +648,8 @@ class AgentManagementService:
             )
         except IntegrityError as exc:
             self.db.rollback()
+            if not is_agent_name_unique_violation(exc):
+                raise
             raise DuplicateAgentNameError(name) from exc
 
         # The agent-name race is handled above via the add_agent flush; the
@@ -891,6 +901,33 @@ def _is_runtime_key_prefix_collision(error: BaseException) -> bool:
         message = str(current).lower()
         if "key_prefix" in message and (
             "agent_api_keys" in message or "unique" in message or "duplicate" in message
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def is_agent_name_unique_violation(error: BaseException) -> bool:
+    """Recognize the authoritative (user_id, name) unique index failure.
+
+    Postgres includes the index name (``uq_agents_user_id_name_active``) in
+    its error message; sqlite instead names the columns
+    (``agents.user_id, agents.name``). Matching either keeps this from
+    misclassifying an unrelated IntegrityError (e.g. a ``widget_key``
+    collision or a foreign-key violation) as a duplicate-name conflict.
+    """
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if AGENT_NAME_UNIQUE_INDEX.lower() in message:
+            return True
+        if (
+            "agents.user_id" in message
+            and "agents.name" in message
+            and ("unique" in message or "duplicate" in message)
         ):
             return True
         current = current.__cause__ or current.__context__

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -21,7 +21,12 @@ from ...core.utils.api_key import (
     generate_api_key,
 )
 from ...templates.manager import TemplateManager
-from ..models.agent import AGENT_NAME_UNIQUE_INDEX, Agent, AgentStatus
+from ..models.agent import (
+    AGENT_NAME_UNIQUE_INDEX,
+    AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX,
+    Agent,
+    AgentOrigin,
+)
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_session_local, release_db_connection_if_clean
 from ..models.model import Model as DBModel
@@ -62,6 +67,12 @@ TEMPLATE_RESOLVE_RACE_RETRIES = 3
 
 class DuplicateAgentNameError(ValueError):
     """Raised when a user already owns an agent with the requested name."""
+
+
+class TemplateQuickAccessRaceError(ValueError):
+    """Raised when a concurrent insert wins the (user_id, template_id)
+    quick-access race - see AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX and
+    _resolve_agent_from_template_sync's retry loop."""
 
 
 class TemplateNotFoundError(LookupError):
@@ -593,6 +604,7 @@ class AgentManagementService:
         generate_runtime_key: bool = True,
         runtime_key_candidate: ApiKeyCandidate | None = None,
         template_id: str | None = None,
+        origin: str = AgentOrigin.USER.value,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
         """Create an agent and (optionally) its first runtime key in a
         single transaction. Internal transaction executor: assumes
@@ -620,8 +632,12 @@ class AgentManagementService:
         ``visibility="team"`` agent, or all of them for an admin) that this
         per-user index does not mirror -- two different users on the same
         team can still race past it with identical names; only a single
-        user's own double-submit is guaranteed to be caught here. The only
-        other IntegrityError source is the runtime key's
+        user's own double-submit is guaranteed to be caught here. A second
+        partial unique index, ``uq_agents_user_id_template_id_quick_access``
+        (scoped to ``origin=template_quick_access``), similarly turns an
+        insert into ``TemplateQuickAccessRaceError`` below -- see
+        ``AgentManagementService._resolve_agent_from_template_sync``. The
+        only remaining IntegrityError source is the runtime key's
         ``key_prefix`` unique constraint (the ``uq_agent_api_keys_agent_active``
         partial index that used to also live here was dropped for multi-key
         support -- an agent may hold more than one active key now), handled
@@ -651,12 +667,15 @@ class AgentManagementService:
                 tool_categories=tool_categories or [],
                 suggested_prompts=suggested_prompts or [],
                 template_id=template_id,
+                origin=origin,
             )
         except IntegrityError as exc:
             self.db.rollback()
-            if not is_agent_name_unique_violation(exc):
-                raise
-            raise DuplicateAgentNameError(name) from exc
+            if is_agent_name_unique_violation(exc):
+                raise DuplicateAgentNameError(name) from exc
+            if is_agent_template_quick_access_unique_violation(exc):
+                raise TemplateQuickAccessRaceError(template_id) from exc
+            raise
 
         # The agent-name race is handled above via the add_agent flush; the
         # runtime key is the only remaining write that can raise
@@ -933,6 +952,33 @@ def is_agent_name_unique_violation(error: BaseException) -> bool:
         if (
             "agents.user_id" in message
             and "agents.name" in message
+            and ("unique" in message or "duplicate" in message)
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def is_agent_template_quick_access_unique_violation(error: BaseException) -> bool:
+    """Recognize the authoritative (user_id, template_id) quick-access
+    unique index failure - the counterpart to is_agent_name_unique_violation
+    above, for AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX. Fires when a
+    concurrent request wins the resolve flow's create race even when the two
+    inserts picked different (disambiguated) names, so
+    is_agent_name_unique_violation alone would miss it (PR review findings
+    B1/B2).
+    """
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX.lower() in message:
+            return True
+        if (
+            "agents.user_id" in message
+            and "agents.template_id" in message
             and ("unique" in message or "duplicate" in message)
         ):
             return True
@@ -1273,19 +1319,26 @@ class AgentManagementRuntime:
         template_id: str,
         name: str | None = None,
     ) -> tuple[AgentResponseSnapshot, bool]:
-        """Atomic server-side get-or-create keyed on (user_id, template_id).
+        """Atomic server-side get-or-create keyed on (user_id, template_id,
+        origin=template_quick_access).
 
         Backs flows with reuse semantics (the /task template quick-access):
-        return the caller's own existing agent for this template - publishing
-        it first if it is still a draft - or create and publish a fresh one.
-        Unlike the plain create path this never raises on a duplicate default
-        name; it disambiguates server-side instead.
+        return the caller's own existing quick-access agent for this
+        template as-is, or create and publish a fresh one. Unlike the plain
+        create path this never raises on a duplicate default name; it
+        disambiguates server-side instead. Reuse never republishes a found
+        agent that isn't currently published - see
+        :meth:`_resolve_agent_from_template_sync` for why.
 
         Contrast with :meth:`create_agent_from_template`, which is a pure
         create used by flows that deliberately mint multiple instances of one
-        template under user-chosen names (workforce workers); a DB-level
-        uniqueness constraint on (user_id, template_id) would break those, so
-        idempotency for the reuse flow lives here instead.
+        template under user-chosen names (workforce workers, via the plain
+        ``origin=user`` ``POST /from-template``); those agents are invisible
+        to this method's reuse query (origin-scoped, see
+        AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX) and a DB-level uniqueness
+        constraint on plain (user_id, template_id) would have broken them, so
+        the constraint backing this method's idempotency is scoped to the
+        quick-access origin specifically.
 
         Returns the detached agent snapshot and whether it was newly created.
         """
@@ -1328,28 +1381,41 @@ class AgentManagementRuntime:
         SessionLocal = get_session_local()
         with SessionLocal() as db:
             service = AgentManagementService(db)
+            last_error: (
+                DuplicateAgentNameError | TemplateQuickAccessRaceError | None
+            ) = None
             for _ in range(TEMPLATE_RESOLVE_RACE_RETRIES):
                 # Strictly the caller's own rows (user_id filter, not the
                 # team-wide owned_agent_clause): this path may publish what it
                 # finds, and publishing a teammate's in-progress draft on this
                 # user's behalf is exactly the bug this server-side resolve
-                # exists to prevent (PR review finding F1). Lowest id wins so
-                # concurrent duplicates resolve deterministically (F3).
+                # exists to prevent (PR review finding F1). Also strictly
+                # scoped to the quick-access origin (PR review finding B4):
+                # without it, this query could adopt (and publish) an
+                # unrelated agent the workforce-builder UI built from the
+                # same template under a user-chosen name, since that flow
+                # writes template_id too. Lowest id wins so concurrent
+                # duplicates resolve deterministically (F3).
                 existing = (
                     db.query(Agent)
                     .filter(
                         Agent.user_id == user_id,
                         Agent.template_id == template_id,
+                        Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
                     )
                     .order_by(Agent.id)
                     .first()
                 )
                 if existing is not None:
-                    if existing.status != AgentStatus.PUBLISHED:
-                        existing = (
-                            service.store.publish_agent(user_id, int(existing.id))
-                            or existing
-                        )
+                    # Deliberately does not auto-publish a found draft (PR
+                    # review finding B3): status/published_at alone can't
+                    # distinguish "never published yet" (the create-then-
+                    # publish below failed) from "the user explicitly
+                    # unpublished it" - both look identical. Silently
+                    # republishing on an unrelated later call would revert
+                    # that choice with zero visible signal. Returning it
+                    # as-is is honest either way; the response's own
+                    # status/published_at fields tell the caller the truth.
                     return (
                         _agent_response_snapshot(
                             service.store.agent_to_response_dict(existing)
@@ -1374,19 +1440,26 @@ class AgentManagementRuntime:
                         suggested_prompts=list(spec.suggested_prompts),
                         generate_runtime_key=False,
                         template_id=template_id,
+                        origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
                     )
-                except DuplicateAgentNameError:
+                except (DuplicateAgentNameError, TemplateQuickAccessRaceError) as exc:
                     # A concurrent request inserted between our select and our
-                    # insert (the unique name we picked, or this same template's
-                    # agent). Re-select: if it was this template we reuse it,
-                    # otherwise resolve_unique_agent_name picks a fresh name.
+                    # insert. DuplicateAgentNameError means it took the exact
+                    # name we picked; TemplateQuickAccessRaceError means it
+                    # won this same (user, template)'s quick-access row even
+                    # under a *different*, disambiguated name - the case the
+                    # name-collision-only retry used to miss entirely (PR
+                    # review findings B1/B2). Either way, re-select: if it was
+                    # this template's quick-access agent we reuse it, else
+                    # resolve_unique_agent_name picks a fresh name next pass.
+                    last_error = exc
                     db.rollback()
                     continue
 
                 # Publish in a second commit. If this fails the create still
-                # stands, and the next resolve call finds the draft and
-                # publishes it - the flow self-heals instead of needing the
-                # client-side delete-on-failure rollback it replaced.
+                # stands as an unpublished draft; per the note on the reuse
+                # branch above, a later resolve call now returns it as-is
+                # rather than silently republishing it.
                 agent = service.store.publish_agent(user_id, int(agent.id)) or agent
                 return (
                     _agent_response_snapshot(
@@ -1394,7 +1467,7 @@ class AgentManagementRuntime:
                     ),
                     True,
                 )
-            raise DuplicateAgentNameError(spec.name)
+            raise last_error or DuplicateAgentNameError(spec.name)
 
     async def rotate_agent_runtime_key(
         self,

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -84,6 +84,7 @@ class AgentCreateSpec:
     tool_categories: tuple[str, ...]
     suggested_prompts: tuple[str, ...]
     generate_runtime_key: bool
+    template_id: str | None = None
 
     @classmethod
     def from_values(
@@ -99,6 +100,7 @@ class AgentCreateSpec:
         tool_categories: list[str] | tuple[str, ...] | None,
         suggested_prompts: list[str] | tuple[str, ...] | None,
         generate_runtime_key: bool,
+        template_id: str | None = None,
     ) -> AgentCreateSpec:
         frozen_models: tuple[tuple[str, int | None], ...] | None = None
         if models is not None:
@@ -116,6 +118,7 @@ class AgentCreateSpec:
             skills=tuple(skills or ()),
             tool_categories=tuple(tool_categories or ()),
             suggested_prompts=tuple(suggested_prompts or ()),
+            template_id=template_id,
             generate_runtime_key=generate_runtime_key,
         )
 
@@ -166,6 +169,7 @@ class AgentResponseSnapshot:
     allowed_domains: tuple[str, ...]
     share_enabled: bool
     share_updated_at: str | None
+    template_id: str | None = None
 
     def model_mapping(self) -> dict[str, Any] | None:
         return dict(self.models) if self.models is not None else None
@@ -196,6 +200,7 @@ class AgentResponseSnapshot:
             "allowed_domains": list(self.allowed_domains),
             "share_enabled": self.share_enabled,
             "share_updated_at": self.share_updated_at,
+            "template_id": self.template_id,
         }
 
 
@@ -538,6 +543,7 @@ class AgentManagementService:
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
         generate_runtime_key: bool = True,
+        template_id: str | None = None,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
         """Sole external create entry point: validate KBs (async) then
         run the transactional create. Every public create path
@@ -562,6 +568,7 @@ class AgentManagementService:
             tool_categories=tool_categories,
             suggested_prompts=suggested_prompts,
             generate_runtime_key=generate_runtime_key,
+            template_id=template_id,
         )
 
     def create_agent_with_optional_key(
@@ -579,6 +586,7 @@ class AgentManagementService:
         suggested_prompts: list[str] | None = None,
         generate_runtime_key: bool = True,
         runtime_key_candidate: ApiKeyCandidate | None = None,
+        template_id: str | None = None,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
         """Create an agent and (optionally) its first runtime key in a
         single transaction. Internal transaction executor: assumes
@@ -593,15 +601,17 @@ class AgentManagementService:
         commits once at the boundary, rolling back atomically on any
         failure.
 
-        Conflict contract: the only IntegrityError this path can raise
-        comes from the runtime key's ``key_prefix`` unique constraint
-        (the ``uq_agent_api_keys_agent_active`` partial index that used
-        to also live here was dropped for multi-key support -- an agent
-        may hold more than one active key now); the agent table has no
-        unique constraint and therefore does not contribute one. If a
-        ``(user_id, name)`` unique constraint is ever added to agents,
-        the conflict translation here must be split by source (agent ->
-        duplicate-name 400, key -> 409).
+        Conflict contract: ``agent_name_exists`` is a fast-path pre-check,
+        not the source of truth -- the ``uq_agents_user_id_name_active``
+        partial unique index (excludes workforce-generated-manager agents,
+        matching ``agent_name_exists``) is what actually prevents a
+        concurrent-request race, so the agent insert's flush can itself
+        raise IntegrityError and is translated to ``DuplicateAgentNameError``
+        below. The only other IntegrityError source is the runtime key's
+        ``key_prefix`` unique constraint (the ``uq_agent_api_keys_agent_active``
+        partial index that used to also live here was dropped for multi-key
+        support -- an agent may hold more than one active key now), handled
+        separately inside ``complete_runtime_key_delivery``.
 
         Delivery contract: once a runtime-key receipt exists, an ambiguous
         commit result or post-commit response failure is wrapped in
@@ -614,23 +624,29 @@ class AgentManagementService:
 
         models = self._validate_models(models, user_id=user_id)
 
-        agent = self.store.add_agent(  # flush, no commit
-            user_id=user_id,
-            name=name,
-            description=description,
-            instructions=instructions,
-            execution_mode=execution_mode or "balanced",
-            models=models,
-            knowledge_bases=knowledge_bases or [],
-            skills=skills or [],
-            tool_categories=tool_categories or [],
-            suggested_prompts=suggested_prompts or [],
-        )
+        try:
+            agent = self.store.add_agent(  # flush, no commit
+                user_id=user_id,
+                name=name,
+                description=description,
+                instructions=instructions,
+                execution_mode=execution_mode or "balanced",
+                models=models,
+                knowledge_bases=knowledge_bases or [],
+                skills=skills or [],
+                tool_categories=tool_categories or [],
+                suggested_prompts=suggested_prompts or [],
+                template_id=template_id,
+            )
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise DuplicateAgentNameError(name) from exc
 
-        # The runtime key is the only write that can raise IntegrityError
-        # here (agent has no unique constraint), so the conflict-to-409
-        # translation wraps key staging + commit together. See the
-        # contract note in the docstring above.
+        # The agent-name race is handled above via the add_agent flush; the
+        # runtime key is the only remaining write that can raise
+        # IntegrityError here, so its conflict-to-409 translation happens
+        # inside complete_runtime_key_delivery. See the contract note in the
+        # docstring above.
         def stage_runtime_key() -> tuple[AgentApiKey, str] | None:
             if generate_runtime_key:
                 staged_key = self.key_service.stage_rotated_key(
@@ -725,6 +741,7 @@ class AgentManagementService:
             generate_runtime_key=generate_runtime_key,
             name=final_name,
             description=final_description,
+            template_id=template_id,
             instructions=(
                 instructions
                 if instructions is not None
@@ -848,6 +865,7 @@ def _agent_response_snapshot(payload: dict[str, Any]) -> AgentResponseSnapshot:
         allowed_domains=tuple(payload.get("allowed_domains") or ()),
         share_enabled=bool(payload["share_enabled"]),
         share_updated_at=cast("str | None", payload.get("share_updated_at")),
+        template_id=cast("str | None", payload.get("template_id")),
     )
 
 
@@ -1076,6 +1094,7 @@ class AgentManagementRuntime:
                     suggested_prompts=list(spec.suggested_prompts),
                     generate_runtime_key=spec.generate_runtime_key,
                     runtime_key_candidate=candidate,
+                    template_id=spec.template_id,
                 )
                 agent_snapshot = _agent_response_snapshot(
                     service.store.agent_to_response_dict(agent)
@@ -1141,6 +1160,7 @@ class AgentManagementRuntime:
         spec = AgentCreateSpec.from_values(
             name=name or template.get("name") or template_id,
             description=final_description,
+            template_id=template_id,
             instructions=(
                 instructions
                 if instructions is not None

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -21,7 +21,7 @@ from ...core.utils.api_key import (
     generate_api_key,
 )
 from ...templates.manager import TemplateManager
-from ..models.agent import AGENT_NAME_UNIQUE_INDEX, Agent
+from ..models.agent import AGENT_NAME_UNIQUE_INDEX, Agent, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_session_local, release_db_connection_if_clean
 from ..models.model import Model as DBModel
@@ -45,6 +45,7 @@ from .db_runtime import (
 )
 from .workforce_access import can_edit_workforce, filter_visible_workforces
 from .workforce_lifecycle import is_workforce_manager_discard_safe
+from .workforce_names import resolve_unique_agent_name
 
 logger = logging.getLogger(__name__)
 _RuntimeKeyResultT = TypeVar("_RuntimeKeyResultT")
@@ -52,6 +53,11 @@ _RuntimeKeyResultT = TypeVar("_RuntimeKeyResultT")
 # Agent-builder tool category that gates knowledge-base access. A KB
 # selection is only valid when this category is also enabled.
 KNOWLEDGE_TOOL_CATEGORY = "knowledge"
+
+# Select-then-insert retries for resolve_agent_from_template: each retry
+# re-selects, so a concurrent insert of this same template's agent converges
+# to reuse and an unrelated name race picks a fresh candidate name.
+TEMPLATE_RESOLVE_RACE_RETRIES = 3
 
 
 class DuplicateAgentNameError(ValueError):
@@ -1162,11 +1168,9 @@ class AgentManagementRuntime:
             traceback=error.__traceback__,
         )
 
-    async def create_agent_from_template(
+    async def _spec_from_template(
         self,
         *,
-        user_id: int,
-        is_admin: bool,
         template_id: str,
         name: str | None,
         description: str | None,
@@ -1178,7 +1182,8 @@ class AgentManagementRuntime:
         tool_categories: list[str] | None,
         suggested_prompts: list[str] | None,
         generate_runtime_key: bool,
-    ) -> AgentCreateSnapshot:
+    ) -> AgentCreateSpec:
+        """Resolve a template (async I/O) into a detached create spec."""
         if self.template_manager is None:
             raise TemplateNotFoundError(template_id)
         template = await self.template_manager.get_template(template_id)
@@ -1194,7 +1199,7 @@ class AgentManagementRuntime:
             elif isinstance(descriptions, str):
                 final_description = descriptions
 
-        spec = AgentCreateSpec.from_values(
+        return AgentCreateSpec.from_values(
             name=name or template.get("name") or template_id,
             description=final_description,
             template_id=template_id,
@@ -1223,11 +1228,173 @@ class AgentManagementRuntime:
             ),
             generate_runtime_key=generate_runtime_key,
         )
+
+    async def create_agent_from_template(
+        self,
+        *,
+        user_id: int,
+        is_admin: bool,
+        template_id: str,
+        name: str | None,
+        description: str | None,
+        instructions: str | None,
+        execution_mode: str | None,
+        models: dict[str, Any] | None,
+        knowledge_bases: list[str] | None,
+        skills: list[str] | None,
+        tool_categories: list[str] | None,
+        suggested_prompts: list[str] | None,
+        generate_runtime_key: bool,
+    ) -> AgentCreateSnapshot:
+        spec = await self._spec_from_template(
+            template_id=template_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
         return await self.create_agent(
             user_id=user_id,
             is_admin=is_admin,
             spec=spec,
         )
+
+    async def resolve_agent_from_template(
+        self,
+        *,
+        user_id: int,
+        is_admin: bool,
+        template_id: str,
+        name: str | None = None,
+    ) -> tuple[AgentResponseSnapshot, bool]:
+        """Atomic server-side get-or-create keyed on (user_id, template_id).
+
+        Backs flows with reuse semantics (the /task template quick-access):
+        return the caller's own existing agent for this template - publishing
+        it first if it is still a draft - or create and publish a fresh one.
+        Unlike the plain create path this never raises on a duplicate default
+        name; it disambiguates server-side instead.
+
+        Contrast with :meth:`create_agent_from_template`, which is a pure
+        create used by flows that deliberately mint multiple instances of one
+        template under user-chosen names (workforce workers); a DB-level
+        uniqueness constraint on (user_id, template_id) would break those, so
+        idempotency for the reuse flow lives here instead.
+
+        Returns the detached agent snapshot and whether it was newly created.
+        """
+        spec = await self._spec_from_template(
+            template_id=template_id,
+            name=name,
+            description=None,
+            instructions=None,
+            execution_mode=None,
+            models=None,
+            knowledge_bases=None,
+            skills=None,
+            tool_categories=None,
+            suggested_prompts=None,
+            # The quick-access flow talks to the agent through the normal
+            # chat session, never through a runtime API key.
+            generate_runtime_key=False,
+        )
+        await _validate_agent_knowledge_bases(
+            knowledge_bases=spec.knowledge_bases,
+            tool_categories=spec.tool_categories,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        return await run_db_io_cancellation_safe(
+            lambda: self._resolve_agent_from_template_sync(
+                user_id=user_id,
+                template_id=template_id,
+                spec=spec,
+            )
+        )
+
+    @staticmethod
+    def _resolve_agent_from_template_sync(
+        *,
+        user_id: int,
+        template_id: str,
+        spec: AgentCreateSpec,
+    ) -> tuple[AgentResponseSnapshot, bool]:
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            service = AgentManagementService(db)
+            for _ in range(TEMPLATE_RESOLVE_RACE_RETRIES):
+                # Strictly the caller's own rows (user_id filter, not the
+                # team-wide owned_agent_clause): this path may publish what it
+                # finds, and publishing a teammate's in-progress draft on this
+                # user's behalf is exactly the bug this server-side resolve
+                # exists to prevent (PR review finding F1). Lowest id wins so
+                # concurrent duplicates resolve deterministically (F3).
+                existing = (
+                    db.query(Agent)
+                    .filter(
+                        Agent.user_id == user_id,
+                        Agent.template_id == template_id,
+                    )
+                    .order_by(Agent.id)
+                    .first()
+                )
+                if existing is not None:
+                    if existing.status != AgentStatus.PUBLISHED:
+                        existing = (
+                            service.store.publish_agent(user_id, int(existing.id))
+                            or existing
+                        )
+                    return (
+                        _agent_response_snapshot(
+                            service.store.agent_to_response_dict(existing)
+                        ),
+                        False,
+                    )
+
+                candidate_name = resolve_unique_agent_name(
+                    db, user_id=user_id, name=spec.name
+                )
+                try:
+                    agent, _ = service.create_agent_with_optional_key(
+                        user_id=user_id,
+                        name=candidate_name,
+                        description=spec.description,
+                        instructions=spec.instructions,
+                        execution_mode=spec.execution_mode,
+                        models=spec.model_mapping(),
+                        knowledge_bases=list(spec.knowledge_bases),
+                        skills=list(spec.skills),
+                        tool_categories=list(spec.tool_categories),
+                        suggested_prompts=list(spec.suggested_prompts),
+                        generate_runtime_key=False,
+                        template_id=template_id,
+                    )
+                except DuplicateAgentNameError:
+                    # A concurrent request inserted between our select and our
+                    # insert (the unique name we picked, or this same template's
+                    # agent). Re-select: if it was this template we reuse it,
+                    # otherwise resolve_unique_agent_name picks a fresh name.
+                    db.rollback()
+                    continue
+
+                # Publish in a second commit. If this fails the create still
+                # stands, and the next resolve call finds the draft and
+                # publishes it - the flow self-heals instead of needing the
+                # client-side delete-on-failure rollback it replaced.
+                agent = service.store.publish_agent(user_id, int(agent.id)) or agent
+                return (
+                    _agent_response_snapshot(
+                        service.store.agent_to_response_dict(agent)
+                    ),
+                    True,
+                )
+            raise DuplicateAgentNameError(spec.name)
 
     async def rotate_agent_runtime_key(
         self,

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -1340,6 +1340,14 @@ class AgentManagementRuntime:
         the constraint backing this method's idempotency is scoped to the
         quick-access origin specifically.
 
+        ``name`` is create-only: it seeds the name for a freshly minted
+        agent (disambiguated server-side on collision) but is not consulted
+        on the reuse path. A caller passing a different ``name`` on a repeat
+        call for a template it already has a quick-access agent for gets
+        that existing agent back under its original name, silently -- the
+        response's ``agent.name`` is the source of truth for what a caller
+        should reconcile against.
+
         Returns the detached agent snapshot and whether it was newly created.
         """
         spec = await self._spec_from_template(
@@ -1381,6 +1389,12 @@ class AgentManagementRuntime:
         SessionLocal = get_session_local()
         with SessionLocal() as db:
             service = AgentManagementService(db)
+            # Sticky: once a TemplateQuickAccessRaceError is seen, it is never
+            # overwritten by a later DuplicateAgentNameError - retry
+            # exhaustion must surface 409 even when a later attempt's
+            # collision happened to be a plain name collision instead,
+            # otherwise the two are indistinguishable to the caller (PR
+            # review finding m6).
             last_error: (
                 DuplicateAgentNameError | TemplateQuickAccessRaceError | None
             ) = None
@@ -1452,7 +1466,8 @@ class AgentManagementRuntime:
                     # review findings B1/B2). Either way, re-select: if it was
                     # this template's quick-access agent we reuse it, else
                     # resolve_unique_agent_name picks a fresh name next pass.
-                    last_error = exc
+                    if not isinstance(last_error, TemplateQuickAccessRaceError):
+                        last_error = exc
                     db.rollback()
                     continue
 

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -152,6 +152,7 @@ class AgentStore:
             "name": agent.name,
             "description": agent.description,
             "instructions": agent.instructions,
+            "template_id": agent.template_id,
             "execution_mode": agent.execution_mode or "graph",
             "models": agent.models,
             "knowledge_bases": ensure_list(agent.knowledge_bases) or [],
@@ -180,6 +181,7 @@ class AgentStore:
             "team_id": agent.team_id,
             "name": agent.name,
             "description": agent.description,
+            "template_id": agent.template_id,
             "logo_url": agent.logo_url,
             "status": agent.status.value,
             "visibility": agent.visibility,
@@ -326,6 +328,7 @@ class AgentStore:
         share_token: str | None = None,
         share_updated_at: datetime | None = None,
         visibility: str | None = None,
+        template_id: str | None = None,
     ) -> Agent:
         agent = self.add_agent(
             user_id=user_id,
@@ -347,6 +350,7 @@ class AgentStore:
             share_token=share_token,
             share_updated_at=share_updated_at,
             visibility=visibility,
+            template_id=template_id,
         )
         self.db.commit()
         self.db.refresh(agent)
@@ -378,6 +382,7 @@ class AgentStore:
         share_token: str | None = None,
         share_updated_at: datetime | None = None,
         visibility: str | None = None,
+        template_id: str | None = None,
     ) -> Agent:
         if status == AgentStatus.PUBLISHED and published_at is None:
             published_at = datetime.now(timezone.utc)
@@ -396,6 +401,7 @@ class AgentStore:
             name=name,
             description=description,
             instructions=instructions,
+            template_id=template_id,
             execution_mode=execution_mode or "graph",
             models=models,
             knowledge_bases=knowledge_bases or [],

--- a/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
@@ -284,6 +284,31 @@ class TestDedupeRenamesLosingDuplicates:
         assert len(set(names.values())) == 3
         engine.dispose()
 
+    def test_rename_candidate_is_truncated_to_fit_the_name_column(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        """Regression test for F5: a pre-existing name at or near
+        Agent.name's String(200) limit must not overflow once the rename
+        suffix is appended - that would raise StringDataRightTruncation on
+        backends (e.g. Postgres) that enforce column length, aborting the
+        exact migration written to survive messy data.
+        """
+        long_name = "x" * 200
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(conn, agent_id=40, user_id=1, name=long_name)
+            _insert_agent(conn, agent_id=41, user_id=1, name=long_name)
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        names = _agent_names_by_id(engine)
+        assert names[40] == long_name
+        assert len(names[41]) <= 200
+        assert names[41] != long_name
+        assert names[41].endswith("(41)")
+        engine.dispose()
+
 
 class TestDowngrade:
     def test_downgrade_removes_column_and_indexes_but_keeps_renamed_names(

--- a/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
@@ -28,7 +28,7 @@ from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
 
-PARENT_REVISION = "20260730_seed_zoom_mcp_app"
+PARENT_REVISION = "20260801_add_trigger_consecutive_prepare_failures"
 TARGET_REVISION = "20260728_add_agent_template_id_and_name_uniqueness"
 
 _CREATE_USERS_TABLE = """

--- a/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
@@ -142,6 +142,34 @@ def _agent_names_by_id(engine: Any) -> dict[int, str]:
     return {row[0]: row[1] for row in rows}
 
 
+def _insert_agent_with_template(
+    conn: Any,
+    *,
+    agent_id: int,
+    user_id: int,
+    name: str,
+    template_id: str,
+    origin: str = "template_quick_access",
+) -> None:
+    """Only valid post-migration - template_id doesn't exist beforehand."""
+    conn.execute(
+        sa.text(
+            "INSERT INTO agents "
+            "(id, user_id, name, execution_mode, widget_enabled, share_enabled, "
+            "origin, status, template_id, created_at, updated_at) "
+            "VALUES (:id, :user_id, :name, 'balanced', 1, 0, :origin, 'draft', "
+            ":template_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        {
+            "id": agent_id,
+            "user_id": user_id,
+            "name": name,
+            "origin": origin,
+            "template_id": template_id,
+        },
+    )
+
+
 class TestUpgradeAddsSchema:
     def test_template_id_column_and_index_added(
         self, db_url: str, config_at_parent_revision: Config
@@ -203,6 +231,90 @@ class TestUpgradeAddsSchema:
         with engine.begin() as conn:
             count = conn.execute(
                 sa.text("SELECT COUNT(*) FROM agents WHERE name = 'Manager'")
+            ).scalar()
+        assert count == 2
+        engine.dispose()
+
+
+class TestTemplateQuickAccessUniqueIndex:
+    """Covers AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX, the partial unique
+    index on (user_id, template_id) scoped to origin='template_quick_access'
+    that backs the /task template quick-access resolve flow's atomicity
+    (PR review findings B1/B2/D2/D3)."""
+
+    def test_index_added(self, db_url: str, config_at_parent_revision: Config) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        index_names = {idx["name"] for idx in inspector.get_indexes("agents")}
+        assert "uq_agents_user_id_template_id_quick_access" in index_names
+        engine.dispose()
+
+    def test_rejects_same_user_template_duplicate_within_quick_access_origin(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            _insert_agent_with_template(
+                conn,
+                agent_id=1,
+                user_id=1,
+                name="Quick Access Agent",
+                template_id="tmpl-a",
+            )
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                _insert_agent_with_template(
+                    conn,
+                    agent_id=2,
+                    user_id=1,
+                    name="Quick Access Agent 2",
+                    template_id="tmpl-a",
+                )
+        engine.dispose()
+
+    def test_allows_a_non_quick_access_duplicate_for_the_same_template(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        """A workforce-builder agent (origin='user') built from the same
+        template as an existing quick-access agent must not collide - the
+        index is scoped to the quick-access origin only (B4)."""
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            _insert_agent_with_template(
+                conn,
+                agent_id=1,
+                user_id=1,
+                name="Quick Access Agent",
+                template_id="tmpl-a",
+                origin="template_quick_access",
+            )
+        with engine.begin() as conn:
+            _insert_agent_with_template(
+                conn,
+                agent_id=2,
+                user_id=1,
+                name="Workforce Worker",
+                template_id="tmpl-a",
+                origin="user",
+            )
+        with engine.begin() as conn:
+            count = conn.execute(
+                sa.text("SELECT COUNT(*) FROM agents WHERE template_id = 'tmpl-a'")
             ).scalar()
         assert count == 2
         engine.dispose()

--- a/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
@@ -1,0 +1,320 @@
+"""Tests for migration 20260728_add_agent_template_id_and_name_uniqueness.
+
+Covers:
+- template_id column + index added on upgrade
+- the per-user (user_id, name) partial unique index, excluding
+  workforce_generated_manager agents
+- the pre-index dedupe rename pass, including the rename-target-collision
+  guard (regression test for PR review finding F3)
+- downgrade removing the column/indexes without attempting to restore
+  renamed names (documented, not a bug - see F4)
+
+Following this repo's existing migration-test convention (see
+tests/migrations/test_custom_api_migration.py): rather than replaying the
+full alembic history, the minimal pre-migration `users`/`agents` schema is
+created directly with raw DDL, stamped to this migration's parent revision,
+and only the migration under test is run against it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+PARENT_REVISION = "20260724_add_upload_source_to_uploaded_files"
+TARGET_REVISION = "20260728_add_agent_template_id_and_name_uniqueness"
+
+_CREATE_USERS_TABLE = """
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    email VARCHAR(255) UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    is_admin BOOLEAN NOT NULL DEFAULT 0,
+    created_at DATETIME,
+    updated_at DATETIME
+)
+"""
+
+# Mirrors Agent's pre-migration columns (everything except template_id,
+# which this migration under test adds).
+_CREATE_AGENTS_TABLE = """
+CREATE TABLE agents (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    team_id INTEGER,
+    visibility VARCHAR(20) NOT NULL DEFAULT 'team',
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    instructions TEXT,
+    execution_mode VARCHAR(20) NOT NULL,
+    models JSON,
+    knowledge_bases JSON,
+    skills JSON,
+    tool_categories JSON,
+    suggested_prompts JSON,
+    logo_url VARCHAR(500),
+    widget_enabled BOOLEAN NOT NULL,
+    allowed_domains JSON,
+    widget_key VARCHAR(255) UNIQUE,
+    share_enabled BOOLEAN NOT NULL,
+    share_token VARCHAR(255),
+    share_updated_at DATETIME,
+    origin VARCHAR(50) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    published_at DATETIME,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+)
+"""
+
+
+@pytest.fixture
+def db_url(tmp_path: Path) -> str:
+    return f"sqlite:///{tmp_path / 'test.db'}"
+
+
+@pytest.fixture
+def config_at_parent_revision(db_url: str) -> Config:
+    """Alembic config for a database already at this migration's parent
+    revision: `agents`/`users` exist with their pre-migration schema."""
+    config = Config()
+    config.set_main_option("sqlalchemy.url", db_url)
+    config.set_main_option("script_location", "src/xagent/migrations")
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                f"INSERT INTO alembic_version (version_num) VALUES ('{PARENT_REVISION}')"
+            )
+        )
+        conn.execute(text(_CREATE_USERS_TABLE))
+        conn.execute(text(_CREATE_AGENTS_TABLE))
+    engine.dispose()
+
+    return config
+
+
+def _insert_user(conn: Any, user_id: int) -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO users (id, username, password_hash, is_admin) "
+            "VALUES (:id, :username, 'hash', 0)"
+        ),
+        {"id": user_id, "username": f"user_{user_id}"},
+    )
+
+
+def _insert_agent(
+    conn: Any,
+    *,
+    agent_id: int,
+    user_id: int,
+    name: str,
+    origin: str = "user",
+) -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO agents "
+            "(id, user_id, name, execution_mode, widget_enabled, share_enabled, "
+            "origin, status, created_at, updated_at) "
+            "VALUES (:id, :user_id, :name, 'balanced', 1, 0, :origin, 'draft', "
+            "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        {"id": agent_id, "user_id": user_id, "name": name, "origin": origin},
+    )
+
+
+def _agent_names_by_id(engine: Any) -> dict[int, str]:
+    with engine.begin() as conn:
+        rows = conn.execute(sa.text("SELECT id, name FROM agents")).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+class TestUpgradeAddsSchema:
+    def test_template_id_column_and_index_added(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("agents")}
+        assert "template_id" in columns
+
+        index_names = {idx["name"] for idx in inspector.get_indexes("agents")}
+        assert "ix_agents_template_id" in index_names
+        assert "uq_agents_user_id_name_active" in index_names
+        engine.dispose()
+
+    def test_unique_index_rejects_same_user_duplicate_after_migration(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(conn, agent_id=1, user_id=1, name="Unique Agent")
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                _insert_agent(conn, agent_id=2, user_id=1, name="Unique Agent")
+        engine.dispose()
+
+    def test_unique_index_allows_workforce_manager_duplicates_after_migration(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(
+                conn,
+                agent_id=1,
+                user_id=1,
+                name="Manager",
+                origin="workforce_generated_manager",
+            )
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            _insert_agent(
+                conn,
+                agent_id=2,
+                user_id=1,
+                name="Manager",
+                origin="workforce_generated_manager",
+            )
+        with engine.begin() as conn:
+            count = conn.execute(
+                sa.text("SELECT COUNT(*) FROM agents WHERE name = 'Manager'")
+            ).scalar()
+        assert count == 2
+        engine.dispose()
+
+
+class TestDedupeRenamesLosingDuplicates:
+    def test_lowest_id_keeps_name_later_rows_get_suffixed(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(conn, agent_id=10, user_id=1, name="Dup Agent")
+            _insert_agent(conn, agent_id=11, user_id=1, name="Dup Agent")
+            _insert_agent(conn, agent_id=12, user_id=1, name="Dup Agent")
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        names = _agent_names_by_id(engine)
+        assert names[10] == "Dup Agent"
+        assert names[11] == "Dup Agent (11)"
+        assert names[12] == "Dup Agent (12)"
+        engine.dispose()
+
+    def test_workforce_manager_rows_are_not_deduped(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(
+                conn,
+                agent_id=20,
+                user_id=1,
+                name="Manager Dup",
+                origin="workforce_generated_manager",
+            )
+            _insert_agent(
+                conn,
+                agent_id=21,
+                user_id=1,
+                name="Manager Dup",
+                origin="workforce_generated_manager",
+            )
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        names = _agent_names_by_id(engine)
+        assert names[20] == "Manager Dup"
+        assert names[21] == "Manager Dup"
+        engine.dispose()
+
+    def test_rename_target_collision_falls_back_to_a_free_name(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        """Regression test for F3: the naive rename target
+        "{name} ({agent_id})" can itself already be taken by an unrelated
+        row for the same user. The dedupe pass must keep searching for a
+        genuinely free name instead of creating a *new* collision that would
+        then make the unique-index build itself fail.
+        """
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(conn, agent_id=30, user_id=1, name="Foo")
+            _insert_agent(conn, agent_id=31, user_id=1, name="Foo")
+            # Pre-existing row that happens to already occupy the naive
+            # rename target the dedupe pass would otherwise pick for id 31.
+            _insert_agent(conn, agent_id=32, user_id=1, name="Foo (31)")
+
+        # Must not raise - the migration should resolve the collision itself.
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        names = _agent_names_by_id(engine)
+        assert names[30] == "Foo"
+        assert names[32] == "Foo (31)"
+        assert names[31] not in ("Foo", "Foo (31)")
+        assert names[31].startswith("Foo (31-")
+        assert len(set(names.values())) == 3
+        engine.dispose()
+
+
+class TestDowngrade:
+    def test_downgrade_removes_column_and_indexes_but_keeps_renamed_names(
+        self, db_url: str, config_at_parent_revision: Config
+    ) -> None:
+        with create_engine(db_url).begin() as conn:
+            _insert_user(conn, 1)
+            _insert_agent(conn, agent_id=40, user_id=1, name="Renamed Group")
+            _insert_agent(conn, agent_id=41, user_id=1, name="Renamed Group")
+
+        command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+        engine = create_engine(db_url)
+        names_after_upgrade = _agent_names_by_id(engine)
+        assert names_after_upgrade[41] == "Renamed Group (41)"
+        engine.dispose()
+
+        command.downgrade(config_at_parent_revision, PARENT_REVISION)
+
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("agents")}
+        assert "template_id" not in columns
+
+        index_names = {idx["name"] for idx in inspector.get_indexes("agents")}
+        assert "ix_agents_template_id" not in index_names
+        assert "uq_agents_user_id_name_active" not in index_names
+
+        # Renaming is a one-way disambiguation - downgrade does not attempt
+        # to restore the pre-migration colliding name (see the migration's
+        # module docstring).
+        names_after_downgrade = _agent_names_by_id(engine)
+        assert names_after_downgrade[41] == "Renamed Group (41)"
+        engine.dispose()

--- a/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
+++ b/tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py
@@ -28,7 +28,7 @@ from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
 
-PARENT_REVISION = "20260724_add_upload_source_to_uploaded_files"
+PARENT_REVISION = "20260730_seed_zoom_mcp_app"
 TARGET_REVISION = "20260728_add_agent_template_id_and_name_uniqueness"
 
 _CREATE_USERS_TABLE = """

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -229,7 +229,11 @@ descriptions:
         template = await manager.get_template("minimal_template")
 
         assert template is not None
-        assert template["tags"] == []
+        # tags/features are per-locale dicts (like descriptions/sample_prompts),
+        # so their "not authored" default is {} - get_localized_value resolves
+        # that to [] per-locale at the API layer (see test_template_data_structure).
+        assert template["tags"] == {}
+        assert template["features"] == {}
         assert template["author"] == "Xagent"
         assert template["version"] == "1.0"
         assert template["featured"] is False
@@ -280,6 +284,67 @@ sample_prompts:
         assert template["sample_prompts"]["en"][0]["title"] == "Do the thing"
         assert template["sample_prompts"]["en"][0]["highlights"] == ["paste input"]
         assert template["sample_prompts"]["zh"][0]["title"] == "做这件事"
+
+    @pytest.mark.asyncio
+    async def test_malformed_sample_prompts_entry_is_skipped_not_fatal(
+        self, temp_templates_dir
+    ):
+        """一个模板的 sample_prompts 条目缺少必需字段时，该模板应被跳过而不是让
+        整个模板目录加载失败（避免单个作者错误导致 GET /api/templates/ 500）。"""
+        bad_template = temp_templates_dir / "bad_prompts.yaml"
+        bad_template.write_text(
+            """
+id: bad_prompts
+name: Bad Prompts Template
+category: Support
+descriptions:
+  en: A template with a malformed sample prompt
+  zh: 一个带有格式错误提示词的模板
+sample_prompts:
+  en:
+  - title: Missing the prompt field
+    highlights: []
+"""
+        )
+
+        manager = TemplateManager(templates_root=temp_templates_dir)
+        await manager.initialize()
+
+        template = await manager.get_template("bad_prompts")
+        assert template is None
+
+        templates = await manager.list_templates()
+        template_ids = [t["id"] for t in templates]
+        assert "bad_prompts" not in template_ids
+        # The other, valid templates in the fixture directory still load.
+        assert "customer_support" in template_ids
+        assert "sales_assistant" in template_ids
+
+    @pytest.mark.asyncio
+    async def test_flat_list_sample_prompts_is_rejected(self, temp_templates_dir):
+        """sample_prompts 必须按语言分组（{"en": [...]}），写成扁平列表会静默
+        跳过本地化解析，因此在解析阶段就应当拒绝该写法。"""
+        bad_template = temp_templates_dir / "flat_prompts.yaml"
+        bad_template.write_text(
+            """
+id: flat_prompts
+name: Flat Prompts Template
+category: Support
+descriptions:
+  en: A template with a flat-list sample_prompts shape
+  zh: 一个 sample_prompts 为扁平列表的模板
+sample_prompts:
+- title: Not locale-keyed
+  prompt: This should have been nested under 'en'.
+  highlights: []
+"""
+        )
+
+        manager = TemplateManager(templates_root=temp_templates_dir)
+        await manager.initialize()
+
+        template = await manager.get_template("flat_prompts")
+        assert template is None
 
     @pytest.mark.asyncio
     async def test_skip_invalid_templates(self, temp_templates_dir):
@@ -389,6 +454,62 @@ sample_prompts:
                     offenders.append(f"{template_file.name}: {name}")
 
         assert not offenders
+
+    def test_builtin_sample_prompt_highlights_are_literal_substrings(self):
+        """Every highlight must be a literal substring of its own prompt, in
+        both locales - otherwise the frontend's highlight matching
+        (replaceFirstOccurrence) silently underlines nothing, or the wrong
+        word if an earlier literal duplicate shadows the intended placeholder
+        (this caught a real bug: see marketing-content-agent and
+        marketing-seo-brief-writer's original prompt wording)."""
+        built_in_dir = (
+            Path(__file__).resolve().parents[2] / "src/xagent/templates/built_in"
+        )
+        offenders: list[str] = []
+
+        for template_file in sorted(built_in_dir.glob("*.yaml")):
+            data = yaml.safe_load(template_file.read_text(encoding="utf-8")) or {}
+            sample_prompts = data.get("sample_prompts") or {}
+            if not isinstance(sample_prompts, dict):
+                offenders.append(
+                    f"{template_file.name}: sample_prompts is not a per-locale dict"
+                )
+                continue
+
+            for locale, prompts in sample_prompts.items():
+                for entry in prompts or []:
+                    prompt_text = entry.get("prompt") or ""
+                    for highlight in entry.get("highlights") or []:
+                        if highlight not in prompt_text:
+                            offenders.append(
+                                f"{template_file.name} [{locale}]: highlight "
+                                f"{highlight!r} not found in prompt {prompt_text!r}"
+                            )
+
+        assert not offenders, "\n".join(offenders)
+
+    def test_builtin_templates_cap_sample_prompts_at_two(self):
+        """The Task-page quick-access grid only ever renders the first 2
+        sample prompts per template (TemplateQuickAccess.tsx), so authoring
+        more than that on a built-in template is dead content that silently
+        never shows - catch it at authoring time instead."""
+        built_in_dir = (
+            Path(__file__).resolve().parents[2] / "src/xagent/templates/built_in"
+        )
+        offenders: list[str] = []
+
+        for template_file in sorted(built_in_dir.glob("*.yaml")):
+            data = yaml.safe_load(template_file.read_text(encoding="utf-8")) or {}
+            sample_prompts = data.get("sample_prompts") or {}
+            if not isinstance(sample_prompts, dict):
+                continue
+            for locale, prompts in sample_prompts.items():
+                if isinstance(prompts, list) and len(prompts) > 2:
+                    offenders.append(
+                        f"{template_file.name} [{locale}]: {len(prompts)} sample_prompts (max 2 are shown)"
+                    )
+
+        assert not offenders, "\n".join(offenders)
 
     @pytest.mark.asyncio
     async def test_nonexistent_templates_directory(self, tmp_path):

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -233,9 +233,53 @@ descriptions:
         assert template["author"] == "Xagent"
         assert template["version"] == "1.0"
         assert template["featured"] is False
+        assert template["sample_prompts"] == {}
         assert template["agent_config"]["instructions"] == ""
         assert template["agent_config"]["skills"] == []
         assert template["agent_config"]["tool_categories"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_template_with_sample_prompts(self, temp_templates_dir):
+        """测试模板的 sample_prompts 能正确加载并保留本地化结构"""
+        template_with_prompts = temp_templates_dir / "with_prompts.yaml"
+        template_with_prompts.write_text(
+            """
+id: with_prompts
+name: Template With Prompts
+category: Support
+descriptions:
+  en: A template with sample prompts
+  zh: 一个带有示例提示词的模板
+sample_prompts:
+  en:
+  - title: Do the thing
+    prompt: 'Do the thing: paste input.'
+    highlights:
+    - paste input
+  - title: Do another thing
+    prompt: Do another thing entirely.
+    highlights: []
+  zh:
+  - title: 做这件事
+    prompt: 做这件事：粘贴输入。
+    highlights:
+    - 粘贴输入
+  - title: 做另一件事
+    prompt: 做另一件完全不同的事。
+    highlights: []
+"""
+        )
+
+        manager = TemplateManager(templates_root=temp_templates_dir)
+        await manager.initialize()
+
+        template = await manager.get_template("with_prompts")
+
+        assert template is not None
+        assert len(template["sample_prompts"]["en"]) == 2
+        assert template["sample_prompts"]["en"][0]["title"] == "Do the thing"
+        assert template["sample_prompts"]["en"][0]["highlights"] == ["paste input"]
+        assert template["sample_prompts"]["zh"][0]["title"] == "做这件事"
 
     @pytest.mark.asyncio
     async def test_skip_invalid_templates(self, temp_templates_dir):

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -32,6 +32,7 @@ from xagent.web.services.agent_management import (
     AgentManagementService,
     AgentWorkforceConflictError,
     AgentWorkforceReference,
+    TemplateQuickAccessRaceError,
 )
 from xagent.web.services.task_runtime import (
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
@@ -334,9 +335,14 @@ def test_resolve_from_template_reuses_the_same_agent_on_repeat_calls(
     assert len(matching) == 1
 
 
-def test_resolve_from_template_publishes_the_callers_own_draft(
+def test_resolve_from_template_does_not_adopt_a_workforce_builder_draft(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Regression test for PR review finding B4: the plain POST
+    /from-template (workforce-builder UI, one-off named creates) writes
+    template_id but not the quick-access origin marker. The resolve flow's
+    reuse query must not adopt (and publish) that unrelated draft - it has
+    to mint its own separate quick-access agent instead."""
     headers = _admin_headers()
     _install_resolve_template_stub(monkeypatch)
 
@@ -354,9 +360,49 @@ def test_resolve_from_template_publishes_the_callers_own_draft(
         json={"template_id": "resolve-template"},
     )
     assert resolved.status_code == 200, resolved.text
-    assert resolved.json()["created"] is False
-    assert resolved.json()["agent"]["id"] == created.json()["id"]
+    assert resolved.json()["created"] is True
+    assert resolved.json()["agent"]["id"] != created.json()["id"]
     assert resolved.json()["agent"]["status"] == "published"
+
+    # The workforce-builder draft is untouched - still its own draft.
+    workforce_draft = client.get(f"/api/agents/{created.json()['id']}", headers=headers)
+    assert workforce_draft.status_code == 200, workforce_draft.text
+    assert workforce_draft.json()["status"] == "draft"
+
+
+def test_resolve_from_template_does_not_republish_a_deliberate_unpublish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding B3: status/published_at alone
+    can't distinguish "never published yet" from "the user explicitly
+    unpublished it" - both are status=draft, published_at=None. Resolve must
+    not silently flip a deliberate unpublish back to published on a later,
+    unrelated call."""
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    first = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["agent"]["status"] == "published"
+    agent_id = first.json()["agent"]["id"]
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+    assert unpublished.json()["agent"]["status"] == "draft"
+
+    second = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["created"] is False
+    assert second.json()["agent"]["id"] == agent_id
+    assert second.json()["agent"]["status"] == "draft"
 
 
 def test_resolve_from_template_never_touches_another_users_agent(
@@ -419,13 +465,15 @@ def test_resolve_from_template_disambiguates_a_colliding_default_name(
     assert body["agent"]["status"] == "published"
 
 
-def test_resolve_from_template_converges_when_a_racing_insert_wins(
+def test_resolve_from_template_converges_when_a_racing_insert_wins_the_same_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression test for PR review finding F3: if a concurrent request
     creates this template's agent between our select and our insert, the
     retry loop must re-select and reuse that row instead of erroring or
-    minting a duplicate."""
+    minting a duplicate. Here the racing insert collides on name too, which
+    is caught by the (user_id, name) unique index alone - see the sibling
+    test below for the interleaving where names do *not* collide (B1/B2)."""
 
     from xagent.web.services import agent_management as management_module
     from xagent.web.services.agent_store import AgentStore
@@ -450,6 +498,7 @@ def test_resolve_from_template_converges_when_a_racing_insert_wins(
                 instructions="Follow the template.",
                 execution_mode="balanced",
                 template_id="resolve-template",
+                origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
             )
             db.commit()
             racing_agent_id["id"] = int(racing.id)
@@ -468,6 +517,99 @@ def test_resolve_from_template_converges_when_a_racing_insert_wins(
     assert resolved.status_code == 200, resolved.text
     assert resolved.json()["created"] is False
     assert resolved.json()["agent"]["id"] == racing_agent_id["id"]
+
+
+def test_resolve_from_template_converges_when_a_racing_insert_wins_a_different_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding B2: the realistic interleaving
+    is a racing insert that takes its *own* disambiguated name - no
+    (user_id, name) collision at all - which the plain name-collision retry
+    from the sibling test above can't catch (it never fires, so the old
+    code's retry loop never re-selected, and two rows ended up sharing one
+    template_id with different names, both reporting created=True).
+    Convergence here depends entirely on
+    AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX - the (user_id, template_id)
+    partial unique index scoped to the quick-access origin (B1/D2/D3)."""
+
+    from xagent.web.services import agent_management as management_module
+    from xagent.web.services.agent_store import AgentStore
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    real_resolve_name = management_module.resolve_unique_agent_name
+    racing_agent_id: dict[str, int] = {}
+
+    def race_then_delegate(db: Any, *, user_id: int, name: str) -> str:
+        # Simulate a concurrent request winning the race between our SELECT
+        # and our INSERT - but, unlike the sibling test above, under a
+        # disambiguated name that never collides with our own. Only the
+        # first call (the "our own" resolve's own resolve_unique_agent_name
+        # lookup) triggers the race; the racing insert's own internal
+        # resolve_unique_agent_name call must not recurse into this hook.
+        if not racing_agent_id:
+            store = AgentStore(db)
+            racing = store.create_agent(
+                user_id=user_id,
+                name="Totally Unrelated Name",
+                description="raced in first, under a name that never collides",
+                instructions="Follow the template.",
+                execution_mode="balanced",
+                template_id="resolve-template",
+                origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+                status=AgentStatus.PUBLISHED,
+            )
+            db.commit()
+            racing_agent_id["id"] = int(racing.id)
+            # Our own insert proceeds under its natural, undisambiguated
+            # name - no name collision occurs at all.
+            return name
+        return real_resolve_name(db, user_id=user_id, name=name)
+
+    monkeypatch.setattr(
+        management_module, "resolve_unique_agent_name", race_then_delegate
+    )
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["created"] is False
+    assert resolved.json()["agent"]["id"] == racing_agent_id["id"]
+    assert resolved.json()["agent"]["name"] == "Totally Unrelated Name"
+
+
+def test_resolve_from_template_reports_409_when_retries_are_exhausted_by_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every TEMPLATE_RESOLVE_RACE_RETRIES attempt loses the
+    (user_id, template_id) quick-access race, the error must say so
+    honestly - not the name-collision 400, since no name collision is
+    involved at all in this failure mode."""
+    from xagent.web.services import agent_management as management_module
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    def always_races(*args: Any, **kwargs: Any) -> Any:
+        raise TemplateQuickAccessRaceError("resolve-template")
+
+    monkeypatch.setattr(
+        management_module.AgentManagementService,
+        "create_agent_with_optional_key",
+        always_races,
+    )
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 409, resolved.text
+    assert "name" not in resolved.json()["detail"].lower()
 
 
 def test_manually_created_agent_has_no_template_id() -> None:

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -211,14 +211,17 @@ def test_create_from_template_persists_template_id(
 def test_create_from_template_duplicate_name_returns_400_with_stable_detail(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The frontend's create-or-reuse flow
-    (template-agent-resolution.ts) branches its entire reuse-vs-duplicate
-    logic on this exact detail string from POST /api/agents/from-template
-    specifically - a different endpoint's exception handling from the plain
-    POST /api/agents duplicate-name test above. See PR review finding F2:
-    without this test, a refactor could change this endpoint's exception
-    mapping while every other test (DB-pool release, the clean-transaction
-    500 guard, template_id persistence) stayed green.
+    """Pins the exact 400 detail string POST /api/agents/from-template
+    returns on a name collision - a different endpoint's exception handling
+    from the plain POST /api/agents duplicate-name test above. See PR review
+    finding F2: without this test, a refactor could change this endpoint's
+    exception mapping while every other test (DB-pool release, the
+    clean-transaction 500 guard, template_id persistence) stayed green.
+
+    Note: template-agent-resolution.ts (the frontend's create-or-reuse
+    flow) does not itself branch on this string - it only checks
+    response.ok and surfaces the HTTP status. This test's value is the
+    stable API contract, not a cross-stack string dependency.
     """
 
     headers = _admin_headers()
@@ -612,6 +615,44 @@ def test_resolve_from_template_reports_409_when_retries_are_exhausted_by_race(
     assert "name" not in resolved.json()["detail"].lower()
 
 
+def test_resolve_from_template_reports_409_when_a_race_hit_precedes_final_name_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding m6: retry exhaustion must
+    report the quick-access race (409) whenever *any* attempt hit it, even
+    if the *last* attempt's collision happened to be a plain name collision
+    instead. Before this fix, only the last error's type was tracked, so
+    this exact interleaving (race, then name-collision, then name-collision)
+    surfaced a misleading 400 "Agent with this name already exists" - which
+    is wrong, since the caller never even chose a colliding name."""
+    from xagent.web.services import agent_management as management_module
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    attempts = {"n": 0}
+
+    def race_then_name_collisions(*args: Any, **kwargs: Any) -> Any:
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise TemplateQuickAccessRaceError("resolve-template")
+        raise management_module.DuplicateAgentNameError("Resolve Flow Agent")
+
+    monkeypatch.setattr(
+        management_module.AgentManagementService,
+        "create_agent_with_optional_key",
+        race_then_name_collisions,
+    )
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 409, resolved.text
+    assert "name" not in resolved.json()["detail"].lower()
+
+
 def test_manually_created_agent_has_no_template_id() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers, name="Hand-built agent")
@@ -622,7 +663,9 @@ def test_manually_created_agent_has_no_template_id() -> None:
 
 
 def test_duplicate_agent_name_returns_400_with_stable_detail() -> None:
-    """The frontend keys retry logic off this exact detail string."""
+    """Pins the exact 400 detail string POST /api/agents returns on a name
+    collision, so a refactor of this endpoint's exception mapping doesn't
+    silently change the API contract."""
 
     headers = _admin_headers()
     _create_agent(headers, name="Duplicate Name Agent")
@@ -678,6 +721,32 @@ def test_db_constraint_catches_name_race_the_app_precheck_missed(
     )
     assert second.status_code == 400, second.text
     assert second.json()["detail"] == "Agent with this name already exists"
+
+
+def test_update_agent_translates_a_raced_rename_collision_to_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding R1-1: update_agent's
+    agent_name_exists precheck is a fast path, not the source of truth,
+    exactly like create_agent's - so a rename that races past it must still
+    surface the DB's uq_agents_user_id_name_active violation as a clean 400,
+    not an uncaught IntegrityError leaking as a 500 (update_agent had no
+    equivalent to create_agent's `except IntegrityError` handler)."""
+    from xagent.web.services.agent_store import AgentStore
+
+    headers = _admin_headers()
+    _create_agent(headers, name="Rename Race Target")
+    renamed_id = _create_agent(headers, name="Rename Race Source")
+
+    monkeypatch.setattr(AgentStore, "agent_name_exists", lambda self, *a, **k: False)
+
+    response = client.put(
+        f"/api/agents/{renamed_id}",
+        headers=headers,
+        json={"name": "Rename Race Target"},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "Agent with this name already exists"
 
 
 def _create_agent_row(

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -165,6 +165,116 @@ def test_create_from_template_fails_closed_when_request_session_is_not_clean(
     assert template_calls == []
 
 
+def test_create_from_template_persists_template_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The created (and later listed) agent must carry its source template id."""
+
+    headers = _admin_headers()
+
+    class TemplateManagerStub:
+        async def get_template(self, template_id: str) -> dict[str, Any]:
+            return {
+                "id": template_id,
+                "name": "Template-Linked Agent",
+                "descriptions": {"en": "Created from a template"},
+                "agent_config": {
+                    "instructions": "Follow the template.",
+                    "execution_mode": "balanced",
+                },
+            }
+
+    monkeypatch.setattr(
+        client.app.state, "template_manager", TemplateManagerStub(), raising=False
+    )
+
+    response = client.post(
+        "/api/agents/from-template",
+        headers=headers,
+        json={"template_id": "linked-template-id"},
+    )
+    assert response.status_code == 200, response.text
+    agent_id = response.json()["id"]
+    assert response.json()["template_id"] == "linked-template-id"
+
+    list_response = client.get("/api/agents", headers=headers)
+    assert list_response.status_code == 200, list_response.text
+    listed = next(a for a in list_response.json() if a["id"] == agent_id)
+    assert listed["template_id"] == "linked-template-id"
+
+    detail_response = client.get(f"/api/agents/{agent_id}", headers=headers)
+    assert detail_response.status_code == 200, detail_response.text
+    assert detail_response.json()["template_id"] == "linked-template-id"
+
+
+def test_manually_created_agent_has_no_template_id() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers, name="Hand-built agent")
+
+    response = client.get(f"/api/agents/{agent_id}", headers=headers)
+    assert response.status_code == 200, response.text
+    assert response.json()["template_id"] is None
+
+
+def test_duplicate_agent_name_returns_400_with_stable_detail() -> None:
+    """The frontend keys retry logic off this exact detail string."""
+
+    headers = _admin_headers()
+    _create_agent(headers, name="Duplicate Name Agent")
+
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "Duplicate Name Agent",
+            "description": "test",
+            "instructions": "You are a test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Agent with this name already exists"
+
+
+def test_db_constraint_catches_name_race_the_app_precheck_missed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulates two concurrent requests both passing the app-level
+    pre-check before either commits: the DB partial unique index must still
+    reject the second insert with a clean DuplicateAgentNameError (400), not
+    a raw IntegrityError (500).
+    """
+    from xagent.web.services.agent_store import AgentStore
+
+    headers = _admin_headers()
+    monkeypatch.setattr(AgentStore, "agent_name_exists", lambda self, *a, **k: False)
+
+    first = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "Raced Agent Name",
+            "description": "test",
+            "instructions": "You are a test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "Raced Agent Name",
+            "description": "test",
+            "instructions": "You are a test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert second.status_code == 400, second.text
+    assert second.json()["detail"] == "Agent with this name already exists"
+
+
 def _create_agent_row(
     *,
     user_id: int,

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -207,6 +207,269 @@ def test_create_from_template_persists_template_id(
     assert detail_response.json()["template_id"] == "linked-template-id"
 
 
+def test_create_from_template_duplicate_name_returns_400_with_stable_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The frontend's create-or-reuse flow
+    (template-agent-resolution.ts) branches its entire reuse-vs-duplicate
+    logic on this exact detail string from POST /api/agents/from-template
+    specifically - a different endpoint's exception handling from the plain
+    POST /api/agents duplicate-name test above. See PR review finding F2:
+    without this test, a refactor could change this endpoint's exception
+    mapping while every other test (DB-pool release, the clean-transaction
+    500 guard, template_id persistence) stayed green.
+    """
+
+    headers = _admin_headers()
+
+    class TemplateManagerStub:
+        async def get_template(self, template_id: str) -> dict[str, Any]:
+            return {
+                "id": template_id,
+                "name": "Duplicate Name Agent",
+                "descriptions": {"en": "Created from a template"},
+                "agent_config": {
+                    "instructions": "Follow the template.",
+                    "execution_mode": "balanced",
+                },
+            }
+
+    monkeypatch.setattr(
+        client.app.state, "template_manager", TemplateManagerStub(), raising=False
+    )
+
+    first_response = client.post(
+        "/api/agents/from-template",
+        headers=headers,
+        json={"template_id": "dup-name-template"},
+    )
+    assert first_response.status_code == 200, first_response.text
+
+    second_response = client.post(
+        "/api/agents/from-template",
+        headers=headers,
+        json={"template_id": "dup-name-template-2"},
+    )
+    assert second_response.status_code == 400
+    assert second_response.json()["detail"] == "Agent with this name already exists"
+
+
+class _ResolveTemplateManagerStub:
+    """Minimal template manager for the resolve-flow tests."""
+
+    def __init__(self, name: str = "Resolve Flow Agent") -> None:
+        self.name = name
+
+    async def get_template(self, template_id: str) -> dict[str, Any]:
+        return {
+            "id": template_id,
+            "name": self.name,
+            "descriptions": {"en": "Created by the resolve flow"},
+            "agent_config": {
+                "instructions": "Follow the template.",
+                "execution_mode": "balanced",
+            },
+        }
+
+
+def _install_resolve_template_stub(
+    monkeypatch: pytest.MonkeyPatch, name: str = "Resolve Flow Agent"
+) -> None:
+    monkeypatch.setattr(
+        client.app.state,
+        "template_manager",
+        _ResolveTemplateManagerStub(name),
+        raising=False,
+    )
+
+
+def test_resolve_from_template_creates_and_publishes_on_first_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    response = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["created"] is True
+    assert body["agent"]["template_id"] == "resolve-template"
+    assert body["agent"]["status"] == "published"
+    assert body["agent"]["name"] == "Resolve Flow Agent"
+
+
+def test_resolve_from_template_reuses_the_same_agent_on_repeat_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of the resolve endpoint (PR review D1): repeat sends
+    must converge on one agent per (user, template), enforced server-side
+    rather than by client-side reconciliation."""
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    first = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["created"] is False
+    assert second.json()["agent"]["id"] == first.json()["agent"]["id"]
+
+    listed = client.get("/api/agents", headers=headers).json()
+    matching = [a for a in listed if a.get("template_id") == "resolve-template"]
+    assert len(matching) == 1
+
+
+def test_resolve_from_template_publishes_the_callers_own_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    created = client.post(
+        "/api/agents/from-template",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["status"] == "draft"
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["created"] is False
+    assert resolved.json()["agent"]["id"] == created.json()["id"]
+    assert resolved.json()["agent"]["status"] == "published"
+
+
+def test_resolve_from_template_never_touches_another_users_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding F1: resolving a template must
+    only ever consider the caller's own agents - another user's draft from
+    the same template stays untouched (not reused, not published)."""
+
+    _install_resolve_template_stub(monkeypatch)
+
+    # Bootstrap the admin (first user) before the public register endpoint
+    # will accept a second account.
+    headers = _admin_headers()
+
+    other_headers = _register_second_user(username="resolveother")
+    other_draft = client.post(
+        "/api/agents/from-template",
+        headers=other_headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert other_draft.status_code == 200, other_draft.text
+    other_agent_id = other_draft.json()["id"]
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["created"] is True
+    assert resolved.json()["agent"]["id"] != other_agent_id
+    assert resolved.json()["agent"]["status"] == "published"
+
+    other_view = client.get(f"/api/agents/{other_agent_id}", headers=other_headers)
+    assert other_view.status_code == 200, other_view.text
+    assert other_view.json()["status"] == "draft"
+
+
+def test_resolve_from_template_disambiguates_a_colliding_default_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated agent already holding the template's default name must
+    not fail the resolve - the server picks a free name itself instead of
+    surfacing the duplicate-name 400 the plain create path returns."""
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+    _create_agent(headers, name="Resolve Flow Agent")
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    body = resolved.json()
+    assert body["created"] is True
+    assert body["agent"]["name"] != "Resolve Flow Agent"
+    assert body["agent"]["name"].startswith("Resolve Flow Agent")
+    assert body["agent"]["status"] == "published"
+
+
+def test_resolve_from_template_converges_when_a_racing_insert_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for PR review finding F3: if a concurrent request
+    creates this template's agent between our select and our insert, the
+    retry loop must re-select and reuse that row instead of erroring or
+    minting a duplicate."""
+
+    from xagent.web.services import agent_management as management_module
+    from xagent.web.services.agent_store import AgentStore
+
+    headers = _admin_headers()
+    _install_resolve_template_stub(monkeypatch)
+
+    real_resolve_name = management_module.resolve_unique_agent_name
+    racing_agent_id: dict[str, int] = {}
+
+    def race_then_delegate(db: Any, *, user_id: int, name: str) -> str:
+        # Simulate a concurrent request winning the race: insert this
+        # template's agent (as the same user) after resolve's select missed
+        # but before its own insert, then hand back the template's default
+        # name so the insert collides on the unique index.
+        if not racing_agent_id:
+            store = AgentStore(db)
+            racing = store.create_agent(
+                user_id=user_id,
+                name=name,
+                description="raced in first",
+                instructions="Follow the template.",
+                execution_mode="balanced",
+                template_id="resolve-template",
+            )
+            db.commit()
+            racing_agent_id["id"] = int(racing.id)
+            return name
+        return real_resolve_name(db, user_id=user_id, name=name)
+
+    monkeypatch.setattr(
+        management_module, "resolve_unique_agent_name", race_then_delegate
+    )
+
+    resolved = client.post(
+        "/api/agents/from-template/resolve",
+        headers=headers,
+        json={"template_id": "resolve-template"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["created"] is False
+    assert resolved.json()["agent"]["id"] == racing_agent_id["id"]
+
+
 def test_manually_created_agent_has_no_template_id() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers, name="Hand-built agent")

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import itertools
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -252,6 +253,9 @@ def _create_gmail_oauth(db, user: User) -> UserOAuth:
     return oauth
 
 
+_gmail_trigger_agent_names = itertools.count(1)
+
+
 def _create_gmail_trigger(
     db,
     user: User,
@@ -261,7 +265,7 @@ def _create_gmail_trigger(
 ) -> AgentTrigger:
     agent = Agent(
         user_id=int(user.id),
-        name="Gmail trigger agent",
+        name=f"Gmail trigger agent {next(_gmail_trigger_agent_names)}",
         description="test",
         instructions="Handle Gmail.",
         execution_mode="balanced",

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -334,6 +334,15 @@ class TestTemplatesAPI:
             assert len(listed["sales_assistant"]["sample_prompts"]) == 2
             assert listed["customer_support"]["sample_prompts"] == []
 
+            # An unrecognised locale falls back to English rather than
+            # erroring or returning an empty list.
+            response = client.get(
+                "/api/templates/sales_assistant?lang=fr", headers=admin_headers
+            )
+            assert response.status_code == 200
+            fr_prompts = response.json()["sample_prompts"]
+            assert fr_prompts == en_prompts
+
     def test_get_template_not_found(self, mock_app_state, admin_headers):
         """测试获取不存在的模板"""
         with patch.object(client.app, "state", mock_app_state):

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -141,6 +141,23 @@ tags:
 descriptions:
   en: Professional sales assistant
   zh: 专业的销售助手
+sample_prompts:
+  en:
+  - title: Draft an outreach email
+    prompt: 'Draft an outreach email for contact.'
+    highlights:
+    - contact
+  - title: Summarise a call
+    prompt: Summarise our last call and suggest next steps.
+    highlights: []
+  zh:
+  - title: 起草外联邮件
+    prompt: 为 联系人 起草一封外联邮件。
+    highlights:
+    - 联系人
+  - title: 总结通话
+    prompt: 总结我们上次的通话并给出下一步建议。
+    highlights: []
 author: Xagent
 version: "1.0"
 
@@ -280,6 +297,42 @@ class TestTemplatesAPI:
             assert "customer support assistant" in agent_config["instructions"].lower()
             assert agent_config["skills"] == ["product_knowledge"]
             assert agent_config["tool_categories"] == ["web_search"]
+
+    def test_sample_prompts_localization_and_default(
+        self, mock_app_state, admin_headers
+    ):
+        """测试 sample_prompts 按语言解析，且未定义时默认为空列表"""
+        with patch.object(client.app, "state", mock_app_state):
+            # Template without sample_prompts defaults to an empty list.
+            response = client.get(
+                "/api/templates/customer_support?lang=en", headers=admin_headers
+            )
+            assert response.status_code == 200
+            assert response.json()["sample_prompts"] == []
+
+            # Template with sample_prompts resolves the requested locale.
+            response = client.get(
+                "/api/templates/sales_assistant?lang=en", headers=admin_headers
+            )
+            assert response.status_code == 200
+            en_prompts = response.json()["sample_prompts"]
+            assert len(en_prompts) == 2
+            assert en_prompts[0]["title"] == "Draft an outreach email"
+            assert en_prompts[0]["highlights"] == ["contact"]
+
+            response = client.get(
+                "/api/templates/sales_assistant?lang=zh", headers=admin_headers
+            )
+            assert response.status_code == 200
+            zh_prompts = response.json()["sample_prompts"]
+            assert zh_prompts[0]["title"] == "起草外联邮件"
+
+            # The list endpoint carries the same field.
+            response = client.get("/api/templates/?lang=en", headers=admin_headers)
+            assert response.status_code == 200
+            listed = {t["id"]: t for t in response.json()}
+            assert len(listed["sales_assistant"]["sample_prompts"]) == 2
+            assert listed["customer_support"]["sample_prompts"] == []
 
     def test_get_template_not_found(self, mock_app_state, admin_headers):
         """测试获取不存在的模板"""


### PR DESCRIPTION
## Summary
- Redesigns /task's landing view: Featured/Marketing/Sales/Support category
  pills + a card grid of templates, each showing up to 2 clickable sample
  prompts (backed by a new `sample_prompts` field on the template schema).
- Selecting a sample prompt fills the chat input (with placeholder terms
  underlined) and shows an "Agent template: <name>" chip above it, mirroring
  the existing "Using @agent" chip pattern in ChatInput. Clicking a
  template's title/description instead navigates to the manual
  /build/new?template=<id> flow.
- Sending now creates + publishes a real agent from the template on first
  use, and reuses that same agent (matched by name) on subsequent sends
  instead of creating a duplicate every time.