### PR TITLE
fix(gmail): propagate _ensure_topic IAM policy failures instead of marking watch ACTIVE

### DIFF
--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -199,24 +199,31 @@ def _get_or_create_watch_state(
 
 
 def _ensure_topic(publisher: Any, topic_path: str) -> None:
+    """Create the topic and grant the Gmail push identity permission to publish.
+
+    IAM failures are never swallowed. The caller marks the watch ``ACTIVE`` on
+    return, so a swallowed ``get_iam_policy``/``set_iam_policy`` failure would
+    record success on a topic Gmail may be unable to publish to — the trigger
+    would silently never fire. Letting the failure propagate lands the watch in
+    ``FAILED`` for the retry sweep instead, matching ``_sync_push_config``.
+    Unlike ``_sync_push_config``, the read cannot fall through to an
+    unconditional write:
+    granting the role is a read-modify-write of the policy, so a failed read
+    must propagate as well.
+    """
     try:
         publisher.create_topic(request={"name": topic_path})
     except Exception as exc:
         if not _is_already_exists(exc):
             raise
     # Gmail publishes watch notifications as this Google-owned identity.
-    try:
-        policy = publisher.get_iam_policy(request={"resource": topic_path})
-        member = f"serviceAccount:{GMAIL_PUSH_PUBLISHER}"
-        for binding in policy.bindings:
-            if binding.role == "roles/pubsub.publisher" and member in binding.members:
-                return
-        policy.bindings.add(role="roles/pubsub.publisher", members=[member])
-        publisher.set_iam_policy(request={"resource": topic_path, "policy": policy})
-    except Exception as exc:
-        logger.warning(
-            "Could not verify Gmail publish permission on %s: %s", topic_path, exc
-        )
+    policy = publisher.get_iam_policy(request={"resource": topic_path})
+    member = f"serviceAccount:{GMAIL_PUSH_PUBLISHER}"
+    for binding in policy.bindings:
+        if binding.role == "roles/pubsub.publisher" and member in binding.members:
+            return
+    policy.bindings.add(role="roles/pubsub.publisher", members=[member])
+    publisher.set_iam_policy(request={"resource": topic_path, "policy": policy})
 
 
 def _ensure_push_subscription(

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -220,9 +220,13 @@ def _ensure_topic(publisher: Any, topic_path: str) -> None:
     policy = publisher.get_iam_policy(request={"resource": topic_path})
     member = f"serviceAccount:{GMAIL_PUSH_PUBLISHER}"
     for binding in policy.bindings:
-        if binding.role == "roles/pubsub.publisher" and member in binding.members:
-            return
-    policy.bindings.add(role="roles/pubsub.publisher", members=[member])
+        if binding.role == "roles/pubsub.publisher":
+            if member in binding.members:
+                return
+            binding.members.append(member)
+            break
+    else:
+        policy.bindings.add(role="roles/pubsub.publisher", members=[member])
     publisher.set_iam_policy(request={"resource": topic_path, "policy": policy})
 
 

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -19,6 +19,7 @@ from xagent.web.models.trigger import (
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services.gmail_provisioning import (
+    GMAIL_PUSH_PUBLISHER,
     ensure_gmail_mailbox_provisioned,
     gmail_subscription_path,
     gmail_topic_path,
@@ -937,6 +938,38 @@ def test_iam_policy_failure_marks_failed_not_active(
     assert expected_error in str(state.last_error)
     # Provisioning must stop at the IAM failure: no watch was registered.
     assert gmail.watch_calls == []
+
+
+def test_iam_grant_appends_to_existing_publisher_binding(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    topic_path = gmail_topic_path("demo-project", "owner@gmail.example")
+    existing_policy = FakePolicy()
+    existing_policy.bindings.add(
+        role="roles/pubsub.publisher", members=["serviceAccount:other@example.iam"]
+    )
+    publisher.policies[topic_path] = existing_policy
+
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: FakeSubscriber(),
+    )
+
+    assert state.status == TriggerProvisioningStatus.ACTIVE.value
+    # The Gmail push identity joins the existing roles/pubsub.publisher
+    # binding instead of creating a duplicate binding for the same role.
+    bindings = publisher.policies[topic_path].bindings
+    assert len(bindings) == 1
+    assert bindings[0].members == [
+        "serviceAccount:other@example.iam",
+        f"serviceAccount:{GMAIL_PUSH_PUBLISHER}",
+    ]
 
 
 def test_renewal_scan_uses_per_mailbox_provisioning_when_project_configured(

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -891,6 +891,54 @@ def test_patch_failure_marks_failed_not_active(
     assert "api-v2.example.com" not in str(second.push_audience)
 
 
+class GetIamPolicyFailsFakePublisher(FakePublisher):
+    """Topic whose IAM policy cannot be read."""
+
+    def get_iam_policy(self, *, request: dict[str, str]) -> FakePolicy:
+        raise RuntimeError("pubsub get_iam_policy unavailable")
+
+
+class SetIamPolicyFailsFakePublisher(FakePublisher):
+    """Topic whose IAM policy cannot be written."""
+
+    def set_iam_policy(self, *, request: dict[str, Any]) -> None:
+        raise RuntimeError("pubsub set_iam_policy unavailable")
+
+
+@pytest.mark.parametrize(
+    ("publisher_cls", "expected_error"),
+    [
+        (GetIamPolicyFailsFakePublisher, "pubsub get_iam_policy unavailable"),
+        (SetIamPolicyFailsFakePublisher, "pubsub set_iam_policy unavailable"),
+    ],
+)
+def test_iam_policy_failure_marks_failed_not_active(
+    db_session: Session,
+    publisher_cls: type[FakePublisher],
+    expected_error: str,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    gmail = FakeGmailService()
+
+    # If the roles/pubsub.publisher grant for the Gmail push identity cannot
+    # be verified or applied, Gmail may be unable to publish to the topic and
+    # the trigger would silently never fire. The failure must propagate so the
+    # watch lands FAILED for the retry sweep instead of recording ACTIVE.
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: gmail,
+        publisher_factory=lambda: publisher_cls(),
+        subscriber_factory=lambda: FakeSubscriber(),
+    )
+
+    assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert expected_error in str(state.last_error)
+    # Provisioning must stop at the IAM failure: no watch was registered.
+    assert gmail.watch_calls == []
+
+
 def test_renewal_scan_uses_per_mailbox_provisioning_when_project_configured(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #1030.

`_ensure_topic` caught `get_iam_policy`/`set_iam_policy` failures, logged a warning, and swallowed them, so `ensure_gmail_mailbox_provisioned` persisted the watch as `ACTIVE` even when the `roles/pubsub.publisher` binding for `gmail-api-push@system.gserviceaccount.com` never actually landed. Gmail could not publish to the topic and the trigger silently never fired — while the DB reported success.

## Changes

- **`src/xagent/web/services/gmail_provisioning.py`**: removed the swallowing `try/except` around the IAM policy read-modify-write in `_ensure_topic`. IAM failures now propagate to `ensure_gmail_mailbox_provisioned`, which persists the watch as `FAILED` with a clear `last_error`, so the retry sweep picks it up — mirroring the `_sync_push_config` resolution from #1012. A docstring documents the rationale, matching the #1012 precedent.
- **`tests/web/services/test_gmail_provisioning.py`**: added `test_iam_policy_failure_marks_failed_not_active`, parametrized over both `get_iam_policy` and `set_iam_policy` failures. Asserts the watch lands `FAILED` (not `ACTIVE`), `last_error` carries the underlying error, and provisioning stops before registering a Gmail watch.

## One deliberate divergence from the #1012 shape

`_sync_push_config` treats a *read* failure as soft and falls through to an unconditional, idempotent `modify_push_config`. That fallback does not exist here: granting the role is a read-modify-write of the topic policy (a blind `set_iam_policy` would clobber existing bindings), so a failed `get_iam_policy` must propagate as well. The docstring calls this out explicitly.

## Behavior change worth noting

Deployments whose provisioning service account lacks `pubsub.topics.getIamPolicy`/`setIamPolicy` (even if an admin granted the publisher binding manually) previously converged to `ACTIVE` with a warning in the logs; they now land `FAILED` with the IAM error in `last_error`. This is the same explicit-failure-over-false-success trade-off #1012 made, and the retry sweep re-converges the watch once permissions are fixed.

## Tests

- `tests/web/services/test_gmail_provisioning.py`: 22 passed (2 skipped, Postgres-only). The pre-existing `test_sweep_retries_stale_failed_referenced_mailbox` already covers the `FAILED` → retry-sweep leg, so the failure path is tested end to end.
- `mypy`, `ruff check`, `ruff format`, `isort` clean on touched files.

Reported during review of #1012 (thanks @rogercloud).