### PR TITLE
fix: make tool user interactions resumable

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -345,6 +345,10 @@ class AgentExecutionAdapter:
             },
             "agent_result": result,
         }
+        completion_outcome = result.get("completion_outcome")
+        if completion_outcome in {"completed", "partial", "blocked"}:
+            normalized["completion_outcome"] = completion_outcome
+            normalized["metadata"]["completion_outcome"] = completion_outcome
         if status == "waiting_for_user":
             message = str(result.get("message") or output or "")
             interactions = result.get("interactions")

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1207,12 +1207,15 @@ class ReActPattern(AgentPattern):
     def _queue_tool_interaction_responses(
         self,
         *,
-        waiting_request: dict[str, Any],
+        waiting_request: Any,
         response: str,
     ) -> None:
         """Persist a user's answer for each tool interaction in the pause."""
 
-        if waiting_request.get("kind") != "tool_waiting_for_user":
+        if (
+            not isinstance(waiting_request, dict)
+            or waiting_request.get("kind") != "tool_waiting_for_user"
+        ):
             return
         raw_requests = waiting_request.get("requests")
         requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
@@ -1810,6 +1813,7 @@ class ReActPattern(AgentPattern):
             request_interactions = _normalize_ask_user_interactions(
                 result.get("interactions", [])
             )
+            deduplicated_request_interactions: list[dict[str, Any]] = []
             for interaction in request_interactions:
                 item = dict(interaction)
                 base_field = str(item.get("field") or "response")
@@ -1821,6 +1825,7 @@ class ReActPattern(AgentPattern):
                 item["field"] = field
                 used_fields.add(field)
                 interactions.append(item)
+                deduplicated_request_interactions.append(item)
 
             requests.append(
                 {
@@ -1835,7 +1840,7 @@ class ReActPattern(AgentPattern):
                         or "This tool requires user input before it can continue."
                     ),
                     "message_type": str(result.get("message_type") or "question"),
-                    "interactions": request_interactions,
+                    "interactions": deduplicated_request_interactions,
                 }
             )
 
@@ -2928,10 +2933,10 @@ class ReActPattern(AgentPattern):
         for index, pending in enumerate(self.pending_tool_interaction_responses):
             if pending.get("tool_name") != tool_name:
                 continue
-            response = self.pending_tool_interaction_responses.pop(index)
+            pending_response = self.pending_tool_interaction_responses.pop(index)
             resumed = resume(
-                interaction_id=response.get("interaction_id", ""),
-                response=response.get("response", ""),
+                interaction_id=pending_response.get("interaction_id", ""),
+                response=pending_response.get("response", ""),
             )
             if inspect.isawaitable(resumed):
                 await resumed

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -252,6 +252,7 @@ class ReActPattern(AgentPattern):
         waiting_result = await self._resume_waiting_for_user_if_needed(
             context=context,
             runtime=runtime,
+            tools=tools,
         )
         if waiting_result is not None:
             await runtime.on_pattern_end(
@@ -1135,6 +1136,7 @@ class ReActPattern(AgentPattern):
         *,
         context: Any,
         runtime: PatternRuntime,
+        tools: list[Any],
     ) -> dict[str, Any] | None:
         if self.status != "waiting_for_user" or not self.waiting_for_user_request:
             return None
@@ -1167,6 +1169,7 @@ class ReActPattern(AgentPattern):
         self._queue_tool_interaction_responses(
             waiting_request=self.waiting_for_user_request,
             response=response or "",
+            tools=tools,
         )
         waiting_task = self.waiting_for_user_request.get("task_text")
         if waiting_task and self.task_text is None:
@@ -1221,8 +1224,9 @@ class ReActPattern(AgentPattern):
         *,
         waiting_request: Any,
         response: str,
+        tools: list[Any],
     ) -> None:
-        """Persist a user's answer for each tool interaction in the pause."""
+        """Queue replies only for tools that expose the optional resume callback."""
 
         if (
             not isinstance(waiting_request, dict)
@@ -1236,6 +1240,14 @@ class ReActPattern(AgentPattern):
                 continue
             tool_name = str(request.get("tool_name") or "")
             if not tool_name:
+                continue
+            try:
+                tool = self._find_tool(tool_name, tools)
+            except ValueError:
+                continue
+            if user_interaction_resume_callable(tool) is None:
+                # Callback-less tools resume through the normal ReAct replan. The
+                # user's answer remains in context with waiting-response metadata.
                 continue
             self.pending_tool_interaction_responses.append(
                 {
@@ -1262,12 +1274,30 @@ class ReActPattern(AgentPattern):
         while self.pending_tool_interaction_responses:
             pending = self.pending_tool_interaction_responses[0]
             tool_name = pending.get("tool_name", "")
-            tool = self._find_tool(tool_name, tools)
-            resume = user_interaction_resume_callable(tool)
+            try:
+                tool = self._find_tool(tool_name, tools)
+            except ValueError:
+                tool = None
+            resume = (
+                user_interaction_resume_callable(tool) if tool is not None else None
+            )
             if resume is None:
-                raise ValueError(
-                    f"Tool {tool_name} cannot resume a pending user interaction."
+                # Legacy checkpoints may contain callback delivery for a tool that
+                # no longer exists or never implemented the optional capability.
+                # The annotated user message is sufficient for the model to replan.
+                self.pending_tool_interaction_responses.pop(0)
+                await runtime.checkpoint(
+                    "tool_interaction_response_skipped",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "tool_name": tool_name,
+                        "tool_call_id": pending.get("tool_call_id", ""),
+                        "interaction_id": pending.get("interaction_id", ""),
+                        "reason": "resume_callback_unavailable",
+                    },
                 )
+                continue
 
             resumed = resume(
                 interaction_id=pending.get("interaction_id", ""),

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -43,6 +43,10 @@ from typing import Any, cast
 
 from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
+from ....tools.user_interaction import (
+    tool_result_waits_for_user,
+    user_interaction_resume_callable,
+)
 from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
@@ -216,6 +220,7 @@ class ReActPattern(AgentPattern):
         self.force_final_answer_next = False
         self.repeated_tool_decision: dict[str, Any] | None = None
         self.waiting_for_user_request: dict[str, Any] | None = None
+        self.pending_tool_interaction_responses: list[dict[str, str]] = []
         self.task_text: str | None = None
         self._memory_store: Any | None = None
         self._tool_decision_groups_by_name: dict[str, str] = {}
@@ -743,7 +748,9 @@ class ReActPattern(AgentPattern):
                 "Produce the final user-facing answer by calling the final_answer "
                 "control tool exactly once using the accumulated conversation and "
                 "tool results. Do not call any other tool and do not output "
-                "tool-call markup as plain text. "
+                "tool-call markup as plain text. Set outcome=completed only when "
+                "every requested action or verification succeeded; otherwise set "
+                "outcome=partial or outcome=blocked and say what remains. "
                 f"{final_answer_language_rule()}"
             )
         elif has_tools:
@@ -1034,6 +1041,9 @@ class ReActPattern(AgentPattern):
             "force_final_answer_next": self.force_final_answer_next,
             "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
+            "pending_tool_interaction_responses": (
+                self.pending_tool_interaction_responses
+            ),
             "task_text": self.task_text,
             "last_response": self.last_response,
             "pending_tool_calls": self.pending_tool_calls,
@@ -1087,6 +1097,20 @@ class ReActPattern(AgentPattern):
         self.waiting_for_user_request = (
             dict(waiting_request) if isinstance(waiting_request, dict) else None
         )
+        pending_interaction_responses = state.get("pending_tool_interaction_responses")
+        self.pending_tool_interaction_responses = [
+            {
+                "tool_name": str(item.get("tool_name") or ""),
+                "interaction_id": str(item.get("interaction_id") or ""),
+                "response": str(item.get("response") or ""),
+            }
+            for item in (
+                pending_interaction_responses
+                if isinstance(pending_interaction_responses, list)
+                else []
+            )
+            if isinstance(item, dict)
+        ]
         stored_task_text = state.get("task_text")
         self.task_text = str(stored_task_text) if stored_task_text else None
         self.last_response = state.get("last_response")
@@ -1129,9 +1153,13 @@ class ReActPattern(AgentPattern):
                 "context": context,
             }
 
-        self._mark_latest_user_message_as_waiting_response(
+        response = self._mark_latest_user_message_as_waiting_response(
             context=context,
             after_message_count=waiting_message_count,
+        )
+        self._queue_tool_interaction_responses(
+            waiting_request=self.waiting_for_user_request,
+            response=response or "",
         )
         waiting_task = self.waiting_for_user_request.get("task_text")
         if waiting_task and self.task_text is None:
@@ -1151,10 +1179,10 @@ class ReActPattern(AgentPattern):
         *,
         context: Any,
         after_message_count: int,
-    ) -> None:
+    ) -> str | None:
         messages = getattr(context, "messages", [])
         if not isinstance(messages, list):
-            return
+            return None
 
         for index in range(len(messages) - 1, after_message_count - 1, -1):
             message = messages[index]
@@ -1162,7 +1190,7 @@ class ReActPattern(AgentPattern):
                 continue
             metadata = dict(getattr(message, "metadata", {}) or {})
             if metadata.get("response_to_waiting_for_user"):
-                return
+                return str(getattr(message, "content", "") or "")
             waiting_request = self.waiting_for_user_request or {}
             metadata["response_to_waiting_for_user"] = {
                 "tool_name": waiting_request.get("tool_name"),
@@ -1170,9 +1198,41 @@ class ReActPattern(AgentPattern):
                 "question": waiting_request.get("message", ""),
                 "message_type": waiting_request.get("message_type", "question"),
                 "interactions": waiting_request.get("interactions"),
+                "requests": waiting_request.get("requests"),
             }
             messages[index] = replace(message, metadata=metadata)
+            return str(getattr(message, "content", "") or "")
+        return None
+
+    def _queue_tool_interaction_responses(
+        self,
+        *,
+        waiting_request: dict[str, Any],
+        response: str,
+    ) -> None:
+        """Persist a user's answer for each tool interaction in the pause."""
+
+        if waiting_request.get("kind") != "tool_waiting_for_user":
             return
+        raw_requests = waiting_request.get("requests")
+        requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
+        for request in requests:
+            if not isinstance(request, dict):
+                continue
+            tool_name = str(request.get("tool_name") or "")
+            if not tool_name:
+                continue
+            self.pending_tool_interaction_responses.append(
+                {
+                    "tool_name": tool_name,
+                    "interaction_id": str(
+                        request.get("interaction_id")
+                        or request.get("tool_call_id")
+                        or ""
+                    ),
+                    "response": response,
+                }
+            )
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
         if isinstance(response, str):
@@ -1355,10 +1415,15 @@ class ReActPattern(AgentPattern):
                     "name": "final_answer",
                     "description": (
                         "Finish the current ReAct step and send the final answer to "
-                        "the user. Use this once the latest tool results satisfy the "
-                        "current user request. Do not call additional tools after "
-                        "this. Set response_language to the target output language "
-                        "for this answer. "
+                        "the user. Set outcome=completed only when every requested "
+                        "action and verification succeeded. Use outcome=partial when "
+                        "some useful work succeeded but the request remains "
+                        "unfinished, or outcome=blocked when no further progress is "
+                        "possible without user input or an external state change. "
+                        "Never mark an answer completed when it admits work is "
+                        "unfinished. Do not call additional tools after this. Set "
+                        "response_language to the target output language for this "
+                        "answer. "
                         f"{final_answer_language_rule()}"
                     ),
                     "parameters": {
@@ -1377,8 +1442,19 @@ class ReActPattern(AgentPattern):
                                     f"{final_answer_language_rule()}"
                                 ),
                             },
+                            "outcome": {
+                                "type": "string",
+                                "enum": ["completed", "partial", "blocked"],
+                                "description": (
+                                    "Semantic outcome of the request. completed "
+                                    "means the whole request was carried out and "
+                                    "verified; partial means only part succeeded; "
+                                    "blocked means progress requires the user or an "
+                                    "external state change."
+                                ),
+                            },
                         },
-                        "required": ["response_language", "answer"],
+                        "required": ["response_language", "answer", "outcome"],
                     },
                 },
             },
@@ -1511,23 +1587,25 @@ class ReActPattern(AgentPattern):
 
         if name == "final_answer":
             answer = str(args.get("answer", ""))
+            outcome = self._final_answer_outcome(args.get("outcome"))
             self._record_tool_call(
                 tool_call,
                 status="completed",
-                result={"answer": answer},
+                result={"answer": answer, "outcome": outcome},
             )
             self.status = "completed"
             context.add_tool_result(
                 tool_name=name,
-                result={"answer": answer},
+                result={"answer": answer, "outcome": outcome},
                 tool_call_id=tool_call.get("id"),
             )
             if answer:
                 context.add_assistant_message(answer)
-            return await self._finalize_success(
+            return await self._finalize_outcome(
                 context=context,
                 runtime=runtime,
                 response=answer,
+                outcome=outcome,
             )
 
         if name == "send_message":
@@ -1716,6 +1794,97 @@ class ReActPattern(AgentPattern):
         )
         self._forget_tool_call_content(tool_call)
 
+    async def _pause_for_tool_results(
+        self,
+        *,
+        waiting_pairs: list[tuple[dict[str, Any], dict[str, Any]]],
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any]:
+        """Publish tool-originated questions and checkpoint the suspended run."""
+
+        requests: list[dict[str, Any]] = []
+        interactions: list[dict[str, Any]] = []
+        used_fields: set[str] = set()
+        for tool_call, result in waiting_pairs:
+            request_interactions = _normalize_ask_user_interactions(
+                result.get("interactions", [])
+            )
+            for interaction in request_interactions:
+                item = dict(interaction)
+                base_field = str(item.get("field") or "response")
+                field = base_field
+                suffix = 2
+                while field in used_fields:
+                    field = f"{base_field}_{suffix}"
+                    suffix += 1
+                item["field"] = field
+                used_fields.add(field)
+                interactions.append(item)
+
+            requests.append(
+                {
+                    "tool_call_id": str(tool_call.get("id") or ""),
+                    "tool_name": str(tool_call.get("name") or ""),
+                    "interaction_id": str(
+                        result.get("interaction_id") or tool_call.get("id") or ""
+                    ),
+                    "message": str(
+                        result.get("message")
+                        or result.get("error")
+                        or "This tool requires user input before it can continue."
+                    ),
+                    "message_type": str(result.get("message_type") or "question"),
+                    "interactions": request_interactions,
+                }
+            )
+
+        if len(requests) == 1:
+            message = requests[0]["message"]
+            message_type = requests[0]["message_type"]
+        else:
+            message = "Multiple tools need your input before the task can continue:\n\n"
+            message += "\n".join(
+                f"- {request['tool_name']}: {request['message']}"
+                for request in requests
+            )
+            message_type = "question"
+
+        await runtime.send_message(
+            message=message,
+            message_type=message_type,
+            expect_response=True,
+            visible=True,
+            metadata={"interactions": interactions},
+        )
+        self.status = "waiting_for_user"
+        self.waiting_for_user_request = {
+            "kind": "tool_waiting_for_user",
+            "requests": requests,
+            "message": message,
+            "message_type": message_type,
+            "interactions": interactions,
+            "task_text": self.task_text,
+            "message_count": len(getattr(context, "messages", [])),
+        }
+        waiting_result = {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": message,
+            "message_type": message_type,
+            "interactions": interactions,
+            "context": context,
+        }
+        await runtime.checkpoint(
+            "waiting_for_user",
+            context=context,
+            pattern=self,
+            metadata={
+                "waiting_for_user_request": self.waiting_for_user_request,
+            },
+        )
+        return waiting_result
+
     async def _run_concurrent_batch(
         self,
         batch: list[dict[str, Any]],
@@ -1873,6 +2042,13 @@ class ReActPattern(AgentPattern):
                 result = await self._execute_tool_safely(tool_call, tools, runtime)
                 self._backfill_result(tool_call, result, context)
                 self.pending_tool_calls = self.pending_tool_calls[1:]
+                if tool_result_waits_for_user(result):
+                    assert isinstance(result, dict)
+                    return await self._pause_for_tool_results(
+                        waiting_pairs=[(tool_call, result)],
+                        context=context,
+                        runtime=runtime,
+                    )
                 await runtime.checkpoint(
                     "after_tool",
                     context=context,
@@ -1891,6 +2067,18 @@ class ReActPattern(AgentPattern):
                     segment, tools, runtime, context
                 )
                 self.pending_tool_calls = self.pending_tool_calls[len(segment) :]
+                waiting_pairs = [
+                    (waiting_call, waiting_result)
+                    for waiting_call, waiting_result in zip(segment, results)
+                    if tool_result_waits_for_user(waiting_result)
+                    and isinstance(waiting_result, dict)
+                ]
+                if waiting_pairs:
+                    return await self._pause_for_tool_results(
+                        waiting_pairs=waiting_pairs,
+                        context=context,
+                        runtime=runtime,
+                    )
                 await runtime.checkpoint(
                     "after_tool_batch",
                     context=context,
@@ -2271,15 +2459,44 @@ class ReActPattern(AgentPattern):
         runtime: PatternRuntime,
         response: Any,
     ) -> dict[str, Any]:
+        return await self._finalize_outcome(
+            context=context,
+            runtime=runtime,
+            response=response,
+            outcome="completed",
+        )
+
+    @staticmethod
+    def _final_answer_outcome(value: Any) -> str:
+        outcome = str(value or "completed").strip().lower()
+        if outcome not in {"completed", "partial", "blocked"}:
+            return "blocked"
+        return outcome
+
+    async def _finalize_outcome(
+        self,
+        *,
+        context: Any,
+        runtime: PatternRuntime,
+        response: Any,
+        outcome: str,
+    ) -> dict[str, Any]:
+        """Finish the run while preserving its semantic completion outcome."""
+
         self.pending_tool_calls = []
         self.waiting_for_user_request = None
+        self.pending_tool_interaction_responses = []
         self.force_final_answer_next = False
         self.status = "completed"
         await runtime.checkpoint("final", context=context, pattern=self)
         result = PatternResult(
             success=True,
             output=response,
-            metadata={"response": response, "status": self.status},
+            metadata={
+                "response": response,
+                "status": self.status,
+                "completion_outcome": outcome,
+            },
         ).to_dict()
         return result
 
@@ -2443,6 +2660,16 @@ class ReActPattern(AgentPattern):
                 )
                 recorded_terminal = True
                 return error_result
+
+            if tool_result_waits_for_user(result):
+                self._record_tool_call(
+                    tool_call,
+                    status="waiting_for_user",
+                    result=result,
+                )
+                recorded_terminal = True
+                await runtime.on_tool_end(tool_call=tool_call, result=result)
+                return result
 
             if not self._tool_result_success(result):
                 error_message = str(
@@ -2661,6 +2888,10 @@ class ReActPattern(AgentPattern):
 
     async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:
         tool = self._find_tool(tool_call["name"], tools)
+        await self._resume_tool_interaction_if_pending(
+            tool=tool,
+            tool_name=self._tool_name(tool),
+        )
         args = self._tool_args_for_execution(tool_call, tool)
 
         execute = getattr(tool, "execute", None)
@@ -2682,6 +2913,29 @@ class ReActPattern(AgentPattern):
         raise ValueError(
             f"Tool {tool_call['name']} does not expose a supported executor."
         )
+
+    async def _resume_tool_interaction_if_pending(
+        self,
+        *,
+        tool: Any,
+        tool_name: str,
+    ) -> None:
+        """Deliver one checkpointed user response to a matching capable tool."""
+
+        resume = user_interaction_resume_callable(tool)
+        if resume is None:
+            return
+        for index, pending in enumerate(self.pending_tool_interaction_responses):
+            if pending.get("tool_name") != tool_name:
+                continue
+            response = self.pending_tool_interaction_responses.pop(index)
+            resumed = resume(
+                interaction_id=response.get("interaction_id", ""),
+                response=response.get("response", ""),
+            )
+            if inspect.isawaitable(resumed):
+                await resumed
+            return
 
     def _tool_args_for_execution(
         self, tool_call: dict[str, Any], tool: Any

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -293,16 +293,22 @@ class ReActPattern(AgentPattern):
                     runtime=runtime,
                     similarity_threshold=kwargs.get("memory_similarity_threshold"),
                 )
+            context_tools = await self._with_context_tools(
+                tools=tools,
+                context=context,
+                task_text=task_text,
+                runtime=runtime,
+                skill_manager=kwargs.get("skill_manager"),
+                allowed_skills=kwargs.get("allowed_skills"),
+            )
+            await self._deliver_pending_tool_interaction_responses(
+                tools=context_tools,
+                context=context,
+                runtime=runtime,
+            )
             result = await self._run_tool_calling_loop(
                 context=context,
-                tools=await self._with_context_tools(
-                    tools=tools,
-                    context=context,
-                    task_text=task_text,
-                    runtime=runtime,
-                    skill_manager=kwargs.get("skill_manager"),
-                    allowed_skills=kwargs.get("allowed_skills"),
-                ),
+                tools=context_tools,
                 llm=active_llm,
                 compact_llm=compact_llm,
                 runtime=runtime,
@@ -1101,6 +1107,7 @@ class ReActPattern(AgentPattern):
         self.pending_tool_interaction_responses = [
             {
                 "tool_name": str(item.get("tool_name") or ""),
+                "tool_call_id": str(item.get("tool_call_id") or ""),
                 "interaction_id": str(item.get("interaction_id") or ""),
                 "response": str(item.get("response") or ""),
             }
@@ -1166,6 +1173,11 @@ class ReActPattern(AgentPattern):
             self.task_text = str(waiting_task)
         self.waiting_for_user_request = None
         self.status = "thinking"
+        await runtime.checkpoint(
+            "tool_interaction_response_received",
+            context=context,
+            pattern=self,
+        )
         return None
 
     def _task_text(self, context: Any) -> str:
@@ -1228,6 +1240,7 @@ class ReActPattern(AgentPattern):
             self.pending_tool_interaction_responses.append(
                 {
                     "tool_name": tool_name,
+                    "tool_call_id": str(request.get("tool_call_id") or ""),
                     "interaction_id": str(
                         request.get("interaction_id")
                         or request.get("tool_call_id")
@@ -1235,6 +1248,45 @@ class ReActPattern(AgentPattern):
                     ),
                     "response": response,
                 }
+            )
+
+    async def _deliver_pending_tool_interaction_responses(
+        self,
+        *,
+        tools: list[Any],
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Deliver checkpointed replies to their exact suspended interactions."""
+
+        while self.pending_tool_interaction_responses:
+            pending = self.pending_tool_interaction_responses[0]
+            tool_name = pending.get("tool_name", "")
+            tool = self._find_tool(tool_name, tools)
+            resume = user_interaction_resume_callable(tool)
+            if resume is None:
+                raise ValueError(
+                    f"Tool {tool_name} cannot resume a pending user interaction."
+                )
+
+            resumed = resume(
+                interaction_id=pending.get("interaction_id", ""),
+                response=pending.get("response", ""),
+            )
+            if inspect.isawaitable(resumed):
+                await resumed
+
+            # Keep the response retryable until the tool acknowledges delivery.
+            self.pending_tool_interaction_responses.pop(0)
+            await runtime.checkpoint(
+                "tool_interaction_response_delivered",
+                context=context,
+                pattern=self,
+                metadata={
+                    "tool_name": tool_name,
+                    "tool_call_id": pending.get("tool_call_id", ""),
+                    "interaction_id": pending.get("interaction_id", ""),
+                },
             )
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
@@ -1797,6 +1849,29 @@ class ReActPattern(AgentPattern):
         )
         self._forget_tool_call_content(tool_call)
 
+    def _discard_pending_tool_plan_after_pause(self, context: Any) -> None:
+        """Close unexecuted calls so resume always starts with a fresh LLM plan."""
+
+        discarded_calls = self.pending_tool_calls
+        self.pending_tool_calls = []
+        self.repeated_tool_decision = None
+        self.force_final_answer_next = False
+        for tool_call in discarded_calls:
+            result = {
+                "success": False,
+                "status": "cancelled",
+                "error": (
+                    "Discarded because an earlier tool requires user input; "
+                    "the agent will replan after the user responds."
+                ),
+            }
+            self._backfill_result(tool_call, result, context)
+            self._record_tool_call(
+                tool_call,
+                status="cancelled",
+                result=result,
+            )
+
     async def _pause_for_tool_results(
         self,
         *,
@@ -2033,6 +2108,7 @@ class ReActPattern(AgentPattern):
                         self.pending_tool_calls = []
                         return control_result
                     if control_result.get("status") == "waiting_for_user":
+                        self._discard_pending_tool_plan_after_pause(context)
                         return control_result
                 continue
 
@@ -2049,6 +2125,7 @@ class ReActPattern(AgentPattern):
                 self.pending_tool_calls = self.pending_tool_calls[1:]
                 if tool_result_waits_for_user(result):
                     assert isinstance(result, dict)
+                    self._discard_pending_tool_plan_after_pause(context)
                     return await self._pause_for_tool_results(
                         waiting_pairs=[(tool_call, result)],
                         context=context,
@@ -2079,6 +2156,7 @@ class ReActPattern(AgentPattern):
                     and isinstance(waiting_result, dict)
                 ]
                 if waiting_pairs:
+                    self._discard_pending_tool_plan_after_pause(context)
                     return await self._pause_for_tool_results(
                         waiting_pairs=waiting_pairs,
                         context=context,
@@ -2893,10 +2971,6 @@ class ReActPattern(AgentPattern):
 
     async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:
         tool = self._find_tool(tool_call["name"], tools)
-        await self._resume_tool_interaction_if_pending(
-            tool=tool,
-            tool_name=self._tool_name(tool),
-        )
         args = self._tool_args_for_execution(tool_call, tool)
 
         execute = getattr(tool, "execute", None)
@@ -2918,29 +2992,6 @@ class ReActPattern(AgentPattern):
         raise ValueError(
             f"Tool {tool_call['name']} does not expose a supported executor."
         )
-
-    async def _resume_tool_interaction_if_pending(
-        self,
-        *,
-        tool: Any,
-        tool_name: str,
-    ) -> None:
-        """Deliver one checkpointed user response to a matching capable tool."""
-
-        resume = user_interaction_resume_callable(tool)
-        if resume is None:
-            return
-        for index, pending in enumerate(self.pending_tool_interaction_responses):
-            if pending.get("tool_name") != tool_name:
-                continue
-            pending_response = self.pending_tool_interaction_responses.pop(index)
-            resumed = resume(
-                interaction_id=pending_response.get("interaction_id", ""),
-                response=pending_response.get("response", ""),
-            )
-            if inspect.isawaitable(resumed):
-                await resumed
-            return
 
     def _tool_args_for_execution(
         self, tool_call: dict[str, Any], tool: Any

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -146,13 +146,13 @@ class AgentRunner:
 
             tools = [*getattr(self.agent, "tools", []), *(extra_tools or [])]
             pattern_errors: list[dict[str, Any]] = []
-            teardown_status: str | None = None
+            teardown_status: str | None = "failed"
 
             try:
                 await self._setup_tools(tools, task_id=execution_id)
                 for pattern in patterns:
                     load_pattern_checkpoint(pattern, checkpoint)
-                    teardown_status = None
+                    teardown_status = "failed"
                     try:
                         result = await pattern.run(
                             **self._build_pattern_kwargs(

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -146,11 +146,13 @@ class AgentRunner:
 
             tools = [*getattr(self.agent, "tools", []), *(extra_tools or [])]
             pattern_errors: list[dict[str, Any]] = []
+            teardown_status: str | None = None
 
             try:
                 await self._setup_tools(tools, task_id=execution_id)
                 for pattern in patterns:
                     load_pattern_checkpoint(pattern, checkpoint)
+                    teardown_status = None
                     try:
                         result = await pattern.run(
                             **self._build_pattern_kwargs(
@@ -163,6 +165,7 @@ class AgentRunner:
                             )
                         )
                     except ExecutionInterrupted as exc:
+                        teardown_status = "interrupted"
                         normalized = {
                             "success": False,
                             "status": "interrupted",
@@ -179,6 +182,7 @@ class AgentRunner:
                         )
                         return normalized
                     except Exception as exc:  # noqa: BLE001
+                        teardown_status = "failed"
                         logger.exception(
                             "Pattern %s failed", pattern.__class__.__name__
                         )
@@ -198,6 +202,7 @@ class AgentRunner:
                         execution_id=execution_id,
                     )
                     if normalized.get("success"):
+                        teardown_status = str(normalized.get("status") or "completed")
                         await self._dispatch_callback(
                             "on_run_end",
                             runner=self,
@@ -205,7 +210,11 @@ class AgentRunner:
                             result=normalized,
                         )
                         return normalized
-                    if normalized.get("status") in {"interrupted", "waiting_for_user"}:
+                    normalized_status = str(
+                        normalized.get("status") or "failed"
+                    ).strip()
+                    teardown_status = normalized_status or "failed"
+                    if normalized_status in {"interrupted", "waiting_for_user"}:
                         await self._dispatch_callback(
                             "on_run_end",
                             runner=self,
@@ -224,7 +233,11 @@ class AgentRunner:
                         }
                     )
             finally:
-                await self._teardown_tools(tools, task_id=execution_id)
+                await self._teardown_tools(
+                    tools,
+                    task_id=execution_id,
+                    execution_status=teardown_status,
+                )
 
             if len(pattern_errors) == 1:
                 single_result = pattern_errors[0].get("result")
@@ -823,13 +836,23 @@ class AgentRunner:
             if inspect.isawaitable(result):
                 await result
 
-    async def _teardown_tools(self, tools: list[Any], *, task_id: str) -> None:
+    async def _teardown_tools(
+        self,
+        tools: list[Any],
+        *,
+        task_id: str,
+        execution_status: str | None = None,
+    ) -> None:
         for tool in reversed(tools):
             teardown = getattr(tool, "teardown", None)
             if not callable(teardown):
                 continue
             try:
-                result = teardown(task_id=task_id)
+                result = self._call_with_supported_kwargs(
+                    teardown,
+                    task_id=task_id,
+                    execution_status=execution_status,
+                )
                 if inspect.isawaitable(result):
                     await result
             except Exception:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -20,6 +20,10 @@ from ..model.chat.exceptions import LLMToolProtocolError
 from ..model.chat.token_context import extract_cached_input_tokens
 from ..model.chat.tool_protocol import TOOL_PROTOCOL_ERROR_KEY
 from ..model.chat.types import ChunkType
+from ..tools.user_interaction import (
+    WAITING_FOR_USER_STATUS,
+    tool_result_waits_for_user,
+)
 from .result import normalize_tool_failure_code, tool_result_succeeded
 from .streaming import merge_streamed_tool_call_arguments
 
@@ -765,6 +769,32 @@ class PatternRuntime:
             await self._maybe_await(start_span(**payload))
 
     async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
+        if tool_result_waits_for_user(result):
+            await self._emit_trace_event(
+                TraceEventType(
+                    TraceScope.ACTION,
+                    TraceAction.END,
+                    TraceCategory.TOOL,
+                ),
+                task_id=self._task_id_from_payload(tool_call),
+                step_id=self._step_id_from_payload(tool_call),
+                data={
+                    "tool_name": tool_call.get("name"),
+                    "tool_params": tool_call.get("args", {}),
+                    "tool_call_id": tool_call.get("id"),
+                    "result": result,
+                    "success": False,
+                    "status": WAITING_FOR_USER_STATUS,
+                    "control_state": WAITING_FOR_USER_STATUS,
+                },
+            )
+            await self._finish_tool_span(
+                tool_call=tool_call,
+                status=WAITING_FOR_USER_STATUS,
+                output=result,
+            )
+            return
+
         success = self._tool_result_success(result)
         if not success:
             await self.on_tool_error(

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -22,6 +22,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_INTERACTION_CONTROL_KEYS = (
+    "type",
+    "field",
+    "id",
+    "name",
+    "value",
+    "action_type",
+)
+
 
 def _accepts_kwarg(func: Any, name: str) -> bool:
     """Return whether ``func`` accepts ``name`` as a keyword argument."""
@@ -212,13 +221,52 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
 
         filtered["status"] = WAITING_FOR_USER_STATUS
         assert isinstance(result, dict)
-        for key in (
-            "interaction_id",
-            "message",
-            "message_type",
-            "interactions",
-        ):
-            if key not in result:
-                continue
-            filtered[key] = self._filter.filter(result[key], self._target.name)
+        for key in ("interaction_id", "message_type"):
+            if key in result:
+                filtered[key] = result[key]
+        if "message" in result:
+            filtered["message"] = self._filter.filter(
+                result["message"], self._target.name
+            )
+        if "interactions" in result:
+            filtered["interactions"] = self._filter_interactions(result["interactions"])
         return filtered
+
+    def _filter_interactions(self, interactions: Any) -> Any:
+        """Filter display text while preserving interaction routing fields."""
+
+        if not isinstance(interactions, list):
+            return self._filter.filter(interactions, self._target.name)
+
+        return [
+            self._filter_interaction_item(item)
+            for item in interactions[: self._filter.max_fields]
+            if isinstance(item, dict)
+        ]
+
+    def _filter_interaction_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        filtered: dict[str, Any] = {
+            key: item[key] for key in _INTERACTION_CONTROL_KEYS if key in item
+        }
+        if "options" in item:
+            filtered["options"] = self._filter_interaction_options(item["options"])
+
+        display_fields = 0
+        for key, value in item.items():
+            if key in _INTERACTION_CONTROL_KEYS or key == "options":
+                continue
+            if display_fields >= self._filter.max_fields:
+                break
+            filtered[key] = self._filter.filter(value, self._target.name)
+            display_fields += 1
+        return filtered
+
+    def _filter_interaction_options(self, options: Any) -> Any:
+        if not isinstance(options, list):
+            return self._filter.filter(options, self._target.name)
+
+        return [
+            self._filter_interaction_item(option)
+            for option in options[: self._filter.max_fields]
+            if isinstance(option, dict)
+        ]

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -22,13 +22,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_INTERACTION_CONTROL_KEYS = (
-    "type",
-    "field",
-    "id",
-    "name",
-    "value",
-    "action_type",
+_INTERACTION_DISPLAY_KEYS = frozenset(
+    {
+        "description",
+        "help_text",
+        "label",
+        "message",
+        "placeholder",
+        "prompt",
+        "title",
+    }
 )
 
 
@@ -233,40 +236,38 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
         return filtered
 
     def _filter_interactions(self, interactions: Any) -> Any:
-        """Filter display text while preserving interaction routing fields."""
+        """Filter display text without changing interaction cardinality."""
 
         if not isinstance(interactions, list):
             return self._filter.filter(interactions, self._target.name)
 
         return [
-            self._filter_interaction_item(item)
-            for item in interactions[: self._filter.max_fields]
-            if isinstance(item, dict)
+            self._filter_interaction_item(item) if isinstance(item, dict) else item
+            for item in interactions
         ]
 
     def _filter_interaction_item(self, item: dict[str, Any]) -> dict[str, Any]:
-        filtered: dict[str, Any] = {
-            key: item[key] for key in _INTERACTION_CONTROL_KEYS if key in item
-        }
-        if "options" in item:
-            filtered["options"] = self._filter_interaction_options(item["options"])
-
-        display_fields = 0
+        filtered: dict[str, Any] = {}
         for key, value in item.items():
-            if key in _INTERACTION_CONTROL_KEYS or key == "options":
-                continue
-            if display_fields >= self._filter.max_fields:
-                break
-            filtered[key] = self._filter.filter(value, self._target.name)
-            display_fields += 1
+            if key in _INTERACTION_DISPLAY_KEYS:
+                filtered[key] = self._filter.filter(value, self._target.name)
+            elif key in {"actions", "options"}:
+                filtered[key] = self._filter_interaction_options(value)
+            elif key == "properties" and isinstance(value, dict):
+                filtered[key] = self._filter_interaction_item(value)
+            else:
+                # Control, routing, cardinality, and submitted-value properties
+                # must remain byte-for-byte equivalent to the tool result.
+                filtered[key] = value
         return filtered
 
     def _filter_interaction_options(self, options: Any) -> Any:
         if not isinstance(options, list):
-            return self._filter.filter(options, self._target.name)
+            return options
 
         return [
             self._filter_interaction_item(option)
-            for option in options[: self._filter.max_fields]
             if isinstance(option, dict)
+            else option
+            for option in options
         ]

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -10,6 +10,10 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 
 from pydantic import BaseModel
 
+from ...user_interaction import (
+    WAITING_FOR_USER_STATUS,
+    tool_result_waits_for_user,
+)
 from .base import AbstractBaseTool
 from .output_filter import OutputValueFilter
 
@@ -17,6 +21,27 @@ if TYPE_CHECKING:
     from .base import ToolCategory
 
 logger = logging.getLogger(__name__)
+
+
+def _accepts_kwarg(func: Any, name: str) -> bool:
+    """Return whether ``func`` accepts ``name`` as a keyword argument."""
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == name
+            and parameter.kind
+            in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        )
+        for parameter in signature.parameters.values()
+    )
 
 
 class OutputFilteredToolWrapper(AbstractBaseTool):
@@ -92,12 +117,12 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         """Execute tool synchronously with output filtering."""
         result = self._target.run_json_sync(args)
-        return self._filter.filter(result, self._target.name)
+        return self._filter_result(result)
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Execute tool asynchronously with output filtering."""
         result = await self._target.run_json_async(args)
-        return self._filter.filter(result, self._target.name)
+        return self._filter_result(result)
 
     async def save_state_json(self) -> Mapping[str, Any]:
         """Save state (delegates to target tool)."""
@@ -112,10 +137,35 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
         if hasattr(self._target, "setup"):
             await self._target.setup(task_id)
 
-    async def teardown(self, task_id: Optional[str] = None) -> None:
-        """Teardown tool (delegates to target tool)."""
-        if hasattr(self._target, "teardown"):
-            await self._target.teardown(task_id)
+    async def teardown(
+        self,
+        task_id: Optional[str] = None,
+        execution_status: Optional[str] = None,
+    ) -> None:
+        """Teardown the target without hiding the execution's final state."""
+
+        teardown = getattr(self._target, "teardown", None)
+        if teardown is None:
+            return
+        kwargs: dict[str, Any] = {"task_id": task_id}
+        if execution_status is not None and _accepts_kwarg(
+            teardown, "execution_status"
+        ):
+            kwargs["execution_status"] = execution_status
+        result = teardown(**kwargs)
+        if inspect.isawaitable(result):
+            await result
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate optional runtime capabilities to the wrapped tool."""
+
+        if name.startswith("_"):
+            raise AttributeError(name)
+        try:
+            target = object.__getattribute__(self, "_target")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(target, name)
 
     @property
     def func(self) -> Any:
@@ -140,7 +190,7 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
 
         def wrapped_func(*args: Any, **kwargs: Any) -> Any:
             result = original_func(*args, **kwargs)
-            return self._filter.filter(result, self._target.name)
+            return self._filter_result(result)
 
         return wrapped_func
 
@@ -149,6 +199,26 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
 
         async def wrapped_func_async(*args: Any, **kwargs: Any) -> Any:
             result = await original_func(*args, **kwargs)
-            return self._filter.filter(result, self._target.name)
+            return self._filter_result(result)
 
         return wrapped_func_async
+
+    def _filter_result(self, result: Any) -> Any:
+        """Filter output without dropping the user-interaction control envelope."""
+
+        filtered = self._filter.filter(result, self._target.name)
+        if not tool_result_waits_for_user(result) or not isinstance(filtered, dict):
+            return filtered
+
+        filtered["status"] = WAITING_FOR_USER_STATUS
+        assert isinstance(result, dict)
+        for key in (
+            "interaction_id",
+            "message",
+            "message_type",
+            "interactions",
+        ):
+            if key not in result:
+                continue
+            filtered[key] = self._filter.filter(result[key], self._target.name)
+        return filtered

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -2,9 +2,9 @@
 
 Tools opt into the control flow by returning a mapping whose ``status`` is
 ``waiting_for_user``.  The execution pattern presents the returned message,
-checkpoints, and stops the current run.  After the user replies, a resumable
-tool can receive that reply through ``resume_user_interaction`` immediately
-before its next invocation.
+checkpoints, and stops the current run. After the user replies, the runtime
+delivers that reply to the exact suspended interaction through
+``resume_user_interaction`` before asking the model to replan.
 
 The response is delivered through a runtime capability instead of model
 arguments.  This keeps server-owned interaction state out of the prompt and
@@ -28,7 +28,7 @@ class ResumableUserInteractionTool(Protocol):
         interaction_id: str,
         response: str,
     ) -> Any:
-        """Accept one user response for the tool's next invocation."""
+        """Accept one user response identified by the suspended interaction."""
 
 
 def tool_result_waits_for_user(result: Any) -> bool:

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -1,0 +1,47 @@
+"""Generic contract for tools that need a user response before continuing.
+
+Tools opt into the control flow by returning a mapping whose ``status`` is
+``waiting_for_user``.  The execution pattern presents the returned message,
+checkpoints, and stops the current run.  After the user replies, a resumable
+tool can receive that reply through ``resume_user_interaction`` immediately
+before its next invocation.
+
+The response is delivered through a runtime capability instead of model
+arguments.  This keeps server-owned interaction state out of the prompt and
+lets tools decide how to interpret the user's answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, runtime_checkable
+
+WAITING_FOR_USER_STATUS = "waiting_for_user"
+
+
+@runtime_checkable
+class ResumableUserInteractionTool(Protocol):
+    """Optional capability implemented by tools with resumable interactions."""
+
+    def resume_user_interaction(
+        self,
+        *,
+        interaction_id: str,
+        response: str,
+    ) -> Any:
+        """Accept one user response for the tool's next invocation."""
+
+
+def tool_result_waits_for_user(result: Any) -> bool:
+    """Return whether a tool result requests a user-interaction pause."""
+
+    return (
+        isinstance(result, dict)
+        and str(result.get("status") or "").strip().lower() == WAITING_FOR_USER_STATUS
+    )
+
+
+def user_interaction_resume_callable(tool: Any) -> Callable[..., Any] | None:
+    """Return a tool's optional user-interaction resume callback."""
+
+    resume = getattr(tool, "resume_user_interaction", None)
+    return resume if callable(resume) else None

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -2,13 +2,15 @@
 
 Tools opt into the control flow by returning a mapping whose ``status`` is
 ``waiting_for_user``.  The execution pattern presents the returned message,
-checkpoints, and stops the current run. After the user replies, the runtime
-delivers that reply to the exact suspended interaction through
-``resume_user_interaction`` before asking the model to replan.
+checkpoints, and stops the current run. After the user replies, the runtime asks
+the model to replan with the annotated response in context. Tools that keep
+server-owned interaction state may additionally implement
+``resume_user_interaction``; the runtime then delivers the reply to that exact
+suspended interaction before replanning.
 
-The response is delivered through a runtime capability instead of model
-arguments.  This keeps server-owned interaction state out of the prompt and
-lets tools decide how to interpret the user's answer.
+The optional runtime capability keeps server-owned interaction state out of
+model-generated tool arguments and lets those tools decide how to interpret the
+user's answer. Callback-less tools use the normal ReAct context and replan path.
 """
 
 from __future__ import annotations

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -963,6 +963,31 @@ def test_execution_adapter_hides_internal_error_for_interrupted_result() -> None
     assert result["error"] == "ReActPattern interrupted."
 
 
+def test_execution_adapter_preserves_completion_outcome() -> None:
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="partial",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = adapter._normalize_result(
+        result={
+            "status": "completed",
+            "success": True,
+            "output": "One item remains.",
+            "completion_outcome": "partial",
+        },
+        execution_type="agent_react",
+        execution_id="partial-exec",
+    )
+
+    assert result["completion_outcome"] == "partial"
+    assert result["metadata"]["completion_outcome"] == "partial"
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_resume_restores_from_tracer_after_restart() -> None:
     tracer = TracerCheckpointStore()

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4579,6 +4579,20 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     )
 
 
+@pytest.mark.parametrize("waiting_request", [None, [], "malformed"])
+def test_tool_interaction_response_queue_ignores_malformed_requests(
+    waiting_request: Any,
+) -> None:
+    pattern = ReActPattern()
+
+    pattern._queue_tool_interaction_responses(
+        waiting_request=waiting_request,
+        response="Continue",
+    )
+
+    assert pattern.pending_tool_interaction_responses == []
+
+
 @pytest.mark.asyncio
 async def test_concurrent_tool_interactions_pause_in_one_deterministic_message() -> (
     None
@@ -4657,6 +4671,10 @@ async def test_concurrent_tool_interactions_pause_in_one_deterministic_message()
         "decision",
         "decision_2",
     ]
+    assert [
+        request["interactions"][0]["field"]
+        for request in pattern.waiting_for_user_request["requests"]
+    ] == ["decision", "decision_2"]
     assert len(runtime.outbound_messages) == 1
     assert pattern.tool_ledger["first-call"].status == "waiting_for_user"
     assert pattern.tool_ledger["second-call"].status == "waiting_for_user"

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4626,9 +4626,103 @@ def test_tool_interaction_response_queue_ignores_malformed_requests(
     pattern._queue_tool_interaction_responses(
         waiting_request=waiting_request,
         response="Continue",
+        tools=[],
     )
 
     assert pattern.pending_tool_interaction_responses == []
+
+
+@pytest.mark.asyncio
+async def test_callback_less_tool_interaction_resumes_by_replanning() -> None:
+    class CallbackLessTool:
+        def __init__(self) -> None:
+            self.metadata = SimpleNamespace(
+                name="clarification_gate",
+                description="Ask for clarification without retaining server state.",
+            )
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "interaction_id": "interaction-1",
+                "message": "Which value should be used?",
+                "message_type": "question",
+                "interactions": [
+                    {
+                        "type": "text_input",
+                        "field": "value",
+                        "label": "Value",
+                    }
+                ],
+            }
+
+    tool = CallbackLessTool()
+    context = ExecutionContext(execution_id="callback-less-interaction")
+    context.add_user_message("Use the requested value.")
+    pattern = ReActPattern(max_iterations=2)
+    waiting = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "wait-call",
+                            "function": {
+                                "name": "clarification_gate",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+    )
+
+    assert waiting["status"] == "waiting_for_user"
+
+    context.add_user_message("Use 42")
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed = await resumed_pattern.run(
+        context=context,
+        tools=[tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "final-call",
+                            "function": {
+                                "name": "final_answer",
+                                "arguments": (
+                                    '{"response_language":"English",'
+                                    '"answer":"Using 42.",'
+                                    '"outcome":"completed"}'
+                                ),
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+    )
+
+    assert resumed["success"] is True
+    assert resumed["completion_outcome"] == "completed"
+    assert resumed_pattern.pending_tool_interaction_responses == []
+    response_message = next(
+        message
+        for message in context.messages
+        if message.role == "user" and message.content == "Use 42"
+    )
+    waiting_metadata = response_message.metadata["response_to_waiting_for_user"]
+    assert waiting_metadata["requests"][0]["tool_name"] == "clarification_gate"
 
 
 @pytest.mark.asyncio
@@ -4696,6 +4790,34 @@ async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
         "interaction_id": "interaction-2",
         "response": "Reject second",
     }
+    assert pattern.pending_tool_interaction_responses == []
+
+
+@pytest.mark.asyncio
+async def test_pending_interaction_without_resume_callback_is_skipped() -> None:
+    class CallbackLessTool:
+        metadata = SimpleNamespace(
+            name="clarification_gate",
+            description="No resume callback.",
+        )
+
+    pending = {
+        "tool_name": "clarification_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Use 42",
+    }
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [pending]
+    context = ExecutionContext(execution_id="callback-less-delivery")
+    runtime = PatternRuntime(execution_id="callback-less-delivery")
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[CallbackLessTool()],
+        context=context,
+        runtime=runtime,
+    )
+
     assert pattern.pending_tool_interaction_responses == []
 
 

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -2996,6 +2996,12 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
         in final_answer_schema["description"]
     )
     assert "response_language" in final_answer_schema["parameters"]["required"]
+    assert "outcome" in final_answer_schema["parameters"]["required"]
+    assert final_answer_schema["parameters"]["properties"]["outcome"]["enum"] == [
+        "completed",
+        "partial",
+        "blocked",
+    ]
     response_language_schema = final_answer_schema["parameters"]["properties"][
         "response_language"
     ]
@@ -3163,6 +3169,7 @@ async def test_react_pattern_accepts_plain_text_response() -> None:
         "output": "Direct answer",
         "response": "Direct answer",
         "status": "completed",
+        "completion_outcome": "completed",
     }
     assert context.messages[-1].content == "Direct answer"
 
@@ -4422,3 +4429,269 @@ async def test_react_pattern_skips_store_memory_tool_in_single_call_mode() -> No
     assert result["success"] is True
     assert "store_memory" not in _tool_names_from_llm_call(llm.calls[0])
     assert memory_store.added == []
+
+
+@pytest.mark.asyncio
+async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
+    class ResumableTool:
+        def __init__(self) -> None:
+            self.metadata = SimpleNamespace(
+                name="approval_gate",
+                description="Run an action after the user responds.",
+            )
+            self.resume_calls: list[dict[str, str]] = []
+            self.user_response: str | None = None
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> None:
+            self.resume_calls.append(
+                {"interaction_id": interaction_id, "response": response}
+            )
+            self.user_response = response
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            if self.user_response is None:
+                return {
+                    "success": False,
+                    "status": "waiting_for_user",
+                    "interaction_id": "interaction-1",
+                    "message": "Should the action continue?",
+                    "message_type": "confirmation",
+                    "interactions": [
+                        {
+                            "type": "select_one",
+                            "field": "decision",
+                            "label": "Decision",
+                            "options": [
+                                {"label": "Continue", "value": "continue"},
+                                {"label": "Stop", "value": "stop"},
+                            ],
+                        }
+                    ],
+                }
+            response = self.user_response
+            self.user_response = None
+            return {
+                "success": True,
+                "expression": args["expression"],
+                "user_response": response,
+            }
+
+    first_tool = ResumableTool()
+    context = ExecutionContext(execution_id="interaction-task")
+    context.add_user_message("Run the gated action.")
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(execution_id="interaction-task", tracer=tracer)
+    pattern = ReActPattern(max_iterations=4)
+    waiting = await pattern.run(
+        context=context,
+        tools=[first_tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "wait-call",
+                            "function": {
+                                "name": "approval_gate",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+        runtime=runtime,
+    )
+
+    assert waiting["status"] == "waiting_for_user"
+    assert waiting["message"] == "Should the action continue?"
+    assert pattern.tool_ledger["wait-call"].status == "waiting_for_user"
+    assert runtime.outbound_messages[0]["expect_response"] is True
+    assert any(
+        event["event_type"] == "action_end_tool"
+        and event["data"]["status"] == "waiting_for_user"
+        for event in tracer.events
+    )
+    assert not any(
+        event["event_type"] == "action_error_tool" for event in tracer.events
+    )
+
+    context.add_user_message("Continue")
+    resumed_tool = ResumableTool()
+    resumed_pattern = ReActPattern(max_iterations=4)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed = await resumed_pattern.run(
+        context=context,
+        tools=[resumed_tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "resume-call",
+                            "function": {
+                                "name": "approval_gate",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ]
+                },
+                {
+                    "tool_calls": [
+                        {
+                            "id": "final-call",
+                            "function": {
+                                "name": "final_answer",
+                                "arguments": (
+                                    '{"response_language":"English",'
+                                    '"answer":"The action completed.",'
+                                    '"outcome":"completed"}'
+                                ),
+                            },
+                        }
+                    ]
+                },
+            ]
+        ),
+    )
+
+    assert resumed["success"] is True
+    assert resumed["completion_outcome"] == "completed"
+    assert resumed_tool.resume_calls == [
+        {"interaction_id": "interaction-1", "response": "Continue"}
+    ]
+    assert resumed_pattern.pending_tool_interaction_responses == []
+    response_metadata = next(
+        message.metadata
+        for message in context.messages
+        if message.role == "user" and message.content == "Continue"
+    )
+    assert response_metadata["response_to_waiting_for_user"]["question"] == (
+        "Should the action continue?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_interactions_pause_in_one_deterministic_message() -> (
+    None
+):
+    class ConcurrentWaitingTool:
+        def __init__(self, name: str, message: str) -> None:
+            self.metadata = SimpleNamespace(
+                name=name,
+                description=f"Wait for {name} input.",
+                concurrency_safe=True,
+            )
+            self.message = message
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "interaction_id": f"{self.metadata.name}-interaction",
+                "message": self.message,
+                "interactions": [
+                    {
+                        "type": "text",
+                        "field": "decision",
+                        "label": self.metadata.name,
+                    }
+                ],
+            }
+
+    tools = [
+        ConcurrentWaitingTool("first_gate", "Answer the first question."),
+        ConcurrentWaitingTool("second_gate", "Answer the second question."),
+    ]
+    pattern = ReActPattern(
+        max_iterations=2,
+        tool_parallel_enabled=True,
+        tool_max_concurrency=2,
+    )
+    runtime = PatternRuntime(execution_id="concurrent-interactions")
+    context = ExecutionContext(execution_id="concurrent-interactions")
+    context.add_user_message("Run both checks.")
+
+    result = await pattern.run(
+        context=context,
+        tools=tools,
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "first-call",
+                            "function": {
+                                "name": "first_gate",
+                                "arguments": '{"expression":"1"}',
+                            },
+                        },
+                        {
+                            "id": "second-call",
+                            "function": {
+                                "name": "second_gate",
+                                "arguments": '{"expression":"2"}',
+                            },
+                        },
+                    ]
+                }
+            ]
+        ),
+        runtime=runtime,
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert result["message"].startswith("Multiple tools need your input")
+    assert [item["field"] for item in result["interactions"]] == [
+        "decision",
+        "decision_2",
+    ]
+    assert len(runtime.outbound_messages) == 1
+    assert pattern.tool_ledger["first-call"].status == "waiting_for_user"
+    assert pattern.tool_ledger["second-call"].status == "waiting_for_user"
+
+
+@pytest.mark.asyncio
+async def test_final_answer_preserves_semantic_completion_outcome() -> None:
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Complete everything if possible.")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "final-partial",
+                            "function": {
+                                "name": "final_answer",
+                                "arguments": (
+                                    '{"response_language":"English",'
+                                    '"answer":"One item remains.",'
+                                    '"outcome":"partial"}'
+                                ),
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert result["completion_outcome"] == "partial"

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -3466,9 +3466,7 @@ async def test_react_pattern_resume_waiting_after_user_response_continues() -> N
 
 
 @pytest.mark.asyncio
-async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool() -> (
-    None
-):
+async def test_react_pattern_replans_after_waiting_control_tool() -> None:
     llm = FakeLLM(
         responses=[
             {
@@ -3500,14 +3498,29 @@ async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool(
     first = await pattern.run(context=context, tools=[tool], llm=llm)
 
     assert first["status"] == "waiting_for_user"
-    assert pattern.pending_tool_calls == [
-        {"id": "call_calc", "name": "calculator", "args": {"expression": "5+5"}}
-    ]
+    assert pattern.pending_tool_calls == []
+    assert pattern.tool_ledger["call_calc"].status == "cancelled"
+    assert tool.calls == []
 
     context.add_user_message("B")
     resumed_pattern = ReActPattern(max_iterations=4)
     resumed_pattern.load_state(pattern.get_state())
-    resumed_llm = FakeLLM([{"content": "The result is 10.", "done": True}])
+    resumed_llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc_replanned",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"5+5"}',
+                        },
+                    }
+                ]
+            },
+            {"content": "The result is 10.", "done": True},
+        ]
+    )
 
     resumed = await resumed_pattern.run(
         context=context,
@@ -3517,19 +3530,16 @@ async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool(
 
     assert resumed["success"] is True
     assert tool.calls == [{"expression": "5+5"}]
-    assert context.get_messages_by_role("tool")[-1].tool_call_id == "call_calc"
+    assert context.get_messages_by_role("tool")[-1].tool_call_id == (
+        "call_calc_replanned"
+    )
     resumed_messages = resumed_llm.calls[0]["messages"]
-    resumed_tool_result = next(
+    cancelled_tool_result = next(
         message
         for message in resumed_messages
         if message.get("role") == "tool" and message.get("tool_call_id") == "call_calc"
     )
-    resumed_tool_envelope_index = resumed_messages.index(resumed_tool_result) - 1
-    assert resumed_messages[resumed_tool_envelope_index]["role"] == "assistant"
-    assert resumed_messages[resumed_tool_envelope_index]["tool_calls"][0]["id"] == (
-        "call_calc"
-    )
-    assert "Tool calculator returned" in resumed_tool_result["content"]
+    assert "cancelled" in cancelled_tool_result["content"]
 
 
 @pytest.mark.asyncio
@@ -4484,7 +4494,23 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
                 "user_response": response,
             }
 
+    class MutationTool:
+        def __init__(self) -> None:
+            self.metadata = SimpleNamespace(
+                name="mutation",
+                description="Mutate state.",
+            )
+            self.calls: list[dict[str, Any]] = []
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            self.calls.append(args)
+            return {"success": True}
+
     first_tool = ResumableTool()
+    first_mutation = MutationTool()
     context = ExecutionContext(execution_id="interaction-task")
     context.add_user_message("Run the gated action.")
     tracer = TraceEventRecorder()
@@ -4492,7 +4518,7 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     pattern = ReActPattern(max_iterations=4)
     waiting = await pattern.run(
         context=context,
-        tools=[first_tool],
+        tools=[first_tool, first_mutation],
         llm=FakeLLM(
             [
                 {
@@ -4503,7 +4529,14 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
                                 "name": "approval_gate",
                                 "arguments": '{"expression":"2+2"}',
                             },
-                        }
+                        },
+                        {
+                            "id": "stale-mutation",
+                            "function": {
+                                "name": "mutation",
+                                "arguments": '{"expression":"99"}',
+                            },
+                        },
                     ]
                 }
             ]
@@ -4514,6 +4547,9 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     assert waiting["status"] == "waiting_for_user"
     assert waiting["message"] == "Should the action continue?"
     assert pattern.tool_ledger["wait-call"].status == "waiting_for_user"
+    assert pattern.tool_ledger["stale-mutation"].status == "cancelled"
+    assert pattern.pending_tool_calls == []
+    assert first_mutation.calls == []
     assert runtime.outbound_messages[0]["expect_response"] is True
     assert any(
         event["event_type"] == "action_end_tool"
@@ -4526,11 +4562,12 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
 
     context.add_user_message("Continue")
     resumed_tool = ResumableTool()
+    resumed_mutation = MutationTool()
     resumed_pattern = ReActPattern(max_iterations=4)
     resumed_pattern.load_state(pattern.get_state())
     resumed = await resumed_pattern.run(
         context=context,
-        tools=[resumed_tool],
+        tools=[resumed_tool, resumed_mutation],
         llm=FakeLLM(
             [
                 {
@@ -4568,6 +4605,7 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     assert resumed_tool.resume_calls == [
         {"interaction_id": "interaction-1", "response": "Continue"}
     ]
+    assert resumed_mutation.calls == []
     assert resumed_pattern.pending_tool_interaction_responses == []
     response_metadata = next(
         message.metadata
@@ -4590,6 +4628,74 @@ def test_tool_interaction_response_queue_ignores_malformed_requests(
         response="Continue",
     )
 
+    assert pattern.pending_tool_interaction_responses == []
+
+
+@pytest.mark.asyncio
+async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
+    class ResumableTool:
+        def __init__(self) -> None:
+            self.metadata = SimpleNamespace(
+                name="approval_gate",
+                description="Resume exact interactions.",
+            )
+            self.calls: list[dict[str, str]] = []
+            self.fail_interaction_id = "interaction-2"
+
+        def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> None:
+            self.calls.append({"interaction_id": interaction_id, "response": response})
+            if interaction_id == self.fail_interaction_id:
+                raise RuntimeError("delivery failed")
+
+    pending = [
+        {
+            "tool_name": "approval_gate",
+            "tool_call_id": "call-1",
+            "interaction_id": "interaction-1",
+            "response": "Approve first",
+        },
+        {
+            "tool_name": "approval_gate",
+            "tool_call_id": "call-2",
+            "interaction_id": "interaction-2",
+            "response": "Reject second",
+        },
+    ]
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = list(pending)
+    tool = ResumableTool()
+    context = ExecutionContext(execution_id="interaction-delivery")
+    runtime = PatternRuntime(execution_id="interaction-delivery")
+
+    with pytest.raises(RuntimeError, match="delivery failed"):
+        await pattern._deliver_pending_tool_interaction_responses(
+            tools=[tool],
+            context=context,
+            runtime=runtime,
+        )
+
+    assert tool.calls == [
+        {"interaction_id": "interaction-1", "response": "Approve first"},
+        {"interaction_id": "interaction-2", "response": "Reject second"},
+    ]
+    assert pattern.pending_tool_interaction_responses == [pending[1]]
+
+    tool.fail_interaction_id = ""
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[tool],
+        context=context,
+        runtime=runtime,
+    )
+
+    assert tool.calls[-1] == {
+        "interaction_id": "interaction-2",
+        "response": "Reject second",
+    }
     assert pattern.pending_tool_interaction_responses == []
 
 
@@ -4624,9 +4730,27 @@ async def test_concurrent_tool_interactions_pause_in_one_deterministic_message()
                 ],
             }
 
+    class MutationTool:
+        def __init__(self) -> None:
+            self.metadata = SimpleNamespace(
+                name="mutation",
+                description="Mutate state.",
+                concurrency_safe=False,
+            )
+            self.calls: list[dict[str, Any]] = []
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            self.calls.append(args)
+            return {"success": True}
+
+    mutation_tool = MutationTool()
     tools = [
         ConcurrentWaitingTool("first_gate", "Answer the first question."),
         ConcurrentWaitingTool("second_gate", "Answer the second question."),
+        mutation_tool,
     ]
     pattern = ReActPattern(
         max_iterations=2,
@@ -4658,6 +4782,13 @@ async def test_concurrent_tool_interactions_pause_in_one_deterministic_message()
                                 "arguments": '{"expression":"2"}',
                             },
                         },
+                        {
+                            "id": "stale-mutation",
+                            "function": {
+                                "name": "mutation",
+                                "arguments": '{"expression":"3"}',
+                            },
+                        },
                     ]
                 }
             ]
@@ -4678,6 +4809,9 @@ async def test_concurrent_tool_interactions_pause_in_one_deterministic_message()
     assert len(runtime.outbound_messages) == 1
     assert pattern.tool_ledger["first-call"].status == "waiting_for_user"
     assert pattern.tool_ledger["second-call"].status == "waiting_for_user"
+    assert pattern.tool_ledger["stale-mutation"].status == "cancelled"
+    assert pattern.pending_tool_calls == []
+    assert mutation_tool.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -97,7 +97,10 @@ async def test_serial_then_ask_user_waits() -> None:
     assert [r["tool_name"] for r in context.tool_results] == [
         "s1",
         "ask_user_question",
+        "s2",
     ]
+    assert context.tool_results[-1]["result"]["status"] == "cancelled"
+    assert pattern.pending_tool_calls == []
     statuses = _checkpoint_statuses(runtime)
     assert "before_tool" in statuses  # serial path used for the lone safe tool
 

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -180,6 +180,21 @@ class FailingUserMessageCallback:
         raise RuntimeError("trace callback failed")
 
 
+class StatusAwareTeardownTool:
+    def __init__(self) -> None:
+        self.teardown_calls: list[tuple[str | None, str | None]] = []
+
+    async def setup(self, task_id: str | None = None) -> None:
+        return None
+
+    async def teardown(
+        self,
+        task_id: str | None = None,
+        execution_status: str | None = None,
+    ) -> None:
+        self.teardown_calls.append((task_id, execution_status))
+
+
 class RecordingTraceEventTracer:
     def __init__(self) -> None:
         self.events: list[dict[str, Any]] = []
@@ -314,6 +329,36 @@ async def test_runner_builds_context_and_invokes_pattern(tmp_path: Path) -> None
     assert isinstance(pattern_call["runtime"], PatternRuntime)
     assert workspace_manager.calls[0]["task_id"] == "exec-1"
     assert callback.events == [("start", "exec-1"), ("end", "exec-1")]
+
+
+@pytest.mark.asyncio
+async def test_runner_passes_waiting_status_to_tool_teardown(tmp_path: Path) -> None:
+    tool = StatusAwareTeardownTool()
+    agent = Agent(
+        name="interactive",
+        patterns=[
+            FakePattern(
+                {
+                    "success": False,
+                    "status": "waiting_for_user",
+                    "message": "Provide the missing value.",
+                }
+            )
+        ],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(
+        task="Run an interactive tool",
+        execution_id="interaction-task",
+        extra_tools=[tool],
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert tool.teardown_calls == [("interaction-task", "waiting_for_user")]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -362,6 +362,33 @@ async def test_runner_passes_waiting_status_to_tool_teardown(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_runner_passes_failed_status_when_tool_setup_raises(
+    tmp_path: Path,
+) -> None:
+    class SetupFailingTool(StatusAwareTeardownTool):
+        async def setup(self, task_id: str | None = None) -> None:
+            raise RuntimeError("setup failed")
+
+    tool = SetupFailingTool()
+    runner = AgentRunner(
+        agent=Agent(
+            name="setup-failure",
+            patterns=[FakePattern({"success": True, "output": "unused"})],
+        ),
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        await runner.run(
+            task="Initialize tools",
+            execution_id="setup-failure-task",
+            extra_tools=[tool],
+        )
+
+    assert tool.teardown_calls == [("setup-failure-task", "failed")]
+
+
+@pytest.mark.asyncio
 async def test_runner_awaits_async_memory_manager(tmp_path: Path) -> None:
     memory_manager = AsyncMemoryManager()
     pattern = FakePattern({"success": True, "output": "done"})

--- a/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
@@ -82,16 +82,29 @@ async def test_waiting_control_envelope_survives_field_filtering() -> None:
                 "message_type": "question",
                 "interactions": [
                     {
-                        "type": "select_one",
+                        "type": "file_upload",
                         "field": "exact-routing-field",
                         "label": "Choose the desired operation",
+                        "accept": ["video/mp4", "audio/mpeg"],
+                        "multiple": False,
+                        "multiline": False,
                         "options": [
                             {
                                 "label": "Approve this operation",
                                 "value": "exact-routing-option-value",
-                            }
+                            },
+                            {
+                                "label": "Reject this operation",
+                                "value": "second-routing-option-value",
+                            },
                         ],
-                    }
+                    },
+                    {
+                        "type": "confirm",
+                        "field": "second-routing-field",
+                        "label": "Continue to the next step?",
+                        "default": False,
+                    },
                 ],
             }
 
@@ -108,13 +121,23 @@ async def test_waiting_control_envelope_survives_field_filtering() -> None:
     assert result["interaction_id"] == "14ee67d1-d18e-47e0-a8f8-b28ef31262f5"
     assert result["message"].startswith("Provide ")
     assert result["message_type"] == "question"
-    assert result["interactions"][0]["type"] == "select_one"
+    assert len(result["interactions"]) == 2
+    assert result["interactions"][0]["type"] == "file_upload"
     assert result["interactions"][0]["field"] == "exact-routing-field"
     assert result["interactions"][0]["label"].startswith("Choose t")
+    assert result["interactions"][0]["accept"] == ["video/mp4", "audio/mpeg"]
+    assert result["interactions"][0]["multiple"] is False
+    assert result["interactions"][0]["multiline"] is False
+    assert len(result["interactions"][0]["options"]) == 2
     assert result["interactions"][0]["options"][0]["value"] == (
         "exact-routing-option-value"
     )
     assert result["interactions"][0]["options"][0]["label"].startswith("Approve ")
+    assert result["interactions"][0]["options"][1]["value"] == (
+        "second-routing-option-value"
+    )
+    assert result["interactions"][1]["field"] == "second-routing-field"
+    assert result["interactions"][1]["default"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
@@ -77,15 +77,27 @@ async def test_waiting_control_envelope_survives_field_filtering() -> None:
             return {
                 "large_unrelated_field": "x" * 100,
                 "status": "waiting_for_user",
-                "interaction_id": "interaction-1",
+                "interaction_id": "14ee67d1-d18e-47e0-a8f8-b28ef31262f5",
                 "message": "Provide a value.",
                 "message_type": "question",
-                "interactions": [{"type": "text", "field": "value"}],
+                "interactions": [
+                    {
+                        "type": "select_one",
+                        "field": "exact-routing-field",
+                        "label": "Choose the desired operation",
+                        "options": [
+                            {
+                                "label": "Approve this operation",
+                                "value": "exact-routing-option-value",
+                            }
+                        ],
+                    }
+                ],
             }
 
     wrapper = OutputFilteredToolWrapper(
         target_tool=WaitingTool(),
-        max_chars=20,
+        max_chars=8,
         max_fields=1,
         max_recursion=3,
     )
@@ -93,12 +105,16 @@ async def test_waiting_control_envelope_survives_field_filtering() -> None:
     result = await wrapper.run_json_async({})
 
     assert result["status"] == "waiting_for_user"
-    assert result["interaction_id"] == "interaction-1"
-    assert result["message"].startswith("Provide a value.")
+    assert result["interaction_id"] == "14ee67d1-d18e-47e0-a8f8-b28ef31262f5"
+    assert result["message"].startswith("Provide ")
     assert result["message_type"] == "question"
-    assert result["interactions"] == [
-        {"type": "text", "... and 1 more keys": "[truncated]"}
-    ]
+    assert result["interactions"][0]["type"] == "select_one"
+    assert result["interactions"][0]["field"] == "exact-routing-field"
+    assert result["interactions"][0]["label"].startswith("Choose t")
+    assert result["interactions"][0]["options"][0]["value"] == (
+        "exact-routing-option-value"
+    )
+    assert result["interactions"][0]["options"][0]["label"].startswith("Approve ")
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter_passthrough.py
@@ -1,0 +1,155 @@
+"""Runtime capabilities that must survive the output-filter wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.output_filter_wrapper import (
+    OutputFilteredToolWrapper,
+)
+
+
+def _wrap(target: Any) -> OutputFilteredToolWrapper:
+    return OutputFilteredToolWrapper(
+        target_tool=target,
+        max_chars=1_000,
+        max_fields=50,
+        max_recursion=5,
+    )
+
+
+def test_optional_capabilities_reach_through_the_wrapper() -> None:
+    class ResumableTool:
+        name = "resumable"
+        description = "Accepts a user response."
+        tags: list[str] = []
+        decision_group = "interactive"
+
+        def __init__(self) -> None:
+            self.responses: list[dict[str, str]] = []
+
+        def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> None:
+            self.responses.append(
+                {"interaction_id": interaction_id, "response": response}
+            )
+
+    target = ResumableTool()
+    wrapper = _wrap(target)
+
+    resume = getattr(wrapper, "resume_user_interaction", None)
+    assert callable(resume)
+    resume(interaction_id="interaction-1", response="Continue")
+
+    assert target.responses == [
+        {"interaction_id": "interaction-1", "response": "Continue"}
+    ]
+    assert wrapper.decision_group == "interactive"
+
+
+def test_absent_capabilities_stay_absent() -> None:
+    class PlainTool:
+        name = "plain"
+        description = "No optional capabilities."
+        tags: list[str] = []
+
+    wrapper = _wrap(PlainTool())
+
+    assert getattr(wrapper, "resume_user_interaction", None) is None
+    with pytest.raises(AttributeError):
+        wrapper.resume_user_interaction  # noqa: B018
+
+
+@pytest.mark.asyncio
+async def test_waiting_control_envelope_survives_field_filtering() -> None:
+    class WaitingTool:
+        name = "waiting"
+        description = "Returns an interaction after unrelated output."
+        tags: list[str] = []
+
+        async def run_json_async(self, args: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "large_unrelated_field": "x" * 100,
+                "status": "waiting_for_user",
+                "interaction_id": "interaction-1",
+                "message": "Provide a value.",
+                "message_type": "question",
+                "interactions": [{"type": "text", "field": "value"}],
+            }
+
+    wrapper = OutputFilteredToolWrapper(
+        target_tool=WaitingTool(),
+        max_chars=20,
+        max_fields=1,
+        max_recursion=3,
+    )
+
+    result = await wrapper.run_json_async({})
+
+    assert result["status"] == "waiting_for_user"
+    assert result["interaction_id"] == "interaction-1"
+    assert result["message"].startswith("Provide a value.")
+    assert result["message_type"] == "question"
+    assert result["interactions"] == [
+        {"type": "text", "... and 1 more keys": "[truncated]"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_teardown_forwards_execution_status_when_supported() -> None:
+    class StatusAwareTool:
+        name = "status-aware"
+        description = "Records teardown."
+        tags: list[str] = []
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def teardown(
+            self,
+            task_id: str | None = None,
+            execution_status: str | None = None,
+        ) -> None:
+            self.calls.append(
+                {"task_id": task_id, "execution_status": execution_status}
+            )
+
+    target = StatusAwareTool()
+
+    await _wrap(target).teardown(
+        task_id="task-1",
+        execution_status="waiting_for_user",
+    )
+
+    assert target.calls == [
+        {"task_id": "task-1", "execution_status": "waiting_for_user"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_teardown_omits_status_for_legacy_tool() -> None:
+    class LegacyTool:
+        name = "legacy"
+        description = "Legacy teardown signature."
+        tags: list[str] = []
+
+        def __init__(self) -> None:
+            self.calls: list[str | None] = []
+
+        async def teardown(self, task_id: str | None = None) -> None:
+            self.calls.append(task_id)
+
+    target = LegacyTool()
+
+    await _wrap(target).teardown(
+        task_id="task-2",
+        execution_status="completed",
+    )
+
+    assert target.calls == ["task-2"]

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from xagent.core.tools.user_interaction import (
+    tool_result_waits_for_user,
+    user_interaction_resume_callable,
+)
+
+
+def test_waiting_status_detection_is_normalized() -> None:
+    assert tool_result_waits_for_user({"status": "waiting_for_user"}) is True
+    assert tool_result_waits_for_user({"status": " WAITING_FOR_USER "}) is True
+    assert tool_result_waits_for_user({"status": "completed"}) is False
+    assert tool_result_waits_for_user("waiting_for_user") is False
+    assert tool_result_waits_for_user(None) is False
+
+
+def test_resume_capability_detection() -> None:
+    class Resumable:
+        def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> None:
+            return None
+
+    assert callable(user_interaction_resume_callable(Resumable()))
+    assert user_interaction_resume_callable(object()) is None


### PR DESCRIPTION
## Summary

- let any tool suspend ReAct execution by returning `status="waiting_for_user"`
- checkpoint the interaction, stop later calls in the turn, and resume from only the new user response
- deliver the response once through an optional `resume_user_interaction` tool capability
- preserve interaction capabilities and control envelopes through output-filter wrappers
- propagate execution status to tool teardown so stateful tools can preserve resources across a pause
- distinguish semantic completion outcomes (`completed`, `partial`, `blocked`) from the execution lifecycle

## Why

`ask_user_question` already pauses the ReAct control flow, but ordinary tools could not request user input safely. Their result was treated as a tool failure, wrappers could hide optional runtime capabilities, and stateful tools could not tell a pause from final teardown.

This change adds a generic interaction contract without embedding any domain-specific approval policy. Tools own the meaning of the response; the runtime only transports, checkpoints, and delivers it.

## Behavior

- serial and concurrent tool results can request a pause
- multiple concurrent requests are presented in one deterministic message
- interaction responses survive checkpoint restoration and are consumed once by the next matching capable tool
- waiting tools close tracing spans with `waiting_for_user`, not an error
- output filtering cannot discard the interaction control envelope
- final answers expose `completion_outcome` while retaining `status="completed"` as the lifecycle state

## Validation

- `python -m pytest -q tests/core/agent tests/core/tools/test_user_interaction.py tests/core/tools/adapters/vibe/test_output_filter_passthrough.py`
- `ruff check` on all changed source and test files
- `mypy` on all changed source files
- repository pre-commit hooks
- private implementation keyword audit over the added diff
