### PR TITLE
feat: add resolvable context references

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -40,6 +40,8 @@ from .skill_tool import LOADED_SKILLS_METADATA_KEY, SKILL_INDEX_METADATA_KEY
 READ_FILE_CONTEXT_LIMIT = 12_000
 COMPACT_SUMMARY_MAX_TOKENS = 1024
 COMPACT_SUMMARY_MIN_TOKENS = 256
+COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
+COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
 
 
 def _utcnow() -> datetime:
@@ -993,8 +995,11 @@ class ExecutionContext:
             )
 
         latest_user = self._latest_visible_user_message()
-        compacted_context_refs = self._context_refs_removed_by_compaction(latest_user)
-        summary_message = Message.role_system(
+        compacted_context_refs, dropped_context_refs = (
+            self._context_refs_removed_by_compaction(latest_user)
+        )
+        dropped_refs_notice = self._dropped_context_refs_notice(dropped_context_refs)
+        summary_content = (
             "Compacted conversation summary:\n"
             f"{summary}\n\n"
             "Use this summary as the current execution state. Continue from the "
@@ -1002,7 +1007,12 @@ class ExecutionContext:
             "regenerate completed artifacts unless the latest user request "
             "explicitly asks to restart, revise, or regenerate them. Current system "
             "instructions still take precedence, and the latest user request remains "
-            "the overall goal.",
+            "the overall goal."
+        )
+        if dropped_refs_notice:
+            summary_content = f"{summary_content}\n\n{dropped_refs_notice}"
+        summary_message = Message.role_system(
+            summary_content,
             metadata={"compacted_context": True},
             context_refs=compacted_context_refs,
         )
@@ -1019,6 +1029,8 @@ class ExecutionContext:
                 "removed_count": max(0, original_count - len(self.messages)),
                 "summary_chars": len(summary),
                 "compact_model": getattr(llm, "model_name", None),
+                "retained_context_ref_count": len(compacted_context_refs),
+                "dropped_context_ref_count": len(dropped_context_refs),
             },
         )
         if original_tokens is not None:
@@ -1027,23 +1039,69 @@ class ExecutionContext:
 
     def _context_refs_removed_by_compaction(
         self, latest_user: Message | None
-    ) -> tuple[ContextReference, ...]:
+    ) -> tuple[tuple[ContextReference, ...], tuple[ContextReference, ...]]:
         seen = (
             {reference.identity_key() for reference in latest_user.context_refs}
             if latest_user is not None
             else set()
         )
+        latest_user_tokens = (
+            sum(reference.estimated_tokens() for reference in latest_user.context_refs)
+            if latest_user is not None
+            else 0
+        )
+        remaining_tokens = max(
+            0,
+            min(
+                COMPACT_CONTEXT_REF_MAX_TOKENS,
+                max(0, self.compact_config.threshold // 8),
+            )
+            - latest_user_tokens,
+        )
         retained: list[ContextReference] = []
-        for message in self.messages:
+        dropped: list[ContextReference] = []
+        for message in reversed(self.messages):
             if message.hidden or message is latest_user:
                 continue
-            for reference in message.context_refs:
+            for reference in reversed(message.context_refs):
                 identity = reference.identity_key()
                 if identity in seen:
                     continue
                 seen.add(identity)
-                retained.append(reference)
-        return tuple(retained)
+                reference_tokens = reference.estimated_tokens()
+                if reference_tokens <= remaining_tokens:
+                    retained.append(reference)
+                    remaining_tokens -= reference_tokens
+                else:
+                    dropped.append(reference)
+        retained.reverse()
+        return tuple(retained), tuple(dropped)
+
+    @staticmethod
+    def _dropped_context_refs_notice(
+        references: tuple[ContextReference, ...],
+    ) -> str:
+        if not references:
+            return ""
+        prefix = (
+            "Older image references exceeded the structured-reference budget and "
+            "will not be automatically rematerialized after compaction. Durable "
+            "handles retained in this summary:\n"
+        )
+        lines: list[str] = []
+        current_chars = len(prefix)
+        omitted = 0
+        for reference in references:
+            filename = reference.safe_file_ref.get("filename") or "image"
+            line = f"- [image: {filename}, file_id={reference.file_id}]"
+            if current_chars + len(line) + 1 > COMPACT_DROPPED_REF_NOTICE_MAX_CHARS:
+                omitted += 1
+                continue
+            lines.append(line)
+            current_chars += len(line) + 1
+        if omitted:
+            lines.append(f"- ... {omitted} additional older reference(s) omitted")
+        return prefix + "\n".join(lines)
 
     def _latest_visible_user_message(self) -> Message | None:
         for message in reversed(self.messages):

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -8,6 +8,8 @@ from typing import Any
 from uuid import uuid4
 
 from ...context_ref import (
+    CONTEXT_REFS_KEY,
+    ContextReference,
     normalize_context_references,
     split_tool_result_context_references,
 )
@@ -345,17 +347,20 @@ class ExecutionContext:
             if include_system and message_dict.get("role") == "system":
                 content = str(message_dict.get("content") or "").strip()
                 if content:
-                    messages.append(
-                        {
-                            "role": "user",
-                            "content": (
-                                "Previous system-context message retained for "
-                                "continuity. Current system instructions above "
-                                "take precedence:\n"
-                                f"{content}"
-                            ),
-                        }
-                    )
+                    continuity_message: dict[str, Any] = {
+                        "role": "user",
+                        "content": (
+                            "Previous system-context message retained for "
+                            "continuity. Current system instructions above "
+                            "take precedence:\n"
+                            f"{content}"
+                        ),
+                    }
+                    if CONTEXT_REFS_KEY in message_dict:
+                        continuity_message[CONTEXT_REFS_KEY] = message_dict[
+                            CONTEXT_REFS_KEY
+                        ]
+                    messages.append(continuity_message)
                 continue
             messages.append(message_dict)
 
@@ -988,6 +993,7 @@ class ExecutionContext:
             )
 
         latest_user = self._latest_visible_user_message()
+        compacted_context_refs = self._context_refs_removed_by_compaction(latest_user)
         summary_message = Message.role_system(
             "Compacted conversation summary:\n"
             f"{summary}\n\n"
@@ -998,6 +1004,7 @@ class ExecutionContext:
             "instructions still take precedence, and the latest user request remains "
             "the overall goal.",
             metadata={"compacted_context": True},
+            context_refs=compacted_context_refs,
         )
         next_messages = [summary_message]
         if latest_user is not None:
@@ -1017,6 +1024,26 @@ class ExecutionContext:
         if original_tokens is not None:
             return self._annotate_compact_result(result, original_tokens)
         return result
+
+    def _context_refs_removed_by_compaction(
+        self, latest_user: Message | None
+    ) -> tuple[ContextReference, ...]:
+        seen = (
+            {reference.identity_key() for reference in latest_user.context_refs}
+            if latest_user is not None
+            else set()
+        )
+        retained: list[ContextReference] = []
+        for message in self.messages:
+            if message.hidden or message is latest_user:
+                continue
+            for reference in message.context_refs:
+                identity = reference.identity_key()
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                retained.append(reference)
+        return tuple(retained)
 
     def _latest_visible_user_message(self) -> Message | None:
         for message in reversed(self.messages):

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -7,6 +7,10 @@ from enum import Enum
 from typing import Any
 from uuid import uuid4
 
+from ...context_ref import (
+    normalize_context_references,
+    split_tool_result_context_references,
+)
 from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS
 from ...tools.artifacts import (
     format_tool_result_for_observation,
@@ -155,8 +159,23 @@ class ExecutionContext:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        context_refs: Any = (),
     ) -> Message:
-        context_result = self._sanitize_tool_result_for_context(tool_name, result)
+        public_result, embedded_refs = split_tool_result_context_references(result)
+        explicit_refs = normalize_context_references(context_refs)
+        all_context_refs = []
+        seen_context_refs: set[str] = set()
+        for reference in (*explicit_refs, *embedded_refs):
+            identity = reference.identity_key()
+            if identity in seen_context_refs:
+                continue
+            seen_context_refs.add(identity)
+            all_context_refs.append(reference)
+
+        context_result = self._sanitize_tool_result_for_context(
+            tool_name, public_result
+        )
         content = self._format_tool_result(tool_name, context_result)
         metadata = {
             "tool_name": tool_name,
@@ -171,6 +190,7 @@ class ExecutionContext:
             content,
             tool_call_id=tool_call_id,
             metadata=metadata,
+            context_refs=tuple(all_context_refs),
         )
 
     def attach_workspace(
@@ -541,6 +561,7 @@ class ExecutionContext:
             tool_call_id=response_message.tool_call_id,
             hidden=response_message.hidden,
             output_tokens=output_tokens,
+            context_refs=response_message.context_refs,
         )
         self.messages.append(updated_response)
         self.llm_calls.append(
@@ -752,6 +773,9 @@ class ExecutionContext:
                     "tool_call_id": message.tool_call_id,
                     "hidden": message.hidden,
                     "output_tokens": message.output_tokens,
+                    "context_refs": [
+                        reference.durable_dict() for reference in message.context_refs
+                    ],
                 }
                 for message in self.messages
             ],
@@ -797,6 +821,7 @@ class ExecutionContext:
                 tool_call_id=item.get("tool_call_id"),
                 hidden=item.get("hidden", False),
                 output_tokens=item.get("output_tokens"),
+                context_refs=item.get("context_refs", ()),
             )
             for item in data.get("messages", [])
         ]
@@ -1057,6 +1082,8 @@ class ExecutionContext:
                     + json.dumps(message.tool_calls, ensure_ascii=False, default=str)
                 )
             chunks.append(message.content)
+            if message.context_refs:
+                chunks.append(message.context_refs_text())
         return "\n".join(chunks)
 
     def _compact_response_text(self, response: Any) -> str:
@@ -1103,10 +1130,16 @@ class ExecutionContext:
         return self._estimate_message_tokens(self.messages)
 
     def _estimate_message_tokens(self, messages: list[Message]) -> int:
-        return sum(max(1, len(message.content) // 4) for message in messages)
+        return sum(
+            max(1, len(message.content) // 4) + message.context_refs_token_estimate()
+            for message in messages
+        )
 
     def _message_content_chars(self, messages: list[Message]) -> int:
-        return sum(len(message.content) for message in messages)
+        return sum(
+            len(message.content) + (4 * message.context_refs_token_estimate())
+            for message in messages
+        )
 
     def _tail_window_preserving_tool_pairs(self, keep_count: int) -> list[Message]:
         """Keep recent messages without cutting a native tool-call exchange."""
@@ -1176,9 +1209,14 @@ class ExecutionContext:
         for index in range(len(messages) - 1, -1, -1):
             message = messages[index]
             if message.role == "assistant" and message.output_tokens is not None:
-                message_tokens = message.output_tokens
+                message_tokens = (
+                    message.output_tokens + message.context_refs_token_estimate()
+                )
             else:
-                message_tokens = max(1, len(message.content) // 4)
+                message_tokens = (
+                    max(1, len(message.content) // 4)
+                    + message.context_refs_token_estimate()
+                )
 
             if current_tokens + message_tokens > max_tokens:
                 break

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -1054,7 +1054,7 @@ class ExecutionContext:
             0,
             min(
                 COMPACT_CONTEXT_REF_MAX_TOKENS,
-                max(0, self.compact_config.threshold // 8),
+                self.compact_config.threshold // 8,
             )
             - latest_user_tokens,
         )

--- a/src/xagent/core/agent/context/message.py
+++ b/src/xagent/core/agent/context/message.py
@@ -4,6 +4,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from ...context_ref import (
+    CONTEXT_REFS_KEY,
+    ContextReference,
+    normalize_context_references,
+)
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -21,6 +27,14 @@ class Message:
     tool_call_id: str | None = None
     hidden: bool = False
     output_tokens: int | None = None
+    context_refs: tuple[ContextReference, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "context_refs",
+            normalize_context_references(self.context_refs),
+        )
 
     @classmethod
     def role_system(cls, content: str, **kwargs: Any) -> "Message":
@@ -46,6 +60,10 @@ class Message:
             result["tool_call_id"] = self.tool_call_id
         if self.hidden:
             result["hidden"] = True
+        if self.context_refs:
+            result[CONTEXT_REFS_KEY] = [
+                reference.durable_dict() for reference in self.context_refs
+            ]
         return result
 
     def __hash__(self) -> int:
@@ -62,7 +80,22 @@ class Message:
             for tool_call in self.tool_calls or []
             if isinstance(tool_call, dict)
         )
-        return (self.role, self.content, tool_call_ids, self.tool_call_id)
+        context_ref_keys = tuple(
+            reference.identity_key() for reference in self.context_refs
+        )
+        return (
+            self.role,
+            self.content,
+            tool_call_ids,
+            self.tool_call_id,
+            context_ref_keys,
+        )
+
+    def context_refs_text(self) -> str:
+        return "\n".join(reference.compact_text() for reference in self.context_refs)
+
+    def context_refs_token_estimate(self) -> int:
+        return sum(reference.estimated_tokens() for reference in self.context_refs)
 
 
 @dataclass

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import inspect
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, cast
 from uuid import uuid4
 
 from ...config import get_compact_threshold_default, get_compact_threshold_ratio
+from ..context_materializer import WorkspaceContextReferenceResolver
+from ..context_ref import CONTEXT_REFS_KEY
 from ..model.intent import enter_goal, exit_goal
 from ..workspace import WorkspaceManager
 from .context import ContextManager, ExecutionContext
@@ -84,8 +87,9 @@ class AgentRunner:
             context = ExecutionContext.from_dict(checkpoint["context"])
             self.context_manager.set_context(context)
             execution_id = context.execution_id
+            workspace = None
         else:
-            context = await self._build_context(
+            context, workspace = await self._build_context(
                 task=task,
                 execution_id=execution_id,
                 user_id=user_id,
@@ -98,8 +102,17 @@ class AgentRunner:
             for message in initial_messages or []:
                 role = str(message.get("role") or "").strip()
                 content = str(message.get("content") or "").strip()
-                if role and content:
-                    context.add_message(role, content)
+                context_refs = message.get(
+                    CONTEXT_REFS_KEY, message.get("context_refs", ())
+                )
+                if role and (content or context_refs):
+                    context.add_message(
+                        role,
+                        content,
+                        context_refs=context_refs,
+                        tool_calls=message.get("tool_calls"),
+                        tool_call_id=message.get("tool_call_id"),
+                    )
             if task:
                 context.add_user_message(
                     task,
@@ -112,6 +125,20 @@ class AgentRunner:
             interrupt_checker=interrupt_checker,
             outbound_message_handler=self.outbound_message_handler,
         )
+        if runtime.context_ref_resolver is None:
+            if workspace is None:
+                workspace_base = base_dir or self.workspace_base_dir
+                if context.workspace_path:
+                    workspace_base = str(Path(context.workspace_path).parent)
+                workspace = self.workspace_manager.get_or_create_workspace(
+                    base_dir=workspace_base,
+                    task_id=context.workspace_id or workspace_id or execution_id,
+                    allowed_external_dirs=allowed_external_dirs,
+                    scope_segments=self.scope_segments,
+                )
+                if inspect.isawaitable(workspace):
+                    workspace = await workspace
+            runtime.context_ref_resolver = WorkspaceContextReferenceResolver(workspace)
         self._active_controls[execution_id] = ExecutionControl(
             runtime=runtime,
             task=task,
@@ -551,7 +578,7 @@ class AgentRunner:
         allowed_external_dirs: list[str] | None,
         base_dir: str | None,
         metadata: dict[str, Any] | None,
-    ) -> ExecutionContext:
+    ) -> tuple[ExecutionContext, Any]:
         workspace = self.workspace_manager.get_or_create_workspace(
             base_dir=base_dir or self.workspace_base_dir,
             task_id=workspace_id or execution_id,
@@ -593,7 +620,7 @@ class AgentRunner:
             memory_id, snapshot = memory_session
             context.attach_memory_session(memory_id, snapshot)
 
-        return context
+        return context, workspace
 
     def _resolve_compact_threshold(self) -> int:
         """Derive the context-compaction threshold from the model's context window.

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -15,6 +15,10 @@ from ..agent.trace import (
     TraceScope,
     normalize_llm_trace_payload,
 )
+from ..context_materializer import (
+    ContextReferenceResolver,
+    materialize_llm_kwargs,
+)
 from ..model.chat.basic.base import BaseLLM
 from ..model.chat.exceptions import LLMToolProtocolError
 from ..model.chat.token_context import extract_cached_input_tokens
@@ -103,6 +107,7 @@ class PatternRuntime:
     execution_id: str | None = None
     interrupt_checker: Callable[[], bool] | Callable[[], Any] | None = None
     outbound_message_handler: Callable[[dict[str, Any]], Any] | None = None
+    context_ref_resolver: ContextReferenceResolver | None = None
     _interrupt_requested: bool = False
     interrupt_reason: str | None = None
     last_checkpoint: dict[str, Any] | None = None
@@ -162,6 +167,11 @@ class PatternRuntime:
     async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
         """Run an LLM call as a cancellable subtask owned by this runtime."""
 
+        kwargs = await materialize_llm_kwargs(
+            llm=llm,
+            kwargs=kwargs,
+            resolver=self.context_ref_resolver,
+        )
         call = llm.chat(**kwargs)
         if not inspect.isawaitable(call):
             return call
@@ -249,6 +259,11 @@ class PatternRuntime:
         stream_chat = getattr(llm, "stream_chat", None)
         if not callable(stream_chat) or not self._has_native_stream_chat(llm):
             return await self.run_llm_call(llm, **kwargs)
+        kwargs = await materialize_llm_kwargs(
+            llm=llm,
+            kwargs=kwargs,
+            resolver=self.context_ref_resolver,
+        )
 
         async def consume_stream() -> Any:
             content_parts: list[str] = []

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -117,6 +117,9 @@ class WorkspaceContextReferenceResolver:
             data_url = f"data:{mime_type};base64,{encoded}"
             encoded_bytes = len(data_url)
             if encoded_bytes <= self.max_cache_bytes:
+                replaced = self._cache.pop(cache_key, None)
+                if replaced is not None:
+                    self._cache_bytes -= replaced.encoded_bytes
                 while self._cache and (
                     len(self._cache) >= self.cache_size
                     or self._cache_bytes + encoded_bytes > self.max_cache_bytes
@@ -179,10 +182,7 @@ class WorkspaceContextReferenceResolver:
         reference: ContextReference,
         generation: _FileGeneration,
     ) -> str:
-        digest = reference.metadata.get("sha256")
         generation_key = ":".join(str(part) for part in generation)
-        if isinstance(digest, str) and digest:
-            return f"{reference.file_id}:{digest}:{generation_key}"
         return f"{reference.file_id}:{generation_key}"
 
 

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Protocol
+
+from .context_ref import (
+    CONTEXT_REFS_KEY,
+    ContextReference,
+    normalize_context_references,
+)
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_CONTEXT_PLACEHOLDER = "Image context for the preceding message."
+
+
+class ContextReferenceResolutionError(RuntimeError):
+    """A durable context reference could not be safely materialized."""
+
+
+class ContextReferenceResolver(Protocol):
+    async def resolve_image(self, reference: ContextReference) -> str: ...
+
+
+class WorkspaceContextReferenceResolver:
+    """Resolve registered image FileRefs to short-lived provider data URLs."""
+
+    def __init__(
+        self,
+        workspace: Any,
+        *,
+        cache_size: int = 8,
+        cache_ttl_seconds: float = 300,
+        max_image_bytes: int = 20 * 1024 * 1024,
+    ) -> None:
+        self.workspace = workspace
+        self.cache_size = max(1, cache_size)
+        self.cache_ttl_seconds = max(0, cache_ttl_seconds)
+        self.max_image_bytes = max(1, max_image_bytes)
+        self._cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
+
+    async def resolve_image(self, reference: ContextReference) -> str:
+        cache_key = self._cache_key(reference)
+        cached = self._cache.get(cache_key)
+        now = time.monotonic()
+        if cached is not None:
+            created_at, data_url = cached
+            if now - created_at <= self.cache_ttl_seconds:
+                self._cache.move_to_end(cache_key)
+                return data_url
+            self._cache.pop(cache_key, None)
+
+        resolve_file_id = getattr(self.workspace, "resolve_file_id", None)
+        if not callable(resolve_file_id):
+            raise ContextReferenceResolutionError(
+                "workspace must expose resolve_file_id"
+            )
+        path = resolve_file_id(reference.file_id)
+        if path is None:
+            raise FileNotFoundError(
+                f"unable to resolve context FileRef {reference.file_id!r}"
+            )
+
+        resolved_path = Path(path)
+        file_size = await asyncio.to_thread(lambda: resolved_path.stat().st_size)
+        if file_size > self.max_image_bytes:
+            raise ContextReferenceResolutionError(
+                f"context image exceeds {self.max_image_bytes} bytes"
+            )
+        mime_type = str(reference.safe_file_ref.get("mime_type") or "image/png")
+        if not mime_type.startswith("image/"):
+            raise ContextReferenceResolutionError(
+                f"unsupported context image MIME type: {mime_type}"
+            )
+
+        image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
+        if len(image_bytes) > self.max_image_bytes:
+            raise ContextReferenceResolutionError(
+                f"context image exceeds {self.max_image_bytes} bytes"
+            )
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        data_url = f"data:{mime_type};base64,{encoded}"
+        self._cache[cache_key] = (now, data_url)
+        while len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)
+        return data_url
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    @staticmethod
+    def _cache_key(reference: ContextReference) -> str:
+        digest = reference.metadata.get("sha256")
+        if isinstance(digest, str) and digest:
+            return f"{reference.file_id}:{digest}"
+        return reference.file_id
+
+
+def llm_supports_vision(llm: Any) -> bool:
+    has_ability = getattr(llm, "has_ability", None)
+    if callable(has_ability):
+        try:
+            return bool(has_ability("vision"))
+        except (TypeError, ValueError):
+            pass
+    abilities = getattr(llm, "abilities", ())
+    return "vision" in abilities if abilities is not None else False
+
+
+def _append_text(content: Any, text: str) -> Any:
+    if not text:
+        return content
+    if isinstance(content, list):
+        copied = [dict(part) if isinstance(part, dict) else part for part in content]
+        copied.append({"type": "text", "text": text})
+        return copied
+    current = str(content or "")
+    return f"{current}\n{text}".strip()
+
+
+async def materialize_messages(
+    *,
+    llm: Any,
+    messages: list[dict[str, Any]],
+    resolver: ContextReferenceResolver | None,
+) -> list[dict[str, Any]]:
+    """Materialize durable context refs without mutating persisted messages."""
+
+    supports_vision = llm_supports_vision(llm)
+    result: list[dict[str, Any]] = []
+    deferred_user_messages: list[dict[str, Any]] = []
+
+    def flush_deferred() -> None:
+        if deferred_user_messages:
+            result.extend(deferred_user_messages)
+            deferred_user_messages.clear()
+
+    for index, message in enumerate(messages):
+        copied = dict(message)
+        refs = normalize_context_references(copied.pop(CONTEXT_REFS_KEY, None))
+        role = copied.get("role")
+
+        if not refs or not supports_vision or resolver is None:
+            if refs:
+                fallback = "\n".join(ref.compact_text() for ref in refs)
+                copied["content"] = _append_text(copied.get("content"), fallback)
+            if role != "tool":
+                flush_deferred()
+            result.append(copied)
+            next_role = (
+                messages[index + 1].get("role") if index + 1 < len(messages) else None
+            )
+            if role == "tool" and next_role != "tool":
+                flush_deferred()
+            continue
+
+        text = copied.get("content")
+        content_parts: list[dict[str, Any]] = []
+        if role == "user":
+            if isinstance(text, list):
+                for part in text:
+                    if isinstance(part, dict):
+                        content_parts.append(dict(part))
+                    elif str(part):
+                        content_parts.append({"type": "text", "text": str(part)})
+            elif str(text or ""):
+                content_parts.append({"type": "text", "text": str(text)})
+        else:
+            content_parts.append({"type": "text", "text": _IMAGE_CONTEXT_PLACEHOLDER})
+
+        unresolved: list[ContextReference] = []
+        for reference in refs:
+            try:
+                url = await resolver.resolve_image(reference)
+            except (
+                ContextReferenceResolutionError,
+                FileNotFoundError,
+                OSError,
+            ):
+                logger.debug(
+                    "Falling back to text for unresolved context ref %s",
+                    reference.file_id,
+                    exc_info=True,
+                )
+                unresolved.append(reference)
+                continue
+
+            image_url: dict[str, Any] = {"url": url}
+            detail = (
+                "high"
+                if reference.detail.value == "original"
+                else reference.detail.value
+            )
+            if detail != "auto":
+                image_url["detail"] = detail
+            content_parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": image_url,
+                }
+            )
+
+        if unresolved:
+            fallback = "\n".join(ref.compact_text() for ref in unresolved)
+            content_parts.append({"type": "text", "text": fallback})
+
+        if not any(part.get("type") == "image_url" for part in content_parts):
+            copied["content"] = _append_text(
+                copied.get("content"),
+                "\n".join(ref.compact_text() for ref in unresolved),
+            )
+            if role != "tool":
+                flush_deferred()
+            result.append(copied)
+        elif role == "user":
+            flush_deferred()
+            copied["content"] = content_parts
+            result.append(copied)
+        else:
+            result.append(copied)
+            deferred_user_messages.append(
+                {
+                    "role": "user",
+                    "content": content_parts,
+                }
+            )
+
+        next_role = (
+            messages[index + 1].get("role") if index + 1 < len(messages) else None
+        )
+        if next_role != "tool":
+            flush_deferred()
+
+    flush_deferred()
+    return result
+
+
+async def materialize_llm_kwargs(
+    *,
+    llm: Any,
+    kwargs: dict[str, Any],
+    resolver: ContextReferenceResolver | None,
+) -> dict[str, Any]:
+    messages = kwargs.get("messages")
+    if not isinstance(messages, list):
+        return kwargs
+    materialized = dict(kwargs)
+    materialized["messages"] = await materialize_messages(
+        llm=llm,
+        messages=messages,
+        resolver=resolver,
+    )
+    return materialized

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -6,7 +6,7 @@ import logging
 import time
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, NamedTuple, Protocol
 
 from .context_ref import (
     CONTEXT_REFS_KEY,
@@ -21,6 +21,18 @@ _IMAGE_CONTEXT_PLACEHOLDER = "Image context for the preceding message."
 
 class ContextReferenceResolutionError(RuntimeError):
     """A durable context reference could not be safely materialized."""
+
+
+class _FileGenerationChanged(RuntimeError):
+    """The resolved file changed while it was being materialized."""
+
+
+class _FileGeneration(NamedTuple):
+    path: str
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
 
 
 class ContextReferenceResolver(Protocol):
@@ -45,60 +57,112 @@ class WorkspaceContextReferenceResolver:
         self._cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
 
     async def resolve_image(self, reference: ContextReference) -> str:
-        cache_key = self._cache_key(reference)
-        cached = self._cache.get(cache_key)
-        now = time.monotonic()
-        if cached is not None:
-            created_at, data_url = cached
-            if now - created_at <= self.cache_ttl_seconds:
-                self._cache.move_to_end(cache_key)
-                return data_url
-            self._cache.pop(cache_key, None)
-
-        resolve_file_id = getattr(self.workspace, "resolve_file_id", None)
-        if not callable(resolve_file_id):
-            raise ContextReferenceResolutionError(
-                "workspace must expose resolve_file_id"
-            )
-        path = resolve_file_id(reference.file_id)
-        if path is None:
-            raise FileNotFoundError(
-                f"unable to resolve context FileRef {reference.file_id!r}"
-            )
-
-        resolved_path = Path(path)
-        file_size = await asyncio.to_thread(lambda: resolved_path.stat().st_size)
-        if file_size > self.max_image_bytes:
-            raise ContextReferenceResolutionError(
-                f"context image exceeds {self.max_image_bytes} bytes"
-            )
         mime_type = str(reference.safe_file_ref.get("mime_type") or "image/png")
         if not mime_type.startswith("image/"):
             raise ContextReferenceResolutionError(
                 f"unsupported context image MIME type: {mime_type}"
             )
 
-        image_bytes = await asyncio.to_thread(resolved_path.read_bytes)
-        if len(image_bytes) > self.max_image_bytes:
-            raise ContextReferenceResolutionError(
-                f"context image exceeds {self.max_image_bytes} bytes"
+        for attempt in range(2):
+            resolved_path, generation = await asyncio.to_thread(
+                self._resolve_generation,
+                reference.file_id,
             )
-        encoded = base64.b64encode(image_bytes).decode("ascii")
-        data_url = f"data:{mime_type};base64,{encoded}"
-        self._cache[cache_key] = (now, data_url)
-        while len(self._cache) > self.cache_size:
-            self._cache.popitem(last=False)
-        return data_url
+            if generation.size > self.max_image_bytes:
+                raise ContextReferenceResolutionError(
+                    f"context image exceeds {self.max_image_bytes} bytes"
+                )
+
+            cache_key = self._cache_key(reference, generation)
+            now = time.monotonic()
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                created_at, data_url = cached
+                if now - created_at <= self.cache_ttl_seconds:
+                    self._cache.move_to_end(cache_key)
+                    return data_url
+                self._cache.pop(cache_key, None)
+
+            try:
+                image_bytes = await asyncio.to_thread(
+                    self._read_generation,
+                    resolved_path,
+                    generation,
+                )
+            except _FileGenerationChanged as exc:
+                if attempt == 0:
+                    continue
+                raise ContextReferenceResolutionError(
+                    "context image changed while it was being read"
+                ) from exc
+
+            if len(image_bytes) > self.max_image_bytes:
+                raise ContextReferenceResolutionError(
+                    f"context image exceeds {self.max_image_bytes} bytes"
+                )
+            encoded = base64.b64encode(image_bytes).decode("ascii")
+            data_url = f"data:{mime_type};base64,{encoded}"
+            self._cache[cache_key] = (time.monotonic(), data_url)
+            while len(self._cache) > self.cache_size:
+                self._cache.popitem(last=False)
+            return data_url
+
+        raise ContextReferenceResolutionError("unable to read a stable context image")
 
     def clear(self) -> None:
         self._cache.clear()
 
+    def _resolve_generation(
+        self,
+        file_id: str,
+    ) -> tuple[Path, _FileGeneration]:
+        resolve_file_id = getattr(self.workspace, "resolve_file_id_detached", None)
+        if not callable(resolve_file_id):
+            resolve_file_id = getattr(self.workspace, "resolve_file_id", None)
+        if not callable(resolve_file_id):
+            raise ContextReferenceResolutionError(
+                "workspace must expose resolve_file_id"
+            )
+        path = resolve_file_id(file_id)
+        if path is None:
+            raise FileNotFoundError(f"unable to resolve context FileRef {file_id!r}")
+
+        resolved_path = Path(path).resolve(strict=True)
+        return resolved_path, self._generation(resolved_path)
+
     @staticmethod
-    def _cache_key(reference: ContextReference) -> str:
+    def _generation(path: Path) -> _FileGeneration:
+        stat = path.stat()
+        return _FileGeneration(
+            path=str(path),
+            device=stat.st_dev,
+            inode=stat.st_ino,
+            size=stat.st_size,
+            modified_ns=stat.st_mtime_ns,
+        )
+
+    def _read_generation(
+        self,
+        path: Path,
+        expected: _FileGeneration,
+    ) -> bytes:
+        if self._generation(path) != expected:
+            raise _FileGenerationChanged
+        image_bytes = path.read_bytes()
+        if self._generation(path) != expected:
+            raise _FileGenerationChanged
+        return image_bytes
+
+    @staticmethod
+    def _cache_key(
+        reference: ContextReference,
+        generation: _FileGeneration,
+    ) -> str:
         digest = reference.metadata.get("sha256")
+        generation_key = ":".join(str(part) for part in generation)
         if isinstance(digest, str) and digest:
-            return f"{reference.file_id}:{digest}"
-        return reference.file_id
+            return f"{reference.file_id}:{digest}:{generation_key}"
+        return f"{reference.file_id}:{generation_key}"
 
 
 def llm_supports_vision(llm: Any) -> bool:

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -17,6 +17,10 @@ from .context_ref import (
 logger = logging.getLogger(__name__)
 
 _IMAGE_CONTEXT_PLACEHOLDER = "Image context for the preceding message."
+_DEFAULT_CACHE_BYTES = 32 * 1024 * 1024
+_DEFAULT_CONTEXT_REF_TOKEN_BUDGET = 8_192
+_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST = 32 * 1024 * 1024
+_CONTEXT_REF_TOKEN_BUDGET_RATIO = 0.25
 
 
 class ContextReferenceResolutionError(RuntimeError):
@@ -35,6 +39,12 @@ class _FileGeneration(NamedTuple):
     modified_ns: int
 
 
+class _CacheEntry(NamedTuple):
+    created_at: float
+    data_url: str
+    encoded_bytes: int
+
+
 class ContextReferenceResolver(Protocol):
     async def resolve_image(self, reference: ContextReference) -> str: ...
 
@@ -49,12 +59,15 @@ class WorkspaceContextReferenceResolver:
         cache_size: int = 8,
         cache_ttl_seconds: float = 300,
         max_image_bytes: int = 20 * 1024 * 1024,
+        max_cache_bytes: int = _DEFAULT_CACHE_BYTES,
     ) -> None:
         self.workspace = workspace
         self.cache_size = max(1, cache_size)
         self.cache_ttl_seconds = max(0, cache_ttl_seconds)
         self.max_image_bytes = max(1, max_image_bytes)
-        self._cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
+        self.max_cache_bytes = max(0, max_cache_bytes)
+        self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._cache_bytes = 0
 
     async def resolve_image(self, reference: ContextReference) -> str:
         mime_type = str(reference.safe_file_ref.get("mime_type") or "image/png")
@@ -77,11 +90,11 @@ class WorkspaceContextReferenceResolver:
             now = time.monotonic()
             cached = self._cache.get(cache_key)
             if cached is not None:
-                created_at, data_url = cached
-                if now - created_at <= self.cache_ttl_seconds:
+                if now - cached.created_at <= self.cache_ttl_seconds:
                     self._cache.move_to_end(cache_key)
-                    return data_url
+                    return cached.data_url
                 self._cache.pop(cache_key, None)
+                self._cache_bytes -= cached.encoded_bytes
 
             try:
                 image_bytes = await asyncio.to_thread(
@@ -102,15 +115,23 @@ class WorkspaceContextReferenceResolver:
                 )
             encoded = base64.b64encode(image_bytes).decode("ascii")
             data_url = f"data:{mime_type};base64,{encoded}"
-            self._cache[cache_key] = (time.monotonic(), data_url)
-            while len(self._cache) > self.cache_size:
-                self._cache.popitem(last=False)
+            encoded_bytes = len(data_url)
+            if encoded_bytes <= self.max_cache_bytes:
+                while self._cache and (
+                    len(self._cache) >= self.cache_size
+                    or self._cache_bytes + encoded_bytes > self.max_cache_bytes
+                ):
+                    _, evicted = self._cache.popitem(last=False)
+                    self._cache_bytes -= evicted.encoded_bytes
+                self._cache[cache_key] = _CacheEntry(
+                    time.monotonic(),
+                    data_url,
+                    encoded_bytes,
+                )
+                self._cache_bytes += encoded_bytes
             return data_url
 
         raise ContextReferenceResolutionError("unable to read a stable context image")
-
-    def clear(self) -> None:
-        self._cache.clear()
 
     def _resolve_generation(
         self,
@@ -187,6 +208,31 @@ def _append_text(content: Any, text: str) -> Any:
     return f"{current}\n{text}".strip()
 
 
+def _context_ref_token_budget(llm: Any) -> int:
+    context_window = getattr(llm, "context_window", None)
+    if isinstance(context_window, int) and context_window > 0:
+        return max(1, int(context_window * _CONTEXT_REF_TOKEN_BUDGET_RATIO))
+    return _DEFAULT_CONTEXT_REF_TOKEN_BUDGET
+
+
+def _enforce_context_ref_request_budget(
+    llm: Any,
+    messages: list[dict[str, Any]],
+) -> None:
+    references = [
+        reference
+        for message in messages
+        for reference in normalize_context_references(message.get(CONTEXT_REFS_KEY))
+    ]
+    estimated_tokens = sum(reference.estimated_tokens() for reference in references)
+    token_budget = _context_ref_token_budget(llm)
+    if estimated_tokens > token_budget:
+        raise ContextReferenceResolutionError(
+            "context image request exceeds the materialization token budget "
+            f"({estimated_tokens} estimated tokens > {token_budget})"
+        )
+
+
 async def materialize_messages(
     *,
     llm: Any,
@@ -196,8 +242,11 @@ async def materialize_messages(
     """Materialize durable context refs without mutating persisted messages."""
 
     supports_vision = llm_supports_vision(llm)
+    if supports_vision and resolver is not None:
+        _enforce_context_ref_request_budget(llm, messages)
     result: list[dict[str, Any]] = []
     deferred_user_messages: list[dict[str, Any]] = []
+    materialized_image_bytes = 0
 
     def flush_deferred() -> None:
         if deferred_user_messages:
@@ -254,6 +303,17 @@ async def materialize_messages(
                 unresolved.append(reference)
                 continue
 
+            image_bytes = len(url.encode("utf-8"))
+            if (
+                materialized_image_bytes + image_bytes
+                > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
+            ):
+                raise ContextReferenceResolutionError(
+                    "context image request exceeds the materialized byte budget "
+                    f"({materialized_image_bytes + image_bytes} bytes > "
+                    f"{_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST})"
+                )
+            materialized_image_bytes += image_bytes
             image_url: dict[str, Any] = {"url": url}
             detail = (
                 "high"

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -69,6 +69,7 @@ def _validated_metadata(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise TypeError("metadata must be an object")
     result = dict(value)
+    _validate_metadata_tree(result)
     try:
         serialized = json.dumps(
             result,
@@ -80,8 +81,12 @@ def _validated_metadata(value: Any) -> dict[str, Any]:
         raise ValueError("metadata must be JSON serializable") from exc
     if len(serialized.encode("utf-8")) > 32_768:
         raise ValueError("metadata must be at most 32 KiB")
-    _validate_metadata_tree(result)
-    return result
+    normalized_value: object = json.loads(serialized)
+    if not isinstance(normalized_value, dict):
+        raise ValueError("metadata must be an object")
+    normalized = cast(dict[str, Any], normalized_value)
+    _validate_metadata_tree(normalized)
+    return normalized
 
 
 def _validated_text_fallback(value: Any) -> str | None:

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .file_ref import sanitize_file_ref_for_context
+
+CONTEXT_REFS_KEY = "_xagent_context_refs"
+
+
+def _validated_metadata(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("metadata must be an object")
+    result = dict(value)
+    try:
+        serialized = json.dumps(
+            result,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("metadata must be JSON serializable") from exc
+    if len(serialized.encode("utf-8")) > 32_768:
+        raise ValueError("metadata must be at most 32 KiB")
+    normalized = serialized.lower()
+    if "data:image/" in normalized and ";base64," in normalized:
+        raise ValueError("metadata must not contain materialized image data")
+    return result
+
+
+class ImageDetail(str, Enum):
+    AUTO = "auto"
+    LOW = "low"
+    HIGH = "high"
+    ORIGINAL = "original"
+
+
+class ContextReference(BaseModel):
+    """Durable reference to non-text content used by a model call.
+
+    The persisted representation contains only a registered FileRef and small,
+    JSON-safe metadata. Provider payloads receive image bytes only after a
+    runtime resolver materializes the reference just in time.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    type: Literal["image"] = "image"
+    file_ref: dict[str, Any]
+    detail: ImageDetail = ImageDetail.AUTO
+    text_fallback: str | None = Field(default=None, max_length=16_000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("file_ref", mode="before")
+    @classmethod
+    def _sanitize_file_ref(cls, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise TypeError("file_ref must be a FileRef object")
+        result = sanitize_file_ref_for_context(value)
+        mime_type = str(result.get("mime_type") or "")
+        if mime_type and not mime_type.startswith("image/"):
+            raise ValueError("image context references require an image MIME type")
+        return result
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _copy_metadata(cls, value: Any) -> dict[str, Any]:
+        return _validated_metadata(value)
+
+    @property
+    def file_id(self) -> str:
+        return str(self.safe_file_ref["file_id"])
+
+    @property
+    def safe_file_ref(self) -> dict[str, Any]:
+        return sanitize_file_ref_for_context(self.file_ref)
+
+    def durable_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "type": self.type,
+            "file_ref": self.safe_file_ref,
+            "detail": self.detail.value,
+            "metadata": _validated_metadata(self.metadata),
+        }
+        if self.text_fallback is not None:
+            result["text_fallback"] = self.text_fallback
+        return result
+
+    def identity_key(self) -> str:
+        return json.dumps(
+            self.durable_dict(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def compact_text(self) -> str:
+        filename = self.safe_file_ref.get("filename") or "image"
+        fallback = f": {self.text_fallback}" if self.text_fallback else ""
+        return f"[image: {filename}, file_id={self.file_id}]{fallback}"
+
+    def estimated_tokens(self) -> int:
+        image_tokens = {
+            ImageDetail.LOW: 85,
+            ImageDetail.AUTO: 255,
+            ImageDetail.HIGH: 765,
+            ImageDetail.ORIGINAL: 765,
+        }[self.detail]
+        return image_tokens + max(1, len(self.compact_text()) // 4)
+
+
+def normalize_context_references(
+    values: Any,
+) -> tuple[ContextReference, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, ContextReference):
+        return (values,)
+    if not isinstance(values, (list, tuple)):
+        raise TypeError("context_refs must be a list or tuple")
+    return tuple(
+        value
+        if isinstance(value, ContextReference)
+        else ContextReference.model_validate(value)
+        for value in values
+    )
+
+
+def split_tool_result_context_references(
+    result: Any,
+) -> tuple[Any, tuple[ContextReference, ...]]:
+    """Detach durable context refs from a tool result before model formatting.
+
+    Tools may return ``_xagent_context_refs`` as a reserved internal envelope
+    field. ExecutionContext stores those refs on the tool Message while keeping
+    the public tool observation free of transport-only bookkeeping.
+    """
+
+    if not isinstance(result, dict) or CONTEXT_REFS_KEY not in result:
+        return result, ()
+    public_result = dict(result)
+    raw_refs = public_result.pop(CONTEXT_REFS_KEY)
+    return public_result, normalize_context_references(raw_refs)

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -44,6 +44,15 @@ def _looks_like_absolute_filesystem_path(value: str) -> bool:
     return stripped.startswith("/") or bool(windows_path.drive or windows_path.root)
 
 
+def _validate_metadata_string(value: str) -> None:
+    if _contains_materialized_image(value):
+        raise ValueError("metadata must not contain materialized image data")
+    if _looks_like_absolute_filesystem_path(value):
+        raise ValueError("metadata must not contain absolute filesystem paths")
+    if _COMMON_PRIVATE_PATH_RE.search(value):
+        raise ValueError("metadata must not contain private filesystem paths")
+
+
 def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
     if key is not None and _metadata_key_is_path_like(key):
         if value not in (None, "", [], {}):
@@ -53,6 +62,7 @@ def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
         for child_key, child_value in value.items():
             if not isinstance(child_key, str):
                 raise ValueError("metadata keys must be strings")
+            _validate_metadata_string(child_key)
             _validate_metadata_tree(child_value, key=child_key)
         return
     if isinstance(value, list):
@@ -60,12 +70,7 @@ def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
             _validate_metadata_tree(child)
         return
     if isinstance(value, str):
-        if _contains_materialized_image(value):
-            raise ValueError("metadata must not contain materialized image data")
-        if _looks_like_absolute_filesystem_path(value):
-            raise ValueError("metadata must not contain absolute filesystem paths")
-        if _COMMON_PRIVATE_PATH_RE.search(value):
-            raise ValueError("metadata must not contain private filesystem paths")
+        _validate_metadata_string(value)
 
 
 def _validated_metadata(value: Any) -> dict[str, Any]:

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from enum import Enum
+from pathlib import PureWindowsPath
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -20,7 +21,6 @@ _PATH_METADATA_PARTS = {
     "path",
     "paths",
 }
-_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
 _COMMON_PRIVATE_PATH_RE = re.compile(
     r"(?:^|\s)/(?:Users|home|private|root|tmp|var/folders|workspace)(?:/|\s|$)"
 )
@@ -34,6 +34,14 @@ def _contains_materialized_image(value: str) -> bool:
 def _metadata_key_is_path_like(key: str) -> bool:
     parts = {part for part in re.split(r"[^a-z0-9]+", key.lower()) if part}
     return bool(parts & _PATH_METADATA_PARTS)
+
+
+def _looks_like_absolute_filesystem_path(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    windows_path = PureWindowsPath(stripped)
+    return stripped.startswith("/") or bool(windows_path.drive or windows_path.root)
 
 
 def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
@@ -54,10 +62,7 @@ def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
     if isinstance(value, str):
         if _contains_materialized_image(value):
             raise ValueError("metadata must not contain materialized image data")
-        stripped = value.strip()
-        if _WINDOWS_ABSOLUTE_PATH_RE.match(stripped) or (
-            stripped.startswith("/") and not stripped.startswith("//")
-        ):
+        if _looks_like_absolute_filesystem_path(value):
             raise ValueError("metadata must not contain absolute filesystem paths")
         if _COMMON_PRIVATE_PATH_RE.search(value):
             raise ValueError("metadata must not contain private filesystem paths")

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from enum import Enum
 from typing import Any, Literal
 
@@ -9,6 +10,57 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from .file_ref import sanitize_file_ref_for_context
 
 CONTEXT_REFS_KEY = "_xagent_context_refs"
+
+_PATH_METADATA_PARTS = {
+    "cwd",
+    "dir",
+    "directory",
+    "directories",
+    "home",
+    "path",
+    "paths",
+}
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_COMMON_PRIVATE_PATH_RE = re.compile(
+    r"(?:^|\s)/(?:Users|home|private|root|tmp|var/folders|workspace)(?:/|\s|$)"
+)
+
+
+def _contains_materialized_image(value: str) -> bool:
+    normalized = value.lower()
+    return "data:image/" in normalized and ";base64," in normalized
+
+
+def _metadata_key_is_path_like(key: str) -> bool:
+    parts = {part for part in re.split(r"[^a-z0-9]+", key.lower()) if part}
+    return bool(parts & _PATH_METADATA_PARTS)
+
+
+def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:
+    if key is not None and _metadata_key_is_path_like(key):
+        if value not in (None, "", [], {}):
+            raise ValueError(f"metadata field {key!r} must not contain a path")
+
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            if not isinstance(child_key, str):
+                raise ValueError("metadata keys must be strings")
+            _validate_metadata_tree(child_value, key=child_key)
+        return
+    if isinstance(value, list):
+        for child in value:
+            _validate_metadata_tree(child)
+        return
+    if isinstance(value, str):
+        if _contains_materialized_image(value):
+            raise ValueError("metadata must not contain materialized image data")
+        stripped = value.strip()
+        if _WINDOWS_ABSOLUTE_PATH_RE.match(stripped) or (
+            stripped.startswith("/") and not stripped.startswith("//")
+        ):
+            raise ValueError("metadata must not contain absolute filesystem paths")
+        if _COMMON_PRIVATE_PATH_RE.search(value):
+            raise ValueError("metadata must not contain private filesystem paths")
 
 
 def _validated_metadata(value: Any) -> dict[str, Any]:
@@ -28,10 +80,17 @@ def _validated_metadata(value: Any) -> dict[str, Any]:
         raise ValueError("metadata must be JSON serializable") from exc
     if len(serialized.encode("utf-8")) > 32_768:
         raise ValueError("metadata must be at most 32 KiB")
-    normalized = serialized.lower()
-    if "data:image/" in normalized and ";base64," in normalized:
-        raise ValueError("metadata must not contain materialized image data")
+    _validate_metadata_tree(result)
     return result
+
+
+def _validated_text_fallback(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if _contains_materialized_image(text):
+        raise ValueError("text_fallback must not contain materialized image data")
+    return text
 
 
 class ImageDetail(str, Enum):
@@ -73,6 +132,11 @@ class ContextReference(BaseModel):
     def _copy_metadata(cls, value: Any) -> dict[str, Any]:
         return _validated_metadata(value)
 
+    @field_validator("text_fallback", mode="before")
+    @classmethod
+    def _sanitize_text_fallback(cls, value: Any) -> str | None:
+        return _validated_text_fallback(value)
+
     @property
     def file_id(self) -> str:
         return str(self.safe_file_ref["file_id"])
@@ -88,8 +152,9 @@ class ContextReference(BaseModel):
             "detail": self.detail.value,
             "metadata": _validated_metadata(self.metadata),
         }
-        if self.text_fallback is not None:
-            result["text_fallback"] = self.text_fallback
+        text_fallback = _validated_text_fallback(self.text_fallback)
+        if text_fallback is not None:
+            result["text_fallback"] = text_fallback
         return result
 
     def identity_key(self) -> str:

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -22,7 +22,16 @@ _PATH_METADATA_PARTS = {
     "paths",
 }
 _COMMON_PRIVATE_PATH_RE = re.compile(
-    r"(?:^|\s)/(?:Users|home|private|root|tmp|var/folders|workspace)(?:/|\s|$)"
+    r"(?<![A-Za-z0-9])/(?:Users|home|private|root|tmp|var/folders|workspace)"
+    r"(?:/|(?=[\s)\]}>,'\";:]|$))"
+)
+_FILE_URI_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9])file:/{1,3}\S+")
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s\"'<>]+")
+_UNC_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9:])(?:\\\\|//)[^\\/\s\"'<>]+[\\/][^\\/\s\"'<>]+"
+)
+_WINDOWS_ROOTED_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9\\/:])\\(?!\\)[^\\\s\"'<>]+(?:\\[^\\\s\"'<>]+)+"
 )
 
 
@@ -41,7 +50,18 @@ def _looks_like_absolute_filesystem_path(value: str) -> bool:
     if not stripped:
         return False
     windows_path = PureWindowsPath(stripped)
-    return stripped.startswith("/") or bool(windows_path.drive or windows_path.root)
+    if stripped.startswith("/") or bool(windows_path.drive or windows_path.root):
+        return True
+    return any(
+        pattern.search(value)
+        for pattern in (
+            _FILE_URI_PATH_RE,
+            _COMMON_PRIVATE_PATH_RE,
+            _WINDOWS_DRIVE_PATH_RE,
+            _UNC_PATH_RE,
+            _WINDOWS_ROOTED_PATH_RE,
+        )
+    )
 
 
 def _validate_metadata_string(value: str) -> None:
@@ -49,8 +69,6 @@ def _validate_metadata_string(value: str) -> None:
         raise ValueError("metadata must not contain materialized image data")
     if _looks_like_absolute_filesystem_path(value):
         raise ValueError("metadata must not contain absolute filesystem paths")
-    if _COMMON_PRIVATE_PATH_RE.search(value):
-        raise ValueError("metadata must not contain private filesystem paths")
 
 
 def _validate_metadata_tree(value: Any, *, key: str | None = None) -> None:

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -160,6 +160,41 @@ def build_workspace_file_ref(
     }
 
 
+def sanitize_file_ref_for_context(file_ref: dict[str, Any]) -> dict[str, Any]:
+    """Return the durable, model-safe subset of a registered FileRef.
+
+    Local storage paths are intentionally excluded so messages, checkpoints,
+    and traces can persist this value without leaking host filesystem details.
+    """
+
+    file_id = str(file_ref.get("file_id") or "").strip()
+    raw_filename = str(file_ref.get("filename") or "").strip()
+    filename = Path(raw_filename.replace("\\", "/")).name.strip()
+    if not file_id:
+        raise ValueError("FileRef must contain a registered file_id")
+    if not filename:
+        raise ValueError("FileRef must contain a filename")
+    build_file_id_ref(file_id)
+
+    mime_type = str(file_ref.get("mime_type") or guess_mime_type(filename))
+    raw_size = file_ref.get("size")
+    size = int(raw_size) if raw_size is not None else None
+    if size is not None and size < 0:
+        raise ValueError("FileRef size must not be negative")
+    result = build_file_ref(
+        file_id=file_id,
+        filename=filename,
+        mime_type=mime_type,
+        size=size,
+    )
+    relative_path = file_ref.get("relative_path")
+    if relative_path is not None:
+        relative = Path(str(relative_path))
+        if not relative.is_absolute() and ".." not in relative.parts:
+            result["relative_path"] = str(relative)
+    return result
+
+
 def safe_asset_filename(filename: str) -> str:
     """Return a browser-safe basename for HTML bundle assets."""
     name = Path(filename).name.strip()

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import mimetypes
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 from urllib.parse import quote, unquote, urlsplit
 
@@ -189,9 +189,17 @@ def sanitize_file_ref_for_context(file_ref: dict[str, Any]) -> dict[str, Any]:
     )
     relative_path = file_ref.get("relative_path")
     if relative_path is not None:
-        relative = Path(str(relative_path))
-        if not relative.is_absolute() and ".." not in relative.parts:
-            result["relative_path"] = str(relative)
+        raw_relative = str(relative_path).strip()
+        windows_relative = PureWindowsPath(raw_relative)
+        relative = Path(raw_relative.replace("\\", "/"))
+        is_windows_rooted = bool(windows_relative.drive or windows_relative.root)
+        if (
+            raw_relative
+            and not is_windows_rooted
+            and not relative.is_absolute()
+            and ".." not in relative.parts
+        ):
+            result["relative_path"] = relative.as_posix()
     return result
 
 

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -66,6 +66,10 @@ _MODALITY_ABILITIES = {
 }
 
 
+class RouterModalityRoutingError(RuntimeError):
+    """The installed router cannot enforce required input modalities."""
+
+
 def _should_retry_without_thinking(
     exc: Exception,
     *,
@@ -564,6 +568,8 @@ class RouterLLM(BaseLLM):
                 prompt,
                 preferred_input_modalities,
             )
+        except RouterModalityRoutingError:
+            raise
         except Exception as exc:  # noqa: BLE001 - routing must not crash the agent
             if self._fallback_model:
                 logger.warning(
@@ -602,6 +608,14 @@ class RouterLLM(BaseLLM):
         )
         if preferred_input_modalities and supports_modality_preferences:
             route_kwargs["preferred_input_modalities"] = preferred_input_modalities
+        elif preferred_input_modalities:
+            requested = ", ".join(preferred_input_modalities)
+            raise RouterModalityRoutingError(
+                "The installed xrouter-llm RoutingService cannot enforce input "
+                f"modalities ({requested}). Choose an explicit compatible model or "
+                "install an xrouter-llm build whose route() API accepts "
+                "preferred_input_modalities."
+            )
         result = service.route(prompt, **route_kwargs)
         return list(result.get("selected") or [])
 

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -28,11 +28,13 @@ Env overrides (all optional; default to the bundled package data):
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 import threading
 from typing import Any, AsyncIterator, Callable, List, Optional, cast
 
+from ....context_ref import CONTEXT_REFS_KEY, normalize_context_references
 from ....model import ChatModelConfig
 from ...providers import default_base_url_for_provider
 from ..types import StreamChunk
@@ -43,6 +45,25 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ROUTER_ABILITIES = ["chat", "tool_calling"]
 _UNROUTED_ROUTER_ABILITIES = {"vision", "thinking_mode"}
 _DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
+_CONTENT_PART_MODALITIES = {
+    "audio": "audio",
+    "audio_url": "audio",
+    "file": "file",
+    "file_url": "file",
+    "image": "image",
+    "image_url": "image",
+    "input_audio": "audio",
+    "input_file": "file",
+    "input_image": "image",
+    "input_video": "video",
+    "video": "video",
+    "video_url": "video",
+}
+_MODALITY_ABILITIES = {
+    "audio": "audio",
+    "image": "vision",
+    "video": "video",
+}
 
 
 def _should_retry_without_thinking(
@@ -212,8 +233,9 @@ class RouterLLM(BaseLLM):
         self.default_temperature = default_temperature
         self.default_max_tokens = default_max_tokens
         self.timeout = timeout
-        # xrouter-llm currently routes from text only and does not filter
-        # candidates by multimodal or reasoning support.
+        # A virtual router cannot advertise one candidate's dynamic abilities.
+        # The resolved per-call wrapper derives those from the selected model's
+        # profile after xrouter applies any input-modality preferences.
         self._abilities = [
             ability
             for ability in (abilities or _DEFAULT_ROUTER_ABILITIES)
@@ -426,7 +448,11 @@ class RouterLLM(BaseLLM):
         routing a second time, and carries the selected model's context window
         from xrouter's model profile catalog.
         """
-        model_id, downstream = await self._resolve_route(messages)
+        preferred_input_modalities = self._preferred_input_modalities(messages)
+        model_id, downstream = await self._resolve_route(
+            messages,
+            preferred_input_modalities=preferred_input_modalities,
+        )
         context_window = getattr(self, "context_window", None)
         if not context_window:
             context_window = await asyncio.to_thread(
@@ -434,15 +460,24 @@ class RouterLLM(BaseLLM):
             )
         if not context_window:
             context_window = getattr(downstream, "context_window", None)
+        input_modalities = (
+            self._profile_input_modalities(model_id)
+            if preferred_input_modalities
+            else ()
+        )
         return _ResolvedRouterLLM(
             router=self,
             downstream=downstream,
             selected_model=model_id,
             context_window=context_window,
+            input_modalities=input_modalities,
         )
 
     async def _resolve_route(
-        self, messages: list[dict[str, Any]]
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        preferred_input_modalities: tuple[str, ...] = (),
     ) -> tuple[str, BaseLLM]:
         # Route on the agent's current goal (the user's request, or a DAG step's
         # objective) rather than the scaffolded sub-prompt this particular LLM
@@ -450,7 +485,13 @@ class RouterLLM(BaseLLM):
         from ...intent import current_goal
 
         prompt = current_goal() or self._extract_prompt(messages)
-        model_id = await self._select_model(prompt)
+        if preferred_input_modalities:
+            model_id = await self._select_model(
+                prompt,
+                preferred_input_modalities=preferred_input_modalities,
+            )
+        else:
+            model_id = await self._select_model(prompt)
         logger.info("xrouter selected %s -> openrouter", model_id)
         if self._downstream_resolver is not None:
             # Reuse the user-configured OpenRouter model (credentials + base_url).
@@ -489,11 +530,40 @@ class RouterLLM(BaseLLM):
             return None
         return value if isinstance(value, int) and value > 0 else None
 
-    async def _select_model(self, prompt: str) -> str:
+    @staticmethod
+    def _profile_input_modalities(model_id: str) -> tuple[str, ...]:
+        try:
+            profile = _get_service().profiles.get(model_id)
+            values = getattr(profile, "input_modalities", ())
+        except Exception as exc:  # noqa: BLE001 - metadata is best effort
+            logger.warning(
+                "Could not resolve xrouter input modalities for %s: %s",
+                model_id,
+                exc,
+            )
+            return ()
+        if not isinstance(values, (list, tuple, set, frozenset)):
+            return ()
+        return tuple(
+            dict.fromkeys(
+                str(value).strip().lower() for value in values if str(value).strip()
+            )
+        )
+
+    async def _select_model(
+        self,
+        prompt: str,
+        *,
+        preferred_input_modalities: tuple[str, ...] = (),
+    ) -> str:
         # The decision loads/embeds in-process and is CPU-bound, so run it in a
         # worker thread to avoid blocking the event loop.
         try:
-            selected = await asyncio.to_thread(self._route_sync, prompt)
+            selected = await asyncio.to_thread(
+                self._route_sync,
+                prompt,
+                preferred_input_modalities,
+            )
         except Exception as exc:  # noqa: BLE001 - routing must not crash the agent
             if self._fallback_model:
                 logger.warning(
@@ -512,10 +582,53 @@ class RouterLLM(BaseLLM):
             raise RuntimeError("xrouter-llm returned no selected model")
         return str(selected[0])
 
-    def _route_sync(self, prompt: str) -> list[str]:
+    def _route_sync(
+        self,
+        prompt: str,
+        preferred_input_modalities: tuple[str, ...] = (),
+    ) -> list[str]:
         service = _get_service()
-        result = service.route(prompt, config_name=self._config_name)
+        route_kwargs: dict[str, Any] = {"config_name": self._config_name}
+        try:
+            route_parameters = dict(inspect.signature(service.route).parameters)
+        except (TypeError, ValueError):
+            route_parameters = {}
+        supports_modality_preferences = (
+            "preferred_input_modalities" in route_parameters
+            or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in route_parameters.values()
+            )
+        )
+        if preferred_input_modalities and supports_modality_preferences:
+            route_kwargs["preferred_input_modalities"] = preferred_input_modalities
+        result = service.route(prompt, **route_kwargs)
         return list(result.get("selected") or [])
+
+    @staticmethod
+    def _preferred_input_modalities(
+        messages: list[dict[str, Any]],
+    ) -> tuple[str, ...]:
+        modalities: set[str] = set()
+        for message in messages:
+            try:
+                references = normalize_context_references(message.get(CONTEXT_REFS_KEY))
+            except (TypeError, ValueError):
+                references = ()
+            modalities.update(reference.type for reference in references)
+
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                modality = _CONTENT_PART_MODALITIES.get(
+                    str(part.get("type") or "").lower()
+                )
+                if modality is not None:
+                    modalities.add(modality)
+        return tuple(sorted(modalities))
 
     @staticmethod
     def _extract_prompt(messages: list[dict[str, Any]]) -> str:
@@ -550,11 +663,18 @@ class _ResolvedRouterLLM(BaseLLM):
         downstream: BaseLLM,
         selected_model: str,
         context_window: int | None,
+        input_modalities: tuple[str, ...],
     ) -> None:
         self._router = router
         self._downstream = downstream
         self._selected_model = selected_model
         self.context_window = context_window
+        abilities = list(router.abilities)
+        for modality in input_modalities:
+            ability = _MODALITY_ABILITIES.get(modality)
+            if ability is not None and ability not in abilities:
+                abilities.append(ability)
+        self._abilities = abilities
 
     @property
     def model_id(self) -> str:
@@ -566,7 +686,7 @@ class _ResolvedRouterLLM(BaseLLM):
 
     @property
     def abilities(self) -> List[str]:
-        return self._router.abilities
+        return self._abilities
 
     @property
     def model_name(self) -> str:

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -982,6 +982,24 @@ class TaskWorkspace:
         return resolved == scoped_root or resolved.is_relative_to(scoped_root)
 
     def resolve_file_id(self, file_id: str) -> Optional[Path]:
+        return self._resolve_file_id(file_id, use_bound_db_session=True)
+
+    def resolve_file_id_detached(self, file_id: str) -> Optional[Path]:
+        """Resolve a file ID without reusing the caller's database session.
+
+        This variant is safe to invoke from a worker thread. It preserves the
+        same workspace ownership and scope checks as :meth:`resolve_file_id`,
+        while opening and closing its own session when a database lookup is
+        needed.
+        """
+        return self._resolve_file_id(file_id, use_bound_db_session=False)
+
+    def _resolve_file_id(
+        self,
+        file_id: str,
+        *,
+        use_bound_db_session: bool,
+    ) -> Optional[Path]:
         raw_file_id = str(file_id).strip()
         file_id = parse_file_id_ref(raw_file_id) or raw_file_id
         if not file_id:
@@ -1011,7 +1029,7 @@ class TaskWorkspace:
         try:
             from ..web.models.uploaded_file import UploadedFile
 
-            if self.db_session is not None:
+            if use_bound_db_session and self.db_session is not None:
                 db = self.db_session
                 should_close = False
             else:

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator
 
 import pytest
 
+from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.types import ChunkType, StreamChunk
@@ -162,6 +163,134 @@ async def test_prepare_for_call_reuses_route_and_exposes_profile_context_window(
     assert prepared.context_window == 1_048_576
     assert await prepared.chat([{"role": "user", "content": "continue"}]) == "ok"
     assert selected == ["make a podcast"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_for_call_prefers_and_exposes_context_ref_modality(
+    monkeypatch,
+):
+    downstream = _ScriptedChatLLM([])
+    router = RouterLLM(downstream_resolver=lambda _model_id: downstream)
+    selected: list[tuple[str, tuple[str, ...]]] = []
+
+    async def select_model(
+        prompt: str,
+        *,
+        preferred_input_modalities: tuple[str, ...] = (),
+    ) -> str:
+        selected.append((prompt, preferred_input_modalities))
+        return "openai/gpt-5.5"
+
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "image.png",
+            "mime_type": "image/png",
+        }
+    )
+    monkeypatch.setattr(router, "_select_model", select_model)
+    monkeypatch.setattr(router, "_profile_context_window", lambda _model_id: 128_000)
+    monkeypatch.setattr(
+        router,
+        "_profile_input_modalities",
+        lambda _model_id: ("text", "image"),
+    )
+
+    prepared = await router.prepare_for_call(
+        [
+            {
+                "role": "user",
+                "content": "inspect",
+                CONTEXT_REFS_KEY: [reference.durable_dict()],
+            }
+        ]
+    )
+
+    assert selected == [("inspect", ("image",))]
+    assert prepared.has_ability("vision")
+
+
+def test_router_detects_modalities_from_refs_and_content_parts() -> None:
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "image.png",
+            "mime_type": "image/png",
+        }
+    )
+
+    modalities = RouterLLM._preferred_input_modalities(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect"},
+                    {"type": "input_audio", "input_audio": {}},
+                ],
+                CONTEXT_REFS_KEY: [reference.durable_dict()],
+            }
+        ]
+    )
+
+    assert modalities == ("audio", "image")
+
+
+def test_route_sync_forwards_modalities_when_router_supports_them(
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class Service:
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            calls.append(
+                {
+                    "prompt": prompt,
+                    "config_name": config_name,
+                    "preferred_input_modalities": preferred_input_modalities,
+                }
+            )
+            return {"selected": ["openai/gpt-5.5"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    selected = RouterLLM()._route_sync("inspect", ("image",))
+
+    assert selected == ["openai/gpt-5.5"]
+    assert calls == [
+        {
+            "prompt": "inspect",
+            "config_name": "auto",
+            "preferred_input_modalities": ("image",),
+        }
+    ]
+
+
+def test_route_sync_keeps_older_router_api_compatible(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class Service:
+        def route(self, prompt: str, *, config_name: str) -> dict[str, Any]:
+            calls.append((prompt, config_name))
+            return {"selected": ["text/model"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    selected = RouterLLM()._route_sync("inspect", ("image",))
+
+    assert selected == ["text/model"]
+    assert calls == [("inspect", "auto")]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -8,7 +8,10 @@ import pytest
 
 from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
 from xagent.core.model.chat.basic.base import BaseLLM
-from xagent.core.model.chat.basic.router import RouterLLM
+from xagent.core.model.chat.basic.router import (
+    RouterLLM,
+    RouterModalityRoutingError,
+)
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 _OPENROUTER_TOOL_CHOICE_ERROR = (
@@ -274,12 +277,11 @@ def test_route_sync_forwards_modalities_when_router_supports_them(
     ]
 
 
-def test_route_sync_keeps_older_router_api_compatible(monkeypatch) -> None:
-    calls: list[tuple[str, str]] = []
-
+def test_route_sync_rejects_older_router_api_for_modality_requests(
+    monkeypatch,
+) -> None:
     class Service:
         def route(self, prompt: str, *, config_name: str) -> dict[str, Any]:
-            calls.append((prompt, config_name))
             return {"selected": ["text/model"]}
 
     monkeypatch.setattr(
@@ -287,10 +289,30 @@ def test_route_sync_keeps_older_router_api_compatible(monkeypatch) -> None:
         lambda: Service(),
     )
 
-    selected = RouterLLM()._route_sync("inspect", ("image",))
+    with pytest.raises(RouterModalityRoutingError, match="image"):
+        RouterLLM()._route_sync("inspect", ("image",))
 
-    assert selected == ["text/model"]
-    assert calls == [("inspect", "auto")]
+
+@pytest.mark.asyncio
+async def test_modality_support_error_is_not_hidden_by_generic_fallback(
+    monkeypatch,
+) -> None:
+    class Service:
+        def route(self, prompt: str, *, config_name: str) -> dict[str, Any]:
+            return {"selected": ["text/model"]}
+
+    monkeypatch.setenv("XAGENT_ROUTER_FALLBACK_MODEL", "fallback/model")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+    router = RouterLLM()
+
+    with pytest.raises(RouterModalityRoutingError, match="explicit compatible model"):
+        await router._select_model(
+            "inspect",
+            preferred_input_modalities=("image",),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import (
+    Agent,
+    AgentRunner,
+    ExecutionContext,
+    PatternRuntime,
+    ReActPattern,
+)
+from xagent.core.context_materializer import (
+    WorkspaceContextReferenceResolver,
+    materialize_messages,
+)
+from xagent.core.context_ref import (
+    CONTEXT_REFS_KEY,
+    ContextReference,
+    ImageDetail,
+)
+from xagent.core.model.chat.types import ChunkType, StreamChunk
+
+
+def image_reference(*, detail: ImageDetail = ImageDetail.AUTO) -> ContextReference:
+    return ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+        },
+        detail=detail,
+        text_fallback="A settings dialog",
+    )
+
+
+class Resolver:
+    async def resolve_image(self, reference: ContextReference) -> str:
+        assert reference.file_id == "image-1"
+        return "data:image/png;base64,c2NyZWVuc2hvdA=="
+
+
+class MissingResolver:
+    async def resolve_image(self, reference: ContextReference) -> str:
+        raise FileNotFoundError(reference.file_id)
+
+
+class VisionLLM:
+    abilities = ["chat", "vision"]
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] | None = None
+
+    async def chat(self, *, messages: list[dict[str, Any]], **_: Any) -> str:
+        self.messages = messages
+        return "ok"
+
+
+class TextLLM:
+    abilities = ["chat"]
+
+
+class StreamingVisionLLM(VisionLLM):
+    async def stream_chat(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        **_: Any,
+    ) -> Any:
+        self.messages = messages
+        yield StreamChunk(type=ChunkType.TOKEN, delta="visible")
+        yield StreamChunk(type=ChunkType.END)
+
+
+@pytest.mark.asyncio
+async def test_vision_materializer_expands_user_image_without_mutating_input() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": "What is visible?",
+            CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+        }
+    ]
+
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=messages,
+        resolver=Resolver(),
+    )
+
+    assert result[0]["content"][0] == {
+        "type": "text",
+        "text": "What is visible?",
+    }
+    assert result[0]["content"][1]["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
+    assert "detail" not in result[0]["content"][1]["image_url"]
+    assert CONTEXT_REFS_KEY not in result[0]
+    assert isinstance(messages[0]["content"], str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("detail", "expected"),
+    [
+        (ImageDetail.LOW, "low"),
+        (ImageDetail.HIGH, "high"),
+        (ImageDetail.ORIGINAL, "high"),
+    ],
+)
+async def test_vision_materializer_preserves_explicit_image_detail(
+    detail: ImageDetail,
+    expected: str,
+) -> None:
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=[
+            {
+                "role": "user",
+                "content": "What is visible?",
+                CONTEXT_REFS_KEY: [image_reference(detail=detail).durable_dict()],
+            }
+        ],
+        resolver=Resolver(),
+    )
+
+    assert result[0]["content"][1]["image_url"]["detail"] == expected
+
+
+@pytest.mark.asyncio
+async def test_tool_image_follows_complete_tool_result_group() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call-1", "type": "function", "function": {}},
+                {"id": "call-2", "type": "function", "function": {}},
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "captured",
+            CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+        },
+        {"role": "tool", "tool_call_id": "call-2", "content": "metadata"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=messages,
+        resolver=Resolver(),
+    )
+
+    assert [message["role"] for message in result] == [
+        "assistant",
+        "tool",
+        "tool",
+        "user",
+        "user",
+    ]
+    assert isinstance(result[3]["content"], list)
+    assert result[3]["content"][0] == {
+        "type": "text",
+        "text": "Image context for the preceding message.",
+    }
+    assert result[4]["content"] == "continue"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resolver", [None, MissingResolver()])
+async def test_unresolved_vision_reference_degrades_to_text(resolver: Any) -> None:
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=[
+            {
+                "role": "user",
+                "content": "Inspect this",
+                CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+            }
+        ],
+        resolver=resolver,
+    )
+
+    assert "file_id=image-1" in result[0]["content"]
+    assert "A settings dialog" in result[0]["content"]
+    assert "base64" not in result[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_nonvision_model_receives_file_ref_text_fallback() -> None:
+    result = await materialize_messages(
+        llm=TextLLM(),
+        messages=[
+            {
+                "role": "user",
+                "content": "Inspect this",
+                CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+            }
+        ],
+        resolver=None,
+    )
+
+    assert "file_id=image-1" in result[0]["content"]
+    assert "A settings dialog" in result[0]["content"]
+    assert "base64" not in result[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_enforces_size_limit_and_caches(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "frame.png"
+    image_path.write_bytes(b"image")
+
+    class Workspace:
+        calls = 0
+
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            self.calls += 1
+            return image_path
+
+    workspace = Workspace()
+    resolver = WorkspaceContextReferenceResolver(
+        workspace,
+        cache_size=1,
+        max_image_bytes=5,
+    )
+
+    first = await resolver.resolve_image(image_reference())
+    second = await resolver.resolve_image(image_reference())
+
+    assert first == second
+    assert workspace.calls == 1
+
+    image_path.write_bytes(b"too-large")
+    resolver.clear()
+    with pytest.raises(RuntimeError, match="exceeds"):
+        await resolver.resolve_image(image_reference())
+
+
+@pytest.mark.asyncio
+async def test_runtime_materializes_chat_and_streaming_calls() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": "Inspect",
+            CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+        }
+    ]
+
+    chat_llm = VisionLLM()
+    runtime = PatternRuntime(context_ref_resolver=Resolver())
+    assert await runtime.run_llm_call(chat_llm, messages=messages) == "ok"
+    assert chat_llm.messages is not None
+    assert isinstance(chat_llm.messages[0]["content"], list)
+
+    stream_llm = StreamingVisionLLM()
+    assert (
+        await runtime.run_streaming_llm_call(stream_llm, messages=messages) == "visible"
+    )
+    assert stream_llm.messages is not None
+    assert isinstance(stream_llm.messages[0]["content"], list)
+    assert isinstance(messages[0]["content"], str)
+    assert CONTEXT_REFS_KEY in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_react_materializes_refs_only_at_llm_boundary() -> None:
+    class ReactLLM(VisionLLM):
+        async def chat(
+            self,
+            *,
+            messages: list[dict[str, Any]],
+            **_: Any,
+        ) -> dict[str, Any]:
+            self.messages = messages
+            return {"content": "The dialog is visible.", "done": True}
+
+    context = ExecutionContext(system_prompt="Inspect the image.")
+    context.add_user_message("What is visible?", context_refs=[image_reference()])
+    runtime = PatternRuntime(context_ref_resolver=Resolver())
+    llm = ReactLLM()
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert llm.messages is not None
+    provider_user_message = next(
+        message for message in llm.messages if message["role"] == "user"
+    )
+    assert provider_user_message["content"][1]["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
+    durable_payload = json.dumps(context.to_dict())
+    assert "image-1" in durable_payload
+    assert "base64" not in durable_payload
+
+
+@pytest.mark.asyncio
+async def test_agent_runner_supplies_workspace_resolver(tmp_path: Path) -> None:
+    captured: list[Any] = []
+
+    class Pattern:
+        async def run(self, *, runtime: PatternRuntime, **_: Any) -> dict[str, Any]:
+            captured.append(runtime.context_ref_resolver)
+            return {"success": True, "output": "done"}
+
+    agent = Agent(name="resolver-test", patterns=[Pattern()])
+    runner = AgentRunner(
+        agent,
+        workspace_base_dir=str(tmp_path),
+    )
+
+    result = await runner.run("inspect an attachment", execution_id="resolver-test")
+
+    assert result["success"] is True
+    assert isinstance(captured[0], WorkspaceContextReferenceResolver)

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from pathlib import Path
@@ -300,6 +301,45 @@ async def test_workspace_resolver_bounds_cache_by_encoded_bytes(
     assert read_calls == 3
     assert len(resolver._cache) == 1
     assert resolver._cache_bytes <= 35
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_counts_concurrent_same_key_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = tmp_path / "frame.png"
+    image_path.write_bytes(b"image")
+    read_barrier = threading.Barrier(2)
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            return image_path
+
+    resolver = WorkspaceContextReferenceResolver(Workspace())
+    original_read_generation = resolver._read_generation
+
+    def synchronized_read_generation(*args: Any) -> bytes:
+        read_barrier.wait(timeout=5)
+        return original_read_generation(*args)
+
+    monkeypatch.setattr(
+        resolver,
+        "_read_generation",
+        synchronized_read_generation,
+    )
+
+    first, second = await asyncio.gather(
+        resolver.resolve_image(image_reference()),
+        resolver.resolve_image(image_reference()),
+    )
+
+    assert first == second
+    assert len(resolver._cache) == 1
+    assert resolver._cache_bytes == sum(
+        entry.encoded_bytes for entry in resolver._cache.values()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -215,6 +216,7 @@ async def test_nonvision_model_receives_file_ref_text_fallback() -> None:
 @pytest.mark.asyncio
 async def test_workspace_resolver_enforces_size_limit_and_caches(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     image_path = tmp_path / "frame.png"
     image_path.write_bytes(b"image")
@@ -233,17 +235,83 @@ async def test_workspace_resolver_enforces_size_limit_and_caches(
         cache_size=1,
         max_image_bytes=5,
     )
+    read_calls = 0
+    original_read_generation = resolver._read_generation
+
+    def counted_read_generation(*args: Any) -> bytes:
+        nonlocal read_calls
+        read_calls += 1
+        return original_read_generation(*args)
+
+    monkeypatch.setattr(resolver, "_read_generation", counted_read_generation)
 
     first = await resolver.resolve_image(image_reference())
     second = await resolver.resolve_image(image_reference())
 
     assert first == second
-    assert workspace.calls == 1
+    assert workspace.calls == 2
+    assert read_calls == 1
 
     image_path.write_bytes(b"too-large")
     resolver.clear()
     with pytest.raises(RuntimeError, match="exceeds"):
         await resolver.resolve_image(image_reference())
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_invalidates_cache_when_file_id_generation_changes(
+    tmp_path: Path,
+) -> None:
+    first_path = tmp_path / "first.png"
+    second_path = tmp_path / "second.png"
+    first_path.write_bytes(b"first")
+    second_path.write_bytes(b"second")
+
+    class Workspace:
+        current_path = first_path
+
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            return self.current_path
+
+    workspace = Workspace()
+    resolver = WorkspaceContextReferenceResolver(workspace)
+
+    first = await resolver.resolve_image(image_reference())
+    workspace.current_path = second_path
+    second = await resolver.resolve_image(image_reference())
+
+    assert first.endswith("Zmlyc3Q=")
+    assert second.endswith("c2Vjb25k")
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_prefers_detached_resolution_off_event_loop(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "frame.png"
+    image_path.write_bytes(b"image")
+    event_loop_thread = threading.get_ident()
+
+    class Workspace:
+        resolver_thread: int | None = None
+
+        def resolve_file_id(self, file_id: str) -> Path:
+            raise AssertionError("bound-session resolver must not be used")
+
+        def resolve_file_id_detached(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            self.resolver_thread = threading.get_ident()
+            return image_path
+
+    workspace = Workspace()
+    resolver = WorkspaceContextReferenceResolver(workspace)
+
+    await resolver.resolve_image(image_reference())
+
+    assert workspace.resolver_thread is not None
+    assert workspace.resolver_thread != event_loop_thread
 
 
 @pytest.mark.asyncio
@@ -307,6 +375,34 @@ async def test_react_materializes_refs_only_at_llm_boundary() -> None:
     durable_payload = json.dumps(context.to_dict())
     assert "image-1" in durable_payload
     assert "base64" not in durable_payload
+
+
+@pytest.mark.asyncio
+async def test_llm_compaction_retains_and_materializes_older_context_refs() -> None:
+    context = ExecutionContext(system_prompt="Inspect the image.")
+    context.add_user_message("What was visible?", context_refs=[image_reference()])
+    context.add_assistant_message("I will inspect it.")
+    context.add_user_message("Continue from the prior image.")
+
+    result = context.compact_with_llm_response("The image still needs inspection.")
+
+    assert result.compacted is True
+    assert context.messages[0].context_refs == (image_reference(),)
+    assert context.messages[1].context_refs == ()
+    assert "base64" not in json.dumps(context.to_dict())
+
+    materialized = await materialize_messages(
+        llm=VisionLLM(),
+        messages=context.get_messages_for_llm(),
+        resolver=Resolver(),
+    )
+
+    continuity = next(
+        message for message in materialized if isinstance(message.get("content"), list)
+    )
+    assert continuity["content"][1]["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import xagent.core.context_materializer as context_materializer
 from xagent.core.agent import (
     Agent,
     AgentRunner,
@@ -15,6 +16,7 @@ from xagent.core.agent import (
     ReActPattern,
 )
 from xagent.core.context_materializer import (
+    ContextReferenceResolutionError,
     WorkspaceContextReferenceResolver,
     materialize_messages,
 )
@@ -26,11 +28,15 @@ from xagent.core.context_ref import (
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 
-def image_reference(*, detail: ImageDetail = ImageDetail.AUTO) -> ContextReference:
+def image_reference(
+    *,
+    detail: ImageDetail = ImageDetail.AUTO,
+    file_id: str = "image-1",
+) -> ContextReference:
     return ContextReference(
         file_ref={
-            "file_id": "image-1",
-            "filename": "frame.png",
+            "file_id": file_id,
+            "filename": f"{file_id}.png",
             "mime_type": "image/png",
         },
         detail=detail,
@@ -253,9 +259,47 @@ async def test_workspace_resolver_enforces_size_limit_and_caches(
     assert read_calls == 1
 
     image_path.write_bytes(b"too-large")
-    resolver.clear()
     with pytest.raises(RuntimeError, match="exceeds"):
         await resolver.resolve_image(image_reference())
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_bounds_cache_by_encoded_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_path = tmp_path / "first.png"
+    second_path = tmp_path / "second.png"
+    first_path.write_bytes(b"first")
+    second_path.write_bytes(b"second")
+    paths = {"image-1": first_path, "image-2": second_path}
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            return paths[file_id]
+
+    resolver = WorkspaceContextReferenceResolver(
+        Workspace(),
+        cache_size=8,
+        max_cache_bytes=35,
+    )
+    read_calls = 0
+    original_read_generation = resolver._read_generation
+
+    def counted_read_generation(*args: Any) -> bytes:
+        nonlocal read_calls
+        read_calls += 1
+        return original_read_generation(*args)
+
+    monkeypatch.setattr(resolver, "_read_generation", counted_read_generation)
+
+    await resolver.resolve_image(image_reference(file_id="image-1"))
+    await resolver.resolve_image(image_reference(file_id="image-2"))
+    await resolver.resolve_image(image_reference(file_id="image-1"))
+
+    assert read_calls == 3
+    assert len(resolver._cache) == 1
+    assert resolver._cache_bytes <= 35
 
 
 @pytest.mark.asyncio
@@ -284,6 +328,62 @@ async def test_workspace_resolver_invalidates_cache_when_file_id_generation_chan
     assert first.endswith("Zmlyc3Q=")
     assert second.endswith("c2Vjb25k")
     assert first != second
+
+
+@pytest.mark.asyncio
+async def test_materializer_rejects_image_request_over_token_budget() -> None:
+    class VisionLLMWithContextWindow(VisionLLM):
+        context_window = 32_768
+
+    references = [
+        image_reference(detail=ImageDetail.HIGH, file_id=f"image-{index}")
+        for index in range(12)
+    ]
+
+    with pytest.raises(
+        ContextReferenceResolutionError,
+        match="materialization token budget",
+    ):
+        await materialize_messages(
+            llm=VisionLLMWithContextWindow(),
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Inspect every image",
+                    CONTEXT_REFS_KEY: [
+                        reference.durable_dict() for reference in references
+                    ],
+                }
+            ],
+            resolver=Resolver(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_materializer_rejects_aggregate_materialized_image_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        context_materializer,
+        "_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST",
+        32,
+    )
+
+    with pytest.raises(
+        ContextReferenceResolutionError,
+        match="materialized byte budget",
+    ):
+        await materialize_messages(
+            llm=VisionLLM(),
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Inspect this image",
+                    CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+                }
+            ],
+            resolver=Resolver(),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -175,6 +175,25 @@ def test_durable_dict_resanitizes_nested_mutations() -> None:
         reference.durable_dict()
 
 
+@pytest.mark.parametrize(
+    ("unsafe_key", "message"),
+    [
+        ("data:image/png;base64,c2NyZWVuc2hvdA==", "materialized image data"),
+        ("/private/frame.png", "absolute filesystem paths"),
+        (r"\\server\share\frame.png", "absolute filesystem paths"),
+    ],
+)
+def test_durable_dict_rejects_sensitive_metadata_keys(
+    unsafe_key: str,
+    message: str,
+) -> None:
+    reference = image_reference()
+    reference.metadata[unsafe_key] = "value"
+
+    with pytest.raises(ValueError, match=message):
+        reference.durable_dict()
+
+
 def test_context_reference_survives_checkpoint_round_trip() -> None:
     context = ExecutionContext(execution_id="execution-1")
     context.add_user_message("inspect", context_refs=[image_reference()])

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -6,7 +6,11 @@ import pytest
 from pydantic import ValidationError
 
 from xagent.core.agent.context import ExecutionContext, Message
-from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
+from xagent.core.context_ref import (
+    CONTEXT_REFS_KEY,
+    ContextReference,
+    ImageDetail,
+)
 
 
 def image_reference() -> ContextReference:
@@ -92,6 +96,30 @@ def test_context_reference_rejects_paths_nested_in_metadata() -> None:
                 "mime_type": "image/png",
             },
             metadata={"source": "/private/frame.png"},
+        )
+
+
+def test_context_reference_validates_json_normalized_tuple_metadata() -> None:
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+        },
+        metadata={"viewport": (1280, 720)},
+    )
+
+    assert reference.metadata == {"viewport": [1280, 720]}
+    assert ContextReference.model_validate(reference.durable_dict()) == reference
+
+    with pytest.raises(ValidationError, match="absolute filesystem paths"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata={"values": ("/private/frame.png",)},
         )
 
 
@@ -188,3 +216,31 @@ def test_llm_compaction_deduplicates_refs_already_on_latest_user() -> None:
 
     assert context.messages[0].context_refs == ()
     assert context.messages[1].context_refs == (image_reference(),)
+
+
+def test_llm_compaction_bounds_structured_refs_and_keeps_recent_handles() -> None:
+    context = ExecutionContext()
+    for index in range(5):
+        context.add_user_message(
+            f"inspect {index}",
+            context_refs=[
+                ContextReference(
+                    file_ref={
+                        "file_id": f"image-{index}",
+                        "filename": f"frame-{index}.png",
+                        "mime_type": "image/png",
+                    },
+                    detail=ImageDetail.HIGH,
+                )
+            ],
+        )
+    context.add_user_message("continue")
+
+    result = context.compact_with_llm_response("Continue the image analysis.")
+
+    retained_ids = [reference.file_id for reference in context.messages[0].context_refs]
+    assert retained_ids == ["image-3", "image-4"]
+    assert "file_id=image-2" in context.messages[0].content
+    assert "file_id=image-0" in context.messages[0].content
+    assert result.metadata["retained_context_ref_count"] == 2
+    assert result.metadata["dropped_context_ref_count"] == 3

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -99,6 +99,30 @@ def test_context_reference_rejects_paths_nested_in_metadata() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"source": r"\\server\share\frame.png"},
+        {"source": r"\rooted\frame.png"},
+        {"source": "//server/share/frame.png"},
+        {"capture": {"source": r"\\server\share\frame.png"}},
+        {"values": [r"\rooted\frame.png"]},
+    ],
+)
+def test_context_reference_rejects_cross_platform_absolute_metadata_paths(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="absolute filesystem paths"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata=metadata,
+        )
+
+
 def test_context_reference_validates_json_normalized_tuple_metadata() -> None:
     reference = ContextReference(
         file_ref={

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -73,6 +73,40 @@ def test_context_reference_rejects_materialized_image_in_metadata() -> None:
         )
 
 
+def test_context_reference_rejects_paths_nested_in_metadata() -> None:
+    with pytest.raises(ValidationError, match="must not contain a path"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata={"capture": {"file_path": "/private/frame.png"}},
+        )
+
+    with pytest.raises(ValidationError, match="absolute filesystem paths"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata={"source": "/private/frame.png"},
+        )
+
+
+def test_context_reference_rejects_materialized_image_in_text_fallback() -> None:
+    with pytest.raises(ValidationError, match="text_fallback"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            text_fallback="data:image/png;base64,c2NyZWVuc2hvdA==",
+        )
+
+
 def test_durable_dict_resanitizes_nested_mutations() -> None:
     reference = image_reference()
     reference.file_ref["file_path"] = "/private/late-mutation.png"
@@ -83,6 +117,10 @@ def test_durable_dict_resanitizes_nested_mutations() -> None:
 
     reference.metadata.pop("image")
     assert "file_path" not in reference.durable_dict()["file_ref"]
+
+    reference.metadata["capture"] = {"file_path": "/private/late-mutation.png"}
+    with pytest.raises(ValueError, match="must not contain a path"):
+        reference.durable_dict()
 
 
 def test_context_reference_survives_checkpoint_round_trip() -> None:
@@ -138,3 +176,15 @@ def test_compaction_transcript_preserves_file_id_without_binary_data() -> None:
     assert "file_id=image-1" in transcript
     assert "base64" not in transcript
     assert context.estimate_context_tokens() > len("inspect") // 4
+
+
+def test_llm_compaction_deduplicates_refs_already_on_latest_user() -> None:
+    context = ExecutionContext()
+    context.add_user_message("inspect", context_refs=[image_reference()])
+    context.add_assistant_message("continuing")
+    context.add_user_message("use it again", context_refs=[image_reference()])
+
+    context.compact_with_llm_response("Continue inspecting the same image.")
+
+    assert context.messages[0].context_refs == ()
+    assert context.messages[1].context_refs == (image_reference(),)

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -123,6 +123,43 @@ def test_context_reference_rejects_cross_platform_absolute_metadata_paths(
         )
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"description": "saved at (/private/frame.png)"},
+        {"capture": {"description": "file:///private/frame.png"}},
+        {"values": [r"source=C:\Users\name\frame.png"]},
+        {"description": r"saved at (\\server\share\frame.png)"},
+        {"description": r"source=\rooted\frame.png"},
+    ],
+)
+def test_context_reference_rejects_embedded_absolute_metadata_paths(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="absolute filesystem paths"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata=metadata,
+        )
+
+
+def test_context_reference_allows_remote_urls_with_path_segments() -> None:
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+        },
+        metadata={"source": "https://example.com/private/frame.png"},
+    )
+
+    assert reference.metadata["source"] == "https://example.com/private/frame.png"
+
+
 def test_context_reference_validates_json_normalized_tuple_metadata() -> None:
     reference = ContextReference(
         file_ref={
@@ -172,6 +209,12 @@ def test_durable_dict_resanitizes_nested_mutations() -> None:
 
     reference.metadata["capture"] = {"file_path": "/private/late-mutation.png"}
     with pytest.raises(ValueError, match="must not contain a path"):
+        reference.durable_dict()
+
+    reference.metadata["capture"] = {
+        "description": "saved at (/private/late-mutation.png)"
+    }
+    with pytest.raises(ValueError, match="absolute filesystem paths"):
         reference.durable_dict()
 
 

--- a/tests/core/test_context_ref.py
+++ b/tests/core/test_context_ref.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from xagent.core.agent.context import ExecutionContext, Message
+from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
+
+
+def image_reference() -> ContextReference:
+    return ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+            "file_path": "/private/frame.png",
+        },
+        text_fallback="A settings dialog",
+    )
+
+
+def test_legacy_message_payload_is_unchanged_without_refs() -> None:
+    message = Message(role="user", content="hello")
+
+    assert message.to_dict() == {"role": "user", "content": "hello"}
+
+
+def test_message_payload_contains_only_durable_reference() -> None:
+    message = Message(
+        role="user",
+        content="inspect",
+        context_refs=(image_reference(),),
+    )
+
+    payload = message.to_dict()
+
+    assert payload["content"] == "inspect"
+    assert payload[CONTEXT_REFS_KEY][0]["file_ref"]["file_id"] == "image-1"
+    assert "file_path" not in json.dumps(payload)
+    assert "base64" not in json.dumps(payload)
+
+
+def test_context_reference_requires_registered_image_file_ref() -> None:
+    with pytest.raises(ValidationError, match="registered file_id"):
+        ContextReference(
+            file_ref={
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            }
+        )
+
+    with pytest.raises(ValidationError, match="image MIME type"):
+        ContextReference(
+            file_ref={
+                "file_id": "file-1",
+                "filename": "notes.txt",
+                "mime_type": "text/plain",
+            }
+        )
+
+
+def test_context_reference_rejects_materialized_image_in_metadata() -> None:
+    with pytest.raises(ValidationError, match="materialized image data"):
+        ContextReference(
+            file_ref={
+                "file_id": "image-1",
+                "filename": "frame.png",
+                "mime_type": "image/png",
+            },
+            metadata={"image": "data:image/png;base64,c2NyZWVuc2hvdA=="},
+        )
+
+
+def test_durable_dict_resanitizes_nested_mutations() -> None:
+    reference = image_reference()
+    reference.file_ref["file_path"] = "/private/late-mutation.png"
+    reference.metadata["image"] = "data:image/png;base64,c2NyZWVuc2hvdA=="
+
+    with pytest.raises(ValueError, match="materialized image data"):
+        reference.durable_dict()
+
+    reference.metadata.pop("image")
+    assert "file_path" not in reference.durable_dict()["file_ref"]
+
+
+def test_context_reference_survives_checkpoint_round_trip() -> None:
+    context = ExecutionContext(execution_id="execution-1")
+    context.add_user_message("inspect", context_refs=[image_reference()])
+
+    serialized = context.to_dict()
+    restored = ExecutionContext.from_dict(serialized)
+
+    assert restored.messages[0].context_refs == (image_reference(),)
+    assert "file_path" not in json.dumps(serialized)
+    assert "base64" not in json.dumps(serialized)
+
+
+def test_tool_result_reserved_envelope_moves_refs_onto_message() -> None:
+    context = ExecutionContext()
+
+    message = context.add_tool_result(
+        "inspect_asset",
+        {
+            "success": True,
+            CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+        },
+        tool_call_id="call-1",
+    )
+
+    assert message.context_refs == (image_reference(),)
+    assert CONTEXT_REFS_KEY not in message.metadata["raw_result"]
+    assert CONTEXT_REFS_KEY not in message.content
+
+
+def test_tool_result_deduplicates_explicit_and_embedded_refs() -> None:
+    context = ExecutionContext()
+
+    message = context.add_tool_result(
+        "inspect_asset",
+        {
+            "success": True,
+            CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+        },
+        context_refs=[image_reference()],
+    )
+
+    assert message.context_refs == (image_reference(),)
+
+
+def test_compaction_transcript_preserves_file_id_without_binary_data() -> None:
+    context = ExecutionContext()
+    context.add_user_message("inspect", context_refs=[image_reference()])
+
+    transcript = context._compact_transcript(context.messages)
+
+    assert "file_id=image-1" in transcript
+    assert "base64" not in transcript
+    assert context.estimate_context_tokens() > len("inspect") // 4

--- a/tests/core/test_file_ref.py
+++ b/tests/core/test_file_ref.py
@@ -4,6 +4,7 @@ from xagent.core.file_ref import (
     build_file_id_ref,
     build_file_ref,
     parse_file_id_ref,
+    sanitize_file_ref_for_context,
 )
 
 
@@ -64,3 +65,39 @@ def test_build_file_ref_uses_canonical_file_id_ref() -> None:
 def test_build_file_id_ref_rejects_path_like_values(file_id: str) -> None:
     with pytest.raises(ValueError):
         build_file_id_ref(file_id)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        r"C:\Users\name\file.png",
+        r"..\secret.png",
+        r"images\..\secret.png",
+        r"\\server\share\file.png",
+        r"\rooted\file.png",
+    ],
+)
+def test_context_file_ref_rejects_windows_shaped_paths(relative_path: str) -> None:
+    result = sanitize_file_ref_for_context(
+        {
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+            "relative_path": relative_path,
+        }
+    )
+
+    assert "relative_path" not in result
+
+
+def test_context_file_ref_normalizes_safe_windows_separators() -> None:
+    result = sanitize_file_ref_for_context(
+        {
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+            "relative_path": r"images\frame.png",
+        }
+    )
+
+    assert result["relative_path"] == "images/frame.png"

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -391,6 +391,47 @@ class TestWorkspaceFileToolConsistency:
 
         assert workspace.resolve_file_id("foreign-file") is None
 
+    def test_resolve_file_id_detached_uses_worker_owned_session(self, tmp_path, mocker):
+        """Detached resolution must not reuse the caller's SQLAlchemy session."""
+        registered_file = tmp_path / "registered.txt"
+        registered_file.write_text("content")
+        workspace = TaskWorkspace("web_task_10", str(tmp_path))
+
+        class BoundSession:
+            def query(self, *_args):
+                raise AssertionError("caller-owned session must not be reused")
+
+        class FakeQuery:
+            def filter(self, *_args):
+                return self
+
+            def first(self):
+                return SimpleNamespace(
+                    file_id="registered-file",
+                    user_id=1,
+                    task_id=None,
+                    storage_path=str(registered_file),
+                )
+
+        class WorkerSession:
+            closed = False
+
+            def query(self, *_args):
+                return FakeQuery()
+
+            def close(self):
+                self.closed = True
+
+        worker_session = WorkerSession()
+        workspace.db_session = BoundSession()
+        mocker.patch(
+            "xagent.core.storage.manager.create_db_session",
+            return_value=worker_session,
+        )
+
+        assert workspace.resolve_file_id_detached("registered-file") == registered_file
+        assert worker_session.closed is True
+
     def test_resolve_file_id_rejects_durable_only_other_user_records(
         self, tmp_path, mocker
     ):


### PR DESCRIPTION
## Summary

- add a durable `ContextReference` protocol backed by registered, sanitized `FileRef` values
- preserve references across messages, checkpoints, compaction, and tool-result boundaries without persisting image bytes or host paths
- materialize image references only at the LLM call boundary for vision-capable models; degrade unresolved or non-vision inputs to safe text/FileRef context
- teach the auto router to prefer matching input modalities and expose the selected model's resolved abilities
- keep resolver memory bounded with size, TTL, and LRU limits

## Scope

This is the generic context/runtime layer only. It intentionally contains no browser, desktop, relay, target-selection, screenshot-frame, or Computer Use product implementation.

## Validation

- `PYTHONPATH=src pytest -q tests/core/agent tests/core/test_context_ref.py tests/core/test_context_materializer.py tests/core/test_file_ref.py tests/core/model/chat/basic/test_router.py`
- `pre-commit run --all-files`
- diff boundary audit for Computer Use-specific concepts