### PR TITLE
test(widget): cover WS per-message revalidation (4003 close) for widget guests (#992)

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -8,7 +8,7 @@ import secrets
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Protocol, TypeVar
+from typing import Any, Callable, Protocol, TypeGuard, TypeVar
 
 from fastapi import Depends, HTTPException, Query, UploadFile, WebSocket
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -124,6 +124,24 @@ class _ChatAccessContext(Protocol):
 
 
 _ChatAccessContextT = TypeVar("_ChatAccessContextT", bound=_ChatAccessContext)
+
+
+def _is_strict_int(value: object) -> TypeGuard[int]:
+    """Whether a JWT claim is a real ``int`` — a row id we may query on.
+
+    Every id claim on a widget/share guest token goes through here rather than a
+    bare ``isinstance(..., int)`` (#992). ``bool`` subclasses ``int``, so a
+    ``true`` claim would pass isinstance, and SQLAlchemy renders it as ``= 1``:
+    it resolves to row id 1 *and* then compares equal to an owner id of 1 in
+    Python (``1 == True``), which would admit a guest as the first user. The
+    behaviour is also backend-dependent — SQLite binds and matches where
+    PostgreSQL typically raises — so a bare isinstance check makes an auth
+    decision that varies by database.
+
+    These tokens are server-minted and signed, so no caller can present such a
+    claim today; this keeps every id claim failing closed regardless.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def create_public_chat_access_token(data: dict[str, Any]) -> str:
@@ -286,33 +304,20 @@ def get_public_chat_user(
         if auth_mode != "widget":
             raise ValueError("Invalid token payload")
 
-        # Defense in depth (#992): the same type guard get_share_chat_user
-        # applies (deliberately the same shape, so tightening one is an obvious
-        # prompt to tighten the other). These tokens are server-minted, so a
-        # malformed user_id is not reachable today — but without the guard the
-        # two widget branches below disagreed about a string one: the agent
-        # branch failed closed on an int/str owner comparison, while the
-        # workforce branch coerced it and admitted the request. Establishing the
-        # type here is what lets both branches pass ``user_id`` straight to their
-        # ``ensure_widget_*_available`` helper.
-        #
-        # ``bool`` is excluded explicitly because it is an ``int`` subclass: a
-        # ``true`` claim would otherwise pass the isinstance check, resolve as
-        # ``User.id = 1``, and then satisfy the owner check against id 1 as well
-        # (``1 == True``) — admitting a guest as the first user.
-        if (
-            not isinstance(user_id, int)
-            or isinstance(user_id, bool)
-            or not user_id
-            or not guest_id
-        ):
+        # Defense in depth (#992): the same guard get_share_chat_user applies.
+        # Without it the two widget branches below disagreed about a string
+        # user_id — the agent branch failed closed on an int/str owner
+        # comparison, while the workforce branch coerced it and admitted the
+        # request. Establishing the type here is what lets both branches pass
+        # ``user_id`` straight to their ``ensure_widget_*_available`` helper.
+        if not _is_strict_int(user_id) or not user_id or not guest_id:
             raise ValueError("Invalid token payload")
 
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
             raise ValueError("User not found")
 
-        if isinstance(widget_workforce_id, int):
+        if _is_strict_int(widget_workforce_id):
             # Workforce widget: re-validate the deployment on every use so
             # disabling the widget or rotating its key cuts off live guests,
             # mirroring the workforce share path.
@@ -337,7 +342,7 @@ def get_public_chat_user(
         # tokens (mirrors the share path). The per-message WS revalidation
         # calls back through here, so live sessions drop on the next inbound
         # message too.
-        if not isinstance(widget_agent_id, int):
+        if not _is_strict_int(widget_agent_id):
             raise ValueError("Invalid widget token payload")
         ensure_widget_agent_available(
             db,
@@ -381,9 +386,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
 
         if auth_mode != "share":
             raise ValueError("Invalid token payload")
-        # ``bool`` excluded for the reason spelled out on the matching guard in
-        # get_public_chat_user: it is an ``int`` subclass that resolves as user 1.
-        if not isinstance(user_id, int) or isinstance(user_id, bool):
+        if not _is_strict_int(user_id):
             raise ValueError("Invalid token payload")
         if not isinstance(share_token, str) or not share_token:
             raise ValueError("Invalid share token payload")
@@ -399,7 +402,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
         if not user:
             raise ValueError("User not found")
 
-        if isinstance(share_workforce_id, int):
+        if _is_strict_int(share_workforce_id):
             workforce = ensure_share_workforce_available(
                 db,
                 share_workforce_id,
@@ -413,7 +416,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
                 workforce=workforce,
             )
 
-        if not isinstance(share_agent_id, int):
+        if not _is_strict_int(share_agent_id):
             raise ValueError("Invalid share token payload")
 
         agent = ensure_share_agent_available(

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -286,7 +286,16 @@ def get_public_chat_user(
         if auth_mode != "widget":
             raise ValueError("Invalid token payload")
 
-        if not user_id or not guest_id:
+        # Defense in depth (#992): the same type guard get_share_chat_user
+        # applies (deliberately the same shape, so tightening one is an obvious
+        # prompt to tighten the other). These tokens are server-minted, so a
+        # non-int user_id is not reachable today — but without the guard the two
+        # widget branches below disagreed about a string one: the agent branch
+        # failed closed on an int/str owner comparison, while the workforce
+        # branch coerced it and admitted the request. Establishing the type here
+        # is what lets both branches pass ``user_id`` straight to their
+        # ``ensure_widget_*_available`` helper.
+        if not isinstance(user_id, int) or not user_id or not guest_id:
             raise ValueError("Invalid token payload")
 
         user = db.query(User).filter(User.id == user_id).first()
@@ -300,7 +309,7 @@ def get_public_chat_user(
             ensure_widget_workforce_available(
                 db,
                 widget_workforce_id,
-                int(user_id),
+                user_id,
                 expected_widget_key=widget_key
                 if isinstance(widget_key, str) and widget_key
                 else None,

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -289,13 +289,18 @@ def get_public_chat_user(
         # Defense in depth (#992): the same type guard get_share_chat_user
         # applies (deliberately the same shape, so tightening one is an obvious
         # prompt to tighten the other). These tokens are server-minted, so a
-        # non-int user_id is not reachable today — but without the guard the two
-        # widget branches below disagreed about a string one: the agent branch
-        # failed closed on an int/str owner comparison, while the workforce
-        # branch coerced it and admitted the request. Establishing the type here
-        # is what lets both branches pass ``user_id`` straight to their
+        # malformed user_id is not reachable today — but without the guard the
+        # two widget branches below disagreed about a string one: the agent
+        # branch failed closed on an int/str owner comparison, while the
+        # workforce branch coerced it and admitted the request. Establishing the
+        # type here is what lets both branches pass ``user_id`` straight to their
         # ``ensure_widget_*_available`` helper.
-        if not isinstance(user_id, int) or not user_id or not guest_id:
+        #
+        # ``type(...) is not int`` rather than ``isinstance``: ``bool`` is an
+        # ``int`` subclass, so a ``true`` claim would pass isinstance, resolve as
+        # ``User.id = 1``, and then satisfy the owner check against id 1 as well
+        # (``1 == True``) — admitting a guest as the first user.
+        if type(user_id) is not int or not user_id or not guest_id:
             raise ValueError("Invalid token payload")
 
         user = db.query(User).filter(User.id == user_id).first()
@@ -371,7 +376,9 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
 
         if auth_mode != "share":
             raise ValueError("Invalid token payload")
-        if not isinstance(user_id, int):
+        # Exact type, not isinstance: see the matching guard in
+        # get_public_chat_user for why a ``bool`` claim must not pass here.
+        if type(user_id) is not int:
             raise ValueError("Invalid token payload")
         if not isinstance(share_token, str) or not share_token:
             raise ValueError("Invalid share token payload")

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -296,11 +296,16 @@ def get_public_chat_user(
         # type here is what lets both branches pass ``user_id`` straight to their
         # ``ensure_widget_*_available`` helper.
         #
-        # ``type(...) is not int`` rather than ``isinstance``: ``bool`` is an
-        # ``int`` subclass, so a ``true`` claim would pass isinstance, resolve as
+        # ``bool`` is excluded explicitly because it is an ``int`` subclass: a
+        # ``true`` claim would otherwise pass the isinstance check, resolve as
         # ``User.id = 1``, and then satisfy the owner check against id 1 as well
         # (``1 == True``) — admitting a guest as the first user.
-        if type(user_id) is not int or not user_id or not guest_id:
+        if (
+            not isinstance(user_id, int)
+            or isinstance(user_id, bool)
+            or not user_id
+            or not guest_id
+        ):
             raise ValueError("Invalid token payload")
 
         user = db.query(User).filter(User.id == user_id).first()
@@ -376,9 +381,9 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
 
         if auth_mode != "share":
             raise ValueError("Invalid token payload")
-        # Exact type, not isinstance: see the matching guard in
-        # get_public_chat_user for why a ``bool`` claim must not pass here.
-        if type(user_id) is not int:
+        # ``bool`` excluded for the reason spelled out on the matching guard in
+        # get_public_chat_user: it is an ``int`` subclass that resolves as user 1.
+        if not isinstance(user_id, int) or isinstance(user_id, bool):
             raise ValueError("Invalid token payload")
         if not isinstance(share_token, str) or not share_token:
             raise ValueError("Invalid share token payload")

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -1,0 +1,355 @@
+"""Widget-guest WS per-message revalidation (#992).
+
+The widget WS endpoint re-derives access from the *live* agent/workforce on
+every inbound message and closes with ``4003`` when it is gone
+(``public_chat_websocket_endpoint``). That was an explicit acceptance criterion
+of the agent (#988/#989) and workforce (#985) widget work, but only the HTTP
+``POST /api/widget/chat/task/create`` re-check was covered — nothing exercised
+the socket, and no test in the suite even reached
+``/api/widget/chat/ws/{task_id}``.
+
+These tests drive the real endpoint end to end: a guest with a valid token holds
+a live socket, the owner revokes the widget (disable or key rotation), and the
+next inbound message must drop the connection with ``4003``. Unlike
+``test_public_chat_websocket_db_boundary.py`` — which mocks
+``_authorize_public_chat_websocket`` to prove the close *plumbing* — nothing is
+stubbed on the auth path here, so the revocation checks in
+``ensure_widget_agent_available`` / ``ensure_widget_workforce_available`` are
+what the assertions actually depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+from starlette.testclient import WebSocketTestSession
+from starlette.websockets import WebSocketDisconnect
+
+from xagent.web.api.public_chat_access import create_public_chat_access_token
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+from xagent.web.services import workforce_runs as workforce_runs_service
+
+from .conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+GUEST_ID = "guest-ws-revalidation"
+
+
+def _owner_id() -> int:
+    """Bootstrap the admin owner if needed and return its user id."""
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user = db.query(User).filter(User.username == "admin").one()
+        return int(user.id)
+    finally:
+        db.close()
+
+
+def _create_published_agent(user_id: int, name: str) -> int:
+    db = _direct_db_session()
+    try:
+        agent = Agent(
+            user_id=user_id,
+            name=name,
+            description=f"{name} description",
+            instructions=f"{name} instructions",
+            execution_mode="balanced",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        return int(agent.id)
+    finally:
+        db.close()
+
+
+def _enable_agent_widget(agent_id: int) -> str:
+    """Turn on an agent's widget and return its key."""
+    response = client.put(
+        f"/api/agents/{agent_id}",
+        headers=_admin_headers(),
+        json={"widget_enabled": True, "allowed_domains": ["*"]},
+    )
+    assert response.status_code == 200, response.text
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        assert agent.widget_key
+        return str(agent.widget_key)
+    finally:
+        db.close()
+
+
+def _create_workforce(name: str) -> int:
+    headers = _admin_headers()
+    owner_id = _owner_id()
+    manager_agent_id = _create_published_agent(owner_id, f"{name} Manager")
+    worker_agent_id = _create_published_agent(owner_id, f"{name} Worker")
+    created = client.post(
+        "/api/workforces",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Coordinates widget WS revalidation tests",
+            "manager_agent_id": manager_agent_id,
+            "workers": [
+                {
+                    "source_type": "existing",
+                    "agent_id": worker_agent_id,
+                    "alias": "worker-1",
+                    "assignment_instructions": "Handle everything",
+                    "enabled": True,
+                    "sort_order": 1,
+                }
+            ],
+        },
+    )
+    assert created.status_code == 200, created.text
+    workforce_id = int(created.json()["id"])
+    published = client.post(f"/api/workforces/{workforce_id}/publish", headers=headers)
+    assert published.status_code == 200, published.text
+    return workforce_id
+
+
+def _enable_workforce_widget(workforce_id: int) -> str:
+    """Turn on a workforce deployment's widget and return its key."""
+    response = client.put(
+        f"/api/workforces/{workforce_id}/widget",
+        headers=_admin_headers(),
+        json={"widget_enabled": True, "allowed_domains": ["*"]},
+    )
+    assert response.status_code == 200, response.text
+    key = response.json()["widget_key"]
+    assert isinstance(key, str) and key
+    return str(key)
+
+
+def _authenticate_widget_guest(widget_key: str) -> str:
+    """Exchange a widget key for a guest access token (direct-visit flow)."""
+    response = client.post(
+        "/api/widget/auth",
+        json={"guest_id": GUEST_ID, "widget_key": widget_key},
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["access_token"])
+
+
+def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let ``create_workforce_run`` build its task/run rows without executing."""
+
+    async def _stub(**_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(background_task=None)
+
+    monkeypatch.setattr(
+        workforce_runs_service.TaskTurnOrchestrator, "begin_turn", _stub
+    )
+
+
+@dataclass(frozen=True)
+class _WidgetGuest:
+    """A widget guest holding a token for a task it is allowed to open."""
+
+    token: str
+    task_id: int
+    # Owner-side revocations, each of which must invalidate ``token``.
+    disable: Callable[[], None]
+    rotate: Callable[[], None]
+
+
+def _agent_widget_guest() -> _WidgetGuest:
+    owner_id = _owner_id()
+    agent_id = _create_published_agent(owner_id, "WS Revalidation Widget Agent")
+    token = _authenticate_widget_guest(_enable_agent_widget(agent_id))
+
+    created = client.post(
+        "/api/widget/chat/task/create",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "hello", "description": "hello", "agent_id": agent_id},
+    )
+    assert created.status_code == 200, created.text
+
+    def disable() -> None:
+        response = client.put(
+            f"/api/agents/{agent_id}",
+            headers=_admin_headers(),
+            json={"widget_enabled": False},
+        )
+        assert response.status_code == 200, response.text
+
+    def rotate() -> None:
+        response = client.post(
+            f"/api/agents/{agent_id}/widget-key/rotate", headers=_admin_headers()
+        )
+        assert response.status_code == 200, response.text
+
+    return _WidgetGuest(
+        token=token,
+        task_id=int(created.json()["task_id"]),
+        disable=disable,
+        rotate=rotate,
+    )
+
+
+def _workforce_widget_guest(monkeypatch: pytest.MonkeyPatch) -> _WidgetGuest:
+    workforce_id = _create_workforce("WS Revalidation Widget Workforce")
+    token = _authenticate_widget_guest(_enable_workforce_widget(workforce_id))
+    _stub_begin_turn(monkeypatch)
+
+    created = client.post(
+        "/api/widget/chat/task/create",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "hello", "description": "hello"},
+    )
+    assert created.status_code == 200, created.text
+
+    def disable() -> None:
+        response = client.put(
+            f"/api/workforces/{workforce_id}/widget",
+            headers=_admin_headers(),
+            json={"widget_enabled": False},
+        )
+        assert response.status_code == 200, response.text
+
+    def rotate() -> None:
+        response = client.post(
+            f"/api/workforces/{workforce_id}/widget-key/rotate",
+            headers=_admin_headers(),
+        )
+        assert response.status_code == 200, response.text
+
+    return _WidgetGuest(
+        token=token,
+        task_id=int(created.json()["task_id"]),
+        disable=disable,
+        rotate=rotate,
+    )
+
+
+def _build_guest(channel: str, monkeypatch: pytest.MonkeyPatch) -> _WidgetGuest:
+    if channel == "agent":
+        return _agent_widget_guest()
+    return _workforce_widget_guest(monkeypatch)
+
+
+def _receive_until(ws: WebSocketTestSession, event_type: str) -> bool:
+    """Read frames until one carries ``event_type``.
+
+    The connect handshake replays the task's historical stream, so the reply to
+    an inbound message can be queued behind an unknown number of earlier frames.
+    A close arriving first raises ``WebSocketDisconnect`` out of here, which is
+    the point: it says the socket died on the message under test.
+    """
+    while True:
+        if json.loads(ws.receive_text()).get("type") == event_type:
+            return True
+
+
+def _drain_until_disconnect(ws: WebSocketTestSession) -> WebSocketDisconnect:
+    """Consume buffered frames and return the close that ends the socket.
+
+    The connect handshake replays the task's historical stream, so an unknown
+    number of frames may already be queued ahead of the close; reading exactly
+    once would assert against a data frame instead of the denial.
+    """
+    with pytest.raises(WebSocketDisconnect) as disconnected:
+        while True:
+            ws.receive_text()
+    return disconnected.value
+
+
+# Bound the run: if the revalidation is ever dropped, the revoked message falls
+# through to the real chat handler and ``_drain_until_disconnect`` blocks on a
+# close that never comes. Without this the regression would hang the suite
+# instead of failing it (there is no global pytest timeout).
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("channel", ["agent", "workforce"])
+@pytest.mark.parametrize("revocation", ["disable", "rotate"])
+def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
+    monkeypatch: pytest.MonkeyPatch,
+    channel: str,
+    revocation: str,
+) -> None:
+    """Revoking a widget must drop live guest sockets on their next message.
+
+    The guest JWT has a 30-day TTL and the socket outlives any single request,
+    so the receive loop — not the token — is what enforces revocation here.
+    Both revocation levers are covered: disabling the widget, and rotating its
+    key (which the guest token pins via its ``widget_key`` claim).
+    """
+    guest = _build_guest(channel, monkeypatch)
+    url = f"/api/widget/chat/ws/{guest.task_id}?token={guest.token}"
+
+    with client.websocket_connect(url) as ws:
+        # Control: prove the socket survives an inbound message while the widget
+        # is still live, so the close below is attributable to the revocation and
+        # not to sending anything at all. ``intervention`` is the cheapest
+        # handled type that answers (no run is started), and receiving its reply
+        # is what makes this an assertion rather than a claim — a close provoked
+        # by *this* message would surface here instead of below.
+        ws.send_text(json.dumps({"type": "intervention", "action": "noop"}))
+        assert _receive_until(ws, "intervention_processed")
+
+        revoke = guest.disable if revocation == "disable" else guest.rotate
+        revoke()
+
+        ws.send_text(json.dumps({"type": "chat", "message": "still there?"}))
+        denied = _drain_until_disconnect(ws)
+
+    assert denied.code == 4003
+    assert denied.reason == "Widget is unavailable"
+
+
+@pytest.mark.parametrize("channel", ["agent", "workforce"])
+def test_widget_guest_token_with_non_int_user_id_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    channel: str,
+) -> None:
+    """``user_id`` must be an int, as ``get_share_chat_user`` already requires.
+
+    Widget guest tokens are server-minted, so this is defense in depth rather
+    than a live hole — but without the type guard the two widget branches
+    disagree about a string ``user_id``: the agent branch happens to fail closed
+    on an int/str owner comparison, while the workforce branch coerced it to
+    compare at all and so admitted the request. Both must now reject the
+    malformed payload rather than depend on that accident.
+    """
+    # A regression that admits the token would otherwise start a real workforce
+    # run before reaching the assertion below.
+    _stub_begin_turn(monkeypatch)
+    owner_id = _owner_id()
+    payload: dict[str, Any] = {
+        "sub": "admin",
+        # A string that would coerce cleanly -- the interesting case, since an
+        # unparseable value fails everywhere anyway.
+        "user_id": str(owner_id),
+        "channel_id": None,
+        "guest_id": GUEST_ID,
+        "auth_mode": "widget",
+    }
+
+    if channel == "agent":
+        agent_id = _create_published_agent(owner_id, "Typed Claim Widget Agent")
+        payload["widget_agent_id"] = agent_id
+        payload["widget_key"] = _enable_agent_widget(agent_id)
+    else:
+        workforce_id = _create_workforce("Typed Claim Widget Workforce")
+        payload["widget_workforce_id"] = workforce_id
+        payload["widget_key"] = _enable_workforce_widget(workforce_id)
+
+    token = create_public_chat_access_token(payload)
+    response = client.post(
+        "/api/widget/chat/task/create",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "hello", "description": "hello"},
+    )
+
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"] == "Invalid widget token"

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -16,6 +16,14 @@ next inbound message must drop the connection with ``4003``. Unlike
 stubbed on the auth path here, so the revocation checks in
 ``ensure_widget_agent_available`` / ``ensure_widget_workforce_available`` are
 what the assertions actually depend on.
+
+Boundary of that guarantee, so it is explicit for the next reader: revalidation
+fires only on *inbound* messages. A revoked guest that simply stops sending
+keeps receiving outbound and broadcast frames on its open socket — "dropped on
+the next message" is the whole contract, not "dropped when revoked". Nor does
+this cover connect-time revocation, which the endpoint reports as a generic
+``4001`` (pre-accept, so uvicorn discards the real code and reason) and which an
+existing test in ``test_public_chat_websocket_db_boundary.py`` pins.
 """
 
 from __future__ import annotations
@@ -142,14 +150,24 @@ def _authenticate_widget_guest(widget_key: str) -> str:
     return str(response.json()["access_token"])
 
 
-def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Let ``create_workforce_run`` build its task/run rows without executing."""
+def _stub_workforce_turn_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let ``create_workforce_run`` build its task/run rows without executing.
+
+    Patches ``schedule_claimed_create_turn`` specifically: that is what
+    ``create_workforce_run`` reaches (via ``_start_normalized_workforce_run``),
+    *not* ``begin_turn``. Stubbing ``begin_turn`` — as the sibling widget and
+    share-link suites do — is inert: the real turn still starts and its
+    background task then races test-DB teardown. The caller only reads
+    ``background_task`` off the result, so a bare namespace is enough.
+    """
 
     async def _stub(**_kwargs: Any) -> SimpleNamespace:
         return SimpleNamespace(background_task=None)
 
     monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator, "begin_turn", _stub
+        workforce_runs_service.TaskTurnOrchestrator,
+        "schedule_claimed_create_turn",
+        _stub,
     )
 
 
@@ -201,7 +219,7 @@ def _agent_widget_guest() -> _WidgetGuest:
 def _workforce_widget_guest(monkeypatch: pytest.MonkeyPatch) -> _WidgetGuest:
     workforce_id = _create_workforce("WS Revalidation Widget Workforce")
     token = _authenticate_widget_guest(_enable_workforce_widget(workforce_id))
-    _stub_begin_turn(monkeypatch)
+    _stub_workforce_turn_start(monkeypatch)
 
     created = client.post(
         "/api/widget/chat/task/create",
@@ -337,7 +355,7 @@ def test_widget_guest_token_with_non_int_user_id_is_rejected(
     """
     # A regression that admits the token would otherwise start a real workforce
     # run before reaching the assertion below.
-    _stub_begin_turn(monkeypatch)
+    _stub_workforce_turn_start(monkeypatch)
     owner_id = _owner_id()
     payload: dict[str, Any] = {
         "sub": "admin",
@@ -359,6 +377,42 @@ def test_widget_guest_token_with_non_int_user_id_is_rejected(
         payload["widget_key"] = _enable_workforce_widget(workforce_id)
 
     token = create_public_chat_access_token(payload)
+    response = client.post(
+        "/api/widget/chat/task/create",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "hello", "description": "hello"},
+    )
+
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"] == "Invalid widget token"
+
+
+def test_widget_guest_token_with_bool_entity_id_claim_is_rejected() -> None:
+    """The entity-id claims get the same exact-int treatment as ``user_id``.
+
+    ``widget_agent_id`` / ``widget_workforce_id`` select *which* entity the guest
+    is scoped to, so a ``bool`` there is an entity substitution rather than an
+    identity one: SQLAlchemy renders ``true`` as ``= 1``, resolving whichever
+    agent happens to hold id 1. The agent below is created first precisely so it
+    *is* id 1 — with a plain isinstance guard the forged claim resolves to it and
+    the request succeeds, which is what makes this more than a smoke test.
+    """
+    owner_id = _owner_id()
+    agent_id = _create_published_agent(owner_id, "Bool Id Claim Widget Agent")
+    assert agent_id == 1, "test relies on this agent holding the id `true` resolves to"
+    widget_key = _enable_agent_widget(agent_id)
+
+    token = create_public_chat_access_token(
+        {
+            "sub": "admin",
+            "user_id": owner_id,
+            "channel_id": None,
+            "guest_id": GUEST_ID,
+            "auth_mode": "widget",
+            "widget_agent_id": True,
+            "widget_key": widget_key,
+        }
+    )
     response = client.post(
         "/api/widget/chat/task/create",
         headers={"Authorization": f"Bearer {token}"},

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -308,18 +308,32 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
 
 
 @pytest.mark.parametrize("channel", ["agent", "workforce"])
+@pytest.mark.parametrize(
+    "user_id_claim",
+    [
+        # A string that would coerce cleanly -- the interesting string case,
+        # since an unparseable one fails everywhere anyway.
+        pytest.param("{owner_id}", id="numeric_string"),
+        # ``bool`` is an ``int`` subclass, so ``isinstance(True, int)`` passes
+        # and ``not True`` is False: a bare isinstance guard admits ``true``,
+        # which SQLAlchemy renders as ``User.id = 1`` and which then compares
+        # equal to owner id 1 in the ownership check (``1 == True``). Only an
+        # exact-type check rejects it.
+        pytest.param(True, id="bool_true"),
+    ],
+)
 def test_widget_guest_token_with_non_int_user_id_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
     channel: str,
+    user_id_claim: object,
 ) -> None:
-    """``user_id`` must be an int, as ``get_share_chat_user`` already requires.
+    """``user_id`` must be exactly an int, mirroring ``get_share_chat_user``.
 
-    Widget guest tokens are server-minted, so this is defense in depth rather
-    than a live hole — but without the type guard the two widget branches
-    disagree about a string ``user_id``: the agent branch happens to fail closed
-    on an int/str owner comparison, while the workforce branch coerced it to
-    compare at all and so admitted the request. Both must now reject the
-    malformed payload rather than depend on that accident.
+    Widget guest tokens are server-minted, so no caller can produce these
+    payloads without the signing key — this is defense in depth. But untyped,
+    the two widget branches disagree about a string ``user_id`` (the agent
+    branch fails closed on an int/str owner comparison; the workforce branch
+    coerced it and admitted the request), and both admit ``true`` as user 1.
     """
     # A regression that admits the token would otherwise start a real workforce
     # run before reaching the assertion below.
@@ -327,9 +341,9 @@ def test_widget_guest_token_with_non_int_user_id_is_rejected(
     owner_id = _owner_id()
     payload: dict[str, Any] = {
         "sub": "admin",
-        # A string that would coerce cleanly -- the interesting case, since an
-        # unparseable value fails everywhere anyway.
-        "user_id": str(owner_id),
+        "user_id": user_id_claim.format(owner_id=owner_id)
+        if isinstance(user_id_claim, str)
+        else user_id_claim,
         "channel_id": None,
         "guest_id": GUEST_ID,
         "auth_mode": "widget",

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -312,13 +312,13 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
     "user_id_claim",
     [
         # A string that would coerce cleanly -- the interesting string case,
-        # since an unparseable one fails everywhere anyway.
+        # since one that is not a number fails everywhere anyway.
         pytest.param("{owner_id}", id="numeric_string"),
         # ``bool`` is an ``int`` subclass, so ``isinstance(True, int)`` passes
-        # and ``not True`` is False: a bare isinstance guard admits ``true``,
-        # which SQLAlchemy renders as ``User.id = 1`` and which then compares
-        # equal to owner id 1 in the ownership check (``1 == True``). Only an
-        # exact-type check rejects it.
+        # and ``not True`` is False: a guard that does not exclude ``bool``
+        # admits ``true``, which SQLAlchemy renders as ``User.id = 1`` and which
+        # then compares equal to owner id 1 in the ownership check
+        # (``1 == True``).
         pytest.param(True, id="bool_true"),
     ],
 )


### PR DESCRIPTION
Closes #992.

## Background

The widget WS endpoint re-derives guest access from the *live* agent/workforce on every inbound message and closes with `4003` when it is gone (`public_chat_websocket_endpoint`). That was an explicit acceptance criterion of the agent (#988/#989) and workforce (#985) widget work, but it had no test:

- The existing `4003` test (`test_public_chat_websocket_db_boundary.py`) mocks `_authorize_public_chat_websocket` to raise, so it only proves the close *plumbing* — never the widget revocation checks.
- The revocation tests (`test_agents_management.py`, `test_workforce_widget.py`) only exercise HTTP `POST /api/widget/chat/task/create`.
- No test in the suite reached `/api/widget/chat/ws/{task_id}` at all.

## What this adds

`tests/web/api/test_widget_ws_revalidation.py` drives the real endpoint end to end, with **nothing stubbed on the auth path**, so the assertions depend on the checks in `ensure_widget_agent_available` / `ensure_widget_workforce_available`.

Four cases — both widget channels × both revocation levers:

| channel | revocation |
| --- | --- |
| agent | disable widget |
| agent | rotate widget key |
| workforce | disable widget |
| workforce | rotate widget key |

Each case: connect a guest with a valid token → prove the socket survives an inbound message while the widget is still live (send `intervention`, receive `intervention_processed`) → owner revokes → send one more message → assert the socket closes with `4003` / `Widget is unavailable`.

The liveness step is what makes the close attributable to the revocation rather than to sending anything at all: without it, a `4003` provoked by the *first* message would drain identically and pass.

`@pytest.mark.timeout(60)` bounds the run. If the revalidation is ever dropped, the revoked message falls through to the real chat handler and the drain blocks on a close that never comes — without the marker that regression would hang the suite instead of failing it (there is no global pytest timeout).

## Also folded in

The `isinstance(user_id, int)` guard from the issue notes, in the same shape as `get_share_chat_user` and at the one point that governs both widget branches — `get_public_chat_user`, before the `widget_workforce_id` / `widget_agent_id` split. Neither `ensure_widget_*_available` helper has callers outside this module, so nothing bypasses it.

It is defense in depth (these tokens are server-minted), but without it the two branches disagreed about a string `user_id`: the agent branch happened to fail closed on an int/str owner comparison, while the workforce branch coerced it via `int(user_id)` and **admitted the request**. The now-redundant coercion is dropped.

## Verification

Mutation-tested both halves rather than trusting green:

- Replacing the receive-loop re-authorize with the connect-time principal → all 4 WS cases fail.
- Reverting the guard to `if not user_id or not guest_id` + `int(user_id)` → both guard cases fail (workforce returns `200`, admitting the token).

`tests/web/api` is green (1339 passed); `mypy`, `ruff`, and `isort` are clean on the touched files.
