### PR TITLE
ref: add Bash command policy boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+command-path-guard = ["bashlex>=0.18"]
+
 # In-process LLM routing for OpenRouter's "auto" model. xrouter-llm currently
 # does not declare its bundled predictor runtime deps, so keep them explicit
 # here until upstream does.
@@ -139,6 +141,7 @@ milvus = ["pymilvus>=2.6.9,<3.0.0"]
 # All optional extras (for users who want everything)
 # Note: List packages directly since optional-dependencies doesn't support include-group
 all = [
+  "bashlex>=0.18",
   "unstructured>=0.15.0",
   "numba>=0.64.0",
   "typer>=0.9.0",            # Required by spacy CLI, used by unstructured
@@ -191,6 +194,7 @@ dev = [
 
 # Testing dependencies
 test = [
+  "bashlex>=0.18",
   "pytest>=8.0",
   "pytest-mock>=3.14.1",
   "pytest-cov>=6.2.1",
@@ -272,6 +276,7 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = [
   "asyncssh",
+  "bashlex",
   "docx",
   "pptx",
   "pptx.*",

--- a/src/xagent/core/tools/core/command_executor.py
+++ b/src/xagent/core/tools/core/command_executor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 from .command_policy import (
+    CommandArgvExecutionPolicy,
     CommandPathViolation,
     CommandPolicyGuard,
     CommandPolicyViolation,
@@ -207,7 +208,7 @@ class CommandExecutorCore:
             working_directory: Directory to use as working directory during execution
             path_guard: Optional policy implementation invoked before process creation
         """
-        self.path_guard = path_guard
+        self._path_guard = path_guard
         self._working_directory = _bind_policy_working_directory(
             working_directory,
             path_guard,
@@ -220,6 +221,11 @@ class CommandExecutorCore:
         if self._working_directory is None:
             return None
         return os.fspath(self._working_directory)
+
+    @property
+    def path_guard(self) -> Optional[CommandPolicyGuard]:
+        """Return the captured policy guard without exposing a mutation surface."""
+        return self._path_guard
 
     def execute_command(
         self,
@@ -252,14 +258,22 @@ class CommandExecutorCore:
         if shell and not isinstance(command, str):
             return _command_rejected_result("shell=True requires a string command")
 
-        if self.path_guard is not None:
+        argv_prepared_by_policy = False
+        if self._path_guard is not None:
             try:
                 if shell:
-                    self.path_guard.validate(cast(str, command))
+                    self._path_guard.validate(cast(str, command))
                 else:
                     argv = [command] if isinstance(command, str) else list(command)
-                    self.path_guard.validate_argv(argv)
-                    command = argv
+                    if isinstance(
+                        self._path_guard,
+                        CommandArgvExecutionPolicy,
+                    ):
+                        command = self._path_guard.prepare_argv_for_execution(argv)
+                        argv_prepared_by_policy = True
+                    else:
+                        self._path_guard.validate_argv(argv)
+                        command = argv
             except CommandPolicyViolation as exc:
                 return _command_rejected_result(exc)
             except Exception:
@@ -285,7 +299,7 @@ class CommandExecutorCore:
             "timeout": timeout,
             "cwd": self._working_directory,
         }
-        if self.path_guard is not None and shell:
+        if self._path_guard is not None and shell:
             try:
                 run_options["executable"] = os.fspath(
                     resolve_trusted_executable("bash")
@@ -293,8 +307,9 @@ class CommandExecutorCore:
             except CommandPolicyViolation as exc:
                 return _command_rejected_result(exc)
         elif (
-            self.path_guard is not None
+            self._path_guard is not None
             and not shell
+            and not argv_prepared_by_policy
             and isinstance(command, list)
             and command
             and os.path.basename(command[0]) == "bash"
@@ -376,7 +391,7 @@ class CommandExecutorCore:
         """
         timeout = _validate_timeout(timeout, self.timeout)
 
-        if self.path_guard is not None:
+        if self._path_guard is not None:
             return _command_rejected_result(
                 CommandPolicyViolation(
                     "restricted execute_script requires race-safe file semantics"

--- a/src/xagent/core/tools/core/command_executor.py
+++ b/src/xagent/core/tools/core/command_executor.py
@@ -7,8 +7,6 @@ Execute shell commands and scripts with proper controls.
 import logging
 import os
 import re
-import shlex
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -18,6 +16,8 @@ from .command_policy import (
     CommandPathViolation,
     CommandPolicyGuard,
     CommandPolicyViolation,
+    CwdBoundCommandPolicy,
+    resolve_trusted_executable,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,16 +31,6 @@ TIMEOUT_EXIT_CODE = -999
 
 # Conventional shell exit code for a command found but not permitted to run.
 COMMAND_REJECTED_EXIT_CODE = 126
-
-
-def _resolve_policy_shell_executable() -> str:
-    """Return the Bash executable whose grammar is owned by the policy parser."""
-    executable = shutil.which("bash")
-    if executable is None:
-        raise CommandPolicyViolation(
-            "restricted command execution requires a Bash executable"
-        )
-    return executable
 
 
 def _command_rejected_result(reason: object) -> Dict[str, Any]:
@@ -155,6 +145,37 @@ def _validate_working_directory(working_directory: Optional[str]) -> None:
         )
 
 
+def _bind_policy_working_directory(
+    working_directory: Optional[str],
+    path_guard: Optional[CommandPolicyGuard],
+) -> str | Path | None:
+    """Bind execution to a cwd-aware policy while preserving legacy guards."""
+    if path_guard is None or not isinstance(path_guard, CwdBoundCommandPolicy):
+        return working_directory
+
+    policy_cwd = path_guard.execution_cwd
+    if policy_cwd is None:
+        return working_directory
+    if not policy_cwd.is_absolute():
+        raise ValueError("command policy execution cwd must be canonical and absolute")
+    try:
+        canonical_policy_cwd = policy_cwd.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("command policy execution cwd must be accessible") from exc
+    if canonical_policy_cwd != policy_cwd:
+        raise ValueError("command policy execution cwd must be canonical and absolute")
+    _validate_working_directory(str(policy_cwd))
+
+    if working_directory:
+        _validate_working_directory(working_directory)
+        caller_cwd = Path(working_directory).expanduser().resolve(strict=True)
+        if caller_cwd != policy_cwd:
+            raise ValueError(
+                "working_directory does not match command policy execution cwd"
+            )
+    return policy_cwd
+
+
 def _sanitize_interpreter_suffix(interpreter: str) -> str:
     """
     Sanitize interpreter name for use as temp file suffix.
@@ -186,9 +207,19 @@ class CommandExecutorCore:
             working_directory: Directory to use as working directory during execution
             path_guard: Optional policy implementation invoked before process creation
         """
-        self.working_directory = working_directory
         self.path_guard = path_guard
+        self._working_directory = _bind_policy_working_directory(
+            working_directory,
+            path_guard,
+        )
         self.timeout = 300  # 5 minutes default
+
+    @property
+    def working_directory(self) -> Optional[str]:
+        """Return the configured cwd without exposing a mutation surface."""
+        if self._working_directory is None:
+            return None
+        return os.fspath(self._working_directory)
 
     def execute_command(
         self,
@@ -252,11 +283,27 @@ class CommandExecutorCore:
             "capture_output": capture_output,
             "text": True,
             "timeout": timeout,
-            "cwd": self.working_directory,
+            "cwd": self._working_directory,
         }
         if self.path_guard is not None and shell:
             try:
-                run_options["executable"] = _resolve_policy_shell_executable()
+                run_options["executable"] = os.fspath(
+                    resolve_trusted_executable("bash")
+                )
+            except CommandPolicyViolation as exc:
+                return _command_rejected_result(exc)
+        elif (
+            self.path_guard is not None
+            and not shell
+            and isinstance(command, list)
+            and command
+            and os.path.basename(command[0]) == "bash"
+        ):
+            try:
+                command = [
+                    os.fspath(resolve_trusted_executable(command[0])),
+                    *command[1:],
+                ]
             except CommandPolicyViolation as exc:
                 return _command_rejected_result(exc)
 
@@ -311,6 +358,11 @@ class CommandExecutorCore:
         """
         Execute script content with specified interpreter.
 
+        Guarded execution is rejected because this method's real-file semantics
+        cannot yet be preserved through the command policy without introducing
+        a validation-to-execution race. Unguarded execution retains its legacy
+        temporary-file behavior.
+
         Args:
             script_content: Script content to execute
             interpreter: Interpreter to use (bash, python, node, sh, etc.)
@@ -325,23 +377,10 @@ class CommandExecutorCore:
         timeout = _validate_timeout(timeout, self.timeout)
 
         if self.path_guard is not None:
-            try:
-                interpreter_argv = shlex.split(interpreter)
-            except ValueError:
-                return _command_rejected_result("invalid script interpreter")
-            if not interpreter_argv:
-                return _command_rejected_result("script interpreter is required")
-            if (
-                len(interpreter_argv) != 1
-                or os.path.basename(interpreter_argv[0]) != "bash"
-            ):
-                return _command_rejected_result(
-                    "restricted execute_script requires the Bash policy shell"
+            return _command_rejected_result(
+                CommandPolicyViolation(
+                    "restricted execute_script requires race-safe file semantics"
                 )
-            return self.execute_command(
-                [*interpreter_argv, "-c", script_content],
-                timeout=timeout,
-                shell=False,
             )
 
         try:

--- a/src/xagent/core/tools/core/command_executor.py
+++ b/src/xagent/core/tools/core/command_executor.py
@@ -7,6 +7,8 @@ Execute shell commands and scripts with proper controls.
 import logging
 import os
 import re
+import shlex
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -29,6 +31,16 @@ TIMEOUT_EXIT_CODE = -999
 
 # Conventional shell exit code for a command found but not permitted to run.
 COMMAND_REJECTED_EXIT_CODE = 126
+
+
+def _resolve_policy_shell_executable() -> str:
+    """Return the Bash executable whose grammar is owned by the policy parser."""
+    executable = shutil.which("bash")
+    if executable is None:
+        raise CommandPolicyViolation(
+            "restricted command execution requires a Bash executable"
+        )
+    return executable
 
 
 def _command_rejected_result(reason: object) -> Dict[str, Any]:
@@ -235,14 +247,23 @@ class CommandExecutorCore:
                 f"CommandExecutor: Using working directory: {self.working_directory}"
             )
 
+        run_options: dict[str, Any] = {
+            "shell": shell,
+            "capture_output": capture_output,
+            "text": True,
+            "timeout": timeout,
+            "cwd": self.working_directory,
+        }
+        if self.path_guard is not None and shell:
+            try:
+                run_options["executable"] = _resolve_policy_shell_executable()
+            except CommandPolicyViolation as exc:
+                return _command_rejected_result(exc)
+
         try:
             result = subprocess.run(
                 command,
-                shell=shell,
-                capture_output=capture_output,
-                text=True,
-                timeout=timeout,
-                cwd=self.working_directory,  # Use cwd parameter instead of os.chdir()
+                **run_options,
             )
 
             output = result.stdout if capture_output else ""
@@ -304,8 +325,23 @@ class CommandExecutorCore:
         timeout = _validate_timeout(timeout, self.timeout)
 
         if self.path_guard is not None:
-            return _command_rejected_result(
-                "script execution is unavailable under an injected command policy"
+            try:
+                interpreter_argv = shlex.split(interpreter)
+            except ValueError:
+                return _command_rejected_result("invalid script interpreter")
+            if not interpreter_argv:
+                return _command_rejected_result("script interpreter is required")
+            if (
+                len(interpreter_argv) != 1
+                or os.path.basename(interpreter_argv[0]) != "bash"
+            ):
+                return _command_rejected_result(
+                    "restricted execute_script requires the Bash policy shell"
+                )
+            return self.execute_command(
+                [*interpreter_argv, "-c", script_content],
+                timeout=timeout,
+                shell=False,
             )
 
         try:

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -26,7 +26,17 @@ from typing import (
     cast,
 )
 
-import bashlex
+try:
+    import bashlex
+except ModuleNotFoundError as _bashlex_import_error:  # pragma: no cover
+    # ``bashlex`` ships in the optional ``command-path-guard`` extra, not the
+    # base dependencies. Import lazily so importing this module (and collecting
+    # its tests) never fails on a plain install; construction fails closed with
+    # an actionable hint when the parser is genuinely required.
+    bashlex = None
+    _BASHLEX_IMPORT_ERROR: ModuleNotFoundError | None = _bashlex_import_error
+else:
+    _BASHLEX_IMPORT_ERROR = None
 
 from ...workspace import TaskWorkspace
 from .command_policy import (
@@ -39,7 +49,11 @@ from .command_policy import (
 logger = logging.getLogger(__name__)
 
 _MAX_COMMAND_POLICY_INPUT_CHARS = 64 * 1024
-_MAX_INSPECTED_SCRIPT_BYTES = _MAX_COMMAND_POLICY_INPUT_CHARS
+# Bounded budget for reading script/config files off disk before inspection.
+# Numerically equal to the character input cap but kept in its own byte domain
+# (compared against ``os.fstat().st_size`` and ``len(raw_bytes)``) so the two
+# limits can move independently instead of silently coupling chars to bytes.
+_MAX_INSPECTED_SCRIPT_BYTES = 64 * 1024
 _MAX_INSPECTED_SCRIPT_DEPTH = 8
 _MAX_COMMAND_WRAPPER_DEPTH = 32
 _MAX_POSSIBLE_SHELL_STATES = 16
@@ -636,6 +650,11 @@ class WorkspaceCommandPathGuard:
     """Validate Bash language boundaries against one task workspace."""
 
     def __init__(self, workspace: TaskWorkspace) -> None:
+        if bashlex is None:
+            raise ModuleNotFoundError(
+                "WorkspaceCommandPathGuard requires the 'bashlex' parser. Install "
+                "the optional extra: pip install 'xagent[command-path-guard]'."
+            ) from _BASHLEX_IMPORT_ERROR
         self._workspace = workspace
         self._initial_cwd = workspace.resolve_path("").resolve()
 
@@ -657,12 +676,19 @@ class WorkspaceCommandPathGuard:
         ):
             return []
         policy_source = _normalize_policy_shell_source(command)
+        if bashlex is None:  # pragma: no cover - guarded at construction
+            raise CommandPolicyViolation("shell command parser is unavailable")
         try:
             nodes = cast(list[Any], bashlex.parse(policy_source))
         except Exception as exc:
             # bashlex exposes several parser-internal exception types. Normalize
             # all of them at this boundary so malformed input never reaches the
             # executor through a parser-version-specific failure mode.
+            #
+            # Invariant: input bashlex cannot model (``$(( ))``, ``[[ ]]``,
+            # ``case``, ``select``, ``coproc``, array assignments, ...) MUST stay
+            # fail-closed here. Never relax this into a fail-open path to reduce
+            # false positives on unparsable input.
             logger.debug("Command path guard rejected unparsed shell input")
             raise CommandPolicyViolation("cannot safely parse shell command") from exc
         _mark_unmodeled_expansions(nodes, policy_source)
@@ -899,11 +925,11 @@ class WorkspaceCommandPathGuard:
                 f"cannot safely inspect privilege escalation via {command_name}"
             )
         if self._is_direct_command_path(command_word):
-            if not self._is_trusted_system_command(command_word, command_name):
+            if not self._is_trusted_system_command(command_word):
                 self._inspect_direct_shell_script(command_word, state)
                 return state
         elif command_name in _CLASSIFIED_EXECUTABLE_COMMANDS:
-            if not self._is_trusted_system_command(command_word, command_name):
+            if not self._is_trusted_system_command(command_word):
                 discovered = shutil.which(command_name)
                 if discovered is not None:
                     self._inspect_direct_shell_script(discovered, state)
@@ -980,6 +1006,53 @@ class WorkspaceCommandPathGuard:
             )
         return home
 
+    @staticmethod
+    def _reject_symlink_traversing_chdir(target_word: str, cwd: Path) -> None:
+        """Reject a directory change whose target path crosses a symlink.
+
+        The guard tracks a *physically* resolved cwd, but Bash's ``cd``/``pushd``
+        (without ``-P``) are *logical*: they collapse ``..`` textually against
+        the pre-symlink path instead of following symlinks. When a target both
+        crosses a symlink and carries ``..`` segments, the guard's resolved cwd
+        diverges from where Bash actually lands, so a later relative operand can
+        resolve inside the workspace while Bash reads/writes a sibling tenant's
+        files. Physical and logical resolution agree whenever no symlink is
+        traversed, so rejecting symlink-crossing directory changes keeps the
+        tracked cwd equal to Bash's logical cwd. Fail closed rather than emulate
+        logical ``cd``. ``cd -``/``popd``/stack rotation restore an
+        already-validated, symlink-free cwd and do not reach this check.
+        """
+        if isinstance(target_word, _CommandValue) and not target_word.is_static:
+            # Dynamic targets are rejected by the resolver below; do not probe
+            # an unexpanded literal against the filesystem.
+            return
+        target = Path(target_word).expanduser()
+        if target.is_absolute():
+            probe = Path(target.anchor)
+            parts = target.parts[1:]
+        else:
+            probe = cwd
+            parts = target.parts
+        for part in parts:
+            if part == ".":
+                continue
+            if part == "..":
+                probe = probe.parent
+                continue
+            probe = probe / part
+            try:
+                crosses_symlink = probe.is_symlink()
+            except OSError as exc:
+                raise CommandPolicyViolation(
+                    "cannot inspect directory change target"
+                ) from exc
+            if crosses_symlink:
+                raise CommandPolicyViolation(
+                    "cannot safely resolve a directory change that traverses a "
+                    "symlink; Bash resolves 'cd' logically while the guard "
+                    "resolves physically"
+                )
+
     def _change_directory(
         self,
         command_name: str,
@@ -998,6 +1071,7 @@ class WorkspaceCommandPathGuard:
                     )
                 target = state.previous_cwd
             else:
+                self._reject_symlink_traversing_chdir(target_word, state.cwd)
                 target = self._check_path(target_word, state.cwd, "read")
             return replace(state, cwd=target, previous_cwd=state.cwd)
 
@@ -1012,6 +1086,7 @@ class WorkspaceCommandPathGuard:
             if operands:
                 if operands[0] == "-":
                     raise CommandPolicyViolation("cannot safely resolve pushd target")
+                self._reject_symlink_traversing_chdir(operands[0], state.cwd)
                 target = self._check_path(operands[0], state.cwd, "read")
                 stack = (state.cwd, *state.directory_stack)
             else:
@@ -1243,7 +1318,7 @@ class WorkspaceCommandPathGuard:
         return "/" in command_word
 
     @staticmethod
-    def _is_trusted_system_command(command_word: str, command_name: str) -> bool:
+    def _is_trusted_system_command(command_word: str) -> bool:
         try:
             resolve_trusted_executable(command_word)
             return True
@@ -1613,7 +1688,7 @@ class WorkspaceCommandPathGuard:
                 "instead of using active globs or shell expansions"
             )
 
-        if raw_path in {"", "-", "{}"}:
+        if raw_path in {"", "-"}:
             return cwd
 
         candidate = Path(raw_path).expanduser()

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1067,6 +1067,8 @@ class WorkspaceCommandPathGuard:
             )
         command_option_index: int | None = None
         for index, value in enumerate(literals[:-1]):
+            if value == "--":
+                break
             if (
                 value.startswith("-")
                 and not value.startswith("--")
@@ -1111,6 +1113,9 @@ class WorkspaceCommandPathGuard:
         index = 0
         while index < len(values):
             value = values[index]
+            if value == "--":
+                remaining.extend(values[index:])
+                break
             if value in _BASH_FILE_OPTIONS:
                 if index + 1 < len(values):
                     initialization_files.append(values[index + 1])

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -182,6 +182,11 @@ _NO_FILESYSTEM_EFFECT_COMMANDS = {
     "declare",
     "typeset",
 }
+# Options that consume a following token as their value, per classified command,
+# so the value is not misread as a path operand (e.g. `mkdir -m 0755 dir`).
+_COMMAND_VALUE_OPTIONS = {
+    "mkdir": frozenset({"-m", "--mode"}),
+}
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
 _BASH_LONG_FLAG_OPTIONS = {
     "--debug",
@@ -966,7 +971,12 @@ class WorkspaceCommandPathGuard:
         if command_name in _READ_COMMANDS:
             self._check_operands(args, state.cwd, "read")
         elif command_name in _WRITE_COMMANDS:
-            self._check_operands(args, state.cwd, "write")
+            self._check_operands(
+                args,
+                state.cwd,
+                "write",
+                value_options=_COMMAND_VALUE_OPTIONS.get(command_name, frozenset()),
+            )
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -1268,8 +1278,10 @@ class WorkspaceCommandPathGuard:
         values: Sequence[str],
         cwd: Path,
         access: PathAccess,
+        *,
+        value_options: frozenset[str] = frozenset(),
     ) -> None:
-        for raw_path in self._operands(values):
+        for raw_path in self._operands(values, value_options=value_options):
             self._check_path(raw_path, cwd, access)
 
     def _read_policy_script(self, raw_path: str, cwd: Path) -> str:
@@ -1664,14 +1676,29 @@ class WorkspaceCommandPathGuard:
             raise CommandPolicyViolation(f"cannot resolve dynamic {context}")
 
     @staticmethod
-    def _operands(values: Sequence[str]) -> list[str]:
+    def _operands(
+        values: Sequence[str],
+        *,
+        value_options: frozenset[str] = frozenset(),
+    ) -> list[str]:
         operands: list[str] = []
         options_done = False
+        skip_next_value = False
         for value in values:
+            if skip_next_value:
+                # Separated value of a preceding value-consuming option.
+                skip_next_value = False
+                continue
             if not options_done and value == "--":
                 options_done = True
                 continue
             if not options_done and value.startswith("-") and value != "-":
+                # An option that consumes a following token must not let that
+                # value be misread as a path operand. Attached forms (`-m0755`,
+                # `--mode=0755`) are already dropped whole; only a separated
+                # value needs to be skipped explicitly.
+                if value in value_options:
+                    skip_next_value = True
                 continue
             operands.append(value)
         return operands

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -33,6 +33,7 @@ from .command_policy import (
     CommandPathViolation,
     CommandPolicyViolation,
     PathAccess,
+    resolve_trusted_executable,
 )
 
 logger = logging.getLogger(__name__)
@@ -180,15 +181,6 @@ _SAFE_DEVICE_PATHS = {
     Path("/dev/stdout"),
     Path("/dev/stderr"),
 }
-_TRUSTED_EXECUTABLE_ROOTS = tuple(
-    path.resolve()
-    for path in (
-        Path("/bin"),
-        Path("/usr/bin"),
-        Path("/usr/local/bin"),
-        Path("/opt/homebrew/bin"),
-    )
-)
 _POLICY_TIME_WRAPPER = "__t_"
 
 
@@ -644,6 +636,11 @@ class WorkspaceCommandPathGuard:
         self._workspace = workspace
         self._initial_cwd = workspace.resolve_path("").resolve()
 
+    @property
+    def execution_cwd(self) -> Path:
+        """Return the canonical directory whose paths this guard validates."""
+        return self._initial_cwd
+
     @staticmethod
     def _parse_shell(command: str) -> list[Any]:
         if len(command) > _MAX_COMMAND_POLICY_INPUT_CHARS:
@@ -878,13 +875,11 @@ class WorkspaceCommandPathGuard:
                 self._inspect_direct_shell_script(command_word, state)
                 return state
         elif command_name in _CLASSIFIED_EXECUTABLE_COMMANDS:
-            discovered = shutil.which(command_name)
-            if discovered is not None and not self._is_trusted_system_command(
-                discovered,
-                command_name,
-            ):
-                self._inspect_direct_shell_script(discovered, state)
-                return state
+            if not self._is_trusted_system_command(command_word, command_name):
+                discovered = shutil.which(command_name)
+                if discovered is not None:
+                    self._inspect_direct_shell_script(discovered, state)
+                    return state
 
         if command_name in {"cd", "pushd", "popd"}:
             return self._change_directory(command_name, args, state)
@@ -1219,18 +1214,10 @@ class WorkspaceCommandPathGuard:
 
     @staticmethod
     def _is_trusted_system_command(command_word: str, command_name: str) -> bool:
-        candidate = Path(command_word).expanduser()
-        if not candidate.is_absolute():
-            return False
-        discovered = shutil.which(command_name)
-        if discovered is None:
-            return False
         try:
-            resolved = candidate.resolve()
-            return resolved == Path(discovered).resolve() and any(
-                resolved.is_relative_to(root) for root in _TRUSTED_EXECUTABLE_ROOTS
-            )
-        except (OSError, RuntimeError):
+            resolve_trusted_executable(command_word)
+            return True
+        except CommandPolicyViolation:
             return False
 
     def _inspect_direct_shell_script(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import errno
 import logging
 import os
-import re
 import shutil
 import stat
 from contextlib import contextmanager
@@ -38,10 +37,10 @@ from .command_policy import (
 
 logger = logging.getLogger(__name__)
 
-_MAX_INSPECTED_SCRIPT_BYTES = 1024 * 1024
+_MAX_COMMAND_POLICY_INPUT_CHARS = 64 * 1024
+_MAX_INSPECTED_SCRIPT_BYTES = _MAX_COMMAND_POLICY_INPUT_CHARS
 _MAX_INSPECTED_SCRIPT_DEPTH = 8
 _MAX_COMMAND_WRAPPER_DEPTH = 32
-_MAX_COMMAND_POLICY_INPUT_CHARS = 64 * 1024
 _MAX_POSSIBLE_SHELL_STATES = 16
 _MAX_POLICY_PARSE_ATTEMPTS = 64
 _MAX_POLICY_SOURCE_CHARS = 1024 * 1024
@@ -147,7 +146,27 @@ _READ_COMMANDS = {"cat"}
 _WRITE_COMMANDS = {"rm"}
 _SHELL_COMMANDS = {"bash"}
 _UNSUPPORTED_SHELL_COMMANDS = {"dash", "sh", "zsh"}
+_UNSUPPORTED_PRIVILEGE_COMMANDS = {"sudo"}
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
+_BASH_LONG_FLAG_OPTIONS = {
+    "--debug",
+    "--debugger",
+    "--dump-po-strings",
+    "--dump-strings",
+    "--help",
+    "--login",
+    "--noediting",
+    "--noprofile",
+    "--norc",
+    "--posix",
+    "--pretty-print",
+    "--protected",
+    "--restricted",
+    "--verbose",
+    "--version",
+    "--wordexp",
+}
+_BASH_SHORT_FLAG_OPTIONS = frozenset("abefhiklmnprstuvxBCDHP")
 _IMPLICIT_SHELL_ENVIRONMENT = {"BASH_ENV", "CDPATH", "ENV", "ZDOTDIR"}
 _REJECTED_SHELL_ASSIGNMENTS = {
     *_IMPLICIT_SHELL_ENVIRONMENT,
@@ -170,14 +189,6 @@ _TRUSTED_EXECUTABLE_ROOTS = tuple(
         Path("/opt/homebrew/bin"),
     )
 )
-_QUOTED_HEREDOC_PATTERN = re.compile(
-    r"(?m)(?P<operator><<-?)(?P<space>[ \t]*)(?P<quote>['\"])"
-    r"(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)(?=[ \t]*$)"
-)
-_TIME_KEYWORD_PATTERN = re.compile(
-    r"(?m)(?P<prefix>^|(?<=[;\n])|(?<=&&)|(?<=\|\|))"
-    r"(?P<space>[ \t]*)time(?=[ \t]+)"
-)
 _POLICY_TIME_WRAPPER = "__t_"
 
 
@@ -192,23 +203,105 @@ def _secure_script_open_flags() -> int:
     return os.O_RDONLY | nonblocking | nofollow
 
 
-def _is_unquoted_on_current_line(source: str, position: int) -> bool:
-    """Return whether ``position`` is outside quotes on its physical line."""
-    line_start = source.rfind("\n", 0, position) + 1
-    in_single_quote = False
-    in_double_quote = False
-    escaped = False
-    for character in source[line_start:position]:
-        if escaped:
-            escaped = False
-            continue
-        if character == "\\" and not in_single_quote:
-            escaped = True
-        elif character == "'" and not in_double_quote:
-            in_single_quote = not in_single_quote
-        elif character == '"' and not in_single_quote:
-            in_double_quote = not in_double_quote
-    return not in_single_quote and not in_double_quote and not escaped
+@dataclass(frozen=True)
+class _HeredocDeclaration:
+    delimiter: str
+    strip_tabs: bool
+    quoted: bool
+
+
+def _is_time_keyword_position(source: str, position: int) -> bool:
+    if not source.startswith("time", position):
+        return False
+    after = position + len("time")
+    if after >= len(source) or source[after] not in " \t":
+        return False
+    cursor = position - 1
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    if cursor < 0 or source[cursor] in ";\n":
+        return True
+    return source[max(0, cursor - 1) : cursor + 1] in {"&&", "||"}
+
+
+def _parse_heredoc_delimiter(
+    source: str,
+    start: int,
+    normalized: list[str],
+) -> tuple[_HeredocDeclaration | None, int]:
+    cursor = start
+    while cursor < len(source) and source[cursor] in " \t":
+        cursor += 1
+    if cursor >= len(source) or source[cursor] in "\r\n;|&()<>":
+        return None, cursor
+
+    token_start = cursor
+    delimiter: list[str] = []
+    quote: str | None = None
+    quoted = False
+    while cursor < len(source):
+        character = source[cursor]
+        if quote is None and character in " \t\r\n;|&()<>":
+            break
+        if quote is None and character in {"'", '"'}:
+            quote = character
+            quoted = True
+            normalized[cursor] = " "
+        elif quote == character:
+            quote = None
+            normalized[cursor] = " "
+        elif quote is None and character == "\\":
+            quoted = True
+            normalized[cursor] = " "
+            cursor += 1
+            if cursor >= len(source):
+                return None, cursor
+            delimiter.append(source[cursor])
+        else:
+            delimiter.append(character)
+        cursor += 1
+
+    if quote is not None or not delimiter:
+        return None, cursor
+    delimiter_value = "".join(delimiter)
+    if quoted:
+        normalized[token_start:cursor] = delimiter_value.ljust(cursor - token_start)
+    return (
+        _HeredocDeclaration(
+            delimiter=delimiter_value,
+            strip_tabs=False,
+            quoted=quoted,
+        ),
+        cursor,
+    )
+
+
+def _consume_heredoc_bodies(
+    source: str,
+    start: int,
+    declarations: Sequence[_HeredocDeclaration],
+    normalized: list[str],
+) -> int:
+    cursor = start
+    for declaration in declarations:
+        while cursor <= len(source):
+            line_end = source.find("\n", cursor)
+            if line_end < 0:
+                line_end = len(source)
+            line = source[cursor:line_end]
+            comparable = line.lstrip("\t") if declaration.strip_tabs else line
+            if comparable == declaration.delimiter:
+                cursor = line_end + (line_end < len(source))
+                break
+            if declaration.quoted:
+                for index in range(cursor, line_end):
+                    normalized[index] = "x"
+            if line_end == len(source):
+                raise CommandPolicyViolation("cannot safely parse shell command")
+            cursor = line_end + 1
+        else:
+            raise CommandPolicyViolation("cannot safely parse shell command")
+    return cursor
 
 
 def _has_active_unmodeled_expansion(raw_word: str) -> bool:
@@ -298,42 +391,80 @@ def _normalize_policy_shell_source(command: str) -> str:
     expansion or nested commands.
     """
     normalized = list(command)
-    for match in _QUOTED_HEREDOC_PATTERN.finditer(command):
-        if not _is_unquoted_on_current_line(command, match.start()):
-            continue
-        quote_start = match.start("quote")
-        quote_end = match.end("delimiter")
-        normalized[quote_start] = " "
-        normalized[quote_end] = " "
+    declarations: list[_HeredocDeclaration] = []
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    in_comment = False
+    cursor = 0
 
-        body_start = command.find("\n", match.end())
-        if body_start < 0:
+    while cursor < len(command):
+        character = command[cursor]
+        if in_comment:
+            if character == "\n":
+                in_comment = False
+            else:
+                cursor += 1
+                continue
+        if escaped:
+            escaped = False
+            cursor += 1
             continue
-        body_start += 1
-        delimiter = match.group("delimiter")
-        strip_tabs = match.group("operator") == "<<-"
-        cursor = body_start
-        while cursor <= len(command):
-            line_end = command.find("\n", cursor)
-            if line_end < 0:
-                line_end = len(command)
-            line = command[cursor:line_end]
-            comparable = line.lstrip("\t") if strip_tabs else line
-            if comparable == delimiter:
-                break
-            for index in range(cursor, line_end):
-                normalized[index] = "x"
-            if line_end == len(command):
-                break
-            cursor = line_end + 1
+        if character == "\\" and not in_single_quote:
+            escaped = True
+            cursor += 1
+            continue
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            cursor += 1
+            continue
+        if character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            cursor += 1
+            continue
+        if in_single_quote or in_double_quote:
+            cursor += 1
+            continue
 
-    source = "".join(normalized)
-    return _TIME_KEYWORD_PATTERN.sub(
-        lambda match: (
-            f"{match.group('prefix')}{match.group('space')}{_POLICY_TIME_WRAPPER}"
-        ),
-        source,
-    )
+        if character == "#" and (cursor == 0 or command[cursor - 1] in " \t\r\n;|&()"):
+            in_comment = True
+            cursor += 1
+            continue
+        if _is_time_keyword_position(command, cursor):
+            normalized[cursor : cursor + len("time")] = _POLICY_TIME_WRAPPER
+            cursor += len("time")
+            continue
+        if (
+            command.startswith("<<", cursor)
+            and not command.startswith("<<<", cursor)
+            and (cursor == 0 or command[cursor - 1] != "<")
+        ):
+            strip_tabs = command.startswith("<<-", cursor)
+            delimiter_start = cursor + (3 if strip_tabs else 2)
+            declaration, delimiter_end = _parse_heredoc_delimiter(
+                command,
+                delimiter_start,
+                normalized,
+            )
+            if declaration is None:
+                raise CommandPolicyViolation("cannot safely parse shell command")
+            declarations.append(replace(declaration, strip_tabs=strip_tabs))
+            cursor = delimiter_end
+            continue
+        if character == "\n" and declarations:
+            cursor = _consume_heredoc_bodies(
+                command,
+                cursor + 1,
+                declarations,
+                normalized,
+            )
+            declarations.clear()
+            continue
+        cursor += 1
+
+    if declarations or in_single_quote or in_double_quote or escaped:
+        raise CommandPolicyViolation("cannot safely parse shell command")
+    return "".join(normalized)
 
 
 class _CommandValue(str):
@@ -379,12 +510,19 @@ class _CommandWrapperGrammar:
     flag_options: frozenset[str] = frozenset()
     value_options: frozenset[str] = frozenset()
     attached_short_value_options: frozenset[str] = frozenset()
-    leading_scalars: int = 0
+    consumes_leading_scalar: bool = False
     allows_assignments: bool = False
     cwd_options: frozenset[str] = frozenset()
     terminal_options: frozenset[str] = frozenset()
     rejected_options: frozenset[str] = frozenset()
     propagates_state: bool = False
+
+
+@dataclass(frozen=True)
+class _BashInvocation:
+    initialization_files: tuple[str, ...]
+    command_text: str | None = None
+    script: str | None = None
 
 
 _COMMAND_WRAPPER_GRAMMARS = {
@@ -463,73 +601,6 @@ _COMMAND_WRAPPER_GRAMMARS = {
         attached_short_value_options=frozenset({"-e", "-i", "-o"}),
         terminal_options=frozenset({"--help", "--version"}),
     ),
-    "sudo": _CommandWrapperGrammar(
-        flag_options=frozenset(
-            {
-                "-A",
-                "--askpass",
-                "-b",
-                "--background",
-                "-E",
-                "--preserve-env",
-                "-H",
-                "--set-home",
-                "-K",
-                "--remove-timestamp",
-                "-k",
-                "--reset-timestamp",
-                "-n",
-                "--non-interactive",
-                "-P",
-                "--preserve-groups",
-                "-S",
-                "--stdin",
-            }
-        ),
-        value_options=frozenset(
-            {
-                "-C",
-                "--close-from",
-                "-D",
-                "--chdir",
-                "-g",
-                "--group",
-                "-h",
-                "--host",
-                "-p",
-                "--prompt",
-                "-R",
-                "--chroot",
-                "-r",
-                "--role",
-                "-T",
-                "--command-timeout",
-                "-t",
-                "--type",
-                "-u",
-                "--user",
-            }
-        ),
-        attached_short_value_options=frozenset(
-            {"-C", "-D", "-g", "-h", "-p", "-R", "-r", "-T", "-t", "-u"}
-        ),
-        cwd_options=frozenset({"-D", "--chdir"}),
-        terminal_options=frozenset({"-V", "--version", "-v", "--validate"}),
-        rejected_options=frozenset(
-            {
-                "-e",
-                "--edit",
-                "-i",
-                "--login",
-                "-l",
-                "--list",
-                "-R",
-                "--chroot",
-                "-s",
-                "--shell",
-            }
-        ),
-    ),
     "time": _CommandWrapperGrammar(
         flag_options=frozenset(
             {"-a", "--append", "-p", "--portability", "-v", "--verbose"}
@@ -545,7 +616,7 @@ _COMMAND_WRAPPER_GRAMMARS = {
         ),
         value_options=frozenset({"-k", "--kill-after", "-s", "--signal"}),
         attached_short_value_options=frozenset({"-k", "-s"}),
-        leading_scalars=1,
+        consumes_leading_scalar=True,
         terminal_options=frozenset({"--help", "--version"}),
     ),
 }
@@ -555,6 +626,7 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     *_WRITE_COMMANDS,
     *_SHELL_COMMANDS,
     *_UNSUPPORTED_SHELL_COMMANDS,
+    *_UNSUPPORTED_PRIVILEGE_COMMANDS,
     "chroot",
     "xargs",
     *(
@@ -797,6 +869,10 @@ class WorkspaceCommandPathGuard:
         if charge_argv:
             _active_validation_session().charge_argv_tokens(1 + len(args))
         command_name = os.path.basename(command_word)
+        if command_name in _UNSUPPORTED_PRIVILEGE_COMMANDS:
+            raise CommandPolicyViolation(
+                f"cannot safely inspect privilege escalation via {command_name}"
+            )
         if self._is_direct_command_path(command_word):
             if not self._is_trusted_system_command(command_word, command_name):
                 self._inspect_direct_shell_script(command_word, state)
@@ -985,7 +1061,7 @@ class WorkspaceCommandPathGuard:
             terminal_mode = terminal_mode or option in grammar.terminal_options
             index += consumed
 
-        for _ in range(grammar.leading_scalars):
+        if grammar.consumes_leading_scalar:
             if index >= len(values):
                 return state
             index += 1
@@ -1082,17 +1158,22 @@ class WorkspaceCommandPathGuard:
         try:
             descriptor = os.open(script_path, _secure_script_open_flags())
             metadata = os.fstat(descriptor)
-            if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_size > _MAX_INSPECTED_SCRIPT_BYTES
-            ):
+            if not stat.S_ISREG(metadata.st_mode):
                 raise CommandPathViolation(access="read", path=script_path)
+            if metadata.st_size > _MAX_INSPECTED_SCRIPT_BYTES:
+                raise CommandPolicyViolation(
+                    "shell policy script exceeds the "
+                    f"{_MAX_INSPECTED_SCRIPT_BYTES}-byte inspection limit"
+                )
             session.charge_script_bytes(metadata.st_size)
             with os.fdopen(descriptor, "rb") as script_file:
                 descriptor = None
                 raw_script = script_file.read(_MAX_INSPECTED_SCRIPT_BYTES + 1)
             if len(raw_script) > _MAX_INSPECTED_SCRIPT_BYTES:
-                raise CommandPathViolation(access="read", path=script_path)
+                raise CommandPolicyViolation(
+                    "shell policy script exceeds the "
+                    f"{_MAX_INSPECTED_SCRIPT_BYTES}-byte inspection limit"
+                )
             script = raw_script.decode("utf-8")
         except OSError as exc:
             # A missing script may be created earlier in the same shell string;
@@ -1203,69 +1284,120 @@ class WorkspaceCommandPathGuard:
                 "cannot safely inspect implicit shell initialization via "
                 f"{active_environment}"
             )
-        command_option_index: int | None = None
-        for index, value in enumerate(literals[:-1]):
-            if value == "--":
-                break
-            if (
-                value.startswith("-")
-                and not value.startswith("--")
-                and "c" in value[1:]
-            ):
-                command_option_index = index
-                break
-
-        file_values = (
-            literals
-            if command_option_index is None
-            else literals[:command_option_index]
-        )
-        if command_name == "bash":
-            file_values, initialization_files = self._extract_bash_file_options(
-                file_values
+        invocation = self._parse_bash_invocation(literals)
+        for initialization_file in invocation.initialization_files:
+            self._inspect_shell_script(
+                initialization_file,
+                state,
+                propagate_state=False,
             )
-            for initialization_file in initialization_files:
-                self._inspect_shell_script(
-                    initialization_file,
-                    state,
-                    propagate_state=False,
-                )
-
-        if command_option_index is not None:
-            self._validate_shell_states(literals[command_option_index + 1], state)
+        if invocation.command_text is not None:
+            self._validate_shell_states(invocation.command_text, state)
             return
-
-        script = self._shell_script_operand(file_values)
-        if script is None:
+        if invocation.script is None:
             raise CommandPolicyViolation(
                 f"cannot inspect {command_name} input without command text or a script"
             )
-        self._inspect_shell_script(script, state, propagate_state=False)
+        self._inspect_shell_script(invocation.script, state, propagate_state=False)
 
     @staticmethod
-    def _extract_bash_file_options(
+    def _parse_bash_invocation(
         values: Sequence[str],
-    ) -> tuple[list[str], list[str]]:
-        remaining: list[str] = []
+    ) -> _BashInvocation:
         initialization_files: list[str] = []
         index = 0
         while index < len(values):
             value = values[index]
+            if isinstance(value, _CommandValue) and not value.is_static:
+                raise CommandPolicyViolation(
+                    "cannot safely inspect dynamic bash option region"
+                )
             if value == "--":
-                remaining.extend(values[index:])
-                break
+                index += 1
+                return _BashInvocation(
+                    initialization_files=tuple(initialization_files),
+                    script=values[index] if index < len(values) else None,
+                )
             if value in _BASH_FILE_OPTIONS:
-                if index + 1 < len(values):
-                    initialization_files.append(values[index + 1])
-                index += 2
-                continue
-            if any(value.startswith(f"{option}=") for option in _BASH_FILE_OPTIONS):
-                initialization_files.append(value.split("=", 1)[1])
+                index += 1
+                if index >= len(values):
+                    raise CommandPolicyViolation(f"missing bash argument for {value}")
+                argument = values[index]
+                if isinstance(argument, _CommandValue) and not argument.is_static:
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect dynamic bash option region"
+                    )
+                initialization_files.append(argument)
                 index += 1
                 continue
-            remaining.append(value)
-            index += 1
-        return remaining, initialization_files
+            if any(value.startswith(f"{option}=") for option in _BASH_FILE_OPTIONS):
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect bash option {value}"
+                )
+            if value in _BASH_LONG_FLAG_OPTIONS:
+                index += 1
+                continue
+            if value.startswith("--"):
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect bash option {value}"
+                )
+            if value == "-":
+                return _BashInvocation(initialization_files=tuple(initialization_files))
+            if value.startswith(("-", "+")) and len(value) > 1:
+                named_option_count = 0
+                has_command_text = False
+                stdin_mode = False
+                for option in value[1:]:
+                    if option in {"o", "O"}:
+                        named_option_count += 1
+                    elif option == "c":
+                        has_command_text = True
+                    elif option == "s":
+                        stdin_mode = True
+                    elif option not in _BASH_SHORT_FLAG_OPTIONS:
+                        raise CommandPolicyViolation(
+                            f"cannot safely inspect bash option {value}"
+                        )
+
+                index += 1
+                for _ in range(named_option_count):
+                    if index >= len(values):
+                        raise CommandPolicyViolation(
+                            f"missing bash argument for {value}"
+                        )
+                    argument = values[index]
+                    if isinstance(argument, _CommandValue) and not argument.is_static:
+                        raise CommandPolicyViolation(
+                            "cannot safely inspect dynamic bash option region"
+                        )
+                    index += 1
+                if has_command_text:
+                    if index >= len(values):
+                        raise CommandPolicyViolation(
+                            f"missing bash argument for {value}"
+                        )
+                    command_text = values[index]
+                    if (
+                        isinstance(command_text, _CommandValue)
+                        and not command_text.is_static
+                    ):
+                        raise CommandPolicyViolation(
+                            "cannot safely inspect dynamic bash option region"
+                        )
+                    return _BashInvocation(
+                        initialization_files=tuple(initialization_files),
+                        command_text=command_text,
+                    )
+                if stdin_mode:
+                    return _BashInvocation(
+                        initialization_files=tuple(initialization_files)
+                    )
+                continue
+            return _BashInvocation(
+                initialization_files=tuple(initialization_files),
+                script=value,
+            )
+        return _BashInvocation(initialization_files=tuple(initialization_files))
 
     def _check_sourced_shell(
         self,
@@ -1280,28 +1412,6 @@ class WorkspaceCommandPathGuard:
             state,
             propagate_state=True,
         )
-
-    @staticmethod
-    def _shell_script_operand(values: Sequence[str]) -> str | None:
-        index = 0
-        while index < len(values):
-            value = values[index]
-            if value == "--":
-                return values[index + 1] if index + 1 < len(values) else None
-            if value in {"-o", "-O"}:
-                index += 2
-                continue
-            if value == "-s" or (
-                value.startswith("-")
-                and not value.startswith("--")
-                and "s" in value[1:]
-            ):
-                return None
-            if value.startswith("-") and value != "-":
-                index += 1
-                continue
-            return value
-        return None
 
     def _check_xargs(self, values: Sequence[str], state: _ShellState) -> None:
         command_start = len(values)

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -14,12 +14,14 @@ import os
 import re
 import shutil
 import stat
+from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import (
     Any,
     Iterable,
+    Iterator,
     Sequence,
     SupportsIndex,
     cast,
@@ -41,10 +43,105 @@ _MAX_INSPECTED_SCRIPT_DEPTH = 8
 _MAX_COMMAND_WRAPPER_DEPTH = 32
 _MAX_COMMAND_POLICY_INPUT_CHARS = 64 * 1024
 _MAX_POSSIBLE_SHELL_STATES = 16
-_COMMAND_WRITTEN_PATHS: ContextVar[set[Path] | None] = ContextVar(
-    "command_written_paths",
+_MAX_POLICY_PARSE_ATTEMPTS = 64
+_MAX_POLICY_SOURCE_CHARS = 1024 * 1024
+_MAX_POLICY_SCRIPT_BYTES = 1024 * 1024
+_MAX_POLICY_NODE_STATE_EVALUATIONS = 4096
+_MAX_POLICY_ARGV_TOKENS = 8192
+
+
+@dataclass
+class _EffectScope:
+    prior_written_paths: frozenset[Path] = frozenset()
+    prior_unknown_effect: bool = False
+    written_paths: set[Path] = field(default_factory=set)
+    unknown_effect: bool = False
+    inspected_scripts: set[Path] = field(default_factory=set)
+
+    @property
+    def visible_written_paths(self) -> frozenset[Path]:
+        return self.prior_written_paths | self.written_paths
+
+    @property
+    def has_visible_unknown_effect(self) -> bool:
+        return self.prior_unknown_effect or self.unknown_effect
+
+    def inspect_script(self, script_path: Path) -> None:
+        if self.has_visible_unknown_effect or script_path in self.visible_written_paths:
+            raise CommandPolicyViolation(
+                "cannot inspect a script affected by an earlier command"
+            )
+        self.inspected_scripts.add(script_path)
+
+    def merge(self, child: _EffectScope) -> None:
+        self.written_paths.update(child.written_paths)
+        self.unknown_effect = self.unknown_effect or child.unknown_effect
+        self.inspected_scripts.update(child.inspected_scripts)
+
+
+@dataclass
+class _ValidationSession:
+    parse_attempts: int = 0
+    source_chars: int = 0
+    script_bytes: int = 0
+    node_state_evaluations: int = 0
+    argv_tokens: int = 0
+    effects: _EffectScope = field(default_factory=_EffectScope)
+
+    def charge_parse(self, source_chars: int) -> None:
+        self.parse_attempts += 1
+        if self.parse_attempts > _MAX_POLICY_PARSE_ATTEMPTS:
+            raise CommandPolicyViolation("command policy parse attempt budget exceeded")
+        self.source_chars += source_chars
+        if self.source_chars > _MAX_POLICY_SOURCE_CHARS:
+            raise CommandPolicyViolation(
+                "command policy source character budget exceeded"
+            )
+
+    def charge_script_bytes(self, script_bytes: int) -> None:
+        self.script_bytes += script_bytes
+        if self.script_bytes > _MAX_POLICY_SCRIPT_BYTES:
+            raise CommandPolicyViolation("command policy script byte budget exceeded")
+
+    def charge_node_state_evaluation(self) -> None:
+        self.node_state_evaluations += 1
+        if self.node_state_evaluations > _MAX_POLICY_NODE_STATE_EVALUATIONS:
+            raise CommandPolicyViolation(
+                "command policy node-state evaluation budget exceeded"
+            )
+
+    def charge_argv_tokens(self, argv_tokens: int) -> None:
+        self.argv_tokens += argv_tokens
+        if self.argv_tokens > _MAX_POLICY_ARGV_TOKENS:
+            raise CommandPolicyViolation("command policy argv token budget exceeded")
+
+
+_VALIDATION_SESSION: ContextVar[_ValidationSession | None] = ContextVar(
+    "command_validation_session",
     default=None,
 )
+
+
+@contextmanager
+def _validation_session_scope() -> Iterator[_ValidationSession]:
+    session = _VALIDATION_SESSION.get()
+    token = None
+    if session is None:
+        session = _ValidationSession()
+        token = _VALIDATION_SESSION.set(session)
+    try:
+        yield session
+    finally:
+        if token is not None:
+            _VALIDATION_SESSION.reset(token)
+
+
+def _active_validation_session() -> _ValidationSession:
+    session = _VALIDATION_SESSION.get()
+    if session is None:
+        raise RuntimeError("command validation requires an active session")
+    return session
+
 
 _READ_COMMANDS = {"cat"}
 _WRITE_COMMANDS = {"rm"}
@@ -481,6 +578,7 @@ class WorkspaceCommandPathGuard:
             raise CommandPolicyViolation("command is too large to inspect")
         if "\x00" in command:
             raise CommandPolicyViolation("command contains a null byte")
+        _active_validation_session().charge_parse(len(command))
         if not any(
             line.strip() and not line.lstrip().startswith("#")
             for line in command.splitlines()
@@ -500,8 +598,7 @@ class WorkspaceCommandPathGuard:
 
     def validate(self, command: str) -> None:
         """Reject unsupported syntax and unsafe paths in ``command``."""
-        write_token = _COMMAND_WRITTEN_PATHS.set(set())
-        try:
+        with _validation_session_scope():
             active_environment = self._active_implicit_shell_environment()
             if active_environment is not None:
                 raise CommandPolicyViolation(
@@ -512,8 +609,6 @@ class WorkspaceCommandPathGuard:
             states: tuple[_ShellState, ...] = (_ShellState(cwd=self._initial_cwd),)
             for node in nodes:
                 states = self._validate_node_states(node, states)
-        finally:
-            _COMMAND_WRITTEN_PATHS.reset(write_token)
 
     def _validate_node_states(
         self,
@@ -580,19 +675,19 @@ class WorkspaceCommandPathGuard:
 
         No shell interprets this form, so shell expansion syntax remains literal.
         """
-        if not argv:
-            return
-        write_token = _COMMAND_WRITTEN_PATHS.set(set())
-        try:
+        with _validation_session_scope() as session:
+            session.charge_argv_tokens(len(argv))
+            if not argv:
+                return
             self._validate_command_values(
                 argv[0],
                 argv[1:],
                 _ShellState(cwd=self._initial_cwd),
+                charge_argv=False,
             )
-        finally:
-            _COMMAND_WRITTEN_PATHS.reset(write_token)
 
     def _validate_node(self, node: Any, state: _ShellState) -> _ShellState:
+        _active_validation_session().charge_node_state_evaluation()
         kind = getattr(node, "kind", None)
         if kind == "list":
             states = self._validate_list_states(node, (state,))
@@ -603,9 +698,7 @@ class WorkspaceCommandPathGuard:
             return states[0]
 
         if kind == "pipeline":
-            for part in node.parts:
-                if getattr(part, "kind", None) != "pipe":
-                    self._validate_node(part, state)
+            self._validate_pipeline(node, state)
             return state
 
         if kind == "compound":
@@ -626,6 +719,47 @@ class WorkspaceCommandPathGuard:
 
         self._validate_nested_nodes(node, state)
         return state
+
+    def _validate_pipeline(self, node: Any, state: _ShellState) -> None:
+        session = _active_validation_session()
+        parent_scope = session.effects
+        member_scopes: list[_EffectScope] = []
+        try:
+            for part in node.parts:
+                if getattr(part, "kind", None) == "pipe":
+                    continue
+                member_scope = _EffectScope(
+                    prior_written_paths=parent_scope.visible_written_paths,
+                    prior_unknown_effect=parent_scope.has_visible_unknown_effect,
+                )
+                session.effects = member_scope
+                self._validate_node(part, state)
+                member_scopes.append(member_scope)
+        finally:
+            session.effects = parent_scope
+
+        unknown_member_count = sum(scope.unknown_effect for scope in member_scopes)
+        write_owner_counts: dict[Path, int] = {}
+        for member_scope in member_scopes:
+            for path in member_scope.written_paths:
+                write_owner_counts[path] = write_owner_counts.get(path, 0) + 1
+
+        for member_scope in member_scopes:
+            concurrent_unknown = unknown_member_count > int(member_scope.unknown_effect)
+            concurrent_write = any(
+                write_owner_counts.get(script_path, 0)
+                > int(script_path in member_scope.written_paths)
+                for script_path in member_scope.inspected_scripts
+            )
+            if member_scope.inspected_scripts and (
+                concurrent_unknown or concurrent_write
+            ):
+                raise CommandPolicyViolation(
+                    "cannot inspect a script affected by a concurrent command"
+                )
+
+        for member_scope in member_scopes:
+            parent_scope.merge(member_scope)
 
     def _validate_command(self, node: Any, state: _ShellState) -> _ShellState:
         words: list[Any] = []
@@ -657,7 +791,11 @@ class WorkspaceCommandPathGuard:
         command_word: str,
         args: Sequence[str],
         state: _ShellState,
+        *,
+        charge_argv: bool = True,
     ) -> _ShellState:
+        if charge_argv:
+            _active_validation_session().charge_argv_tokens(1 + len(args))
         command_name = os.path.basename(command_word)
         if self._is_direct_command_path(command_word):
             if not self._is_trusted_system_command(command_word, command_name):
@@ -701,6 +839,8 @@ class WorkspaceCommandPathGuard:
             )
         elif command_name in _COMMAND_WRAPPER_GRAMMARS:
             return self._check_command_wrapper(command_name, args, state)
+        else:
+            _active_validation_session().effects.unknown_effect = True
         return state
 
     def _validate_redirect(self, node: Any, state: _ShellState) -> None:
@@ -935,11 +1075,8 @@ class WorkspaceCommandPathGuard:
 
     def _read_policy_script(self, raw_path: str, cwd: Path) -> str:
         script_path = self._check_path(raw_path, cwd, "read")
-        written_paths = _COMMAND_WRITTEN_PATHS.get()
-        if written_paths is not None and script_path in written_paths:
-            raise CommandPolicyViolation(
-                "cannot inspect a script modified earlier in the same command"
-            )
+        session = _active_validation_session()
+        session.effects.inspect_script(script_path)
 
         descriptor: int | None = None
         try:
@@ -950,6 +1087,7 @@ class WorkspaceCommandPathGuard:
                 or metadata.st_size > _MAX_INSPECTED_SCRIPT_BYTES
             ):
                 raise CommandPathViolation(access="read", path=script_path)
+            session.charge_script_bytes(metadata.st_size)
             with os.fdopen(descriptor, "rb") as script_file:
                 descriptor = None
                 raw_script = script_file.read(_MAX_INSPECTED_SCRIPT_BYTES + 1)
@@ -1348,7 +1486,6 @@ class WorkspaceCommandPathGuard:
             )
         except ValueError as exc:
             raise CommandPathViolation(access=access, path=candidate) from exc
-        written_paths = _COMMAND_WRITTEN_PATHS.get()
-        if access == "write" and written_paths is not None:
-            written_paths.add(resolved)
+        if access == "write":
+            _active_validation_session().effects.written_paths.add(resolved)
         return resolved

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -86,6 +86,7 @@ class _ValidationSession:
     script_bytes: int = 0
     node_state_evaluations: int = 0
     argv_tokens: int = 0
+    wrapped_bash_dispatch: bool = False
     effects: _EffectScope = field(default_factory=_EffectScope)
 
     def charge_parse(self, source_chars: int) -> None:
@@ -746,16 +747,41 @@ class WorkspaceCommandPathGuard:
 
         No shell interprets this form, so shell expansion syntax remains literal.
         """
+        self._validate_and_prepare_argv(argv, prepare_execution=False)
+
+    def prepare_argv_for_execution(self, argv: Sequence[str]) -> list[str]:
+        """Validate argv and bind direct Bash to its trusted executable identity."""
+        return self._validate_and_prepare_argv(argv, prepare_execution=True)
+
+    def _validate_and_prepare_argv(
+        self,
+        argv: Sequence[str],
+        *,
+        prepare_execution: bool,
+    ) -> list[str]:
         with _validation_session_scope() as session:
             session.charge_argv_tokens(len(argv))
+            execution_argv = list(argv)
             if not argv:
-                return
+                return execution_argv
+            if (
+                prepare_execution
+                and os.path.basename(execution_argv[0]) in _SHELL_COMMANDS
+            ):
+                execution_argv[0] = os.fspath(
+                    resolve_trusted_executable(execution_argv[0])
+                )
             self._validate_command_values(
-                argv[0],
-                argv[1:],
+                execution_argv[0],
+                execution_argv[1:],
                 _ShellState(cwd=self._initial_cwd),
                 charge_argv=False,
             )
+            if prepare_execution and session.wrapped_bash_dispatch:
+                raise CommandPolicyViolation(
+                    "cannot safely execute Bash through a command wrapper"
+                )
+            return execution_argv
 
     def _validate_node(self, node: Any, state: _ShellState) -> _ShellState:
         _active_validation_session().charge_node_state_evaluation()
@@ -1075,6 +1101,8 @@ class WorkspaceCommandPathGuard:
         command_word = values[index]
         if isinstance(command_word, _CommandValue) and not command_word.is_static:
             raise CommandPolicyViolation("cannot resolve dynamic command name")
+        if os.path.basename(command_word) in _SHELL_COMMANDS:
+            _active_validation_session().wrapped_bash_dispatch = True
         # Wrappers spawn a child command: validate its paths against the adjusted
         # child cwd, but never propagate child shell directory state to the parent.
         validated_state = self._validate_command_values(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -84,6 +84,17 @@ _TIME_KEYWORD_PATTERN = re.compile(
 _POLICY_TIME_WRAPPER = "__t_"
 
 
+def _secure_script_open_flags() -> int:
+    """Return mandatory flags for race-resistant, non-blocking script reads."""
+    nonblocking = getattr(os, "O_NONBLOCK", None)
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if not isinstance(nonblocking, int) or not isinstance(nofollow, int):
+        raise CommandPolicyViolation(
+            "secure direct-script inspection is unavailable on this platform"
+        )
+    return os.O_RDONLY | nonblocking | nofollow
+
+
 def _is_unquoted_on_current_line(source: str, position: int) -> bool:
     """Return whether ``position`` is outside quotes on its physical line."""
     line_start = source.rfind("\n", 0, position) + 1
@@ -932,8 +943,7 @@ class WorkspaceCommandPathGuard:
 
         descriptor: int | None = None
         try:
-            flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW
-            descriptor = os.open(script_path, flags)
+            descriptor = os.open(script_path, _secure_script_open_flags())
             metadata = os.fstat(descriptor)
             if (
                 not stat.S_ISREG(metadata.st_mode)

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1,0 +1,1337 @@
+"""Best-effort workspace path guard for shell commands.
+
+This module deliberately provides a cooperative guard, not an operating-system
+security boundary. For supported commands, it rejects out-of-scope paths and
+path-bearing arguments that cannot be resolved statically. Unknown commands
+remain unchanged.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import re
+import shutil
+import stat
+from contextvars import ContextVar
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import (
+    Any,
+    Iterable,
+    Sequence,
+    SupportsIndex,
+    cast,
+)
+
+import bashlex
+
+from ...workspace import TaskWorkspace
+from .command_policy import (
+    CommandPathViolation,
+    CommandPolicyViolation,
+    PathAccess,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_INSPECTED_SCRIPT_BYTES = 1024 * 1024
+_MAX_INSPECTED_SCRIPT_DEPTH = 8
+_MAX_COMMAND_WRAPPER_DEPTH = 32
+_MAX_COMMAND_POLICY_INPUT_CHARS = 64 * 1024
+_MAX_POSSIBLE_SHELL_STATES = 16
+_COMMAND_WRITTEN_PATHS: ContextVar[set[Path] | None] = ContextVar(
+    "command_written_paths",
+    default=None,
+)
+
+_READ_COMMANDS = {"cat"}
+_WRITE_COMMANDS = {"rm"}
+_SHELL_COMMANDS = {"bash"}
+_UNSUPPORTED_SHELL_COMMANDS = {"dash", "sh", "zsh"}
+_BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
+_IMPLICIT_SHELL_ENVIRONMENT = {"BASH_ENV", "CDPATH", "ENV", "ZDOTDIR"}
+_REJECTED_SHELL_ASSIGNMENTS = {
+    *_IMPLICIT_SHELL_ENVIRONMENT,
+    "BASHOPTS",
+    "PATH",
+    "SHELLOPTS",
+}
+_SAFE_DEVICE_PATHS = {
+    Path("/dev/null"),
+    Path("/dev/stdin"),
+    Path("/dev/stdout"),
+    Path("/dev/stderr"),
+}
+_TRUSTED_EXECUTABLE_ROOTS = tuple(
+    path.resolve()
+    for path in (
+        Path("/bin"),
+        Path("/usr/bin"),
+        Path("/usr/local/bin"),
+        Path("/opt/homebrew/bin"),
+    )
+)
+_QUOTED_HEREDOC_PATTERN = re.compile(
+    r"(?m)(?P<operator><<-?)(?P<space>[ \t]*)(?P<quote>['\"])"
+    r"(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)(?=[ \t]*$)"
+)
+_TIME_KEYWORD_PATTERN = re.compile(
+    r"(?m)(?P<prefix>^|(?<=[;\n])|(?<=&&)|(?<=\|\|))"
+    r"(?P<space>[ \t]*)time(?=[ \t]+)"
+)
+_POLICY_TIME_WRAPPER = "__t_"
+
+
+def _is_unquoted_on_current_line(source: str, position: int) -> bool:
+    """Return whether ``position`` is outside quotes on its physical line."""
+    line_start = source.rfind("\n", 0, position) + 1
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    for character in source[line_start:position]:
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and not in_single_quote:
+            escaped = True
+        elif character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+    return not in_single_quote and not in_double_quote and not escaped
+
+
+def _has_active_unmodeled_expansion(raw_word: str) -> bool:
+    """Return whether Bash may expand syntax omitted from the bashlex AST."""
+    brace_has_expander: list[bool] = []
+    bracket_start: int | None = None
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    index = 0
+
+    while index < len(raw_word):
+        character = raw_word[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if character == "\\" and not in_single_quote:
+            escaped = True
+            index += 1
+            continue
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            index += 1
+            continue
+        if character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            index += 1
+            continue
+        if in_single_quote or in_double_quote:
+            index += 1
+            continue
+
+        if character in {"*", "?"}:
+            return True
+        if character == "[" and bracket_start is None:
+            bracket_start = index
+        elif character == "]" and bracket_start is not None:
+            if index > bracket_start + 1:
+                return True
+        elif character == "{":
+            brace_has_expander.append(False)
+        elif character == "," and brace_has_expander:
+            brace_has_expander[-1] = True
+        elif (
+            character == "."
+            and index + 1 < len(raw_word)
+            and raw_word[index + 1] == "."
+            and brace_has_expander
+        ):
+            brace_has_expander[-1] = True
+            index += 1
+        elif character == "}" and brace_has_expander:
+            if brace_has_expander.pop():
+                return True
+        index += 1
+
+    return False
+
+
+def _mark_unmodeled_expansions(nodes: Sequence[Any], source: str) -> None:
+    """Attach source-aware expansion metadata missing from the Bash AST."""
+    pending = list(nodes)
+    while pending:
+        node = pending.pop()
+        if getattr(node, "kind", None) == "word":
+            start, end = cast(tuple[int, int], node.pos)
+            node.xagent_has_unmodeled_expansion = _has_active_unmodeled_expansion(
+                source[start:end]
+            )
+        for value in vars(node).values():
+            if getattr(value, "kind", None) is not None:
+                pending.append(value)
+            elif isinstance(value, (list, tuple)):
+                pending.extend(
+                    item for item in value if getattr(item, "kind", None) is not None
+                )
+
+
+def _normalize_policy_shell_source(command: str) -> str:
+    """Normalize narrowly supported Bash syntax that bashlex cannot parse.
+
+    The normalized text is used only for policy parsing; the executor receives
+    the original command. Replacements preserve source length so bashlex node
+    positions still describe the original command. Quoted here-document bodies
+    are literal by Bash definition, so masking them cannot hide executable
+    expansion or nested commands.
+    """
+    normalized = list(command)
+    for match in _QUOTED_HEREDOC_PATTERN.finditer(command):
+        if not _is_unquoted_on_current_line(command, match.start()):
+            continue
+        quote_start = match.start("quote")
+        quote_end = match.end("delimiter")
+        normalized[quote_start] = " "
+        normalized[quote_end] = " "
+
+        body_start = command.find("\n", match.end())
+        if body_start < 0:
+            continue
+        body_start += 1
+        delimiter = match.group("delimiter")
+        strip_tabs = match.group("operator") == "<<-"
+        cursor = body_start
+        while cursor <= len(command):
+            line_end = command.find("\n", cursor)
+            if line_end < 0:
+                line_end = len(command)
+            line = command[cursor:line_end]
+            comparable = line.lstrip("\t") if strip_tabs else line
+            if comparable == delimiter:
+                break
+            for index in range(cursor, line_end):
+                normalized[index] = "x"
+            if line_end == len(command):
+                break
+            cursor = line_end + 1
+
+    source = "".join(normalized)
+    return _TIME_KEYWORD_PATTERN.sub(
+        lambda match: (
+            f"{match.group('prefix')}{match.group('space')}{_POLICY_TIME_WRAPPER}"
+        ),
+        source,
+    )
+
+
+class _CommandValue(str):
+    """A shell word plus whether bashlex proved it has no runtime expansion."""
+
+    is_static: bool
+
+    def __new__(cls, value: str, *, is_static: bool = True) -> _CommandValue:
+        instance = super().__new__(cls, value)
+        instance.is_static = is_static
+        return instance
+
+    def __getitem__(self, key: SupportsIndex | slice) -> str:
+        value = super().__getitem__(key)
+        if isinstance(key, slice):
+            return _CommandValue(value, is_static=self.is_static)
+        return value
+
+    def split(
+        self,
+        sep: str | None = None,
+        maxsplit: SupportsIndex = -1,
+    ) -> list[str]:
+        # Runtime values retain the marker while the public return type keeps
+        # this str subclass substitutable for normal parser code.
+        return [
+            _CommandValue(value, is_static=self.is_static)
+            for value in super().split(sep, maxsplit)
+        ]
+
+
+@dataclass(frozen=True)
+class _ShellState:
+    cwd: Path
+    directory_stack: tuple[Path, ...] = ()
+    previous_cwd: Path | None = None
+    script_depth: int = 0
+    wrapper_depth: int = 0
+
+
+@dataclass(frozen=True)
+class _CommandWrapperGrammar:
+    flag_options: frozenset[str] = frozenset()
+    value_options: frozenset[str] = frozenset()
+    attached_short_value_options: frozenset[str] = frozenset()
+    leading_scalars: int = 0
+    allows_assignments: bool = False
+    cwd_options: frozenset[str] = frozenset()
+    terminal_options: frozenset[str] = frozenset()
+    rejected_options: frozenset[str] = frozenset()
+    propagates_state: bool = False
+
+
+_COMMAND_WRAPPER_GRAMMARS = {
+    _POLICY_TIME_WRAPPER: _CommandWrapperGrammar(
+        flag_options=frozenset({"-p"}),
+        propagates_state=True,
+    ),
+    "builtin": _CommandWrapperGrammar(
+        propagates_state=True,
+    ),
+    "command": _CommandWrapperGrammar(
+        flag_options=frozenset({"-p"}),
+        terminal_options=frozenset({"-v", "-V"}),
+        propagates_state=True,
+    ),
+    "env": _CommandWrapperGrammar(
+        flag_options=frozenset({"-", "-0", "-i", "--ignore-environment", "--null"}),
+        value_options=frozenset({"-a", "--argv0", "-C", "--chdir", "-u", "--unset"}),
+        attached_short_value_options=frozenset({"-a", "-C", "-u"}),
+        allows_assignments=True,
+        cwd_options=frozenset({"-C", "--chdir"}),
+        terminal_options=frozenset({"--help", "--version"}),
+        rejected_options=frozenset({"-S", "--split-string"}),
+    ),
+    "exec": _CommandWrapperGrammar(
+        flag_options=frozenset({"-c", "-l"}),
+        value_options=frozenset({"-a"}),
+        attached_short_value_options=frozenset({"-a"}),
+    ),
+    "ionice": _CommandWrapperGrammar(
+        flag_options=frozenset({"-t", "--ignore"}),
+        value_options=frozenset(
+            {
+                "-c",
+                "--class",
+                "-n",
+                "--classdata",
+                "-P",
+                "--pgid",
+                "-p",
+                "--pid",
+                "-u",
+                "--uid",
+            }
+        ),
+        attached_short_value_options=frozenset({"-c", "-n", "-P", "-p", "-u"}),
+        terminal_options=frozenset(
+            {
+                "-P",
+                "--pgid",
+                "-p",
+                "--pid",
+                "-u",
+                "--uid",
+                "-h",
+                "--help",
+                "-V",
+                "--version",
+            }
+        ),
+    ),
+    "nice": _CommandWrapperGrammar(
+        value_options=frozenset({"-n", "--adjustment"}),
+        attached_short_value_options=frozenset({"-n"}),
+        terminal_options=frozenset({"--help", "--version"}),
+    ),
+    "nohup": _CommandWrapperGrammar(
+        terminal_options=frozenset({"--help", "--version"}),
+    ),
+    "setsid": _CommandWrapperGrammar(
+        flag_options=frozenset({"-c", "--ctty", "-f", "--fork", "-w", "--wait"}),
+        terminal_options=frozenset({"-h", "--help", "-V", "--version"}),
+    ),
+    "stdbuf": _CommandWrapperGrammar(
+        value_options=frozenset({"-e", "--error", "-i", "--input", "-o", "--output"}),
+        attached_short_value_options=frozenset({"-e", "-i", "-o"}),
+        terminal_options=frozenset({"--help", "--version"}),
+    ),
+    "sudo": _CommandWrapperGrammar(
+        flag_options=frozenset(
+            {
+                "-A",
+                "--askpass",
+                "-b",
+                "--background",
+                "-E",
+                "--preserve-env",
+                "-H",
+                "--set-home",
+                "-K",
+                "--remove-timestamp",
+                "-k",
+                "--reset-timestamp",
+                "-n",
+                "--non-interactive",
+                "-P",
+                "--preserve-groups",
+                "-S",
+                "--stdin",
+            }
+        ),
+        value_options=frozenset(
+            {
+                "-C",
+                "--close-from",
+                "-D",
+                "--chdir",
+                "-g",
+                "--group",
+                "-h",
+                "--host",
+                "-p",
+                "--prompt",
+                "-R",
+                "--chroot",
+                "-r",
+                "--role",
+                "-T",
+                "--command-timeout",
+                "-t",
+                "--type",
+                "-u",
+                "--user",
+            }
+        ),
+        attached_short_value_options=frozenset(
+            {"-C", "-D", "-g", "-h", "-p", "-R", "-r", "-T", "-t", "-u"}
+        ),
+        cwd_options=frozenset({"-D", "--chdir"}),
+        terminal_options=frozenset({"-V", "--version", "-v", "--validate"}),
+        rejected_options=frozenset(
+            {
+                "-e",
+                "--edit",
+                "-i",
+                "--login",
+                "-l",
+                "--list",
+                "-R",
+                "--chroot",
+                "-s",
+                "--shell",
+            }
+        ),
+    ),
+    "time": _CommandWrapperGrammar(
+        flag_options=frozenset(
+            {"-a", "--append", "-p", "--portability", "-v", "--verbose"}
+        ),
+        value_options=frozenset({"-f", "--format"}),
+        attached_short_value_options=frozenset({"-f"}),
+        terminal_options=frozenset({"--help", "-V", "--version"}),
+        rejected_options=frozenset({"-o", "--output"}),
+    ),
+    "timeout": _CommandWrapperGrammar(
+        flag_options=frozenset(
+            {"-f", "--foreground", "--preserve-status", "-v", "--verbose"}
+        ),
+        value_options=frozenset({"-k", "--kill-after", "-s", "--signal"}),
+        attached_short_value_options=frozenset({"-k", "-s"}),
+        leading_scalars=1,
+        terminal_options=frozenset({"--help", "--version"}),
+    ),
+}
+
+_CLASSIFIED_EXECUTABLE_COMMANDS = {
+    *_READ_COMMANDS,
+    *_WRITE_COMMANDS,
+    *_SHELL_COMMANDS,
+    *_UNSUPPORTED_SHELL_COMMANDS,
+    "chroot",
+    "xargs",
+    *(
+        name
+        for name in _COMMAND_WRAPPER_GRAMMARS
+        if name not in {"builtin", "command", "exec", _POLICY_TIME_WRAPPER}
+    ),
+}
+
+
+class WorkspaceCommandPathGuard:
+    """Validate Bash language boundaries against one task workspace."""
+
+    def __init__(self, workspace: TaskWorkspace) -> None:
+        self._workspace = workspace
+        self._initial_cwd = workspace.resolve_path("").resolve()
+
+    @staticmethod
+    def _parse_shell(command: str) -> list[Any]:
+        if len(command) > _MAX_COMMAND_POLICY_INPUT_CHARS:
+            raise CommandPolicyViolation("command is too large to inspect")
+        if "\x00" in command:
+            raise CommandPolicyViolation("command contains a null byte")
+        if not any(
+            line.strip() and not line.lstrip().startswith("#")
+            for line in command.splitlines()
+        ):
+            return []
+        policy_source = _normalize_policy_shell_source(command)
+        try:
+            nodes = cast(list[Any], bashlex.parse(policy_source))
+        except Exception as exc:
+            # bashlex exposes several parser-internal exception types. Normalize
+            # all of them at this boundary so malformed input never reaches the
+            # executor through a parser-version-specific failure mode.
+            logger.debug("Command path guard rejected unparsed shell input")
+            raise CommandPolicyViolation("cannot safely parse shell command") from exc
+        _mark_unmodeled_expansions(nodes, policy_source)
+        return nodes
+
+    def validate(self, command: str) -> None:
+        """Reject unsupported syntax and unsafe paths in ``command``."""
+        write_token = _COMMAND_WRITTEN_PATHS.set(set())
+        try:
+            active_environment = self._active_implicit_shell_environment()
+            if active_environment is not None:
+                raise CommandPolicyViolation(
+                    "cannot safely inspect implicit shell initialization via "
+                    f"{active_environment}"
+                )
+            nodes = self._parse_shell(command)
+            states: tuple[_ShellState, ...] = (_ShellState(cwd=self._initial_cwd),)
+            for node in nodes:
+                states = self._validate_node_states(node, states)
+        finally:
+            _COMMAND_WRITTEN_PATHS.reset(write_token)
+
+    def _validate_node_states(
+        self,
+        node: Any,
+        states: Sequence[_ShellState],
+    ) -> tuple[_ShellState, ...]:
+        if getattr(node, "kind", None) == "list":
+            return self._validate_list_states(node, states)
+        return self._dedupe_shell_states(
+            self._validate_node(node, state) for state in states
+        )
+
+    def _validate_list_states(
+        self,
+        node: Any,
+        states: Sequence[_ShellState],
+    ) -> tuple[_ShellState, ...]:
+        active = self._dedupe_shell_states(states)
+        deferred: tuple[_ShellState, ...] = ()
+        successful = active
+        failed = active
+
+        for part in node.parts:
+            if getattr(part, "kind", None) in {"operator", "pipe"}:
+                operator = getattr(part, "op", None)
+                if operator == "&&":
+                    deferred = self._dedupe_shell_states((*deferred, *failed))
+                    active = successful
+                elif operator == "||":
+                    deferred = self._dedupe_shell_states((*deferred, *successful))
+                    active = failed
+                elif operator == ";":
+                    active = self._dedupe_shell_states(
+                        (*deferred, *successful, *failed)
+                    )
+                    deferred = ()
+                else:
+                    raise CommandPolicyViolation(
+                        f"unsupported shell operator {operator!r}; split the "
+                        "operation into separate command calls"
+                    )
+                continue
+
+            before = active
+            successful = self._validate_node_states(part, before)
+            # A state-changing shell builtin can fail without changing the
+            # process cwd. Keep that failure state until the shell operator
+            # determines whether the next command runs.
+            failed = before
+
+        return self._dedupe_shell_states((*deferred, *successful, *failed))
+
+    @staticmethod
+    def _dedupe_shell_states(
+        states: Iterable[_ShellState],
+    ) -> tuple[_ShellState, ...]:
+        unique = tuple(dict.fromkeys(states))
+        if len(unique) > _MAX_POSSIBLE_SHELL_STATES:
+            raise CommandPolicyViolation("too many possible shell directory states")
+        return unique
+
+    def validate_argv(self, argv: Sequence[str]) -> None:
+        """Reject out-of-policy paths in literal, pre-tokenized arguments.
+
+        No shell interprets this form, so shell expansion syntax remains literal.
+        """
+        if not argv:
+            return
+        write_token = _COMMAND_WRITTEN_PATHS.set(set())
+        try:
+            self._validate_command_values(
+                argv[0],
+                argv[1:],
+                _ShellState(cwd=self._initial_cwd),
+            )
+        finally:
+            _COMMAND_WRITTEN_PATHS.reset(write_token)
+
+    def _validate_node(self, node: Any, state: _ShellState) -> _ShellState:
+        kind = getattr(node, "kind", None)
+        if kind == "list":
+            states = self._validate_list_states(node, (state,))
+            if len(states) != 1:
+                raise CommandPolicyViolation(
+                    "cannot propagate multiple shell directory states"
+                )
+            return states[0]
+
+        if kind == "pipeline":
+            for part in node.parts:
+                if getattr(part, "kind", None) != "pipe":
+                    self._validate_node(part, state)
+            return state
+
+        if kind == "compound":
+            current = state
+            reserved_words = [
+                getattr(part, "word", None)
+                for part in getattr(node, "list", ())
+                if getattr(part, "kind", None) == "reservedword"
+            ]
+            for part in getattr(node, "list", ()):
+                current = self._validate_node(part, current)
+            for redirect in getattr(node, "redirects", ()):
+                self._validate_redirect(redirect, current)
+            return state if reserved_words[:1] == ["("] else current
+
+        if kind == "command":
+            return self._validate_command(node, state)
+
+        self._validate_nested_nodes(node, state)
+        return state
+
+    def _validate_command(self, node: Any, state: _ShellState) -> _ShellState:
+        words: list[Any] = []
+        for part in node.parts:
+            kind = getattr(part, "kind", None)
+            if kind == "redirect":
+                self._validate_redirect(part, state)
+            elif kind == "word":
+                words.append(part)
+                self._validate_nested_nodes(part, state)
+            elif kind == "assignment":
+                self._reject_implicit_shell_environment((str(part.word),))
+                self._validate_nested_nodes(part, state)
+            else:
+                self._validate_nested_nodes(part, state)
+
+        if not words:
+            return state
+
+        command_word = self._command_value(words[0])
+        if not command_word.is_static:
+            raise CommandPolicyViolation("cannot resolve dynamic command name")
+        args = self._command_values(words[1:])
+
+        return self._validate_command_values(command_word, args, state)
+
+    def _validate_command_values(
+        self,
+        command_word: str,
+        args: Sequence[str],
+        state: _ShellState,
+    ) -> _ShellState:
+        command_name = os.path.basename(command_word)
+        if self._is_direct_command_path(command_word):
+            if not self._is_trusted_system_command(command_word, command_name):
+                self._inspect_direct_shell_script(command_word, state)
+                return state
+        elif command_name in _CLASSIFIED_EXECUTABLE_COMMANDS:
+            discovered = shutil.which(command_name)
+            if discovered is not None and not self._is_trusted_system_command(
+                discovered,
+                command_name,
+            ):
+                self._inspect_direct_shell_script(discovered, state)
+                return state
+
+        if command_name in {"cd", "pushd", "popd"}:
+            return self._change_directory(command_name, args, state)
+
+        if command_name in {"alias", "eval", "hash", "trap"}:
+            raise CommandPolicyViolation(
+                f"cannot safely inspect shell text executed by {command_name}"
+            )
+        if command_name in {"declare", "export", "typeset"}:
+            self._reject_implicit_shell_environment(args)
+        if command_name in _READ_COMMANDS:
+            self._check_operands(args, state.cwd, "read")
+        elif command_name in _WRITE_COMMANDS:
+            self._check_operands(args, state.cwd, "write")
+        elif command_name in _SHELL_COMMANDS:
+            self._check_nested_shell(command_name, args, state)
+        elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
+            raise CommandPolicyViolation(
+                f"shell dialect {command_name} does not match the Bash policy parser"
+            )
+        elif command_name in {".", "source"}:
+            return self._check_sourced_shell(args, state)
+        elif command_name == "xargs":
+            self._check_xargs(args, state)
+        elif command_name == "chroot":
+            raise CommandPolicyViolation(
+                "cannot safely inspect chroot filesystem remapping"
+            )
+        elif command_name in _COMMAND_WRAPPER_GRAMMARS:
+            return self._check_command_wrapper(command_name, args, state)
+        return state
+
+    def _validate_redirect(self, node: Any, state: _ShellState) -> None:
+        redirect_type = getattr(node, "type", "")
+        if redirect_type in {"<<", "<<-"}:
+            heredoc = getattr(node, "heredoc", None)
+            body = str(getattr(heredoc, "value", ""))
+            if "$" in body or "`" in body:
+                raise CommandPolicyViolation(
+                    "cannot safely inspect expanding here-document"
+                )
+            return
+        output = getattr(node, "output", None)
+        if redirect_type == "<<<":
+            if getattr(output, "kind", None) is not None:
+                self._validate_nested_nodes(output, state)
+            return
+        # bashlex emits descriptor-duplication targets such as 2>&1 as integers.
+        if output is None or getattr(output, "kind", None) != "word":
+            return
+        raw_path = self._command_value(output)
+        access: PathAccess = "read" if redirect_type == "<" else "write"
+        self._check_path(raw_path, state.cwd, access)
+
+    @staticmethod
+    def _active_implicit_shell_environment() -> str | None:
+        return next(
+            (name for name in _IMPLICIT_SHELL_ENVIRONMENT if os.environ.get(name)),
+            None,
+        )
+
+    @staticmethod
+    def _policy_home_directory() -> str:
+        home = os.environ.get("HOME")
+        if not home:
+            raise CommandPolicyViolation(
+                "cannot resolve bare cd without HOME in the execution environment"
+            )
+        return home
+
+    def _change_directory(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        state: _ShellState,
+    ) -> _ShellState:
+        operands = self._operands(values)
+        if command_name == "cd":
+            if len(operands) > 1:
+                raise CommandPolicyViolation("cannot safely resolve cd arguments")
+            target_word = operands[0] if operands else self._policy_home_directory()
+            if target_word == "-":
+                if state.previous_cwd is None:
+                    raise CommandPolicyViolation(
+                        "cannot resolve cd - without a previous directory"
+                    )
+                target = state.previous_cwd
+            else:
+                target = self._check_path(target_word, state.cwd, "read")
+            return replace(state, cwd=target, previous_cwd=state.cwd)
+
+        if any(value.startswith("-") and value != "--" for value in values):
+            raise CommandPolicyViolation(
+                f"cannot safely resolve {command_name} options"
+            )
+
+        if command_name == "pushd":
+            if len(operands) > 1:
+                raise CommandPolicyViolation("cannot safely resolve pushd arguments")
+            if operands:
+                if operands[0] == "-":
+                    raise CommandPolicyViolation("cannot safely resolve pushd target")
+                target = self._check_path(operands[0], state.cwd, "read")
+                stack = (state.cwd, *state.directory_stack)
+            else:
+                if not state.directory_stack:
+                    raise CommandPolicyViolation(
+                        "cannot resolve pushd without a directory stack"
+                    )
+                target = state.directory_stack[0]
+                stack = (state.cwd, *state.directory_stack[1:])
+            return replace(
+                state,
+                cwd=target,
+                directory_stack=stack,
+                previous_cwd=state.cwd,
+            )
+
+        if operands:
+            raise CommandPolicyViolation("cannot safely resolve popd arguments")
+        if not state.directory_stack:
+            raise CommandPolicyViolation(
+                "cannot resolve popd without a directory stack"
+            )
+        return replace(
+            state,
+            cwd=state.directory_stack[0],
+            directory_stack=state.directory_stack[1:],
+            previous_cwd=state.cwd,
+        )
+
+    def _check_command_wrapper(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        state: _ShellState,
+    ) -> _ShellState:
+        if state.wrapper_depth >= _MAX_COMMAND_WRAPPER_DEPTH:
+            raise CommandPolicyViolation("wrapper nesting depth exceeded")
+        grammar = _COMMAND_WRAPPER_GRAMMARS[command_name]
+        self._reject_dynamic_values(f"{command_name} arguments", values)
+        index = 0
+        options_done = False
+        terminal_mode = False
+        nested_state = replace(state, wrapper_depth=state.wrapper_depth + 1)
+
+        while index < len(values):
+            value = values[index]
+            if not options_done and value == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not value.startswith("-"):
+                break
+            if value in grammar.rejected_options or any(
+                value.startswith(f"{option}=")
+                for option in grammar.rejected_options
+                if option.startswith("--")
+            ):
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect {command_name} option {value}"
+                )
+            option, argument, consumed = self._parse_wrapper_option(
+                command_name,
+                values,
+                index,
+                grammar,
+            )
+            if option in grammar.cwd_options and argument is not None:
+                target = self._check_path(argument, nested_state.cwd, "read")
+                nested_state = replace(nested_state, cwd=target)
+            terminal_mode = terminal_mode or option in grammar.terminal_options
+            index += consumed
+
+        for _ in range(grammar.leading_scalars):
+            if index >= len(values):
+                return state
+            index += 1
+
+        if grammar.allows_assignments:
+            assignments_start = index
+            while index < len(values) and "=" in values[index]:
+                index += 1
+            self._reject_implicit_shell_environment(values[assignments_start:index])
+
+        if terminal_mode or index >= len(values):
+            return state
+
+        command_word = values[index]
+        if isinstance(command_word, _CommandValue) and not command_word.is_static:
+            raise CommandPolicyViolation("cannot resolve dynamic command name")
+        # Wrappers spawn a child command: validate its paths against the adjusted
+        # child cwd, but never propagate child shell directory state to the parent.
+        validated_state = self._validate_command_values(
+            command_word, values[index + 1 :], nested_state
+        )
+        if not grammar.propagates_state:
+            return state
+        return replace(validated_state, wrapper_depth=state.wrapper_depth)
+
+    def _parse_wrapper_option(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        index: int,
+        grammar: _CommandWrapperGrammar,
+    ) -> tuple[str, str | None, int]:
+        value = values[index]
+        if value in grammar.flag_options or (
+            value in grammar.terminal_options and value not in grammar.value_options
+        ):
+            return value, None, 1
+        if value in grammar.value_options:
+            if index + 1 >= len(values):
+                raise CommandPolicyViolation(
+                    f"missing {command_name} argument for {value}"
+                )
+            return value, values[index + 1], 2
+
+        matching_long = next(
+            (
+                option
+                for option in grammar.value_options
+                if option.startswith("--") and value.startswith(f"{option}=")
+            ),
+            None,
+        )
+        if matching_long is not None:
+            return (
+                matching_long,
+                self._derived_value(value, value.split("=", 1)[1]),
+                1,
+            )
+
+        matching_short = next(
+            (
+                option
+                for option in grammar.attached_short_value_options
+                if value.startswith(option) and len(value) > len(option)
+            ),
+            None,
+        )
+        if matching_short is not None:
+            return (
+                matching_short,
+                self._derived_value(value, value[len(matching_short) :]),
+                1,
+            )
+
+        raise CommandPolicyViolation(
+            f"cannot safely inspect {command_name} option {value}"
+        )
+
+    def _check_operands(
+        self,
+        values: Sequence[str],
+        cwd: Path,
+        access: PathAccess,
+    ) -> None:
+        for raw_path in self._operands(values):
+            self._check_path(raw_path, cwd, access)
+
+    def _read_policy_script(self, raw_path: str, cwd: Path) -> str:
+        script_path = self._check_path(raw_path, cwd, "read")
+        written_paths = _COMMAND_WRITTEN_PATHS.get()
+        if written_paths is not None and script_path in written_paths:
+            raise CommandPolicyViolation(
+                "cannot inspect a script modified earlier in the same command"
+            )
+
+        descriptor: int | None = None
+        try:
+            flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW
+            descriptor = os.open(script_path, flags)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_size > _MAX_INSPECTED_SCRIPT_BYTES
+            ):
+                raise CommandPathViolation(access="read", path=script_path)
+            with os.fdopen(descriptor, "rb") as script_file:
+                descriptor = None
+                raw_script = script_file.read(_MAX_INSPECTED_SCRIPT_BYTES + 1)
+            if len(raw_script) > _MAX_INSPECTED_SCRIPT_BYTES:
+                raise CommandPathViolation(access="read", path=script_path)
+            script = raw_script.decode("utf-8")
+        except OSError as exc:
+            # A missing script may be created earlier in the same shell string;
+            # skipping inspection would allow its embedded file I/O unchecked.
+            if exc.errno == errno.ELOOP:
+                raise CommandPolicyViolation(
+                    f"{script_path} symbolic link changed during inspection"
+                ) from exc
+            raise CommandPathViolation(access="read", path=script_path) from exc
+        except UnicodeError as exc:
+            raise CommandPolicyViolation(
+                f"{script_path} is not a UTF-8 policy script"
+            ) from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        return script
+
+    def _inspect_shell_script(
+        self,
+        raw_path: str,
+        state: _ShellState,
+        *,
+        propagate_state: bool,
+    ) -> _ShellState:
+        if state.script_depth >= _MAX_INSPECTED_SCRIPT_DEPTH:
+            raise CommandPolicyViolation("shell script inspection depth exceeded")
+        script = self._read_policy_script(raw_path, state.cwd)
+        nested_state = replace(state, script_depth=state.script_depth + 1)
+        validated_states = self._validate_shell_states(script, nested_state)
+        if not propagate_state:
+            return state
+        if len(validated_states) != 1:
+            raise CommandPolicyViolation(
+                "cannot propagate multiple shell directory states from source"
+            )
+        validated_state = validated_states[0]
+        return replace(validated_state, script_depth=state.script_depth)
+
+    @staticmethod
+    def _is_direct_command_path(command_word: str) -> bool:
+        return "/" in command_word
+
+    @staticmethod
+    def _is_trusted_system_command(command_word: str, command_name: str) -> bool:
+        candidate = Path(command_word).expanduser()
+        if not candidate.is_absolute():
+            return False
+        discovered = shutil.which(command_name)
+        if discovered is None:
+            return False
+        try:
+            resolved = candidate.resolve()
+            return resolved == Path(discovered).resolve() and any(
+                resolved.is_relative_to(root) for root in _TRUSTED_EXECUTABLE_ROOTS
+            )
+        except (OSError, RuntimeError):
+            return False
+
+    def _inspect_direct_shell_script(
+        self,
+        raw_path: str,
+        state: _ShellState,
+    ) -> None:
+        if state.script_depth >= _MAX_INSPECTED_SCRIPT_DEPTH:
+            raise CommandPolicyViolation("shell script inspection depth exceeded")
+        script_path = self._check_workspace_path(raw_path, state.cwd, "read")
+        script = self._read_policy_script(str(script_path), state.cwd)
+
+        first_line = script.splitlines()[0] if script.splitlines() else ""
+        if first_line.startswith("#!"):
+            interpreter = os.path.basename(first_line[2:].strip().split()[0])
+            if interpreter == "env":
+                interpreter_parts = first_line[2:].strip().split()
+                interpreter = (
+                    os.path.basename(interpreter_parts[1])
+                    if len(interpreter_parts) > 1
+                    else ""
+                )
+            if interpreter not in _SHELL_COMMANDS:
+                raise CommandPolicyViolation(
+                    "direct scripts must use the Bash policy shell dialect"
+                )
+
+        nested_state = replace(state, script_depth=state.script_depth + 1)
+        self._validate_shell_states(script, nested_state)
+
+    @staticmethod
+    def _reject_implicit_shell_environment(values: Sequence[str]) -> None:
+        for value in values:
+            name, _, _ = str(value).partition("=")
+            if name in _REJECTED_SHELL_ASSIGNMENTS:
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect shell execution environment via {name}"
+                )
+
+    def _check_nested_shell(
+        self,
+        command_name: str,
+        literals: Sequence[str],
+        state: _ShellState,
+    ) -> None:
+        active_environment = self._active_implicit_shell_environment()
+        if active_environment is not None:
+            raise CommandPolicyViolation(
+                "cannot safely inspect implicit shell initialization via "
+                f"{active_environment}"
+            )
+        command_option_index: int | None = None
+        for index, value in enumerate(literals[:-1]):
+            if (
+                value.startswith("-")
+                and not value.startswith("--")
+                and "c" in value[1:]
+            ):
+                command_option_index = index
+                break
+
+        file_values = (
+            literals
+            if command_option_index is None
+            else literals[:command_option_index]
+        )
+        if command_name == "bash":
+            file_values, initialization_files = self._extract_bash_file_options(
+                file_values
+            )
+            for initialization_file in initialization_files:
+                self._inspect_shell_script(
+                    initialization_file,
+                    state,
+                    propagate_state=False,
+                )
+
+        if command_option_index is not None:
+            self._validate_shell_states(literals[command_option_index + 1], state)
+            return
+
+        script = self._shell_script_operand(file_values)
+        if script is None:
+            raise CommandPolicyViolation(
+                f"cannot inspect {command_name} input without command text or a script"
+            )
+        self._inspect_shell_script(script, state, propagate_state=False)
+
+    @staticmethod
+    def _extract_bash_file_options(
+        values: Sequence[str],
+    ) -> tuple[list[str], list[str]]:
+        remaining: list[str] = []
+        initialization_files: list[str] = []
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value in _BASH_FILE_OPTIONS:
+                if index + 1 < len(values):
+                    initialization_files.append(values[index + 1])
+                index += 2
+                continue
+            if any(value.startswith(f"{option}=") for option in _BASH_FILE_OPTIONS):
+                initialization_files.append(value.split("=", 1)[1])
+                index += 1
+                continue
+            remaining.append(value)
+            index += 1
+        return remaining, initialization_files
+
+    def _check_sourced_shell(
+        self,
+        values: Sequence[str],
+        state: _ShellState,
+    ) -> _ShellState:
+        operands = self._operands(values)
+        if not operands:
+            raise CommandPolicyViolation("cannot inspect source without a script")
+        return self._inspect_shell_script(
+            operands[0],
+            state,
+            propagate_state=True,
+        )
+
+    @staticmethod
+    def _shell_script_operand(values: Sequence[str]) -> str | None:
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                return values[index + 1] if index + 1 < len(values) else None
+            if value in {"-o", "-O"}:
+                index += 2
+                continue
+            if value == "-s" or (
+                value.startswith("-")
+                and not value.startswith("--")
+                and "s" in value[1:]
+            ):
+                return None
+            if value.startswith("-") and value != "-":
+                index += 1
+                continue
+            return value
+        return None
+
+    def _check_xargs(self, values: Sequence[str], state: _ShellState) -> None:
+        command_start = len(values)
+        index = 0
+        options_with_value = {
+            "-a",
+            "--arg-file",
+            "-d",
+            "--delimiter",
+            "-E",
+            "--eof",
+            "-I",
+            "--replace",
+            "-L",
+            "--max-lines",
+            "-n",
+            "--max-args",
+            "-P",
+            "--max-procs",
+            "-s",
+            "--max-chars",
+        }
+        attached_prefixes = ("-a", "-d", "-E", "-I", "-L", "-n", "-P", "-s")
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                command_start = index + 1
+                break
+            if value in options_with_value:
+                index += 2
+                continue
+            if value.startswith("--") and "=" in value:
+                index += 1
+                continue
+            if value.startswith(attached_prefixes) and len(value) > 2:
+                index += 1
+                continue
+            if value.startswith("-") and value != "-":
+                index += 1
+                continue
+            command_start = index
+            break
+
+        if command_start < len(values):
+            # Validate the fixed command first so wrapper limits and any static
+            # path violations keep their precise diagnostics. Runtime stdin
+            # arguments remain uninspectable regardless of that result.
+            self._validate_nested_command_words(values[command_start:], state)
+        raise CommandPolicyViolation(
+            "cannot safely inspect runtime file arguments produced by xargs"
+        )
+
+    def _validate_nested_command_words(
+        self,
+        words: Sequence[str],
+        state: _ShellState,
+    ) -> None:
+        if not words:
+            return
+        if isinstance(words[0], _CommandValue) and not words[0].is_static:
+            raise CommandPolicyViolation("cannot resolve dynamic command name")
+        self._validate_command_values(words[0], words[1:], state)
+
+    def _validate_shell_states(
+        self,
+        command: str,
+        state: _ShellState,
+    ) -> tuple[_ShellState, ...]:
+        if isinstance(command, _CommandValue) and not command.is_static:
+            raise CommandPolicyViolation("cannot resolve dynamic shell command text")
+        nodes = self._parse_shell(command)
+        current: tuple[_ShellState, ...] = (state,)
+        for node in nodes:
+            current = self._validate_node_states(node, current)
+        return current
+
+    def _validate_nested_nodes(self, node: Any, state: _ShellState) -> None:
+        for attr_name in ("parts", "command", "list"):
+            child = getattr(node, attr_name, None)
+            if isinstance(child, list):
+                for item in child:
+                    if getattr(item, "kind", None) is not None:
+                        self._validate_node(item, state)
+            elif getattr(child, "kind", None) is not None:
+                self._validate_node(child, state)
+
+    @staticmethod
+    def _command_value(word: Any) -> _CommandValue:
+        parts = getattr(word, "parts", ())
+        return _CommandValue(
+            str(word.word),
+            # Tilde expansion is deterministic at the policy boundary and is
+            # resolved by Path.expanduser(); parser parts and source-marked
+            # expansions that cannot be resolved here remain dynamic.
+            is_static=not getattr(word, "xagent_has_unmodeled_expansion", False)
+            and (
+                not parts
+                or all(getattr(part, "kind", None) == "tilde" for part in parts)
+            ),
+        )
+
+    def _command_values(self, words: Sequence[Any]) -> list[_CommandValue]:
+        return [self._command_value(word) for word in words]
+
+    @staticmethod
+    def _derived_value(source: str, value: str) -> _CommandValue:
+        return _CommandValue(
+            value,
+            is_static=(not isinstance(source, _CommandValue) or source.is_static),
+        )
+
+    @staticmethod
+    def _reject_dynamic_values(context: str, values: Sequence[str]) -> None:
+        if any(
+            isinstance(value, _CommandValue) and not value.is_static for value in values
+        ):
+            raise CommandPolicyViolation(f"cannot resolve dynamic {context}")
+
+    @staticmethod
+    def _operands(values: Sequence[str]) -> list[str]:
+        operands: list[str] = []
+        options_done = False
+        for value in values:
+            if not options_done and value == "--":
+                options_done = True
+                continue
+            if not options_done and value.startswith("-") and value != "-":
+                continue
+            operands.append(value)
+        return operands
+
+    def _check_path(self, raw_path: str, cwd: Path, access: PathAccess) -> Path:
+        return self._resolve_policy_path(
+            raw_path,
+            cwd,
+            access,
+            include_external_dirs=access == "read",
+        )
+
+    def _check_workspace_path(
+        self,
+        raw_path: str,
+        cwd: Path,
+        access: PathAccess,
+    ) -> Path:
+        return self._resolve_policy_path(
+            raw_path,
+            cwd,
+            access,
+            include_external_dirs=False,
+        )
+
+    def _resolve_policy_path(
+        self,
+        raw_path: str,
+        cwd: Path,
+        access: PathAccess,
+        *,
+        include_external_dirs: bool,
+    ) -> Path:
+        if isinstance(raw_path, _CommandValue) and not raw_path.is_static:
+            raise CommandPolicyViolation(
+                "cannot resolve dynamic path operand; enumerate concrete paths "
+                "instead of using active globs or shell expansions"
+            )
+
+        if raw_path in {"", "-", "{}"}:
+            return cwd
+
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = cwd / candidate
+
+        if candidate in _SAFE_DEVICE_PATHS:
+            return candidate
+
+        try:
+            resolved = self._workspace.resolve_authorized_path(
+                candidate,
+                base_dir=cwd,
+                include_external_dirs=include_external_dirs,
+            )
+        except ValueError as exc:
+            raise CommandPathViolation(access=access, path=candidate) from exc
+        written_paths = _COMMAND_WRITTEN_PATHS.get()
+        if access == "write" and written_paths is not None:
+            written_paths.add(resolved)
+        return resolved

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1016,9 +1016,11 @@ class WorkspaceCommandPathGuard:
 
         first_line = script.splitlines()[0] if script.splitlines() else ""
         if first_line.startswith("#!"):
-            interpreter = os.path.basename(first_line[2:].strip().split()[0])
+            interpreter_parts = first_line[2:].strip().split()
+            interpreter = (
+                os.path.basename(interpreter_parts[0]) if interpreter_parts else ""
+            )
             if interpreter == "env":
-                interpreter_parts = first_line[2:].strip().split()
                 interpreter = (
                     os.path.basename(interpreter_parts[1])
                     if len(interpreter_parts) > 1

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -159,10 +159,29 @@ def _active_validation_session() -> _ValidationSession:
 
 
 _READ_COMMANDS = {"cat"}
-_WRITE_COMMANDS = {"rm"}
+# Path-scoped writers: every operand is validated as a workspace write and
+# recorded per-path, so they never poison the session-wide unknown-effect flag.
+_WRITE_COMMANDS = {"rm", "mkdir"}
 _SHELL_COMMANDS = {"bash"}
 _UNSUPPORTED_SHELL_COMMANDS = {"dash", "sh", "zsh"}
 _UNSUPPORTED_PRIVILEGE_COMMANDS = {"sudo"}
+# Commands with no filesystem write effect of their own. Redirections are
+# validated separately, so these can never mutate a later-inspected script and
+# must not poison the session-wide unknown-effect flag. Keep this conservative:
+# only add a command here once it is known to be unable to write the filesystem.
+_NO_FILESYSTEM_EFFECT_COMMANDS = {
+    "echo",
+    "printf",
+    "pwd",
+    "true",
+    "false",
+    ":",
+    "test",
+    "[",
+    "export",
+    "declare",
+    "typeset",
+}
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
 _BASH_LONG_FLAG_OPTIONS = {
     "--debug",
@@ -964,6 +983,10 @@ class WorkspaceCommandPathGuard:
             )
         elif command_name in _COMMAND_WRAPPER_GRAMMARS:
             return self._check_command_wrapper(command_name, args, state)
+        elif command_name in _NO_FILESYSTEM_EFFECT_COMMANDS:
+            # No filesystem write effect of its own; any redirection is validated
+            # separately, so this cannot have mutated a later-inspected script.
+            pass
         else:
             _active_validation_session().effects.unknown_effect = True
         return state

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -515,6 +515,8 @@ class _BashInvocation:
     initialization_files: tuple[str, ...]
     command_text: str | None = None
     script: str | None = None
+    reads_stdin: bool = False
+    lists_options: bool = False
 
 
 _COMMAND_WRAPPER_GRAMMARS = {
@@ -1281,6 +1283,14 @@ class WorkspaceCommandPathGuard:
         if invocation.command_text is not None:
             self._validate_shell_states(invocation.command_text, state)
             return
+        if invocation.reads_stdin:
+            listing_context = (
+                " after listing options" if invocation.lists_options else ""
+            )
+            raise CommandPolicyViolation(
+                f"cannot inspect {command_name} input without command text or a script"
+                f"{listing_context}"
+            )
         if invocation.script is None:
             raise CommandPolicyViolation(
                 f"cannot inspect {command_name} input without command text or a script"
@@ -1304,6 +1314,7 @@ class WorkspaceCommandPathGuard:
                 return _BashInvocation(
                     initialization_files=tuple(initialization_files),
                     script=values[index] if index < len(values) else None,
+                    reads_stdin=index >= len(values),
                 )
             if value in _BASH_FILE_OPTIONS:
                 index += 1
@@ -1329,7 +1340,10 @@ class WorkspaceCommandPathGuard:
                     f"cannot safely inspect bash option {value}"
                 )
             if value == "-":
-                return _BashInvocation(initialization_files=tuple(initialization_files))
+                return _BashInvocation(
+                    initialization_files=tuple(initialization_files),
+                    reads_stdin=True,
+                )
             if value.startswith(("-", "+")) and len(value) > 1:
                 named_option_count = 0
                 has_command_text = False
@@ -1349,8 +1363,10 @@ class WorkspaceCommandPathGuard:
                 index += 1
                 for _ in range(named_option_count):
                     if index >= len(values):
-                        raise CommandPolicyViolation(
-                            f"missing bash argument for {value}"
+                        return _BashInvocation(
+                            initialization_files=tuple(initialization_files),
+                            reads_stdin=True,
+                            lists_options=True,
                         )
                     argument = values[index]
                     if isinstance(argument, _CommandValue) and not argument.is_static:
@@ -1377,14 +1393,18 @@ class WorkspaceCommandPathGuard:
                     )
                 if stdin_mode:
                     return _BashInvocation(
-                        initialization_files=tuple(initialization_files)
+                        initialization_files=tuple(initialization_files),
+                        reads_stdin=True,
                     )
                 continue
             return _BashInvocation(
                 initialization_files=tuple(initialization_files),
                 script=value,
             )
-        return _BashInvocation(initialization_files=tuple(initialization_files))
+        return _BashInvocation(
+            initialization_files=tuple(initialization_files),
+            reads_stdin=True,
+        )
 
     def _check_sourced_shell(
         self,

--- a/src/xagent/core/tools/core/command_policy.py
+++ b/src/xagent/core/tools/core/command_policy.py
@@ -48,6 +48,13 @@ class CwdBoundCommandPolicy(Protocol):
     def execution_cwd(self) -> Path | None: ...
 
 
+@runtime_checkable
+class CommandArgvExecutionPolicy(Protocol):
+    """Validate argv once and return the exact vector safe to execute."""
+
+    def prepare_argv_for_execution(self, argv: Sequence[str]) -> list[str]: ...
+
+
 def resolve_trusted_executable(executable: str) -> Path:
     """Resolve an executable to one canonical identity under a system root."""
     if "/" in executable and not Path(executable).is_absolute():

--- a/src/xagent/core/tools/core/command_policy.py
+++ b/src/xagent/core/tools/core/command_policy.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
-from typing import Literal, Protocol, Sequence
+from typing import Literal, Protocol, Sequence, runtime_checkable
 
 PathAccess = Literal["read", "write"]
+
+_TRUSTED_EXECUTABLE_ROOTS = tuple(
+    path.resolve()
+    for path in (
+        Path("/bin"),
+        Path("/usr/bin"),
+        Path("/usr/local/bin"),
+        Path("/opt/homebrew/bin"),
+    )
+)
 
 
 class CommandPolicyViolation(ValueError):
@@ -27,3 +38,37 @@ class CommandPolicyGuard(Protocol):
     def validate(self, command: str) -> None: ...
 
     def validate_argv(self, argv: Sequence[str]) -> None: ...
+
+
+@runtime_checkable
+class CwdBoundCommandPolicy(Protocol):
+    """Optionally bind command execution to one canonical absolute directory."""
+
+    @property
+    def execution_cwd(self) -> Path | None: ...
+
+
+def resolve_trusted_executable(executable: str) -> Path:
+    """Resolve an executable to one canonical identity under a system root."""
+    if "/" in executable and not Path(executable).is_absolute():
+        raise CommandPolicyViolation(
+            f"restricted command execution requires a trusted {executable} executable"
+        )
+    discovered = shutil.which(executable)
+    if discovered is None:
+        raise CommandPolicyViolation(
+            f"restricted command execution requires a trusted {executable} executable"
+        )
+    try:
+        resolved = Path(discovered).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise CommandPolicyViolation(
+            f"cannot resolve trusted executable identity for {executable}"
+        ) from exc
+    if not resolved.is_file() or not any(
+        resolved.is_relative_to(root) for root in _TRUSTED_EXECUTABLE_ROOTS
+    ):
+        raise CommandPolicyViolation(
+            f"restricted command execution requires a trusted {executable} executable"
+        )
+    return resolved

--- a/tests/core/tools/test_command_executor.py
+++ b/tests/core/tools/test_command_executor.py
@@ -336,23 +336,47 @@ class TestCommandPolicyFoundation:
         assert "internal parser detail" not in result["error"]
         mock_run.assert_not_called()
 
-    def test_injected_policy_rejects_execute_script_before_tempfile_creation(
+    def test_injected_policy_validates_bash_script_without_tempfile_creation(
         self,
+        mock_run,
         monkeypatch,
     ):
         guard = Mock(spec=CommandPolicyGuard)
         create_tempfile = Mock()
+        mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
         monkeypatch.setattr(
             "xagent.core.tools.core.command_executor.tempfile.NamedTemporaryFile",
             create_tempfile,
         )
 
-        result = CommandExecutorCore(path_guard=guard).execute_script("echo unsafe")
+        result = CommandExecutorCore(path_guard=guard).execute_script("echo allowed")
+
+        guard.validate.assert_not_called()
+        guard.validate_argv.assert_called_once_with(["bash", "-c", "echo allowed"])
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[0] == ["bash", "-c", "echo allowed"]
+        assert mock_run.call_args.kwargs["shell"] is False
+        assert result["success"] is True
+        create_tempfile.assert_not_called()
+
+    @pytest.mark.parametrize("interpreter", ["python", "bash -O extglob", "'"])
+    def test_injected_policy_rejects_noncanonical_script_interpreter(
+        self,
+        mock_run,
+        interpreter,
+    ):
+        guard = Mock(spec=CommandPolicyGuard)
+
+        result = CommandExecutorCore(path_guard=guard).execute_script(
+            "echo unsafe",
+            interpreter=interpreter,
+        )
 
         assert result["success"] is False
         assert result["return_code"] == 126
-        assert "script execution is unavailable" in result["error"]
-        create_tempfile.assert_not_called()
+        guard.validate.assert_not_called()
+        guard.validate_argv.assert_not_called()
+        mock_run.assert_not_called()
 
     def test_injected_policy_allows_shell_command_execution(self, mock_run):
         guard = Mock(spec=CommandPolicyGuard)
@@ -365,7 +389,26 @@ class TestCommandPolicyFoundation:
         mock_run.assert_called_once()
         assert mock_run.call_args.args[0] == "printf allowed"
         assert mock_run.call_args.kwargs["shell"] is True
+        assert os.path.basename(mock_run.call_args.kwargs["executable"]) == "bash"
         assert result["success"] is True
+
+    def test_injected_policy_fails_closed_when_bash_is_unavailable(
+        self,
+        mock_run,
+        monkeypatch,
+    ):
+        guard = Mock(spec=CommandPolicyGuard)
+        monkeypatch.setattr(
+            "xagent.core.tools.core.command_executor.shutil.which",
+            lambda _: None,
+        )
+
+        result = CommandExecutorCore(path_guard=guard).execute_command("printf allowed")
+
+        guard.validate.assert_called_once_with("printf allowed")
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        mock_run.assert_not_called()
 
     def test_injected_policy_allows_argv_command_execution(self, mock_run):
         guard = Mock(spec=CommandPolicyGuard)

--- a/tests/core/tools/test_command_executor.py
+++ b/tests/core/tools/test_command_executor.py
@@ -437,6 +437,37 @@ class TestCommandPolicyFoundation:
 
         assert mock_run.call_args.kwargs["cwd"] == canonical_cwd
 
+    @pytest.mark.parametrize("replacement", ["other_guard", "none"])
+    def test_executor_path_guard_is_read_only_and_keeps_original_binding(
+        self,
+        tmp_path,
+        mock_run,
+        replacement,
+    ):
+        class CwdBoundGuard:
+            def __init__(self, execution_cwd):
+                self.execution_cwd = execution_cwd
+                self.validate = Mock()
+                self.validate_argv = Mock()
+
+        original_cwd = tmp_path / "original"
+        original_cwd.mkdir()
+        other_cwd = tmp_path / "other"
+        other_cwd.mkdir()
+        original_guard = CwdBoundGuard(original_cwd.resolve())
+        other_guard = CwdBoundGuard(other_cwd.resolve())
+        executor = CommandExecutorCore(path_guard=original_guard)
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        with pytest.raises(AttributeError):
+            executor.path_guard = other_guard if replacement == "other_guard" else None
+        result = executor.execute_command(["true"], shell=False)
+
+        original_guard.validate_argv.assert_called_once_with(["true"])
+        other_guard.validate_argv.assert_not_called()
+        assert mock_run.call_args.kwargs["cwd"] == original_cwd.resolve()
+        assert result["success"] is True
+
     def test_trusted_executable_resolution_rejects_relative_command_paths(self):
         bash = shutil.which("bash")
         assert bash is not None
@@ -655,6 +686,86 @@ class TestCommandPolicyFoundation:
             "-c",
             "printf allowed",
         ]
+        assert result["success"] is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ["env", "bash", "-c", "printf unsafe"],
+            ["timeout", "1", "bash", "-c", "printf unsafe"],
+        ],
+    )
+    def test_workspace_policy_rejects_wrapped_bash_argv_before_spawn(
+        self,
+        tmp_path,
+        mock_run,
+        monkeypatch,
+        command,
+    ):
+        workspace, guard = self._workspace_guard(tmp_path)
+        marker = tmp_path / "fake-bash-ran"
+        fake_bin = workspace.output_dir / "bin"
+        fake_bin.mkdir()
+        fake_bash = fake_bin / "bash"
+        fake_bash.write_text(
+            f"touch {shlex.quote(str(marker))}\n",
+            encoding="utf-8",
+        )
+        fake_bash.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        )
+
+        result = CommandExecutorCore(path_guard=guard).execute_command(
+            command,
+            shell=False,
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        mock_run.assert_not_called()
+        assert not marker.exists()
+
+    def test_workspace_policy_uses_absolute_bash_identity_for_direct_argv(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        _, guard = self._workspace_guard(tmp_path)
+        command = ["bash", "-c", "printf allowed"]
+        bash = shutil.which("bash")
+        assert bash is not None
+        trusted_bash = str(Path(bash).resolve())
+        mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
+
+        result = CommandExecutorCore(path_guard=guard).execute_command(
+            command,
+            shell=False,
+        )
+
+        assert mock_run.call_args.args[0] == [
+            trusted_bash,
+            "-c",
+            "printf allowed",
+        ]
+        assert result["success"] is True
+
+    def test_workspace_policy_preserves_non_bash_wrapper_argv(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        _, guard = self._workspace_guard(tmp_path)
+        command = ["env", "printf", "allowed"]
+        mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
+
+        result = CommandExecutorCore(path_guard=guard).execute_command(
+            command,
+            shell=False,
+        )
+
+        assert mock_run.call_args.args[0] == command
         assert result["success"] is True
 
     def test_injected_policy_allows_argv_command_execution(self, mock_run):

--- a/tests/core/tools/test_command_executor.py
+++ b/tests/core/tools/test_command_executor.py
@@ -4,6 +4,7 @@ Tests for CommandExecutor tool
 
 import os
 import shlex
+import shutil
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -21,11 +22,14 @@ from xagent.core.tools.core.command_executor import (
     execute_command,
     execute_script,
 )
+from xagent.core.tools.core.command_path_guard import WorkspaceCommandPathGuard
 from xagent.core.tools.core.command_policy import (
     CommandPathViolation,
     CommandPolicyGuard,
     CommandPolicyViolation,
+    resolve_trusted_executable,
 )
+from xagent.core.workspace import TaskWorkspace
 
 
 @pytest.fixture
@@ -263,6 +267,184 @@ class TestCommandExecutorTool:
 
 
 class TestCommandPolicyFoundation:
+    @staticmethod
+    def _workspace_guard(tmp_path):
+        workspace = TaskWorkspace("task", str(tmp_path / "workspace"))
+        guard = WorkspaceCommandPathGuard(workspace)
+        return workspace, guard
+
+    @pytest.mark.parametrize("working_directory", [None, ""])
+    def test_executor_adopts_guard_working_directory(
+        self,
+        tmp_path,
+        mock_run,
+        working_directory,
+    ):
+        workspace, guard = self._workspace_guard(tmp_path)
+        canonical_cwd = workspace.resolve_path("").resolve()
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        executor = CommandExecutorCore(
+            working_directory=working_directory,
+            path_guard=guard,
+        )
+        result = executor.execute_command(["true"], shell=False)
+
+        assert executor.working_directory == str(canonical_cwd)
+        assert mock_run.call_args.kwargs["cwd"] == canonical_cwd
+        assert result["success"] is True
+
+    @pytest.mark.parametrize("spelling", ["exact", "equivalent", "symlink"])
+    def test_executor_accepts_canonically_equivalent_guard_cwd(
+        self,
+        tmp_path,
+        mock_run,
+        spelling,
+    ):
+        workspace, guard = self._workspace_guard(tmp_path)
+        canonical_cwd = workspace.resolve_path("").resolve()
+        if spelling == "exact":
+            caller_cwd = str(canonical_cwd)
+        elif spelling == "equivalent":
+            caller_cwd = f"{canonical_cwd}/."
+        else:
+            alias = tmp_path / "workspace-alias"
+            alias.symlink_to(canonical_cwd, target_is_directory=True)
+            caller_cwd = str(alias)
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        executor = CommandExecutorCore(
+            working_directory=caller_cwd,
+            path_guard=guard,
+        )
+        executor.execute_command(["true"], shell=False)
+
+        assert executor.working_directory == str(canonical_cwd)
+        assert mock_run.call_args.kwargs["cwd"] == canonical_cwd
+
+    def test_executor_keeps_guard_cwd_after_caller_symlink_retarget(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        workspace, guard = self._workspace_guard(tmp_path)
+        canonical_cwd = workspace.resolve_path("").resolve()
+        other_cwd = tmp_path / "other"
+        other_cwd.mkdir()
+        alias = tmp_path / "workspace-alias"
+        alias.symlink_to(canonical_cwd, target_is_directory=True)
+        executor = CommandExecutorCore(
+            working_directory=str(alias),
+            path_guard=guard,
+        )
+        alias.unlink()
+        alias.symlink_to(other_cwd, target_is_directory=True)
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        executor.execute_command(["true"], shell=False)
+
+        assert mock_run.call_args.kwargs["cwd"] == canonical_cwd
+
+    def test_executor_rejects_guard_cwd_mismatch_before_validation_or_spawn(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        class CwdBoundGuard:
+            def __init__(self, execution_cwd):
+                self.execution_cwd = execution_cwd
+                self.validate = Mock()
+                self.validate_argv = Mock()
+
+        guard_cwd = tmp_path / "guard"
+        guard_cwd.mkdir()
+        caller_cwd = tmp_path / "caller"
+        caller_cwd.mkdir()
+        guard = CwdBoundGuard(guard_cwd.resolve())
+
+        with pytest.raises(
+            ValueError,
+            match="working_directory does not match command policy execution cwd",
+        ):
+            CommandExecutorCore(
+                working_directory=str(caller_cwd),
+                path_guard=guard,
+            )
+
+        guard.validate.assert_not_called()
+        guard.validate_argv.assert_not_called()
+        mock_run.assert_not_called()
+
+    def test_executor_preserves_legacy_cwd_for_guard_without_binding(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        guard = Mock(spec=CommandPolicyGuard)
+        caller_cwd = f"{tmp_path}/."
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        executor = CommandExecutorCore(
+            working_directory=caller_cwd,
+            path_guard=guard,
+        )
+        executor.execute_command(["true"], shell=False)
+
+        assert executor.working_directory == caller_cwd
+        assert mock_run.call_args.kwargs["cwd"] == caller_cwd
+
+    def test_executor_preserves_legacy_cwd_for_policy_with_no_requirement(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        class OptionalCwdGuard:
+            execution_cwd = None
+
+            def validate(self, command):
+                return None
+
+            def validate_argv(self, argv):
+                return None
+
+        caller_cwd = f"{tmp_path}/."
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        executor = CommandExecutorCore(
+            working_directory=caller_cwd,
+            path_guard=OptionalCwdGuard(),
+        )
+        executor.execute_command(["true"], shell=False)
+
+        assert executor.working_directory == caller_cwd
+        assert mock_run.call_args.kwargs["cwd"] == caller_cwd
+
+    def test_executor_working_directory_is_read_only_with_bound_policy(
+        self,
+        tmp_path,
+        mock_run,
+    ):
+        workspace, guard = self._workspace_guard(tmp_path)
+        canonical_cwd = workspace.resolve_path("").resolve()
+        other_cwd = tmp_path / "other"
+        other_cwd.mkdir()
+        executor = CommandExecutorCore(path_guard=guard)
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        with pytest.raises(AttributeError):
+            executor.working_directory = str(other_cwd)
+        executor.execute_command(["true"], shell=False)
+
+        assert mock_run.call_args.kwargs["cwd"] == canonical_cwd
+
+    def test_trusted_executable_resolution_rejects_relative_command_paths(self):
+        bash = shutil.which("bash")
+        assert bash is not None
+        relative_bash = os.path.relpath(bash, Path.cwd())
+
+        with pytest.raises(CommandPolicyViolation):
+            resolve_trusted_executable(relative_bash)
+
     @pytest.mark.parametrize(
         ("command", "shell"),
         [
@@ -336,14 +518,27 @@ class TestCommandPolicyFoundation:
         assert "internal parser detail" not in result["error"]
         mock_run.assert_not_called()
 
-    def test_injected_policy_validates_bash_script_without_tempfile_creation(
+    def test_injected_policy_rejects_execute_script_without_side_effects(
         self,
+        tmp_path,
         mock_run,
         monkeypatch,
     ):
         guard = Mock(spec=CommandPolicyGuard)
         create_tempfile = Mock()
-        mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
+        marker = tmp_path / "fake-bash-ran"
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_bash = fake_bin / "bash"
+        fake_bash.write_text(
+            f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\n",
+            encoding="utf-8",
+        )
+        fake_bash.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        )
         monkeypatch.setattr(
             "xagent.core.tools.core.command_executor.tempfile.NamedTemporaryFile",
             create_tempfile,
@@ -352,15 +547,29 @@ class TestCommandPolicyFoundation:
         result = CommandExecutorCore(path_guard=guard).execute_script("echo allowed")
 
         guard.validate.assert_not_called()
-        guard.validate_argv.assert_called_once_with(["bash", "-c", "echo allowed"])
-        mock_run.assert_called_once()
-        assert mock_run.call_args.args[0] == ["bash", "-c", "echo allowed"]
-        assert mock_run.call_args.kwargs["shell"] is False
-        assert result["success"] is True
+        guard.validate_argv.assert_not_called()
+        mock_run.assert_not_called()
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert result["error"] == (
+            "Command rejected by workspace path policy: command denied by policy"
+        )
         create_tempfile.assert_not_called()
+        assert not marker.exists()
 
-    @pytest.mark.parametrize("interpreter", ["python", "bash -O extglob", "'"])
-    def test_injected_policy_rejects_noncanonical_script_interpreter(
+    def test_unguarded_execute_script_preserves_real_tempfile_semantics(self):
+        result = CommandExecutorCore().execute_script(
+            'printf \'%s\\n%s\\n\' "$0" "${BASH_SOURCE[0]}"',
+        )
+
+        script_path, bash_source = result["output"].splitlines()
+        assert result["success"] is True
+        assert script_path == bash_source
+        assert Path(script_path).is_absolute()
+        assert not Path(script_path).exists()
+
+    @pytest.mark.parametrize("interpreter", ["bash", "python", "bash -O extglob", "'"])
+    def test_injected_policy_rejects_execute_script_for_all_interpreters(
         self,
         mock_run,
         interpreter,
@@ -381,6 +590,9 @@ class TestCommandPolicyFoundation:
     def test_injected_policy_allows_shell_command_execution(self, mock_run):
         guard = Mock(spec=CommandPolicyGuard)
         mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
+        bash = shutil.which("bash")
+        assert bash is not None
+        trusted_bash = str(Path(bash).resolve())
 
         result = CommandExecutorCore(path_guard=guard).execute_command("printf allowed")
 
@@ -389,18 +601,28 @@ class TestCommandPolicyFoundation:
         mock_run.assert_called_once()
         assert mock_run.call_args.args[0] == "printf allowed"
         assert mock_run.call_args.kwargs["shell"] is True
-        assert os.path.basename(mock_run.call_args.kwargs["executable"]) == "bash"
+        assert mock_run.call_args.kwargs["executable"] == trusted_bash
         assert result["success"] is True
 
-    def test_injected_policy_fails_closed_when_bash_is_unavailable(
+    def test_injected_policy_rejects_path_shadowed_bash_before_spawn(
         self,
+        tmp_path,
         mock_run,
         monkeypatch,
     ):
         guard = Mock(spec=CommandPolicyGuard)
-        monkeypatch.setattr(
-            "xagent.core.tools.core.command_executor.shutil.which",
-            lambda _: None,
+        marker = tmp_path / "fake-bash-ran"
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_bash = fake_bin / "bash"
+        fake_bash.write_text(
+            f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\n",
+            encoding="utf-8",
+        )
+        fake_bash.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
         )
 
         result = CommandExecutorCore(path_guard=guard).execute_command("printf allowed")
@@ -409,6 +631,31 @@ class TestCommandPolicyFoundation:
         assert result["success"] is False
         assert result["return_code"] == 126
         mock_run.assert_not_called()
+        assert not marker.exists()
+
+    def test_injected_policy_uses_absolute_bash_identity_for_argv_execution(
+        self,
+        mock_run,
+    ):
+        guard = Mock(spec=CommandPolicyGuard)
+        mock_run.return_value = Mock(stdout="allowed", stderr="", returncode=0)
+        command = ["bash", "-c", "printf allowed"]
+        bash = shutil.which("bash")
+        assert bash is not None
+        trusted_bash = str(Path(bash).resolve())
+
+        result = CommandExecutorCore(path_guard=guard).execute_command(
+            command,
+            shell=False,
+        )
+
+        guard.validate_argv.assert_called_once_with(command)
+        assert mock_run.call_args.args[0] == [
+            trusted_bash,
+            "-c",
+            "printf allowed",
+        ]
+        assert result["success"] is True
 
     def test_injected_policy_allows_argv_command_execution(self, mock_run):
         guard = Mock(spec=CommandPolicyGuard)

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2,9 +2,11 @@
 
 import os
 import shlex
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from xagent.core.tools.core import command_path_guard as command_path_guard_module
 from xagent.core.tools.core.command_executor import CommandExecutorCore
 from xagent.core.tools.core.command_path_guard import WorkspaceCommandPathGuard
 from xagent.core.tools.core.command_policy import (
@@ -1181,3 +1183,295 @@ class TestScopedCommandPathGuardBash:
 
         with pytest.raises(CommandPolicyViolation):
             guard.validate(command_template)
+
+    @pytest.mark.parametrize("effect_command", ["rm -f safe.sh", "python -c pass"])
+    def test_effect_before_script_rejects_but_script_before_effect_is_allowed(
+        self,
+        scoped_command_workspace,
+        effect_command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "safe.sh"
+        script.write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(f"{effect_command}; bash safe.sh")
+
+        guard.validate(f"bash safe.sh; {effect_command}")
+
+    @pytest.mark.parametrize("effect_command", ["rm -f safe.sh", "python -c pass"])
+    @pytest.mark.parametrize("script_first", [False, True])
+    def test_pipeline_rejects_concurrent_script_effects_in_both_directions(
+        self,
+        scoped_command_workspace,
+        effect_command,
+        script_first,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "safe.sh"
+        script.write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        members = ["bash safe.sh", effect_command]
+        if not script_first:
+            members.reverse()
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by a concurrent command",
+        ):
+            guard.validate(" | ".join(members))
+
+    def test_effect_ledger_resets_for_fresh_top_level_validation(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "safe.sh"
+        script.write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("python -c pass")
+        guard.validate("bash safe.sh")
+
+    def test_parse_attempt_budget_is_shared_across_nested_scripts(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "outer.sh").write_text(
+            "bash inner.sh\n",
+            encoding="utf-8",
+        )
+        (workspace.output_dir / "inner.sh").write_text(":\n", encoding="utf-8")
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_MAX_POLICY_PARSE_ATTEMPTS",
+            2,
+            raising=False,
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy parse attempt budget exceeded",
+        ):
+            guard.validate("bash outer.sh")
+
+    def test_node_state_evaluation_budget_is_deterministic(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_MAX_POLICY_NODE_STATE_EVALUATIONS",
+            1,
+            raising=False,
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy node-state evaluation budget exceeded",
+        ):
+            guard.validate("true; true")
+
+    def test_argv_token_budget_accepts_boundary_and_rejects_exhaustion(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        limit = 8192
+
+        guard.validate_argv(["unknown", *(["value"] * (limit - 1))])
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy argv token budget exceeded",
+        ):
+            guard.validate_argv(["unknown", *(["value"] * limit)])
+
+    def test_nested_public_reentry_shares_session_and_exception_resets_it(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        original = guard._validate_command_values
+        reentered = False
+
+        def reenter(*args, **kwargs):
+            nonlocal reentered
+            if not reentered:
+                reentered = True
+                guard.validate_argv(["nested", "value"])
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_ARGV_TOKENS", 3)
+        monkeypatch.setattr(guard, "_validate_command_values", reenter)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy argv token budget exceeded",
+        ):
+            guard.validate_argv(["outer", "value"])
+
+        monkeypatch.setattr(guard, "_validate_command_values", original)
+        guard.validate_argv(["fresh", "value", "control"])
+
+    def test_validation_sessions_are_isolated_across_concurrent_contexts(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_ARGV_TOKENS", 1)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(guard.validate_argv, (["one"], ["two"])))
+
+        assert results == [None, None]
+
+    def test_cumulative_source_character_budget_is_shared(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        command = "bash -c ':'"
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_MAX_POLICY_SOURCE_CHARS",
+            len(command),
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy source character budget exceeded",
+        ):
+            guard.validate(command)
+
+    def test_cumulative_script_byte_budget_is_shared(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script_source = "# comment\n"
+        (workspace.output_dir / "one.sh").write_text(script_source, encoding="utf-8")
+        (workspace.output_dir / "two.sh").write_text(script_source, encoding="utf-8")
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_MAX_POLICY_SCRIPT_BYTES",
+            len(script_source.encode("utf-8")) * 2 - 1,
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy script byte budget exceeded",
+        ):
+            guard.validate("bash one.sh; bash two.sh")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "env python -c pass; bash safe.sh",
+            "(python -c pass); bash safe.sh",
+            "source effect.sh; bash safe.sh",
+            "bash -c 'python -c pass'; bash safe.sh",
+        ],
+    )
+    def test_unknown_effect_propagates_through_nested_shell_regions(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text("# safe\n", encoding="utf-8")
+        (workspace.output_dir / "effect.sh").write_text(
+            "python -c pass\n",
+            encoding="utf-8",
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(command)
+
+    @pytest.mark.parametrize("command", ["env true", "xargs true"])
+    def test_nested_argv_dispatch_charges_shared_token_budget(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_ARGV_TOKENS", 2)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy argv token budget exceeded",
+        ):
+            guard.validate(command)
+
+    def test_deterministic_budgets_allow_ordinary_nested_validation(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_PARSE_ATTEMPTS", 2)
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_SOURCE_CHARS", 32)
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_MAX_POLICY_NODE_STATE_EVALUATIONS",
+            2,
+        )
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_ARGV_TOKENS", 4)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("bash -c ':'")
+
+    def test_comment_only_input_consumes_parse_attempt_budget(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        monkeypatch.setattr(command_path_guard_module, "_MAX_POLICY_PARSE_ATTEMPTS", 0)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="command policy parse attempt budget exceeded",
+        ):
+            guard.validate("# comment only\n")
+
+    def test_new_effect_rejection_keeps_executor_exit_126_contract(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text("# safe\n", encoding="utf-8")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": "python -c pass; bash safe.sh"},
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2,6 +2,7 @@
 
 import os
 import shlex
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -58,6 +59,11 @@ class _GuardedCommandTool:
 
 def _guarded_tool(workspace):
     return _GuardedCommandTool(workspace)
+
+
+def _write_comment_script_bytes(path, size):
+    prefix = b"#"
+    path.write_bytes(prefix + (b"x" * (size - len(prefix))))
 
 
 class TestScopedCommandPathGuardBash:
@@ -217,6 +223,41 @@ class TestScopedCommandPathGuardBash:
             guard.validate(
                 f"printf %s \"<<'EOF'\"\ncat {shlex.quote(str(sibling_file))}\nEOF\n"
             )
+
+    def test_nested_quoted_heredoc_body_is_masked_once(self):
+        source = "cat <<'OUTER'\nreport <<'INNER'\nOUTER\nINNER\nprintf live\n"
+
+        normalized = command_path_guard_module._normalize_policy_shell_source(source)
+
+        assert len(normalized) == len(source)
+        assert normalized.splitlines()[2] == "OUTER"
+        assert normalized.endswith("printf live\n")
+
+    def test_multiple_quoted_heredocs_are_consumed_in_declaration_order(self):
+        source = (
+            "cat <<'FIRST' <<-'SECOND'\n"
+            "first <<'NESTED'\n"
+            "FIRST\n"
+            "\tsecond time\n"
+            "\tSECOND\n"
+            "printf live\n"
+        )
+
+        normalized = command_path_guard_module._normalize_policy_shell_source(source)
+
+        assert len(normalized) == len(source)
+        assert normalized.splitlines()[2] == "FIRST"
+        assert normalized.splitlines()[4] == "\tSECOND"
+        assert normalized.endswith("printf live\n")
+
+    def test_time_keyword_normalization_ignores_multiline_quoted_literal(self):
+        source = 'printf "%s" "literal\ntime cat own.txt"\ntime cat own.txt\n'
+
+        normalized = command_path_guard_module._normalize_policy_shell_source(source)
+
+        assert normalized == (
+            'printf "%s" "literal\ntime cat own.txt"\n__t_ cat own.txt\n'
+        )
 
     def test_allows_time_keyword_with_validated_nested_command(
         self,
@@ -433,7 +474,6 @@ class TestScopedCommandPathGuardBash:
             "command -p cat {path}",
             "setsid -f cat {path}",
             "ionice -c 2 -n 7 cat {path}",
-            "sudo -n cat {path}",
             "/usr/bin/time -p cat {path}",
         ],
     )
@@ -464,7 +504,6 @@ class TestScopedCommandPathGuardBash:
             "command -p cat own.txt",
             "setsid -f cat own.txt",
             "ionice -c 2 -n 7 cat own.txt",
-            "sudo -n cat own.txt",
             "/usr/bin/time -p cat own.txt",
         ],
     )
@@ -475,6 +514,65 @@ class TestScopedCommandPathGuardBash:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sudo -n cat own.txt",
+            "env sudo -n cat own.txt",
+            "command sudo -n cat own.txt",
+        ],
+    )
+    def test_rejects_sudo_privilege_wrapper(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely inspect privilege escalation via sudo",
+        ):
+            guard.validate(command)
+
+    def test_rejects_trusted_absolute_sudo_path_when_available(
+        self,
+        scoped_command_workspace,
+    ):
+        sudo = shutil.which("sudo")
+        if sudo is None:
+            pytest.skip("sudo is unavailable")
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely inspect privilege escalation via sudo",
+        ):
+            guard.validate(f"{shlex.quote(sudo)} -n cat own.txt")
+
+    def test_rejects_path_shadowed_sudo_before_script_inspection(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        fake_sudo = workspace.output_dir / "sudo"
+        fake_sudo.write_text("#!/usr/bin/env bash\n:\n", encoding="utf-8")
+        fake_sudo.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{workspace.output_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely inspect privilege escalation via sudo",
+        ):
+            guard.validate("sudo -n cat own.txt")
 
     @pytest.mark.parametrize(
         "command",
@@ -583,7 +681,6 @@ class TestScopedCommandPathGuardBash:
         "command_template",
         [
             "bash --rcfile {path} -i",
-            "bash --rcfile={path} -i",
             "bash --init-file {path} -i -c exit",
             "bash --rcfile {path} -i -c exit",
         ],
@@ -596,6 +693,129 @@ class TestScopedCommandPathGuardBash:
 
         with pytest.raises(CommandPathViolation):
             guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize("option", ["--rcfile", "--init-file"])
+    def test_bash_file_option_consumes_dash_prefixed_argument(
+        self,
+        scoped_command_workspace,
+        option,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"bash {option} -c 'printf safe'")
+
+    @pytest.mark.parametrize("option", ["--rcfile", "--init-file"])
+    def test_rejects_attached_bash_long_file_option(
+        self,
+        scoped_command_workspace,
+        option,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        init_file = workspace.output_dir / "safe.rc"
+        init_file.write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely inspect bash option",
+        ):
+            guard.validate(f"bash {option}={shlex.quote(str(init_file))} -c exit")
+
+    @pytest.mark.parametrize("option", ["-o", "+o", "-O", "+O"])
+    def test_bash_named_option_consumes_required_value(
+        self,
+        scoped_command_workspace,
+        option,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        option_value = "posix" if option in {"-o", "+o"} else "extglob"
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"bash {option} {option_value} -c 'printf safe'")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash --rcfile",
+            "bash --init-file",
+            "bash -o",
+            "bash +o",
+            "bash -O",
+            "bash +O",
+            "bash -c",
+        ],
+    )
+    def test_rejects_missing_bash_option_argument(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="missing bash argument"):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash $BASH_OPTIONS -c 'printf safe'",
+            "bash -o $BASH_OPTION -c 'printf safe'",
+            "bash --norc $BASH_OPTIONS -c 'printf safe'",
+        ],
+    )
+    def test_rejects_dynamic_bash_option_region(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely inspect dynamic bash option region",
+        ):
+            guard.validate(command)
+
+    @pytest.mark.parametrize("cluster", ["-xc", "-cx", "-sc", "-cs"])
+    def test_bash_short_clusters_consume_command_text(
+        self,
+        scoped_command_workspace,
+        cluster,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"bash {cluster} 'printf %s \"$1\"' ignored "
+            f"{shlex.quote(str(sibling_file))}"
+        )
+
+    @pytest.mark.parametrize("command", ["bash", "bash -s", "bash --", "bash -"])
+    def test_rejects_stdin_fed_or_missing_bash_input(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation, match="without command text or a script"
+        ):
+            guard.validate(command)
+
+    def test_dynamic_bash_command_positionals_are_not_option_region(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("bash -c 'printf safe' ignored \"$DYNAMIC_POSITIONAL\"")
 
     def test_shell_c_positional_arguments_are_not_treated_as_file_paths(
         self, scoped_command_workspace
@@ -1381,6 +1601,69 @@ class TestScopedCommandPathGuardBash:
             match="command policy script byte budget exceeded",
         ):
             guard.validate("bash one.sh; bash two.sh")
+
+    @pytest.mark.parametrize("invocation", ["bash {script}", "source {script}"])
+    @pytest.mark.parametrize("offset", [-1, 0, 1])
+    def test_policy_script_byte_limit_boundary(
+        self,
+        scoped_command_workspace,
+        invocation,
+        offset,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        limit = command_path_guard_module._MAX_INSPECTED_SCRIPT_BYTES
+        script = workspace.output_dir / f"boundary-{offset}.sh"
+        _write_comment_script_bytes(script, limit + offset)
+        guard = WorkspaceCommandPathGuard(workspace)
+        command = invocation.format(script=shlex.quote(str(script)))
+
+        if offset <= 0:
+            guard.validate(command)
+        else:
+            with pytest.raises(
+                CommandPolicyViolation,
+                match=rf"shell policy script exceeds the {limit}-byte inspection limit",
+            ):
+                guard.validate(command)
+
+    @pytest.mark.parametrize("offset", [0, 1])
+    def test_policy_script_byte_limit_counts_multibyte_utf8(
+        self,
+        scoped_command_workspace,
+        offset,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        limit = command_path_guard_module._MAX_INSPECTED_SCRIPT_BYTES
+        script = workspace.output_dir / f"multibyte-{offset}.sh"
+        payload = b"#" + ("é".encode("utf-8") * ((limit - 1) // 2))
+        payload += b"x" * (limit + offset - len(payload))
+        script.write_bytes(payload)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        if offset == 0:
+            guard.validate(f"bash {shlex.quote(str(script))}")
+        else:
+            with pytest.raises(
+                CommandPolicyViolation,
+                match=rf"shell policy script exceeds the {limit}-byte inspection limit",
+            ):
+                guard.validate(f"bash {shlex.quote(str(script))}")
+
+    def test_script_size_rejection_keeps_executor_generic_error(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        limit = command_path_guard_module._MAX_INSPECTED_SCRIPT_BYTES
+        script = workspace.output_dir / "oversized.sh"
+        _write_comment_script_bytes(script, limit + 1)
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": f"bash {shlex.quote(str(script))}"})
+
+        assert result["return_code"] == 126
+        assert result["error"].endswith("command denied by policy")
+        assert "inspection limit" not in result["error"]
 
     @pytest.mark.parametrize(
         "command",

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5,6 +5,7 @@ import shlex
 import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
 
@@ -1934,3 +1935,92 @@ class TestScopedCommandPathGuardBash:
         assert result["success"] is False
         assert result["return_code"] == 126
         assert "command denied by policy" in result["error"]
+
+
+class TestCdSymlinkTraversal:
+    """`cd`/`pushd` logical-vs-physical divergence must not escape the workspace.
+
+    Bash's ``cd`` (without ``-P``) is logical: it collapses ``..`` textually
+    against the pre-symlink path. The guard resolves physically. When a target
+    crosses a symlink and carries enough ``..`` to round-trip past its real
+    depth, the two disagree and a fully-classified ``cd`` + ``cat``/``rm``
+    sequence could reach a sibling tenant's files. The guard fails closed on any
+    directory change that traverses a symlink.
+    """
+
+    def test_cd_through_symlink_with_dotdot_is_rejected(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "a" / "b" / "c" / "d" / "e" / "f").mkdir(parents=True)
+        (ws / "s").symlink_to(ws / "a" / "b" / "c" / "d" / "e" / "f")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="traverses a symlink"):
+            guard.validate("cd s/../../../../../..")
+
+    def test_pushd_through_symlink_is_rejected(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "deep" / "nested").mkdir(parents=True)
+        (ws / "link").symlink_to(ws / "deep" / "nested")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="traverses a symlink"):
+            guard.validate("pushd link/../..")
+
+    def test_symlink_free_cd_still_resolves(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "sub" / "inner").mkdir(parents=True)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        # Real directories with a textual ``..`` cross no symlink and stay in
+        # the workspace, so navigation and a subsequent read are allowed.
+        guard.validate("cd sub/inner/.. && cat placeholder.txt")
+
+    def test_guarded_executor_blocks_cd_symlink_escape(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "a" / "b" / "c" / "d" / "e" / "f").mkdir(parents=True)
+        (ws / "s").symlink_to(ws / "a" / "b" / "c" / "d" / "e" / "f")
+        tool = _guarded_tool(workspace)
+        rel_secret = os.path.relpath(sibling_file, ws)
+
+        result = tool.run_json_sync(
+            {"command": f"cd s/../../../../../.. && cat {rel_secret}"}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in (result.get("output") or "")
+        assert sibling_file.read_text(encoding="utf-8") == "sibling secret"
+
+    def test_guarded_executor_blocks_cd_symlink_escape_rm_variant(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "a" / "b" / "c" / "d" / "e" / "f").mkdir(parents=True)
+        (ws / "s").symlink_to(ws / "a" / "b" / "c" / "d" / "e" / "f")
+        tool = _guarded_tool(workspace)
+        rel_secret = os.path.relpath(sibling_file, ws)
+
+        result = tool.run_json_sync(
+            {"command": f"cd s/../../../../../.. && rm {rel_secret}"}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert sibling_file.exists()
+
+    def test_quoted_brace_literal_is_checked_as_a_file_path(
+        self, scoped_command_workspace
+    ):
+        # ``{}`` is no longer a cwd sentinel: a quoted literal is authorized as
+        # the file itself and still resolves inside the workspace.
+        workspace, _, _ = scoped_command_workspace
+        ws = Path(workspace.resolve_path(""))
+        (ws / "{}").write_text("brace", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cat '{}'")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -882,6 +882,24 @@ class TestScopedCommandPathGuardBash:
         assert result["return_code"] == 126
         assert "sibling secret" not in result["output"]
 
+    @pytest.mark.parametrize("shebang", ["#!", "#!   "])
+    def test_rejects_direct_script_without_shebang_interpreter(
+        self,
+        scoped_command_workspace,
+        shebang,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "malformed-shebang"
+        script.write_text(f"{shebang}\nprintf safe\n", encoding="utf-8")
+        script.chmod(0o755)
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command(["./malformed-shebang"], shell=False)
+
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]
+        assert "command validation failed" not in result["error"]
+
     @pytest.mark.parametrize(
         "command",
         [

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -183,6 +183,27 @@ class TestScopedCommandPathGuardBash:
         assert result["success"] is True
         assert result["output"] == "$HOME `printf not-executed`\n"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat <<'EOF'\r\nbody\r\nEOF\r\nprintf AFTER\r\n",
+            "cat <<'EOF'\nbody\r\nEOF\r\nprintf AFTER\n",
+        ],
+    )
+    def test_crlf_heredoc_syntax_fails_closed(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot safely parse shell command",
+        ):
+            guard.validate(command)
+
     def test_quoted_heredoc_normalization_does_not_mask_later_commands(
         self,
         scoped_command_workspace,
@@ -895,6 +916,26 @@ class TestScopedCommandPathGuardBash:
         executor = _guarded_executor(workspace)
 
         result = executor.execute_command(["./malformed-shebang"], shell=False)
+
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]
+        assert "command validation failed" not in result["error"]
+
+    @pytest.mark.parametrize("missing_flag", ["O_NONBLOCK", "O_NOFOLLOW"])
+    def test_direct_script_inspection_requires_secure_open_flags(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+        missing_flag,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "direct-script"
+        script.write_text("#!/usr/bin/env bash\nprintf safe\n", encoding="utf-8")
+        script.chmod(0o755)
+        monkeypatch.delattr(os, missing_flag)
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command(["./direct-script"], shell=False)
 
         assert result["return_code"] == 126
         assert "command denied by policy" in result["error"]

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -1014,6 +1014,45 @@ class TestScopedCommandPathGuardBash:
             f"bash {shlex.quote(str(script))} {shlex.quote(str(sibling_file))}"
         )
 
+    @pytest.mark.parametrize("script_name", ["-c", "--rcfile"])
+    def test_shell_option_terminator_treats_dash_prefixed_name_as_script(
+        self,
+        scoped_command_workspace,
+        script_name,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / script_name
+        script.write_text("printf 'safe script\\n'\n", encoding="utf-8")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {
+                "command": (
+                    f"bash -- {shlex.quote(script_name)} "
+                    f"{shlex.quote(str(sibling_file))}"
+                )
+            }
+        )
+
+        assert result["return_code"] == 0
+        assert result["output"] == "safe script\n"
+
+    def test_rejects_unsafe_dash_prefixed_script_after_option_terminator(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "-c"
+        script.write_text(
+            f"cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "bash -- -c safe-argument"})
+
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
     def test_recursive_shell_script_inspection_is_bounded(
         self, scoped_command_workspace
     ):

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 import shutil
+import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -13,6 +14,7 @@ from xagent.core.tools.core.command_path_guard import WorkspaceCommandPathGuard
 from xagent.core.tools.core.command_policy import (
     CommandPathViolation,
     CommandPolicyViolation,
+    resolve_trusted_executable,
 )
 from xagent.core.workspace import TaskWorkspace
 
@@ -64,6 +66,14 @@ def _guarded_tool(workspace):
 def _write_comment_script_bytes(path, size):
     prefix = b"#"
     path.write_bytes(prefix + (b"x" * (size - len(prefix))))
+
+
+@pytest.fixture(scope="module")
+def trusted_bash_executable():
+    try:
+        return resolve_trusted_executable("bash")
+    except CommandPolicyViolation:
+        pytest.skip("trusted Bash is unavailable")
 
 
 class TestScopedCommandPathGuardBash:
@@ -736,14 +746,180 @@ class TestScopedCommandPathGuardBash:
         guard.validate(f"bash {option} {option_value} -c 'printf safe'")
 
     @pytest.mark.parametrize(
+        ("case", "expected_markers"),
+        [
+            ("minus-o", {"command"}),
+            ("plus-o", {"command"}),
+            ("minus-O", {"command"}),
+            ("plus-O", {"command"}),
+            ("short-cluster", {"command"}),
+            ("stdin", {"stdin"}),
+            ("file-option", {"init", "command"}),
+            ("terminator", {"script"}),
+            ("command-text", {"command"}),
+            ("bare-minus-o", {"listing", "stdin"}),
+            ("bare-plus-o", {"listing", "stdin"}),
+            ("bare-minus-O", {"listing", "stdin"}),
+            ("bare-plus-O", {"listing", "stdin"}),
+            ("bare-minus-xo", {"listing", "stdin"}),
+            ("bare-plus-xO", {"listing", "stdin"}),
+        ],
+    )
+    def test_trusted_bash_invocation_outcome_matrix(
+        self,
+        scoped_command_workspace,
+        trusted_bash_executable,
+        case,
+        expected_markers,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        markers = {
+            "command": "__COMMAND_MARKER__",
+            "init": "__INIT_MARKER__",
+            "script": "__SCRIPT_MARKER__",
+            "stdin": "__STDIN_MARKER__",
+        }
+        script = workspace.output_dir / "-policy-script"
+        script.write_text(
+            f"printf %s {markers['script']}\n",
+            encoding="utf-8",
+        )
+        init_file = workspace.output_dir / "policy.rc"
+        init_file.write_text(
+            f"printf %s {markers['init']}\n",
+            encoding="utf-8",
+        )
+        named_options = {
+            "minus-o": ["-o", "posix"],
+            "plus-o": ["+o", "posix"],
+            "minus-O": ["-O", "extglob"],
+            "plus-O": ["+O", "extglob"],
+        }
+        if case in named_options:
+            arguments = [
+                *named_options[case],
+                "-c",
+                f"printf %s {markers['command']}",
+            ]
+            stdin = ""
+        elif case == "short-cluster":
+            arguments = ["-xc", f"printf %s {markers['command']}"]
+            stdin = ""
+        elif case == "stdin":
+            arguments = ["-s"]
+            stdin = f"printf %s {markers['stdin']}"
+        elif case == "file-option":
+            arguments = [
+                "--rcfile",
+                str(init_file),
+                "-i",
+                "-c",
+                f"printf %s {markers['command']}",
+            ]
+            stdin = ""
+        elif case == "terminator":
+            arguments = ["--", script.name]
+            stdin = ""
+        elif case == "command-text":
+            arguments = ["-c", f"printf %s {markers['command']}"]
+            stdin = ""
+        else:
+            arguments = [
+                {
+                    "bare-minus-o": "-o",
+                    "bare-plus-o": "+o",
+                    "bare-minus-O": "-O",
+                    "bare-plus-O": "+O",
+                    "bare-minus-xo": "-xo",
+                    "bare-plus-xO": "+xO",
+                }[case]
+            ]
+            stdin = f"printf %s {markers['stdin']}"
+
+        environment = os.environ.copy()
+        for name in command_path_guard_module._IMPLICIT_SHELL_ENVIRONMENT:
+            environment.pop(name, None)
+        completed = subprocess.run(
+            [str(trusted_bash_executable), *arguments],
+            cwd=workspace.output_dir,
+            env=environment,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        assert completed.returncode == 0
+        for outcome, marker in markers.items():
+            if outcome in expected_markers:
+                assert marker in completed.stdout
+            else:
+                assert marker not in completed.stdout
+        if "listing" in expected_markers:
+            assert completed.stdout.index(markers["stdin"]) > 0
+
+        guard = WorkspaceCommandPathGuard(workspace)
+        if expected_markers == {"stdin"} or "listing" in expected_markers:
+            with pytest.raises(
+                CommandPolicyViolation,
+                match="without command text or a script",
+            ):
+                guard.validate_argv(["bash", *arguments])
+        else:
+            guard.validate_argv(["bash", *arguments])
+
+    @pytest.mark.parametrize("option", ["-o", "+o", "-O", "+O", "-xo", "+xO"])
+    def test_bare_bash_named_option_listing_remains_stdin_fed_and_rejected(
+        self,
+        scoped_command_workspace,
+        option,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="without command text or a script",
+        ):
+            guard.validate(f"bash {option}")
+
+    def test_guarded_executor_runs_named_bash_option_value_once(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command(
+            ["bash", "-o", "posix", "-c", "printf %s __COMMAND_MARKER__"],
+            shell=False,
+        )
+
+        assert result["return_code"] == 0
+        assert result["output"] == "__COMMAND_MARKER__"
+
+    @pytest.mark.parametrize("option", ["-o", "+o", "-O", "+O"])
+    def test_guarded_executor_rejects_bare_bash_named_option_as_stdin_fed(
+        self,
+        scoped_command_workspace,
+        caplog,
+        option,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command(["bash", option], shell=False)
+
+        assert result["return_code"] == 126
+        assert result["error"].endswith("command denied by policy")
+        assert "without command text or a script" in caplog.text
+        assert "missing bash argument" not in caplog.text
+
+    @pytest.mark.parametrize(
         "command",
         [
             "bash --rcfile",
             "bash --init-file",
-            "bash -o",
-            "bash +o",
-            "bash -O",
-            "bash +O",
             "bash -c",
         ],
     )

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2024,3 +2024,81 @@ class TestCdSymlinkTraversal:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("cat '{}'")
+
+
+class TestNoEffectCommandClassification:
+    """Commands with no filesystem write effect must not poison script inspection.
+
+    The unknown-effect flag stays session-wide (an *unknown* command has an
+    unknowable target set), but commands that cannot write the filesystem, and
+    path-scoped writers whose writes are recorded per-path, no longer trip it.
+    """
+
+    @pytest.mark.parametrize(
+        "setup_command",
+        [
+            "echo hi",
+            "printf hi",
+            "pwd",
+            "true",
+            "test -f safe.sh",
+            "export FOO=bar",
+            "declare BAR=baz",
+        ],
+    )
+    def test_no_effect_command_before_script_is_allowed(
+        self, scoped_command_workspace, setup_command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"{setup_command} && bash safe.sh")
+
+    def test_mkdir_before_script_is_allowed_and_scopes_write(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        # mkdir writes only its operand (recorded per-path), so a later,
+        # unrelated script inspection is not blocked.
+        guard.validate("mkdir out && bash safe.sh")
+
+    def test_mkdir_outside_workspace_is_rejected(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"mkdir {shlex.quote(str(sibling_file.parent / 'x'))}")
+
+    def test_redirect_write_from_no_effect_command_still_blocks_inspection(
+        self, scoped_command_workspace
+    ):
+        # A no-effect command with a redirect still registers the redirect's
+        # write, so inspecting that script afterwards is rejected. Declassifying
+        # the command does not exempt its redirections.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("echo hi > safe.sh; bash safe.sh")
+
+    def test_unknown_command_still_poisons_script_inspection(
+        self, scoped_command_workspace
+    ):
+        # Genuinely unknown commands keep the session-wide fail-closed contract.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("python -c pass && bash safe.sh")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2073,6 +2073,37 @@ class TestNoEffectCommandClassification:
         with pytest.raises(CommandPathViolation):
             guard.validate(f"mkdir {shlex.quote(str(sibling_file.parent / 'x'))}")
 
+    @pytest.mark.parametrize(
+        "mkdir_command",
+        [
+            "mkdir -m ../../../../../../etc newdir",
+            "mkdir --mode ../../../../../../etc newdir",
+            "mkdir -m0755 newdir",
+            "mkdir --mode=0755 newdir",
+        ],
+    )
+    def test_mkdir_mode_value_is_not_treated_as_a_path(
+        self, scoped_command_workspace, mkdir_command
+    ):
+        # The `-m`/`--mode` value is consumed as the mode, not validated as a
+        # path operand, so an out-of-workspace-looking mode token does not cause
+        # a spurious rejection. Only the real directory operand is checked.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(mkdir_command)
+
+    def test_mkdir_real_directory_outside_workspace_still_rejected_with_mode(
+        self, scoped_command_workspace
+    ):
+        # Skipping the mode value must not skip the real path operand.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        target = shlex.quote(str(sibling_file.parent / "x"))
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"mkdir -m 0755 {target}")
+
     def test_redirect_write_from_no_effect_command_still_blocks_inspection(
         self, scoped_command_workspace
     ):

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -1,0 +1,1085 @@
+"""Bash-semantics regressions for the scoped command path guard."""
+
+import os
+import shlex
+
+import pytest
+
+from xagent.core.tools.core.command_executor import CommandExecutorCore
+from xagent.core.tools.core.command_path_guard import WorkspaceCommandPathGuard
+from xagent.core.tools.core.command_policy import (
+    CommandPathViolation,
+    CommandPolicyViolation,
+)
+from xagent.core.workspace import TaskWorkspace
+
+
+@pytest.fixture
+def scoped_command_workspace(tmp_path):
+    """Workspace plus same-mount sibling and read-only external roots."""
+    alice_base = tmp_path / "clients" / "1" / "end_users" / "7"
+    external = tmp_path / "external" / "7"
+    external.mkdir(parents=True, exist_ok=True)
+    workspace = TaskWorkspace(
+        "task",
+        str(alice_base),
+        allowed_external_dirs=[str(external)],
+    )
+    external_file = external / "reference.txt"
+    external_file.write_text("external reference", encoding="utf-8")
+
+    sibling = tmp_path / "clients" / "1" / "end_users" / "8"
+    sibling.mkdir(parents=True, exist_ok=True)
+    sibling_file = sibling / "secret.txt"
+    sibling_file.write_text("sibling secret", encoding="utf-8")
+
+    return workspace, external_file, sibling_file
+
+
+def _guarded_executor(workspace):
+    return CommandExecutorCore(
+        str(workspace.resolve_path("")),
+        path_guard=WorkspaceCommandPathGuard(workspace),
+    )
+
+
+class _GuardedCommandTool:
+    def __init__(self, workspace):
+        self._executor = _guarded_executor(workspace)
+
+    def run_json_sync(self, args):
+        return self._executor.execute_command(
+            args["command"],
+            timeout=args.get("timeout"),
+        )
+
+
+def _guarded_tool(workspace):
+    return _GuardedCommandTool(workspace)
+
+
+class TestScopedCommandPathGuardBash:
+    """Bash parsing and shell-state policy checks."""
+
+    @pytest.mark.parametrize(
+        ("command_name", "access"),
+        [("cat", "read"), ("rm", "write")],
+    )
+    def test_minimal_file_command_set_uses_workspace_authorization(
+        self,
+        scoped_command_workspace,
+        command_name,
+        access,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"{command_name} {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == access
+
+    def test_unknown_commands_keep_the_explicit_fail_open_contract(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"python {shlex.quote(str(sibling_file))}")
+
+    def test_recognized_name_workspace_script_is_inspected_before_dispatch(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "cat"
+        script.write_text(
+            f"#!/usr/bin/env bash\ncat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{workspace.output_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        )
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": str(script)})
+
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_bare_recognized_name_uses_validated_executable_identity(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "cat"
+        script.write_text(
+            f"#!/usr/bin/env bash\n/bin/cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            f"{workspace.output_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        )
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "cat"})
+
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "PATH=. cat own.txt",
+            "env PATH=. cat own.txt",
+            "export PATH=.; cat own.txt",
+            "hash -p ./cat cat; cat own.txt",
+        ],
+    )
+    def test_rejects_runtime_command_identity_changes(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_rejects_alias_definition_before_shell_execution(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": (f"alias leak='cat {shlex.quote(str(sibling_file))}'\nleak")}
+        )
+
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]
+        assert "sibling secret" not in result["output"]
+
+    def test_allows_literal_quoted_here_document(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": "cat <<'EOF'\n$HOME `printf not-executed`\nEOF\n"}
+        )
+
+        assert result["success"] is True
+        assert result["output"] == "$HOME `printf not-executed`\n"
+
+    def test_quoted_heredoc_normalization_does_not_mask_later_commands(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(
+                f"printf %s \"<<'EOF'\"\ncat {shlex.quote(str(sibling_file))}\nEOF\n"
+            )
+
+    def test_allows_time_keyword_with_validated_nested_command(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        own_file = workspace.output_dir / "own.txt"
+        own_file.write_text("own", encoding="utf-8")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "time cat own.txt"})
+
+        assert result["success"] is True
+        assert result["output"] == "own"
+
+    def test_time_keyword_propagates_builtin_directory_state(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"time cd {shlex.quote(str(external_file.parent))} "
+                "&& printf leaked > leaked.txt"
+            )
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize("shell_name", ["sh", "dash", "zsh"])
+    def test_rejects_shell_dialects_not_owned_by_policy_parser(
+        self,
+        scoped_command_workspace,
+        shell_name,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="shell dialect"):
+            guard.validate(f"{shell_name} -c 'cat own.txt'")
+
+    def test_guarded_shell_execution_uses_bash_dialect(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured.update(kwargs)
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "", "stderr": ""},
+            )()
+
+        monkeypatch.setattr(
+            "xagent.core.tools.core.command_executor.subprocess.run",
+            fake_run,
+        )
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command("printf ok")
+
+        assert result["success"] is True
+        assert os.path.basename(captured["executable"]) == "bash"
+
+    def test_unsupported_operator_error_is_actionable(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="unsupported shell operator.*separate command calls",
+        ):
+            guard.validate("printf one & printf two")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "printf changed >> {path}",
+            "cat missing 2> {path}",
+        ],
+    )
+    def test_append_and_stderr_redirects_require_write_authorization(
+        self,
+        scoped_command_workspace,
+        command_template,
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                command_template.format(path=shlex.quote(str(external_file)))
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_possible_directory_state_growth_is_bounded(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        for index in range(17):
+            (workspace.output_dir / f"d{index}").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+        command = " || ".join(f"cd d{index}" for index in range(17))
+
+        with pytest.raises(CommandPolicyViolation, match="too many possible"):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cat {{{path},missing}}",
+            "{{cat,printf}} {path}",
+            "rm -f {{{path},missing}}",
+            "printf changed > {{{path},own.txt}}",
+            "bash -c 'cat {{{path},missing}}'",
+        ],
+    )
+    def test_rejects_brace_expansion_before_read_write_or_nested_execution(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+        command = command_template.format(path=str(sibling_file))
+
+        result = tool.run_json_sync({"command": command})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert sibling_file.read_text(encoding="utf-8") == "sibling secret"
+
+    @pytest.mark.parametrize("operand", ["{a,b}", "{1..3}", "{a..z..2}"])
+    def test_rejects_unmodeled_brace_expansion_forms(
+        self, scoped_command_workspace, operand
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="dynamic path operand"):
+            guard.validate(f"cat {operand}")
+
+    @pytest.mark.parametrize("operand", ["'{a,b}'", r"\{1..3\}"])
+    def test_allows_quoted_or_escaped_literal_braces(
+        self, scoped_command_workspace, operand
+    ):
+        workspace, _, _ = scoped_command_workspace
+        literal_name = operand.replace("'", "").replace("\\", "")
+        (workspace.output_dir / literal_name).write_text("literal", encoding="utf-8")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": f"cat {operand}"})
+
+        assert result["success"] is True
+        assert result["output"] == "literal"
+
+    @pytest.mark.parametrize("operand", ["*", "file?.txt", "[ab].txt"])
+    def test_rejects_unmodeled_glob_expansion_forms(
+        self, scoped_command_workspace, operand
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="dynamic path operand"):
+            guard.validate(f"cat {operand}")
+
+    @pytest.mark.parametrize(
+        ("operand", "literal_name"),
+        [
+            ("'*'", "*"),
+            ('"file?.txt"', "file?.txt"),
+            (r"\[ab\].txt", "[ab].txt"),
+        ],
+    )
+    def test_allows_quoted_or_escaped_literal_globs(
+        self, scoped_command_workspace, operand, literal_name
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / literal_name).write_text("literal", encoding="utf-8")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": f"cat {operand}"})
+
+        assert result["success"] is True
+        assert result["output"] == "literal"
+
+    def test_rejects_active_glob_before_execution(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "cat *.txt"})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "exec cat {path}",
+            "env cat {path}",
+            "env -i NAME=value cat {path}",
+            "timeout --signal=TERM 5 cat {path}",
+            "nohup cat {path}",
+            "nice -n 5 cat {path}",
+            "stdbuf -oL cat {path}",
+            "command -p cat {path}",
+            "setsid -f cat {path}",
+            "ionice -c 2 -n 7 cat {path}",
+            "sudo -n cat {path}",
+            "/usr/bin/time -p cat {path}",
+        ],
+    )
+    def test_rejects_supported_wrapper_commands_accessing_sibling(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": command_template.format(path=shlex.quote(str(sibling_file)))}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "exec cat own.txt",
+            "env cat own.txt",
+            "env -i NAME=value cat own.txt",
+            "timeout --signal=TERM 5 cat own.txt",
+            "nohup cat own.txt",
+            "nice -n 5 cat own.txt",
+            "stdbuf -oL cat own.txt",
+            "command -p cat own.txt",
+            "setsid -f cat own.txt",
+            "ionice -c 2 -n 7 cat own.txt",
+            "sudo -n cat own.txt",
+            "/usr/bin/time -p cat own.txt",
+        ],
+    )
+    def test_supported_wrapper_commands_preserve_nested_command_classification(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "chroot / cat own.txt",
+            "sudo --chroot=/ cat own.txt",
+            "sudo --shell",
+            "/usr/bin/time --output=timing.txt cat own.txt",
+        ],
+    )
+    def test_rejects_wrapper_modes_that_change_unmodeled_execution_context(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        ("variable", "value", "command_template"),
+        [
+            ("COMMAND", "cat", 'env "$COMMAND" own.txt'),
+            ("ENV_ARGS", "UNUSED cat", "env -u $ENV_ARGS {path}"),
+            ("TIMEOUT_ARGS", "1 cat", "timeout $TIMEOUT_ARGS {path}"),
+        ],
+    )
+    def test_rejects_dynamic_wrapper_argv_shape(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+        variable,
+        value,
+        command_template,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        monkeypatch.setenv(variable, value)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    def test_wrapper_nesting_depth_is_bounded(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation, match="wrapper nesting depth exceeded"
+        ):
+            guard.validate(f"{'env ' * 33}cat own.txt")
+
+    def test_wrapper_nesting_depth_survives_nested_dispatch(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation, match="wrapper nesting depth exceeded"
+        ):
+            guard.validate(f"{'command xargs ' * 33}cat own.txt")
+
+    def test_env_chdir_applies_only_to_nested_command(self, scoped_command_workspace):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"env --chdir={shlex.quote(str(external_file.parent))} "
+            f"cat {shlex.quote(external_file.name)}"
+        )
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"env -C {shlex.quote(str(external_file.parent))} "
+                f"rm -f {shlex.quote(external_file.name)}"
+            )
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize("directory_command", ["cd", "pushd"])
+    def test_command_wrapper_propagates_shell_builtin_directory_state(
+        self, scoped_command_workspace, directory_command
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"command {directory_command} "
+                f"{shlex.quote(str(external_file.parent))} "
+                "&& printf leak > leak.txt"
+            )
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize("redirect", ["2>&1", "1>&2", "3<&0"])
+    def test_descriptor_duplication_is_not_treated_as_path(
+        self, scoped_command_workspace, redirect
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"cd {shlex.quote(str(external_file.parent))} && printf ok {redirect}"
+        )
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "bash --rcfile {path} -i",
+            "bash --rcfile={path} -i",
+            "bash --init-file {path} -i -c exit",
+            "bash --rcfile {path} -i -c exit",
+        ],
+    )
+    def test_rejects_bash_file_options_outside_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    def test_shell_c_positional_arguments_are_not_treated_as_file_paths(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"bash -c 'printf %s \"$1\"' ignored {shlex.quote(str(sibling_file))}"
+        )
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            'cat "$TARGET"',
+            'cat "$(printf %s {path})"',
+            "cat `printf %s {path}`",
+        ],
+    )
+    def test_rejects_unresolved_expansion_in_supported_path_operand(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+        command = command_template.format(path=shlex.quote(str(sibling_file)))
+        if "$TARGET" in command:
+            command = f"TARGET={shlex.quote(str(sibling_file))}; {command}"
+
+        result = tool.run_json_sync({"command": command})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_rejects_unresolved_expansion_in_redirect_path(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {
+                "command": (
+                    f"TARGET={shlex.quote(str(sibling_file))}; "
+                    'printf changed > "$TARGET"'
+                )
+            }
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert sibling_file.read_text(encoding="utf-8") == "sibling secret"
+
+    def test_allows_unresolved_expansion_in_non_path_operand(
+        self, scoped_command_workspace, monkeypatch
+    ):
+        workspace, _, _ = scoped_command_workspace
+        own_file = workspace.output_dir / "own.txt"
+        own_file.write_text("needle", encoding="utf-8")
+        monkeypatch.setenv("PATTERN", "needle")
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": ('bash -c \'printf "%s\\n" "$1"\' _ "$PATTERN"')}
+        )
+
+        assert result["success"] is True
+        assert result["output"] == "needle\n"
+
+    def test_tilde_path_is_resolved_as_a_static_path(
+        self, scoped_command_workspace, monkeypatch
+    ):
+        workspace, _, _ = scoped_command_workspace
+        monkeypatch.setenv("HOME", str(workspace.output_dir))
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cat ~/own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo '",
+            "for ((i=0;i<1;i++)); do cat sibling.txt; done",
+            "coproc cat sibling.txt",
+            "select x in a b; do cat sibling.txt; done",
+            "cat $'sibling.txt'",
+        ],
+    )
+    def test_unparsed_top_level_shell_input_fails_closed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": command})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+
+    def test_unparsed_nested_shell_input_fails_closed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": 'sh -c "echo \'"'})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "eval 'cat {path}'",
+            "trap 'cat {path}' EXIT",
+            "builtin eval 'cat {path}'",
+            "command eval 'cat {path}'",
+        ],
+    )
+    def test_rejects_shell_text_reentry_builtins(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": command_template.format(path=shlex.quote(str(sibling_file)))}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "BASH_ENV=hook.sh bash -c true",
+            "env BASH_ENV=hook.sh bash -c true",
+            "export BASH_ENV=hook.sh; bash -c true",
+        ],
+    )
+    def test_rejects_implicit_shell_initialization_files(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "hook.sh").write_text(
+            f"cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": command_template})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_rejects_ambient_shell_initialization_file(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        hook = workspace.output_dir / "hook.sh"
+        hook.write_text(
+            f"cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BASH_ENV", str(hook))
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "printf safe"})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_rejects_ambient_cdpath_that_changes_directory_resolution(
+        self,
+        scoped_command_workspace,
+        monkeypatch,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        monkeypatch.setenv("CDPATH", str(sibling_file.parent.parent))
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": f"cd {shlex.quote(sibling_file.parent.name)}; cat secret.txt"}
+        )
+
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cat <<EOF\n$(cat {path})\nEOF",
+            "cat <<EOF\n`cat {path}`\nEOF",
+            'cat <<<"$(cat {path})"',
+        ],
+    )
+    def test_rejects_shell_execution_from_here_input(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": command_template.format(path=shlex.quote(str(sibling_file)))}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_allows_literal_here_document(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "cat <<EOF\nliteral\nEOF"})
+
+        assert result["success"] is True
+        assert result["output"] == "literal\n"
+
+    @pytest.mark.parametrize("command", ["", "   ", "\n", "# comment"])
+    def test_guard_allows_noop_shell_input(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": command})
+
+        assert result["success"] is True
+        assert result["return_code"] == 0
+        assert result["output"] == ""
+
+    def test_guard_rejects_oversized_shell_input(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "printf " + "x" * (64 * 1024)})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]
+
+    def test_guard_rejects_null_byte_input(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": "printf 'before\x00after'"})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "command denied by policy" in result["error"]
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cat <(cat {path})",
+            "cat >(rm -f {path})",
+        ],
+    )
+    def test_process_substitution_uses_nested_command_policy(
+        self,
+        scoped_command_workspace,
+        command_template,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_rejects_direct_shell_script_with_out_of_scope_access(
+        self, scoped_command_workspace, absolute
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "deploy.sh"
+        script.write_text(
+            f"#!/bin/sh\ncat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        command = str(script) if absolute else "./deploy.sh"
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": shlex.quote(command)})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_rejects_direct_shell_script_in_literal_argv(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "deploy.sh"
+        script.write_text(
+            f"#!/bin/sh\ncat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        executor = _guarded_executor(workspace)
+
+        result = executor.execute_command(["./deploy.sh"], shell=False)
+
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sh",
+            "sh -s",
+            "printf 'cat own.txt' | sh",
+            "sh < run.sh",
+        ],
+    )
+    def test_rejects_shell_input_that_cannot_be_inspected(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync({"command": command})
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+
+    @pytest.mark.parametrize(
+        "invocation", ["bash {script}", "sh {script}", ". {script}", "source {script}"]
+    )
+    def test_rejects_shell_script_that_accesses_sibling(
+        self, scoped_command_workspace, invocation
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "read-sibling.sh"
+        script.write_text(
+            f"cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {"command": invocation.format(script=shlex.quote(str(script)))}
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert "sibling secret" not in result["output"]
+
+    def test_rejects_dynamically_created_shell_script_before_partial_execution(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = f"cat {shlex.quote(str(sibling_file))}"
+        tool = _guarded_tool(workspace)
+
+        result = tool.run_json_sync(
+            {
+                "command": (
+                    f"printf '%s\\n' {shlex.quote(script)} > run.sh && bash run.sh"
+                )
+            }
+        )
+
+        assert result["success"] is False
+        assert result["return_code"] == 126
+        assert not (workspace.output_dir / "run.sh").exists()
+
+    def test_shell_script_arguments_are_not_treated_as_paths(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "print-arg.sh"
+        script.write_text("printf '%s\\n' \"$1\"\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"bash {shlex.quote(str(script))} {shlex.quote(str(sibling_file))}"
+        )
+
+    def test_recursive_shell_script_inspection_is_bounded(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        script = workspace.output_dir / "loop.sh"
+        script.write_text("source loop.sh\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="depth exceeded"):
+            guard.validate("bash loop.sh")
+
+    def test_rejects_unsafe_bash_initialization_file(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        script = workspace.output_dir / "unsafe.rc"
+        script.write_text(
+            f"cat {shlex.quote(str(sibling_file))}\n",
+            encoding="utf-8",
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"bash --rcfile {shlex.quote(str(script))} -i -c exit")
+
+    def test_directory_stack_keeps_relative_paths_bound_to_real_cwd(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        subdirectory = workspace.output_dir / "sub"
+        subdirectory.mkdir()
+        forbidden = workspace.base_dir / "forbidden" / "secret.txt"
+        forbidden.parent.mkdir()
+        forbidden.write_text("outside workspace", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate("pushd sub && popd && cat ../../forbidden/secret.txt")
+
+        guard.validate("pushd sub && popd && cat own.txt")
+
+    def test_cd_dash_uses_tracked_previous_directory(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cd sub && cd - && cat own.txt")
+
+    def test_rejects_background_directory_state(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("cd sub & cat own.txt")
+
+    @pytest.mark.parametrize("operator", [";", "||"])
+    def test_validates_each_possible_directory_state_across_shell_operator(
+        self,
+        scoped_command_workspace,
+        operator,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"cd sub {operator} cat own.txt")
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"cd sub {operator} cat ../../forbidden/secret.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cd sub; cat own.txt",
+            "cd sub && cat own.txt; echo done",
+            "cd sub && cat own.txt || echo fail",
+        ],
+    )
+    def test_allows_common_directory_chains(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_tracks_conditional_directory_state_at_unconditional_join(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cd missing && true; rm -f ../outside.txt")
+        guard.validate("cd sub && printf reached-only-after-success")
+
+    def test_source_state_propagates_but_child_shell_state_does_not(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        script = workspace.output_dir / "change-directory.sh"
+        script.write_text("cd sub\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f". {shlex.quote(str(script))} && cat ../../forbidden/secret.txt"
+        )
+        with pytest.raises(CommandPathViolation):
+            guard.validate(
+                f"bash {shlex.quote(str(script))} && cat ../../forbidden/secret.txt"
+            )
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            'COMMAND=rm; printf "%s\\n" own.txt | xargs "$COMMAND"',
+        ],
+    )
+    def test_rejects_dynamic_nested_command_names(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command_template)

--- a/uv.lock
+++ b/uv.lock
@@ -396,6 +396,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bashlex"
+version = "0.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7789,6 +7798,7 @@ ai-document = [
     { name = "docling" },
 ]
 all = [
+    { name = "bashlex" },
     { name = "chromadb" },
     { name = "curl-cffi" },
     { name = "docling" },
@@ -7811,6 +7821,9 @@ browser = [
 ]
 chromadb = [
     { name = "chromadb" },
+]
+command-path-guard = [
+    { name = "bashlex" },
 ]
 document-processing = [
     { name = "numba" },
@@ -7869,6 +7882,7 @@ backend-image = [
 ]
 dev = [
     { name = "asyncssh" },
+    { name = "bashlex" },
     { name = "chromadb" },
     { name = "copilotkit" },
     { name = "flake8" },
@@ -7902,6 +7916,7 @@ static-type-check = [
 ]
 test = [
     { name = "asyncssh" },
+    { name = "bashlex" },
     { name = "chromadb" },
     { name = "copilotkit" },
     { name = "langgraph-prebuilt" },
@@ -7927,6 +7942,8 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
     { name = "asyncssh", specifier = ">=2.14.0" },
     { name = "authlib", specifier = ">=1.7.2" },
+    { name = "bashlex", marker = "extra == 'all'", specifier = ">=0.18" },
+    { name = "bashlex", marker = "extra == 'command-path-guard'", specifier = ">=0.18" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "beartype", specifier = ">=0.18.5" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
@@ -8024,7 +8041,7 @@ requires-dist = [
     { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.2" },
     { name = "zai-sdk", specifier = ">=0.0.3.2" },
 ]
-provides-extras = ["ai-document", "all", "browser", "chromadb", "document-processing", "duckdb", "milvus", "postgresql", "router", "waf-crawl"]
+provides-extras = ["ai-document", "all", "browser", "chromadb", "command-path-guard", "document-processing", "duckdb", "milvus", "postgresql", "router", "waf-crawl"]
 
 [package.metadata.requires-dev]
 backend-image = [
@@ -8049,6 +8066,7 @@ backend-image = [
 ]
 dev = [
     { name = "asyncssh", specifier = ">=2.14.0" },
+    { name = "bashlex", specifier = ">=0.18" },
     { name = "chromadb" },
     { name = "copilotkit", specifier = "==0.1.69" },
     { name = "flake8", specifier = ">=7.3.0" },
@@ -8082,6 +8100,7 @@ static-type-check = [
 ]
 test = [
     { name = "asyncssh", specifier = ">=2.14.0" },
+    { name = "bashlex", specifier = ">=0.18" },
     { name = "chromadb" },
     { name = "copilotkit", specifier = "==0.1.69" },
     { name = "langgraph-prebuilt", specifier = "<1.0.9" },


### PR DESCRIPTION
## Summary

- add an opt-in `bashlex`-backed workspace command guard for Bash syntax, shell state, nested execution, wrappers, scripts, and redirections
- keep file-command classification deliberately minimal to `cat`, `rm`, redirections, and directory state
- bind guarded shell execution to Bash and validate guarded Bash scripts without temporary files

## Boundary

- dormant unless a caller explicitly injects the command guard
- unknown executable commands retain the current cooperative fail-open contract
- reuses `TaskWorkspace.resolve_authorized_path` as the path-authorization owner
- does not add `ExecutionScope`, tool-factory, preview, service, or SaaS activation
- provides defense in depth and is not an OS or container isolation boundary

This is the shell-language layer for #171, following #1015. Broader file-command classification, runtime hardening, and production activation remain in subsequent PRs.

## Verification

- `uv run pytest -q tests/core/tools/test_command_executor.py tests/core/tools/test_command_path_guard_bash.py tests/core/test_workspace_path_containment.py`
- `uv run mypy src/xagent/core/tools/core/command_executor.py src/xagent/core/tools/core/command_path_guard.py`
- `uv run ruff check pyproject.toml src/xagent/core/tools/core/command_executor.py src/xagent/core/tools/core/command_path_guard.py tests/core/tools/test_command_executor.py tests/core/tools/test_command_path_guard_bash.py`
- `uv run ruff format --check src/xagent/core/tools/core/command_executor.py src/xagent/core/tools/core/command_path_guard.py tests/core/tools/test_command_executor.py tests/core/tools/test_command_path_guard_bash.py`
- `uv lock --check`
- `uv build`