### PR TITLE
feat(connectors): expose selected visible connector resolver

### DIFF
--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -607,6 +607,10 @@ def resolve_agent_selected_connectors(
 ) -> dict[ConnectorRef, Any]:
     """Return visible connectors selected by ``agent`` for the supplied owner.
 
+    Selection derives only from ``Agent.tool_categories``; task-level runtime
+    overlays are not applied. Callers that need the effective per-task tool set
+    must apply those policies at the task-selection boundary.
+
     Runtime-declaration filtering is intentionally left to consumers. Results
     iterate deterministically by ``(connector_type, connector_id)``.
     """
@@ -640,6 +644,8 @@ def _runtime_declared_refs(
 def _select_agent_visible_connectors(
     agent: Agent, visible: dict[ConnectorRef, Any]
 ) -> dict[ConnectorRef, Any]:
+    """Select visible connectors and establish canonical ref iteration order."""
+
     tool_categories = (
         list(agent.tool_categories) if isinstance(agent.tool_categories, list) else None
     )

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -634,11 +634,10 @@ def _select_agent_visible_connectors(
     )
     spec = ToolSelectionSpec.from_raw(tool_categories=tool_categories)
     selected: dict[ConnectorRef, Any] = {}
-    for ref in _sort_connector_refs(visible):
-        connector = visible[ref]
+    for ref, connector in visible.items():
         if _is_agent_selected_connector(spec, ref, connector):
             selected[ref] = connector
-    return selected
+    return {ref: selected[ref] for ref in _sort_connector_refs(selected)}
 
 
 def _is_agent_selected_connector(

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -645,7 +645,7 @@ def _is_agent_selected_connector(
     spec: ToolSelectionSpec, ref: ConnectorRef, connector: Any
 ) -> bool:
     scoped_mcp_servers = spec.scoped_mcp_servers()
-    name_key = normalize_mcp_server_name(str(connector.name or ""))
+    name_key = normalize_mcp_server_name(connector.name)
     if ref.connector_type == CONNECTOR_TYPE_MCP:
         if not spec.includes_mcp():
             return False

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -644,17 +644,20 @@ def _select_agent_visible_connectors(
 def _is_agent_selected_connector(
     spec: ToolSelectionSpec, ref: ConnectorRef, connector: Any
 ) -> bool:
-    scoped_mcp_servers = spec.scoped_mcp_servers()
-    name_key = normalize_mcp_server_name(connector.name)
     if ref.connector_type == CONNECTOR_TYPE_MCP:
         if not spec.includes_mcp():
             return False
-        return scoped_mcp_servers is None or name_key in scoped_mcp_servers
-    if ref.connector_type == CONNECTOR_TYPE_CUSTOM_API:
+    elif ref.connector_type == CONNECTOR_TYPE_CUSTOM_API:
         if not spec.includes_custom_api():
             return False
-        return scoped_mcp_servers is None or name_key in scoped_mcp_servers
-    return False
+    else:
+        return False
+
+    scoped_mcp_servers = spec.scoped_mcp_servers()
+    if scoped_mcp_servers is None:
+        return True
+    name_key = normalize_mcp_server_name(connector.name)
+    return name_key in scoped_mcp_servers
 
 
 def _sort_connector_refs(refs: Iterable[ConnectorRef]) -> tuple[ConnectorRef, ...]:

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -391,8 +391,16 @@ def prepare_connector_runtime_selection_snapshot(
 
     if agent is None or connector_user_id is None:
         return ()
-    visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
-    return _plan_selected_refs(agent, visible)
+    selected = resolve_agent_selected_connectors(
+        db=db,
+        agent=agent,
+        connector_user_id=int(connector_user_id),
+    )
+    return _sort_connector_refs(
+        ref
+        for ref, connector in selected.items()
+        if _has_runtime_declaration(connector)
+    )
 
 
 def bind_connector_runtime_selection_snapshot(
@@ -598,31 +606,55 @@ def _load_visible_runtime_connectors(
     return visible
 
 
+def resolve_agent_selected_connectors(
+    *, db: Session, agent: Agent, connector_user_id: int
+) -> dict[ConnectorRef, Any]:
+    """Return visible connectors selected by ``agent`` for the supplied owner."""
+
+    visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
+    return _select_agent_visible_connectors(agent, visible)
+
+
 def _plan_selected_refs(
     agent: Agent, visible: dict[ConnectorRef, Any]
 ) -> tuple[ConnectorRef, ...]:
+    selected = _select_agent_visible_connectors(agent, visible)
+    return _sort_connector_refs(
+        ref
+        for ref, connector in selected.items()
+        if _has_runtime_declaration(connector)
+    )
+
+
+def _select_agent_visible_connectors(
+    agent: Agent, visible: dict[ConnectorRef, Any]
+) -> dict[ConnectorRef, Any]:
     tool_categories = (
         list(agent.tool_categories) if isinstance(agent.tool_categories, list) else None
     )
     spec = ToolSelectionSpec.from_raw(tool_categories=tool_categories)
-    selected: list[ConnectorRef] = []
+    selected: dict[ConnectorRef, Any] = {}
+    for ref in _sort_connector_refs(visible):
+        connector = visible[ref]
+        if _is_agent_selected_connector(spec, ref, connector):
+            selected[ref] = connector
+    return selected
+
+
+def _is_agent_selected_connector(
+    spec: ToolSelectionSpec, ref: ConnectorRef, connector: Any
+) -> bool:
     scoped_mcp_servers = spec.scoped_mcp_servers()
-    for ref, connector in visible.items():
-        if not _has_runtime_declaration(connector):
-            continue
-        name_key = normalize_mcp_server_name(str(connector.name or ""))
-        if ref.connector_type == CONNECTOR_TYPE_MCP:
-            if not spec.includes_mcp():
-                continue
-            if scoped_mcp_servers is not None and name_key not in scoped_mcp_servers:
-                continue
-        elif ref.connector_type == CONNECTOR_TYPE_CUSTOM_API:
-            if not spec.includes_custom_api():
-                continue
-            if scoped_mcp_servers is not None and name_key not in scoped_mcp_servers:
-                continue
-        selected.append(ref)
-    return _sort_connector_refs(selected)
+    name_key = normalize_mcp_server_name(str(connector.name or ""))
+    if ref.connector_type == CONNECTOR_TYPE_MCP:
+        if not spec.includes_mcp():
+            return False
+        return scoped_mcp_servers is None or name_key in scoped_mcp_servers
+    if ref.connector_type == CONNECTOR_TYPE_CUSTOM_API:
+        if not spec.includes_custom_api():
+            return False
+        return scoped_mcp_servers is None or name_key in scoped_mcp_servers
+    return False
 
 
 def _sort_connector_refs(refs: Iterable[ConnectorRef]) -> tuple[ConnectorRef, ...]:

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -366,7 +366,7 @@ def prepare_create_connector_runtime(
     return ConnectorRuntimeCreatePlan(
         task_source=task_source,
         connector_user_id=int(connector_user_id),
-        selected_refs=_sort_connector_refs(selected_refs),
+        selected_refs=selected_refs,
         context_by_ref=context_by_ref,
         ephemeral_by_ref=ephemeral_by_ref,
     )
@@ -396,11 +396,7 @@ def prepare_connector_runtime_selection_snapshot(
         agent=agent,
         connector_user_id=int(connector_user_id),
     )
-    return _sort_connector_refs(
-        ref
-        for ref, connector in selected.items()
-        if _has_runtime_declaration(connector)
-    )
+    return _runtime_declared_refs(selected)
 
 
 def bind_connector_runtime_selection_snapshot(
@@ -609,7 +605,11 @@ def _load_visible_runtime_connectors(
 def resolve_agent_selected_connectors(
     *, db: Session, agent: Agent, connector_user_id: int
 ) -> dict[ConnectorRef, Any]:
-    """Return visible connectors selected by ``agent`` for the supplied owner."""
+    """Return visible connectors selected by ``agent`` for the supplied owner.
+
+    Runtime-declaration filtering is intentionally left to consumers. Results
+    iterate deterministically by ``(connector_type, connector_id)``.
+    """
 
     visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
     return _select_agent_visible_connectors(agent, visible)
@@ -619,7 +619,18 @@ def _plan_selected_refs(
     agent: Agent, visible: dict[ConnectorRef, Any]
 ) -> tuple[ConnectorRef, ...]:
     selected = _select_agent_visible_connectors(agent, visible)
-    return _sort_connector_refs(
+    return _runtime_declared_refs(selected)
+
+
+def _runtime_declared_refs(
+    selected: dict[ConnectorRef, Any],
+) -> tuple[ConnectorRef, ...]:
+    """Project declared refs while preserving canonical selection order.
+
+    Callers provide the mapping ordered by the connector selection owner.
+    """
+
+    return tuple(
         ref
         for ref, connector in selected.items()
         if _has_runtime_declaration(connector)

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -469,6 +469,7 @@ def test_create_plan_preserves_canonical_cross_type_connector_order(
     db_session.flush()
     selected_mcp = _create_runtime_mcp(db_session, user, "Records")
     selected_api = _create_runtime_custom_api(db_session, user, "records")
+    unselected_mcp = _create_runtime_mcp(db_session, user, "Billing")
 
     plan = prepare_create_connector_runtime(
         db=db_session,
@@ -482,6 +483,7 @@ def test_create_plan_preserves_canonical_cross_type_connector_order(
         ConnectorRef("custom_api", int(selected_api.id)),
         ConnectorRef("mcp", int(selected_mcp.id)),
     )
+    assert ConnectorRef("mcp", int(unselected_mcp.id)) not in plan.selected_refs
 
 
 def test_selection_snapshot_uses_public_resolver_and_filters_runtime_declarations(

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -7,12 +7,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.connector_runtime import (
+    ConnectorRef,
+    ConnectorRuntimeError,
+)
 from xagent.web.models import Agent, Base, MCPServer, Task, User, UserMCPServer
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.models.task import TaskStatus
 from xagent.web.services import connector_runtime as connector_runtime_service
+from xagent.web.services import connector_team_scope
 from xagent.web.services.connector_runtime import (
     ConnectorRuntimeValues,
     bind_connector_runtime_selection_snapshot,
@@ -252,6 +256,204 @@ def test_selection_snapshot_scopes_custom_api_by_source_server_name(
         "connector_type": "custom_api",
         "connector_id": int(unselected_api.id),
     } not in (task.connector_runtime_selected_refs or [])
+
+
+def test_selected_connector_resolver_returns_selected_mcp_without_runtime_declaration(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="OAuth Connector Agent",
+        description="shared",
+        instructions="Use the selected connector.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(db_session, user, "oauth-only")
+    server.runtime_input_schema = None
+    server.runtime_bindings = None
+    db_session.flush()
+
+    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    ref = ConnectorRef("mcp", int(server.id))
+    assert list(resolved) == [ref]
+    assert resolved[ref] is server
+
+
+def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_only(
+    db_session: Session,
+) -> None:
+    viewer = _create_user(db_session, "viewer")
+    other_user = _create_user(db_session, "other-user")
+    hidden_user = _create_user(db_session, "hidden-user")
+    agent = Agent(
+        user_id=viewer.id,
+        name="Scoped Connector Agent",
+        description="shared",
+        instructions="Use selected tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp: Team Records"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    owner_server = _create_runtime_mcp(db_session, viewer, "team-records")
+    team_server = _create_runtime_mcp(db_session, other_user, "Team Records")
+    hidden_server = _create_runtime_mcp(db_session, hidden_user, "TEAM_records")
+    unselected_server = _create_runtime_mcp(db_session, viewer, "Billing")
+
+    connector_team_scope.set_connector_team_hooks(
+        visibility=lambda db, user_id: {
+            "mcp": {int(team_server.id)} if user_id == int(viewer.id) else set(),
+            "custom_api": set(),
+        }
+    )
+    try:
+        resolved = connector_runtime_service.resolve_agent_selected_connectors(
+            db=db_session,
+            agent=agent,
+            connector_user_id=int(viewer.id),
+        )
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+    owner_ref = ConnectorRef("mcp", int(owner_server.id))
+    team_ref = ConnectorRef("mcp", int(team_server.id))
+    assert list(resolved) == [owner_ref, team_ref]
+    assert ConnectorRef("mcp", int(hidden_server.id)) not in resolved
+    assert ConnectorRef("mcp", int(unselected_server.id)) not in resolved
+
+
+def test_selected_connector_resolver_normalizes_names_and_orders_refs(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Normalized Connector Agent",
+        description="shared",
+        instructions="Use selected tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp: Google Drive"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    mcp_server = _create_runtime_mcp(db_session, user, "Google-Drive")
+    custom_api = _create_runtime_custom_api(db_session, user, "google drive")
+
+    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    assert list(resolved) == [
+        ConnectorRef("custom_api", int(custom_api.id)),
+        ConnectorRef("mcp", int(mcp_server.id)),
+    ]
+
+
+def test_selection_snapshot_uses_public_resolver_and_filters_runtime_declarations(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Snapshot Connector Agent",
+        description="shared",
+        instructions="Use selected tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    declared = _create_runtime_mcp(db_session, user, "declared")
+    undeclared = _create_runtime_mcp(db_session, user, "undeclared")
+    undeclared.runtime_input_schema = None
+    undeclared.runtime_bindings = None
+    db_session.flush()
+    calls = []
+
+    def resolve_selected(**kwargs):
+        calls.append(kwargs)
+        return {
+            ConnectorRef("mcp", int(declared.id)): declared,
+            ConnectorRef("mcp", int(undeclared.id)): undeclared,
+        }
+
+    monkeypatch.setattr(
+        connector_runtime_service,
+        "resolve_agent_selected_connectors",
+        resolve_selected,
+        raising=False,
+    )
+
+    selected_refs = prepare_connector_runtime_selection_snapshot(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    assert selected_refs == (ConnectorRef("mcp", int(declared.id)),)
+    assert calls == [
+        {
+            "db": db_session,
+            "agent": agent,
+            "connector_user_id": int(user.id),
+        }
+    ]
+
+
+def test_create_plan_rejects_undeclared_selected_connector_payload(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Runtime Declaration Agent",
+        description="shared",
+        instructions="Use selected tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    server = _create_runtime_mcp(db_session, user, "oauth-only")
+    server.runtime_input_schema = None
+    server.runtime_bindings = None
+    db_session.flush()
+
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        prepare_create_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task_source="sdk",
+            connector_user_id=int(user.id),
+            payload_items=[
+                {
+                    "connector_ref": {
+                        "connector_type": "mcp",
+                        "connector_id": int(server.id),
+                    }
+                }
+            ],
+        )
+
+    assert exc_info.value.code == "invalid_runtime_context"
+    assert exc_info.value.details["reason"] == "connector_not_selected"
 
 
 def test_scoped_resolver_applies_consistently_to_create_and_binding(

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 
 import pytest
 from sqlalchemy import create_engine
@@ -289,6 +289,53 @@ def test_selected_connector_resolver_returns_selected_mcp_without_runtime_declar
     assert resolved[ref] is server
 
 
+@pytest.mark.parametrize(
+    ("tool_categories", "selects_all"),
+    [
+        (None, True),
+        ([], False),
+    ],
+)
+def test_selected_connector_resolver_honors_all_and_none_sentinels(
+    db_session: Session,
+    tool_categories: list[str] | None,
+    selects_all: bool,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Sentinel Connector Agent",
+        description="shared",
+        instructions="Use selected connectors.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=tool_categories,
+    )
+    db_session.add(agent)
+    db_session.flush()
+    mcp_server = _create_runtime_mcp(db_session, user, "Records")
+    custom_api = _create_runtime_custom_api(db_session, user, "Records")
+
+    db_session.expire(agent, ["tool_categories"])
+    assert agent.tool_categories == tool_categories
+
+    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    expected = (
+        [
+            ConnectorRef("custom_api", int(custom_api.id)),
+            ConnectorRef("mcp", int(mcp_server.id)),
+        ]
+        if selects_all
+        else []
+    )
+    assert list(resolved) == expected
+
+
 def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_only(
     db_session: Session,
 ) -> None:
@@ -306,8 +353,8 @@ def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_
     )
     db_session.add(agent)
     db_session.flush()
-    owner_server = _create_runtime_mcp(db_session, viewer, "team-records")
     team_server = _create_runtime_mcp(db_session, other_user, "Team Records")
+    owner_server = _create_runtime_mcp(db_session, viewer, "team-records")
     hidden_server = _create_runtime_mcp(db_session, hidden_user, "TEAM_records")
     unselected_server = _create_runtime_mcp(db_session, viewer, "Billing")
 
@@ -328,7 +375,7 @@ def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_
 
     owner_ref = ConnectorRef("mcp", int(owner_server.id))
     team_ref = ConnectorRef("mcp", int(team_server.id))
-    assert list(resolved) == [owner_ref, team_ref]
+    assert list(resolved) == [team_ref, owner_ref]
     assert ConnectorRef("mcp", int(hidden_server.id)) not in resolved
     assert ConnectorRef("mcp", int(unselected_server.id)) not in resolved
 
@@ -405,55 +452,36 @@ def test_selected_connector_resolver_normalizes_names_and_orders_refs(
     ]
 
 
-def test_selected_connector_resolver_filters_before_sorting_selected_refs(
+def test_create_plan_preserves_canonical_cross_type_connector_order(
     db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user = _create_user(db_session, "owner")
     agent = Agent(
         user_id=user.id,
-        name="Filtered Connector Agent",
+        name="Ordered Connector Agent",
         description="shared",
         instructions="Use selected tools.",
         execution_mode="balanced",
         status=AgentStatus.PUBLISHED,
-        tool_categories=["mcp: Google Drive"],
+        tool_categories=["mcp: Records"],
     )
     db_session.add(agent)
     db_session.flush()
-    selected_mcp = _create_runtime_mcp(db_session, user, "Google-Drive")
-    selected_api = _create_runtime_custom_api(db_session, user, "google drive")
-    _create_runtime_mcp(db_session, user, "Billing")
-    _create_runtime_custom_api(db_session, user, "Invoices")
+    selected_mcp = _create_runtime_mcp(db_session, user, "Records")
+    selected_api = _create_runtime_custom_api(db_session, user, "records")
 
-    sort_inputs: list[frozenset[ConnectorRef]] = []
-    sort_refs = connector_runtime_service._sort_connector_refs
-
-    def record_sort_input(refs: Iterable[ConnectorRef]) -> tuple[ConnectorRef, ...]:
-        materialized = tuple(refs)
-        sort_inputs.append(frozenset(materialized))
-        return sort_refs(materialized)
-
-    monkeypatch.setattr(
-        connector_runtime_service,
-        "_sort_connector_refs",
-        record_sort_input,
-    )
-
-    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+    plan = prepare_create_connector_runtime(
         db=db_session,
         agent=agent,
         connector_user_id=int(user.id),
+        task_source="sdk",
+        payload_items=None,
     )
 
-    selected_refs = frozenset(
-        {
-            ConnectorRef("custom_api", int(selected_api.id)),
-            ConnectorRef("mcp", int(selected_mcp.id)),
-        }
+    assert plan.selected_refs == (
+        ConnectorRef("custom_api", int(selected_api.id)),
+        ConnectorRef("mcp", int(selected_mcp.id)),
     )
-    assert sort_inputs == [selected_refs]
-    assert list(resolved) == sorted(selected_refs)
 
 
 def test_selection_snapshot_uses_public_resolver_and_filters_runtime_declarations(
@@ -490,7 +518,6 @@ def test_selection_snapshot_uses_public_resolver_and_filters_runtime_declaration
         connector_runtime_service,
         "resolve_agent_selected_connectors",
         resolve_selected,
-        raising=False,
     )
 
     selected_refs = prepare_connector_runtime_selection_snapshot(

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 
 import pytest
 from sqlalchemy import create_engine
@@ -403,6 +403,57 @@ def test_selected_connector_resolver_normalizes_names_and_orders_refs(
         ConnectorRef("custom_api", int(custom_api.id)),
         ConnectorRef("mcp", int(mcp_server.id)),
     ]
+
+
+def test_selected_connector_resolver_filters_before_sorting_selected_refs(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Filtered Connector Agent",
+        description="shared",
+        instructions="Use selected tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp: Google Drive"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    selected_mcp = _create_runtime_mcp(db_session, user, "Google-Drive")
+    selected_api = _create_runtime_custom_api(db_session, user, "google drive")
+    _create_runtime_mcp(db_session, user, "Billing")
+    _create_runtime_custom_api(db_session, user, "Invoices")
+
+    sort_inputs: list[frozenset[ConnectorRef]] = []
+    sort_refs = connector_runtime_service._sort_connector_refs
+
+    def record_sort_input(refs: Iterable[ConnectorRef]) -> tuple[ConnectorRef, ...]:
+        materialized = tuple(refs)
+        sort_inputs.append(frozenset(materialized))
+        return sort_refs(materialized)
+
+    monkeypatch.setattr(
+        connector_runtime_service,
+        "_sort_connector_refs",
+        record_sort_input,
+    )
+
+    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    selected_refs = frozenset(
+        {
+            ConnectorRef("custom_api", int(selected_api.id)),
+            ConnectorRef("mcp", int(selected_mcp.id)),
+        }
+    )
+    assert sort_inputs == [selected_refs]
+    assert list(resolved) == sorted(selected_refs)
 
 
 def test_selection_snapshot_uses_public_resolver_and_filters_runtime_declarations(

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -333,6 +333,48 @@ def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_
     assert ConnectorRef("mcp", int(unselected_server.id)) not in resolved
 
 
+def test_selected_connector_resolver_skips_name_normalization_without_server_scope(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = _create_user(db_session, "owner")
+    agent = Agent(
+        user_id=user.id,
+        name="Unscoped Connector Agent",
+        description="shared",
+        instructions="Use MCP tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+    )
+    db_session.add(agent)
+    db_session.flush()
+    selected_mcp = _create_runtime_mcp(db_session, user, "Records")
+    _create_runtime_custom_api(db_session, user, "Billing")
+
+    normalization_calls: list[str] = []
+    normalize_name = connector_runtime_service.normalize_mcp_server_name
+
+    def record_normalization(name: str) -> str:
+        normalization_calls.append(name)
+        return normalize_name(name)
+
+    monkeypatch.setattr(
+        connector_runtime_service,
+        "normalize_mcp_server_name",
+        record_normalization,
+    )
+
+    resolved = connector_runtime_service.resolve_agent_selected_connectors(
+        db=db_session,
+        agent=agent,
+        connector_user_id=int(user.id),
+    )
+
+    assert list(resolved) == [ConnectorRef("mcp", int(selected_mcp.id))]
+    assert normalization_calls == []
+
+
 def test_selected_connector_resolver_normalizes_names_and_orders_refs(
     db_session: Session,
 ) -> None:


### PR DESCRIPTION
## Summary

- expose one shared resolver for the MCP and Custom API connectors that are both visible to a user and selected by an Agent
- keep runtime-declaration projection in one helper shared by task snapshot and create-plan paths while allowing consumers to resolve selected connectors without that restriction
- preserve scoped-name selection, owner/team visibility, normalization, and deterministic `(connector_type, connector_id)` ordering
- document the public resolver contract and cover persisted `None`/`[]` selection sentinels at the ORM boundary

## Verification

- `uv run pytest -q tests/web/services/test_connector_runtime_snapshot.py` — 26 passed
- `uv run pytest -q tests/web/services/test_connector_runtime_snapshot.py tests/core/tools/adapters/vibe/test_selection_spec.py` — 127 passed
- `uv run mypy src/xagent/web/services/connector_runtime.py` — passed
- `uv run pre-commit run --files src/xagent/web/services/connector_runtime.py tests/web/services/test_connector_runtime_snapshot.py` — passed
- `git diff --check` — passed