### PR TITLE
ref(config): extract shared URL-normalization helper for base-URL getters

### DIFF
--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -338,6 +338,16 @@ def _get_bool_env(env_var: str, default: bool) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _normalized_env_url(env_var: str) -> str | None:
+    """Return the env var's value normalized as a base URL.
+
+    Strips surrounding whitespace and trailing slashes; unset or blank
+    values normalize to None.
+    """
+    value = (os.getenv(env_var) or "").strip()
+    return value.rstrip("/") or None
+
+
 def get_password_reset_expire_minutes() -> int:
     """Return the password reset token expiry window in minutes."""
     return _get_positive_int_env(PASSWORD_RESET_EXPIRE_MINUTES, 30)
@@ -345,11 +355,7 @@ def get_password_reset_expire_minutes() -> int:
 
 def get_app_base_url() -> str | None:
     """Return the trusted frontend base URL used in email links."""
-    value = os.getenv(APP_BASE_URL)
-    if value is None:
-        return None
-    value = value.strip()
-    return value.rstrip("/") or None
+    return _normalized_env_url(APP_BASE_URL)
 
 
 def get_smtp_host() -> str:
@@ -898,8 +904,7 @@ def get_public_api_base_url() -> str | None:
     callbacks can override this via XAGENT_TRIGGER_CALLBACK_BASE_URL
     (see get_trigger_callback_base_url).
     """
-    value = (os.getenv(PUBLIC_API_BASE_URL) or "").strip()
-    return value.rstrip("/") or None
+    return _normalized_env_url(PUBLIC_API_BASE_URL)
 
 
 def get_trigger_callback_base_url() -> str | None:
@@ -914,8 +919,8 @@ def get_trigger_callback_base_url() -> str | None:
     callbacks must reach a different host than the advertised public API
     origin (e.g. a dedicated ingress).
     """
-    cleaned = (os.getenv(TRIGGER_CALLBACK_BASE_URL) or "").strip().rstrip("/")
-    if cleaned:
+    cleaned = _normalized_env_url(TRIGGER_CALLBACK_BASE_URL)
+    if cleaned is not None:
         return cleaned
     return get_public_api_base_url()
 


### PR DESCRIPTION
## What

Extract a single private helper `_normalized_env_url(env_var) -> str | None` in `src/xagent/config.py` and rewire the three base-URL getters onto it:

- `get_app_base_url`
- `get_public_api_base_url`
- `get_trigger_callback_base_url` (keeps its own fallback to `get_public_api_base_url()`)

Purely a dedup refactor — **no behavior change**. The helper preserves the exact `strip() -> rstrip("/") -> None` semantics of all three original implementations, verified case by case (unset, empty, whitespace-only, `"/"`, trailing slashes, and the trigger-callback fallback chain).

## Why

The three getters repeated the same normalization idiom. Raised as a non-blocking cleanup during review of #1012.

Closes #1031

## Verification

- `mypy`, `ruff format/check`, `isort` clean
- `tests/core/test_config.py` passes unchanged (342 tests), including the existing edge-case coverage for all three getters — serving as the no-behavior-change safety net

## Notes

`get_frontend_url()` has a similar-looking normalization but subtly different semantics for `"/"`-only values (returns `""` instead of falling back to its default), so folding it into the helper would be a behavior change — deliberately left out of this PR as a possible follow-up.