### PR TITLE
fix(ci): pin the mypy hook to the project's resolved mcp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,12 @@ repos:
           - chromadb
           - openpyxl
           - types-openpyxl
-          - mcp
+          # Pin to the project's resolved mcp (uv.lock). Unpinned, the mypy
+          # hook env resolves the latest release, and mcp 2.0.0 moved
+          # `mcp.server.fastmcp`, renamed `streamablehttp_client` and
+          # dropped `Server.list_tools`/`call_tool`, which fails the whole
+          # run against code written for the locked 1.x API.
+          - mcp==1.19.0
           - pandas-stubs
           - matplotlib-stubs
           - docker


### PR DESCRIPTION
## Summary

The `mypy` pre-commit hook resolves `mcp` unpinned, so its isolated hook environment installs whatever is latest on PyPI rather than the version the project locks. `mcp` 2.0.0 was published today and breaks the hook run for code written against the locked 1.x API: `mcp.server.fastmcp` moved, `streamablehttp_client` was renamed, `Server.list_tools`/`call_tool` were dropped, and the httpx dependency changed. Pinning it to `uv.lock`'s resolved version restores a reproducible hook environment.

## Impact this is fixing

`pre-commit` started failing for every pull request whose CI ran after the release, with about twenty `import-not-found` and `attr-defined` errors in `src/xagent/web/tools/mcp/` and `src/xagent/core/tools/core/mcp/` — none of them related to the changes under review.

The timing isolates the cause: `main` did not move between a passing and a failing run.

| Time (UTC) | Event |
|---|---|
| 09:38 | last `main` commit (`bb18b0cd`) |
| 11:34 | `pre-commit` passes on a PR built from that same `main` |
| 13:41 | `mcp` 1.29.0 published |
| 13:45 | `mcp` 2.0.0 published |
| 13:52 | `pre-commit` fails on a PR, same `main` |
| 13:54 | `pre-commit` fails on another PR |

`uv.lock` and `pyproject.toml` were untouched in that window, dependency installation succeeded in the failing job, and `uv run mypy --package xagent` still passes locally against the locked `mcp` 1.19.0 — the hook environment is the only place resolving a different version.

## Verification

Resolved the hook's full dependency set (39 entries plus `mypy==1.19.0`) in a throwaway environment: 167 packages, `mcp==1.19.0` selected, no conflict — so no other hook dependency requires `mcp` 2.x.

## Note on the general case

This is the third dependency pinned into this hook for the same reason; the existing `numpy` and `google-auth`/`google-api-core` pins carry the same rationale in their comments. Roughly thirty entries in `additional_dependencies` remain unpinned, so any upstream release can red-light every open PR at an arbitrary time, and the hook environment stays a second dependency resolution alongside `uv.lock`. Worth closing systematically rather than one package at a time — happy to follow up separately with either a check that keeps the pinned entries aligned with `uv.lock`, or a move to running `mypy` from the project environment (that path also needs `googleapiclient` and `pyarrow` typing coverage, which currently produces 40 pre-existing errors, so it is not a drop-in change).
