### PR TITLE
fix(widget): remove mocked demo agents from the chat start screen

### DIFF
--- a/frontend/src/components/chat/ChatStartScreen.test.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: () => "http://api.local",
+}))
+
+vi.mock("@/components/chat/ChatInput", () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}))
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
+
+const AGENTS_SECTION = "chatPage.sections.chatWithAgents"
+
+// The agents block only renders inside the prompts branch, so every case needs
+// a non-empty prompts list to reach it at all.
+const renderScreen = (agents?: React.ComponentProps<typeof ChatStartScreen>["agents"]) =>
+  render(
+    <ChatStartScreen
+      title="Support Agent"
+      prompts={["Summarize this page"]}
+      agents={agents}
+      onSend={vi.fn()}
+    />
+  )
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("ChatStartScreen agents section", () => {
+  it("renders nothing when no agent list is passed", () => {
+    renderScreen(undefined)
+
+    expect(screen.queryByText(AGENTS_SECTION)).toBeNull()
+  })
+
+  it("renders nothing for an empty agent list", () => {
+    renderScreen([])
+
+    expect(screen.queryByText(AGENTS_SECTION)).toBeNull()
+  })
+
+  it("renders the agents that were passed", () => {
+    renderScreen([{ id: 7, name: "Billing Agent" }])
+
+    expect(screen.getByText(AGENTS_SECTION)).toBeTruthy()
+    expect(screen.getByText("Billing Agent")).toBeTruthy()
+  })
+})

--- a/frontend/src/components/chat/ChatStartScreen.test.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.test.tsx
@@ -8,10 +8,6 @@ vi.mock("@/contexts/i18n-context", () => ({
   }),
 }))
 
-vi.mock("@/lib/utils", () => ({
-  getApiUrl: () => "http://api.local",
-}))
-
 vi.mock("@/components/chat/ChatInput", () => ({
   ChatInput: () => <div data-testid="chat-input" />,
 }))
@@ -26,6 +22,10 @@ vi.mock("@/components/ui/tooltip", () => ({
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 
 const AGENTS_SECTION = "chatPage.sections.chatWithAgents"
+// t() is mocked as identity, so the deleted demo cards would surface as their
+// literal keys — assert on those directly rather than only on the header they
+// happened to share a branch with.
+const MOCKED_AGENT_KEYS = /chatPage\.agents\./
 
 // The agents block only renders inside the prompts branch, so every case needs
 // a non-empty prompts list to reach it at all.
@@ -48,12 +48,14 @@ describe("ChatStartScreen agents section", () => {
     renderScreen(undefined)
 
     expect(screen.queryByText(AGENTS_SECTION)).toBeNull()
+    expect(screen.queryByText(MOCKED_AGENT_KEYS)).toBeNull()
   })
 
   it("renders nothing for an empty agent list", () => {
     renderScreen([])
 
     expect(screen.queryByText(AGENTS_SECTION)).toBeNull()
+    expect(screen.queryByText(MOCKED_AGENT_KEYS)).toBeNull()
   })
 
   it("renders the agents that were passed", () => {

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Bot, Sparkles, Smartphone } from "lucide-react";
+import { Bot, Sparkles } from "lucide-react";
 import { ChatInput } from "@/components/chat/ChatInput";
 import { useI18n } from "@/contexts/i18n-context";
 import {
@@ -167,7 +167,7 @@ export function ChatStartScreen({
             </div>
 
             {/* Chat with Agents section */}
-            {(agents && agents.length > 0) || !agents ? (
+            {agents && agents.length > 0 ? (
               <>
                 <div className="flex items-center gap-2 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] mt-6 px-1">
                   <Bot className="w-3.5 h-3.5" />
@@ -176,63 +176,39 @@ export function ChatStartScreen({
                 {/* Horizontal scroll container for agents, limited width to show about 3 items initially */}
                 <TooltipProvider delayDuration={200}>
                   <div className="flex gap-8 mt-4 overflow-x-auto pb-4 pt-2 px-1 snap-x snap-mandatory scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
-                    {agents ? (
-                      agents.map((agent) => {
-                        const isSelected = selectedAgents.some(
-                          (selectedAgent) => selectedAgent.id === agent.id
-                        );
+                    {agents.map((agent) => {
+                      const isSelected = selectedAgents.some(
+                        (selectedAgent) => selectedAgent.id === agent.id
+                      );
 
-                        return (
-                          <Tooltip key={agent.id}>
-                            <TooltipTrigger asChild>
-                              <div
-                                className="flex flex-col items-center gap-2 cursor-pointer group flex-shrink-0 snap-start w-[64px]"
-                                onClick={() => onAgentClick?.(agent)}
-                              >
-                                <div className={`w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 shadow-sm border overflow-hidden transition-all ${isSelected ? "border-primary ring-2 ring-primary/20" : "border-blue-200 group-hover:shadow-md"}`}>
-                                  {agent.logo_url ? (
-                                    <img src={agent.logo_url.startsWith('http') ? agent.logo_url : `${getApiUrl()}${agent.logo_url}`} alt={agent.name} className="w-full h-full object-cover" />
-                                  ) : (
-                                    <Bot className="w-6 h-6" />
-                                  )}
-                                </div>
-                                <span className={`text-xs font-medium text-center leading-tight max-w-[64px] line-clamp-2 ${isSelected ? "text-primary" : "text-muted-foreground"}`} title={agent.name}>{agent.name}</span>
+                      return (
+                        <Tooltip key={agent.id}>
+                          <TooltipTrigger asChild>
+                            <div
+                              className="flex flex-col items-center gap-2 cursor-pointer group flex-shrink-0 snap-start w-[64px]"
+                              onClick={() => onAgentClick?.(agent)}
+                            >
+                              <div className={`w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 shadow-sm border overflow-hidden transition-all ${isSelected ? "border-primary ring-2 ring-primary/20" : "border-blue-200 group-hover:shadow-md"}`}>
+                                {agent.logo_url ? (
+                                  <img src={agent.logo_url.startsWith('http') ? agent.logo_url : `${getApiUrl()}${agent.logo_url}`} alt={agent.name} className="w-full h-full object-cover" />
+                                ) : (
+                                  <Bot className="w-6 h-6" />
+                                )}
                               </div>
-                            </TooltipTrigger>
-                            {agent.description ? (
-                              <TooltipContent side="top" className="max-w-[240px] text-left">
-                                <div className="space-y-1">
-                                  <div className="font-medium">{agent.name}</div>
-                                  <p className="text-xs text-muted-foreground">{agent.description}</p>
-                                </div>
-                              </TooltipContent>
-                            ) : null}
-                          </Tooltip>
-                        );
-                      })
-                    ) : (
-                      // Fallback mocked agents to match design if no agents prop provided
-                      <>
-                        <div className="flex flex-col items-center gap-2 cursor-pointer group flex-shrink-0 snap-start w-[64px]">
-                          <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 shadow-sm border border-blue-200 group-hover:shadow-md transition-all">
-                            <Bot className="w-6 h-6" />
-                          </div>
-                          <span className="text-xs text-muted-foreground font-medium text-center leading-tight max-w-[64px]">{t("chatPage.agents.researcher")}</span>
-                        </div>
-                        <div className="flex flex-col items-center gap-2 cursor-pointer group flex-shrink-0 snap-start w-[64px]">
-                          <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center text-purple-600 shadow-sm border border-purple-200 group-hover:shadow-md transition-all">
-                            <Sparkles className="w-6 h-6" />
-                          </div>
-                          <span className="text-xs text-muted-foreground font-medium text-center leading-tight max-w-[64px]">{t("chatPage.agents.poster")}</span>
-                        </div>
-                        <div className="flex flex-col items-center gap-2 cursor-pointer group flex-shrink-0 snap-start w-[64px]">
-                          <div className="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center text-blue-500 shadow-sm border border-blue-200 group-hover:shadow-md transition-all">
-                            <Smartphone className="w-6 h-6" />
-                          </div>
-                          <span className="text-xs text-muted-foreground font-medium text-center leading-tight max-w-[64px]">{t("chatPage.agents.linkedin")}</span>
-                        </div>
-                      </>
-                    )}
+                              <span className={`text-xs font-medium text-center leading-tight max-w-[64px] line-clamp-2 ${isSelected ? "text-primary" : "text-muted-foreground"}`} title={agent.name}>{agent.name}</span>
+                            </div>
+                          </TooltipTrigger>
+                          {agent.description ? (
+                            <TooltipContent side="top" className="max-w-[240px] text-left">
+                              <div className="space-y-1">
+                                <div className="font-medium">{agent.name}</div>
+                                <p className="text-xs text-muted-foreground">{agent.description}</p>
+                              </div>
+                            </TooltipContent>
+                          ) : null}
+                        </Tooltip>
+                      );
+                    })}
                   </div>
                 </TooltipProvider>
               </>

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -167,7 +167,7 @@ export function ChatStartScreen({
             </div>
 
             {/* Chat with Agents section */}
-            {agents && agents.length > 0 ? (
+            {agents && agents.length > 0 && (
               <>
                 <div className="flex items-center gap-2 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] mt-6 px-1">
                   <Bot className="w-3.5 h-3.5" />
@@ -212,7 +212,7 @@ export function ChatStartScreen({
                   </div>
                 </TooltipProvider>
               </>
-            ) : null}
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -214,11 +214,6 @@ const en = {
       startingPrompts: "STARTING PROMPTS",
       chatWithAgents: "CHAT WITH AGENTS",
     },
-    agents: {
-      researcher: "Researcher Agent",
-      poster: "Poster Maker",
-      linkedin: "LinkedIn Post Creator",
-    },
     cards: {
       research: {
         title: "Research a topic in depth",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -214,11 +214,6 @@ const zh = {
       startingPrompts: "快捷指令",
       chatWithAgents: "与智能体聊天",
     },
-    agents: {
-      researcher: "研究助手",
-      poster: "海报设计师",
-      linkedin: "LinkedIn 发帖助手",
-    },
     cards: {
       research: {
         title: "深入研究一个话题",


### PR DESCRIPTION
Closes #1038

## Problem

The chat start screen shows three agents — "Researcher Agent", "Poster Maker",
"LinkedIn Post Creator" — that exist in no deployment. They are hardcoded design
placeholders, they are not clickable, and in the embedded widget they look like
agents the tenant configured.

`ChatStartScreen.tsx:170` rendered the "chat with agents" block even when no list
was passed (`(agents && agents.length > 0) || !agents`) and then fell through to
mocked markup. Both callers that omit `agents` were affected:

- `src/components/widget/public-agent-chat-page.tsx:377` — widget and share chat
- `src/app/agent/[id]/page-client.tsx:152` — agent detail page

`src/app/task/page.tsx:243` passes a real list, so it never hit the fallback.

## Change

- Require a real list: `{agents && agents.length > 0 ? (`
- Delete the mocked markup and the now-unused `Smartphone` import
- Drop the `chatPage.agents.{researcher,poster,linkedin}` keys from `en.ts` / `zh.ts`
  (`cards.linkedin` and `cards.design_poster` are prompt-card copy and stay)

No behaviour change for the internal task page.

## Tests

New `ChatStartScreen.test.tsx`: the agents section is absent when `agents` is
`undefined` and when it is empty, and renders the passed agents otherwise.

`vitest run src/components/chat src/components/widget src/components/task` — 96 passed.
`npm run lint` and `npm run type-check` pass.