### PR TITLE
fix(runtime): complete pool isolation acceptance coverage

### DIFF
--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -934,9 +934,15 @@ class _TaskLeaseHeartbeatManager:
                     )
                 except Exception as error:
                     if is_database_pool_timeout(error):
+                        task_ids = ",".join(
+                            str(task_id)
+                            for task_id in sorted({lease.task_id for lease in snapshot})
+                        )
                         logger.warning(
-                            "Task lease heartbeat batch pool checkout timed out "
-                            "for %s active leases: %s",
+                            "component=lease-heartbeat task_ids=[%s] "
+                            "active_lease_count=%s database pool checkout "
+                            "timed out: %s",
+                            task_ids,
                             len(snapshot),
                             error,
                         )

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1,6 +1,7 @@
 """Tests for task execution leases."""
 
 import asyncio
+import logging
 import threading
 from datetime import timedelta
 
@@ -16,6 +17,7 @@ from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import ExecutionMode, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
 from xagent.web.services import task_lease_service
+from xagent.web.services.db_runtime import drain_async_task_cancellation_safe
 from xagent.web.services.task_lease_recovery import (
     recover_task_lease_candidate_isolated,
 )
@@ -829,7 +831,9 @@ async def test_old_batch_result_does_not_contaminate_replacement_registration(
 
 
 @pytest.mark.asyncio
-async def test_stop_heartbeat_reports_shared_batch_pool_timeout(monkeypatch) -> None:
+async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
+    monkeypatch, caplog
+) -> None:
     refresh_attempted = threading.Event()
     allow_timeout = threading.Event()
     heartbeat_timeout = SQLAlchemyTimeoutError("pool checkout timed out")
@@ -852,28 +856,96 @@ async def test_stop_heartbeat_reports_shared_batch_pool_timeout(monkeypatch) -> 
         lambda: 0.001,
     )
 
-    stop_event = asyncio.Event()
-    heartbeat_task = asyncio.create_task(
-        run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
-            stop_event,
+    first_stop_event = asyncio.Event()
+    second_stop_event = asyncio.Event()
+    first_heartbeat_task = None
+    second_heartbeat_task = None
+    first_stopping = None
+    second_stopping = None
+
+    async def stop_and_drain_heartbeat(
+        stopping,
+        heartbeat_task,
+        stop_event,
+    ) -> None:
+        stop_event.set()
+        if heartbeat_task is None:
+            return
+        if stopping is None:
+            stopping = asyncio.create_task(
+                stop_task_lease_heartbeat(heartbeat_task, stop_event)
+            )
+        try:
+            await drain_async_task_cancellation_safe(stopping)
+        finally:
+            await drain_async_task_cancellation_safe(heartbeat_task)
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            first_heartbeat_task = asyncio.create_task(
+                run_task_lease_heartbeat(
+                    TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+                    first_stop_event,
+                )
+            )
+            second_heartbeat_task = asyncio.create_task(
+                run_task_lease_heartbeat(
+                    TaskLease(task_id=2, runner_id="runner-b", run_id="run-b"),
+                    second_stop_event,
+                )
+            )
+            await asyncio.wait_for(
+                asyncio.to_thread(refresh_attempted.wait, 1), timeout=1
+            )
+
+            first_stopping = asyncio.create_task(
+                stop_task_lease_heartbeat(first_heartbeat_task, first_stop_event)
+            )
+            second_stopping = asyncio.create_task(
+                stop_task_lease_heartbeat(second_heartbeat_task, second_stop_event)
+            )
+            await asyncio.sleep(0.02)
+            assert not first_stopping.done()
+            assert not second_stopping.done()
+
+            allow_timeout.set()
+            first_outcome, second_outcome = await asyncio.wait_for(
+                asyncio.gather(first_stopping, second_stopping),
+                timeout=1,
+            )
+
+        heartbeat_warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "component=lease-heartbeat" in record.getMessage()
+        ]
+        assert len(heartbeat_warnings) == 1
+        assert heartbeat_warnings[0].getMessage() == (
+            "component=lease-heartbeat task_ids=[1,2] active_lease_count=2 "
+            "database pool checkout timed out: pool checkout timed out"
         )
-    )
-    await asyncio.wait_for(asyncio.to_thread(refresh_attempted.wait, 1), timeout=1)
-
-    stopping = asyncio.create_task(
-        stop_task_lease_heartbeat(heartbeat_task, stop_event)
-    )
-    await asyncio.sleep(0.02)
-    assert not stopping.done()
-
-    allow_timeout.set()
-    outcome = await asyncio.wait_for(stopping, timeout=1)
-    await task_lease_service.wait_for_heartbeat_manager_idle()
-
-    assert outcome.pool_timeout is heartbeat_timeout
-    assert outcome.lease_lost is False
-    assert outcome.requires_ttl_recovery is True
+        for outcome in (first_outcome, second_outcome):
+            assert outcome.pool_timeout is heartbeat_timeout
+            assert outcome.lease_lost is False
+            assert outcome.requires_ttl_recovery is True
+    finally:
+        allow_timeout.set()
+        try:
+            await stop_and_drain_heartbeat(
+                first_stopping,
+                first_heartbeat_task,
+                first_stop_event,
+            )
+        finally:
+            try:
+                await stop_and_drain_heartbeat(
+                    second_stopping,
+                    second_heartbeat_task,
+                    second_stop_event,
+                )
+            finally:
+                await task_lease_service.wait_for_heartbeat_manager_idle()
 
 
 @pytest.mark.asyncio

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from xagent.core.model.chat.token_context import (
     get_token_usage,
 )
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.services.db_runtime import drain_async_task_cancellation_safe
 from xagent.web.tracking import TaskTracker, TaskTrackerManager
 
 
@@ -151,6 +153,139 @@ def _run_tracker_ownership_race(
     return result["owned"], persisted
 
 
+def _create_tracker_pool_db(tmp_path, filename):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / filename}",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=1,
+    )
+    Task.__table__.create(engine)
+    session_factory = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+    )
+    with session_factory() as db:
+        db.add(
+            Task(
+                id=123,
+                user_id=1,
+                title="pool isolation",
+                status=TaskStatus.RUNNING,
+            )
+        )
+        db.commit()
+    return engine, session_factory
+
+
+async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
+    monkeypatch,
+    tmp_path,
+    filename,
+    sync_helper_name,
+    prepare,
+    operation,
+    verify,
+    *,
+    operation_scheduled=None,
+    timer_created=None,
+):
+    """Exercise one tracker DB operation while its QueuePool is exhausted."""
+    from xagent.web.models import database
+    from xagent.web.tracking import task_tracker as tracker_module
+
+    engine, session_factory = _create_tracker_pool_db(tmp_path, filename)
+    monkeypatch.setattr(database, "get_session_local", lambda: session_factory)
+    tracker = TaskTracker(task_id=123, update_interval_seconds=60)
+    operation_task = None
+    ticker_task = None
+    held_connection = None
+    window_timer = None
+    ticker_stop = threading.Event()
+    window_elapsed = threading.Event()
+    ticker_ticks = 0
+    worker_entered = threading.Event()
+    event_loop_thread_id = threading.get_ident()
+    worker_thread_id: int | None = None
+    original_helper = getattr(tracker_module, sync_helper_name)
+
+    def traced_helper(*args, **kwargs):
+        nonlocal window_timer, worker_thread_id
+        worker_thread_id = threading.get_ident()
+        window_timer = threading.Timer(0.1, end_window)
+        if timer_created is not None:
+            timer_created(window_timer)
+        window_timer.start()
+        worker_entered.set()
+        return original_helper(*args, **kwargs)
+
+    async def ticker():
+        nonlocal ticker_ticks
+        while not ticker_stop.is_set():
+            await asyncio.sleep(0.01)
+            ticker_ticks += 1
+
+    def end_window():
+        ticker_stop.set()
+        window_elapsed.set()
+
+    try:
+        await prepare(tracker)
+        monkeypatch.setattr(tracker_module, sync_helper_name, traced_helper)
+        held_connection = engine.connect()
+        ticker_task = asyncio.create_task(ticker())
+        await asyncio.sleep(0)
+        operation_task = asyncio.create_task(operation(tracker))
+        if operation_scheduled is not None:
+            operation_scheduled.set()
+        assert await asyncio.wait_for(
+            asyncio.to_thread(worker_entered.wait, 2), timeout=2
+        )
+
+        assert await asyncio.wait_for(
+            asyncio.to_thread(window_elapsed.wait, 0.2), timeout=0.3
+        )
+        assert ticker_ticks >= 3
+        assert not operation_task.done()
+        assert worker_thread_id is not None
+        assert worker_thread_id != event_loop_thread_id
+
+        held_connection.close()
+        held_connection = None
+        result = await asyncio.wait_for(operation_task, timeout=1)
+        verify(tracker, session_factory, result)
+    finally:
+        window_elapsed.set()
+        ticker_stop.set()
+        try:
+            if held_connection is not None:
+                held_connection.close()
+        finally:
+            try:
+                if operation_task is not None:
+                    await drain_async_task_cancellation_safe(operation_task)
+            finally:
+                try:
+                    if window_timer is not None:
+                        try:
+                            window_timer.cancel()
+                        finally:
+                            window_timer.join()
+                finally:
+                    try:
+                        if ticker_task is not None:
+                            await drain_async_task_cancellation_safe(ticker_task)
+                    finally:
+                        try:
+                            if tracker.is_tracking:
+                                await tracker.stop_periodic_updates()
+                        finally:
+                            engine.dispose()
+
+
 class TestTaskTracker:
     """Test cases for TaskTracker."""
 
@@ -208,53 +343,172 @@ class TestTaskTracker:
         self, monkeypatch, tmp_path
     ):
         """A pool wait belongs in a worker thread, never on the event loop."""
-        from xagent.web.models import database
 
-        engine = create_engine(
-            f"sqlite:///{tmp_path / 'tracker.db'}",
-            connect_args={"check_same_thread": False},
-            poolclass=QueuePool,
-            pool_size=1,
-            max_overflow=0,
-            pool_timeout=1,
-        )
-        Task.__table__.create(engine)
-        session_factory = sessionmaker(
-            autocommit=False,
-            autoflush=False,
-            bind=engine,
-        )
-        with session_factory() as db:
-            db.add(
-                Task(
-                    id=123,
-                    user_id=1,
-                    title="pool isolation",
-                    status=TaskStatus.RUNNING,
-                )
-            )
-            db.commit()
+        async def prepare(_tracker):
+            return None
 
-        monkeypatch.setattr(database, "get_session_local", lambda: session_factory)
-        held_connection = engine.connect()
-        tracker = None
-        try:
-            tracker = TaskTracker(task_id=123)
-            start_task = asyncio.create_task(tracker.start_tracking())
-
-            # The worker is waiting for the only pool slot, but the event loop
-            # must remain responsive enough to run this ticker.
-            await asyncio.sleep(0.05)
-            assert not start_task.done()
-
-            held_connection.close()
-            await asyncio.wait_for(start_task, timeout=1)
+        def verify(tracker, _session_factory, _result):
             assert tracker.is_tracking
+
+        await _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
+            monkeypatch,
+            tmp_path,
+            "tracker-start.db",
+            "_load_task_seed_sync",
+            prepare,
+            lambda tracker: tracker.start_tracking(),
+            verify,
+        )
+
+    @pytest.mark.asyncio
+    async def test_periodic_update_does_not_block_event_loop_when_pool_is_full(
+        self, monkeypatch, tmp_path
+    ):
+        """A periodic usage write must wait for the pool off the event loop."""
+
+        async def prepare(tracker):
+            await tracker.start_tracking()
+            add_token_usage(input_tokens=10, output_tokens=5)
+
+        def verify(tracker, session_factory, _result):
+            assert tracker.is_tracking
+            with session_factory() as db:
+                task = db.get(Task, 123)
+                assert task is not None
+                assert (task.input_tokens, task.output_tokens, task.total_tokens) == (
+                    10,
+                    5,
+                    15,
+                )
+
+        await _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
+            monkeypatch,
+            tmp_path,
+            "tracker-periodic.db",
+            "_write_task_usage_sync",
+            prepare,
+            lambda tracker: tracker.periodic_update(),
+            verify,
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_tracking_does_not_block_event_loop_when_pool_is_full(
+        self, monkeypatch, tmp_path
+    ):
+        """Final usage persistence must wait for the pool off the event loop."""
+
+        async def prepare(tracker):
+            await tracker.start_tracking()
+            add_token_usage(input_tokens=20, output_tokens=10)
+
+        def verify(tracker, session_factory, result):
+            assert not tracker.is_tracking
+            assert (result.input_tokens, result.output_tokens, result.total_tokens) == (
+                20,
+                10,
+                30,
+            )
+            with session_factory() as db:
+                task = db.get(Task, 123)
+                assert task is not None
+                assert (task.input_tokens, task.output_tokens, task.total_tokens) == (
+                    20,
+                    10,
+                    30,
+                )
+
+        await _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
+            monkeypatch,
+            tmp_path,
+            "tracker-complete.db",
+            "_complete_task_usage_sync",
+            prepare,
+            lambda tracker: tracker.complete_tracking(),
+            verify,
+        )
+
+    @pytest.mark.parametrize(
+        "inject_cleanup_error",
+        [False, True],
+        ids=["normal-cleanup", "cleanup-error"],
+    )
+    @pytest.mark.asyncio
+    async def test_tracker_pool_helper_joins_timer_created_by_delayed_worker(
+        self, monkeypatch, tmp_path, inject_cleanup_error
+    ):
+        """Cancellation must not leave a delayed worker's timer alive."""
+        loop = asyncio.get_running_loop()
+        executor = ThreadPoolExecutor(max_workers=1)
+        original_executor = getattr(loop, "_default_executor")
+        blocker_started = asyncio.Event()
+        release_worker = threading.Event()
+        operation_scheduled = asyncio.Event()
+        recorded_timers = []
+
+        def occupy_default_executor():
+            loop.call_soon_threadsafe(blocker_started.set)
+            assert release_worker.wait(timeout=2)
+
+        async def prepare(_tracker):
+            return None
+
+        def verify(_tracker, _session_factory, _result):
+            pytest.fail("cancelled helper completed normally")
+
+        async def run_probe():
+            blocker = loop.run_in_executor(None, occupy_default_executor)
+            helper_task = None
+            try:
+                await asyncio.wait_for(blocker_started.wait(), timeout=1)
+                helper_task = asyncio.create_task(
+                    _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
+                        monkeypatch,
+                        tmp_path,
+                        "tracker-delayed-worker.db",
+                        "_load_task_seed_sync",
+                        prepare,
+                        lambda tracker: tracker.start_tracking(),
+                        verify,
+                        operation_scheduled=operation_scheduled,
+                        timer_created=recorded_timers.append,
+                    )
+                )
+                await asyncio.wait_for(operation_scheduled.wait(), timeout=1)
+                helper_task.cancel()
+                release_worker.set()
+                await blocker
+                with pytest.raises(asyncio.CancelledError):
+                    await helper_task
+
+                assert helper_task.cancelled()
+                assert len(recorded_timers) == 1
+                assert not recorded_timers[0].is_alive()
+            finally:
+                try:
+                    release_worker.set()
+                    if helper_task is not None and not helper_task.done():
+                        helper_task.cancel()
+                        await asyncio.gather(helper_task, return_exceptions=True)
+                    if not blocker.done():
+                        await blocker
+                finally:
+                    if inject_cleanup_error:
+                        raise RuntimeError("injected cleanup failure")
+
+        monkeypatch.setattr(loop, "_default_executor", executor)
+        try:
+            if inject_cleanup_error:
+                with pytest.raises(RuntimeError, match="injected cleanup failure"):
+                    await run_probe()
+            else:
+                await run_probe()
         finally:
-            held_connection.close()
-            if tracker is not None and tracker.is_tracking:
-                await tracker.stop_periodic_updates()
-            engine.dispose()
+            setattr(loop, "_default_executor", original_executor)
+            executor.shutdown(wait=True)
+
+        assert getattr(loop, "_default_executor") is original_executor
+        with pytest.raises(RuntimeError):
+            executor.submit(lambda: None)
 
     @pytest.mark.asyncio
     async def test_final_usage_does_not_overwrite_a_replacement_run(


### PR DESCRIPTION
## Summary

This completes the remaining constrained-pool acceptance coverage for the task-runtime database isolation already merged in #986.

- Exercise TaskTracker startup, periodic usage persistence, and final usage persistence against a real file-backed `QueuePool` configured with `pool_size=1`, `max_overflow=0`, and `pool_timeout=1`.
- Prove that each operation waits in a worker thread while an asyncio ticker remains responsive, then completes correctly after the held connection is released.
- Attribute a shared lease-heartbeat pool timeout to `component=lease-heartbeat`, the complete deterministic task-ID batch, and the active lease count.
- Verify that every lease in the failed batch receives the same timeout object and remains eligible for TTL recovery.
- Make cancellation and cleanup coverage deterministic so delayed worker startup cannot leave timers, tasks, executors, connections, or heartbeat-manager state behind.

## Behavior and compatibility

- No database schema or migration changes.
- No public API changes.
- No connection-pool size, overflow, or timeout changes.
- No task lifecycle, lease ownership, or TTL-recovery semantic changes.
- The heartbeat diagnostic uses the manager's existing in-memory batch snapshot and performs no additional database query.
- One warning is emitted per failed heartbeat batch.

## Verification

- `uv run pytest tests/web/test_task_lease_service.py tests/web/tracking/test_task_tracker.py -q`: 75 passed.
- `uv run pre-commit run --files src/xagent/web/services/task_lease_service.py tests/web/test_task_lease_service.py tests/web/tracking/test_task_tracker.py`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Local PostgreSQL 16 and Uvicorn end-to-end probe with `pool_size=1`, `max_overflow=0`, and `pool_timeout=1`: TaskTracker startup, periodic, and final persistence remained pending while the only connection was held; the HTTP health probe remained responsive; persistence completed after release; the pool returned to zero checked-out connections.
- In the same constrained-pool probe, a two-task heartbeat batch produced exactly one attributed warning, preserved the shared timeout identity for both leases, and selected TTL recovery without marking either lease lost.

Closes #935.

Related to #955.