### PR TITLE
ref: add file-command path classification

### DIFF
--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -998,6 +998,12 @@ _WGET_KNOWN_LONG_OPTIONS = frozenset(
     | _WGET_READ_LONG_OPTIONS
     | {"--spider"}
 )
+_WGET_SHORT_FLAG_OPTIONS = frozenset("bqvcNSdF")
+_WGET_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "O": "write",
+    "P": "write",
+    "o": "write",
+}
 
 
 @dataclass(frozen=True)
@@ -4349,13 +4355,20 @@ class WorkspaceCommandPathGuard:
     def _check_wget(self, values: Sequence[str], cwd: Path) -> None:
         """`wget`: `-O`/`--output-document` write; `-P`/`--directory-prefix`
         write directory; `-o`/`--output-file` (log file) write;
-        `--post-file`/`--body-file` read. `--config` and `-i`/`--input-file`
-        (a runtime URL list) cannot be inspected safely and fail closed. A
-        URL operand with no explicit `-O` output (and not `--spider`, which
-        fetches nothing to disk) resolves its output filename from the
-        remote response, which is not statically knowable, so that
-        combination fails closed too. An unrecognized long option with an
-        attached `=value` also fails closed (mirroring `rsync`/`curl`).
+        `--save-cookies` write; `--post-file`/`--body-file` read. `--config`
+        and `-i`/`--input-file` (a runtime URL list) cannot be inspected
+        safely and fail closed, including bundled behind another short flag
+        (e.g. `-qi`). A URL operand with no explicit `-O` output (and not
+        `--spider`, which fetches nothing to disk) resolves its output
+        filename from the remote response, which is not statically
+        knowable, so that combination fails closed too. Long options resolve
+        through `_resolve_long_option` (GNU unambiguous-prefix abbreviation,
+        e.g. `--output-docu=` for `--output-document`); an unrecognized long
+        option with an attached `=value` also fails closed (mirroring
+        `rsync`/`curl`). Short options bundle through the same
+        `_parse_short_option_cluster` substrate `curl`/`sort`/`grep`/
+        `install` use, so `-O`/`-P`/`-o` still consume their argument even
+        when not the leading character of the cluster (e.g. `-qO`).
         """
         self._reject_dynamic_values("wget arguments", values)
         has_explicit_output = False
@@ -4365,87 +4378,74 @@ class WorkspaceCommandPathGuard:
         while index < len(values):
             value = values[index]
             text = str(value)
-            if text == "--config" or text.startswith("--config="):
-                raise CommandPolicyViolation(
-                    "cannot safely inspect wget runtime configuration"
+            if text.startswith("--"):
+                raw_option, separator, attached_text = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _WGET_KNOWN_LONG_OPTIONS
                 )
-            if text in {"-i", "--input-file"} or text.startswith(
-                ("-i", "--input-file=")
-            ):
-                raise CommandPolicyViolation(
-                    "cannot safely inspect wget runtime URL list"
-                )
-            if text == "--spider":
-                spider_mode = True
-                index += 1
-                continue
-            if text in {"-O", "--output-document", "-P", "--directory-prefix"} or (
-                text.startswith("--output-document=")
-                or text.startswith("--directory-prefix=")
-            ):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"wget argument for {option}",
-                )
-                assert argument is not None
-                self._check_path(argument, cwd, "write")
-                if text in {"-O", "--output-document"} or text.startswith(
-                    "--output-document="
+                if resolved in _WGET_CONFIG_LONG_OPTIONS:
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect wget runtime configuration"
+                    )
+                if resolved in _WGET_HARD_DENY_LONG_OPTIONS:
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect wget runtime URL list"
+                    )
+                if resolved == "--spider":
+                    spider_mode = True
+                    index += 1
+                    continue
+                if resolved in _WGET_WRITE_LONG_OPTIONS or (
+                    resolved in _WGET_READ_LONG_OPTIONS
                 ):
-                    has_explicit_output = True
-                continue
-            if (text.startswith("-O") or text.startswith("-P")) and len(text) > 2:
-                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
-                if text.startswith("-O"):
-                    has_explicit_output = True
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"wget argument for {resolved}",
+                    )
+                    assert argument is not None
+                    access: PathAccess = (
+                        "write" if resolved in _WGET_WRITE_LONG_OPTIONS else "read"
+                    )
+                    self._check_path(argument, cwd, access)
+                    if resolved == "--output-document":
+                        has_explicit_output = True
+                    continue
+                if separator:
+                    raise CommandPolicyViolation(
+                        f"cannot safely inspect wget option {raw_option}"
+                    )
                 index += 1
                 continue
-            if text in {"--post-file", "--body-file"} or text.startswith(
-                ("--post-file=", "--body-file=")
-            ):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
+            if text.startswith("-") and text != "-":
+                # `-i` fails closed even bundled behind another flag (e.g.
+                # `-qi`); scanning stops at the first character that is not
+                # a known no-value flag, since anything past a value-taking
+                # option is that option's value, not another flag letter.
+                for character in text[1:]:
+                    if character in _WGET_SHORT_FLAG_OPTIONS:
+                        continue
+                    if character == "i":
+                        raise CommandPolicyViolation(
+                            "cannot safely inspect wget runtime URL list"
+                        )
+                    break
+                index, matched_option, _ = self._parse_short_option_cluster(
                     values,
                     index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"wget argument for {option}",
+                    cwd,
+                    flag_options=_WGET_SHORT_FLAG_OPTIONS,
+                    value_options=_WGET_SHORT_VALUE_OPTIONS,
                 )
-                assert argument is not None
-                self._check_path(argument, cwd, "read")
+                if matched_option == "O":
+                    has_explicit_output = True
                 continue
-            if text in {"-o", "--output-file"} or text.startswith("--output-file="):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"wget argument for {option}",
-                )
-                assert argument is not None
-                self._check_path(argument, cwd, "write")
-                continue
-            if text.startswith("-o") and not text.startswith("--") and len(text) > 2:
-                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
-                index += 1
-                continue
-            if not text.startswith("-"):
-                has_url_operand = True
-                index += 1
-                continue
-            option, separator, _ = text.partition("=")
-            if text.startswith("--") and separator:
-                raise CommandPolicyViolation(
-                    f"cannot safely inspect wget option {option}"
-                )
+            has_url_operand = True
             index += 1
         if has_url_operand and not has_explicit_output and not spider_mode:
             raise CommandPolicyViolation(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1005,6 +1005,20 @@ _WGET_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "o": "write",
 }
 
+# `rsync` has no short-option grammar today beyond a crude bundled-character
+# scan for the highest-risk options; this builds one. `-T`/`--temp-dir` is
+# the only short option that carries a path. `-K`/`--keep-dirlinks` and
+# `-k`/`--copy-dirlinks` let rsync write through (or read through) an
+# existing destination/source-side symlink instead of the literal directory
+# entry, which can escape the intended root, so both are denied outright —
+# matching `--keep-dirlinks`'s existing long-option denial — rather than
+# access-classified. `-e`/`-f`/`-L`/`-H` mirror the long options already
+# denied below (`--rsh`, `--filter`, `--copy-links`; `-H`/`--hard-links` is
+# conservatively denied too, matching this family's pre-existing posture).
+_RSYNC_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {"T": "write"}
+_RSYNC_SHORT_DENIED_OPTIONS = frozenset("efLHKk")
+_RSYNC_SHORT_FLAG_OPTIONS = frozenset("vqarRbudlpAXogDtOJnWxzCIm8h4y6sP")
+
 # `base64`'s short options bundle into one token (e.g. `-do<file>` combines
 # the `-d` decode flag with the `-o` output-path option), so its grammar is
 # split into a flag set and a value set for the short-option-cluster parser,
@@ -4283,26 +4297,33 @@ class WorkspaceCommandPathGuard:
         unchanged files from that tree straight into the destination, so a
         read-only external root is not sufficient authorization for it.
         `--log-file`/`--write-batch`/`--only-write-batch` also write to a
-        filename argument; `--read-batch` reads one (the batched changes it
-        replays are still bounded by the invocation's own destination
-        operand, so its file argument is a plain read, not a write slot).
-        `--files-from`/`--include-from`/`--exclude-from`/`-f`/`--filter`/
-        `-e`/`--rsh`/... delegate to an external file list or shell command
-        this guard cannot inspect safely and fail closed unconditionally
-        rather than access-checking their own argument: the file's
-        *contents* can name further paths this guard never sees, so a
-        plain read check of the file itself would not bound what rsync
-        actually touches.
+        filename argument. `--files-from`/`--include-from`/`--exclude-from`/
+        `--read-batch`/`-f`/`--filter`/`-e`/`--rsh`/... delegate to an
+        external file list or shell command this guard cannot inspect safely
+        and fail closed unconditionally rather than access-checking their
+        own argument: the file's *contents* can name further paths this
+        guard never sees (`--read-batch`'s replayed changes are not bounded
+        by the invocation's own destination operand the way a plain file
+        argument would be), so a plain read check of the file itself would
+        not bound what rsync actually touches.
+
+        Short options bundle into one token (e.g. `-avz`); `-T`/`--temp-dir`
+        is the only short option that carries a path (write). `-K`/
+        `-k` (`--keep-dirlinks`/`--copy-dirlinks`) let rsync write through
+        (or read through) an existing symlink at the destination/source
+        instead of the literal directory entry, which can escape the
+        intended root, so both fail closed regardless of position in a
+        bundle, matching `--keep-dirlinks`'s long-option denial (see
+        `_RSYNC_SHORT_DENIED_OPTIONS`).
 
         Long options resolve through `_resolve_long_option` (GNU
         unambiguous-prefix abbreviation, e.g. `--link-des=`/`--link-des ` for
         `--link-dest`), so an abbreviation of any modeled option — write,
         read, scalar, or denied — is classified identically to its full
-        name in both the `=`-attached and space-separated spelling. An
-        option this map cannot resolve (a typo, an unsupported flag, or an
-        ambiguous abbreviation) fails closed when it visibly carries a
-        value (`=`-attached); a bare unmodeled long option is still assumed
-        to be a value-free flag, matching curl/wget.
+        name in both the `=`-attached and space-separated spelling. Module
+        invariant: any option (short or long, bare or `=value`-attached)
+        this allowlist cannot resolve fails closed rather than being treated
+        as an operand or a value-free flag.
         """
         self._reject_dynamic_values("rsync arguments", values)
         denied_options = {
@@ -4313,11 +4334,13 @@ class WorkspaceCommandPathGuard:
             "--files-from",
             "--include-from",
             "--exclude-from",
+            "--read-batch",
             "--password-file",
             "--rsync-path",
             "--copy-links",
             "--copy-unsafe-links",
             "--keep-dirlinks",
+            "--copy-dirlinks",
         }
         path_options: dict[str, PathAccess] = {
             "--backup-dir": "write",
@@ -4329,7 +4352,6 @@ class WorkspaceCommandPathGuard:
             "--log-file": "write",
             "--write-batch": "write",
             "--only-write-batch": "write",
-            "--read-batch": "read",
         }
         scalar_options = {
             "--block-size",
@@ -4369,22 +4391,40 @@ class WorkspaceCommandPathGuard:
                 operands.append(value)
                 index += 1
                 continue
+            if not text.startswith("--"):
+                # Scan leading flag characters; stop at the first one that
+                # is not a plain flag (a denied character, `-T`'s value
+                # slot, or an unmodeled character `_parse_short_option_cluster`
+                # itself will fail closed on) rather than scanning past it,
+                # since any remainder past a value-taking option's letter is
+                # that option's own value, not another flag character.
+                for character in text[1:]:
+                    if character in _RSYNC_SHORT_FLAG_OPTIONS:
+                        continue
+                    if character in _RSYNC_SHORT_DENIED_OPTIONS:
+                        raise CommandPolicyViolation(
+                            f"cannot safely inspect rsync option -{character}"
+                        )
+                    break
+                index, _, _ = self._parse_short_option_cluster(
+                    values,
+                    index,
+                    cwd,
+                    flag_options=_RSYNC_SHORT_FLAG_OPTIONS,
+                    value_options=_RSYNC_SHORT_VALUE_OPTIONS,
+                )
+                continue
             option, separator, attached_text = text.partition("=")
             resolved_option = option
             if (
-                text.startswith("--")
-                and option not in path_options
+                option not in path_options
                 and option not in scalar_options
                 and option not in denied_options
             ):
                 candidate = self._resolve_long_option(option, known_long_options)
                 if candidate is not None:
                     resolved_option = candidate
-            if resolved_option in denied_options or (
-                text.startswith("-")
-                and not text.startswith("--")
-                and any(flag in text[1:] for flag in {"e", "f", "L", "H"})
-            ):
+            if resolved_option in denied_options:
                 raise CommandPolicyViolation(
                     f"cannot safely inspect rsync option {option}"
                 )
@@ -4410,23 +4450,21 @@ class WorkspaceCommandPathGuard:
                     context=f"rsync argument for {resolved_option}",
                 )
                 continue
-            if text.startswith("--"):
-                # Long flag options are argument-free here. An option this
-                # map cannot resolve fails closed instead of shifting
-                # operands when it visibly carries a value.
-                if separator:
-                    raise CommandPolicyViolation(
-                        f"cannot safely inspect rsync option {option}"
-                    )
-                index += 1
-                continue
-            # Common short flags may be bundled (for example -avz).
-            index += 1
+            # Module invariant: an unresolved long option fails closed, bare
+            # or `=value`-attached alike.
+            raise CommandPolicyViolation(f"cannot safely inspect rsync option {option}")
 
-        if len(operands) < 2:
-            return
+        # N1: the remote-operand check must run regardless of operand count
+        # — a single-operand invocation is not exempt from it — and a sole
+        # local operand still gets contained as an ordinary read instead of
+        # skipping containment entirely for lack of a second operand.
         if any(self._is_remote_transfer_operand(operand) for operand in operands):
             raise CommandPolicyViolation("cannot safely inspect remote rsync operands")
+        if not operands:
+            return
+        if len(operands) == 1:
+            self._check_path(operands[0], cwd, "read")
+            return
         for operand in operands[:-1]:
             self._check_path(operand, cwd, "read")
         self._check_path(operands[-1], cwd, "write")

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -806,6 +806,12 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     "shred",
     "find",
     "tar",
+    "dd",
+    "base64",
+    "gzip",
+    "rsync",
+    "curl",
+    "wget",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
@@ -1279,6 +1285,18 @@ class WorkspaceCommandPathGuard:
             self._check_script_command(_SED_GRAMMAR, args, state.cwd)
         elif command_name == "awk":
             self._check_script_command(_AWK_GRAMMAR, args, state.cwd)
+        elif command_name == "dd":
+            self._check_dd(args, state.cwd)
+        elif command_name == "base64":
+            self._check_base64(args, state.cwd)
+        elif command_name == "gzip":
+            self._check_gzip(args, state.cwd)
+        elif command_name == "rsync":
+            self._check_rsync(args, state.cwd)
+        elif command_name == "curl":
+            self._check_curl(args, state.cwd)
+        elif command_name == "wget":
+            self._check_wget(args, state.cwd)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -3366,6 +3384,553 @@ class WorkspaceCommandPathGuard:
                 return script[start:cursor]
             cursor += 1
         raise CommandPolicyViolation("cannot safely inspect awk redirect target")
+
+    def _check_dd(self, values: Sequence[str], cwd: Path) -> None:
+        """`dd`: `if=`/`of=` operands are paths; every other `key=value`
+        operand (`bs=`, `count=`, `seek=`, `iflag=`, `oflag=`, ...) is a
+        scalar and is never a path.
+        """
+        self._reject_dynamic_values("dd arguments", values)
+        for value in values:
+            text = str(value)
+            if text.startswith("if="):
+                self._check_path(value.split("=", 1)[1], cwd, "read")
+            elif text.startswith("of="):
+                self._check_path(value.split("=", 1)[1], cwd, "write")
+
+    def _check_base64(self, values: Sequence[str], cwd: Path) -> None:
+        """`base64`: `-i`/`--input` reads, `-o`/`--output` writes.
+
+        `-b`/`--break` and `-w`/`--wrap` take a scalar column-width value
+        that is never a path.
+        """
+        self._reject_dynamic_values("base64 arguments", values)
+        inputs: list[str] = []
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                inputs.extend(values[index + 1 :])
+                break
+            if value in {"--input", "--output"}:
+                if index + 1 < len(values):
+                    self._check_path(
+                        values[index + 1],
+                        cwd,
+                        "read" if value == "--input" else "write",
+                    )
+                index += 2
+                continue
+            if value.startswith(("--input=", "--output=")):
+                self._check_path(
+                    value.split("=", 1)[1],
+                    cwd,
+                    "read" if value.startswith("--input=") else "write",
+                )
+                index += 1
+                continue
+            if value in {"--break", "--wrap"}:
+                index += 2
+                continue
+            if value.startswith(("--break=", "--wrap=")):
+                index += 1
+                continue
+            if value.startswith("-") and not value.startswith("--") and value != "-":
+                index = self._check_base64_short_options(values, index, cwd)
+                continue
+            inputs.append(value)
+            index += 1
+        for raw_path in inputs:
+            self._check_path(raw_path, cwd, "read")
+
+    def _check_base64_short_options(
+        self,
+        values: Sequence[str],
+        index: int,
+        cwd: Path,
+    ) -> int:
+        """Parse one bundled base64 short-option token (e.g. `-di<file>`).
+
+        Only `i`/`o`/`b`/`w` take a value (attached, e.g. `-ifile`, or as the
+        following token); any other character in the cluster (`-d` decode,
+        etc.) is a flag and is skipped without consuming an argument.
+        """
+        value = values[index]
+        options = value[1:]
+        cursor = 0
+        while cursor < len(options):
+            option = options[cursor]
+            if option in {"i", "o", "b", "w"}:
+                attached = options[cursor + 1 :]
+                argument, next_index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached) if attached else None
+                    ),
+                    context=f"base64 argument for -{option}",
+                    required=False,
+                )
+                if argument is not None and option in {"i", "o"}:
+                    self._check_path(
+                        argument,
+                        cwd,
+                        "read" if option == "i" else "write",
+                    )
+                return next_index
+            cursor += 1
+        return index + 1
+
+    def _check_gzip(self, values: Sequence[str], cwd: Path) -> None:
+        """`gzip`: default mode replaces its operand with a derived `.gz` file.
+
+        The `.gz` suffix (and any `--suffix`-overridden variant) is a
+        distinct, non-enumerable path this guard does not compute, so
+        default mode both write-checks the operand itself (gzip removes the
+        original after compressing it) and poisons `unknown_effect` for the
+        derived compressed file — additive to, not a replacement for, the
+        operand's own containment check (M2). `-c`/`--stdout`/`-l`/`--list`/
+        `-t`/`--test` never create or remove a file, so the operand stays a
+        plain read in those modes.
+        """
+        self._reject_dynamic_values("gzip arguments", values)
+        read_only_mode = any(
+            value
+            in {
+                "-c",
+                "--stdout",
+                "--to-stdout",
+                "-l",
+                "--list",
+                "-t",
+                "--test",
+            }
+            or (
+                str(value).startswith("-")
+                and not str(value).startswith("--")
+                and any(flag in str(value)[1:] for flag in {"c", "l", "t"})
+            )
+            for value in values
+        )
+        operands = self._strict_simple_operands(
+            "gzip",
+            values,
+            flag_options={
+                "-a",
+                "--ascii",
+                "-c",
+                "--stdout",
+                "--to-stdout",
+                "-d",
+                "--decompress",
+                "--uncompress",
+                "-f",
+                "--force",
+                "-h",
+                "--help",
+                "-k",
+                "--keep",
+                "-l",
+                "--list",
+                "-n",
+                "--no-name",
+                "-N",
+                "--name",
+                "-q",
+                "--quiet",
+                "-r",
+                "--recursive",
+                "-t",
+                "--test",
+                "-v",
+                "--verbose",
+                "-V",
+                "--version",
+                *{f"-{level}" for level in range(1, 10)},
+            },
+            scalar_options={"-S", "--suffix"},
+            allow_short_bundles=True,
+        )
+        access: PathAccess = "read" if read_only_mode else "write"
+        if not read_only_mode:
+            _active_validation_session().effects.unknown_effect = True
+        for operand in operands:
+            self._check_path(operand, cwd, access)
+
+    def _strict_simple_operands(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        *,
+        flag_options: set[str],
+        scalar_options: set[str] | frozenset[str] = frozenset(),
+        allow_short_bundles: bool = False,
+    ) -> list[str]:
+        """Parse a simple GNU-style argv into flag/scalar options and operands.
+
+        An option this family does not recognize fails closed rather than
+        being silently treated as an operand or skipped, so an unmodeled
+        option can never hide (or misclassify) a path argument. Only used by
+        families narrow enough that every option is either a no-value flag
+        or a single-scalar-value option (gzip); families with path-bearing
+        options use `_partition_path_options` instead.
+        """
+        operands: list[str] = []
+        options_done = False
+        index = 0
+        short_flags = {
+            option[1:]
+            for option in flag_options
+            if option.startswith("-") and not option.startswith("--")
+        }
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                operands.append(value)
+                index += 1
+                continue
+            if text in flag_options:
+                index += 1
+                continue
+            if text in scalar_options:
+                if index + 1 >= len(values):
+                    raise CommandPolicyViolation(
+                        f"missing {command_name} argument for {text}"
+                    )
+                index += 2
+                continue
+            if any(
+                text.startswith(f"{option}=")
+                for option in scalar_options
+                if option.startswith("--")
+            ):
+                index += 1
+                continue
+            if (
+                allow_short_bundles
+                and text.startswith("-")
+                and not text.startswith("--")
+                and set(text[1:]).issubset(short_flags)
+            ):
+                index += 1
+                continue
+            raise CommandPolicyViolation(
+                f"cannot safely inspect {command_name} option {text}"
+            )
+        return operands
+
+    def _check_rsync(self, values: Sequence[str], cwd: Path) -> None:
+        """`rsync`: any remote operand rejects the WHOLE invocation (M5).
+
+        A local invocation classifies its source/dest positionals plus its
+        write/read-control options. `--link-dest` is a write slot even
+        though it only *reads* its argument today: rsync may hard-link
+        unchanged files from that tree straight into the destination, so a
+        read-only external root is not sufficient authorization for it.
+        `--files-from`/`-f`/`--filter`/`-e`/`--rsh`/... delegate to an
+        external file list or shell command this guard cannot inspect
+        safely and fail closed rather than silently bypassing containment.
+        """
+        self._reject_dynamic_values("rsync arguments", values)
+        denied_options = {
+            "-e",
+            "--rsh",
+            "-f",
+            "--filter",
+            "--files-from",
+            "--include-from",
+            "--exclude-from",
+            "--password-file",
+            "--rsync-path",
+            "--copy-links",
+            "--copy-unsafe-links",
+            "--keep-dirlinks",
+        }
+        path_options: dict[str, PathAccess] = {
+            "--backup-dir": "write",
+            "--partial-dir": "write",
+            "--temp-dir": "write",
+            "--compare-dest": "read",
+            "--copy-dest": "read",
+            "--link-dest": "write",
+        }
+        scalar_options = {
+            "--block-size",
+            "--bwlimit",
+            "--checksum-choice",
+            "--chmod",
+            "--compress-choice",
+            "--compress-level",
+            "--contimeout",
+            "--max-alloc",
+            "--max-delete",
+            "--max-size",
+            "--min-size",
+            "--out-format",
+            "--port",
+            "--sockopts",
+            "--timeout",
+            "--usermap",
+            "--groupmap",
+        }
+        operands: list[str] = []
+        options_done = False
+        index = 0
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                operands.append(value)
+                index += 1
+                continue
+            option, separator, attached_text = text.partition("=")
+            if option in denied_options or (
+                text.startswith("-")
+                and not text.startswith("--")
+                and any(flag in text[1:] for flag in {"e", "f", "L", "H"})
+            ):
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect rsync option {option}"
+                )
+            if option in path_options:
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"rsync argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, path_options[option])
+                continue
+            if option in scalar_options:
+                _, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"rsync argument for {option}",
+                )
+                continue
+            if text.startswith("--"):
+                # Long flag options are argument-free here. Options with
+                # unmodeled values fail closed instead of shifting operands.
+                if separator:
+                    raise CommandPolicyViolation(
+                        f"cannot safely inspect rsync option {option}"
+                    )
+                index += 1
+                continue
+            # Common short flags may be bundled (for example -avz).
+            index += 1
+
+        if len(operands) < 2:
+            return
+        if any(self._is_remote_transfer_operand(operand) for operand in operands):
+            raise CommandPolicyViolation("cannot safely inspect remote rsync operands")
+        for operand in operands[:-1]:
+            self._check_path(operand, cwd, "read")
+        self._check_path(operands[-1], cwd, "write")
+
+    @staticmethod
+    def _is_remote_transfer_operand(value: str) -> bool:
+        """Return whether `value` is a remote address, not a local path.
+
+        Covers `rsync://host/path`, `host:path`, and `user@host:path`.
+        """
+        text = str(value)
+        return text.startswith("rsync://") or ":" in text
+
+    def _check_curl(self, values: Sequence[str], cwd: Path) -> None:
+        """`curl`: `-o`/`--output`/`--output-dir` write; `-T`/`--upload-file`/
+        `--netrc-file` read; an `@file` payload to `-d`/`--data*` reads that
+        file. `-K`/`--config` (arbitrary runtime options) and `-O`/
+        `--remote-name[-all]` (output filename derived from the remote URL
+        or response, not statically knowable) cannot be inspected safely and
+        fail closed.
+        """
+        self._reject_dynamic_values("curl arguments", values)
+        index = 0
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if text in {"-O", "--remote-name", "--remote-name-all"} or (
+                text.startswith("-O") and not text.startswith("--")
+            ):
+                raise CommandPolicyViolation(
+                    "cannot safely resolve curl remote output filename"
+                )
+            if (
+                text in {"-K", "--config"}
+                or text.startswith("--config=")
+                or (text.startswith("-K") and len(text) > 2)
+            ):
+                raise CommandPolicyViolation(
+                    "cannot safely inspect curl runtime configuration"
+                )
+            if text in {"-o", "--output", "--output-dir"} or text.startswith(
+                ("--output=", "--output-dir=")
+            ):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"curl argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "write")
+                continue
+            if text.startswith("-o") and len(text) > 2:
+                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
+                index += 1
+                continue
+            if text in {"-T", "--upload-file", "--netrc-file"} or text.startswith(
+                ("--upload-file=", "--netrc-file=")
+            ):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"curl argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "read")
+                continue
+            if text.startswith("-T") and len(text) > 2:
+                self._check_path(self._derived_value(value, text[2:]), cwd, "read")
+                index += 1
+                continue
+            if text in {
+                "-d",
+                "--data",
+                "--data-binary",
+                "--data-raw",
+            } or text.startswith(("--data=", "--data-binary=", "--data-raw=")):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"curl argument for {option}",
+                )
+                assert argument is not None
+                if str(argument).startswith("@"):
+                    self._check_path(
+                        self._derived_value(argument, str(argument)[1:]),
+                        cwd,
+                        "read",
+                    )
+                continue
+            if text.startswith("-d") and len(text) > 2:
+                argument = self._derived_value(value, text[2:])
+                if str(argument).startswith("@"):
+                    self._check_path(
+                        self._derived_value(argument, str(argument)[1:]),
+                        cwd,
+                        "read",
+                    )
+                index += 1
+                continue
+            index += 1
+
+    def _check_wget(self, values: Sequence[str], cwd: Path) -> None:
+        """`wget`: `-O`/`--output-document` write; `-P`/`--directory-prefix`
+        write directory; `--post-file`/`--body-file` read. `--config` and
+        `-i`/`--input-file` (a runtime URL list) cannot be inspected safely
+        and fail closed. A URL operand with no explicit `-O` output (and not
+        `--spider`, which fetches nothing to disk) resolves its output
+        filename from the remote response, which is not statically
+        knowable, so that combination fails closed too.
+        """
+        self._reject_dynamic_values("wget arguments", values)
+        has_explicit_output = False
+        spider_mode = False
+        has_url_operand = False
+        index = 0
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if text == "--config" or text.startswith("--config="):
+                raise CommandPolicyViolation(
+                    "cannot safely inspect wget runtime configuration"
+                )
+            if text in {"-i", "--input-file"} or text.startswith(
+                ("-i", "--input-file=")
+            ):
+                raise CommandPolicyViolation(
+                    "cannot safely inspect wget runtime URL list"
+                )
+            if text == "--spider":
+                spider_mode = True
+                index += 1
+                continue
+            if text in {"-O", "--output-document", "-P", "--directory-prefix"} or (
+                text.startswith("--output-document=")
+                or text.startswith("--directory-prefix=")
+            ):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"wget argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "write")
+                if text in {"-O", "--output-document"} or text.startswith(
+                    "--output-document="
+                ):
+                    has_explicit_output = True
+                continue
+            if (text.startswith("-O") or text.startswith("-P")) and len(text) > 2:
+                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
+                if text.startswith("-O"):
+                    has_explicit_output = True
+                index += 1
+                continue
+            if text in {"--post-file", "--body-file"} or text.startswith(
+                ("--post-file=", "--body-file=")
+            ):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"wget argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "read")
+                continue
+            if not text.startswith("-"):
+                has_url_operand = True
+            index += 1
+        if has_url_operand and not has_explicit_output and not spider_mode:
+            raise CommandPolicyViolation(
+                "cannot safely resolve wget remote output filename"
+            )
 
     def _inspect_shell_script(
         self,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -251,7 +251,6 @@ _COMMAND_VALUE_OPTIONS = {
     "head": frozenset({"-c", "--bytes", "-n", "--lines"}),
     "tail": frozenset({"-c", "--bytes", "-n", "--lines"}),
     "tac": frozenset({"-s", "--separator"}),
-    "truncate": frozenset({"-s", "--size"}),
 }
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
 _BASH_LONG_FLAG_OPTIONS = {
@@ -631,7 +630,18 @@ class _CommandWrapperGrammar:
 
 @dataclass(frozen=True)
 class _ScriptCommandGrammar:
-    """`sed`/`awk` argv shape: script source options plus file operands."""
+    """`sed`/`awk` argv shape: script source options plus file operands.
+
+    `value_options` holds long option names (`--...`) that take a mandatory
+    scalar (non-path) value, such as sed's `--line-length`; the matching
+    short spelling, if any, belongs in `short_value_options` instead.
+    `optional_write_options` holds awk's gawk-style `-o`/`--pretty-print`,
+    `-p`/`--profile`, `-d`/`--dump-variables` options, keyed by BOTH the
+    short (`-x`) and long (`--xxx`) spelling, mapped to the fixed filename
+    gawk uses when no explicit argument is given; unlike `value_options`,
+    these never consume a separate token (GNU optional-argument
+    convention: the value, if given, must be attached).
+    """
 
     language: Literal["sed", "awk"]
     expression_long_option: str
@@ -641,6 +651,7 @@ class _ScriptCommandGrammar:
     short_value_options: frozenset[str] = frozenset()
     in_place_short_option: str | None = None
     in_place_long_option: str | None = None
+    optional_write_options: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -757,13 +768,13 @@ _COMMAND_WRAPPER_GRAMMARS = {
 
 # `-l`/`--line-length` (sed) and `-F`/`-v` (awk) take a scalar value that is
 # never a path, so they are skipped rather than routed through the file-
-# operand check. sed's short options additionally bundle (e.g. `-ne`,
-# `-i.bak`), which `awk` does not, so `short_flag_options` stays empty for awk
-# and its `-e`/`-f` are only ever standalone or attached without bundling.
+# operand check. Both families bundle short options (e.g. sed's `-ne`,
+# `-i.bak`; awk's `-Fx`, gawk's `-o[file]`), so both list at least one
+# `short_value_options`/`optional_write_options` entry.
 _SED_GRAMMAR = _ScriptCommandGrammar(
     language="sed",
     expression_long_option="--expression",
-    value_options=frozenset({"-l", "--line-length"}),
+    value_options=frozenset({"--line-length"}),
     short_flag_options=frozenset({"E", "n", "r", "s", "u", "z"}),
     short_value_options=frozenset({"l"}),
     in_place_short_option="i",
@@ -772,8 +783,19 @@ _SED_GRAMMAR = _ScriptCommandGrammar(
 _AWK_GRAMMAR = _ScriptCommandGrammar(
     language="awk",
     expression_long_option="--source",
-    value_options=frozenset({"-F", "-v"}),
+    short_value_options=frozenset({"F", "v"}),
     ignores_assignment_arguments=True,
+    # gawk's optional-argument write options: the value, if present, is
+    # always attached (never a separate token); the default is the fixed
+    # filename gawk itself writes when no argument is given.
+    optional_write_options={
+        "-o": "awkprof.out",
+        "--pretty-print": "awkprof.out",
+        "-p": "awkprof.out",
+        "--profile": "awkprof.out",
+        "-d": "awkvars.out",
+        "--dump-variables": "awkvars.out",
+    },
 )
 # `system(...)` always executes an arbitrary shell command; `print`/`printf`
 # redirection and `getline` I/O are located structurally instead (see
@@ -784,34 +806,48 @@ _AWK_PRINT_PATTERN = re.compile(r"\b(?:print|printf)\b")
 _AWK_GETLINE_PATTERN = re.compile(r"\bgetline\b")
 _AWK_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
+# Commands routed to a dedicated per-family handler in
+# `_validate_command_values` (own a slot — write/read split, target-directory,
+# every-operand-write-sensitivity, script-source parsing, ... — a flat
+# read/write classification cannot express). This is the single source of
+# truth for that dispatch set: `_CLASSIFIED_EXECUTABLE_COMMANDS` below and the
+# test suite's coverage registry both derive from it, so a command dispatched
+# here without a matching test entry fails the coverage gate instead of
+# silently going untested.
+_DEDICATED_HANDLER_COMMANDS = frozenset(
+    {
+        "sort",
+        "uniq",
+        "diff",
+        "grep",
+        "cp",
+        "install",
+        "mv",
+        "ln",
+        "unlink",
+        "shred",
+        "find",
+        "tar",
+        "sed",
+        "awk",
+        "dd",
+        "base64",
+        "gzip",
+        "rsync",
+        "curl",
+        "wget",
+    }
+)
+
 _CLASSIFIED_EXECUTABLE_COMMANDS = {
     *_READ_COMMANDS,
     *_WRITE_COMMANDS,
     *_SHELL_COMMANDS,
     *_UNSUPPORTED_SHELL_COMMANDS,
     *_UNSUPPORTED_PRIVILEGE_COMMANDS,
+    *_DEDICATED_HANDLER_COMMANDS,
     "chroot",
     "xargs",
-    "sort",
-    "uniq",
-    "diff",
-    "grep",
-    "cp",
-    "install",
-    "mv",
-    "ln",
-    "sed",
-    "awk",
-    "unlink",
-    "shred",
-    "find",
-    "tar",
-    "dd",
-    "base64",
-    "gzip",
-    "rsync",
-    "curl",
-    "wget",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
@@ -882,6 +918,24 @@ _SORT_KNOWN_LONG_OPTIONS = frozenset(
     }
 )
 
+# `grep`'s short options bundle into one token (e.g. `-if file` combines the
+# `-i` flag with the `-f` pattern-file option), so its grammar is split into a
+# flag set (no value) and a value set (one following/attached argument, with
+# a read/scalar access) for the short-option-cluster parser, the same shape
+# `sort` uses. `-e`/`-f` also carry the (never-a-path) pattern text/pattern
+# file, so they are not paths themselves in this map; only `-f`'s argument is.
+_GREP_SHORT_FLAG_OPTIONS = frozenset("EFGPivwxcLloqsaIHhnTZzrRVb")
+_GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "e": None,
+    "f": "read",
+    "m": None,
+    "A": None,
+    "B": None,
+    "C": None,
+    "D": None,
+    "d": None,
+}
+
 
 @dataclass(frozen=True)
 class _PathEvent:
@@ -943,6 +997,8 @@ _TarEventKind = Literal[
     "positional",
     "dangerous",
     "absolute_names",
+    "verbose_output",
+    "unresolved_option",
 ]
 
 
@@ -1722,9 +1778,12 @@ class WorkspaceCommandPathGuard:
 
         `uniq [OPTION]... [INPUT [OUTPUT]]`: the first operand is the input
         (read), the second, if present, is the output (write). Its own
-        options only take scalar (non-path) values, so an unrecognized
-        `--`-option must still fail closed rather than silently shift the
-        positional write slot.
+        value-bearing options only take scalar (non-path) values, and its
+        no-value long options (`--count`, `--repeated`, `--all-repeated`,
+        `--ignore-case`, `--unique`, `--zero-terminated`, `--group`) never
+        consume an argument, so listing them separately keeps an
+        unrecognized `--`-option failing closed rather than silently
+        shifting the positional write slot.
         """
         scalar_options = frozenset(
             {"-f", "--skip-fields", "-s", "--skip-chars", "-w", "--check-chars"}
@@ -1734,6 +1793,17 @@ class WorkspaceCommandPathGuard:
             cwd,
             option_access=dict.fromkeys(scalar_options),
             attached_short_options=frozenset({"-f", "-s", "-w"}),
+            flag_long_options=frozenset(
+                {
+                    "--count",
+                    "--repeated",
+                    "--all-repeated",
+                    "--ignore-case",
+                    "--unique",
+                    "--zero-terminated",
+                    "--group",
+                }
+            ),
             fail_closed_on_unknown_long_option=True,
         )
         if operands:
@@ -1744,9 +1814,12 @@ class WorkspaceCommandPathGuard:
     def _check_diff(self, values: Sequence[str], cwd: Path) -> None:
         """Classify `diff`'s write (`--output`) and read-control options.
 
-        `-N`/`--new-file` takes no argument, so it is unaffected by the
-        write-slot fail-closed rule below (which only gates `--`-prefixed
-        options that would otherwise consume an argument silently).
+        `-N`/`--new-file` and diff's other common no-value long options
+        (`--brief`, `--unified`, `--recursive`, `--ignore-case`, `--color`,
+        `--side-by-side`) never consume an argument, so listing them
+        separately keeps the write-slot fail-closed rule below (which only
+        gates `--`-prefixed options that would otherwise consume an
+        argument silently) from rejecting ordinary read-only usage.
         """
         for raw_path in self._partition_path_options(
             values,
@@ -1756,6 +1829,17 @@ class WorkspaceCommandPathGuard:
                 "--from-file": "read",
                 "--to-file": "read",
             },
+            flag_long_options=frozenset(
+                {
+                    "--brief",
+                    "--unified",
+                    "--recursive",
+                    "--ignore-case",
+                    "--color",
+                    "--side-by-side",
+                    "--new-file",
+                }
+            ),
             fail_closed_on_unknown_long_option=True,
         ):
             self._check_path(raw_path, cwd, "read")
@@ -1810,8 +1894,27 @@ class WorkspaceCommandPathGuard:
                 )
                 index += 1
                 continue
-            if value_text.startswith("-") and value_text != "-":
+            if value_text.startswith("--"):
+                # Long flag options this family does not model (e.g.
+                # `--color=auto`) carry no path, so they are skipped rather
+                # than parsed further.
                 index += 1
+                continue
+            if value_text.startswith("-") and value_text != "-":
+                # A bundled short-option cluster (e.g. `-if`, `-vf`, `-nf`):
+                # only the trailing character may carry a value, so `-f`'s
+                # pattern-file argument is still read-checked even when it is
+                # not the leading flag in the token.
+                cluster_chars = value_text[1:]
+                if "e" in cluster_chars or "f" in cluster_chars:
+                    explicit_pattern = True
+                index = self._parse_short_option_cluster(
+                    values,
+                    index,
+                    cwd,
+                    flag_options=_GREP_SHORT_FLAG_OPTIONS,
+                    value_options=_GREP_SHORT_VALUE_OPTIONS,
+                )
                 continue
             positionals.append(value)
             index += 1
@@ -1832,8 +1935,11 @@ class WorkspaceCommandPathGuard:
         argument are not paths, so that leading operand is excluded from the
         write check. `--reference=RFILE` supplies the same role from a file
         instead (itself a read path, classified through the access-map
-        substrate), so no positional is excluded when it is present. Every
-        other write command in this family has no non-path positional.
+        substrate), so no positional is excluded when it is present.
+        `touch`/`truncate` own their own `-r`/`--reference` read slot (the
+        reference file's timestamps/size are read, never written) plus, for
+        `truncate`, the `-s`/`--size` scalar; every other write command in
+        this family has no non-path positional.
         """
         if command_name in _OWNERSHIP_MODE_COMMANDS:
             operands = self._partition_path_options(
@@ -1847,6 +1953,24 @@ class WorkspaceCommandPathGuard:
             )
             if not has_reference and operands:
                 operands = operands[1:]
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "write")
+            return
+        if command_name in {"touch", "truncate"}:
+            option_access: dict[str, PathAccess | None] = {
+                "-r": "read",
+                "--reference": "read",
+            }
+            attached_short_options = {"-r"}
+            if command_name == "truncate":
+                option_access.update({"-s": None, "--size": None})
+                attached_short_options.add("-s")
+            operands = self._partition_path_options(
+                values,
+                cwd,
+                option_access=option_access,
+                attached_short_options=frozenset(attached_short_options),
+            )
             for raw_path in operands:
                 self._check_path(raw_path, cwd, "write")
             return
@@ -2038,6 +2162,18 @@ class WorkspaceCommandPathGuard:
                 continue
             if text in flag_options:
                 index += 1
+                continue
+            if not text.startswith("--"):
+                # A bundled cluster (e.g. `-Dm755`): only the trailing
+                # value-taking character may carry an attached argument, so
+                # this shares the same GNU bundling contract as `sort`.
+                index = self._parse_short_option_cluster(
+                    values,
+                    index,
+                    cwd,
+                    flag_options=frozenset("bcCDpsTv"),
+                    value_options={"g": None, "m": None, "o": None, "S": None},
+                )
                 continue
             raise CommandPolicyViolation(f"cannot safely inspect install option {text}")
 
@@ -2335,6 +2471,12 @@ class WorkspaceCommandPathGuard:
                         "tar absolute extraction paths cannot be inspected safely"
                     )
                 continue
+            if event.kind == "unresolved_option":
+                if invocation.mode in {"extract", "list"}:
+                    raise CommandPolicyViolation(
+                        f"cannot safely resolve tar option {event.value}"
+                    )
+                continue
             if event.value is None:
                 continue
 
@@ -2355,6 +2497,10 @@ class WorkspaceCommandPathGuard:
             elif event.kind == "incremental":
                 # The snapshot file can be updated even when the archive
                 # itself is only read (e.g. listing against a snapshot).
+                self._check_path(event.value, cwd, "write")
+            elif event.kind == "verbose_output":
+                # `--index-file` always writes the verbose listing, even
+                # when the archive itself is only read (e.g. `--list`).
                 self._check_path(event.value, cwd, "write")
             elif event.kind == "add_file":
                 self._check_path(event.value, active_cwd, source_access)
@@ -2487,6 +2633,21 @@ class WorkspaceCommandPathGuard:
         values: Sequence[str],
         index: int,
     ) -> tuple[int, _TarEvent | None]:
+        """Parse one `--`-prefixed tar argument into a typed event.
+
+        An unrecognized long option with an attached `=value` unambiguously
+        carries a value this family does not model, and fails closed
+        immediately regardless of mode (mirroring `rsync`/`curl`/`wget`).
+        An unrecognized option with NO attached value is ambiguous: it may
+        be a bare flag (common; e.g. `--gzip`), or it may take a separate
+        following token this parser cannot identify as its argument, which
+        would otherwise be misclassified as an unchecked archive-member
+        positional in extract/list mode (that value is never path-checked
+        there). Rather than guess its arity, it is returned as an
+        `unresolved_option` event so `_check_tar` can fail closed in
+        extract/list mode specifically, where that ambiguity is exploitable,
+        while leaving other modes' (already-checked) positionals unaffected.
+        """
         value = values[index]
         text = str(value)
         path_options: dict[str, _TarEventKind] = {
@@ -2496,6 +2657,7 @@ class WorkspaceCommandPathGuard:
             "--exclude-from": "exclude_from",
             "--listed-incremental": "incremental",
             "--add-file": "add_file",
+            "--index-file": "verbose_output",
         }
         dangerous_options = {
             "--use-compress-program",
@@ -2509,7 +2671,11 @@ class WorkspaceCommandPathGuard:
         kind = path_options.get(option)
         is_dangerous = option in dangerous_options
         if kind is None and not is_dangerous:
-            return index + 1, None
+            if separator:
+                raise CommandPolicyViolation(
+                    f"cannot safely resolve tar option {option}"
+                )
+            return index + 1, _TarEvent("unresolved_option", option)
 
         argument, next_index = self._take_option_argument(
             values,
@@ -2682,13 +2848,19 @@ class WorkspaceCommandPathGuard:
         *,
         option_access: Mapping[str, PathAccess | None],
         attached_short_options: frozenset[str] = frozenset(),
+        flag_long_options: frozenset[str] = frozenset(),
         fail_closed_on_unknown_long_option: bool = False,
     ) -> list[str]:
         """Split path-bearing options from operands using a per-option access map.
 
         Each key in `option_access` consumes exactly one following or attached
         token; a `None` access consumes it without a path check (a scalar
-        value), `"read"`/`"write"` checks it. Long options resolve through
+        value), `"read"`/`"write"` checks it. `flag_long_options` is a
+        separate set of long options that never take an argument (bare, or
+        with an optional attached `=value` this family ignores); listing a
+        long option there instead of in `option_access` is required for any
+        option that owns no value slot, since `option_access` always consumes
+        a following/attached token. Long options resolve through
         `_resolve_long_option` first, so an accepted abbreviation (`--out=`
         for `--output`) is classified identically to the full name. A family
         that owns a write slot must set `fail_closed_on_unknown_long_option`
@@ -2698,8 +2870,9 @@ class WorkspaceCommandPathGuard:
         left in place as an ordinary (over-checked, never under-checked)
         operand, matching the family's existing single-access classification.
         """
-        known_long_options = frozenset(
-            option for option in option_access if option.startswith("--")
+        known_long_options = (
+            frozenset(option for option in option_access if option.startswith("--"))
+            | flag_long_options
         )
         remaining: list[str] = []
         options_done = False
@@ -2727,12 +2900,19 @@ class WorkspaceCommandPathGuard:
             if value_text.startswith("--"):
                 raw_option, separator, _ = value_text.partition("=")
                 resolved = raw_option
-                if resolved not in option_access and known_long_options:
+                if (
+                    resolved not in option_access
+                    and resolved not in flag_long_options
+                    and known_long_options
+                ):
                     candidate = self._resolve_long_option(
                         raw_option, known_long_options
                     )
                     if candidate is not None:
                         resolved = candidate
+                if resolved in flag_long_options:
+                    index += 1
+                    continue
                 if resolved in option_access:
                     access = option_access[resolved]
                     argument: str
@@ -2836,11 +3016,33 @@ class WorkspaceCommandPathGuard:
         `_read_policy_script` (M4: the same `unknown_effect` gate, non-regular-
         file rejection, and bounded read every other script read uses) before
         the same lexer, rather than a parallel copy. sed's `-i`/`--in-place`
-        switches the remaining file operands from read to write.
+        switches the remaining file operands from read to write. Long options
+        resolve through `_resolve_long_option` (GNU unambiguous-prefix
+        abbreviation, e.g. `--expr=` for `--expression`); an option this
+        family does not recognize fails closed instead of being silently
+        skipped, since a write-owning spelling (`--file`, `--in-place`, awk's
+        `--pretty-print`/`--profile`/`--dump-variables`) could otherwise hide
+        behind an unrecognized abbreviation or typo. Single-dash tokens are
+        always parsed as a short-option cluster (`_consume_script_short_options`),
+        which fails closed the same way for an unmodeled short option.
         """
         positionals: list[str] = []
         explicit_script = False
         file_access: PathAccess = "read"
+        known_long_options = frozenset(
+            {"--file", grammar.expression_long_option}
+            | {option for option in grammar.value_options if option.startswith("--")}
+            | (
+                {grammar.in_place_long_option}
+                if grammar.in_place_long_option is not None
+                else set()
+            )
+            | {
+                option
+                for option in grammar.optional_write_options
+                if option.startswith("--")
+            }
+        )
         index = 0
         while index < len(values):
             value = values[index]
@@ -2848,66 +3050,70 @@ class WorkspaceCommandPathGuard:
                 positionals.extend(values[index + 1 :])
                 break
             value_text = str(value)
-            if value_text in {"-f", "--file"}:
-                explicit_script = True
-                if index + 1 < len(values):
-                    self._inspect_script_file(grammar.language, values[index + 1], cwd)
-                index += 2
-                continue
-            if value_text.startswith("--file="):
-                explicit_script = True
-                self._inspect_script_file(
-                    grammar.language,
-                    self._derived_value(value, value_text[len("--file=") :]),
-                    cwd,
-                )
-                index += 1
-                continue
-            if value_text.startswith("-f") and not value_text.startswith("--f"):
-                explicit_script = True
-                self._inspect_script_file(
-                    grammar.language, self._derived_value(value, value_text[2:]), cwd
-                )
-                index += 1
-                continue
-            if value_text in {"-e", grammar.expression_long_option}:
-                explicit_script = True
-                if index + 1 < len(values):
-                    self._check_script_expression(
-                        grammar.language, values[index + 1], cwd
+            if value_text.startswith("--") and value_text != "--":
+                raw_option, separator, attached = value_text.partition("=")
+                resolved = self._resolve_long_option(raw_option, known_long_options)
+                if resolved is None:
+                    raise CommandPolicyViolation(
+                        f"cannot safely inspect {grammar.language} option {raw_option}"
                     )
-                index += 2
-                continue
-            if value_text.startswith(f"{grammar.expression_long_option}="):
-                explicit_script = True
-                self._check_script_expression(
-                    grammar.language,
-                    self._derived_value(
-                        value,
-                        value_text[len(grammar.expression_long_option) + 1 :],
+                if resolved == "--file":
+                    explicit_script = True
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"{grammar.language} argument for {resolved}",
+                    )
+                    assert argument is not None
+                    self._inspect_script_file(grammar.language, argument, cwd)
+                    continue
+                if resolved == grammar.expression_long_option:
+                    explicit_script = True
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"{grammar.language} argument for {resolved}",
+                    )
+                    assert argument is not None
+                    self._check_script_expression(grammar.language, argument, cwd)
+                    continue
+                if resolved == grammar.in_place_long_option:
+                    file_access = "write"
+                    index += 1
+                    continue
+                if resolved in grammar.optional_write_options:
+                    argument = (
+                        self._derived_value(value, attached)
+                        if separator
+                        else _CommandValue(grammar.optional_write_options[resolved])
+                    )
+                    self._check_path(argument, cwd, "write")
+                    index += 1
+                    continue
+                # The remaining known long options are mandatory scalar
+                # values (e.g. sed's `--line-length`), never a path.
+                _, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached) if separator else None
                     ),
-                    cwd,
+                    context=f"{grammar.language} argument for {resolved}",
                 )
-                index += 1
-                continue
-            if value_text.startswith("-e") and not value_text.startswith("--"):
-                explicit_script = True
-                self._check_script_expression(
-                    grammar.language, self._derived_value(value, value_text[2:]), cwd
-                )
-                index += 1
-                continue
-            if grammar.in_place_long_option is not None and (
-                value_text == grammar.in_place_long_option
-                or value_text.startswith(f"{grammar.in_place_long_option}=")
-            ):
-                file_access = "write"
-                index += 1
                 continue
             if (
-                grammar.short_flag_options
+                (
+                    grammar.short_flag_options
+                    or grammar.short_value_options
+                    or grammar.optional_write_options
+                )
                 and value_text.startswith("-")
-                and not value_text.startswith("--")
                 and value_text != "-"
             ):
                 option_result = self._consume_script_short_options(
@@ -2918,12 +3124,10 @@ class WorkspaceCommandPathGuard:
                     file_access = "write"
                 index = option_result.next_index
                 continue
-            if value_text in grammar.value_options:
-                index += 2
-                continue
             if value_text.startswith("-") and value_text != "-":
-                index += 1
-                continue
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect {grammar.language} option {value_text}"
+                )
             if not grammar.ignores_assignment_arguments or "=" not in value_text:
                 positionals.append(value)
             index += 1
@@ -2983,6 +3187,19 @@ class WorkspaceCommandPathGuard:
                     next_index=next_index,
                     explicit_script=option in {"e", "f"},
                 )
+            if f"-{option}" in grammar.optional_write_options:
+                # gawk's optional-argument convention: an attached value is
+                # this option's argument, but a separate following token
+                # never is (unlike `-e`/`-f` above), so nothing beyond this
+                # token is ever consumed.
+                attached_text = token_text[cursor + 1 :]
+                argument = (
+                    self._derived_value(token, attached_text)
+                    if attached_text
+                    else _CommandValue(grammar.optional_write_options[f"-{option}"])
+                )
+                self._check_path(argument, cwd, "write")
+                return _ScriptShortOptionResult(next_index=index + 1)
             raise CommandPolicyViolation(
                 f"cannot safely inspect {grammar.language} option -{option}"
             )
@@ -3338,6 +3555,15 @@ class WorkspaceCommandPathGuard:
             index += 1
 
     def _scan_awk_getline_io(self, script: str, cwd: Path) -> None:
+        """Path-check `getline`'s `< FILE` source past any receiving target.
+
+        `getline` may fill a plain identifier, a field reference (`$0`,
+        `$1`, a dynamic `$(expr)`), or an array element (`arr[i]`) before
+        the optional `< FILE` clause; `_skip_awk_getline_target` advances
+        past whichever form is present so the `<` is still found instead of
+        the read check being silently skipped when the target is not a bare
+        identifier.
+        """
         for match in _AWK_GETLINE_PATTERN.finditer(script):
             prefix = script[: match.start()].rstrip()
             if prefix.endswith("|"):
@@ -3348,14 +3574,93 @@ class WorkspaceCommandPathGuard:
             cursor = match.end()
             while cursor < len(script) and script[cursor] in " \t":
                 cursor += 1
-            identifier = _AWK_IDENTIFIER_PATTERN.match(script, cursor)
-            if identifier is not None:
-                cursor = identifier.end()
-                while cursor < len(script) and script[cursor] in " \t":
-                    cursor += 1
+            cursor = self._skip_awk_getline_target(script, cursor)
+            while cursor < len(script) and script[cursor] in " \t":
+                cursor += 1
             if cursor < len(script) and script[cursor] == "<":
                 target = self._scan_awk_redirect_target(script, cursor + 1)
                 self._check_path(target, cwd, "read")
+
+    def _skip_awk_getline_target(self, script: str, cursor: int) -> int:
+        """Advance past a `getline` receiving target, if one is present.
+
+        Recognizes a plain identifier (optionally subscripted, `arr[i]`), a
+        field reference (`$0`, `$NF`, or a parenthesized `$(expr)`), or a
+        parenthesized expression; a bare `getline` (no target) or any other
+        following syntax is left untouched, so the caller still finds an
+        immediately following `< FILE`.
+        """
+        if cursor >= len(script):
+            return cursor
+        character = script[cursor]
+        if character == "$":
+            cursor += 1
+            if cursor < len(script) and script[cursor].isdigit():
+                while cursor < len(script) and script[cursor].isdigit():
+                    cursor += 1
+                return self._skip_awk_getline_subscript(script, cursor)
+            identifier = _AWK_IDENTIFIER_PATTERN.match(script, cursor)
+            if identifier is not None:
+                return self._skip_awk_getline_subscript(script, identifier.end())
+            if cursor < len(script) and script[cursor] == "(":
+                return self._skip_awk_balanced(script, cursor, "(", ")")
+            raise CommandPolicyViolation(
+                "cannot safely inspect awk getline field target"
+            )
+        if character == "(":
+            return self._skip_awk_balanced(script, cursor, "(", ")")
+        identifier = _AWK_IDENTIFIER_PATTERN.match(script, cursor)
+        if identifier is not None:
+            return self._skip_awk_getline_subscript(script, identifier.end())
+        return cursor
+
+    def _skip_awk_getline_subscript(self, script: str, cursor: int) -> int:
+        while cursor < len(script) and script[cursor] in " \t":
+            cursor += 1
+        if cursor < len(script) and script[cursor] == "[":
+            return self._skip_awk_balanced(script, cursor, "[", "]")
+        return cursor
+
+    @staticmethod
+    def _skip_awk_balanced(
+        script: str,
+        index: int,
+        open_char: str,
+        close_char: str,
+    ) -> int:
+        """Advance past one balanced `open_char`/`close_char` region.
+
+        Quoted content inside is skipped whole (escape-aware) so a string
+        literal carrying a stray `<`, `(`, `)`, `[`, or `]` cannot desynchronize
+        depth tracking or be misread as the following redirect operator.
+        """
+        depth = 0
+        quote: str | None = None
+        escaped = False
+        cursor = index
+        while cursor < len(script):
+            character = script[cursor]
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+                cursor += 1
+                continue
+            if character in {"'", '"'}:
+                quote = character
+                cursor += 1
+                continue
+            if character == open_char:
+                depth += 1
+            elif character == close_char:
+                depth -= 1
+                if depth == 0:
+                    return cursor + 1
+            cursor += 1
+        raise CommandPolicyViolation("cannot safely inspect awk getline target")
 
     @staticmethod
     def _scan_awk_redirect_target(script: str, index: int) -> str:
@@ -3546,6 +3851,8 @@ class WorkspaceCommandPathGuard:
                 "--verbose",
                 "-V",
                 "--version",
+                "--fast",
+                "--best",
                 *{f"-{level}" for level in range(1, 10)},
             },
             scalar_options={"-S", "--suffix"},
@@ -3755,10 +4062,15 @@ class WorkspaceCommandPathGuard:
     def _check_curl(self, values: Sequence[str], cwd: Path) -> None:
         """`curl`: `-o`/`--output`/`--output-dir` write; `-T`/`--upload-file`/
         `--netrc-file` read; an `@file` payload to `-d`/`--data*` reads that
-        file. `-K`/`--config` (arbitrary runtime options) and `-O`/
+        file. `-D`/`--dump-header`, `-c`/`--cookie-jar`, `--trace`,
+        `--trace-ascii`, and `--stderr` also write to a filename argument.
+        `-K`/`--config` (arbitrary runtime options) and `-O`/
         `--remote-name[-all]` (output filename derived from the remote URL
         or response, not statically knowable) cannot be inspected safely and
-        fail closed.
+        fail closed. An unrecognized long option with an attached `=value`
+        also fails closed (mirroring `rsync`): curl accepts a value for many
+        long options this family does not model, so an unmodeled one cannot
+        be assumed to be a value-free flag once it visibly carries a value.
         """
         self._reject_dynamic_values("curl arguments", values)
         index = 0
@@ -3795,6 +4107,43 @@ class WorkspaceCommandPathGuard:
                 self._check_path(argument, cwd, "write")
                 continue
             if text.startswith("-o") and len(text) > 2:
+                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
+                index += 1
+                continue
+            if text in {
+                "-D",
+                "--dump-header",
+                "-c",
+                "--cookie-jar",
+                "--trace",
+                "--trace-ascii",
+                "--stderr",
+            } or text.startswith(
+                (
+                    "--dump-header=",
+                    "--cookie-jar=",
+                    "--trace=",
+                    "--trace-ascii=",
+                    "--stderr=",
+                )
+            ):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"curl argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "write")
+                continue
+            if (
+                (text.startswith("-D") or text.startswith("-c"))
+                and not text.startswith("--")
+                and len(text) > 2
+            ):
                 self._check_path(self._derived_value(value, text[2:]), cwd, "write")
                 index += 1
                 continue
@@ -3850,16 +4199,23 @@ class WorkspaceCommandPathGuard:
                     )
                 index += 1
                 continue
+            option, separator, _ = text.partition("=")
+            if text.startswith("--") and separator:
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect curl option {option}"
+                )
             index += 1
 
     def _check_wget(self, values: Sequence[str], cwd: Path) -> None:
         """`wget`: `-O`/`--output-document` write; `-P`/`--directory-prefix`
-        write directory; `--post-file`/`--body-file` read. `--config` and
-        `-i`/`--input-file` (a runtime URL list) cannot be inspected safely
-        and fail closed. A URL operand with no explicit `-O` output (and not
-        `--spider`, which fetches nothing to disk) resolves its output
-        filename from the remote response, which is not statically
-        knowable, so that combination fails closed too.
+        write directory; `-o`/`--output-file` (log file) write;
+        `--post-file`/`--body-file` read. `--config` and `-i`/`--input-file`
+        (a runtime URL list) cannot be inspected safely and fail closed. A
+        URL operand with no explicit `-O` output (and not `--spider`, which
+        fetches nothing to disk) resolves its output filename from the
+        remote response, which is not statically knowable, so that
+        combination fails closed too. An unrecognized long option with an
+        attached `=value` also fails closed (mirroring `rsync`/`curl`).
         """
         self._reject_dynamic_values("wget arguments", values)
         has_explicit_output = False
@@ -3924,8 +4280,32 @@ class WorkspaceCommandPathGuard:
                 assert argument is not None
                 self._check_path(argument, cwd, "read")
                 continue
+            if text in {"-o", "--output-file"} or text.startswith("--output-file="):
+                option, separator, attached_text = text.partition("=")
+                argument, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(value, attached_text) if separator else None
+                    ),
+                    context=f"wget argument for {option}",
+                )
+                assert argument is not None
+                self._check_path(argument, cwd, "write")
+                continue
+            if text.startswith("-o") and not text.startswith("--") and len(text) > 2:
+                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
+                index += 1
+                continue
             if not text.startswith("-"):
                 has_url_operand = True
+                index += 1
+                continue
+            option, separator, _ = text.partition("=")
+            if text.startswith("--") and separator:
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect wget option {option}"
+                )
             index += 1
         if has_url_operand and not has_explicit_output and not spider_mode:
             raise CommandPolicyViolation(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2727,7 +2727,17 @@ class WorkspaceCommandPathGuard:
 
         `shred` additionally accepts `--random-source=FILE` (itself a read
         path) and scalar `-n`/`--iterations`, `-s`/`--size` options whose
-        value must not be misread as a path operand.
+        value must not be misread as a path operand, plus its remaining
+        no-value short options (`-f`/`-u`/`-v`/`-x`/`-z`, R11). Both commands
+        route through the same fail-closed `_partition_path_options`
+        substrate (R3): `unlink` previously used the permissive `_operands`
+        helper, which silently skips any unrecognized short option (and its
+        attached suffix) as an ordinary token, letting a path hide behind an
+        unmodeled option (e.g. `-X<path>`) go completely unchecked — the
+        same class of bypass the fail-closed flip already closed for
+        `shred`. `unlink` takes no short options of its own in real GNU
+        coreutils, so its `flag_short_options` is empty: every short option
+        fails closed.
         """
         if command_name == "shred":
             operands = self._partition_path_options(
@@ -2741,9 +2751,15 @@ class WorkspaceCommandPathGuard:
                     "--size": None,
                 },
                 attached_short_options=frozenset({"-n", "-s"}),
+                flag_short_options=frozenset({"-f", "-u", "-v", "-x", "-z"}),
             )
         else:
-            operands = self._operands(values)
+            operands = self._partition_path_options(
+                values,
+                cwd,
+                option_access={},
+                flag_long_options=frozenset({"--help", "--version"}),
+            )
         for raw_path in operands:
             self._check_path(raw_path, cwd, "write")
 

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2076,7 +2076,10 @@ class WorkspaceCommandPathGuard:
         `--ignore-case`, `--unique`, `--zero-terminated`, `--group`) never
         consume an argument, so listing them separately keeps an
         unrecognized `--`-option failing closed rather than silently
-        shifting the positional write slot.
+        shifting the positional write slot. `-c`/`-i`/`-u`/`-d`/`-z` are the
+        short-spelling equivalents of those same no-value long options and
+        are listed in `flag_short_options` for the same reason (R11): an
+        unrecognized short option still fails closed.
         """
         scalar_options = frozenset(
             {"-f", "--skip-fields", "-s", "--skip-chars", "-w", "--check-chars"}
@@ -2097,6 +2100,7 @@ class WorkspaceCommandPathGuard:
                     "--group",
                 }
             ),
+            flag_short_options=frozenset({"-c", "-i", "-u", "-d", "-z"}),
             fail_closed_on_unknown_long_option=True,
         )
         if operands:
@@ -2111,10 +2115,13 @@ class WorkspaceCommandPathGuard:
         (`--brief`, `--unified`, `--recursive`, `--ignore-case`, `--color`,
         `--side-by-side`) never consume an argument, so listing them
         separately keeps the module's fail-closed-on-unrecognized-option
-        invariant from rejecting ordinary read-only usage. `-N`'s short
-        spelling is listed in `flag_short_options` (not `option_access`), the
-        same no-value/no-bundling short-option allowlist `_partition_path_options`
-        offers, since it takes no value either.
+        invariant from rejecting ordinary read-only usage. `flag_short_options`
+        is the short-spelling analogue (R11): `-u`/`-c`/`-y`/`-e`/`-n` are
+        alternate output-format flags, `-r`/`-q`/`-i`/`-w`/`-b`/`-B`/`-a`/
+        `-t`/`-T`/`-p`/`-s` are the remaining common no-value short options,
+        and `-N` is `--new-file`'s short spelling — none of them take a
+        value, so listing them keeps an unrecognized short option failing
+        closed instead of rejecting this ordinary usage.
         """
         for raw_path in self._partition_path_options(
             values,
@@ -2135,7 +2142,27 @@ class WorkspaceCommandPathGuard:
                     "--new-file",
                 }
             ),
-            flag_short_options=frozenset({"-N"}),
+            flag_short_options=frozenset(
+                {
+                    "-u",
+                    "-r",
+                    "-q",
+                    "-N",
+                    "-i",
+                    "-w",
+                    "-b",
+                    "-B",
+                    "-c",
+                    "-y",
+                    "-a",
+                    "-t",
+                    "-T",
+                    "-p",
+                    "-s",
+                    "-e",
+                    "-n",
+                }
+            ),
         ):
             self._check_path(raw_path, cwd, "read")
 

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -179,7 +179,24 @@ _READ_COMMANDS = {
 }
 # Path-scoped writers: every operand is validated as a workspace write and
 # recorded per-path, so they never poison the session-wide unknown-effect flag.
-_WRITE_COMMANDS = {"rm", "mkdir"}
+# `chmod`/`chown`/`chgrp` own a leading non-path positional (mode or
+# owner[:group]/group spec) that `_check_write_command` strips before the
+# write check; every other member here has no non-path positional.
+_WRITE_COMMANDS = {
+    "chgrp",
+    "chmod",
+    "chown",
+    "mkdir",
+    "rm",
+    "rmdir",
+    "tee",
+    "touch",
+    "truncate",
+}
+# Subset of `_WRITE_COMMANDS` whose first non-option operand is a mode or
+# owner/group spec, not a path; `--reference=RFILE` supplies that role from a
+# file instead, so no positional is stripped when it is present.
+_OWNERSHIP_MODE_COMMANDS = frozenset({"chmod", "chown", "chgrp"})
 _SHELL_COMMANDS = {"bash"}
 _UNSUPPORTED_SHELL_COMMANDS = {"dash", "sh", "zsh"}
 _UNSUPPORTED_PRIVILEGE_COMMANDS = {"sudo"}
@@ -223,6 +240,7 @@ _COMMAND_VALUE_OPTIONS = {
     "head": frozenset({"-c", "--bytes", "-n", "--lines"}),
     "tail": frozenset({"-c", "--bytes", "-n", "--lines"}),
     "tac": frozenset({"-s", "--separator"}),
+    "truncate": frozenset({"-s", "--size"}),
 }
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
 _BASH_LONG_FLAG_OPTIONS = {
@@ -703,6 +721,12 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     "uniq",
     "diff",
     "grep",
+    "cp",
+    "install",
+    "mv",
+    "ln",
+    "unlink",
+    "shred",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
@@ -1075,12 +1099,7 @@ class WorkspaceCommandPathGuard:
         if command_name in _READ_COMMANDS:
             self._check_read_command(command_name, args, state.cwd)
         elif command_name in _WRITE_COMMANDS:
-            self._check_operands(
-                args,
-                state.cwd,
-                "write",
-                value_options=_COMMAND_VALUE_OPTIONS.get(command_name, frozenset()),
-            )
+            self._check_write_command(command_name, args, state.cwd)
         elif command_name == "sort":
             self._check_sort(args, state.cwd)
         elif command_name == "uniq":
@@ -1089,6 +1108,14 @@ class WorkspaceCommandPathGuard:
             self._check_diff(args, state.cwd)
         elif command_name == "grep":
             self._check_grep(args, state.cwd)
+        elif command_name == "cp":
+            self._check_copy(args, state.cwd)
+        elif command_name == "install":
+            self._check_install(args, state.cwd)
+        elif command_name in {"mv", "ln"}:
+            self._check_move_or_link(args, state.cwd)
+        elif command_name in {"unlink", "shred"}:
+            self._check_destructive_file_command(command_name, args, state.cwd)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -1611,6 +1638,286 @@ class WorkspaceCommandPathGuard:
         file_operands = positionals if explicit_pattern else positionals[1:]
         for raw_path in file_operands:
             self._check_path(raw_path, cwd, "read")
+
+    def _check_write_command(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        cwd: Path,
+    ) -> None:
+        """Dispatch a `_WRITE_COMMANDS` member to its operand write check.
+
+        `chmod`'s MODE and `chown`/`chgrp`'s OWNER[:GROUP]/GROUP positional
+        argument are not paths, so that leading operand is excluded from the
+        write check. `--reference=RFILE` supplies the same role from a file
+        instead (itself a read path, classified through the access-map
+        substrate), so no positional is excluded when it is present. Every
+        other write command in this family has no non-path positional.
+        """
+        if command_name in _OWNERSHIP_MODE_COMMANDS:
+            operands = self._partition_path_options(
+                values,
+                cwd,
+                option_access={"--reference": "read"},
+            )
+            has_reference = any(
+                str(value) == "--reference" or str(value).startswith("--reference=")
+                for value in values
+            )
+            if not has_reference and operands:
+                operands = operands[1:]
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "write")
+            return
+        self._check_operands(
+            values,
+            cwd,
+            "write",
+            value_options=_COMMAND_VALUE_OPTIONS.get(command_name, frozenset()),
+        )
+
+    def _parse_target_directory(
+        self,
+        values: Sequence[str],
+    ) -> tuple[str | None, list[str]]:
+        """Split a `-t`/`--target-directory VALUE` destination from operands.
+
+        Shared by `cp` and `mv`/`ln`: when present, every remaining operand is
+        a source and the target directory is the sole write destination;
+        otherwise the caller treats the last operand as the destination.
+        """
+        target_dir: str | None = None
+        operands: list[str] = []
+        options_done = False
+        index = 0
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if not options_done and text in {"-t", "--target-directory"}:
+                if index + 1 >= len(values):
+                    raise CommandPolicyViolation(f"missing argument for {text}")
+                target_dir = values[index + 1]
+                index += 2
+                continue
+            if not options_done and text.startswith("--target-directory="):
+                target_dir = self._derived_value(value, text.split("=", 1)[1])
+                index += 1
+                continue
+            if not options_done and text.startswith("-t") and len(text) > 2:
+                target_dir = self._derived_value(value, text[2:])
+                index += 1
+                continue
+            if not options_done and text.startswith("-") and text != "-":
+                index += 1
+                continue
+            operands.append(value)
+            index += 1
+        return target_dir, operands
+
+    def _check_copy(self, values: Sequence[str], cwd: Path) -> None:
+        """`cp`: sources read, destination (or `-t` target directory) write.
+
+        Recursively copying through a dereferenced symlink (`-L`/
+        `--dereference`, `-H`) can read arbitrarily deep external content
+        through a single approved read boundary, which cannot be bounded
+        statically, so that combination is a hard denial regardless of the
+        actual paths involved.
+        """
+        recursive = False
+        dereferences_links = False
+        for value in values:
+            text = str(value)
+            if text == "--":
+                break
+            if text == "--recursive":
+                recursive = True
+            elif text in {"--dereference", "--follow-command-line-symlink"}:
+                dereferences_links = True
+            elif text.startswith("-") and not text.startswith("--"):
+                flags = text[1:]
+                recursive = recursive or "r" in flags or "R" in flags
+                dereferences_links = dereferences_links or "L" in flags or "H" in flags
+        if recursive and dereferences_links:
+            raise CommandPolicyViolation(
+                "cannot safely inspect recursive copying that follows symbolic links"
+            )
+
+        target_dir, operands = self._parse_target_directory(values)
+        if target_dir is not None:
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "read")
+            self._check_path(target_dir, cwd, "write")
+            return
+        if len(operands) < 2:
+            return
+        for raw_path in operands[:-1]:
+            self._check_path(raw_path, cwd, "read")
+        self._check_path(operands[-1], cwd, "write")
+
+    def _check_install(self, values: Sequence[str], cwd: Path) -> None:
+        """`install`: `-t/--target-directory` write; `-d` marks every operand write.
+
+        Scalar options (`-g/-m/-o/-S/--context`) never carry a path, and the
+        delegated `--strip-program` is a hard denial; an unrecognized option
+        fails closed rather than silently letting one shift the destination
+        slot.
+        """
+        target_dir: str | None = None
+        operands: list[str] = []
+        directory_mode = False
+        options_done = False
+        scalar_options = frozenset(
+            {
+                "-g",
+                "--group",
+                "-m",
+                "--mode",
+                "-o",
+                "--owner",
+                "-S",
+                "--suffix",
+                "--context",
+            }
+        )
+        flag_options = frozenset(
+            {
+                "-b",
+                "--backup",
+                "-c",
+                "-C",
+                "--compare",
+                "-D",
+                "-p",
+                "--preserve-timestamps",
+                "-s",
+                "--strip",
+                "-T",
+                "--no-target-directory",
+                "-v",
+                "--verbose",
+                "--help",
+                "--version",
+            }
+        )
+        index = 0
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                operands.append(value)
+                index += 1
+                continue
+            if text in {"-d", "--directory"}:
+                directory_mode = True
+                index += 1
+                continue
+            if text in {"-t", "--target-directory"}:
+                if index + 1 >= len(values):
+                    raise CommandPolicyViolation(f"missing install argument for {text}")
+                target_dir = values[index + 1]
+                index += 2
+                continue
+            if text.startswith("--target-directory="):
+                target_dir = self._derived_value(value, text.split("=", 1)[1])
+                index += 1
+                continue
+            if text.startswith("-t") and len(text) > 2:
+                target_dir = self._derived_value(value, text[2:])
+                index += 1
+                continue
+            if text == "--strip-program" or text.startswith("--strip-program="):
+                raise CommandPolicyViolation(
+                    "cannot safely inspect install delegated strip program"
+                )
+            if text in scalar_options:
+                if index + 1 >= len(values):
+                    raise CommandPolicyViolation(f"missing install argument for {text}")
+                index += 2
+                continue
+            if any(
+                text.startswith(f"{option}=")
+                for option in scalar_options
+                if option.startswith("--")
+            ):
+                index += 1
+                continue
+            if any(
+                text.startswith(option) and len(text) > len(option)
+                for option in {"-g", "-m", "-o", "-S"}
+            ):
+                index += 1
+                continue
+            if text in flag_options:
+                index += 1
+                continue
+            raise CommandPolicyViolation(f"cannot safely inspect install option {text}")
+
+        if directory_mode:
+            for operand in operands:
+                self._check_path(operand, cwd, "write")
+            return
+        if target_dir is not None:
+            for operand in operands:
+                self._check_path(operand, cwd, "read")
+            self._check_path(target_dir, cwd, "write")
+            return
+        if len(operands) < 2:
+            return
+        for operand in operands[:-1]:
+            self._check_path(operand, cwd, "read")
+        self._check_path(operands[-1], cwd, "write")
+
+    def _check_move_or_link(self, values: Sequence[str], cwd: Path) -> None:
+        """`mv`/`ln`: every operand is write-sensitive, including `ln` sources.
+
+        A hard link inside the workspace aliases its source inode; later path
+        resolution sees only the workspace-side alias, so an external
+        read-only source must be write-checked here rather than read-checked,
+        or it would stay silently mutable through the link.
+        """
+        target_dir, operands = self._parse_target_directory(values)
+        for raw_path in operands:
+            self._check_path(raw_path, cwd, "write")
+        if target_dir is not None:
+            self._check_path(target_dir, cwd, "write")
+
+    def _check_destructive_file_command(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        cwd: Path,
+    ) -> None:
+        """`unlink`/`shred`: every remaining operand is a write target.
+
+        `shred` additionally accepts `--random-source=FILE` (itself a read
+        path) and scalar `-n`/`--iterations`, `-s`/`--size` options whose
+        value must not be misread as a path operand.
+        """
+        if command_name == "shred":
+            operands = self._partition_path_options(
+                values,
+                cwd,
+                option_access={
+                    "--random-source": "read",
+                    "-n": None,
+                    "--iterations": None,
+                    "-s": None,
+                    "--size": None,
+                },
+                attached_short_options=frozenset({"-n", "-s"}),
+            )
+        else:
+            operands = self._operands(values)
+        for raw_path in operands:
+            self._check_path(raw_path, cwd, "write")
 
     def _parse_short_option_cluster(
         self,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -630,6 +630,27 @@ class _CommandWrapperGrammar:
 
 
 @dataclass(frozen=True)
+class _ScriptCommandGrammar:
+    """`sed`/`awk` argv shape: script source options plus file operands."""
+
+    language: Literal["sed", "awk"]
+    expression_long_option: str
+    value_options: frozenset[str] = frozenset()
+    ignores_assignment_arguments: bool = False
+    short_flag_options: frozenset[str] = frozenset()
+    short_value_options: frozenset[str] = frozenset()
+    in_place_short_option: str | None = None
+    in_place_long_option: str | None = None
+
+
+@dataclass(frozen=True)
+class _ScriptShortOptionResult:
+    next_index: int
+    explicit_script: bool = False
+    requests_in_place: bool = False
+
+
+@dataclass(frozen=True)
 class _BashInvocation:
     initialization_files: tuple[str, ...]
     command_text: str | None = None
@@ -734,6 +755,35 @@ _COMMAND_WRAPPER_GRAMMARS = {
     ),
 }
 
+# `-l`/`--line-length` (sed) and `-F`/`-v` (awk) take a scalar value that is
+# never a path, so they are skipped rather than routed through the file-
+# operand check. sed's short options additionally bundle (e.g. `-ne`,
+# `-i.bak`), which `awk` does not, so `short_flag_options` stays empty for awk
+# and its `-e`/`-f` are only ever standalone or attached without bundling.
+_SED_GRAMMAR = _ScriptCommandGrammar(
+    language="sed",
+    expression_long_option="--expression",
+    value_options=frozenset({"-l", "--line-length"}),
+    short_flag_options=frozenset({"E", "n", "r", "s", "u", "z"}),
+    short_value_options=frozenset({"l"}),
+    in_place_short_option="i",
+    in_place_long_option="--in-place",
+)
+_AWK_GRAMMAR = _ScriptCommandGrammar(
+    language="awk",
+    expression_long_option="--source",
+    value_options=frozenset({"-F", "-v"}),
+    ignores_assignment_arguments=True,
+)
+# `system(...)` always executes an arbitrary shell command; `print`/`printf`
+# redirection and `getline` I/O are located structurally instead (see
+# `_check_awk_program`), since their file targets must be classified as a
+# read or write path rather than a blanket rejection.
+_AWK_SYSTEM_CALL_PATTERN = re.compile(r"\bsystem\s*\(")
+_AWK_PRINT_PATTERN = re.compile(r"\b(?:print|printf)\b")
+_AWK_GETLINE_PATTERN = re.compile(r"\bgetline\b")
+_AWK_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
 _CLASSIFIED_EXECUTABLE_COMMANDS = {
     *_READ_COMMANDS,
     *_WRITE_COMMANDS,
@@ -750,6 +800,8 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     "install",
     "mv",
     "ln",
+    "sed",
+    "awk",
     "unlink",
     "shred",
     "find",
@@ -1223,6 +1275,10 @@ class WorkspaceCommandPathGuard:
             self._check_find(args, state)
         elif command_name == "tar":
             self._check_tar(args, state.cwd)
+        elif command_name == "sed":
+            self._check_script_command(_SED_GRAMMAR, args, state.cwd)
+        elif command_name == "awk":
+            self._check_script_command(_AWK_GRAMMAR, args, state.cwd)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -2746,6 +2802,570 @@ class WorkspaceCommandPathGuard:
             if descriptor is not None:
                 os.close(descriptor)
         return script
+
+    def _check_script_command(
+        self,
+        grammar: _ScriptCommandGrammar,
+        values: Sequence[str],
+        cwd: Path,
+    ) -> None:
+        """Classify `sed`/`awk`'s script source(s) and file operand access.
+
+        Every `-e`/`--expression` (sed) or `--source` (awk) argument and,
+        absent an explicit script, the leading positional program are
+        inspected through the family's command-slot lexer (`_check_sed_program`
+        / `_check_awk_program`). `-f`/`--file` script files route through
+        `_read_policy_script` (M4: the same `unknown_effect` gate, non-regular-
+        file rejection, and bounded read every other script read uses) before
+        the same lexer, rather than a parallel copy. sed's `-i`/`--in-place`
+        switches the remaining file operands from read to write.
+        """
+        positionals: list[str] = []
+        explicit_script = False
+        file_access: PathAccess = "read"
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                positionals.extend(values[index + 1 :])
+                break
+            value_text = str(value)
+            if value_text in {"-f", "--file"}:
+                explicit_script = True
+                if index + 1 < len(values):
+                    self._inspect_script_file(grammar.language, values[index + 1], cwd)
+                index += 2
+                continue
+            if value_text.startswith("--file="):
+                explicit_script = True
+                self._inspect_script_file(
+                    grammar.language,
+                    self._derived_value(value, value_text[len("--file=") :]),
+                    cwd,
+                )
+                index += 1
+                continue
+            if value_text.startswith("-f") and not value_text.startswith("--f"):
+                explicit_script = True
+                self._inspect_script_file(
+                    grammar.language, self._derived_value(value, value_text[2:]), cwd
+                )
+                index += 1
+                continue
+            if value_text in {"-e", grammar.expression_long_option}:
+                explicit_script = True
+                if index + 1 < len(values):
+                    self._check_script_expression(
+                        grammar.language, values[index + 1], cwd
+                    )
+                index += 2
+                continue
+            if value_text.startswith(f"{grammar.expression_long_option}="):
+                explicit_script = True
+                self._check_script_expression(
+                    grammar.language,
+                    self._derived_value(
+                        value,
+                        value_text[len(grammar.expression_long_option) + 1 :],
+                    ),
+                    cwd,
+                )
+                index += 1
+                continue
+            if value_text.startswith("-e") and not value_text.startswith("--"):
+                explicit_script = True
+                self._check_script_expression(
+                    grammar.language, self._derived_value(value, value_text[2:]), cwd
+                )
+                index += 1
+                continue
+            if grammar.in_place_long_option is not None and (
+                value_text == grammar.in_place_long_option
+                or value_text.startswith(f"{grammar.in_place_long_option}=")
+            ):
+                file_access = "write"
+                index += 1
+                continue
+            if (
+                grammar.short_flag_options
+                and value_text.startswith("-")
+                and not value_text.startswith("--")
+                and value_text != "-"
+            ):
+                option_result = self._consume_script_short_options(
+                    grammar, values, index, cwd
+                )
+                explicit_script = explicit_script or option_result.explicit_script
+                if option_result.requests_in_place:
+                    file_access = "write"
+                index = option_result.next_index
+                continue
+            if value_text in grammar.value_options:
+                index += 2
+                continue
+            if value_text.startswith("-") and value_text != "-":
+                index += 1
+                continue
+            if not grammar.ignores_assignment_arguments or "=" not in value_text:
+                positionals.append(value)
+            index += 1
+
+        if not explicit_script and positionals:
+            self._check_script_expression(grammar.language, positionals[0], cwd)
+        file_operands = positionals if explicit_script else positionals[1:]
+        for raw_path in file_operands:
+            self._check_path(raw_path, cwd, file_access)
+
+    def _consume_script_short_options(
+        self,
+        grammar: _ScriptCommandGrammar,
+        values: Sequence[str],
+        index: int,
+        cwd: Path,
+    ) -> _ScriptShortOptionResult:
+        token = values[index]
+        if isinstance(token, _CommandValue) and not token.is_static:
+            raise CommandPolicyViolation(
+                f"cannot inspect dynamic {grammar.language} options"
+            )
+
+        cursor = 1
+        token_text = str(token)
+        while cursor < len(token_text):
+            option = token_text[cursor]
+            if option in grammar.short_flag_options:
+                cursor += 1
+                continue
+            if option == grammar.in_place_short_option:
+                # GNU sed treats the remainder of this token as the optional
+                # backup suffix, so no later character is another option.
+                return _ScriptShortOptionResult(
+                    next_index=index + 1,
+                    requests_in_place=True,
+                )
+            if option in {"e", "f"} or option in grammar.short_value_options:
+                attached_text = token_text[cursor + 1 :]
+                argument, next_index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(token, attached_text)
+                        if attached_text
+                        else None
+                    ),
+                    context=f"{grammar.language} argument for -{option}",
+                )
+                assert argument is not None
+
+                if option == "e":
+                    self._check_script_expression(grammar.language, argument, cwd)
+                elif option == "f":
+                    self._inspect_script_file(grammar.language, argument, cwd)
+                return _ScriptShortOptionResult(
+                    next_index=next_index,
+                    explicit_script=option in {"e", "f"},
+                )
+            raise CommandPolicyViolation(
+                f"cannot safely inspect {grammar.language} option -{option}"
+            )
+
+        return _ScriptShortOptionResult(next_index=index + 1)
+
+    def _inspect_script_file(
+        self,
+        language: Literal["sed", "awk"],
+        raw_path: str,
+        cwd: Path,
+    ) -> None:
+        script = self._read_policy_script(raw_path, cwd)
+        self._check_script_program(language, script, cwd)
+
+    def _check_script_expression(
+        self,
+        language: Literal["sed", "awk"],
+        script: str,
+        cwd: Path,
+    ) -> None:
+        """Classify an inline `-e`/positional sed|awk program (I8/I9/I13)."""
+        if isinstance(script, _CommandValue) and not script.is_static:
+            raise CommandPolicyViolation(f"cannot inspect dynamic {language} program")
+        self._check_script_program(language, str(script), cwd)
+
+    def _check_script_program(
+        self,
+        language: Literal["sed", "awk"],
+        script: str,
+        cwd: Path,
+    ) -> None:
+        if language == "awk":
+            self._check_awk_program(script, cwd)
+        else:
+            self._check_sed_program(script, cwd)
+
+    def _check_sed_program(self, script: str, cwd: Path) -> None:
+        """Walk a sed program one command slot at a time (I8).
+
+        Traverses blocks (`{`/`}`), addresses/ranges, and repeated `!`
+        negation before classifying the command letter; braces/delimiters
+        inside patterns, replacements, addresses, `y///` transliterations,
+        `#` comments, and `a`/`i`/`c` text payloads are DATA and are never
+        re-entered as structure. `r`/`R` read a filename that runs to the end
+        of the line (read); `w`/`W` and the `s///w` flag write one (write);
+        `e` (bare, or `s///e`) executes an arbitrary shell command and always
+        fails closed, since its argument cannot be inspected safely.
+        """
+        index = 0
+        while index < len(script):
+            while index < len(script) and script[index] in " \t;\n}":
+                index += 1
+            if index >= len(script):
+                break
+
+            index = self._skip_sed_addresses(script, index)
+            while index < len(script) and script[index] in " \t":
+                index += 1
+            # BSD sed accepts repeated negation operators, so command
+            # discovery must consume the complete prefix before classifying.
+            while index < len(script) and script[index] == "!":
+                index += 1
+                while index < len(script) and script[index] in " \t":
+                    index += 1
+            if index >= len(script):
+                raise CommandPolicyViolation("cannot safely inspect sed program")
+
+            command = script[index]
+            index += 1
+            if command in "rR":
+                index, raw_path = self._scan_sed_filename(script, index)
+                self._check_path(raw_path, cwd, "read")
+                continue
+            if command in "wW":
+                index, raw_path = self._scan_sed_filename(script, index)
+                self._check_path(raw_path, cwd, "write")
+                continue
+            if command == "e":
+                raise CommandPolicyViolation(
+                    "sed 'e' command executes an arbitrary shell command and "
+                    "cannot be inspected safely"
+                )
+            if command == "{":
+                continue
+            if command == "#":
+                index = self._skip_sed_to_boundary(script, index, boundaries="\n")
+                continue
+            if command == "s":
+                index = self._scan_sed_substitution(script, index, cwd)
+                continue
+            if command == "y":
+                index = self._scan_sed_transliteration(script, index)
+                continue
+            if command in "aic":
+                index = self._skip_sed_to_boundary(script, index, boundaries="\n")
+                continue
+            if command in "bTt:":
+                index = self._skip_sed_to_boundary(script, index, boundaries=";\n")
+                continue
+            index = self._skip_sed_to_boundary(script, index, boundaries=";\n}")
+
+    @staticmethod
+    def _skip_sed_addresses(script: str, index: int) -> int:
+        first_end = WorkspaceCommandPathGuard._skip_sed_address(
+            script, index, allow_relative=False
+        )
+        if first_end is None:
+            return index
+
+        cursor = first_end
+        while cursor < len(script) and script[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(script) or script[cursor] != ",":
+            return cursor
+
+        cursor += 1
+        while cursor < len(script) and script[cursor] in " \t":
+            cursor += 1
+        second_end = WorkspaceCommandPathGuard._skip_sed_address(
+            script, cursor, allow_relative=True
+        )
+        if second_end is None:
+            raise CommandPolicyViolation("cannot safely inspect sed address range")
+        return second_end
+
+    @staticmethod
+    def _skip_sed_address(
+        script: str,
+        index: int,
+        *,
+        allow_relative: bool,
+    ) -> int | None:
+        if index >= len(script):
+            return None
+        character = script[index]
+        if character.isdigit():
+            cursor = index + 1
+            while cursor < len(script) and script[cursor].isdigit():
+                cursor += 1
+            if cursor < len(script) and script[cursor] == "~":
+                cursor += 1
+                step_start = cursor
+                while cursor < len(script) and script[cursor].isdigit():
+                    cursor += 1
+                if cursor == step_start:
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect sed step address"
+                    )
+            return cursor
+        if character == "$":
+            return index + 1
+        if character == "/":
+            return WorkspaceCommandPathGuard._scan_sed_delimited(
+                script, delimiter_index=index
+            )
+        if character == "\\" and index + 1 < len(script):
+            return WorkspaceCommandPathGuard._scan_sed_delimited(
+                script, delimiter_index=index + 1
+            )
+        if allow_relative and character in {"+", "~"}:
+            cursor = index + 1
+            number_start = cursor
+            while cursor < len(script) and script[cursor].isdigit():
+                cursor += 1
+            if cursor == number_start:
+                raise CommandPolicyViolation(
+                    "cannot safely inspect sed relative address"
+                )
+            return cursor
+        return None
+
+    @staticmethod
+    def _scan_sed_delimited(
+        script: str,
+        *,
+        delimiter_index: int,
+    ) -> int:
+        delimiter = script[delimiter_index]
+        if delimiter == "\n":
+            raise CommandPolicyViolation("cannot safely inspect sed delimiter")
+        cursor = delimiter_index + 1
+        escaped = False
+        while cursor < len(script):
+            character = script[cursor]
+            cursor += 1
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == delimiter:
+                return cursor
+            elif character == "\n":
+                raise CommandPolicyViolation("cannot safely inspect sed expression")
+        raise CommandPolicyViolation(
+            "cannot safely inspect unterminated sed expression"
+        )
+
+    def _scan_sed_substitution(self, script: str, index: int, cwd: Path) -> int:
+        if index >= len(script):
+            raise CommandPolicyViolation("cannot safely inspect sed substitution")
+        delimiter = script[index]
+        if delimiter.isalnum() or delimiter.isspace() or delimiter == "\\":
+            raise CommandPolicyViolation("cannot safely inspect sed substitution")
+
+        cursor = self._scan_sed_fields(script, index, field_count=2)
+
+        while cursor < len(script) and script[cursor] not in ";\n}":
+            if script[cursor] == "e":
+                raise CommandPolicyViolation(
+                    "sed 's///e' executes an arbitrary shell command and "
+                    "cannot be inspected safely"
+                )
+            if script[cursor] == "w":
+                cursor, raw_path = self._scan_sed_filename(script, cursor + 1)
+                self._check_path(raw_path, cwd, "write")
+                return cursor
+            cursor += 1
+        return cursor
+
+    @staticmethod
+    def _scan_sed_transliteration(script: str, index: int) -> int:
+        if index >= len(script):
+            raise CommandPolicyViolation("cannot safely inspect sed transliteration")
+        delimiter = script[index]
+        if delimiter.isalnum() or delimiter.isspace() or delimiter == "\\":
+            raise CommandPolicyViolation("cannot safely inspect sed transliteration")
+
+        cursor = WorkspaceCommandPathGuard._scan_sed_fields(
+            script,
+            index,
+            field_count=2,
+        )
+        return WorkspaceCommandPathGuard._skip_sed_to_boundary(
+            script, cursor, boundaries=";\n}"
+        )
+
+    @staticmethod
+    def _scan_sed_fields(
+        script: str,
+        delimiter_index: int,
+        *,
+        field_count: int,
+    ) -> int:
+        cursor = delimiter_index
+        for _ in range(field_count):
+            cursor = WorkspaceCommandPathGuard._scan_sed_delimited(
+                script,
+                delimiter_index=cursor,
+            )
+            # The next field reuses the delimiter that closed this one.
+            cursor -= 1
+        return cursor + 1
+
+    @staticmethod
+    def _skip_sed_to_boundary(script: str, index: int, *, boundaries: str) -> int:
+        escaped = False
+        while index < len(script):
+            character = script[index]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character in boundaries:
+                return index
+            index += 1
+        return index
+
+    @staticmethod
+    def _scan_sed_filename(script: str, index: int) -> tuple[int, str]:
+        """Read a `r`/`R`/`w`/`W` command's filename argument (I8).
+
+        Sed's file-command filename is the remainder of the script line
+        verbatim after any leading whitespace (an embedded `;` is part of
+        the filename, not a command separator), so it runs to the next
+        newline or the end of the script, never to `;`/`}`.
+        """
+        cursor = index
+        while cursor < len(script) and script[cursor] in " \t":
+            cursor += 1
+        start = cursor
+        end = WorkspaceCommandPathGuard._skip_sed_to_boundary(
+            script, cursor, boundaries="\n"
+        )
+        filename = script[start:end]
+        if not filename:
+            raise CommandPolicyViolation("missing sed file command filename")
+        return end, filename
+
+    def _check_awk_program(self, script: str, cwd: Path) -> None:
+        """Classify awk's unsafe I/O forms (I9).
+
+        `system(...)` always executes an arbitrary shell command and fails
+        closed unconditionally. `print`/`printf` redirection (`>`, `>>`) and
+        `getline < FILE` are located structurally and path-checked instead;
+        a redirect target that is not a double-quoted string literal cannot
+        be resolved statically (e.g. a field/variable like `$1`) and is
+        rejected rather than silently skipped. Piping to or from a command
+        (`| "cmd"`, `"cmd" | getline`) always executes an arbitrary shell
+        command and fails closed unconditionally.
+        """
+        if _AWK_SYSTEM_CALL_PATTERN.search(script):
+            raise CommandPolicyViolation(
+                "awk 'system' call executes an arbitrary shell command and "
+                "cannot be inspected safely"
+            )
+        for match in _AWK_PRINT_PATTERN.finditer(script):
+            self._scan_awk_print_redirect(script, match.end(), cwd)
+        self._scan_awk_getline_io(script, cwd)
+
+    def _scan_awk_print_redirect(self, script: str, start: int, cwd: Path) -> None:
+        index = start
+        depth = 0
+        quote: str | None = None
+        escaped = False
+        while index < len(script):
+            char = script[index]
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                index += 1
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                index += 1
+                continue
+            if char == "(":
+                depth += 1
+                index += 1
+                continue
+            if char == ")" and depth:
+                depth -= 1
+                index += 1
+                continue
+            if char in ";\n}" and depth == 0:
+                return
+            if char == "|" and depth == 0:
+                raise CommandPolicyViolation(
+                    "awk pipe output executes an arbitrary shell command and "
+                    "cannot be inspected safely"
+                )
+            if char == ">" and depth == 0:
+                index += 1
+                if index < len(script) and script[index] == ">":
+                    index += 1
+                target = self._scan_awk_redirect_target(script, index)
+                self._check_path(target, cwd, "write")
+                return
+            index += 1
+
+    def _scan_awk_getline_io(self, script: str, cwd: Path) -> None:
+        for match in _AWK_GETLINE_PATTERN.finditer(script):
+            prefix = script[: match.start()].rstrip()
+            if prefix.endswith("|"):
+                raise CommandPolicyViolation(
+                    "awk pipe input to 'getline' executes an arbitrary shell "
+                    "command and cannot be inspected safely"
+                )
+            cursor = match.end()
+            while cursor < len(script) and script[cursor] in " \t":
+                cursor += 1
+            identifier = _AWK_IDENTIFIER_PATTERN.match(script, cursor)
+            if identifier is not None:
+                cursor = identifier.end()
+                while cursor < len(script) and script[cursor] in " \t":
+                    cursor += 1
+            if cursor < len(script) and script[cursor] == "<":
+                target = self._scan_awk_redirect_target(script, cursor + 1)
+                self._check_path(target, cwd, "read")
+
+    @staticmethod
+    def _scan_awk_redirect_target(script: str, index: int) -> str:
+        """Read a quoted-string-literal redirect target (I9/I13).
+
+        Only a double-quoted string literal can be resolved to a concrete
+        path statically; any other form (a bareword, a field reference like
+        `$1`, a variable, a parenthesized expression) is dynamic from this
+        lexer's point of view and is rejected rather than silently skipped.
+        """
+        cursor = index
+        while cursor < len(script) and script[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(script) or script[cursor] != '"':
+            raise CommandPolicyViolation("cannot resolve dynamic awk redirect target")
+        start = cursor + 1
+        cursor = start
+        escaped = False
+        while cursor < len(script):
+            character = script[cursor]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                return script[start:cursor]
+            cursor += 1
+        raise CommandPolicyViolation("cannot safely inspect awk redirect target")
 
     def _inspect_shell_script(
         self,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1005,19 +1005,27 @@ _WGET_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "o": "write",
 }
 
-# `base64`'s short options bundle into one token (e.g. `-di<file>` combines
-# the `-d` decode flag with the `-i` input-path option), so its grammar is
+# `base64`'s short options bundle into one token (e.g. `-do<file>` combines
+# the `-d` decode flag with the `-o` output-path option), so its grammar is
 # split into a flag set and a value set for the short-option-cluster parser,
 # the same shape `sort`/`grep`/`curl`/`wget` use. `-b`/`-w` take a scalar
-# column-width value that is never a path.
-_BASE64_SHORT_FLAG_OPTIONS = frozenset("dDh")
+# column-width value that is never a path. `-i`/`--ignore-garbage` is a
+# BOOLEAN flag (GNU coreutils: discard non-alphabet input when decoding
+# instead of erroring), never value-taking: modeling it as value-taking
+# would let it silently swallow the NEXT token as its own (read-checked)
+# argument even when that token is itself another option (e.g. `-o`'s own
+# write-path flag), so `-o`'s real argument would fall through unclassified
+# as a plain read operand instead of being write-checked.
+_BASE64_SHORT_FLAG_OPTIONS = frozenset("dDhi")
 _BASE64_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
-    "i": "read",
     "o": "write",
     "b": None,
     "w": None,
 }
-_BASE64_KNOWN_LONG_OPTIONS = frozenset({"--input", "--output", "--break", "--wrap"})
+_BASE64_LONG_FLAG_OPTIONS = frozenset({"--ignore-garbage"})
+_BASE64_KNOWN_LONG_OPTIONS = frozenset(
+    {"--output", "--break", "--wrap"} | _BASE64_LONG_FLAG_OPTIONS
+)
 
 # `cp`/`mv`/`ln` share `_parse_target_directory`'s `-t`/`--target-directory`
 # extraction. Short options bundle into one token (e.g. `-rt` combines the
@@ -4023,38 +4031,47 @@ class WorkspaceCommandPathGuard:
                 self._check_path(value.split("=", 1)[1], cwd, "write")
 
     def _check_base64(self, values: Sequence[str], cwd: Path) -> None:
-        """`base64`: `-i`/`--input` reads, `-o`/`--output` writes.
+        """`base64`: `-o`/`--output` writes; every remaining operand reads.
 
+        `-i`/`--ignore-garbage` is a boolean flag (see `_BASE64_SHORT_FLAG_OPTIONS`);
         `-b`/`--break` and `-w`/`--wrap` take a scalar column-width value
         that is never a path. Long options resolve through
         `_resolve_long_option` (GNU unambiguous-prefix abbreviation, e.g.
         `--outp=` for `--output`), so an abbreviated spelling is classified
         identically to the full name instead of falling through as an
         unrecognized option — which would silently skip the write check on
-        `--output`'s argument. An unrecognized long option with an attached
-        `=value` cannot be assumed to be a value-free flag once it visibly
-        carries a value, and fails closed (mirroring `curl`/`wget`); a bare
-        unmodeled flag (e.g. `--help`) stays permissive. Short options
-        bundle through the same `_parse_short_option_cluster` substrate
-        `sort`/`grep`/`curl`/`wget` use, so `-i`/`-o` still consume their
+        `--output`'s argument. Module invariant: ANY long option this
+        allowlist cannot resolve fails closed, bare or `=value`-attached
+        alike — an unmodeled flag is not assumed value-free, since one could
+        otherwise consume (and hide) a later option's real path argument.
+        Short options bundle through the same `_parse_short_option_cluster`
+        substrate `sort`/`grep`/`curl`/`wget` use, so `-o` still consumes its
         argument even when not the leading character of the cluster (e.g.
-        `-di`).
+        `-do`); an unrecognized short option fails closed the same way. A
+        literal `--` ends option parsing; every token after it is a plain
+        (read) operand even if it looks like an option.
         """
         self._reject_dynamic_values("base64 arguments", values)
         inputs: list[str] = []
+        options_done = False
         index = 0
         while index < len(values):
             value = values[index]
             text = str(value)
-            if text == "--":
-                inputs.extend(values[index + 1 :])
-                break
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                inputs.append(value)
+                index += 1
+                continue
             if text.startswith("--"):
                 raw_option, separator, attached_text = text.partition("=")
                 resolved = self._resolve_long_option(
                     raw_option, _BASE64_KNOWN_LONG_OPTIONS
                 )
-                if resolved in {"--input", "--output"}:
+                if resolved == "--output":
                     argument, index = self._take_option_argument(
                         values,
                         index,
@@ -4066,9 +4083,7 @@ class WorkspaceCommandPathGuard:
                         context=f"base64 argument for {resolved}",
                     )
                     assert argument is not None
-                    self._check_path(
-                        argument, cwd, "read" if resolved == "--input" else "write"
-                    )
+                    self._check_path(argument, cwd, "write")
                     continue
                 if resolved in {"--break", "--wrap"}:
                     _, index = self._take_option_argument(
@@ -4082,26 +4097,23 @@ class WorkspaceCommandPathGuard:
                         context=f"base64 argument for {resolved}",
                     )
                     continue
-                # An unmodeled long option that visibly carries a value
-                # cannot be assumed to be a value-free flag; a bare
-                # unmodeled flag stays permissive.
-                if separator:
-                    raise CommandPolicyViolation(
-                        f"cannot safely resolve base64 option {raw_option}"
-                    )
-                index += 1
-                continue
-            if text.startswith("-") and text != "-":
-                index, _, _ = self._parse_short_option_cluster(
-                    values,
-                    index,
-                    cwd,
-                    flag_options=_BASE64_SHORT_FLAG_OPTIONS,
-                    value_options=_BASE64_SHORT_VALUE_OPTIONS,
+                if resolved in _BASE64_LONG_FLAG_OPTIONS:
+                    if separator:
+                        raise CommandPolicyViolation(
+                            f"cannot safely resolve base64 option {raw_option}"
+                        )
+                    index += 1
+                    continue
+                raise CommandPolicyViolation(
+                    f"cannot safely resolve base64 option {raw_option}"
                 )
-                continue
-            inputs.append(value)
-            index += 1
+            index, _, _ = self._parse_short_option_cluster(
+                values,
+                index,
+                cwd,
+                flag_options=_BASE64_SHORT_FLAG_OPTIONS,
+                value_options=_BASE64_SHORT_VALUE_OPTIONS,
+            )
         for raw_path in inputs:
             self._check_path(raw_path, cwd, "read")
 

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import errno
 import logging
 import os
+import re
 import shutil
 import stat
 from contextlib import contextmanager
@@ -22,6 +23,7 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     Sequence,
     SupportsIndex,
@@ -751,6 +753,7 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     "unlink",
     "shred",
     "find",
+    "tar",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
@@ -857,6 +860,45 @@ _FIND_OUTPUT_ACTIONS: dict[str, int] = {
 }
 _FIND_REFERENCE_PREDICATES = frozenset({"-newer", "-anewer", "-cnewer", "-samefile"})
 _FIND_EXEC_MARKERS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
+
+_TarMode = Literal[
+    "create",
+    "append",
+    "update",
+    "concatenate",
+    "delete",
+    "extract",
+    "list",
+    "compare",
+]
+
+# Every parsed tar argument's role in path classification. `positional`
+# members are only local paths in create/append/update/concatenate/compare
+# mode (list/extract members are in-archive selectors, not filesystem paths).
+_TarEventKind = Literal[
+    "archive",
+    "directory",
+    "files_from",
+    "exclude_from",
+    "incremental",
+    "add_file",
+    "positional",
+    "dangerous",
+    "absolute_names",
+]
+
+
+@dataclass(frozen=True)
+class _TarEvent:
+    kind: _TarEventKind
+    value: str | None = None
+
+
+@dataclass(frozen=True)
+class _TarInvocation:
+    mode: _TarMode
+    events: tuple[_TarEvent, ...]
+    remove_files: bool = False
 
 
 class WorkspaceCommandPathGuard:
@@ -1179,6 +1221,8 @@ class WorkspaceCommandPathGuard:
             self._check_destructive_file_command(command_name, args, state.cwd)
         elif command_name == "find":
             self._check_find(args, state)
+        elif command_name == "tar":
+            self._check_tar(args, state.cwd)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -2177,6 +2221,324 @@ class WorkspaceCommandPathGuard:
                 _CommandValue(word, is_static=is_static, find_placeholder_cwd=cwd)
             )
         return tuple(tagged)
+
+    def _check_tar(self, values: Sequence[str], cwd: Path) -> None:
+        """Classify `tar`'s archive/control/member paths.
+
+        The archive path (`-f`/`--file`) and the two control-file options
+        (`-T`/`--files-from`, `-X`/`--exclude-from`) stay anchored to the
+        process `cwd`; only `-C`/`--directory` shifts the active directory,
+        and only for later source/destination member operands, never for the
+        archive itself. Extract mode additionally poisons the session
+        (`unknown_effect`): per-member extracted children are not
+        individually enumerable, so the `-C`/default extraction root's own
+        write-containment check (below, via the `directory` event) cannot by
+        itself capture them — the poison is additive to that check, not a
+        replacement for it (M2).
+        """
+        self._reject_dynamic_values("tar arguments", values)
+        invocation = self._parse_tar(values)
+        archive_access: PathAccess = (
+            "write"
+            if invocation.mode
+            in {"create", "append", "update", "concatenate", "delete"}
+            else "read"
+        )
+        source_access: PathAccess = "write" if invocation.remove_files else "read"
+        active_cwd = cwd
+
+        if invocation.mode == "extract":
+            _active_validation_session().effects.unknown_effect = True
+
+        for event in invocation.events:
+            if event.kind == "dangerous":
+                raise CommandPolicyViolation(
+                    "tar command hooks cannot be inspected safely"
+                )
+            if event.kind == "absolute_names":
+                if invocation.mode == "extract":
+                    raise CommandPolicyViolation(
+                        "tar absolute extraction paths cannot be inspected safely"
+                    )
+                continue
+            if event.value is None:
+                continue
+
+            if event.kind == "archive":
+                self._check_tar_archive_path(event.value, cwd, archive_access)
+            elif event.kind == "directory":
+                active_cwd = self._check_path(
+                    event.value,
+                    active_cwd,
+                    "write" if invocation.mode == "extract" else "read",
+                )
+            elif event.kind == "files_from":
+                raise CommandPolicyViolation(
+                    "tar file lists cannot be inspected safely"
+                )
+            elif event.kind == "exclude_from":
+                self._check_path(event.value, cwd, "read")
+            elif event.kind == "incremental":
+                # The snapshot file can be updated even when the archive
+                # itself is only read (e.g. listing against a snapshot).
+                self._check_path(event.value, cwd, "write")
+            elif event.kind == "add_file":
+                self._check_path(event.value, active_cwd, source_access)
+            elif event.kind == "positional" and invocation.mode in {
+                "create",
+                "append",
+                "update",
+                "concatenate",
+                "compare",
+            }:
+                # List/extract positionals are in-archive member selectors,
+                # not local filesystem paths, and are intentionally not
+                # checked here. `@file` includes another archive/file-list in
+                # place of a literal member; the same source access applies.
+                raw_path = (
+                    event.value[1:] if event.value.startswith("@") else event.value
+                )
+                self._check_path(raw_path, active_cwd, source_access)
+
+    def _check_tar_archive_path(
+        self,
+        raw_path: str,
+        cwd: Path,
+        access: PathAccess,
+    ) -> None:
+        """Reject stdin/stdout and remote archive forms; else check normally.
+
+        `-f -` streams the archive through standard input/output, and a
+        `host:path` (or `user@host:path`) form delegates to a remote `rsh`
+        transfer; neither is a local path this guard can inspect statically.
+        """
+        if raw_path == "-":
+            raise CommandPolicyViolation(
+                "tar archive on standard input/output cannot be inspected safely"
+            )
+        if ":" in raw_path:
+            raise CommandPolicyViolation(
+                "remote tar archives cannot be inspected safely"
+            )
+        self._check_path(raw_path, cwd, access)
+
+    def _parse_tar(self, values: Sequence[str]) -> _TarInvocation:
+        """Parse tar's argv once into its operation mode and typed events.
+
+        Traditional syntax omits the leading dash on the first argument
+        (`tar cf archive.tar file`); GNU long/short syntax may follow.
+        Exactly one mode letter must be present across the whole invocation
+        (POSIX tar requires exactly one of create/append/update/concatenate/
+        delete/extract/list/compare) or the operation cannot be resolved.
+        """
+        long_modes: dict[str, _TarMode] = {
+            "--create": "create",
+            "--append": "append",
+            "--update": "update",
+            "--concatenate": "concatenate",
+            "--catenate": "concatenate",
+            "--delete": "delete",
+            "--extract": "extract",
+            "--get": "extract",
+            "--list": "list",
+            "--compare": "compare",
+            "--diff": "compare",
+        }
+        modes: list[_TarMode] = []
+        events: list[_TarEvent] = []
+        remove_files = False
+        options_done = False
+        index = 0
+
+        if (
+            values
+            and re.fullmatch(r"[A-Za-z]+", str(values[0]))
+            and any(option in "cruAxtd" for option in str(values[0]))
+        ):
+            index, short_modes, short_events = self._parse_tar_short_events(
+                values, 0, values[0]
+            )
+            modes.extend(short_modes)
+            events.extend(short_events)
+
+        while index < len(values):
+            value = values[index]
+            text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                events.append(_TarEvent("positional", value))
+                index += 1
+                continue
+            if text in long_modes:
+                modes.append(long_modes[text])
+                index += 1
+                continue
+            if text == "--remove-files":
+                remove_files = True
+                index += 1
+                continue
+            if text in {"--to-stdout", "-O"}:
+                index += 1
+                continue
+            if text in {"--absolute-names", "--absolute-paths"}:
+                events.append(_TarEvent("absolute_names"))
+                index += 1
+                continue
+            if text.startswith("--"):
+                index, event = self._parse_tar_long_event(values, index)
+                if event is not None:
+                    events.append(event)
+                continue
+
+            index, short_modes, short_events = self._parse_tar_short_events(
+                values, index, value[1:]
+            )
+            modes.extend(short_modes)
+            events.extend(short_events)
+
+        unique_modes = set(modes)
+        if len(unique_modes) != 1:
+            raise CommandPolicyViolation("cannot safely resolve tar operation")
+        return _TarInvocation(
+            mode=unique_modes.pop(),
+            events=tuple(events),
+            remove_files=remove_files,
+        )
+
+    def _parse_tar_long_event(
+        self,
+        values: Sequence[str],
+        index: int,
+    ) -> tuple[int, _TarEvent | None]:
+        value = values[index]
+        text = str(value)
+        path_options: dict[str, _TarEventKind] = {
+            "--file": "archive",
+            "--directory": "directory",
+            "--files-from": "files_from",
+            "--exclude-from": "exclude_from",
+            "--listed-incremental": "incremental",
+            "--add-file": "add_file",
+        }
+        dangerous_options = {
+            "--use-compress-program",
+            "--to-command",
+            "--checkpoint-action",
+            "--info-script",
+            "--new-volume-script",
+            "--rsh-command",
+        }
+        option, separator, attached = text.partition("=")
+        kind = path_options.get(option)
+        is_dangerous = option in dangerous_options
+        if kind is None and not is_dangerous:
+            return index + 1, None
+
+        argument, next_index = self._take_option_argument(
+            values,
+            index,
+            attached_argument=(
+                self._derived_value(value, attached) if separator else None
+            ),
+            context=f"tar argument for {option}",
+        )
+
+        if is_dangerous:
+            return next_index, _TarEvent("dangerous", argument)
+        return next_index, _TarEvent(cast(_TarEventKind, kind), argument)
+
+    def _parse_tar_short_events(
+        self,
+        values: Sequence[str],
+        index: int,
+        options: str,
+    ) -> tuple[int, list[_TarMode], list[_TarEvent]]:
+        """Parse one traditional/bundled short-option token (e.g. `-xzf`).
+
+        Only the last argument-taking character in the cluster may carry a
+        value (attached, e.g. `-fname`, or as the following token); this
+        matches GNU tar's own traditional-syntax parser. Unrecognized
+        characters are silently skipped (compression/verbosity flags like
+        `z`/`v` this guard does not need to model), consistent with the
+        conservative flag-only treatment of unknown tar options elsewhere.
+        """
+        short_modes: dict[str, _TarMode] = {
+            "c": "create",
+            "r": "append",
+            "u": "update",
+            "A": "concatenate",
+            "x": "extract",
+            "t": "list",
+            "d": "compare",
+        }
+        argument_events: dict[str, _TarEventKind | None] = {
+            "f": "archive",
+            "C": "directory",
+            "T": "files_from",
+            "X": "exclude_from",
+            "g": "incremental",
+            "I": "dangerous",
+            "F": "dangerous",
+            "b": None,
+        }
+        modes: list[_TarMode] = []
+        events: list[_TarEvent] = []
+        cursor = 0
+        next_index = index + 1
+
+        while cursor < len(options):
+            option = options[cursor]
+            if option in short_modes:
+                modes.append(short_modes[option])
+                cursor += 1
+                continue
+            if option == "P":
+                events.append(_TarEvent("absolute_names"))
+                cursor += 1
+                continue
+            if option == "O":
+                cursor += 1
+                continue
+            if option not in argument_events:
+                cursor += 1
+                continue
+
+            attached = options[cursor + 1 :]
+            argument, next_index = self._take_option_argument(
+                values,
+                index,
+                attached_argument=(
+                    self._derived_value(values[index], attached) if attached else None
+                ),
+                context=f"tar argument for -{option}",
+            )
+            assert argument is not None
+            kind = argument_events[option]
+            if kind is not None:
+                events.append(_TarEvent(kind, argument))
+            break
+
+        return next_index, modes, events
+
+    @staticmethod
+    def _take_option_argument(
+        values: Sequence[str],
+        index: int,
+        *,
+        attached_argument: str | None,
+        context: str,
+        required: bool = True,
+    ) -> tuple[str | None, int]:
+        if attached_argument is not None:
+            return attached_argument, index + 1
+        if index + 1 < len(values):
+            return values[index + 1], index + 2
+        if required:
+            raise CommandPolicyViolation(f"missing {context}")
+        return None, index + 1
 
     def _parse_short_option_cluster(
         self,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1005,6 +1005,20 @@ _WGET_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "o": "write",
 }
 
+# `base64`'s short options bundle into one token (e.g. `-di<file>` combines
+# the `-d` decode flag with the `-i` input-path option), so its grammar is
+# split into a flag set and a value set for the short-option-cluster parser,
+# the same shape `sort`/`grep`/`curl`/`wget` use. `-b`/`-w` take a scalar
+# column-width value that is never a path.
+_BASE64_SHORT_FLAG_OPTIONS = frozenset("dDh")
+_BASE64_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "i": "read",
+    "o": "write",
+    "b": None,
+    "w": None,
+}
+_BASE64_KNOWN_LONG_OPTIONS = frozenset({"--input", "--output", "--break", "--wrap"})
+
 # `cp`/`mv`/`ln` share `_parse_target_directory`'s `-t`/`--target-directory`
 # extraction. Short options bundle into one token (e.g. `-rt` combines the
 # `-r` flag with the `-t` write-path option), so the grammar is split into a
@@ -2776,7 +2790,7 @@ class WorkspaceCommandPathGuard:
             and any(option in "cruAxtd" for option in str(values[0]))
         ):
             index, short_modes, short_events = self._parse_tar_short_events(
-                values, 0, values[0], allow_attached_value=False
+                values, 0, values[0]
             )
             modes.extend(short_modes)
             events.extend(short_events)
@@ -2895,25 +2909,26 @@ class WorkspaceCommandPathGuard:
         values: Sequence[str],
         index: int,
         options: str,
-        *,
-        allow_attached_value: bool = True,
     ) -> tuple[int, list[_TarMode], list[_TarEvent]]:
-        """Parse one traditional/bundled short-option token (e.g. `-xzf`).
+        """Parse one bundled short-option token (e.g. `-xzf`, `-xfC`, `xfC`).
 
-        Two distinct bundling conventions share this parser. The GNU
-        dash-prefixed cluster (`allow_attached_value=True`, e.g. `-xzf`,
-        `-farchive.tar`) only ever expects ONE argument-taking character per
-        token: once found, the rest of the token (if any) is its attached
-        value, or it takes the next whitespace-separated token; parsing then
-        stops, matching GNU getopt's own bundling contract. The historical
-        no-dash traditional "key" form (`allow_attached_value=False`, e.g.
-        `xfC archive.tar dir`) has no attached-value form at all: EVERY
-        argument-taking letter takes its OWN separate subsequent
-        whitespace-token, in the order the letters appear in the key, per
-        POSIX tar. Conflating the two would let a later letter in a
-        no-dash key (e.g. `C` in `xfC`) be misread as the earlier letter's
-        (`f`'s) attached value, leaving both the archive and that later
-        letter's real argument as unchecked positionals. Unrecognized
+        The GNU dash-prefixed cluster (`-xzf`, `-xfC`) and the historical
+        no-dash traditional "key" form (`xfC archive.tar dir`) share this
+        same walk. The no-dash form has no attached-value convention at
+        all: every argument-taking letter takes its OWN separate
+        subsequent whitespace token, in the order the letters appear, per
+        POSIX tar. The dash-prefixed form additionally allows a single
+        trailing argument-taking letter to carry its value attached to the
+        same token (e.g. `-farchive.tar`); once such a letter is found,
+        whatever follows it in the token is normally taken whole as that
+        value. But when that remainder itself STARTS with another
+        recognized tar option letter (e.g. `C` in `-xfC`, from tar's own
+        fixed short-option alphabet), attaching it as `f`'s value would
+        misread an active `-C` as an inert path suffix, leaving both the
+        archive and `-C`'s own directory argument as unchecked
+        positionals; in that ambiguous shape this letter instead takes its
+        own separate next token too, and scanning continues into the
+        remainder exactly as the no-dash form does. Unrecognized
         characters are silently skipped (compression/verbosity flags like
         `z`/`v` this guard does not need to model), consistent with the
         conservative flag-only treatment of unknown tar options elsewhere.
@@ -2937,6 +2952,9 @@ class WorkspaceCommandPathGuard:
             "F": "dangerous",
             "b": None,
         }
+        known_option_characters = (
+            frozenset(short_modes) | frozenset(argument_events) | {"P", "O"}
+        )
         modes: list[_TarMode] = []
         events: list[_TarEvent] = []
         cursor = 0
@@ -2959,32 +2977,29 @@ class WorkspaceCommandPathGuard:
                 cursor += 1
                 continue
 
-            if allow_attached_value:
-                attached = options[cursor + 1 :]
-                argument, next_index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(values[index], attached)
-                        if attached
-                        else None
-                    ),
-                    context=f"tar argument for -{option}",
-                )
-                assert argument is not None
+            attached = options[cursor + 1 :]
+            if not attached or attached[0] in known_option_characters:
+                if next_index >= len(values):
+                    raise CommandPolicyViolation(f"missing tar argument for -{option}")
+                argument: str | None = values[next_index]
+                next_index += 1
                 kind = argument_events[option]
                 if kind is not None:
                     events.append(_TarEvent(kind, argument))
-                break
+                cursor += 1
+                continue
 
-            if next_index >= len(values):
-                raise CommandPolicyViolation(f"missing tar argument for -{option}")
-            argument = values[next_index]
-            next_index += 1
+            argument, next_index = self._take_option_argument(
+                values,
+                index,
+                attached_argument=self._derived_value(values[index], attached),
+                context=f"tar argument for -{option}",
+            )
+            assert argument is not None
             kind = argument_events[option]
             if kind is not None:
                 events.append(_TarEvent(kind, argument))
-            cursor += 1
+            break
 
         return next_index, modes, events
 
@@ -3964,84 +3979,84 @@ class WorkspaceCommandPathGuard:
         """`base64`: `-i`/`--input` reads, `-o`/`--output` writes.
 
         `-b`/`--break` and `-w`/`--wrap` take a scalar column-width value
-        that is never a path.
+        that is never a path. Long options resolve through
+        `_resolve_long_option` (GNU unambiguous-prefix abbreviation, e.g.
+        `--outp=` for `--output`), so an abbreviated spelling is classified
+        identically to the full name instead of falling through as an
+        unrecognized option — which would silently skip the write check on
+        `--output`'s argument. An unrecognized long option with an attached
+        `=value` cannot be assumed to be a value-free flag once it visibly
+        carries a value, and fails closed (mirroring `curl`/`wget`); a bare
+        unmodeled flag (e.g. `--help`) stays permissive. Short options
+        bundle through the same `_parse_short_option_cluster` substrate
+        `sort`/`grep`/`curl`/`wget` use, so `-i`/`-o` still consume their
+        argument even when not the leading character of the cluster (e.g.
+        `-di`).
         """
         self._reject_dynamic_values("base64 arguments", values)
         inputs: list[str] = []
         index = 0
         while index < len(values):
             value = values[index]
-            if value == "--":
+            text = str(value)
+            if text == "--":
                 inputs.extend(values[index + 1 :])
                 break
-            if value in {"--input", "--output"}:
-                if index + 1 < len(values):
-                    self._check_path(
-                        values[index + 1],
-                        cwd,
-                        "read" if value == "--input" else "write",
-                    )
-                index += 2
-                continue
-            if value.startswith(("--input=", "--output=")):
-                self._check_path(
-                    value.split("=", 1)[1],
-                    cwd,
-                    "read" if value.startswith("--input=") else "write",
+            if text.startswith("--"):
+                raw_option, separator, attached_text = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _BASE64_KNOWN_LONG_OPTIONS
                 )
+                if resolved in {"--input", "--output"}:
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"base64 argument for {resolved}",
+                    )
+                    assert argument is not None
+                    self._check_path(
+                        argument, cwd, "read" if resolved == "--input" else "write"
+                    )
+                    continue
+                if resolved in {"--break", "--wrap"}:
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"base64 argument for {resolved}",
+                    )
+                    continue
+                # An unmodeled long option that visibly carries a value
+                # cannot be assumed to be a value-free flag; a bare
+                # unmodeled flag stays permissive.
+                if separator:
+                    raise CommandPolicyViolation(
+                        f"cannot safely resolve base64 option {raw_option}"
+                    )
                 index += 1
                 continue
-            if value in {"--break", "--wrap"}:
-                index += 2
-                continue
-            if value.startswith(("--break=", "--wrap=")):
-                index += 1
-                continue
-            if value.startswith("-") and not value.startswith("--") and value != "-":
-                index = self._check_base64_short_options(values, index, cwd)
+            if text.startswith("-") and text != "-":
+                index, _, _ = self._parse_short_option_cluster(
+                    values,
+                    index,
+                    cwd,
+                    flag_options=_BASE64_SHORT_FLAG_OPTIONS,
+                    value_options=_BASE64_SHORT_VALUE_OPTIONS,
+                )
                 continue
             inputs.append(value)
             index += 1
         for raw_path in inputs:
             self._check_path(raw_path, cwd, "read")
-
-    def _check_base64_short_options(
-        self,
-        values: Sequence[str],
-        index: int,
-        cwd: Path,
-    ) -> int:
-        """Parse one bundled base64 short-option token (e.g. `-di<file>`).
-
-        Only `i`/`o`/`b`/`w` take a value (attached, e.g. `-ifile`, or as the
-        following token); any other character in the cluster (`-d` decode,
-        etc.) is a flag and is skipped without consuming an argument.
-        """
-        value = values[index]
-        options = value[1:]
-        cursor = 0
-        while cursor < len(options):
-            option = options[cursor]
-            if option in {"i", "o", "b", "w"}:
-                attached = options[cursor + 1 :]
-                argument, next_index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached) if attached else None
-                    ),
-                    context=f"base64 argument for -{option}",
-                    required=False,
-                )
-                if argument is not None and option in {"i", "o"}:
-                    self._check_path(
-                        argument,
-                        cwd,
-                        "read" if option == "i" else "write",
-                    )
-                return next_index
-            cursor += 1
-        return index + 1
 
     def _check_gzip(self, values: Sequence[str], cwd: Path) -> None:
         """`gzip`: default mode replaces its operand with a derived `.gz` file.

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1949,9 +1949,11 @@ class WorkspaceCommandPathGuard:
         `-N`/`--new-file` and diff's other common no-value long options
         (`--brief`, `--unified`, `--recursive`, `--ignore-case`, `--color`,
         `--side-by-side`) never consume an argument, so listing them
-        separately keeps the write-slot fail-closed rule below (which only
-        gates `--`-prefixed options that would otherwise consume an
-        argument silently) from rejecting ordinary read-only usage.
+        separately keeps the module's fail-closed-on-unrecognized-option
+        invariant from rejecting ordinary read-only usage. `-N`'s short
+        spelling is listed in `flag_short_options` (not `option_access`), the
+        same no-value/no-bundling short-option allowlist `_partition_path_options`
+        offers, since it takes no value either.
         """
         for raw_path in self._partition_path_options(
             values,
@@ -1972,7 +1974,7 @@ class WorkspaceCommandPathGuard:
                     "--new-file",
                 }
             ),
-            fail_closed_on_unknown_long_option=True,
+            flag_short_options=frozenset({"-N"}),
         ):
             self._check_path(raw_path, cwd, "read")
 
@@ -3119,9 +3121,20 @@ class WorkspaceCommandPathGuard:
         option_access: Mapping[str, PathAccess | None],
         attached_short_options: frozenset[str] = frozenset(),
         flag_long_options: frozenset[str] = frozenset(),
-        fail_closed_on_unknown_long_option: bool = False,
+        flag_short_options: frozenset[str] = frozenset(),
+        fail_closed_on_unknown_long_option: bool = True,
     ) -> list[str]:
         """Split path-bearing options from operands using a per-option access map.
+
+        Module invariant: an option grammar this family does not explicitly
+        model FAILS CLOSED rather than being silently skipped or treated as
+        an ordinary operand, for BOTH short and long options. Over-rejecting
+        an unmodeled legitimate option is acceptable; silently letting an
+        unmodeled option hide a path argument is not. This applies uniformly
+        — there is no pure-read exemption — so `fail_closed_on_unknown_long_option`
+        defaults to `True` for every caller; a caller may only pass `False`
+        when it has an independent, equally strict reason to trust an
+        unresolved long option cannot carry a path (rare, and must say why).
 
         Each key in `option_access` consumes exactly one following or attached
         token; a `None` access consumes it without a path check (a scalar
@@ -3130,15 +3143,18 @@ class WorkspaceCommandPathGuard:
         with an optional attached `=value` this family ignores); listing a
         long option there instead of in `option_access` is required for any
         option that owns no value slot, since `option_access` always consumes
-        a following/attached token. Long options resolve through
-        `_resolve_long_option` first, so an accepted abbreviation (`--out=`
-        for `--output`) is classified identically to the full name. A family
-        that owns a write slot must set `fail_closed_on_unknown_long_option`
-        so a long option this map cannot resolve — a typo, an unsupported
-        flag, or an ambiguous abbreviation — cannot silently bypass write
-        containment; pure-read families leave it unset and such an option is
-        left in place as an ordinary (over-checked, never under-checked)
-        operand, matching the family's existing single-access classification.
+        a following/attached token. `flag_short_options` is the short-option
+        analogue: a bare (never bundled, never valued) single-dash token this
+        family recognizes as a no-op flag, e.g. `-N`. Long options resolve
+        through `_resolve_long_option` first, so an accepted abbreviation
+        (`--out=` for `--output`) is classified identically to the full name.
+        A single-dash token that is not an exact `option_access` key, not an
+        `attached_short_options` prefix carrying a value, and not an exact
+        `flag_short_options` member fails closed: this substrate has no
+        bundled short-option-cluster grammar of its own (see
+        `_parse_short_option_cluster` for families that need one), so it
+        cannot tell a genuinely unknown flag apart from one hiding a path
+        argument and must not guess by skipping it.
         """
         known_long_options = (
             frozenset(option for option in option_access if option.startswith("--"))
@@ -3224,8 +3240,13 @@ class WorkspaceCommandPathGuard:
                     )
                 index += 1
                 continue
-            # Unknown short options are not paths for these simple grammars.
-            index += 1
+            if value_text in flag_short_options:
+                index += 1
+                continue
+            # Module invariant (see docstring): an unrecognized short option
+            # fails closed rather than being silently skipped, so it can
+            # never hide a path argument behind it.
+            raise CommandPolicyViolation(f"cannot safely resolve option {value_text}")
         return remaining
 
     def _read_policy_script(self, raw_path: str, cwd: Path) -> str:

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -963,7 +963,7 @@ _GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
 # grep long options that consume a value which is never a path (a pattern,
 # label, count, or action keyword), so the value must be skipped as a unit
 # rather than left in the token stream for `--label`'s argument (e.g., a real
-# path) to slide into the implicit-pattern positional slot (R6).
+# path) to slide into the implicit-pattern positional slot.
 _GREP_LONG_VALUE_OPTIONS = frozenset(
     {
         "--label",
@@ -1225,7 +1225,7 @@ _TARGET_DIR_KNOWN_LONG_OPTIONS = frozenset(
 # wholesale; only `_resolve_long_option` itself (the GNU unambiguous-prefix
 # abbreviation resolver) is reused, against this dedicated known-option set,
 # so `--target-dir=`/`--targ=` resolves to `--target-directory` exactly like
-# `cp`'s `--targ=` does (R9), instead of a literal-prefix-only string match.
+# `cp`'s `--targ=` does, instead of a literal-prefix-only string match.
 _INSTALL_SCALAR_LONG_OPTIONS = frozenset(
     {"--group", "--mode", "--owner", "--suffix", "--context"}
 )
@@ -1991,7 +1991,7 @@ class WorkspaceCommandPathGuard:
         that result back through `_check_operands`/`_operands` would re-apply
         `_operands`'s own `-`-prefix filter with no memory of the `--` it
         already passed, silently dropping (and never read-checking) such an
-        operand a second time (R1). So `file`/`wc` check their partitioned
+        operand a second time. So `file`/`wc` check their partitioned
         operands directly here instead of routing through `_check_operands`.
         """
         if command_name == "file":
@@ -2128,7 +2128,7 @@ class WorkspaceCommandPathGuard:
         unrecognized `--`-option failing closed rather than silently
         shifting the positional write slot. `-c`/`-i`/`-u`/`-d`/`-z` are the
         short-spelling equivalents of those same no-value long options and
-        are listed in `flag_short_options` for the same reason (R11): an
+        are listed in `flag_short_options` for the same reason: an
         unrecognized short option still fails closed.
         """
         scalar_options = frozenset(
@@ -2166,7 +2166,7 @@ class WorkspaceCommandPathGuard:
         `--side-by-side`) never consume an argument, so listing them
         separately keeps the module's fail-closed-on-unrecognized-option
         invariant from rejecting ordinary read-only usage. `flag_short_options`
-        is the short-spelling analogue (R11): `-u`/`-c`/`-y`/`-e`/`-n` are
+        is the short-spelling analogue: `-u`/`-c`/`-y`/`-e`/`-n` are
         alternate output-format flags, `-r`/`-q`/`-i`/`-w`/`-b`/`-B`/`-a`/
         `-t`/`-T`/`-p`/`-s` are the remaining common no-value short options,
         and `-N` is `--new-file`'s short spelling — none of them take a
@@ -2238,7 +2238,7 @@ class WorkspaceCommandPathGuard:
         checked) implicit-pattern slot, but once an explicit `-e`/`-f`/
         `--regexp` pattern IS present it instead lands in the checked file
         operands, spuriously rejecting an ordinary out-of-workspace-looking
-        label/glob/count value that is never actually read from disk (R6).
+        label/glob/count value that is never actually read from disk.
         Consuming the value up front makes the classification of every
         other positional deterministic regardless of that context. An
         option this family does not otherwise recognize stays permissive
@@ -2316,7 +2316,7 @@ class WorkspaceCommandPathGuard:
                     # but it must still be consumed as a unit: skipping only
                     # the option token would leave the argument in the
                     # stream as an ordinary positional, whose classification
-                    # then depends on unrelated context (R6) — misread as
+                    # then depends on unrelated context — misread as
                     # the excluded implicit-pattern slot with no explicit
                     # pattern elsewhere, or spuriously checked (and
                     # rejected) as a file operand once one is present.
@@ -2374,7 +2374,7 @@ class WorkspaceCommandPathGuard:
         reference file's timestamps/size are read, never written) plus, for
         `truncate`, the `-s`/`--size` scalar; every other write command in
         this family has no non-path positional. `flag_short_options` lists
-        each command's remaining common no-value short options (R11) so an
+        each command's remaining common no-value short options so an
         unrecognized short option still fails closed without over-rejecting
         ordinary usage.
         """
@@ -2584,7 +2584,7 @@ class WorkspaceCommandPathGuard:
         if len(operands) < 2:
             # A single (or zero) operand has no destination slot to split
             # off, but a lone operand is still a real source and must still
-            # be read-checked (R9), not silently exempted for lack of a
+            # be read-checked, not silently exempted for lack of a
             # second (destination) operand — the same fix `rsync` already
             # applies to its own single-operand invocation (N1).
             for raw_path in operands:
@@ -2608,7 +2608,7 @@ class WorkspaceCommandPathGuard:
         unambiguous-prefix abbreviation, e.g. `--target-dir=` for
         `--target-directory`, matching `cp`'s `--targ=`), instead of a
         literal-prefix-only string match that only recognized the full
-        spelling (R9).
+        spelling.
         """
         target_dir: str | None = None
         operands: list[str] = []
@@ -2737,7 +2737,7 @@ class WorkspaceCommandPathGuard:
         if len(operands) < 2:
             # A single (or zero) operand has no destination slot to split
             # off, but a lone operand is still a real source and must still
-            # be read-checked (R9), not silently exempted for lack of a
+            # be read-checked, not silently exempted for lack of a
             # second (destination) operand.
             for operand in operands:
                 self._check_path(operand, cwd, "read")
@@ -2770,9 +2770,9 @@ class WorkspaceCommandPathGuard:
         `shred` additionally accepts `--random-source=FILE` (itself a read
         path) and scalar `-n`/`--iterations`, `-s`/`--size` options whose
         value must not be misread as a path operand, plus its remaining
-        no-value short options (`-f`/`-u`/`-v`/`-x`/`-z`, R11). Both commands
+        no-value short options (`-f`/`-u`/`-v`/`-x`/`-z`). Both commands
         route through the same fail-closed `_partition_path_options`
-        substrate (R3): `unlink` previously used the permissive `_operands`
+        substrate: `unlink` previously used the permissive `_operands`
         helper, which silently skips any unrecognized short option (and its
         attached suffix) as an ordinary token, letting a path hide behind an
         unmodeled option (e.g. `-X<path>`) go completely unchecked — the
@@ -3070,7 +3070,7 @@ class WorkspaceCommandPathGuard:
                 self._check_path(event.value, cwd, "read")
             elif event.kind == "newer_mtime":
                 # `-N`/`--newer-mtime`/`--after-date`'s DATE-OR-FILE argument
-                # can name a reference file whose mtime is read (R2); model
+                # can name a reference file whose mtime is read; model
                 # it as a read path rather than leaving it as an unmodeled
                 # bare flag, which would let its argument fall through as an
                 # unchecked positional.
@@ -3260,7 +3260,7 @@ class WorkspaceCommandPathGuard:
             "--listed-incremental": "incremental",
             "--add-file": "add_file",
             "--index-file": "verbose_output",
-            # `-N`'s two long spellings (R2); both name the same
+            # `-N`'s two long spellings; both name the same
             # DATE-OR-FILE argument, so both resolve to the same read path.
             "--newer-mtime": "newer_mtime",
             "--after-date": "newer_mtime",
@@ -3346,7 +3346,7 @@ class WorkspaceCommandPathGuard:
             "F": "dangerous",
             "b": None,
             # `-N`/`--newer-mtime`/`--after-date`: a DATE-OR-FILE argument
-            # (R2). Modeling it here means its argument always takes its own
+            # . Modeling it here means its argument always takes its own
             # token/attached-value slot like every other argument-taking
             # short letter, so it can never fall through as an unmodeled
             # bare flag whose argument becomes an unchecked positional.
@@ -3479,7 +3479,7 @@ class WorkspaceCommandPathGuard:
         violation (families that own a write slot). A bare `--` is the
         argument-list terminator, never an abbreviation: every candidate
         starts with `--`, so it would otherwise "unambiguously" prefix-match
-        a known set containing exactly one option (R7).
+        a known set containing exactly one option.
         """
         if value in known:
             return value
@@ -4409,7 +4409,7 @@ class WorkspaceCommandPathGuard:
         this lexer cannot resolve; that must fail closed too, rather than
         validating only the leading literal while the concatenated
         remainder silently escapes containment. `)` is also a valid
-        terminator (R13): the idiomatic `while ((getline line < "file") > 0)`
+        terminator: the idiomatic `while ((getline line < "file") > 0)`
         read loop closes the parenthesized `getline` expression right after
         the quoted target, and that closing paren is not itself part of a
         concatenated expression.

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -978,7 +978,7 @@ _CURL_WRITE_LONG_OPTIONS = frozenset(
         "--etag-save",
     }
 )
-_CURL_READ_LONG_OPTIONS = frozenset({"--upload-file", "--netrc-file"})
+_CURL_READ_LONG_OPTIONS = frozenset({"--upload-file", "--netrc-file", "--cookie"})
 _CURL_DATA_LONG_OPTIONS = frozenset({"--data", "--data-binary", "--data-raw"})
 # Long-form spellings of `_CURL_SHORT_FLAG_OPTIONS`'s no-value flags, so the
 # common long spelling of an already-modeled short flag is not rejected
@@ -4606,22 +4606,30 @@ class WorkspaceCommandPathGuard:
 
     def _check_curl(self, values: Sequence[str], cwd: Path) -> None:
         """`curl`: `-o`/`--output`/`--output-dir` write; `-T`/`--upload-file`/
-        `--netrc-file` read; an `@file` payload to `-d`/`--data*` reads that
-        file. `-D`/`--dump-header`, `-c`/`--cookie-jar`, `--trace`,
-        `--trace-ascii`, `--stderr`, `--libcurl`, `--hsts`, and
-        `--etag-save` also write to a filename argument. `-K`/`--config`
-        (arbitrary runtime options) and `-O`/`--remote-name[-all]` (output
-        filename derived from the remote URL or response, not statically
-        knowable) cannot be inspected safely and fail closed, including
-        bundled behind another short flag (e.g. `-sO`). Long options resolve
-        through `_resolve_long_option` (GNU unambiguous-prefix abbreviation,
-        e.g. `--dump-hea=` for `--dump-header`). Module invariant: any
-        option (short or long, bare or `=value`-attached) this allowlist
-        cannot resolve fails closed. Short options bundle through the same
-        `_parse_short_option_cluster` substrate `sort`/`grep`/`install` use,
-        so a value-taking option (`-o`/`-D`/`-c`/`-T`) still consumes its
-        argument even when it is not the leading character of the cluster
-        (e.g. `-sD`). A literal `--` ends option parsing.
+        `--netrc-file`/`--cookie` read; an `@file` payload to `-d`/`--data*`
+        reads that file. `--cookie` is modeled explicitly (not left to
+        prefix-abbreviation) because it is a real, distinct option from
+        `--cookie-jar`: leaving it unresolved let its own unambiguous-prefix
+        match snap to `--cookie-jar` (a write path) and write-check a file
+        the invocation only ever reads (N2). `-D`/`--dump-header`,
+        `-c`/`--cookie-jar`, `--trace`, `--trace-ascii`, `--stderr`,
+        `--libcurl`, `--hsts`, and `--etag-save` also write to a filename
+        argument. `-K`/`--config` (arbitrary runtime options) and
+        `-O`/`--remote-name[-all]` (output filename derived from the remote
+        URL or response, not statically knowable) cannot be inspected safely
+        and fail closed, including bundled behind another short flag (e.g.
+        `-sO`). Long options resolve through `_resolve_long_option` (GNU
+        unambiguous-prefix abbreviation, e.g. `--dump-hea=` for
+        `--dump-header`); every strict abbreviation of `--cookie` is also a
+        prefix of `--cookie-jar`, so once both are modeled only the exact
+        `--cookie` spelling resolves and a truncated one is ambiguous and
+        fails closed, as this family's invariant requires. Module invariant:
+        any option (short or long, bare or `=value`-attached) this
+        allowlist cannot resolve fails closed. Short options bundle through
+        the same `_parse_short_option_cluster` substrate `sort`/`grep`/
+        `install` use, so a value-taking option (`-o`/`-D`/`-c`/`-T`) still
+        consumes its argument even when it is not the leading character of
+        the cluster (e.g. `-sD`). A literal `--` ends option parsing.
 
         The positional URL/operand (T3) is classified through
         `_classify_url_operand`: a `file:` URL is a real filesystem channel

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -960,7 +960,28 @@ _GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "D": None,
     "d": None,
 }
-_GREP_KNOWN_LONG_OPTIONS = frozenset({"--regexp", "--file", "--exclude-from"})
+# grep long options that consume a value which is never a path (a pattern,
+# label, count, or action keyword), so the value must be skipped as a unit
+# rather than left in the token stream for `--label`'s argument (e.g., a real
+# path) to slide into the implicit-pattern positional slot (R6).
+_GREP_LONG_VALUE_OPTIONS = frozenset(
+    {
+        "--label",
+        "--include",
+        "--exclude",
+        "--exclude-dir",
+        "--binary-files",
+        "--context",
+        "--after-context",
+        "--before-context",
+        "--max-count",
+        "--directories",
+        "--devices",
+    }
+)
+_GREP_KNOWN_LONG_OPTIONS = (
+    frozenset({"--regexp", "--file", "--exclude-from"}) | _GREP_LONG_VALUE_OPTIONS
+)
 
 # A `curl`/`wget` positional operand is a URL, not a bare filesystem path,
 # EXCEPT when its scheme is `file:`, which is a real local filesystem
@@ -2179,10 +2200,21 @@ class WorkspaceCommandPathGuard:
         `--file`/`--exclude-from` that would silently skip the read check
         on the pattern-file argument, and for `--regexp` it would leave
         `explicit_pattern` unset, misreading the real first file operand as
-        the (excluded) pattern positional. An option this family does not
-        recognize stays permissive (an ordinary, over-checked-never-
-        under-checked operand) rather than failing closed, matching grep's
-        existing pure-read classification.
+        the (excluded) pattern positional. `_GREP_LONG_VALUE_OPTIONS`
+        (`--label`, `--include`, `--context`, etc.) resolve the same way and
+        have their own value consumed as a unit for the same reason: leaving
+        the value in the token stream (the old skip-the-flag-only treatment)
+        makes its classification depend on unrelated context — with no
+        explicit pattern elsewhere it lands in the excluded (never
+        checked) implicit-pattern slot, but once an explicit `-e`/`-f`/
+        `--regexp` pattern IS present it instead lands in the checked file
+        operands, spuriously rejecting an ordinary out-of-workspace-looking
+        label/glob/count value that is never actually read from disk (R6).
+        Consuming the value up front makes the classification of every
+        other positional deterministic regardless of that context. An
+        option this family does not otherwise recognize stays permissive
+        (an ordinary, over-checked-never-under-checked operand) rather than
+        failing closed, matching grep's existing pure-read classification.
         """
         positionals: list[str] = []
         explicit_pattern = False
@@ -2248,6 +2280,25 @@ class WorkspaceCommandPathGuard:
                     )
                     assert argument is not None
                     self._check_path(argument, cwd, "read")
+                    continue
+                if resolved in _GREP_LONG_VALUE_OPTIONS:
+                    # `--label`, `--include`, `--context`, etc. take a value
+                    # that is never a path (a label, glob pattern, or count),
+                    # but it must still be consumed as a unit: skipping only
+                    # the option token would leave the argument in the
+                    # stream as an ordinary positional, whose classification
+                    # then depends on unrelated context (R6) — misread as
+                    # the excluded implicit-pattern slot with no explicit
+                    # pattern elsewhere, or spuriously checked (and
+                    # rejected) as a file operand once one is present.
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"grep argument for {resolved}",
+                    )
                     continue
                 # Long flag options this family does not model (e.g.
                 # `--color=auto`) carry no path, so they are skipped rather

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -4211,9 +4211,27 @@ class WorkspaceCommandPathGuard:
         though it only *reads* its argument today: rsync may hard-link
         unchanged files from that tree straight into the destination, so a
         read-only external root is not sufficient authorization for it.
-        `--files-from`/`-f`/`--filter`/`-e`/`--rsh`/... delegate to an
-        external file list or shell command this guard cannot inspect
-        safely and fail closed rather than silently bypassing containment.
+        `--log-file`/`--write-batch`/`--only-write-batch` also write to a
+        filename argument; `--read-batch` reads one (the batched changes it
+        replays are still bounded by the invocation's own destination
+        operand, so its file argument is a plain read, not a write slot).
+        `--files-from`/`--include-from`/`--exclude-from`/`-f`/`--filter`/
+        `-e`/`--rsh`/... delegate to an external file list or shell command
+        this guard cannot inspect safely and fail closed unconditionally
+        rather than access-checking their own argument: the file's
+        *contents* can name further paths this guard never sees, so a
+        plain read check of the file itself would not bound what rsync
+        actually touches.
+
+        Long options resolve through `_resolve_long_option` (GNU
+        unambiguous-prefix abbreviation, e.g. `--link-des=`/`--link-des ` for
+        `--link-dest`), so an abbreviation of any modeled option — write,
+        read, scalar, or denied — is classified identically to its full
+        name in both the `=`-attached and space-separated spelling. An
+        option this map cannot resolve (a typo, an unsupported flag, or an
+        ambiguous abbreviation) fails closed when it visibly carries a
+        value (`=`-attached); a bare unmodeled long option is still assumed
+        to be a value-free flag, matching curl/wget.
         """
         self._reject_dynamic_values("rsync arguments", values)
         denied_options = {
@@ -4237,6 +4255,10 @@ class WorkspaceCommandPathGuard:
             "--compare-dest": "read",
             "--copy-dest": "read",
             "--link-dest": "write",
+            "--log-file": "write",
+            "--write-batch": "write",
+            "--only-write-batch": "write",
+            "--read-batch": "read",
         }
         scalar_options = {
             "--block-size",
@@ -4257,6 +4279,11 @@ class WorkspaceCommandPathGuard:
             "--usermap",
             "--groupmap",
         }
+        known_long_options = (
+            frozenset(path_options)
+            | frozenset(scalar_options)
+            | frozenset(option for option in denied_options if option.startswith("--"))
+        )
         operands: list[str] = []
         options_done = False
         index = 0
@@ -4272,7 +4299,17 @@ class WorkspaceCommandPathGuard:
                 index += 1
                 continue
             option, separator, attached_text = text.partition("=")
-            if option in denied_options or (
+            resolved_option = option
+            if (
+                text.startswith("--")
+                and option not in path_options
+                and option not in scalar_options
+                and option not in denied_options
+            ):
+                candidate = self._resolve_long_option(option, known_long_options)
+                if candidate is not None:
+                    resolved_option = candidate
+            if resolved_option in denied_options or (
                 text.startswith("-")
                 and not text.startswith("--")
                 and any(flag in text[1:] for flag in {"e", "f", "L", "H"})
@@ -4280,31 +4317,32 @@ class WorkspaceCommandPathGuard:
                 raise CommandPolicyViolation(
                     f"cannot safely inspect rsync option {option}"
                 )
-            if option in path_options:
+            if resolved_option in path_options:
                 argument, index = self._take_option_argument(
                     values,
                     index,
                     attached_argument=(
                         self._derived_value(value, attached_text) if separator else None
                     ),
-                    context=f"rsync argument for {option}",
+                    context=f"rsync argument for {resolved_option}",
                 )
                 assert argument is not None
-                self._check_path(argument, cwd, path_options[option])
+                self._check_path(argument, cwd, path_options[resolved_option])
                 continue
-            if option in scalar_options:
+            if resolved_option in scalar_options:
                 _, index = self._take_option_argument(
                     values,
                     index,
                     attached_argument=(
                         self._derived_value(value, attached_text) if separator else None
                     ),
-                    context=f"rsync argument for {option}",
+                    context=f"rsync argument for {resolved_option}",
                 )
                 continue
             if text.startswith("--"):
-                # Long flag options are argument-free here. Options with
-                # unmodeled values fail closed instead of shifting operands.
+                # Long flag options are argument-free here. An option this
+                # map cannot resolve fails closed instead of shifting
+                # operands when it visibly carries a value.
                 if separator:
                     raise CommandPolicyViolation(
                         f"cannot safely inspect rsync option {option}"

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -4000,11 +4000,14 @@ class WorkspaceCommandPathGuard:
         the optional `< FILE` clause; `_skip_awk_getline_target` advances
         past whichever form is present so the `<` is still found instead of
         the read check being silently skipped when the target is not a bare
-        identifier.
+        identifier. A prefix ending in `|&` (gawk's two-way coprocess pipe)
+        executes a shell command exactly like a plain `|` and fails closed
+        the same way (M5): checking `endswith("|")` alone missed it, since
+        `&` — not `|` — is the trailing character.
         """
         for match in _AWK_GETLINE_PATTERN.finditer(script):
             prefix = script[: match.start()].rstrip()
-            if prefix.endswith("|"):
+            if prefix.endswith("|") or prefix.endswith("|&"):
                 raise CommandPolicyViolation(
                     "awk pipe input to 'getline' executes an arbitrary shell "
                     "command and cannot be inspected safely"

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -937,6 +937,68 @@ _GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
 }
 _GREP_KNOWN_LONG_OPTIONS = frozenset({"--regexp", "--file", "--exclude-from"})
 
+# `curl`'s short options bundle into one token (e.g. `-sD file` combines the
+# `-s` flag with the `-D` write-path option), so its grammar is split into a
+# flag set and a value set for the short-option-cluster parser, the same
+# shape `sort`/`grep`/`install` use. `-d`'s value is only conditionally a
+# path (an `@file` payload), so it is modeled here as a plain (unchecked)
+# value and given its own `@`-prefix classification by the caller.
+_CURL_SHORT_FLAG_OPTIONS = frozenset("sSLkfiIvNgGq#")
+_CURL_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "o": "write",
+    "D": "write",
+    "c": "write",
+    "T": "read",
+    "d": None,
+}
+_CURL_HARD_DENY_LONG_OPTIONS = frozenset({"--remote-name", "--remote-name-all"})
+_CURL_CONFIG_LONG_OPTIONS = frozenset({"--config"})
+_CURL_WRITE_LONG_OPTIONS = frozenset(
+    {
+        "--output",
+        "--output-dir",
+        "--dump-header",
+        "--cookie-jar",
+        "--trace",
+        "--trace-ascii",
+        "--stderr",
+        "--libcurl",
+        "--hsts",
+        "--etag-save",
+    }
+)
+_CURL_READ_LONG_OPTIONS = frozenset({"--upload-file", "--netrc-file"})
+_CURL_DATA_LONG_OPTIONS = frozenset({"--data", "--data-binary", "--data-raw"})
+_CURL_KNOWN_LONG_OPTIONS = frozenset(
+    _CURL_HARD_DENY_LONG_OPTIONS
+    | _CURL_CONFIG_LONG_OPTIONS
+    | _CURL_WRITE_LONG_OPTIONS
+    | _CURL_READ_LONG_OPTIONS
+    | _CURL_DATA_LONG_OPTIONS
+)
+
+# `wget`'s own short options never bundle a value-taking option behind a
+# flag in this family's existing tests or documented usage, but the same
+# split keeps its long-option handling consistent with curl/rsync/sort.
+_WGET_HARD_DENY_LONG_OPTIONS = frozenset({"--input-file"})
+_WGET_CONFIG_LONG_OPTIONS = frozenset({"--config"})
+_WGET_WRITE_LONG_OPTIONS = frozenset(
+    {
+        "--output-document",
+        "--directory-prefix",
+        "--output-file",
+        "--save-cookies",
+    }
+)
+_WGET_READ_LONG_OPTIONS = frozenset({"--post-file", "--body-file"})
+_WGET_KNOWN_LONG_OPTIONS = frozenset(
+    _WGET_HARD_DENY_LONG_OPTIONS
+    | _WGET_CONFIG_LONG_OPTIONS
+    | _WGET_WRITE_LONG_OPTIONS
+    | _WGET_READ_LONG_OPTIONS
+    | {"--spider"}
+)
+
 
 @dataclass(frozen=True)
 class _PathEvent:
@@ -1762,7 +1824,7 @@ class WorkspaceCommandPathGuard:
                 continue
 
             if value_text.startswith("-") and value_text != "-":
-                index = self._parse_short_option_cluster(
+                index, _, _ = self._parse_short_option_cluster(
                     values,
                     index,
                     cwd,
@@ -1941,7 +2003,7 @@ class WorkspaceCommandPathGuard:
                 cluster_chars = value_text[1:]
                 if "e" in cluster_chars or "f" in cluster_chars:
                     explicit_pattern = True
-                index = self._parse_short_option_cluster(
+                index, _, _ = self._parse_short_option_cluster(
                     values,
                     index,
                     cwd,
@@ -2211,7 +2273,7 @@ class WorkspaceCommandPathGuard:
                 # A bundled cluster (e.g. `-Dm755`): only the trailing
                 # value-taking character may carry an attached argument, so
                 # this shares the same GNU bundling contract as `sort`.
-                index = self._parse_short_option_cluster(
+                index, _, _ = self._parse_short_option_cluster(
                     values,
                     index,
                     cwd,
@@ -2857,7 +2919,7 @@ class WorkspaceCommandPathGuard:
         *,
         flag_options: frozenset[str],
         value_options: Mapping[str, PathAccess | None],
-    ) -> int:
+    ) -> tuple[int, str | None, str | None]:
         """Parse one bundled short-option token (e.g. `-no<file>`).
 
         GNU short options bundle into a single token where only the last
@@ -2865,7 +2927,11 @@ class WorkspaceCommandPathGuard:
         as the following token). Any character not recognized as a flag or a
         value option fails closed rather than being silently skipped, so an
         unmodeled option can never hide a path argument. Returns the index of
-        the next unconsumed token.
+        the next unconsumed token, plus the matched value option and its raw
+        argument (both `None` when the cluster was flags only) for callers
+        that need to act on which option fired — a `None` access here still
+        skips the path check but the caller can still see the raw argument,
+        e.g. to apply its own non-path classification to it.
         """
         source = values[index]
         options = str(source)[1:]
@@ -2890,8 +2956,8 @@ class WorkspaceCommandPathGuard:
             access = value_options[option]
             if access is not None:
                 self._check_path(argument, cwd, access)
-            return next_index
-        return index + 1
+            return next_index, option, argument
+        return index + 1, None, None
 
     @staticmethod
     def _resolve_long_option(value: str, known: Iterable[str]) -> str | None:
@@ -4160,147 +4226,124 @@ class WorkspaceCommandPathGuard:
         """`curl`: `-o`/`--output`/`--output-dir` write; `-T`/`--upload-file`/
         `--netrc-file` read; an `@file` payload to `-d`/`--data*` reads that
         file. `-D`/`--dump-header`, `-c`/`--cookie-jar`, `--trace`,
-        `--trace-ascii`, and `--stderr` also write to a filename argument.
-        `-K`/`--config` (arbitrary runtime options) and `-O`/
-        `--remote-name[-all]` (output filename derived from the remote URL
-        or response, not statically knowable) cannot be inspected safely and
-        fail closed. An unrecognized long option with an attached `=value`
-        also fails closed (mirroring `rsync`): curl accepts a value for many
-        long options this family does not model, so an unmodeled one cannot
-        be assumed to be a value-free flag once it visibly carries a value.
+        `--trace-ascii`, `--stderr`, `--libcurl`, `--hsts`, and
+        `--etag-save` also write to a filename argument. `-K`/`--config`
+        (arbitrary runtime options) and `-O`/`--remote-name[-all]` (output
+        filename derived from the remote URL or response, not statically
+        knowable) cannot be inspected safely and fail closed, including
+        bundled behind another short flag (e.g. `-sO`). Long options resolve
+        through `_resolve_long_option` (GNU unambiguous-prefix abbreviation,
+        e.g. `--dump-hea=` for `--dump-header`); an unrecognized long option
+        with an attached `=value` also fails closed (mirroring `rsync`):
+        curl accepts a value for many long options this family does not
+        model, so an unmodeled one cannot be assumed to be a value-free
+        flag once it visibly carries a value. Short options bundle through
+        the same `_parse_short_option_cluster` substrate `sort`/`grep`/
+        `install` use, so a value-taking option (`-o`/`-D`/`-c`/`-T`) still
+        consumes its argument even when it is not the leading character of
+        the cluster (e.g. `-sD`).
         """
         self._reject_dynamic_values("curl arguments", values)
         index = 0
         while index < len(values):
             value = values[index]
             text = str(value)
-            if text in {"-O", "--remote-name", "--remote-name-all"} or (
-                text.startswith("-O") and not text.startswith("--")
-            ):
-                raise CommandPolicyViolation(
-                    "cannot safely resolve curl remote output filename"
+            if text.startswith("--"):
+                raw_option, separator, attached_text = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _CURL_KNOWN_LONG_OPTIONS
                 )
-            if (
-                text in {"-K", "--config"}
-                or text.startswith("--config=")
-                or (text.startswith("-K") and len(text) > 2)
-            ):
-                raise CommandPolicyViolation(
-                    "cannot safely inspect curl runtime configuration"
-                )
-            if text in {"-o", "--output", "--output-dir"} or text.startswith(
-                ("--output=", "--output-dir=")
-            ):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"curl argument for {option}",
-                )
-                assert argument is not None
-                self._check_path(argument, cwd, "write")
-                continue
-            if text.startswith("-o") and len(text) > 2:
-                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
+                if resolved in _CURL_HARD_DENY_LONG_OPTIONS:
+                    raise CommandPolicyViolation(
+                        "cannot safely resolve curl remote output filename"
+                    )
+                if resolved in _CURL_CONFIG_LONG_OPTIONS:
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect curl runtime configuration"
+                    )
+                if resolved in _CURL_WRITE_LONG_OPTIONS or (
+                    resolved in _CURL_READ_LONG_OPTIONS
+                ):
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"curl argument for {resolved}",
+                    )
+                    assert argument is not None
+                    access: PathAccess = (
+                        "write" if resolved in _CURL_WRITE_LONG_OPTIONS else "read"
+                    )
+                    self._check_path(argument, cwd, access)
+                    continue
+                if resolved in _CURL_DATA_LONG_OPTIONS:
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"curl argument for {resolved}",
+                    )
+                    assert argument is not None
+                    if str(argument).startswith("@"):
+                        self._check_path(
+                            self._derived_value(argument, str(argument)[1:]),
+                            cwd,
+                            "read",
+                        )
+                    continue
+                # An unmodeled long option that visibly carries a value
+                # cannot be assumed to be a value-free flag; a bare
+                # unmodeled flag stays permissive.
+                if separator:
+                    raise CommandPolicyViolation(
+                        f"cannot safely inspect curl option {raw_option}"
+                    )
                 index += 1
                 continue
-            if text in {
-                "-D",
-                "--dump-header",
-                "-c",
-                "--cookie-jar",
-                "--trace",
-                "--trace-ascii",
-                "--stderr",
-            } or text.startswith(
-                (
-                    "--dump-header=",
-                    "--cookie-jar=",
-                    "--trace=",
-                    "--trace-ascii=",
-                    "--stderr=",
-                )
-            ):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
+            if text.startswith("-") and text != "-":
+                # `-O`/`-K` fail closed even bundled behind another flag
+                # (e.g. `-sO`); scanning stops at the first character that
+                # is not a known no-value flag, since anything past a
+                # value-taking option is that option's value, not another
+                # flag letter.
+                for character in text[1:]:
+                    if character in _CURL_SHORT_FLAG_OPTIONS:
+                        continue
+                    if character == "O":
+                        raise CommandPolicyViolation(
+                            "cannot safely resolve curl remote output filename"
+                        )
+                    if character == "K":
+                        raise CommandPolicyViolation(
+                            "cannot safely inspect curl runtime configuration"
+                        )
+                    break
+                index, matched_option, argument = self._parse_short_option_cluster(
                     values,
                     index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"curl argument for {option}",
+                    cwd,
+                    flag_options=_CURL_SHORT_FLAG_OPTIONS,
+                    value_options=_CURL_SHORT_VALUE_OPTIONS,
                 )
-                assert argument is not None
-                self._check_path(argument, cwd, "write")
-                continue
-            if (
-                (text.startswith("-D") or text.startswith("-c"))
-                and not text.startswith("--")
-                and len(text) > 2
-            ):
-                self._check_path(self._derived_value(value, text[2:]), cwd, "write")
-                index += 1
-                continue
-            if text in {"-T", "--upload-file", "--netrc-file"} or text.startswith(
-                ("--upload-file=", "--netrc-file=")
-            ):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"curl argument for {option}",
-                )
-                assert argument is not None
-                self._check_path(argument, cwd, "read")
-                continue
-            if text.startswith("-T") and len(text) > 2:
-                self._check_path(self._derived_value(value, text[2:]), cwd, "read")
-                index += 1
-                continue
-            if text in {
-                "-d",
-                "--data",
-                "--data-binary",
-                "--data-raw",
-            } or text.startswith(("--data=", "--data-binary=", "--data-raw=")):
-                option, separator, attached_text = text.partition("=")
-                argument, index = self._take_option_argument(
-                    values,
-                    index,
-                    attached_argument=(
-                        self._derived_value(value, attached_text) if separator else None
-                    ),
-                    context=f"curl argument for {option}",
-                )
-                assert argument is not None
-                if str(argument).startswith("@"):
+                if (
+                    matched_option == "d"
+                    and argument is not None
+                    and str(argument).startswith("@")
+                ):
                     self._check_path(
                         self._derived_value(argument, str(argument)[1:]),
                         cwd,
                         "read",
                     )
                 continue
-            if text.startswith("-d") and len(text) > 2:
-                argument = self._derived_value(value, text[2:])
-                if str(argument).startswith("@"):
-                    self._check_path(
-                        self._derived_value(argument, str(argument)[1:]),
-                        cwd,
-                        "read",
-                    )
-                index += 1
-                continue
-            option, separator, _ = text.partition("=")
-            if text.startswith("--") and separator:
-                raise CommandPolicyViolation(
-                    f"cannot safely inspect curl option {option}"
-                )
             index += 1
 
     def _check_wget(self, values: Sequence[str], cwd: Path) -> None:

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -3128,8 +3128,21 @@ class WorkspaceCommandPathGuard:
                 raise CommandPolicyViolation(
                     f"cannot safely inspect {grammar.language} option {value_text}"
                 )
-            if not grammar.ignores_assignment_arguments or "=" not in value_text:
-                positionals.append(value)
+            # The CLI `var=value` assignment-operand skip only applies once
+            # the program itself has already been consumed (an explicit
+            # script via `-f`/`--file`/`-e`, or a prior positional): it must
+            # never swallow the program token, or an inline program whose
+            # text happens to contain "=" would be silently dropped from
+            # inspection entirely.
+            already_have_program = explicit_script or bool(positionals)
+            if (
+                grammar.ignores_assignment_arguments
+                and already_have_program
+                and "=" in value_text
+            ):
+                index += 1
+                continue
+            positionals.append(value)
             index += 1
 
         if not explicit_script and positionals:
@@ -3670,6 +3683,13 @@ class WorkspaceCommandPathGuard:
         path statically; any other form (a bareword, a field reference like
         `$1`, a variable, a parenthesized expression) is dynamic from this
         lexer's point of view and is rejected rather than silently skipped.
+        Awk concatenates adjacent expressions by bare juxtaposition (no
+        operator), so anything other than a statement terminator following
+        the closing quote (another string literal, an identifier, `$`, `(`,
+        ...) means the true runtime target is this literal PLUS more text
+        this lexer cannot resolve; that must fail closed too, rather than
+        validating only the leading literal while the concatenated
+        remainder silently escapes containment.
         """
         cursor = index
         while cursor < len(script) and script[cursor] in " \t":
@@ -3686,7 +3706,15 @@ class WorkspaceCommandPathGuard:
             elif character == "\\":
                 escaped = True
             elif character == '"':
-                return script[start:cursor]
+                literal = script[start:cursor]
+                trailer = cursor + 1
+                while trailer < len(script) and script[trailer] in " \t":
+                    trailer += 1
+                if trailer < len(script) and script[trailer] not in ";\n}":
+                    raise CommandPolicyViolation(
+                        "cannot resolve dynamic awk redirect target"
+                    )
+                return literal
             cursor += 1
         raise CommandPolicyViolation("cannot safely inspect awk redirect target")
 

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2246,7 +2246,12 @@ class WorkspaceCommandPathGuard:
         `--dereference`, `-H`) can read arbitrarily deep external content
         through a single approved read boundary, which cannot be bounded
         statically, so that combination is a hard denial regardless of the
-        actual paths involved.
+        actual paths involved. `--recursive`/`--dereference`/
+        `--follow-command-line-symlink` resolve through `_resolve_long_option`
+        against the same `_TARGET_DIR_KNOWN_LONG_OPTIONS` set
+        `_parse_target_directory` uses for this family, so a GNU-abbreviated
+        spelling (`--derefe`) is classified identically to the full name
+        instead of silently missing this detection.
         """
         recursive = False
         dereferences_links = False
@@ -2254,10 +2259,15 @@ class WorkspaceCommandPathGuard:
             text = str(value)
             if text == "--":
                 break
-            if text == "--recursive":
-                recursive = True
-            elif text in {"--dereference", "--follow-command-line-symlink"}:
-                dereferences_links = True
+            if text.startswith("--"):
+                raw_option, _, _ = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _TARGET_DIR_KNOWN_LONG_OPTIONS
+                )
+                if resolved == "--recursive":
+                    recursive = True
+                elif resolved in {"--dereference", "--follow-command-line-symlink"}:
+                    dereferences_links = True
             elif text.startswith("-") and not text.startswith("--"):
                 flags = text[1:]
                 recursive = recursive or "r" in flags or "R" in flags
@@ -2686,11 +2696,16 @@ class WorkspaceCommandPathGuard:
                     )
                 continue
             if event.kind == "unresolved_option":
-                if invocation.mode in {"extract", "list"}:
-                    raise CommandPolicyViolation(
-                        f"cannot safely resolve tar option {event.value}"
-                    )
-                continue
+                # Fails closed in every mode, not only extract/list: the
+                # same parser ambiguity (bare flag vs. a hidden argument)
+                # would otherwise let an abbreviated write-checked
+                # (`--listed-incremental`) or hard-denied (`--files-from`)
+                # option's value leak through as an ordinary source/
+                # destination positional in create/append/update/
+                # concatenate/compare mode.
+                raise CommandPolicyViolation(
+                    f"cannot safely resolve tar option {event.value}"
+                )
             if event.value is None:
                 continue
 
@@ -2849,18 +2864,27 @@ class WorkspaceCommandPathGuard:
     ) -> tuple[int, _TarEvent | None]:
         """Parse one `--`-prefixed tar argument into a typed event.
 
-        An unrecognized long option with an attached `=value` unambiguously
-        carries a value this family does not model, and fails closed
-        immediately regardless of mode (mirroring `rsync`/`curl`/`wget`).
-        An unrecognized option with NO attached value is ambiguous: it may
-        be a bare flag (common; e.g. `--gzip`), or it may take a separate
-        following token this parser cannot identify as its argument, which
-        would otherwise be misclassified as an unchecked archive-member
-        positional in extract/list mode (that value is never path-checked
-        there). Rather than guess its arity, it is returned as an
-        `unresolved_option` event so `_check_tar` can fail closed in
-        extract/list mode specifically, where that ambiguity is exploitable,
-        while leaving other modes' (already-checked) positionals unaffected.
+        The option resolves through `_resolve_long_option` (GNU
+        unambiguous-prefix abbreviation, e.g. `--listed-incr` for
+        `--listed-incremental`, `--files-fr` for `--files-from`) against
+        this family's known path-bearing and dangerous long options, so an
+        abbreviated spelling is classified identically to the full name
+        instead of falling through as unmodeled. An unrecognized long
+        option with an attached `=value` unambiguously carries a value this
+        family does not model, and fails closed immediately regardless of
+        mode (mirroring `rsync`/`curl`/`wget`). An unrecognized option with
+        NO attached value is ambiguous: it may be a bare flag (common; e.g.
+        `--gzip`), or it may take a separate following token this parser
+        cannot identify as its argument, which would otherwise be
+        misclassified as an unchecked archive-member positional in
+        extract/list mode (never path-checked there) or as an unchecked
+        source/destination positional in the other modes (source_access-
+        checked, not the write/hard-deny classification the real option
+        would receive). Rather than guess its arity, it is returned as an
+        `unresolved_option` event; `_check_tar` fails closed on that event
+        in every mode, not only extract/list, since the same ambiguity is
+        exploitable wherever a long option could silently misclassify a
+        value it would otherwise write-check or hard-deny.
         """
         value = values[index]
         text = str(value)
@@ -2882,8 +2906,10 @@ class WorkspaceCommandPathGuard:
             "--rsh-command",
         }
         option, separator, attached = text.partition("=")
-        kind = path_options.get(option)
-        is_dangerous = option in dangerous_options
+        known_long_options = frozenset(path_options) | dangerous_options
+        resolved = self._resolve_long_option(option, known_long_options)
+        kind = path_options.get(resolved) if resolved is not None else None
+        is_dangerous = resolved in dangerous_options if resolved is not None else False
         if kind is None and not is_dangerous:
             if separator:
                 raise CommandPolicyViolation(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import (
     Any,
+    Callable,
     Iterable,
     Iterator,
     Mapping,
@@ -103,6 +104,14 @@ class _ValidationSession:
     argv_tokens: int = 0
     wrapped_bash_dispatch: bool = False
     effects: _EffectScope = field(default_factory=_EffectScope)
+    # `find`-scoped side channel: while set, every `_check_path` resolution
+    # reports its (raw_path, access) pair here before any short-circuit, so a
+    # `-exec`/`-execdir`/`-ok`/`-okdir` clause's write-ness can be classified
+    # from the same single enforcement pass that validates it. `None` outside
+    # find's own clause enforcement; `_check_find` saves and restores the
+    # prior value around every entry (including nested `find`) so an inner
+    # find's clause classification can never leak into an outer one.
+    find_clause_observer: Callable[[str, PathAccess], None] | None = None
 
     def charge_parse(self, source_chars: int) -> None:
         self.parse_attempts += 1
@@ -557,10 +566,24 @@ class _CommandValue(str):
     """A shell word plus whether bashlex proved it has no runtime expansion."""
 
     is_static: bool
+    # Arity-preserving no-op resolution target for this exact value, set only
+    # on the specific `{}` word tagged by `find`'s exec/execdir/ok/okdir clause
+    # enforcement (see `_tag_find_placeholder`). The tag rides on the value
+    # itself rather than on any shared instance/session state, so it cannot
+    # outlive the one call it was built for and cannot leak into unrelated
+    # path resolution (e.g. a literal `{}` filename outside `find`).
+    find_placeholder_cwd: Path | None
 
-    def __new__(cls, value: str, *, is_static: bool = True) -> _CommandValue:
+    def __new__(
+        cls,
+        value: str,
+        *,
+        is_static: bool = True,
+        find_placeholder_cwd: Path | None = None,
+    ) -> _CommandValue:
         instance = super().__new__(cls, value)
         instance.is_static = is_static
+        instance.find_placeholder_cwd = find_placeholder_cwd
         return instance
 
     def __getitem__(self, key: SupportsIndex | slice) -> str:
@@ -727,6 +750,7 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     "ln",
     "unlink",
     "shred",
+    "find",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
@@ -796,6 +820,43 @@ _SORT_KNOWN_LONG_OPTIONS = frozenset(
         *_SORT_DENIED_LONG_OPTIONS,
     }
 )
+
+
+@dataclass(frozen=True)
+class _PathEvent:
+    """One fixed (non-`{}`) find operand and the access it must be checked as."""
+
+    value: str
+    access: PathAccess
+
+
+@dataclass(frozen=True)
+class _FindExecClause:
+    """One `-exec`/`-execdir`/`-ok`/`-okdir ... ;`/`+` clause, unparsed inside."""
+
+    marker: str
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _FindInvocation:
+    roots: tuple[str, ...]
+    path_events: tuple[_PathEvent, ...]
+    exec_clauses: tuple[_FindExecClause, ...]
+    writes_delete: bool = False
+
+
+# `-fprint`/`-fprint0`/`-fls` write one filename argument; `-fprintf` writes
+# the same filename argument followed by a separate format-string argument
+# that is never itself a path.
+_FIND_OUTPUT_ACTIONS: dict[str, int] = {
+    "-fprint": 1,
+    "-fprint0": 1,
+    "-fls": 1,
+    "-fprintf": 2,
+}
+_FIND_REFERENCE_PREDICATES = frozenset({"-newer", "-anewer", "-cnewer", "-samefile"})
+_FIND_EXEC_MARKERS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
 
 
 class WorkspaceCommandPathGuard:
@@ -1116,6 +1177,8 @@ class WorkspaceCommandPathGuard:
             self._check_move_or_link(args, state.cwd)
         elif command_name in {"unlink", "shred"}:
             self._check_destructive_file_command(command_name, args, state.cwd)
+        elif command_name == "find":
+            self._check_find(args, state)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -1919,6 +1982,202 @@ class WorkspaceCommandPathGuard:
         for raw_path in operands:
             self._check_path(raw_path, cwd, "write")
 
+    def _check_find(self, literals: Sequence[str], state: _ShellState) -> None:
+        """Classify `find` per the frozen single-pass, observer-scoped algorithm.
+
+        1. Parse once into fixed path events, exec/execdir/ok/okdir clauses,
+           and a delete flag.
+        2. Fixed path events are checked on the real session effects.
+        3. Each clause's write-ness is classified through the SAME real
+           enforcement pass (`_validate_nested_command_words`), via a
+           clause-scoped observer that inspects every raw operand before that
+           operand's own path resolution: an OR over `{}` presence and
+           execdir/okdir-relative operands, aggregated with `-delete`.
+        4. The root is then checked write if any clause (or `-delete`) writes,
+           read otherwise; a write root additionally poisons the session
+           (find's per-match children are not exact-registerable, so the
+           write effect cannot be captured as a single path).
+        """
+        invocation = self._parse_find_invocation(literals)
+        for event in invocation.path_events:
+            self._check_path(event.value, state.cwd, event.access)
+
+        session = _active_validation_session()
+        writes_root = invocation.writes_delete
+        saved_observer = session.find_clause_observer
+        # Suspend whatever observer an enclosing find clause left active: this
+        # find's own path events and root must never be misclassified as
+        # belonging to an outer find's clause, and a nested find below must
+        # not corrupt this find's own classification either.
+        session.find_clause_observer = None
+        try:
+            for clause in invocation.exec_clauses:
+                clause_writes_root = False
+
+                def _observe(
+                    raw_path: str,
+                    access: PathAccess,
+                    _clause: _FindExecClause = clause,
+                ) -> None:
+                    nonlocal clause_writes_root
+                    if access != "write":
+                        return
+                    if "{}" in str(raw_path) or (
+                        _clause.marker in {"-execdir", "-okdir"}
+                        and self._is_relative_file_operand(raw_path)
+                    ):
+                        clause_writes_root = True
+
+                session.find_clause_observer = _observe
+                try:
+                    self._validate_nested_command_words(
+                        self._tag_find_placeholder(clause.command, state.cwd),
+                        state,
+                    )
+                finally:
+                    session.find_clause_observer = None
+                writes_root = writes_root or clause_writes_root
+
+            root_access: PathAccess = "write" if writes_root else "read"
+            for root in invocation.roots:
+                self._check_path(root, state.cwd, root_access)
+            if writes_root:
+                session.effects.unknown_effect = True
+        finally:
+            session.find_clause_observer = saved_observer
+
+    def _parse_find_invocation(self, literals: Sequence[str]) -> _FindInvocation:
+        """Parse `find`'s argv once into roots, fixed path events and clauses.
+
+        Global traversal-mode options (`-H`/`-L`/`-P`, `-Olevel`, `-D debugopts`)
+        precede the starting points and must not consume them. `-files0-from`
+        supplies roots at runtime and is rejected outright rather than trusted
+        blind. Reference predicates take a path argument except `-newerXt`,
+        whose argument is a timestamp string, not a path.
+        """
+        self._reject_dynamic_values("find arguments", literals)
+
+        root_start = 0
+        while root_start < len(literals):
+            option = str(literals[root_start])
+            if option in {"-H", "-L"}:
+                raise CommandPolicyViolation(
+                    "cannot safely inspect find traversal that follows symbolic links"
+                )
+            if option == "-P" or option.startswith("-O"):
+                root_start += 1
+                continue
+            if option == "-D":
+                if root_start + 1 >= len(literals):
+                    raise CommandPolicyViolation("missing find argument for -D")
+                root_start += 2
+                continue
+            if option.startswith("-D"):
+                root_start += 1
+                continue
+            break
+
+        roots: list[str] = []
+        expression_start = len(literals)
+        for index, value in enumerate(literals[root_start:], start=root_start):
+            text = str(value)
+            if text.startswith("-") or text in {"!", "("}:
+                expression_start = index
+                break
+            roots.append(value)
+        if not roots:
+            roots = ["."]
+
+        expression = literals[expression_start:]
+        path_events: list[_PathEvent] = []
+        clauses: list[_FindExecClause] = []
+        writes_delete = False
+        index = 0
+        while index < len(expression):
+            marker = str(expression[index])
+            if marker == "-files0-from" or marker.startswith("-files0-from="):
+                raise CommandPolicyViolation(
+                    "cannot safely inspect find runtime root list"
+                )
+            if marker == "-delete":
+                writes_delete = True
+                index += 1
+                continue
+            if marker in _FIND_OUTPUT_ACTIONS:
+                argument_count = _FIND_OUTPUT_ACTIONS[marker]
+                if index + argument_count >= len(expression):
+                    raise CommandPolicyViolation(f"missing find argument for {marker}")
+                path_events.append(_PathEvent(expression[index + 1], "write"))
+                index += argument_count + 1
+                continue
+            if marker in _FIND_REFERENCE_PREDICATES or (
+                marker.startswith("-newer")
+                and marker != "-newer"
+                and not marker.endswith("t")
+            ):
+                if index + 1 >= len(expression):
+                    raise CommandPolicyViolation(f"missing find argument for {marker}")
+                path_events.append(_PathEvent(expression[index + 1], "read"))
+                index += 2
+                continue
+            if marker.startswith("-newer") and marker.endswith("t"):
+                if index + 1 >= len(expression):
+                    raise CommandPolicyViolation(f"missing find argument for {marker}")
+                index += 2
+                continue
+            if marker not in _FIND_EXEC_MARKERS:
+                index += 1
+                continue
+
+            nested: list[str] = []
+            index += 1
+            while index < len(expression) and str(expression[index]) not in {";", "+"}:
+                nested.append(expression[index])
+                index += 1
+            if not nested or index >= len(expression):
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect unterminated find action {marker}"
+                )
+            clauses.append(_FindExecClause(marker=marker, command=tuple(nested)))
+            index += 1
+
+        return _FindInvocation(
+            roots=tuple(roots),
+            path_events=tuple(path_events),
+            exec_clauses=tuple(clauses),
+            writes_delete=writes_delete,
+        )
+
+    @staticmethod
+    def _is_relative_file_operand(raw_path: str) -> bool:
+        return raw_path not in {"", "-", "{}"} and not Path(str(raw_path)).is_absolute()
+
+    @staticmethod
+    def _tag_find_placeholder(
+        words: Sequence[str],
+        cwd: Path,
+    ) -> tuple[_CommandValue, ...]:
+        """Tag exact `{}` operands with find's arity-preserving cwd resolution.
+
+        `{}` is never removed or replaced in the operand vector (removing it
+        would shift positional operands, e.g. turning a 2-operand `cp` into a
+        1-operand call that silently skips its destination check); only the
+        specific `_CommandValue` instance representing a literal `{}` word
+        carries the resolution target, so an unrelated word is never affected.
+        """
+        tagged: list[_CommandValue] = []
+        for word in words:
+            if str(word) != "{}":
+                tagged.append(
+                    word if isinstance(word, _CommandValue) else _CommandValue(word)
+                )
+                continue
+            is_static = not isinstance(word, _CommandValue) or word.is_static
+            tagged.append(
+                _CommandValue(word, is_static=is_static, find_placeholder_cwd=cwd)
+            )
+        return tuple(tagged)
+
     def _parse_short_option_cluster(
         self,
         values: Sequence[str],
@@ -2536,6 +2795,21 @@ class WorkspaceCommandPathGuard:
                 "cannot resolve dynamic path operand; enumerate concrete paths "
                 "instead of using active globs or shell expansions"
             )
+
+        # Invariant: the find-clause observer must fire before any sentinel
+        # short-circuit below (including the `{}` no-op resolution). A `{}`
+        # write operand that returns early first would never reach the
+        # observer, so `find`'s write-root classification would silently miss
+        # every `{}` exec argument.
+        find_observer = _active_validation_session().find_clause_observer
+        if find_observer is not None:
+            find_observer(raw_path, access)
+
+        if (
+            isinstance(raw_path, _CommandValue)
+            and raw_path.find_placeholder_cwd is not None
+        ):
+            return raw_path.find_placeholder_cwd
 
         if raw_path in {"", "-"}:
             return cwd

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1935,10 +1935,17 @@ class WorkspaceCommandPathGuard:
         path (a pattern/magic file, or a NUL-delimited file-of-filenames), so
         they are partitioned through the access-map substrate first; every
         other read command is a flat operand check with only skip-valued
-        options (`_COMMAND_VALUE_OPTIONS`).
+        options (`_COMMAND_VALUE_OPTIONS`). `_partition_path_options` already
+        consumes/discards a `--` operand separator and returns pure operands
+        (some legitimately starting with `-` if they followed `--`); feeding
+        that result back through `_check_operands`/`_operands` would re-apply
+        `_operands`'s own `-`-prefix filter with no memory of the `--` it
+        already passed, silently dropping (and never read-checking) such an
+        operand a second time (R1). So `file`/`wc` check their partitioned
+        operands directly here instead of routing through `_check_operands`.
         """
         if command_name == "file":
-            values = self._partition_path_options(
+            operands = self._partition_path_options(
                 values,
                 cwd,
                 option_access={
@@ -1948,13 +1955,36 @@ class WorkspaceCommandPathGuard:
                     "--magic-file": "read",
                 },
                 attached_short_options=frozenset({"-f", "-m"}),
+                flag_short_options=frozenset(
+                    {
+                        "-b",
+                        "-i",
+                        "-h",
+                        "-L",
+                        "-s",
+                        "-z",
+                        "-k",
+                        "-n",
+                        "-p",
+                        "-r",
+                        "-v",
+                        "-0",
+                    }
+                ),
             )
-        elif command_name == "wc":
-            values = self._partition_path_options(
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "read")
+            return
+        if command_name == "wc":
+            operands = self._partition_path_options(
                 values,
                 cwd,
                 option_access={"--files0-from": "read"},
+                flag_short_options=frozenset({"-l", "-c", "-w", "-m", "-L"}),
             )
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "read")
+            return
         self._check_operands(
             values,
             cwd,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -640,7 +640,10 @@ class _ScriptCommandGrammar:
     short (`-x`) and long (`--xxx`) spelling, mapped to the fixed filename
     gawk uses when no explicit argument is given; unlike `value_options`,
     these never consume a separate token (GNU optional-argument
-    convention: the value, if given, must be attached).
+    convention: the value, if given, must be attached). `flag_long_options`
+    holds long options that take NO value and name NO path at all (sed's
+    `--quiet`/`--posix`/etc.); each is consumed as an inert flag, unlike
+    `value_options`, which always consumes a following/attached token.
     """
 
     language: Literal["sed", "awk"]
@@ -652,6 +655,7 @@ class _ScriptCommandGrammar:
     in_place_short_option: str | None = None
     in_place_long_option: str | None = None
     optional_write_options: Mapping[str, str] = field(default_factory=dict)
+    flag_long_options: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -771,7 +775,10 @@ _COMMAND_WRAPPER_GRAMMARS = {
 # never a path, so they are skipped rather than routed through the file-
 # operand check. Both families bundle short options (e.g. sed's `-ne`,
 # `-i.bak`; awk's `-Fx`, gawk's `-o[file]`), so both list at least one
-# `short_value_options`/`optional_write_options` entry.
+# `short_value_options`/`optional_write_options` entry. The long-only flags
+# below take no value and name no path (verified against GNU sed's own
+# option list); `--line-length` already has a value entry above and stays
+# there — it is the one long option in this family that does carry a value.
 _SED_GRAMMAR = _ScriptCommandGrammar(
     language="sed",
     expression_long_option="--expression",
@@ -780,6 +787,23 @@ _SED_GRAMMAR = _ScriptCommandGrammar(
     short_value_options=frozenset({"l"}),
     in_place_short_option="i",
     in_place_long_option="--in-place",
+    flag_long_options=frozenset(
+        {
+            "--quiet",
+            "--silent",
+            "--posix",
+            "--sandbox",
+            "--separate",
+            "--null-data",
+            "--zero-terminated",
+            "--unbuffered",
+            "--regexp-extended",
+            "--debug",
+            "--follow-symlinks",
+            "--help",
+            "--version",
+        }
+    ),
 )
 _AWK_GRAMMAR = _ScriptCommandGrammar(
     language="awk",
@@ -2408,7 +2432,10 @@ class WorkspaceCommandPathGuard:
         Scalar options (`-g/-m/-o/-S/--context`) never carry a path, and the
         delegated `--strip-program` is a hard denial; an unrecognized option
         fails closed rather than silently letting one shift the destination
-        slot.
+        slot. `-t` also resolves when bundled behind another short flag
+        (`-Dt destdir`), sharing the bundled-cluster parser `-Dm755` already
+        uses; its value is write-checked below alongside every other
+        `target_dir` spelling.
         """
         target_dir: str | None = None
         operands: list[str] = []
@@ -2505,14 +2532,28 @@ class WorkspaceCommandPathGuard:
             if not text.startswith("--"):
                 # A bundled cluster (e.g. `-Dm755`): only the trailing
                 # value-taking character may carry an attached argument, so
-                # this shares the same GNU bundling contract as `sort`.
-                index, _, _ = self._parse_short_option_cluster(
+                # this shares the same GNU bundling contract as `sort`. `-t`
+                # bundles the same way (`-Dt destdir`); its value is deferred
+                # to the same `target_dir` slot the standalone `-t`/
+                # `--target-directory` forms populate above, so the single
+                # write check at the bottom of this method covers every
+                # spelling instead of a second inline check here.
+                index, matched_option, argument = self._parse_short_option_cluster(
                     values,
                     index,
                     cwd,
                     flag_options=frozenset("bcCDpsTv"),
-                    value_options={"g": None, "m": None, "o": None, "S": None},
+                    value_options={
+                        "g": None,
+                        "m": None,
+                        "o": None,
+                        "S": None,
+                        "t": None,
+                    },
                 )
+                if matched_option == "t":
+                    assert argument is not None
+                    target_dir = argument
                 continue
             raise CommandPolicyViolation(f"cannot safely inspect install option {text}")
 
@@ -3460,6 +3501,7 @@ class WorkspaceCommandPathGuard:
                 for option in grammar.optional_write_options
                 if option.startswith("--")
             }
+            | grammar.flag_long_options
         )
         index = 0
         while index < len(values):
@@ -3520,6 +3562,12 @@ class WorkspaceCommandPathGuard:
                         else _CommandValue(grammar.optional_write_options[resolved])
                     )
                     self._check_path(argument, cwd, "write")
+                    index += 1
+                    continue
+                if resolved in grammar.flag_long_options:
+                    # Takes no value and names no path (e.g. sed's
+                    # `--quiet`/`--posix`): consumed as an inert flag, never
+                    # routed through `_take_option_argument`.
                     index += 1
                     continue
                 # The remaining known long options are mandatory scalar

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -659,6 +659,7 @@ class _ScriptShortOptionResult:
     next_index: int
     explicit_script: bool = False
     requests_in_place: bool = False
+    has_backup_suffix: bool = False
 
 
 @dataclass(frozen=True)
@@ -3430,8 +3431,11 @@ class WorkspaceCommandPathGuard:
         `_read_policy_script` (M4: the same `unknown_effect` gate, non-regular-
         file rejection, and bounded read every other script read uses) before
         the same lexer, rather than a parallel copy. sed's `-i`/`--in-place`
-        switches the remaining file operands from read to write. Long options
-        resolve through `_resolve_long_option` (GNU unambiguous-prefix
+        switches the remaining file operands from read to write; a backup
+        suffix (`-i.bak`, `--in-place=.bak`) additionally poisons
+        `unknown_effect`, since the derived backup file it also writes is
+        never itself path-checked (N3). Long options resolve through
+        `_resolve_long_option` (GNU unambiguous-prefix
         abbreviation, e.g. `--expr=` for `--expression`); an option this
         family does not recognize fails closed instead of being silently
         skipped, since a write-owning spelling (`--file`, `--in-place`, awk's
@@ -3499,6 +3503,14 @@ class WorkspaceCommandPathGuard:
                     continue
                 if resolved == grammar.in_place_long_option:
                     file_access = "write"
+                    if separator and attached:
+                        # A backup suffix (`--in-place=.bak`) derives a
+                        # second write target (the backup file) whose exact
+                        # name this guard never computes; poison the same
+                        # way find/tar/gzip's other non-enumerable derived
+                        # writes do (N3), additive to the operand's own
+                        # write check above, not a replacement for it.
+                        _active_validation_session().effects.unknown_effect = True
                     index += 1
                     continue
                 if resolved in grammar.optional_write_options:
@@ -3536,6 +3548,11 @@ class WorkspaceCommandPathGuard:
                 explicit_script = explicit_script or option_result.explicit_script
                 if option_result.requests_in_place:
                     file_access = "write"
+                    if option_result.has_backup_suffix:
+                        # See the `--in-place=SUFFIX` branch above (N3): the
+                        # same non-enumerable derived backup write applies
+                        # to the short-option form (`-i.bak`).
+                        _active_validation_session().effects.unknown_effect = True
                 index = option_result.next_index
                 continue
             if value_text.startswith("-") and value_text != "-":
@@ -3591,6 +3608,7 @@ class WorkspaceCommandPathGuard:
                 return _ScriptShortOptionResult(
                     next_index=index + 1,
                     requests_in_place=True,
+                    has_backup_suffix=bool(token_text[cursor + 1 :]),
                 )
             if option in {"e", "f"} or option in grammar.short_value_options:
                 attached_text = token_text[cursor + 1 :]

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2576,7 +2576,7 @@ class WorkspaceCommandPathGuard:
             and any(option in "cruAxtd" for option in str(values[0]))
         ):
             index, short_modes, short_events = self._parse_tar_short_events(
-                values, 0, values[0]
+                values, 0, values[0], allow_attached_value=False
             )
             modes.extend(short_modes)
             events.extend(short_events)
@@ -2695,12 +2695,25 @@ class WorkspaceCommandPathGuard:
         values: Sequence[str],
         index: int,
         options: str,
+        *,
+        allow_attached_value: bool = True,
     ) -> tuple[int, list[_TarMode], list[_TarEvent]]:
         """Parse one traditional/bundled short-option token (e.g. `-xzf`).
 
-        Only the last argument-taking character in the cluster may carry a
-        value (attached, e.g. `-fname`, or as the following token); this
-        matches GNU tar's own traditional-syntax parser. Unrecognized
+        Two distinct bundling conventions share this parser. The GNU
+        dash-prefixed cluster (`allow_attached_value=True`, e.g. `-xzf`,
+        `-farchive.tar`) only ever expects ONE argument-taking character per
+        token: once found, the rest of the token (if any) is its attached
+        value, or it takes the next whitespace-separated token; parsing then
+        stops, matching GNU getopt's own bundling contract. The historical
+        no-dash traditional "key" form (`allow_attached_value=False`, e.g.
+        `xfC archive.tar dir`) has no attached-value form at all: EVERY
+        argument-taking letter takes its OWN separate subsequent
+        whitespace-token, in the order the letters appear in the key, per
+        POSIX tar. Conflating the two would let a later letter in a
+        no-dash key (e.g. `C` in `xfC`) be misread as the earlier letter's
+        (`f`'s) attached value, leaving both the archive and that later
+        letter's real argument as unchecked positionals. Unrecognized
         characters are silently skipped (compression/verbosity flags like
         `z`/`v` this guard does not need to model), consistent with the
         conservative flag-only treatment of unknown tar options elsewhere.
@@ -2746,20 +2759,32 @@ class WorkspaceCommandPathGuard:
                 cursor += 1
                 continue
 
-            attached = options[cursor + 1 :]
-            argument, next_index = self._take_option_argument(
-                values,
-                index,
-                attached_argument=(
-                    self._derived_value(values[index], attached) if attached else None
-                ),
-                context=f"tar argument for -{option}",
-            )
-            assert argument is not None
+            if allow_attached_value:
+                attached = options[cursor + 1 :]
+                argument, next_index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=(
+                        self._derived_value(values[index], attached)
+                        if attached
+                        else None
+                    ),
+                    context=f"tar argument for -{option}",
+                )
+                assert argument is not None
+                kind = argument_events[option]
+                if kind is not None:
+                    events.append(_TarEvent(kind, argument))
+                break
+
+            if next_index >= len(values):
+                raise CommandPolicyViolation(f"missing tar argument for -{option}")
+            argument = values[next_index]
+            next_index += 1
             kind = argument_events[option]
             if kind is not None:
                 events.append(_TarEvent(kind, argument))
-            break
+            cursor += 1
 
         return next_index, modes, events
 

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1027,6 +1027,43 @@ _BASE64_KNOWN_LONG_OPTIONS = frozenset(
     {"--output", "--break", "--wrap"} | _BASE64_LONG_FLAG_OPTIONS
 )
 
+# `gzip`'s short options bundle into one token (e.g. `-lt`, `-9v`); unlike
+# the other bundled-cluster families, more than one character in the bundle
+# is independently meaningful for the read-only-mode classification, so
+# gzip owns its own cluster parser (`_parse_gzip_short_cluster`) instead of
+# `_parse_short_option_cluster`. `-S`/`--suffix` takes a scalar value that is
+# never a path. `-c`/`--stdout`/`--to-stdout`, `-l`/`--list`, and
+# `-t`/`--test` never create or remove a file, so they keep the operand a
+# plain read instead of the default mode's write.
+_GZIP_SHORT_FLAG_OPTIONS = frozenset("acdfhklnNqrtvV123456789")
+_GZIP_READ_ONLY_SHORT_FLAGS = frozenset("clt")
+_GZIP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {"S": None}
+_GZIP_LONG_FLAG_OPTIONS = frozenset(
+    {
+        "--ascii",
+        "--decompress",
+        "--uncompress",
+        "--force",
+        "--help",
+        "--keep",
+        "--no-name",
+        "--name",
+        "--quiet",
+        "--recursive",
+        "--verbose",
+        "--version",
+        "--fast",
+        "--best",
+    }
+)
+_GZIP_READ_ONLY_LONG_OPTIONS = frozenset(
+    {"--stdout", "--to-stdout", "--list", "--test"}
+)
+_GZIP_SCALAR_LONG_OPTIONS = frozenset({"--suffix"})
+_GZIP_KNOWN_LONG_OPTIONS = frozenset(
+    _GZIP_LONG_FLAG_OPTIONS | _GZIP_READ_ONLY_LONG_OPTIONS | _GZIP_SCALAR_LONG_OPTIONS
+)
+
 # `cp`/`mv`/`ln` share `_parse_target_directory`'s `-t`/`--target-directory`
 # extraction. Short options bundle into one token (e.g. `-rt` combines the
 # `-r` flag with the `-t` write-path option), so the grammar is split into a
@@ -4127,100 +4164,23 @@ class WorkspaceCommandPathGuard:
         derived compressed file — additive to, not a replacement for, the
         operand's own containment check (M2). `-c`/`--stdout`/`-l`/`--list`/
         `-t`/`--test` never create or remove a file, so the operand stays a
-        plain read in those modes.
+        plain read in those modes — but that classification MUST be
+        option-aware, not a position-independent character scan: `-S` takes
+        a value (its own suffix argument, e.g. the `-t` in `-S -t <path>`),
+        so a bare `t`/`c`/`l` character occurring as another option's
+        consumed value must not be misread as the read-only mode flag
+        (`_parse_gzip_short_cluster` tracks which characters were actually
+        parsed as flags, not merely present in the token stream). Long
+        options resolve through `_resolve_long_option` (GNU unambiguous-
+        prefix abbreviation); module invariant: any option (short or long,
+        bare or `=value`-attached) this allowlist cannot resolve fails
+        closed rather than being treated as an operand or skipped.
         """
         self._reject_dynamic_values("gzip arguments", values)
-        read_only_mode = any(
-            value
-            in {
-                "-c",
-                "--stdout",
-                "--to-stdout",
-                "-l",
-                "--list",
-                "-t",
-                "--test",
-            }
-            or (
-                str(value).startswith("-")
-                and not str(value).startswith("--")
-                and any(flag in str(value)[1:] for flag in {"c", "l", "t"})
-            )
-            for value in values
-        )
-        operands = self._strict_simple_operands(
-            "gzip",
-            values,
-            flag_options={
-                "-a",
-                "--ascii",
-                "-c",
-                "--stdout",
-                "--to-stdout",
-                "-d",
-                "--decompress",
-                "--uncompress",
-                "-f",
-                "--force",
-                "-h",
-                "--help",
-                "-k",
-                "--keep",
-                "-l",
-                "--list",
-                "-n",
-                "--no-name",
-                "-N",
-                "--name",
-                "-q",
-                "--quiet",
-                "-r",
-                "--recursive",
-                "-t",
-                "--test",
-                "-v",
-                "--verbose",
-                "-V",
-                "--version",
-                "--fast",
-                "--best",
-                *{f"-{level}" for level in range(1, 10)},
-            },
-            scalar_options={"-S", "--suffix"},
-            allow_short_bundles=True,
-        )
-        access: PathAccess = "read" if read_only_mode else "write"
-        if not read_only_mode:
-            _active_validation_session().effects.unknown_effect = True
-        for operand in operands:
-            self._check_path(operand, cwd, access)
-
-    def _strict_simple_operands(
-        self,
-        command_name: str,
-        values: Sequence[str],
-        *,
-        flag_options: set[str],
-        scalar_options: set[str] | frozenset[str] = frozenset(),
-        allow_short_bundles: bool = False,
-    ) -> list[str]:
-        """Parse a simple GNU-style argv into flag/scalar options and operands.
-
-        An option this family does not recognize fails closed rather than
-        being silently treated as an operand or skipped, so an unmodeled
-        option can never hide (or misclassify) a path argument. Only used by
-        families narrow enough that every option is either a no-value flag
-        or a single-scalar-value option (gzip); families with path-bearing
-        options use `_partition_path_options` instead.
-        """
         operands: list[str] = []
+        read_only_mode = False
         options_done = False
         index = 0
-        short_flags = {
-            option[1:]
-            for option in flag_options
-            if option.startswith("-") and not option.startswith("--")
-        }
         while index < len(values):
             value = values[index]
             text = str(value)
@@ -4232,35 +4192,87 @@ class WorkspaceCommandPathGuard:
                 operands.append(value)
                 index += 1
                 continue
-            if text in flag_options:
-                index += 1
-                continue
-            if text in scalar_options:
-                if index + 1 >= len(values):
-                    raise CommandPolicyViolation(
-                        f"missing {command_name} argument for {text}"
+            if text.startswith("--"):
+                raw_option, separator, attached_text = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _GZIP_KNOWN_LONG_OPTIONS
+                )
+                if resolved in _GZIP_SCALAR_LONG_OPTIONS:
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached_text)
+                            if separator
+                            else None
+                        ),
+                        context=f"gzip argument for {resolved}",
                     )
-                index += 2
+                    continue
+                if resolved in _GZIP_READ_ONLY_LONG_OPTIONS:
+                    if separator:
+                        raise CommandPolicyViolation(
+                            f"cannot safely resolve gzip option {raw_option}"
+                        )
+                    read_only_mode = True
+                    index += 1
+                    continue
+                if resolved in _GZIP_LONG_FLAG_OPTIONS:
+                    if separator:
+                        raise CommandPolicyViolation(
+                            f"cannot safely resolve gzip option {raw_option}"
+                        )
+                    index += 1
+                    continue
+                raise CommandPolicyViolation(
+                    f"cannot safely resolve gzip option {raw_option}"
+                )
+            index, matched_flags = self._parse_gzip_short_cluster(values, index)
+            if matched_flags & _GZIP_READ_ONLY_SHORT_FLAGS:
+                read_only_mode = True
+        access: PathAccess = "read" if read_only_mode else "write"
+        if not read_only_mode:
+            _active_validation_session().effects.unknown_effect = True
+        for operand in operands:
+            self._check_path(operand, cwd, access)
+
+    @staticmethod
+    def _parse_gzip_short_cluster(
+        values: Sequence[str], index: int
+    ) -> tuple[int, frozenset[str]]:
+        """Parse one bundled gzip short-option token, e.g. `-lt`/`-9v`.
+
+        Unlike `_parse_short_option_cluster`, this returns EVERY flag
+        character actually consumed as a flag (not just the last
+        value-option match), since `-c`/`-l`/`-t`'s read-only-mode
+        classification depends on which characters were parsed as flags —
+        `-S`'s own attached/separate suffix argument (e.g. the `-t` in
+        `-S -t <path>`) must not count, even though it contains the same
+        character. An unrecognized character fails closed.
+        """
+        source = values[index]
+        options = str(source)[1:]
+        seen_flags: set[str] = set()
+        cursor = 0
+        while cursor < len(options):
+            option = options[cursor]
+            if option in _GZIP_SHORT_FLAG_OPTIONS:
+                seen_flags.add(option)
+                cursor += 1
                 continue
-            if any(
-                text.startswith(f"{option}=")
-                for option in scalar_options
-                if option.startswith("--")
-            ):
-                index += 1
-                continue
-            if (
-                allow_short_bundles
-                and text.startswith("-")
-                and not text.startswith("--")
-                and set(text[1:]).issubset(short_flags)
-            ):
-                index += 1
-                continue
-            raise CommandPolicyViolation(
-                f"cannot safely inspect {command_name} option {text}"
-            )
-        return operands
+            if option not in _GZIP_SHORT_VALUE_OPTIONS:
+                raise CommandPolicyViolation(
+                    f"cannot safely resolve gzip option -{option}"
+                )
+            attached = options[cursor + 1 :]
+            if attached:
+                next_index = index + 1
+            elif index + 1 < len(values):
+                next_index = index + 2
+            else:
+                raise CommandPolicyViolation(f"missing gzip argument for -{option}")
+            return next_index, frozenset(seen_flags)
+        return index + 1, frozenset(seen_flags)
 
     def _check_rsync(self, values: Sequence[str], cwd: Path) -> None:
         """`rsync`: any remote operand rejects the WHOLE invocation (M5).

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -3762,12 +3762,18 @@ class WorkspaceCommandPathGuard:
         if character == "$":
             return index + 1
         if character == "/":
-            return WorkspaceCommandPathGuard._scan_sed_delimited(
-                script, delimiter_index=index
+            return WorkspaceCommandPathGuard._skip_sed_address_modifiers(
+                script,
+                WorkspaceCommandPathGuard._scan_sed_delimited(
+                    script, delimiter_index=index
+                ),
             )
         if character == "\\" and index + 1 < len(script):
-            return WorkspaceCommandPathGuard._scan_sed_delimited(
-                script, delimiter_index=index + 1
+            return WorkspaceCommandPathGuard._skip_sed_address_modifiers(
+                script,
+                WorkspaceCommandPathGuard._scan_sed_delimited(
+                    script, delimiter_index=index + 1
+                ),
             )
         if allow_relative and character in {"+", "~"}:
             cursor = index + 1
@@ -3780,6 +3786,24 @@ class WorkspaceCommandPathGuard:
                 )
             return cursor
         return None
+
+    @staticmethod
+    def _skip_sed_address_modifiers(script: str, index: int) -> int:
+        """Consume a regex address's trailing `I`/`M` modifiers (C3).
+
+        GNU sed allows either modifier, in either order and repeated, right
+        after a `/regexp/` or `\\%regexp%` address (`/re/I`, `/re/MI`, ...).
+        Neither letter is ever a valid sed command name on its own, so
+        consuming them here cannot swallow a real command; skipping this
+        step left the command-letter scan land on the modifier itself,
+        misreading it as the command and treating everything after it
+        (including a following `w`/`W` write clause) as opaque trailing
+        text of a fallback command it never was.
+        """
+        cursor = index
+        while cursor < len(script) and script[cursor] in "IM":
+            cursor += 1
+        return cursor
 
     @staticmethod
     def _scan_sed_delimited(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -935,6 +935,7 @@ _GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "D": None,
     "d": None,
 }
+_GREP_KNOWN_LONG_OPTIONS = frozenset({"--regexp", "--file", "--exclude-from"})
 
 
 @dataclass(frozen=True)
@@ -1849,7 +1850,18 @@ class WorkspaceCommandPathGuard:
 
         `-r`/`-R` (recurse into a directory) take no argument, so the
         directory they precede already reaches the file-operand loop below
-        unmodified; no dedicated handling is needed for them.
+        unmodified; no dedicated handling is needed for them. `--regexp`/
+        `--file`/`--exclude-from` resolve through `_resolve_long_option`
+        (GNU unambiguous-prefix abbreviation, e.g. `--fil=` for `--file`),
+        so an abbreviated spelling is classified identically to the full
+        name instead of falling through as an unrecognized option: for
+        `--file`/`--exclude-from` that would silently skip the read check
+        on the pattern-file argument, and for `--regexp` it would leave
+        `explicit_pattern` unset, misreading the real first file operand as
+        the (excluded) pattern positional. An option this family does not
+        recognize stays permissive (an ordinary, over-checked-never-
+        under-checked operand) rather than failing closed, matching grep's
+        existing pure-read classification.
         """
         positionals: list[str] = []
         explicit_pattern = False
@@ -1860,41 +1872,62 @@ class WorkspaceCommandPathGuard:
                 positionals.extend(values[index + 1 :])
                 break
             value_text = str(value)
-            if value_text in {"-e", "--regexp"}:
+            if value_text == "-e":
                 explicit_pattern = True
-                index += 2
+                _, index = self._take_option_argument(
+                    values,
+                    index,
+                    attached_argument=None,
+                    context="grep argument for -e",
+                )
                 continue
-            if value_text.startswith("-e") or value_text.startswith("--regexp="):
+            if value_text.startswith("-e") and not value_text.startswith("--"):
                 explicit_pattern = True
                 index += 1
                 continue
-            if value_text in {"-f", "--file"}:
+            if value_text == "-f":
                 explicit_pattern = True
                 if index + 1 < len(values):
                     self._check_path(values[index + 1], cwd, "read")
                 index += 2
                 continue
-            if value_text.startswith("-f") or value_text.startswith("--file="):
+            if value_text.startswith("-f") and not value_text.startswith("--"):
                 explicit_pattern = True
-                attached = value.split("=", 1)[1] if "=" in value_text else value[2:]
+                attached = value_text[2:]
                 if attached:
                     self._check_path(self._derived_value(value, attached), cwd, "read")
                 index += 1
                 continue
-            if value_text == "--exclude-from":
-                if index + 1 < len(values):
-                    self._check_path(values[index + 1], cwd, "read")
-                index += 2
-                continue
-            if value_text.startswith("--exclude-from="):
-                self._check_path(
-                    self._derived_value(value, value.split("=", 1)[1]),
-                    cwd,
-                    "read",
-                )
-                index += 1
-                continue
             if value_text.startswith("--"):
+                raw_option, separator, attached = value_text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _GREP_KNOWN_LONG_OPTIONS
+                )
+                if resolved == "--regexp":
+                    explicit_pattern = True
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"grep argument for {resolved}",
+                    )
+                    continue
+                if resolved in {"--file", "--exclude-from"}:
+                    if resolved == "--file":
+                        explicit_pattern = True
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"grep argument for {resolved}",
+                    )
+                    assert argument is not None
+                    self._check_path(argument, cwd, "read")
+                    continue
                 # Long flag options this family does not model (e.g.
                 # `--color=auto`) carry no path, so they are skipped rather
                 # than parsed further.

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -21,6 +21,7 @@ from typing import (
     Any,
     Iterable,
     Iterator,
+    Mapping,
     Sequence,
     SupportsIndex,
     cast,
@@ -158,7 +159,24 @@ def _active_validation_session() -> _ValidationSession:
     return session
 
 
-_READ_COMMANDS = {"cat"}
+# Plain readers: every operand is validated as a workspace read. A command
+# whose grammar carries a write slot or a read-control file argument (that
+# argument is itself a path, not a value to skip) gets its own dedicated
+# handler below instead and must not be added here.
+_READ_COMMANDS = {
+    "cat",
+    "cmp",
+    "cut",
+    "file",
+    "head",
+    "less",
+    "ls",
+    "more",
+    "stat",
+    "tac",
+    "tail",
+    "wc",
+}
 # Path-scoped writers: every operand is validated as a workspace write and
 # recorded per-path, so they never poison the session-wide unknown-effect flag.
 _WRITE_COMMANDS = {"rm", "mkdir"}
@@ -184,8 +202,27 @@ _NO_FILESYSTEM_EFFECT_COMMANDS = {
 }
 # Options that consume a following token as their value, per classified command,
 # so the value is not misread as a path operand (e.g. `mkdir -m 0755 dir`).
+# Only options whose value is never a path belong here; a value option that is
+# itself a path (e.g. `wc --files0-from`) needs a dedicated handler instead so
+# the argument gets checked, not skipped.
 _COMMAND_VALUE_OPTIONS = {
     "mkdir": frozenset({"-m", "--mode"}),
+    "cut": frozenset(
+        {
+            "-b",
+            "--bytes",
+            "-c",
+            "--characters",
+            "-d",
+            "--delimiter",
+            "-f",
+            "--fields",
+            "--output-delimiter",
+        }
+    ),
+    "head": frozenset({"-c", "--bytes", "-n", "--lines"}),
+    "tail": frozenset({"-c", "--bytes", "-n", "--lines"}),
+    "tac": frozenset({"-s", "--separator"}),
 }
 _BASH_FILE_OPTIONS = {"--init-file", "--rcfile"}
 _BASH_LONG_FLAG_OPTIONS = {
@@ -662,12 +699,79 @@ _CLASSIFIED_EXECUTABLE_COMMANDS = {
     *_UNSUPPORTED_PRIVILEGE_COMMANDS,
     "chroot",
     "xargs",
+    "sort",
+    "uniq",
+    "diff",
+    "grep",
     *(
         name
         for name in _COMMAND_WRAPPER_GRAMMARS
         if name not in {"builtin", "command", "exec", _POLICY_TIME_WRAPPER}
     ),
 }
+
+# `sort`'s short options bundle into one token (e.g. `-no file` combines the
+# `-n` flag with the `-o` write-path option), so its grammar is split into a
+# flag set (no value) and a value set (one following/attached argument, with
+# a read/write/skip access) for the short-option-cluster parser.
+_SORT_SHORT_FLAG_OPTIONS = frozenset("bdfgiMhnRrVcCmsuz")
+_SORT_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "k": None,
+    "o": "write",
+    "S": None,
+    "t": None,
+    "T": "write",
+}
+_SORT_LONG_PATH_OPTIONS: dict[str, PathAccess] = {
+    "--files0-from": "read",
+    "--output": "write",
+    "--random-source": "read",
+    "--temporary-directory": "write",
+}
+_SORT_LONG_SCALAR_OPTIONS = frozenset(
+    {
+        "--batch-size",
+        "--buffer-size",
+        "--field-separator",
+        "--key",
+        "--parallel",
+        "--sort",
+    }
+)
+_SORT_LONG_FLAG_OPTIONS = frozenset(
+    {
+        "--check",
+        "--debug",
+        "--dictionary-order",
+        "--general-numeric-sort",
+        "--help",
+        "--human-numeric-sort",
+        "--ignore-case",
+        "--ignore-leading-blanks",
+        "--ignore-nonprinting",
+        "--merge",
+        "--month-sort",
+        "--numeric-sort",
+        "--random-sort",
+        "--reverse",
+        "--stable",
+        "--unique",
+        "--version",
+        "--version-sort",
+        "--zero-terminated",
+    }
+)
+# `--compress-program` delegates to an arbitrary external program; this is a
+# hard denial regardless of abbreviation, not a plain unknown option.
+_SORT_DENIED_LONG_OPTIONS = frozenset({"--compress-program"})
+_SORT_KNOWN_LONG_OPTIONS = frozenset(
+    {
+        *_SORT_LONG_PATH_OPTIONS,
+        *_SORT_LONG_SCALAR_OPTIONS,
+        *_SORT_LONG_FLAG_OPTIONS,
+        *_SORT_DENIED_LONG_OPTIONS,
+    }
+)
 
 
 class WorkspaceCommandPathGuard:
@@ -969,7 +1073,7 @@ class WorkspaceCommandPathGuard:
         if command_name in {"declare", "export", "typeset"}:
             self._reject_implicit_shell_environment(args)
         if command_name in _READ_COMMANDS:
-            self._check_operands(args, state.cwd, "read")
+            self._check_read_command(command_name, args, state.cwd)
         elif command_name in _WRITE_COMMANDS:
             self._check_operands(
                 args,
@@ -977,6 +1081,14 @@ class WorkspaceCommandPathGuard:
                 "write",
                 value_options=_COMMAND_VALUE_OPTIONS.get(command_name, frozenset()),
             )
+        elif command_name == "sort":
+            self._check_sort(args, state.cwd)
+        elif command_name == "uniq":
+            self._check_uniq(args, state.cwd)
+        elif command_name == "diff":
+            self._check_diff(args, state.cwd)
+        elif command_name == "grep":
+            self._check_grep(args, state.cwd)
         elif command_name in _SHELL_COMMANDS:
             self._check_nested_shell(command_name, args, state)
         elif command_name in _UNSUPPORTED_SHELL_COMMANDS:
@@ -1283,6 +1395,386 @@ class WorkspaceCommandPathGuard:
     ) -> None:
         for raw_path in self._operands(values, value_options=value_options):
             self._check_path(raw_path, cwd, access)
+
+    def _check_read_command(
+        self,
+        command_name: str,
+        values: Sequence[str],
+        cwd: Path,
+    ) -> None:
+        """Dispatch a plain read-family command to its operand check.
+
+        `file` and `wc` carry a read-control option whose value is itself a
+        path (a pattern/magic file, or a NUL-delimited file-of-filenames), so
+        they are partitioned through the access-map substrate first; every
+        other read command is a flat operand check with only skip-valued
+        options (`_COMMAND_VALUE_OPTIONS`).
+        """
+        if command_name == "file":
+            values = self._partition_path_options(
+                values,
+                cwd,
+                option_access={
+                    "-f": "read",
+                    "-m": "read",
+                    "--files-from": "read",
+                    "--magic-file": "read",
+                },
+                attached_short_options=frozenset({"-f", "-m"}),
+            )
+        elif command_name == "wc":
+            values = self._partition_path_options(
+                values,
+                cwd,
+                option_access={"--files0-from": "read"},
+            )
+        self._check_operands(
+            values,
+            cwd,
+            "read",
+            value_options=_COMMAND_VALUE_OPTIONS.get(command_name, frozenset()),
+        )
+
+    def _check_sort(self, values: Sequence[str], cwd: Path) -> None:
+        """Classify `sort`'s write (`-o`/`-T`) and read-control path options.
+
+        `sort` owns two write slots (`-o`/`--output`, `-T`/`--temporary-directory`)
+        and two read-control slots (`--files0-from`, `--random-source`), so it
+        cannot be a flat read command: an unrecognized option must fail closed
+        rather than silently let a write slot bypass containment.
+        """
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                for raw_path in values[index + 1 :]:
+                    self._check_path(raw_path, cwd, "read")
+                return
+
+            value_text = str(value)
+            if value_text.startswith("--"):
+                raw_option, separator, _ = value_text.partition("=")
+                option = self._resolve_long_option(raw_option, _SORT_KNOWN_LONG_OPTIONS)
+                if option is None:
+                    raise CommandPolicyViolation(
+                        f"cannot safely resolve sort option {raw_option}"
+                    )
+                if option in _SORT_DENIED_LONG_OPTIONS:
+                    raise CommandPolicyViolation(
+                        f"sort option {option} cannot safely delegate execution"
+                    )
+                path_access = _SORT_LONG_PATH_OPTIONS.get(option)
+                if path_access is not None:
+                    argument: str
+                    if separator:
+                        argument = self._derived_value(
+                            value, value[len(raw_option) + 1 :]
+                        )
+                        index += 1
+                    elif index + 1 < len(values):
+                        argument = values[index + 1]
+                        index += 2
+                    else:
+                        raise CommandPolicyViolation(
+                            f"missing sort argument for {option}"
+                        )
+                    self._check_path(argument, cwd, path_access)
+                    continue
+                if option in _SORT_LONG_SCALAR_OPTIONS:
+                    if separator:
+                        index += 1
+                    elif index + 1 < len(values):
+                        index += 2
+                    else:
+                        raise CommandPolicyViolation(
+                            f"missing sort argument for {option}"
+                        )
+                    continue
+                # The remaining recognized long options (`_SORT_LONG_FLAG_OPTIONS`,
+                # including the optional-value `--check[=WHEN]`) take no
+                # separate argument.
+                index += 1
+                continue
+
+            if value_text.startswith("-") and value_text != "-":
+                index = self._parse_short_option_cluster(
+                    values,
+                    index,
+                    cwd,
+                    flag_options=_SORT_SHORT_FLAG_OPTIONS,
+                    value_options=_SORT_SHORT_VALUE_OPTIONS,
+                )
+                continue
+
+            self._check_path(value, cwd, "read")
+            index += 1
+
+    def _check_uniq(self, values: Sequence[str], cwd: Path) -> None:
+        """Classify `uniq`'s positional read/write slots.
+
+        `uniq [OPTION]... [INPUT [OUTPUT]]`: the first operand is the input
+        (read), the second, if present, is the output (write). Its own
+        options only take scalar (non-path) values, so an unrecognized
+        `--`-option must still fail closed rather than silently shift the
+        positional write slot.
+        """
+        scalar_options = frozenset(
+            {"-f", "--skip-fields", "-s", "--skip-chars", "-w", "--check-chars"}
+        )
+        operands = self._partition_path_options(
+            values,
+            cwd,
+            option_access=dict.fromkeys(scalar_options),
+            attached_short_options=frozenset({"-f", "-s", "-w"}),
+            fail_closed_on_unknown_long_option=True,
+        )
+        if operands:
+            self._check_path(operands[0], cwd, "read")
+        if len(operands) > 1:
+            self._check_path(operands[1], cwd, "write")
+
+    def _check_diff(self, values: Sequence[str], cwd: Path) -> None:
+        """Classify `diff`'s write (`--output`) and read-control options.
+
+        `-N`/`--new-file` takes no argument, so it is unaffected by the
+        write-slot fail-closed rule below (which only gates `--`-prefixed
+        options that would otherwise consume an argument silently).
+        """
+        for raw_path in self._partition_path_options(
+            values,
+            cwd,
+            option_access={
+                "--output": "write",
+                "--from-file": "read",
+                "--to-file": "read",
+            },
+            fail_closed_on_unknown_long_option=True,
+        ):
+            self._check_path(raw_path, cwd, "read")
+
+    def _check_grep(self, values: Sequence[str], cwd: Path) -> None:
+        """Classify `grep`'s pattern-file read option and file operands.
+
+        `-r`/`-R` (recurse into a directory) take no argument, so the
+        directory they precede already reaches the file-operand loop below
+        unmodified; no dedicated handling is needed for them.
+        """
+        positionals: list[str] = []
+        explicit_pattern = False
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if value == "--":
+                positionals.extend(values[index + 1 :])
+                break
+            value_text = str(value)
+            if value_text in {"-e", "--regexp"}:
+                explicit_pattern = True
+                index += 2
+                continue
+            if value_text.startswith("-e") or value_text.startswith("--regexp="):
+                explicit_pattern = True
+                index += 1
+                continue
+            if value_text in {"-f", "--file"}:
+                explicit_pattern = True
+                if index + 1 < len(values):
+                    self._check_path(values[index + 1], cwd, "read")
+                index += 2
+                continue
+            if value_text.startswith("-f") or value_text.startswith("--file="):
+                explicit_pattern = True
+                attached = value.split("=", 1)[1] if "=" in value_text else value[2:]
+                if attached:
+                    self._check_path(self._derived_value(value, attached), cwd, "read")
+                index += 1
+                continue
+            if value_text == "--exclude-from":
+                if index + 1 < len(values):
+                    self._check_path(values[index + 1], cwd, "read")
+                index += 2
+                continue
+            if value_text.startswith("--exclude-from="):
+                self._check_path(
+                    self._derived_value(value, value.split("=", 1)[1]),
+                    cwd,
+                    "read",
+                )
+                index += 1
+                continue
+            if value_text.startswith("-") and value_text != "-":
+                index += 1
+                continue
+            positionals.append(value)
+            index += 1
+
+        file_operands = positionals if explicit_pattern else positionals[1:]
+        for raw_path in file_operands:
+            self._check_path(raw_path, cwd, "read")
+
+    def _parse_short_option_cluster(
+        self,
+        values: Sequence[str],
+        index: int,
+        cwd: Path,
+        *,
+        flag_options: frozenset[str],
+        value_options: Mapping[str, PathAccess | None],
+    ) -> int:
+        """Parse one bundled short-option token (e.g. `-no<file>`).
+
+        GNU short options bundle into a single token where only the last
+        option in the cluster may carry a value (attached, e.g. `-ofile`, or
+        as the following token). Any character not recognized as a flag or a
+        value option fails closed rather than being silently skipped, so an
+        unmodeled option can never hide a path argument. Returns the index of
+        the next unconsumed token.
+        """
+        source = values[index]
+        options = str(source)[1:]
+        cursor = 0
+        while cursor < len(options):
+            option = options[cursor]
+            if option in flag_options:
+                cursor += 1
+                continue
+            if option not in value_options:
+                raise CommandPolicyViolation(f"cannot safely resolve option -{option}")
+            attached = options[cursor + 1 :]
+            argument: str
+            if attached:
+                argument = self._derived_value(source, attached)
+                next_index = index + 1
+            elif index + 1 < len(values):
+                argument = values[index + 1]
+                next_index = index + 2
+            else:
+                raise CommandPolicyViolation(f"missing argument for -{option}")
+            access = value_options[option]
+            if access is not None:
+                self._check_path(argument, cwd, access)
+            return next_index
+        return index + 1
+
+    @staticmethod
+    def _resolve_long_option(value: str, known: Iterable[str]) -> str | None:
+        """Resolve a GNU unambiguous-prefix long option, or None if it can't be.
+
+        `known` must contain the full `--...` option name. An exact match
+        always wins; otherwise a prefix must match exactly one candidate.
+        Ambiguous or unmatched prefixes return None so the caller decides
+        whether that is a benign skip (pure-read families) or a fail-closed
+        violation (families that own a write slot).
+        """
+        if value in known:
+            return value
+        matches = [candidate for candidate in known if candidate.startswith(value)]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    def _partition_path_options(
+        self,
+        values: Sequence[str],
+        cwd: Path,
+        *,
+        option_access: Mapping[str, PathAccess | None],
+        attached_short_options: frozenset[str] = frozenset(),
+        fail_closed_on_unknown_long_option: bool = False,
+    ) -> list[str]:
+        """Split path-bearing options from operands using a per-option access map.
+
+        Each key in `option_access` consumes exactly one following or attached
+        token; a `None` access consumes it without a path check (a scalar
+        value), `"read"`/`"write"` checks it. Long options resolve through
+        `_resolve_long_option` first, so an accepted abbreviation (`--out=`
+        for `--output`) is classified identically to the full name. A family
+        that owns a write slot must set `fail_closed_on_unknown_long_option`
+        so a long option this map cannot resolve — a typo, an unsupported
+        flag, or an ambiguous abbreviation — cannot silently bypass write
+        containment; pure-read families leave it unset and such an option is
+        left in place as an ordinary (over-checked, never under-checked)
+        operand, matching the family's existing single-access classification.
+        """
+        known_long_options = frozenset(
+            option for option in option_access if option.startswith("--")
+        )
+        remaining: list[str] = []
+        options_done = False
+        index = 0
+        while index < len(values):
+            value = values[index]
+            if not options_done and value == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not value.startswith("-") or value == "-":
+                remaining.append(value)
+                index += 1
+                continue
+            if value in option_access:
+                if index + 1 >= len(values):
+                    raise CommandPolicyViolation(f"missing argument for {value}")
+                access = option_access[value]
+                if access is not None:
+                    self._check_path(values[index + 1], cwd, access)
+                index += 2
+                continue
+
+            value_text = str(value)
+            if value_text.startswith("--"):
+                raw_option, separator, _ = value_text.partition("=")
+                resolved = raw_option
+                if resolved not in option_access and known_long_options:
+                    candidate = self._resolve_long_option(
+                        raw_option, known_long_options
+                    )
+                    if candidate is not None:
+                        resolved = candidate
+                if resolved in option_access:
+                    access = option_access[resolved]
+                    argument: str
+                    if separator:
+                        argument = self._derived_value(
+                            value, value[len(raw_option) + 1 :]
+                        )
+                        index += 1
+                    elif index + 1 < len(values):
+                        argument = values[index + 1]
+                        index += 2
+                    else:
+                        raise CommandPolicyViolation(f"missing argument for {resolved}")
+                    if access is not None:
+                        self._check_path(argument, cwd, access)
+                    continue
+                if fail_closed_on_unknown_long_option:
+                    raise CommandPolicyViolation(
+                        f"cannot safely resolve option {raw_option}"
+                    )
+                index += 1
+                continue
+
+            matching_short = next(
+                (
+                    option
+                    for option in attached_short_options
+                    if value_text.startswith(option) and len(value_text) > len(option)
+                ),
+                None,
+            )
+            if matching_short is not None:
+                access = option_access[matching_short]
+                if access is not None:
+                    self._check_path(
+                        self._derived_value(value, value_text[len(matching_short) :]),
+                        cwd,
+                        access,
+                    )
+                index += 1
+                continue
+            # Unknown short options are not paths for these simple grammars.
+            index += 1
+        return remaining
 
     def _read_policy_script(self, raw_path: str, cwd: Path) -> str:
         script_path = self._check_path(raw_path, cwd, "read")

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -3269,10 +3269,15 @@ class WorkspaceCommandPathGuard:
         always wins; otherwise a prefix must match exactly one candidate.
         Ambiguous or unmatched prefixes return None so the caller decides
         whether that is a benign skip (pure-read families) or a fail-closed
-        violation (families that own a write slot).
+        violation (families that own a write slot). A bare `--` is the
+        argument-list terminator, never an abbreviation: every candidate
+        starts with `--`, so it would otherwise "unambiguously" prefix-match
+        a known set containing exactly one option (R7).
         """
         if value in known:
             return value
+        if value == "--":
+            return None
         matches = [candidate for candidate in known if candidate.startswith(value)]
         if len(matches) == 1:
             return matches[0]

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -937,6 +937,17 @@ _GREP_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
 }
 _GREP_KNOWN_LONG_OPTIONS = frozenset({"--regexp", "--file", "--exclude-from"})
 
+# A `curl`/`wget` positional operand is a URL, not a bare filesystem path,
+# EXCEPT when its scheme is `file:`, which is a real local filesystem
+# channel. These are the network schemes this family recognizes as
+# definitely non-local; any other or unparsable scheme fails closed rather
+# than being assumed safe, since an exotic scheme this map does not model
+# could still resolve to a local resource.
+_CURL_WGET_NETWORK_URL_SCHEMES = frozenset(
+    {"http", "https", "ftp", "ftps", "sftp", "scp"}
+)
+_URL_SCHEME_PATTERN = re.compile(r"^([A-Za-z][A-Za-z0-9+.\-]*):(//)?(.*)\Z", re.DOTALL)
+
 # `curl`'s short options bundle into one token (e.g. `-sD file` combines the
 # `-s` flag with the `-D` write-path option), so its grammar is split into a
 # flag set and a value set for the short-option-cluster parser, the same
@@ -969,12 +980,32 @@ _CURL_WRITE_LONG_OPTIONS = frozenset(
 )
 _CURL_READ_LONG_OPTIONS = frozenset({"--upload-file", "--netrc-file"})
 _CURL_DATA_LONG_OPTIONS = frozenset({"--data", "--data-binary", "--data-raw"})
+# Long-form spellings of `_CURL_SHORT_FLAG_OPTIONS`'s no-value flags, so the
+# common long spelling of an already-modeled short flag is not rejected
+# merely for being spelled out.
+_CURL_KNOWN_LONG_FLAG_OPTIONS = frozenset(
+    {
+        "--silent",
+        "--show-error",
+        "--location",
+        "--insecure",
+        "--fail",
+        "--include",
+        "--head",
+        "--verbose",
+        "--no-buffer",
+        "--globoff",
+        "--get",
+        "--progress-bar",
+    }
+)
 _CURL_KNOWN_LONG_OPTIONS = frozenset(
     _CURL_HARD_DENY_LONG_OPTIONS
     | _CURL_CONFIG_LONG_OPTIONS
     | _CURL_WRITE_LONG_OPTIONS
     | _CURL_READ_LONG_OPTIONS
     | _CURL_DATA_LONG_OPTIONS
+    | _CURL_KNOWN_LONG_FLAG_OPTIONS
 )
 
 # `wget`'s own short options never bundle a value-taking option behind a
@@ -991,11 +1022,26 @@ _WGET_WRITE_LONG_OPTIONS = frozenset(
     }
 )
 _WGET_READ_LONG_OPTIONS = frozenset({"--post-file", "--body-file"})
+# Long-form spellings of `_WGET_SHORT_FLAG_OPTIONS`'s no-value flags, for the
+# same reason `_CURL_KNOWN_LONG_FLAG_OPTIONS` exists.
+_WGET_KNOWN_LONG_FLAG_OPTIONS = frozenset(
+    {
+        "--background",
+        "--quiet",
+        "--verbose",
+        "--continue",
+        "--timestamping",
+        "--server-response",
+        "--debug",
+        "--force-html",
+    }
+)
 _WGET_KNOWN_LONG_OPTIONS = frozenset(
     _WGET_HARD_DENY_LONG_OPTIONS
     | _WGET_CONFIG_LONG_OPTIONS
     | _WGET_WRITE_LONG_OPTIONS
     | _WGET_READ_LONG_OPTIONS
+    | _WGET_KNOWN_LONG_FLAG_OPTIONS
     | {"--spider"}
 )
 _WGET_SHORT_FLAG_OPTIONS = frozenset("bqvcNSdF")
@@ -4478,6 +4524,41 @@ class WorkspaceCommandPathGuard:
         text = str(value)
         return text.startswith("rsync://") or ":" in text
 
+    def _classify_url_operand(self, value: str, cwd: Path, access: PathAccess) -> None:
+        """Classify a curl/wget positional URL operand (T3).
+
+        A `file:` scheme is a real local filesystem channel — not a network
+        transfer — so it is resolved to a path and checked with `access`
+        (the caller decides read vs. write: a plain source URL is a read;
+        curl's upload target when `-T`/`--upload-file` is in play is a
+        write). A recognized network scheme
+        (`_CURL_WGET_NETWORK_URL_SCHEMES`) is not a local path and is
+        allowed through unchecked. Module invariant: any other or
+        unparsable scheme fails closed — this family cannot assume an
+        exotic/unmodeled scheme (some of which, e.g. `smb:`/`scp:`-like
+        variants, can themselves resolve to local or attacker-controlled
+        resources) is safely non-local.
+        """
+        text = str(value)
+        match = _URL_SCHEME_PATTERN.match(text)
+        if match is None:
+            raise CommandPolicyViolation(
+                f"cannot safely resolve operand {text} as a URL"
+            )
+        scheme = match.group(1).lower()
+        has_authority_separator = match.group(2) == "//"
+        remainder = match.group(3)
+        if scheme == "file":
+            if has_authority_separator and not remainder.startswith("/"):
+                raise CommandPolicyViolation(
+                    "cannot safely resolve a file:// URL host component"
+                )
+            self._check_path(self._derived_value(value, remainder), cwd, access)
+            return
+        if scheme in _CURL_WGET_NETWORK_URL_SCHEMES:
+            return
+        raise CommandPolicyViolation(f"cannot safely resolve URL scheme {scheme}:")
+
     def _check_curl(self, values: Sequence[str], cwd: Path) -> None:
         """`curl`: `-o`/`--output`/`--output-dir` write; `-T`/`--upload-file`/
         `--netrc-file` read; an `@file` payload to `-d`/`--data*` reads that
@@ -4489,21 +4570,39 @@ class WorkspaceCommandPathGuard:
         knowable) cannot be inspected safely and fail closed, including
         bundled behind another short flag (e.g. `-sO`). Long options resolve
         through `_resolve_long_option` (GNU unambiguous-prefix abbreviation,
-        e.g. `--dump-hea=` for `--dump-header`); an unrecognized long option
-        with an attached `=value` also fails closed (mirroring `rsync`):
-        curl accepts a value for many long options this family does not
-        model, so an unmodeled one cannot be assumed to be a value-free
-        flag once it visibly carries a value. Short options bundle through
-        the same `_parse_short_option_cluster` substrate `sort`/`grep`/
-        `install` use, so a value-taking option (`-o`/`-D`/`-c`/`-T`) still
-        consumes its argument even when it is not the leading character of
-        the cluster (e.g. `-sD`).
+        e.g. `--dump-hea=` for `--dump-header`). Module invariant: any
+        option (short or long, bare or `=value`-attached) this allowlist
+        cannot resolve fails closed. Short options bundle through the same
+        `_parse_short_option_cluster` substrate `sort`/`grep`/`install` use,
+        so a value-taking option (`-o`/`-D`/`-c`/`-T`) still consumes its
+        argument even when it is not the leading character of the cluster
+        (e.g. `-sD`). A literal `--` ends option parsing.
+
+        The positional URL/operand (T3) is classified through
+        `_classify_url_operand`: a `file:` URL is a real filesystem channel
+        (read by default; write when `-T`/`--upload-file` is anywhere in the
+        invocation, since that turns the request into an upload whose
+        destination is the URL — `has_upload_target` is computed by a
+        presence-only pre-scan so the classification does not depend on
+        argv order, matching curl's own order-independent option parsing).
         """
         self._reject_dynamic_values("curl arguments", values)
+        has_upload_target = self._curl_has_upload_target(values)
+        options_done = False
         index = 0
         while index < len(values):
             value = values[index]
             text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                self._classify_url_operand(
+                    value, cwd, "write" if has_upload_target else "read"
+                )
+                index += 1
+                continue
             if text.startswith("--"):
                 raw_option, separator, attached_text = text.partition("=")
                 resolved = self._resolve_long_option(
@@ -4555,52 +4654,91 @@ class WorkspaceCommandPathGuard:
                             "read",
                         )
                     continue
-                # An unmodeled long option that visibly carries a value
-                # cannot be assumed to be a value-free flag; a bare
-                # unmodeled flag stays permissive.
-                if separator:
+                if resolved in _CURL_KNOWN_LONG_FLAG_OPTIONS:
+                    if separator:
+                        raise CommandPolicyViolation(
+                            f"cannot safely inspect curl option {raw_option}"
+                        )
+                    index += 1
+                    continue
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect curl option {raw_option}"
+                )
+            # `-O`/`-K` fail closed even bundled behind another flag
+            # (e.g. `-sO`); scanning stops at the first character that
+            # is not a known no-value flag, since anything past a
+            # value-taking option is that option's value, not another
+            # flag letter.
+            for character in text[1:]:
+                if character in _CURL_SHORT_FLAG_OPTIONS:
+                    continue
+                if character == "O":
                     raise CommandPolicyViolation(
-                        f"cannot safely inspect curl option {raw_option}"
+                        "cannot safely resolve curl remote output filename"
                     )
+                if character == "K":
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect curl runtime configuration"
+                    )
+                break
+            index, matched_option, argument = self._parse_short_option_cluster(
+                values,
+                index,
+                cwd,
+                flag_options=_CURL_SHORT_FLAG_OPTIONS,
+                value_options=_CURL_SHORT_VALUE_OPTIONS,
+            )
+            if (
+                matched_option == "d"
+                and argument is not None
+                and str(argument).startswith("@")
+            ):
+                self._check_path(
+                    self._derived_value(argument, str(argument)[1:]),
+                    cwd,
+                    "read",
+                )
+
+    @staticmethod
+    def _curl_has_upload_target(values: Sequence[str]) -> bool:
+        """Detect `-T`/`--upload-file` anywhere in argv (presence only).
+
+        curl's own option parsing does not require `-T` to precede the URL
+        operand, so the URL's read-vs-write classification must not depend
+        on argv order either: this mirrors the same short-cluster and
+        long-option resolution `_check_curl`'s real pass uses, but only
+        checks presence — it performs no path checks of its own.
+        """
+        options_done = False
+        index = 0
+        while index < len(values):
+            text = str(values[index])
+            if not options_done and text == "--":
+                options_done = True
                 index += 1
                 continue
-            if text.startswith("-") and text != "-":
-                # `-O`/`-K` fail closed even bundled behind another flag
-                # (e.g. `-sO`); scanning stops at the first character that
-                # is not a known no-value flag, since anything past a
-                # value-taking option is that option's value, not another
-                # flag letter.
-                for character in text[1:]:
-                    if character in _CURL_SHORT_FLAG_OPTIONS:
-                        continue
-                    if character == "O":
-                        raise CommandPolicyViolation(
-                            "cannot safely resolve curl remote output filename"
-                        )
-                    if character == "K":
-                        raise CommandPolicyViolation(
-                            "cannot safely inspect curl runtime configuration"
-                        )
-                    break
-                index, matched_option, argument = self._parse_short_option_cluster(
-                    values,
-                    index,
-                    cwd,
-                    flag_options=_CURL_SHORT_FLAG_OPTIONS,
-                    value_options=_CURL_SHORT_VALUE_OPTIONS,
-                )
-                if (
-                    matched_option == "d"
-                    and argument is not None
-                    and str(argument).startswith("@")
-                ):
-                    self._check_path(
-                        self._derived_value(argument, str(argument)[1:]),
-                        cwd,
-                        "read",
-                    )
+            if options_done or not text.startswith("-") or text == "-":
+                index += 1
                 continue
+            if text.startswith("--"):
+                raw_option = text.partition("=")[0]
+                if (
+                    WorkspaceCommandPathGuard._resolve_long_option(
+                        raw_option, _CURL_KNOWN_LONG_OPTIONS
+                    )
+                    == "--upload-file"
+                ):
+                    return True
+                index += 1
+                continue
+            for character in text[1:]:
+                if character in _CURL_SHORT_FLAG_OPTIONS:
+                    continue
+                if character == "T":
+                    return True
+                break
             index += 1
+        return False
 
     def _check_wget(self, values: Sequence[str], cwd: Path) -> None:
         """`wget`: `-O`/`--output-document` write; `-P`/`--directory-prefix`
@@ -4613,21 +4751,36 @@ class WorkspaceCommandPathGuard:
         filename from the remote response, which is not statically
         knowable, so that combination fails closed too. Long options resolve
         through `_resolve_long_option` (GNU unambiguous-prefix abbreviation,
-        e.g. `--output-docu=` for `--output-document`); an unrecognized long
-        option with an attached `=value` also fails closed (mirroring
-        `rsync`/`curl`). Short options bundle through the same
-        `_parse_short_option_cluster` substrate `curl`/`sort`/`grep`/
-        `install` use, so `-O`/`-P`/`-o` still consume their argument even
-        when not the leading character of the cluster (e.g. `-qO`).
+        e.g. `--output-docu=` for `--output-document`). Module invariant:
+        any option (short or long, bare or `=value`-attached) this
+        allowlist cannot resolve fails closed. Short options bundle through
+        the same `_parse_short_option_cluster` substrate `curl`/`sort`/
+        `grep`/`install` use, so `-O`/`-P`/`-o` still consume their argument
+        even when not the leading character of the cluster (e.g. `-qO`). A
+        literal `--` ends option parsing.
+
+        The positional URL/operand (T3) is classified through
+        `_classify_url_operand` as a plain read: wget's URL is always the
+        fetch source, never an upload target.
         """
         self._reject_dynamic_values("wget arguments", values)
         has_explicit_output = False
         spider_mode = False
         has_url_operand = False
+        options_done = False
         index = 0
         while index < len(values):
             value = values[index]
             text = str(value)
+            if not options_done and text == "--":
+                options_done = True
+                index += 1
+                continue
+            if options_done or not text.startswith("-") or text == "-":
+                self._classify_url_operand(value, cwd, "read")
+                has_url_operand = True
+                index += 1
+                continue
             if text.startswith("--"):
                 raw_option, separator, attached_text = text.partition("=")
                 resolved = self._resolve_long_option(
@@ -4666,37 +4819,37 @@ class WorkspaceCommandPathGuard:
                     if resolved == "--output-document":
                         has_explicit_output = True
                     continue
-                if separator:
-                    raise CommandPolicyViolation(
-                        f"cannot safely inspect wget option {raw_option}"
-                    )
-                index += 1
-                continue
-            if text.startswith("-") and text != "-":
-                # `-i` fails closed even bundled behind another flag (e.g.
-                # `-qi`); scanning stops at the first character that is not
-                # a known no-value flag, since anything past a value-taking
-                # option is that option's value, not another flag letter.
-                for character in text[1:]:
-                    if character in _WGET_SHORT_FLAG_OPTIONS:
-                        continue
-                    if character == "i":
+                if resolved in _WGET_KNOWN_LONG_FLAG_OPTIONS:
+                    if separator:
                         raise CommandPolicyViolation(
-                            "cannot safely inspect wget runtime URL list"
+                            f"cannot safely inspect wget option {raw_option}"
                         )
-                    break
-                index, matched_option, _ = self._parse_short_option_cluster(
-                    values,
-                    index,
-                    cwd,
-                    flag_options=_WGET_SHORT_FLAG_OPTIONS,
-                    value_options=_WGET_SHORT_VALUE_OPTIONS,
+                    index += 1
+                    continue
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect wget option {raw_option}"
                 )
-                if matched_option == "O":
-                    has_explicit_output = True
-                continue
-            has_url_operand = True
-            index += 1
+            # `-i` fails closed even bundled behind another flag (e.g.
+            # `-qi`); scanning stops at the first character that is not
+            # a known no-value flag, since anything past a value-taking
+            # option is that option's value, not another flag letter.
+            for character in text[1:]:
+                if character in _WGET_SHORT_FLAG_OPTIONS:
+                    continue
+                if character == "i":
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect wget runtime URL list"
+                    )
+                break
+            index, matched_option, _ = self._parse_short_option_cluster(
+                values,
+                index,
+                cwd,
+                flag_options=_WGET_SHORT_FLAG_OPTIONS,
+                value_options=_WGET_SHORT_VALUE_OPTIONS,
+            )
+            if matched_option == "O":
+                has_explicit_output = True
         if has_url_operand and not has_explicit_output and not spider_mode:
             raise CommandPolicyViolation(
                 "cannot safely resolve wget remote output filename"

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1219,6 +1219,34 @@ _TARGET_DIR_KNOWN_LONG_OPTIONS = frozenset(
     | _TARGET_DIR_LONG_SCALAR_OPTIONS
 )
 
+# `install` owns its own short/long grammar (`-d`/`--directory`,
+# `-g`/`-m`/`-o`/`-S` scalar owner/mode/suffix options, etc.), distinct from
+# `cp`/`mv`/`ln`'s, so it cannot share `_TARGET_DIR_KNOWN_LONG_OPTIONS`
+# wholesale; only `_resolve_long_option` itself (the GNU unambiguous-prefix
+# abbreviation resolver) is reused, against this dedicated known-option set,
+# so `--target-dir=`/`--targ=` resolves to `--target-directory` exactly like
+# `cp`'s `--targ=` does (R9), instead of a literal-prefix-only string match.
+_INSTALL_SCALAR_LONG_OPTIONS = frozenset(
+    {"--group", "--mode", "--owner", "--suffix", "--context"}
+)
+_INSTALL_FLAG_LONG_OPTIONS = frozenset(
+    {
+        "--backup",
+        "--compare",
+        "--preserve-timestamps",
+        "--strip",
+        "--no-target-directory",
+        "--verbose",
+        "--help",
+        "--version",
+    }
+)
+_INSTALL_KNOWN_LONG_OPTIONS = (
+    frozenset({"--target-directory", "--directory", "--strip-program"})
+    | _INSTALL_SCALAR_LONG_OPTIONS
+    | _INSTALL_FLAG_LONG_OPTIONS
+)
+
 
 @dataclass(frozen=True)
 class _PathEvent:
@@ -2553,6 +2581,13 @@ class WorkspaceCommandPathGuard:
                 self._check_path(raw_path, cwd, "read")
             return
         if len(operands) < 2:
+            # A single (or zero) operand has no destination slot to split
+            # off, but a lone operand is still a real source and must still
+            # be read-checked (R9), not silently exempted for lack of a
+            # second (destination) operand — the same fix `rsync` already
+            # applies to its own single-operand invocation (N1).
+            for raw_path in operands:
+                self._check_path(raw_path, cwd, "read")
             return
         for raw_path in operands[:-1]:
             self._check_path(raw_path, cwd, "read")
@@ -2567,45 +2602,19 @@ class WorkspaceCommandPathGuard:
         slot. `-t` also resolves when bundled behind another short flag
         (`-Dt destdir`), sharing the bundled-cluster parser `-Dm755` already
         uses; its value is write-checked below alongside every other
-        `target_dir` spelling.
+        `target_dir` spelling. Long options resolve through
+        `_resolve_long_option` against `_INSTALL_KNOWN_LONG_OPTIONS` (GNU
+        unambiguous-prefix abbreviation, e.g. `--target-dir=` for
+        `--target-directory`, matching `cp`'s `--targ=`), instead of a
+        literal-prefix-only string match that only recognized the full
+        spelling (R9).
         """
         target_dir: str | None = None
         operands: list[str] = []
         directory_mode = False
         options_done = False
-        scalar_options = frozenset(
-            {
-                "-g",
-                "--group",
-                "-m",
-                "--mode",
-                "-o",
-                "--owner",
-                "-S",
-                "--suffix",
-                "--context",
-            }
-        )
-        flag_options = frozenset(
-            {
-                "-b",
-                "--backup",
-                "-c",
-                "-C",
-                "--compare",
-                "-D",
-                "-p",
-                "--preserve-timestamps",
-                "-s",
-                "--strip",
-                "-T",
-                "--no-target-directory",
-                "-v",
-                "--verbose",
-                "--help",
-                "--version",
-            }
-        )
+        scalar_options = frozenset({"-g", "-m", "-o", "-S"})
+        flag_options = frozenset({"-b", "-c", "-C", "-D", "-p", "-s", "-T", "-v"})
         index = 0
         while index < len(values):
             value = values[index]
@@ -2618,76 +2627,102 @@ class WorkspaceCommandPathGuard:
                 operands.append(value)
                 index += 1
                 continue
-            if text in {"-d", "--directory"}:
+            if text.startswith("--"):
+                raw_option, separator, attached = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _INSTALL_KNOWN_LONG_OPTIONS
+                )
+                if resolved is None:
+                    raise CommandPolicyViolation(
+                        f"cannot safely inspect install option {raw_option}"
+                    )
+                if resolved == "--target-directory":
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"install argument for {resolved}",
+                    )
+                    assert argument is not None
+                    target_dir = argument
+                    continue
+                if resolved == "--directory":
+                    directory_mode = True
+                    index += 1
+                    continue
+                if resolved == "--strip-program":
+                    raise CommandPolicyViolation(
+                        "cannot safely inspect install delegated strip program"
+                    )
+                if resolved in _INSTALL_SCALAR_LONG_OPTIONS:
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"install argument for {resolved}",
+                    )
+                    continue
+                # The remaining recognized long options
+                # (`_INSTALL_FLAG_LONG_OPTIONS`) take no separate argument.
+                index += 1
+                continue
+            if text == "-d":
                 directory_mode = True
                 index += 1
                 continue
-            if text in {"-t", "--target-directory"}:
+            if text == "-t":
                 if index + 1 >= len(values):
                     raise CommandPolicyViolation(f"missing install argument for {text}")
                 target_dir = values[index + 1]
                 index += 2
                 continue
-            if text.startswith("--target-directory="):
-                target_dir = self._derived_value(value, text.split("=", 1)[1])
-                index += 1
-                continue
             if text.startswith("-t") and len(text) > 2:
                 target_dir = self._derived_value(value, text[2:])
                 index += 1
                 continue
-            if text == "--strip-program" or text.startswith("--strip-program="):
-                raise CommandPolicyViolation(
-                    "cannot safely inspect install delegated strip program"
-                )
             if text in scalar_options:
                 if index + 1 >= len(values):
                     raise CommandPolicyViolation(f"missing install argument for {text}")
                 index += 2
                 continue
             if any(
-                text.startswith(f"{option}=")
-                for option in scalar_options
-                if option.startswith("--")
-            ):
-                index += 1
-                continue
-            if any(
                 text.startswith(option) and len(text) > len(option)
-                for option in {"-g", "-m", "-o", "-S"}
+                for option in scalar_options
             ):
                 index += 1
                 continue
             if text in flag_options:
                 index += 1
                 continue
-            if not text.startswith("--"):
-                # A bundled cluster (e.g. `-Dm755`): only the trailing
-                # value-taking character may carry an attached argument, so
-                # this shares the same GNU bundling contract as `sort`. `-t`
-                # bundles the same way (`-Dt destdir`); its value is deferred
-                # to the same `target_dir` slot the standalone `-t`/
-                # `--target-directory` forms populate above, so the single
-                # write check at the bottom of this method covers every
-                # spelling instead of a second inline check here.
-                index, matched_option, argument = self._parse_short_option_cluster(
-                    values,
-                    index,
-                    cwd,
-                    flag_options=frozenset("bcCDpsTv"),
-                    value_options={
-                        "g": None,
-                        "m": None,
-                        "o": None,
-                        "S": None,
-                        "t": None,
-                    },
-                )
-                if matched_option == "t":
-                    assert argument is not None
-                    target_dir = argument
-                continue
-            raise CommandPolicyViolation(f"cannot safely inspect install option {text}")
+            # A bundled cluster (e.g. `-Dm755`): only the trailing
+            # value-taking character may carry an attached argument, so this
+            # shares the same GNU bundling contract as `sort`. `-t` bundles
+            # the same way (`-Dt destdir`); its value is deferred to the same
+            # `target_dir` slot the standalone `-t`/`--target-directory`
+            # forms populate above, so the single write check at the bottom
+            # of this method covers every spelling instead of a second
+            # inline check here.
+            index, matched_option, argument = self._parse_short_option_cluster(
+                values,
+                index,
+                cwd,
+                flag_options=frozenset("bcCDpsTv"),
+                value_options={
+                    "g": None,
+                    "m": None,
+                    "o": None,
+                    "S": None,
+                    "t": None,
+                },
+            )
+            if matched_option == "t":
+                assert argument is not None
+                target_dir = argument
+            continue
 
         if directory_mode:
             for operand in operands:
@@ -2699,6 +2734,12 @@ class WorkspaceCommandPathGuard:
             self._check_path(target_dir, cwd, "write")
             return
         if len(operands) < 2:
+            # A single (or zero) operand has no destination slot to split
+            # off, but a lone operand is still a real source and must still
+            # be read-checked (R9), not silently exempted for lack of a
+            # second (destination) operand.
+            for operand in operands:
+                self._check_path(operand, cwd, "read")
             return
         for operand in operands[:-1]:
             self._check_path(operand, cwd, "read")

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1236,6 +1236,7 @@ _TarEventKind = Literal[
     "absolute_names",
     "verbose_output",
     "unresolved_option",
+    "pattern",
 ]
 
 
@@ -2835,6 +2836,12 @@ class WorkspaceCommandPathGuard:
                 )
             elif event.kind == "exclude_from":
                 self._check_path(event.value, cwd, "read")
+            elif event.kind == "pattern":
+                # `--exclude`'s argument is a glob PATTERN matched against
+                # in-archive member names, never a local filesystem path;
+                # its argument is already consumed by the parser, so there
+                # is nothing left to check here (N2).
+                continue
             elif event.kind == "incremental":
                 # The snapshot file can be updated even when the archive
                 # itself is only read (e.g. listing against a snapshot).
@@ -2979,15 +2986,20 @@ class WorkspaceCommandPathGuard:
         The option resolves through `_resolve_long_option` (GNU
         unambiguous-prefix abbreviation, e.g. `--listed-incr` for
         `--listed-incremental`, `--files-fr` for `--files-from`) against
-        this family's known path-bearing and dangerous long options, so an
-        abbreviated spelling is classified identically to the full name
-        instead of falling through as unmodeled. An unrecognized long
-        option with an attached `=value` unambiguously carries a value this
-        family does not model, and fails closed immediately regardless of
-        mode (mirroring `rsync`/`curl`/`wget`). An unrecognized option with
-        NO attached value is ambiguous: it may be a bare flag (common; e.g.
-        `--gzip`), or it may take a separate following token this parser
-        cannot identify as its argument, which would otherwise be
+        this family's known path-bearing, pattern, and dangerous long
+        options, so an abbreviated spelling is classified identically to
+        the full name instead of falling through as unmodeled. `--exclude`
+        (kind `pattern`) consumes its glob-PATTERN argument without a path
+        check: it is a real, distinct tar option from `--exclude-from`, and
+        omitting it from this set previously let its own unambiguous-prefix
+        match snap to `--exclude-from` (a real path option) and misclassify
+        an ordinary pattern as a file to read-check (N2). An unrecognized
+        long option with an attached `=value` unambiguously carries a value
+        this family does not model, and fails closed immediately regardless
+        of mode (mirroring `rsync`/`curl`/`wget`). An unrecognized option
+        with NO attached value is ambiguous: it may be a bare flag (common;
+        e.g. `--gzip`), or it may take a separate following token this
+        parser cannot identify as its argument, which would otherwise be
         misclassified as an unchecked archive-member positional in
         extract/list mode (never path-checked there) or as an unchecked
         source/destination positional in the other modes (source_access-
@@ -3005,6 +3017,7 @@ class WorkspaceCommandPathGuard:
             "--directory": "directory",
             "--files-from": "files_from",
             "--exclude-from": "exclude_from",
+            "--exclude": "pattern",
             "--listed-incremental": "incremental",
             "--add-file": "add_file",
             "--index-file": "verbose_output",

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2353,7 +2353,12 @@ class WorkspaceCommandPathGuard:
         `--dereference`, `-H`) can read arbitrarily deep external content
         through a single approved read boundary, which cannot be bounded
         statically, so that combination is a hard denial regardless of the
-        actual paths involved. `--recursive`/`--dereference`/
+        actual paths involved. `-a`/`--archive` implies `-r` (GNU documents
+        it as `-dR --preserve=all`) and therefore counts as recursive for
+        this denial too (M1), even though it also implies `-d`/no-dereference
+        on its own — `-a` combined with an explicit `-L`/`--dereference`
+        still overrides that default and follows symlinks, so the denial
+        must still fire. `--recursive`/`--archive`/`--dereference`/
         `--follow-command-line-symlink` resolve through `_resolve_long_option`
         against the same `_TARGET_DIR_KNOWN_LONG_OPTIONS` set
         `_parse_target_directory` uses for this family, so a GNU-abbreviated
@@ -2371,13 +2376,13 @@ class WorkspaceCommandPathGuard:
                 resolved = self._resolve_long_option(
                     raw_option, _TARGET_DIR_KNOWN_LONG_OPTIONS
                 )
-                if resolved == "--recursive":
+                if resolved in {"--recursive", "--archive"}:
                     recursive = True
                 elif resolved in {"--dereference", "--follow-command-line-symlink"}:
                     dereferences_links = True
             elif text.startswith("-") and not text.startswith("--"):
                 flags = text[1:]
-                recursive = recursive or "r" in flags or "R" in flags
+                recursive = recursive or "r" in flags or "R" in flags or "a" in flags
                 dereferences_links = dereferences_links or "L" in flags or "H" in flags
         if recursive and dereferences_links:
             raise CommandPolicyViolation(

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1942,13 +1942,24 @@ class WorkspaceCommandPathGuard:
         this family has no non-path positional.
         """
         if command_name in _OWNERSHIP_MODE_COMMANDS:
+            reference_options = frozenset({"--reference"})
             operands = self._partition_path_options(
                 values,
                 cwd,
                 option_access={"--reference": "read"},
             )
+            # Must resolve through the same `_resolve_long_option` set the
+            # partitioning pass above uses for this option, not an
+            # independent raw-string pass: otherwise a GNU-abbreviated
+            # `--ref=` is consumed (and read-checked) above but looks absent
+            # here, so the real target is misread as the excluded MODE
+            # positional and its write check is silently skipped.
             has_reference = any(
-                str(value) == "--reference" or str(value).startswith("--reference=")
+                str(value).startswith("--")
+                and self._resolve_long_option(
+                    str(value).partition("=")[0], reference_options
+                )
+                is not None
                 for value in values
             )
             if not has_reference and operands:

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1005,6 +1005,55 @@ _WGET_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
     "o": "write",
 }
 
+# `cp`/`mv`/`ln` share `_parse_target_directory`'s `-t`/`--target-directory`
+# extraction. Short options bundle into one token (e.g. `-rt` combines the
+# `-r` flag with the `-t` write-path option), so the grammar is split into a
+# flag set and a value set for the short-option-cluster parser, the union of
+# the three commands' real GNU short options (over-permissive for any one of
+# them is safe here: none of these carry a path this parser would otherwise
+# miss). `-S`'s value is a scalar backup suffix, never a path.
+_TARGET_DIR_SHORT_FLAG_OPTIONS = frozenset("abdfFHilLnPprRsuvxZ")
+_TARGET_DIR_SHORT_VALUE_OPTIONS: dict[str, PathAccess | None] = {
+    "t": "write",
+    "S": None,
+}
+_TARGET_DIR_LONG_FLAG_OPTIONS = frozenset(
+    {
+        "--archive",
+        "--attributes-only",
+        "--backup",
+        "--copy-contents",
+        "--dereference",
+        "--follow-command-line-symlink",
+        "--force",
+        "--help",
+        "--interactive",
+        "--link",
+        "--logical",
+        "--no-clobber",
+        "--no-dereference",
+        "--no-target-directory",
+        "--one-file-system",
+        "--parents",
+        "--physical",
+        "--preserve",
+        "--recursive",
+        "--relative",
+        "--remove-destination",
+        "--strip-trailing-slashes",
+        "--symbolic-link",
+        "--update",
+        "--verbose",
+        "--version",
+    }
+)
+_TARGET_DIR_LONG_SCALAR_OPTIONS = frozenset({"--suffix", "--sparse", "--context"})
+_TARGET_DIR_KNOWN_LONG_OPTIONS = frozenset(
+    {"--target-directory"}
+    | _TARGET_DIR_LONG_FLAG_OPTIONS
+    | _TARGET_DIR_LONG_SCALAR_OPTIONS
+)
+
 
 @dataclass(frozen=True)
 class _PathEvent:
@@ -2096,14 +2145,27 @@ class WorkspaceCommandPathGuard:
     def _parse_target_directory(
         self,
         values: Sequence[str],
-    ) -> tuple[str | None, list[str]]:
+        cwd: Path,
+    ) -> tuple[bool, list[str]]:
         """Split a `-t`/`--target-directory VALUE` destination from operands.
 
         Shared by `cp` and `mv`/`ln`: when present, every remaining operand is
         a source and the target directory is the sole write destination;
         otherwise the caller treats the last operand as the destination.
+        `-t`/`--target-directory` resolve through the same bundled-cluster
+        (`_parse_short_option_cluster`) and GNU-abbreviation
+        (`_resolve_long_option`) substrates every other family uses, so a
+        bundled form (`-rt`, `-vt`) or an abbreviated long form (`--targ=`)
+        is classified identically to the standalone/full-name form instead
+        of falling through as an ordinary operand — for `cp` that would
+        misclassify the real write destination as an under-strict
+        read-checked source. The target directory is write-checked here
+        (every caller treats it as the write destination), so the return
+        value is only whether one was found, not the raw string. `cp`/`mv`/
+        `ln` own a write slot, so an option this parser cannot resolve fails
+        closed.
         """
-        target_dir: str | None = None
+        found_target_dir = False
         operands: list[str] = []
         options_done = False
         index = 0
@@ -2114,26 +2176,54 @@ class WorkspaceCommandPathGuard:
                 options_done = True
                 index += 1
                 continue
-            if not options_done and text in {"-t", "--target-directory"}:
-                if index + 1 >= len(values):
-                    raise CommandPolicyViolation(f"missing argument for {text}")
-                target_dir = values[index + 1]
-                index += 2
-                continue
-            if not options_done and text.startswith("--target-directory="):
-                target_dir = self._derived_value(value, text.split("=", 1)[1])
+            if options_done or not text.startswith("-") or text == "-":
+                operands.append(value)
                 index += 1
                 continue
-            if not options_done and text.startswith("-t") and len(text) > 2:
-                target_dir = self._derived_value(value, text[2:])
-                index += 1
-                continue
-            if not options_done and text.startswith("-") and text != "-":
-                index += 1
-                continue
-            operands.append(value)
-            index += 1
-        return target_dir, operands
+            if text.startswith("--"):
+                raw_option, separator, attached = text.partition("=")
+                resolved = self._resolve_long_option(
+                    raw_option, _TARGET_DIR_KNOWN_LONG_OPTIONS
+                )
+                if resolved == "--target-directory":
+                    argument, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"argument for {resolved}",
+                    )
+                    assert argument is not None
+                    self._check_path(argument, cwd, "write")
+                    found_target_dir = True
+                    continue
+                if resolved in _TARGET_DIR_LONG_SCALAR_OPTIONS:
+                    _, index = self._take_option_argument(
+                        values,
+                        index,
+                        attached_argument=(
+                            self._derived_value(value, attached) if separator else None
+                        ),
+                        context=f"argument for {resolved}",
+                    )
+                    continue
+                if resolved in _TARGET_DIR_LONG_FLAG_OPTIONS:
+                    index += 1
+                    continue
+                raise CommandPolicyViolation(
+                    f"cannot safely inspect option {raw_option}"
+                )
+            index, matched_option, _ = self._parse_short_option_cluster(
+                values,
+                index,
+                cwd,
+                flag_options=_TARGET_DIR_SHORT_FLAG_OPTIONS,
+                value_options=_TARGET_DIR_SHORT_VALUE_OPTIONS,
+            )
+            if matched_option == "t":
+                found_target_dir = True
+        return found_target_dir, operands
 
     def _check_copy(self, values: Sequence[str], cwd: Path) -> None:
         """`cp`: sources read, destination (or `-t` target directory) write.
@@ -2163,11 +2253,10 @@ class WorkspaceCommandPathGuard:
                 "cannot safely inspect recursive copying that follows symbolic links"
             )
 
-        target_dir, operands = self._parse_target_directory(values)
-        if target_dir is not None:
+        found_target_dir, operands = self._parse_target_directory(values, cwd)
+        if found_target_dir:
             for raw_path in operands:
                 self._check_path(raw_path, cwd, "read")
-            self._check_path(target_dir, cwd, "write")
             return
         if len(operands) < 2:
             return
@@ -2310,13 +2399,12 @@ class WorkspaceCommandPathGuard:
         A hard link inside the workspace aliases its source inode; later path
         resolution sees only the workspace-side alias, so an external
         read-only source must be write-checked here rather than read-checked,
-        or it would stay silently mutable through the link.
+        or it would stay silently mutable through the link. `_parse_target_directory`
+        already write-checks a `-t`/`--target-directory` destination inline.
         """
-        target_dir, operands = self._parse_target_directory(values)
+        _, operands = self._parse_target_directory(values, cwd)
         for raw_path in operands:
             self._check_path(raw_path, cwd, "write")
-        if target_dir is not None:
-            self._check_path(target_dir, cwd, "write")
 
     def _check_destructive_file_command(
         self,

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -2344,7 +2344,10 @@ class WorkspaceCommandPathGuard:
         `touch`/`truncate` own their own `-r`/`--reference` read slot (the
         reference file's timestamps/size are read, never written) plus, for
         `truncate`, the `-s`/`--size` scalar; every other write command in
-        this family has no non-path positional.
+        this family has no non-path positional. `flag_short_options` lists
+        each command's remaining common no-value short options (R11) so an
+        unrecognized short option still fails closed without over-rejecting
+        ordinary usage.
         """
         if command_name in _OWNERSHIP_MODE_COMMANDS:
             reference_options = frozenset({"--reference"})
@@ -2352,6 +2355,14 @@ class WorkspaceCommandPathGuard:
                 values,
                 cwd,
                 option_access={"--reference": "read"},
+                # `-R`/`--recursive`, `-v`/`--verbose`, `-c`/`--changes`,
+                # `-f`/`--silent`/`--quiet`, and `-H`/`-L`/`-P` (symlink-
+                # traversal mode for `chown`/`chgrp`'s recursive walk) are the
+                # GNU short options shared across chmod/chown/chgrp; none of
+                # them carry a value.
+                flag_short_options=frozenset(
+                    {"-R", "-v", "-c", "-f", "-H", "-L", "-P"}
+                ),
             )
             # Must resolve through the same `_resolve_long_option` set the
             # partitioning pass above uses for this option, not an
@@ -2378,14 +2389,27 @@ class WorkspaceCommandPathGuard:
                 "--reference": "read",
             }
             attached_short_options = {"-r"}
+            flag_short_options: set[str] = set()
             if command_name == "truncate":
+                # `-s`/`--size` is already a non-path scalar; `-c`/`--no-create`
+                # and `-o`/`--io-blocks` are truncate's remaining no-value
+                # short options.
                 option_access.update({"-s": None, "--size": None})
                 attached_short_options.add("-s")
+                flag_short_options.update({"-c", "-o"})
+            else:
+                # `-t STAMP` and `-d`/`--date DATE` are non-path scalar
+                # values (a timestamp/date string, never a filesystem path);
+                # `-a`/`-c`/`-m` are touch's remaining no-value short options.
+                option_access.update({"-t": None, "-d": None, "--date": None})
+                attached_short_options.update({"-t", "-d"})
+                flag_short_options.update({"-a", "-c", "-m"})
             operands = self._partition_path_options(
                 values,
                 cwd,
                 option_access=option_access,
                 attached_short_options=frozenset(attached_short_options),
+                flag_short_options=frozenset(flag_short_options),
             )
             for raw_path in operands:
                 self._check_path(raw_path, cwd, "write")

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -4408,7 +4408,11 @@ class WorkspaceCommandPathGuard:
         ...) means the true runtime target is this literal PLUS more text
         this lexer cannot resolve; that must fail closed too, rather than
         validating only the leading literal while the concatenated
-        remainder silently escapes containment.
+        remainder silently escapes containment. `)` is also a valid
+        terminator (R13): the idiomatic `while ((getline line < "file") > 0)`
+        read loop closes the parenthesized `getline` expression right after
+        the quoted target, and that closing paren is not itself part of a
+        concatenated expression.
         """
         cursor = index
         while cursor < len(script) and script[cursor] in " \t":
@@ -4429,7 +4433,7 @@ class WorkspaceCommandPathGuard:
                 trailer = cursor + 1
                 while trailer < len(script) and script[trailer] in " \t":
                     trailer += 1
-                if trailer < len(script) and script[trailer] not in ";\n}":
+                if trailer < len(script) and script[trailer] not in ";\n})":
                     raise CommandPolicyViolation(
                         "cannot resolve dynamic awk redirect target"
                     )

--- a/src/xagent/core/tools/core/command_path_guard.py
+++ b/src/xagent/core/tools/core/command_path_guard.py
@@ -1311,6 +1311,7 @@ _TarEventKind = Literal[
     "verbose_output",
     "unresolved_option",
     "pattern",
+    "newer_mtime",
 ]
 
 
@@ -3067,6 +3068,13 @@ class WorkspaceCommandPathGuard:
                 )
             elif event.kind == "exclude_from":
                 self._check_path(event.value, cwd, "read")
+            elif event.kind == "newer_mtime":
+                # `-N`/`--newer-mtime`/`--after-date`'s DATE-OR-FILE argument
+                # can name a reference file whose mtime is read (R2); model
+                # it as a read path rather than leaving it as an unmodeled
+                # bare flag, which would let its argument fall through as an
+                # unchecked positional.
+                self._check_path(event.value, cwd, "read")
             elif event.kind == "pattern":
                 # `--exclude`'s argument is a glob PATTERN matched against
                 # in-archive member names, never a local filesystem path;
@@ -3252,6 +3260,10 @@ class WorkspaceCommandPathGuard:
             "--listed-incremental": "incremental",
             "--add-file": "add_file",
             "--index-file": "verbose_output",
+            # `-N`'s two long spellings (R2); both name the same
+            # DATE-OR-FILE argument, so both resolve to the same read path.
+            "--newer-mtime": "newer_mtime",
+            "--after-date": "newer_mtime",
         }
         dangerous_options = {
             "--use-compress-program",
@@ -3333,6 +3345,12 @@ class WorkspaceCommandPathGuard:
             "I": "dangerous",
             "F": "dangerous",
             "b": None,
+            # `-N`/`--newer-mtime`/`--after-date`: a DATE-OR-FILE argument
+            # (R2). Modeling it here means its argument always takes its own
+            # token/attached-value slot like every other argument-taking
+            # short letter, so it can never fall through as an unmodeled
+            # bare flag whose argument becomes an unchecked positional.
+            "N": "newer_mtime",
         }
         known_option_characters = (
             frozenset(short_modes) | frozenset(argument_events) | {"P", "O"}

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -1937,6 +1937,669 @@ class TestScopedCommandPathGuardBash:
         assert "command denied by policy" in result["error"]
 
 
+class TestReadCommandFamily:
+    """Pure readers newly classified alongside `cat`: I1 (out-of-ws reject) and
+
+    I2 (a value-consuming option's separate argument is skipped, not
+    misread as a path, while the real operand is still checked).
+    """
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cmp own.txt {path}",
+            "file {path}",
+            "head {path}",
+            "less {path}",
+            "ls {path}",
+            "more {path}",
+            "stat {path}",
+            "tac {path}",
+            "tail {path}",
+            "wc {path}",
+            "cut -f1 {path}",
+        ],
+    )
+    def test_read_family_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cmp own.txt own.txt",
+            "file own.txt",
+            "head -n 2 -c 10 own.txt",
+            "less own.txt",
+            "ls own.txt",
+            "more own.txt",
+            "stat own.txt",
+            "tac -s , own.txt",
+            "tail -n 2 -c 10 own.txt",
+            "wc own.txt",
+            "cut -d , -f 1 own.txt",
+        ],
+    )
+    def test_read_family_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "head -n {path} own.txt",
+            "head -c {path} own.txt",
+            "tail -n {path} own.txt",
+            "tail -c {path} own.txt",
+            "cut -d {path} -f 1 own.txt",
+            "tac -s {path} own.txt",
+        ],
+    )
+    def test_value_option_scalar_argument_is_not_treated_as_a_path(
+        self, scoped_command_workspace, command_template
+    ):
+        # A value-consuming option's argument (line count, delimiter, etc.) is
+        # never a path, so an out-of-workspace-looking value does not cause a
+        # spurious rejection.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "head -n 1 {path}",
+            "tail -n 1 {path}",
+            "cut -d , -f 1 {path}",
+            "tac -s , {path}",
+        ],
+    )
+    def test_real_operand_outside_workspace_still_rejected_with_value_option(
+        self, scoped_command_workspace, command_template
+    ):
+        # Skipping the option's own value must not skip the real file operand.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "file -f {path}",
+            "file -m {path} own.txt",
+            "file --files-from={path}",
+            "file --magic-file={path} own.txt",
+            "wc --files0-from={path}",
+        ],
+    )
+    def test_read_control_file_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "file -f control.txt own.txt",
+            "file -m control.txt own.txt",
+            "file --files-from=control.txt",
+            "file --magic-file=control.txt own.txt",
+            "wc --files0-from=control.txt",
+        ],
+    )
+    def test_read_control_file_options_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "control.txt").write_text("c", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+
+class TestSortUniqDiffGrepHandlers:
+    """Dedicated handlers for commands that own a write or read-control slot.
+
+    Each owns at least one slot that a flat read/write classification cannot
+    express: `sort`'s `-o`/`-T` write options, `uniq`'s second positional
+    operand, `diff`'s `--output`, and `grep`'s `-f` pattern file.
+    """
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "sort -o {path} own.txt",
+            "sort -o{path} own.txt",
+            "sort -ro{path} own.txt",
+            "sort -T{path} own.txt",
+            "sort -rT{path} own.txt",
+            "sort --output={path} own.txt",
+            "sort --temporary-directory={path} own.txt",
+            "sort --temp={path} own.txt",
+        ],
+    )
+    def test_sort_write_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sort -o out.txt own.txt",
+            "sort -oout.txt own.txt",
+            "sort -roout.txt own.txt",
+            "sort -Tout.txt own.txt",
+            "sort --output=out.txt own.txt",
+            "sort --temporary-directory=out.txt own.txt",
+            "sort --temp=out.txt own.txt",
+            "sort own.txt",
+        ],
+    )
+    def test_sort_write_options_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "sort --files0-from={path}",
+            "sort --files0={path}",
+            "sort --random-source={path} own.txt",
+            "sort --random-sour={path} own.txt",
+        ],
+    )
+    def test_sort_read_control_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'sort -t "$SEPARATOR" own.txt',
+            'sort -t"$SEPARATOR" own.txt',
+            'sort -k "$KEY" own.txt',
+            'sort -k"$KEY" own.txt',
+            'sort --field-separator="$SEPARATOR" own.txt',
+        ],
+    )
+    def test_sort_dynamic_scalar_option_values_are_not_paths(
+        self, scoped_command_workspace, command
+    ):
+        # A dynamic (unexpanded) value is only rejected when it feeds a path
+        # check; sort's scalar options never do, so it is simply skipped.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'sort -o"$TARGET" own.txt',
+            'sort -ro"$TARGET" own.txt',
+            'sort -T"$TARGET" own.txt',
+            'sort --output="$TARGET" own.txt',
+            'sort --temporary-directory="$TARGET" own.txt',
+        ],
+    )
+    def test_sort_rejects_dynamic_write_option_values(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sort --not-a-sort-option own.txt",
+            "sort --random-s=/dev/zero own.txt",
+            "sort --compress-program=cat own.txt",
+            "sort -q own.txt",
+        ],
+    )
+    def test_sort_rejects_unrecognized_or_ambiguous_options(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sort --human-numeric-sort own.txt",
+            "sort --check=quiet own.txt",
+            "sort -bdfgiMhnRrVcmsuz own.txt",
+        ],
+    )
+    def test_sort_allows_recognized_flag_options(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_uniq_second_operand_is_write_checked(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"uniq own.txt {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_uniq_first_operand_out_of_workspace_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"uniq {shlex.quote(str(sibling_file))} out.txt")
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        ["uniq own.txt", "uniq own.txt out.txt", "uniq -f 1 own.txt out.txt"],
+    )
+    def test_uniq_workspace_paths_are_allowed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_uniq_skip_fields_value_is_not_treated_as_a_path(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        # The skip-fields count is not a path, so an out-of-workspace-looking
+        # value does not cause a spurious rejection; the real operand does.
+        guard.validate(f"uniq -f {shlex.quote(str(sibling_file))} own.txt")
+
+    def test_uniq_rejects_unrecognized_long_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("uniq --count own.txt")
+
+    def test_diff_output_option_registers_write(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"diff --output={shlex.quote(str(sibling_file))} own.txt own.txt"
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_diff_workspace_output_is_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("diff --output=out.txt own.txt own.txt")
+        guard.validate("diff -N own.txt own.txt")
+
+    def test_diff_rejects_unrecognized_long_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("diff --brief own.txt own.txt")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "grep sibling {path}",
+            "grep --regexp=sibling {path}",
+            "grep -f {path} own.txt",
+            "grep -f{path} own.txt",
+        ],
+    )
+    def test_grep_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "grep needle own.txt",
+            "grep -e needle own.txt",
+            "grep -f pattern.txt own.txt",
+            "grep -r needle .",
+        ],
+    )
+    def test_grep_workspace_paths_are_allowed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "pattern.txt").write_text("needle", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_grep_recursive_directory_operand_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"grep -r needle {shlex.quote(str(sibling_file.parent))}")
+
+        assert exc_info.value.access == "read"
+
+
+class TestPathClassificationSubstrate:
+    """Unit tests for the shared option-classification substrate itself.
+
+    Exercised directly (not only through a specific command family) so a
+    regression in the abbreviation resolver, the access-map partitioner, or
+    the short-option-cluster parser is caught at the substrate boundary.
+    """
+
+    def test_resolve_long_option_exact_match(self):
+        known = frozenset({"--output", "--other-flag"})
+
+        assert (
+            WorkspaceCommandPathGuard._resolve_long_option("--output", known)
+            == "--output"
+        )
+
+    def test_resolve_long_option_unambiguous_abbreviation(self):
+        known = frozenset({"--output", "--other-flag"})
+
+        assert (
+            WorkspaceCommandPathGuard._resolve_long_option("--out", known) == "--output"
+        )
+
+    def test_resolve_long_option_ambiguous_abbreviation_returns_none(self):
+        known = frozenset({"--output", "--outline"})
+
+        assert WorkspaceCommandPathGuard._resolve_long_option("--out", known) is None
+
+    def test_resolve_long_option_unmatched_returns_none(self):
+        known = frozenset({"--output"})
+
+        assert (
+            WorkspaceCommandPathGuard._resolve_long_option("--nonexistent", known)
+            is None
+        )
+
+    def test_partition_path_options_drives_the_access_map(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        cwd = guard.execution_cwd
+
+        with command_path_guard_module._validation_session_scope():
+            remaining = guard._partition_path_options(
+                ["--in", "own.txt", "positional"],
+                cwd,
+                option_access={"--in": "read"},
+            )
+
+        assert remaining == ["positional"]
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(CommandPathViolation) as exc_info:
+                guard._partition_path_options(
+                    ["--in", str(sibling_file)],
+                    cwd,
+                    option_access={"--in": "read"},
+                )
+        assert exc_info.value.access == "read"
+
+    def test_partition_path_options_resolves_abbreviation_to_write(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        cwd = guard.execution_cwd
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(CommandPathViolation) as exc_info:
+                guard._partition_path_options(
+                    [f"--out={sibling_file}"],
+                    cwd,
+                    option_access={"--output": "write"},
+                )
+        assert exc_info.value.access == "write"
+
+        with command_path_guard_module._validation_session_scope():
+            remaining = guard._partition_path_options(
+                ["--out=out.txt"],
+                cwd,
+                option_access={"--output": "write"},
+            )
+        assert remaining == []
+
+    def test_partition_path_options_fails_closed_on_unknown_long_option_for_write_family(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        cwd = guard.execution_cwd
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(CommandPolicyViolation):
+                guard._partition_path_options(
+                    ["--unmodeled-option", "value"],
+                    cwd,
+                    option_access={"--output": "write"},
+                    fail_closed_on_unknown_long_option=True,
+                )
+
+    def test_short_option_cluster_carries_a_path(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        cwd = guard.execution_cwd
+
+        with command_path_guard_module._validation_session_scope():
+            next_index = guard._parse_short_option_cluster(
+                ["-nofile.txt"],
+                0,
+                cwd,
+                flag_options=frozenset({"n"}),
+                value_options={"o": "write"},
+            )
+        assert next_index == 1
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(CommandPathViolation) as exc_info:
+                guard._parse_short_option_cluster(
+                    [f"-no{sibling_file}"],
+                    0,
+                    cwd,
+                    flag_options=frozenset({"n"}),
+                    value_options={"o": "write"},
+                )
+        assert exc_info.value.access == "write"
+
+    def test_short_option_cluster_fails_closed_on_unknown_character(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        cwd = guard.execution_cwd
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(CommandPolicyViolation):
+                guard._parse_short_option_cluster(
+                    ["-z"],
+                    0,
+                    cwd,
+                    flag_options=frozenset({"n"}),
+                    value_options={"o": "write"},
+                )
+
+
+class TestS1CommandCoverage:
+    """Mutation-sensitive coverage gate for every command classified in S1.
+
+    Reflects over the guard's live classification sets so a command dropped
+    from dispatch, from the shadow-script set, or left without a test is
+    caught here rather than by chance in an unrelated test.
+    """
+
+    _READ_FAMILY_COMMANDS = frozenset(
+        {
+            "cmp",
+            "file",
+            "head",
+            "less",
+            "ls",
+            "more",
+            "stat",
+            "tac",
+            "tail",
+            "wc",
+            "cut",
+        }
+    )
+    _DEDICATED_HANDLER_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"})
+    _S1_COMMANDS = _READ_FAMILY_COMMANDS | _DEDICATED_HANDLER_COMMANDS
+
+    # Each entry: (positive command, negative command template with `{outside}`).
+    _REGISTRY: dict[str, tuple[str, str]] = {
+        "cmp": ("cmp own.txt own.txt", "cmp own.txt {outside}"),
+        "file": ("file own.txt", "file {outside}"),
+        "head": ("head -n 1 own.txt", "head -n 1 {outside}"),
+        "less": ("less own.txt", "less {outside}"),
+        "ls": ("ls own.txt", "ls {outside}"),
+        "more": ("more own.txt", "more {outside}"),
+        "stat": ("stat own.txt", "stat {outside}"),
+        "tac": ("tac -s , own.txt", "tac -s , {outside}"),
+        "tail": ("tail -n 1 own.txt", "tail -n 1 {outside}"),
+        "wc": ("wc own.txt", "wc {outside}"),
+        "cut": ("cut -d , -f 1 own.txt", "cut -d , -f 1 {outside}"),
+        "sort": ("sort own.txt", "sort {outside}"),
+        "uniq": ("uniq own.txt", "uniq {outside}"),
+        "diff": ("diff own.txt own.txt", "diff own.txt {outside}"),
+        "grep": ("grep pattern own.txt", "grep pattern {outside}"),
+    }
+
+    def test_registry_covers_every_s1_command(self):
+        assert set(self._REGISTRY) == self._S1_COMMANDS
+
+    def test_read_family_commands_are_classified_as_read(self):
+        for command_name in self._READ_FAMILY_COMMANDS:
+            assert command_name in command_path_guard_module._READ_COMMANDS
+
+    def test_dedicated_handlers_are_not_flat_read_or_write(self):
+        for command_name in self._DEDICATED_HANDLER_COMMANDS:
+            assert command_name not in command_path_guard_module._READ_COMMANDS
+            assert command_name not in command_path_guard_module._WRITE_COMMANDS
+            assert hasattr(WorkspaceCommandPathGuard, f"_check_{command_name}")
+
+    def test_every_s1_command_is_shadow_script_classified(self):
+        for command_name in self._S1_COMMANDS:
+            assert (
+                command_name
+                in command_path_guard_module._CLASSIFIED_EXECUTABLE_COMMANDS
+            )
+
+    @pytest.mark.parametrize("command_name", sorted(_S1_COMMANDS))
+    def test_registry_positive_case_is_accepted(
+        self, scoped_command_workspace, command_name
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        positive_command, _ = self._REGISTRY[command_name]
+
+        guard.validate(positive_command)
+
+    @pytest.mark.parametrize("command_name", sorted(_S1_COMMANDS))
+    def test_registry_negative_case_is_rejected(
+        self, scoped_command_workspace, command_name
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        _, negative_template = self._REGISTRY[command_name]
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(
+                negative_template.format(outside=shlex.quote(str(sibling_file)))
+            )
+
+
 class TestCdSymlinkTraversal:
     """`cd`/`pushd` logical-vs-physical divergence must not escape the workspace.
 

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5418,6 +5418,80 @@ class TestDdBase64GzipRemoteTransferCommand:
         with pytest.raises(CommandPolicyViolation):
             guard.validate("curl -sO https://example.invalid/file")
 
+    def test_curl_file_url_output_source_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        # T3/C1: a `file:` URL is a real filesystem channel, not a network
+        # transfer; the positional URL operand was never inspected at all
+        # (a bare `index += 1`), so this used to ALLOW unconditionally.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"curl -o out.txt file://{sibling_file}")
+
+        assert exc_info.value.access == "read"
+
+    def test_curl_upload_to_file_url_is_write_checked(self, scoped_command_workspace):
+        # T3/C1: `-T`/`--upload-file` turns the request into an upload whose
+        # DESTINATION is the URL operand, so a `file:` URL there is a write
+        # target, not a read source.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"curl -T own.txt file://{sibling_file}")
+
+        assert exc_info.value.access == "write"
+
+    def test_curl_upload_target_classification_is_order_independent(
+        self, scoped_command_workspace
+    ):
+        # `-T` need not precede the URL operand for curl's own option
+        # parsing; the guard's write-vs-read classification of the URL must
+        # not depend on argv order either.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"curl file://{sibling_file} -T own.txt")
+
+        assert exc_info.value.access == "write"
+
+    def test_curl_file_url_workspace_path_is_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        own_file = workspace.output_dir / "own.txt"
+        own_file.write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"curl -o out.txt file://{own_file}")
+
+    @pytest.mark.parametrize(
+        "scheme", ["gopher", "smb", "dict", "ldap", "unknown-scheme"]
+    )
+    def test_curl_unrecognized_url_scheme_fails_closed(
+        self, scoped_command_workspace, scheme
+    ):
+        # Any scheme this family does not explicitly recognize as network
+        # transfer fails closed rather than being assumed non-local.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"curl -o out.txt {scheme}://example.invalid/file")
+
+    def test_curl_end_of_options_marker_stops_option_parsing(
+        self, scoped_command_workspace
+    ):
+        # A literal `--` ends option parsing; a URL-shaped token after it is
+        # still a plain operand, not silently reinterpreted as an option.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("curl -o out.txt -- https://example.invalid/file")
+
     # -- wget ------------------------------------------------------------
 
     def test_wget_output_outside_workspace_rejected(self, scoped_command_workspace):
@@ -5566,6 +5640,33 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         with pytest.raises(CommandPolicyViolation):
             guard.validate("wget -qi urls.txt")
+
+    def test_wget_file_url_source_is_read_checked(self, scoped_command_workspace):
+        # T3/C1: a `file:` URL is a real filesystem channel; wget's URL
+        # operand was never inspected at all, so this used to ALLOW
+        # unconditionally.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"wget -O out.txt file://{sibling_file}")
+
+        assert exc_info.value.access == "read"
+
+    def test_wget_file_url_workspace_path_is_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        own_file = workspace.output_dir / "own.txt"
+        own_file.write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"wget -O out.txt file://{own_file}")
+
+    def test_wget_unrecognized_url_scheme_fails_closed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("wget -O out.txt gopher://example.invalid/file")
 
     # -- path-classification bypass regressions -------------------------
 

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4240,6 +4240,43 @@ class TestSedAwkCommand:
         guard.validate("sed 'w own_out.txt' own.txt")
         guard.validate("sed 's/a/b/w own_out.txt' own.txt")
 
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "sed -n '/x/Iw {path}' own.txt",
+            "sed '/x/M w {path}' own.txt",
+            "sed -n '/x/IMw {path}' own.txt",
+            "sed -n '/x/MIw {path}' own.txt",
+            "sed -n '1,/x/Iw {path}' own.txt",
+        ],
+    )
+    def test_sed_regex_address_modifier_does_not_hide_write_command(
+        self, scoped_command_workspace, command_template
+    ):
+        # C3: a trailing `I`/`M` regex-address modifier (in either order or
+        # combination, on either address of a range) must be consumed as
+        # part of the address, not misread as the command letter itself --
+        # otherwise the real `w` command and its filename are swallowed
+        # whole as opaque trailing text and never path-checked.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_sed_regex_address_modifier_write_command_inside_workspace_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed -n '/x/Iw own_out.txt' own.txt")
+        guard.validate("sed '/x/M w own_out.txt' own.txt")
+
     def test_sed_braces_in_pattern_are_data(self, scoped_command_workspace):
         # `{`/`}`/`/` inside a delimited pattern or replacement are DATA, not
         # block/command structure; a benign program using them must be

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2918,6 +2918,10 @@ class TestCopyInstallMoveLinkDestructive:
             "cp -r --derefe . copied",
             "cp --recurs --dereference . copied",
             "cp -r --follow-comm . copied",
+            "cp -aL . copied",
+            "cp -a -L . copied",
+            "cp --archive --dereference . copied",
+            "cp --archive -L . copied",
         ],
     )
     def test_copy_recursive_symlink_dereference_is_rejected(
@@ -2927,7 +2931,10 @@ class TestCopyInstallMoveLinkDestructive:
         # abbreviations of `--dereference`/`--recursive`/
         # `--follow-command-line-symlink`; an abbreviated spelling of
         # either flag must be classified identically to the full name so
-        # this hard denial still fires.
+        # this hard denial still fires. `-a`/`--archive` implies `-r`
+        # (GNU cp documents `-a` as `-dR --preserve=all`), so it must be
+        # treated as recursive for this denial too, not only the literal
+        # `-r`/`-R`/`--recursive` spellings (M1).
         workspace, _, _ = scoped_command_workspace
         guard = WorkspaceCommandPathGuard(workspace)
 
@@ -2945,6 +2952,19 @@ class TestCopyInstallMoveLinkDestructive:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("cp --derefe own.txt copied.txt")
+
+    def test_copy_archive_alone_without_dereference_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # `-a`/`--archive` implies recursive, but the hard denial only fires
+        # for recursive+dereference together; `-a` alone (no `-L`/`-H`/
+        # `--dereference`) must not be misclassified as triggering it.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cp -a own.txt copied.txt")
+        guard.validate("cp --archive own.txt copied.txt")
 
     def test_cp_target_directory_bundled_behind_recursive_is_write_checked(
         self, scoped_command_workspace

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2862,6 +2862,7 @@ class TestCommandCoverage:
         "unlink": "_check_destructive_file_command",
         "shred": "_check_destructive_file_command",
         "find": "_check_find",
+        "tar": "_check_tar",
     }
     _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
     _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
@@ -2869,7 +2870,8 @@ class TestCommandCoverage:
         {"cp", "install", "mv", "ln", "unlink", "shred"}
     )
     _S3_COMMANDS = frozenset({"find"})
-    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS
+    _S4_COMMANDS = frozenset({"tar"})
+    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS | _S4_COMMANDS
 
     # Each entry: (positive command, negative command template with `{outside}`).
     _REGISTRY: dict[str, tuple[str, str]] = {
@@ -2902,6 +2904,7 @@ class TestCommandCoverage:
         "unlink": ("unlink own.txt", "unlink {outside}"),
         "shred": ("shred own.txt", "shred {outside}"),
         "find": ("find own.txt -print", "find {outside}"),
+        "tar": ("tar -cf archive.tar own.txt", "tar -cf archive.tar {outside}"),
     }
 
     def test_registry_covers_every_classified_command(self):
@@ -3384,3 +3387,244 @@ class TestFindCommand:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("find . -exec cat {} \\;")
+
+
+class TestTarCommand:
+    """`tar`: archive/control paths anchored to cwd; `-C` scopes only members;
+
+    extract poisons `unknown_effect` (M2 additive) in addition to a real
+    containment check on its extraction root; remote/stdin archives and
+    executable hooks fail closed.
+    """
+
+    def test_extract_change_directory_outside_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        # M2 containment: `-C`'s extraction root is still write-checked even
+        # though extract also poisons `unknown_effect` for its members.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(external_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar -x -C {outside} -f a.tar")
+
+        assert exc_info.value.access == "write"
+
+    def test_extract_write_root_poisons_later_script_inspection(
+        self, scoped_command_workspace
+    ):
+        # Extraction targets are non-enumerable per-match children, so the
+        # `-C` write-check alone cannot capture them; `unknown_effect` must
+        # additionally poison later script inspection in the same chain.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own_dir").mkdir()
+        (workspace.output_dir / "own_dir" / "x.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("tar -x -C own_dir -f a.tar ; bash own_dir/x.sh")
+
+    def test_create_archive_write_outside_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own_dir").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside_archive = shlex.quote(f"{sibling_file}.tar")
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar -c -f {outside_archive} own_dir")
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar -xf host:a.tar",
+            "tar --file=host:a.tar --list",
+            "tar -xf user@host:a.tar",
+        ],
+    )
+    def test_remote_archive_fails_closed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar -xf -",
+            "tar --file - --list",
+        ],
+    )
+    def test_stdin_archive_fails_closed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar --to-command=sh -xf a.tar",
+            "tar -I sh -cf archive.tar own.txt",
+            "tar --use-compress-program=sh -xf a.tar",
+        ],
+    )
+    def test_executable_hooks_rejected(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar -x --absolute-names -f a.tar",
+            "tar -xPf a.tar",
+        ],
+    )
+    def test_rejects_absolute_extraction(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_list_with_change_directory_inside_workspace_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own_dir").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("tar -C own_dir -tf a.tar")
+
+    def test_change_directory_scope_applies_to_extract_destination(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own_dir").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("tar -xzf a.tgz -C own_dir")
+
+    def test_change_directory_scope_does_not_reanchor_the_archive_path(
+        self, scoped_command_workspace
+    ):
+        # `-C sub` shifts member resolution to `own_dir/sub`, but the archive
+        # path is anchored to the unshifted process cwd: from `sub`, "../.."
+        # would still land inside the workspace, but from the real cwd it
+        # escapes. A wrong implementation that resolves the archive against
+        # `-C`'s directory would let this pass instead of rejecting it.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "sub").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate("tar -c -C sub -f ../../escape.tar file")
+
+    def test_delete_and_compare_keep_distinct_archive_access(
+        self, scoped_command_workspace
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(external_file))
+
+        # Compare only reads the archive, so an approved external read-only
+        # path is fine.
+        guard.validate(f"tar -df {outside}")
+        # Delete rewrites the archive in place, so the same path must now be
+        # rejected as a write, not silently reused as a read.
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar --delete -f {outside} member")
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar -tf own.tar ../../member",
+            "tar -xf own.tar ../../member -C extracted",
+        ],
+    )
+    def test_member_selectors_are_not_local_paths(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "tar -f{path} -t",
+            "tar --file {path} --list",
+            "tar tf {path}",
+            "tar cf archive.tar {path}",
+            "tar --add-file={path} -cf archive.tar",
+            "tar -cf archive.tar @{path}",
+        ],
+    )
+    def test_rejects_read_path_variants(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "tar -cf archive.tar -T file-list.txt",
+            "tar --create --files-from=file-list.txt -f archive.tar",
+            "tar -cf archive.tar --checkpoint-action=exec=sh own.txt",
+            "tar -cf archive.tar --checkpoint-action exec=sh own.txt",
+            "tar -cf archive.tar -F hook.sh own.txt",
+        ],
+    )
+    def test_rejects_indirect_or_executable_path_sources(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_short_option_bundle_consumes_archive_value(self, scoped_command_workspace):
+        # `-xzf archive.tgz`: `x`=extract, `z`=unrecognized flag (skipped),
+        # `f`=archive (consumes the next token), all in one bundled token.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(f"tar -xzf {outside}")
+
+    def test_rejects_dynamic_short_option_bundle(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate('OPTION=farchive.tar; tar -c"$OPTION" own.txt')
+
+    def test_added_command_argv_uses_same_path_policy(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate_argv(["tar", "-tf", str(sibling_file)])

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2364,6 +2364,314 @@ class TestSortUniqDiffGrepHandlers:
         assert exc_info.value.access == "read"
 
 
+def _trust_locally_shadowed_ownership_commands(monkeypatch):
+    """Treat `chown` as a trusted system command regardless of its host path.
+
+    macOS ships `chown` under `/usr/sbin`, outside this guard's fixed trusted
+    executable roots (`/bin`, `/usr/bin`, `/usr/local/bin`,
+    `/opt/homebrew/bin`, owned by `command_policy.py`); most Linux
+    distributions ship it under `/usr/bin`, already trusted there. This keeps
+    the S2 write-classification tests independent of that host difference
+    without touching the trusted-roots list itself.
+    """
+    original = WorkspaceCommandPathGuard._is_trusted_system_command
+
+    def _is_trusted(command_word: str) -> bool:
+        if os.path.basename(command_word) == "chown":
+            return True
+        return original(command_word)
+
+    monkeypatch.setattr(
+        WorkspaceCommandPathGuard,
+        "_is_trusted_system_command",
+        staticmethod(_is_trusted),
+    )
+
+
+class TestWriteCreateFamily:
+    """Write/create commands newly classified alongside `rm`/`mkdir`: I3 (the
+
+    destination registers a write) plus I2 (a non-path positional or option
+    value is not misread as a path while the real operand is still checked).
+    """
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "chmod 755 {path}",
+            "chown owner {path}",
+            "chgrp staff {path}",
+            "rmdir {path}",
+            "tee {path}",
+            "touch {path}",
+            "truncate -s 10 {path}",
+        ],
+    )
+    def test_write_create_family_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template, monkeypatch
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "chmod 755 own.txt",
+            "chown owner own.txt",
+            "chgrp staff own.txt",
+            "rmdir own_dir",
+            "tee own.txt",
+            "touch own.txt",
+            "truncate -s 10 own.txt",
+        ],
+    )
+    def test_write_create_family_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command, monkeypatch
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "chmod {path} own.txt",
+            "chown {path} own.txt",
+            "chgrp {path} own.txt",
+            "truncate -s {path} own.txt",
+        ],
+    )
+    def test_write_create_leading_scalar_is_not_treated_as_a_path(
+        self, scoped_command_workspace, command_template, monkeypatch
+    ):
+        # chmod's mode, chown/chgrp's owner/group spec, and truncate's -s size
+        # are never paths, so an out-of-workspace-looking value does not
+        # cause a spurious rejection.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "chmod 755 {path}",
+            "chown owner {path}",
+            "chgrp staff {path}",
+            "truncate -s 100 {path}",
+        ],
+    )
+    def test_write_create_real_operand_outside_workspace_still_rejected(
+        self, scoped_command_workspace, command_template, monkeypatch
+    ):
+        # Skipping the leading scalar must not skip the real path operand.
+        workspace, _, sibling_file = scoped_command_workspace
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    def test_chmod_reference_file_is_read_checked(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"chmod --reference={shlex.quote(str(sibling_file))} own.txt"
+            )
+
+        assert exc_info.value.access == "read"
+
+    def test_chmod_reference_file_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "mode.ref").write_text("", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("chmod --reference=mode.ref own.txt")
+
+
+class TestCopyInstallMoveLinkDestructive:
+    """Dedicated handlers for cp/install/mv/ln/unlink/shred.
+
+    Each owns a slot a flat write classification cannot express: `cp`/
+    `install`'s source-vs-destination split (and `-t/--target-directory`),
+    `ln`'s every-operand-write-sensitivity (I4), and `shred`'s scalar/read
+    options.
+    """
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cp own.txt {path}",
+            "install own.txt {path}",
+            "mv own.txt {path}",
+            "ln own.txt {path}",
+            "unlink {path}",
+            "shred {path}",
+        ],
+    )
+    def test_copy_move_link_family_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cp own.txt dest.txt",
+            "install own.txt dest.txt",
+            "mv own.txt dest.txt",
+            "ln own.txt dest.txt",
+            "unlink own.txt",
+            "shred own.txt",
+        ],
+    )
+    def test_copy_move_link_family_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_copy_source_outside_workspace_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"cp {shlex.quote(str(sibling_file))} dest.txt")
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cp own.txt -t {path}",
+            "install own.txt -t {path}",
+        ],
+    )
+    def test_target_directory_option_outside_workspace_is_rejected(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                command_template.format(path=shlex.quote(str(sibling_file.parent)))
+            )
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cp own.txt -t out",
+            "install own.txt -t out",
+        ],
+    )
+    def test_target_directory_option_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "out").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_install_directory_mode_marks_every_operand_write(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"install -d {shlex.quote(str(sibling_file.parent / 'x'))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_ln_source_inside_workspace_aliasing_external_read_only_dir_is_rejected(
+        self, scoped_command_workspace
+    ):
+        # I4: a hard link inside the workspace aliases the external source
+        # inode, so the source is write-checked, not merely read-checked;
+        # the external directory is only approved for read.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"ln {shlex.quote(str(external_file))} alias.txt")
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cp -rL . copied",
+            "cp --recursive --dereference . copied",
+            "cp -rH . copied",
+        ],
+    )
+    def test_copy_recursive_symlink_dereference_is_rejected(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="symbolic links"):
+            guard.validate(command)
+
+    def test_shred_scalar_options_are_not_treated_as_paths(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"shred -n {shlex.quote(str(sibling_file))} -s10 own.txt")
+
+    def test_shred_random_source_is_read_checked(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"shred --random-source={shlex.quote(str(sibling_file))} own.txt"
+            )
+
+        assert exc_info.value.access == "read"
+
+
 class TestPathClassificationSubstrate:
     """Unit tests for the shared option-classification substrate itself.
 
@@ -2509,8 +2817,8 @@ class TestPathClassificationSubstrate:
                 )
 
 
-class TestS1CommandCoverage:
-    """Mutation-sensitive coverage gate for every command classified in S1.
+class TestCommandCoverage:
+    """Mutation-sensitive coverage gate for every classified command (S1+S2).
 
     Reflects over the guard's live classification sets so a command dropped
     from dispatch, from the shadow-script set, or left without a test is
@@ -2532,8 +2840,34 @@ class TestS1CommandCoverage:
             "cut",
         }
     )
-    _DEDICATED_HANDLER_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"})
-    _S1_COMMANDS = _READ_FAMILY_COMMANDS | _DEDICATED_HANDLER_COMMANDS
+    # Flat write/create family: every operand is a plain workspace write, with
+    # at most an option-keyed scalar value skipped (`_COMMAND_VALUE_OPTIONS`)
+    # or, for chmod/chown/chgrp, a leading non-path positional.
+    _WRITE_CREATE_FAMILY_COMMANDS = frozenset(
+        {"chmod", "chown", "chgrp", "rmdir", "tee", "touch", "truncate"}
+    )
+    # Dedicated handlers: each owns a slot (write/read split, target-directory,
+    # every-operand-write-sensitivity, ...) a flat classification cannot
+    # express. Maps command name to the guard method that classifies it; a
+    # method may serve more than one command name (`mv`/`ln`, `unlink`/`shred`).
+    _DEDICATED_HANDLER_METHODS: dict[str, str] = {
+        "sort": "_check_sort",
+        "uniq": "_check_uniq",
+        "diff": "_check_diff",
+        "grep": "_check_grep",
+        "cp": "_check_copy",
+        "install": "_check_install",
+        "mv": "_check_move_or_link",
+        "ln": "_check_move_or_link",
+        "unlink": "_check_destructive_file_command",
+        "shred": "_check_destructive_file_command",
+    }
+    _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
+    _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
+    _S2_COMMANDS = _WRITE_CREATE_FAMILY_COMMANDS | frozenset(
+        {"cp", "install", "mv", "ln", "unlink", "shred"}
+    )
+    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS
 
     # Each entry: (positive command, negative command template with `{outside}`).
     _REGISTRY: dict[str, tuple[str, str]] = {
@@ -2552,45 +2886,64 @@ class TestS1CommandCoverage:
         "uniq": ("uniq own.txt", "uniq {outside}"),
         "diff": ("diff own.txt own.txt", "diff own.txt {outside}"),
         "grep": ("grep pattern own.txt", "grep pattern {outside}"),
+        "chmod": ("chmod 755 own.txt", "chmod 755 {outside}"),
+        "chown": ("chown owner own.txt", "chown owner {outside}"),
+        "chgrp": ("chgrp staff own.txt", "chgrp staff {outside}"),
+        "rmdir": ("rmdir own_dir", "rmdir {outside}"),
+        "tee": ("tee own.txt", "tee {outside}"),
+        "touch": ("touch own.txt", "touch {outside}"),
+        "truncate": ("truncate -s 1 own.txt", "truncate -s 1 {outside}"),
+        "cp": ("cp own.txt dest.txt", "cp own.txt {outside}"),
+        "install": ("install own.txt dest.txt", "install own.txt {outside}"),
+        "mv": ("mv own.txt dest.txt", "mv own.txt {outside}"),
+        "ln": ("ln own.txt dest.txt", "ln own.txt {outside}"),
+        "unlink": ("unlink own.txt", "unlink {outside}"),
+        "shred": ("shred own.txt", "shred {outside}"),
     }
 
-    def test_registry_covers_every_s1_command(self):
-        assert set(self._REGISTRY) == self._S1_COMMANDS
+    def test_registry_covers_every_classified_command(self):
+        assert set(self._REGISTRY) == self._ALL_COMMANDS
 
     def test_read_family_commands_are_classified_as_read(self):
         for command_name in self._READ_FAMILY_COMMANDS:
             assert command_name in command_path_guard_module._READ_COMMANDS
 
+    def test_write_create_family_commands_are_classified_as_write(self):
+        for command_name in self._WRITE_CREATE_FAMILY_COMMANDS:
+            assert command_name in command_path_guard_module._WRITE_COMMANDS
+
     def test_dedicated_handlers_are_not_flat_read_or_write(self):
-        for command_name in self._DEDICATED_HANDLER_COMMANDS:
+        for command_name, method_name in self._DEDICATED_HANDLER_METHODS.items():
             assert command_name not in command_path_guard_module._READ_COMMANDS
             assert command_name not in command_path_guard_module._WRITE_COMMANDS
-            assert hasattr(WorkspaceCommandPathGuard, f"_check_{command_name}")
+            assert hasattr(WorkspaceCommandPathGuard, method_name)
 
-    def test_every_s1_command_is_shadow_script_classified(self):
-        for command_name in self._S1_COMMANDS:
+    def test_every_command_is_shadow_script_classified(self):
+        for command_name in self._ALL_COMMANDS:
             assert (
                 command_name
                 in command_path_guard_module._CLASSIFIED_EXECUTABLE_COMMANDS
             )
 
-    @pytest.mark.parametrize("command_name", sorted(_S1_COMMANDS))
+    @pytest.mark.parametrize("command_name", sorted(_ALL_COMMANDS))
     def test_registry_positive_case_is_accepted(
-        self, scoped_command_workspace, command_name
+        self, scoped_command_workspace, command_name, monkeypatch
     ):
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
         guard = WorkspaceCommandPathGuard(workspace)
         positive_command, _ = self._REGISTRY[command_name]
 
         guard.validate(positive_command)
 
-    @pytest.mark.parametrize("command_name", sorted(_S1_COMMANDS))
+    @pytest.mark.parametrize("command_name", sorted(_ALL_COMMANDS))
     def test_registry_negative_case_is_rejected(
-        self, scoped_command_workspace, command_name
+        self, scoped_command_workspace, command_name, monkeypatch
     ):
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
         guard = WorkspaceCommandPathGuard(workspace)
         _, negative_template = self._REGISTRY[command_name]
 

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2840,6 +2840,77 @@ class TestWriteCreateFamily:
         with pytest.raises(CommandPolicyViolation):
             guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "chmod -R 644 own.txt",
+            "chmod -v 644 own.txt",
+            "chmod -c 644 own.txt",
+            "chmod -f 644 own.txt",
+            "chown -R owner own.txt",
+            "chown -H owner own.txt",
+            "chown -L owner own.txt",
+            "chown -P owner own.txt",
+            "chgrp -R staff own.txt",
+            "touch -a own.txt",
+            "touch -c own.txt",
+            "touch -m own.txt",
+        ],
+    )
+    def test_ownership_and_touch_common_short_flags_are_allowed(
+        self, scoped_command_workspace, command, monkeypatch
+    ):
+        # R11: the fail-closed short-option flip left `chmod`/`chown`/
+        # `chgrp`/`touch` with an empty (or narrower) `flag_short_options`,
+        # rejecting their own ordinary GNU flags.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "truncate -c -s 10 own.txt",
+            "truncate -o -s 10 own.txt",
+        ],
+    )
+    def test_truncate_common_short_flags_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_touch_date_option_value_is_not_treated_as_a_path(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        # `-t`/`-d`/`--date`'s value is a timestamp/date string, never a
+        # path, so an out-of-workspace-looking value does not cause a
+        # spurious rejection; the real operand is still write-checked.
+        guard.validate("touch -t 202601010000 own.txt")
+        guard.validate('touch -d "yesterday" own.txt')
+        guard.validate(f"touch -d {shlex.quote(str(sibling_file))} own.txt")
+
+    def test_touch_date_option_real_operand_still_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"touch -c {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
     def test_chmod_reference_file_is_read_checked(self, scoped_command_workspace):
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4393,6 +4393,65 @@ class TestSedAwkCommand:
 
         guard.validate(command)
 
+    def test_awk_program_containing_assignment_syntax_is_still_inspected(
+        self, scoped_command_workspace
+    ):
+        # The CLI `var=value` operand skip (`ignores_assignment_arguments`)
+        # must never apply to the PROGRAM token itself: dropping it here
+        # (because the program text happens to contain "=") would silently
+        # disable all program inspection, letting `system()` through
+        # unchecked.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("awk 'BEGIN{x=1; system(\"id\")}'")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "awk '{{x=1; print > \"{path}\"}}' own.txt",
+            "awk '{{x=1; getline l < \"{path}\"}}' own.txt",
+        ],
+    )
+    def test_awk_assignment_bearing_program_still_classifies_redirect_targets(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=str(sibling_file)))
+
+    def test_awk_positional_assignment_operand_after_program_is_not_a_path(
+        self, scoped_command_workspace
+    ):
+        # A real `var=value` CLI operand, positioned AFTER the program, is
+        # still a scalar assignment, not a file operand — the fix must not
+        # turn this into a spurious path check.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk '{print}' x=1 own.txt")
+
+    def test_awk_redirect_target_string_concatenation_fails_closed(
+        self, scoped_command_workspace
+    ):
+        # `print > "sub/" "../../8/x"` is awk string concatenation (bare
+        # juxtaposition); only resolving the first quoted literal and
+        # ignoring what follows would validate `"sub/"` while the actual
+        # runtime target escapes it. Anything after the closing quote other
+        # than a statement terminator must fail closed.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate('awk \'{print > "sub/" "../../8/x"}\' own.txt')
+
     @pytest.mark.parametrize(
         "command",
         [

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4432,6 +4432,47 @@ class TestSedAwkCommand:
 
         assert exc_info.value.access == "write"
 
+    @pytest.mark.parametrize(
+        "in_place_option",
+        ["-i.bak", "-i.orig", "--in-place=.bak", "--in-place=bak"],
+    )
+    def test_sed_in_place_backup_suffix_poisons_unknown_effect(
+        self, scoped_command_workspace, in_place_option
+    ):
+        # N3: `-i`/`--in-place` with a backup suffix derives a second write
+        # target (the backup file) whose exact name this guard never
+        # computes and never path-checks, unlike find/tar/gzip's other
+        # poisoning sites for a non-enumerable derived write. It must
+        # poison `unknown_effect` the same way, so a later, unrelated
+        # script inspection in the same chain fails closed instead of
+        # silently ignoring the untracked backup write.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "other_safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(
+                f"sed {in_place_option} 's/a/b/' own.txt; bash other_safe.sh"
+            )
+
+    def test_sed_in_place_without_backup_suffix_does_not_poison_unknown_effect(
+        self, scoped_command_workspace
+    ):
+        # The no-suffix form (`-i`/`--in-place` alone) only ever writes the
+        # operand itself, which is already write-checked per-path; it must
+        # not poison unrelated later script inspection.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "other_safe.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed -i 's/a/b/' own.txt; bash other_safe.sh")
+        guard.validate("sed --in-place 's/a/b/' own.txt; bash other_safe.sh")
+
     def test_sed_long_option_abbreviation_is_resolved(self, scoped_command_workspace):
         # GNU unambiguous-prefix abbreviation must resolve `--expr=` to
         # `--expression=` and still write-check its `w` file command, not

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2616,6 +2616,31 @@ class TestWriteCreateFamily:
         with pytest.raises(CommandPathViolation):
             guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
 
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "chmod -X{path} 644 f",
+            "chown -X{path} owner f",
+            "chgrp -X{path} staff f",
+            "touch -X{path} f",
+        ],
+    )
+    def test_ownership_and_touch_reject_unrecognized_short_option(
+        self, scoped_command_workspace, command_template, monkeypatch
+    ):
+        # D1: an unrecognized short option must fail closed instead of being
+        # silently skipped — `_partition_path_options` used to skip any
+        # short option it didn't model by exact match, so a path embedded in
+        # an unmodeled option's own token (e.g. `-X<path>`) went completely
+        # unchecked. `f` itself need not exist for this: the invocation must
+        # never get far enough to check it.
+        workspace, _, sibling_file = scoped_command_workspace
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
     def test_chmod_reference_file_is_read_checked(self, scoped_command_workspace):
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2081,6 +2081,84 @@ class TestReadCommandFamily:
 
         guard.validate(command)
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "wc -l own.txt",
+            "wc -c own.txt",
+            "wc -w own.txt",
+            "wc -m own.txt",
+            "wc -L own.txt",
+            "file -b own.txt",
+            "file -i own.txt",
+            "file -h own.txt",
+            "file -L own.txt",
+            "file -s own.txt",
+            "file -z own.txt",
+            "file -k own.txt",
+            "file -n own.txt",
+            "file -p own.txt",
+            "file -r own.txt",
+            "file -v own.txt",
+            "file -0 own.txt",
+        ],
+    )
+    def test_file_and_wc_common_flags_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        # R11: the fail-closed short-option flip left `file`/`wc` with an
+        # empty `flag_short_options`, rejecting their own ordinary GNU flags.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_file_rejects_unrecognized_short_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("file -@ own.txt")
+
+    def test_wc_rejects_unrecognized_short_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("wc -@ own.txt")
+
+    @pytest.mark.parametrize("command_name", ["file", "wc"])
+    def test_file_and_wc_post_terminator_operand_is_still_read_checked(
+        self, scoped_command_workspace, command_name
+    ):
+        # R1: `_partition_path_options` consumes `--` and returns a plain
+        # operand list; routing that list back through `_check_operands`/
+        # `_operands` re-applied `_operands`'s own `-`-prefix filter with no
+        # memory of the `--` it already passed, silently dropping (and never
+        # read-checking) a post-`--` operand that happens to start with `-`.
+        workspace, _, sibling_file = scoped_command_workspace
+        cwd = workspace.resolve_path("")
+        relative_escape = os.path.relpath(str(sibling_file), start=str(cwd))
+        disguised = f"-x/{relative_escape}"
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"{command_name} -- {shlex.quote(disguised)}")
+
+        assert exc_info.value.access == "read"
+
+    def test_file_post_terminator_workspace_operand_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "-x").write_text("dashed name", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("file -- -x")
+
 
 class TestSortUniqDiffGrepHandlers:
     """Dedicated handlers for commands that own a write or read-control slot.

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4539,9 +4539,15 @@ class TestSedAwkCommand:
         [
             "awk '\"cmd\" | getline' own.txt",
             "awk '{print | \"cmd\"}' own.txt",
+            "awk '\"cmd\" |& getline' own.txt",
+            "awk 'BEGIN{ \"cat /etc/passwd\" |& getline l }' own.txt",
         ],
     )
     def test_awk_pipe_io_fails_closed(self, scoped_command_workspace, command):
+        # M5: a two-way coprocess pipe (`|&`) reads from and writes to an
+        # arbitrary shell command exactly like a plain `|` pipe and must
+        # fail closed the same way, not be silently missed because the
+        # detection only recognized a prefix ending in a bare `|`.
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
         guard = WorkspaceCommandPathGuard(workspace)

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4886,10 +4886,6 @@ class TestDdBase64GzipRemoteTransferCommand:
     @pytest.mark.parametrize(
         "command_template",
         [
-            "base64 -i{path}",
-            "base64 --input {path}",
-            "base64 --input={path}",
-            "base64 -di{path}",
             "base64 -o{path}",
             "base64 --output {path}",
             "base64 --output={path}",
@@ -4903,6 +4899,32 @@ class TestDdBase64GzipRemoteTransferCommand:
         guard = WorkspaceCommandPathGuard(workspace)
 
         with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "base64 -i{path}",
+            "base64 --input {path}",
+            "base64 --input={path}",
+            "base64 -di{path}",
+        ],
+    )
+    def test_base64_ignore_garbage_is_boolean_not_a_path_option(
+        self, scoped_command_workspace, command_template
+    ):
+        # `-i`/`--ignore-garbage` is a boolean flag (GNU coreutils), not a
+        # value-taking `--input` option: this family no longer models a
+        # "-i"-consumes-a-path grammar at all, so a value attempted against
+        # it (attached, or `--input`, which base64 does not actually have)
+        # fails closed as an unrecognized option rather than being
+        # write/read-classified — still a REJECT, just not a path-specific
+        # one, since `-i` never carries a path to classify in the first
+        # place.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
             guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
 
     def test_base64_workspace_input_and_output_are_allowed(

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2593,6 +2593,26 @@ class TestWriteCreateFamily:
 
         guard.validate("chmod --reference=mode.ref own.txt")
 
+    def test_chmod_reference_abbreviation_still_write_checks_the_target(
+        self, scoped_command_workspace
+    ):
+        # `--ref=` is the same option as `--reference=` via GNU unambiguous-
+        # prefix abbreviation. The presence check deciding whether the
+        # leading operand is the (excluded) MODE positional must use the
+        # SAME resolved option set `_partition_path_options` itself uses,
+        # not a second raw-string pass: otherwise an abbreviated
+        # `--reference` looks absent, the real target gets misread as MODE
+        # and stripped from the operand list, and the write check on it is
+        # silently skipped entirely.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "mode.ref").write_text("", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"chmod --ref=mode.ref {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
     @pytest.mark.parametrize(
         "command_template",
         ["touch --reference={path} own.txt", "touch -r {path} own.txt"],

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2865,6 +2865,12 @@ class TestCommandCoverage:
         "tar": "_check_tar",
         "sed": "_check_script_command",
         "awk": "_check_script_command",
+        "dd": "_check_dd",
+        "base64": "_check_base64",
+        "gzip": "_check_gzip",
+        "rsync": "_check_rsync",
+        "curl": "_check_curl",
+        "wget": "_check_wget",
     }
     _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
     _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
@@ -2874,8 +2880,14 @@ class TestCommandCoverage:
     _S3_COMMANDS = frozenset({"find"})
     _S4_COMMANDS = frozenset({"tar"})
     _S5_COMMANDS = frozenset({"sed", "awk"})
+    _S6_COMMANDS = frozenset({"dd", "base64", "gzip", "rsync", "curl", "wget"})
     _ALL_COMMANDS = (
-        _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS | _S4_COMMANDS | _S5_COMMANDS
+        _S1_COMMANDS
+        | _S2_COMMANDS
+        | _S3_COMMANDS
+        | _S4_COMMANDS
+        | _S5_COMMANDS
+        | _S6_COMMANDS
     )
 
     # Each entry: (positive command, negative command template with `{outside}`).
@@ -2914,6 +2926,21 @@ class TestCommandCoverage:
         "awk": (
             "awk '{print $0}' own.txt",
             "awk '{{print $0 > \"{outside}\"}}' own.txt",
+        ),
+        "dd": ("dd if=own.txt of=dest.bin", "dd if=own.txt of={outside}"),
+        "base64": (
+            "base64 -i own.txt -o own.b64",
+            "base64 -i own.txt -o {outside}",
+        ),
+        "gzip": ("gzip own.txt", "gzip {outside}"),
+        "rsync": ("rsync own.txt dest.txt", "rsync own.txt {outside}"),
+        "curl": (
+            "curl -o out.bin https://example.invalid/file",
+            "curl -o {outside} https://example.invalid/file",
+        ),
+        "wget": (
+            "wget -O out.bin https://example.invalid/file",
+            "wget -O {outside} https://example.invalid/file",
         ),
     }
 
@@ -4039,3 +4066,302 @@ class TestSedAwkCommand:
                 guard._inspect_script_file(
                     "sed", str(script_path), workspace.output_dir
                 )
+
+
+class TestDdBase64GzipRemoteTransferCommand:
+    """`dd`/`base64`/`gzip` and the remote-transfer family (`rsync`/`curl`/
+    `wget`): the final family stage of the file-command policy layer.
+
+    `gzip`'s default mode is the family's M2-additive case (a real write
+    check on the operand plus `unknown_effect` for the non-enumerable
+    derived `.gz`); `rsync` is the family's all-or-nothing remote case
+    (M5: any remote operand rejects the whole invocation, not just the
+    remote side); `curl`/`wget` fail closed on their own uninspectable
+    option grammar, independent of `_is_remote_transfer_operand`.
+    """
+
+    # -- dd --------------------------------------------------------------
+
+    def test_dd_write_operand_outside_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"dd if=own.txt of={shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_dd_read_operand_outside_workspace_rejected(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"dd if={shlex.quote(str(sibling_file))} of=own.txt")
+
+        assert exc_info.value.access == "read"
+
+    def test_dd_non_path_assignments_are_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("dd if=own.txt of=own2.txt bs=512 count=1")
+
+    def test_dd_flag_assignments_are_not_paths(self, scoped_command_workspace):
+        # `iflag=`/`oflag=` share the `if=`/`of=` prefix character but are
+        # not path-bearing; a substring match instead of an exact prefix
+        # match would misclassify them.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("dd iflag=fullblock oflag=sync")
+
+    def test_dd_argv_uses_same_path_policy(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate_argv(["dd", f"if={sibling_file}", "of=copy.bin"])
+
+    # -- base64 ------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "base64 -i{path}",
+            "base64 --input {path}",
+            "base64 --input={path}",
+            "base64 -di{path}",
+            "base64 -o{path}",
+            "base64 --output {path}",
+            "base64 --output={path}",
+            "base64 -do{path}",
+        ],
+    )
+    def test_rejects_base64_path_option_variants(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    def test_base64_workspace_input_and_output_are_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("base64 -i own.txt -o own.b64")
+
+    def test_base64_argv_uses_same_path_policy(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation):
+            guard.validate_argv(["base64", "-i", str(sibling_file)])
+
+    # -- gzip ----------------------------------------------------------------
+
+    def test_gzip_default_mode_write_checks_the_operand(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"gzip {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_gzip_stdout_mode_keeps_external_operand_read_only(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"gzip -c {shlex.quote(str(external_file))}")
+        guard.validate(f"gzip -lt {shlex.quote(str(external_file))}")
+
+    def test_gzip_default_mode_poisons_later_script_inspection(
+        self, scoped_command_workspace
+    ):
+        # The `.gz` gzip actually creates is a distinct, non-enumerable path
+        # this guard never computes; the operand's own write check cannot
+        # capture that derived file, so `unknown_effect` (M2 additive) must
+        # poison later script inspection in the same chain.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("gzip own.txt ; bash own.txt.gz")
+
+    # -- rsync -----------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rsync own.txt host:/remote",
+            "rsync own.txt user@host:/remote",
+            "rsync own.txt rsync://host/remote",
+        ],
+    )
+    def test_rsync_remote_operand_rejects_the_whole_invocation(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_rsync_local_destination_outside_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"rsync own.txt {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_rsync_link_dest_requires_write_authorization(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync -a --link-dest={shlex.quote(str(external_file.parent))} "
+                "source copied"
+            )
+
+        assert exc_info.value.access == "write"
+
+    # -- curl/wget/rsync shared uninspectable-option pins -----------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl -O https://example.invalid/file",
+            "wget --config config",
+            "rsync host:/secret copied",
+            "rsync --files-from=list.txt source copied",
+        ],
+    )
+    def test_rejects_uninspectable_new_tool_path_sources(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_wget_config_option_fails_closed_regardless_of_path(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"wget --config {shlex.quote(str(sibling_file))}")
+
+    # -- curl ----------------------------------------------------------------
+
+    def test_curl_output_outside_workspace_rejected(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"curl -o {outside} https://example.invalid/file")
+
+        assert exc_info.value.access == "write"
+
+    # -- wget ------------------------------------------------------------
+
+    def test_wget_output_outside_workspace_rejected(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"wget -O {outside} https://example.invalid/file")
+
+        assert exc_info.value.access == "write"
+
+    # -- bypass-pin allow-list (ported from the abandoned command-families
+    # branch, re-expressed on the current effect model; the `environment=`
+    # kwarg variants from that branch are not ported — see m2/S6 deviation
+    # notes) ----------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gzip -c own.txt",
+            "rsync -av own.txt copied.txt",
+            "curl -oout.txt https://example.invalid/file",
+            "wget -Oout.txt https://example.invalid/file",
+        ],
+    )
+    def test_allows_newly_classified_tool_workspace_paths(
+        self,
+        scoped_command_workspace,
+        command,
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "gzip {path}",
+            "rsync own.txt {path}",
+            "curl -o {path} https://example.invalid/file",
+            "wget -O {path} https://example.invalid/file",
+        ],
+    )
+    def test_rejects_newly_classified_tool_writes_to_sibling(
+        self,
+        scoped_command_workspace,
+        command_template,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_rejects_newly_classified_tool_reads_from_sibling(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"rsync {shlex.quote(str(sibling_file))} copied.txt")
+
+        assert exc_info.value.access == "read"

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2863,6 +2863,8 @@ class TestCommandCoverage:
         "shred": "_check_destructive_file_command",
         "find": "_check_find",
         "tar": "_check_tar",
+        "sed": "_check_script_command",
+        "awk": "_check_script_command",
     }
     _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
     _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
@@ -2871,7 +2873,10 @@ class TestCommandCoverage:
     )
     _S3_COMMANDS = frozenset({"find"})
     _S4_COMMANDS = frozenset({"tar"})
-    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS | _S4_COMMANDS
+    _S5_COMMANDS = frozenset({"sed", "awk"})
+    _ALL_COMMANDS = (
+        _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS | _S4_COMMANDS | _S5_COMMANDS
+    )
 
     # Each entry: (positive command, negative command template with `{outside}`).
     _REGISTRY: dict[str, tuple[str, str]] = {
@@ -2905,6 +2910,11 @@ class TestCommandCoverage:
         "shred": ("shred own.txt", "shred {outside}"),
         "find": ("find own.txt -print", "find {outside}"),
         "tar": ("tar -cf archive.tar own.txt", "tar -cf archive.tar {outside}"),
+        "sed": ("sed 's/a/b/' own.txt", "sed 'w {outside}' own.txt"),
+        "awk": (
+            "awk '{print $0}' own.txt",
+            "awk '{{print $0 > \"{outside}\"}}' own.txt",
+        ),
     }
 
     def test_registry_covers_every_classified_command(self):
@@ -3628,3 +3638,404 @@ class TestTarCommand:
 
         with pytest.raises(CommandPathViolation):
             guard.validate_argv(["tar", "-tf", str(sibling_file)])
+
+
+class TestSedAwkCommand:
+    """`sed`/`awk`: command-slot lexer over the embedded program (I8/I9).
+
+    sed's `r`/`R`/`w`/`W`/`s///w` file commands and awk's `print`/`printf`
+    redirection and `getline` are path-checked through the same containment
+    every other family uses; `e`/`s///e` and any awk pipe I/O execute an
+    arbitrary shell command and always fail closed. `-f`/`--file` script
+    reads route through `_read_policy_script` (M4), the same unknown_effect
+    gate, non-regular-file rejection, and bounded read every other script
+    read uses.
+    """
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "sed 'r {path}' own.txt",
+            "sed 'R {path}' own.txt",
+            "sed '/own/r {path}' own.txt",
+        ],
+    )
+    def test_sed_read_commands_target_out_of_workspace_rejected(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "sed 'w {path}' own.txt",
+            "sed 'W {path}' own.txt",
+            "sed 's/a/b/w {path}' own.txt",
+        ],
+    )
+    def test_sed_write_commands_target_out_of_workspace_rejected(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_sed_write_commands_inside_workspace_are_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed 'w own_out.txt' own.txt")
+        guard.validate("sed 's/a/b/w own_out.txt' own.txt")
+
+    def test_sed_braces_in_pattern_are_data(self, scoped_command_workspace):
+        # `{`/`}`/`/` inside a delimited pattern or replacement are DATA, not
+        # block/command structure; a benign program using them must be
+        # allowed, not misparsed as an unterminated or unsafe command.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(r"sed 's/a\/b{}/x/' own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sed 'e cmd' own.txt",
+            "sed '1e' own.txt",
+        ],
+    )
+    def test_sed_execute_command_fails_closed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_sed_substitution_execute_flag_fails_closed(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"sed 's#.*#cat {outside}#e' own.txt")
+
+    def test_sed_script_file_read_out_of_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(f"{sibling_file}.sed")
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"sed -f {outside} own.txt")
+
+        assert exc_info.value.access == "read"
+
+    def test_sed_script_file_inside_workspace_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "safe.sed").write_text(
+            "s/own/safe/\n", encoding="utf-8"
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed -f safe.sed own.txt")
+
+    @pytest.mark.parametrize("command_name", ["sed", "awk"])
+    def test_unknown_effect_poisons_script_file_inspection(
+        self, scoped_command_workspace, command_name
+    ):
+        # M4: `-f`/`--file` script reads route through the same shared
+        # `_read_policy_script` every other family uses, so an unclassified
+        # command earlier in the same chain (poisoning `unknown_effect`)
+        # blocks the later script read exactly like it would for `bash`.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "prog").write_text(
+            "s/own/safe/\n" if command_name == "sed" else "{ print $0 }\n",
+            encoding="utf-8",
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(f"python -c pass; {command_name} -f prog own.txt")
+
+    def test_sed_in_place_switches_file_operand_to_write(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed -i 's/a/b/' own.txt")
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"sed -i 's/a/b/' {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "awk '{{print $0 > \"{path}\"}}' own.txt",
+            'awk \'{{printf "%s", $0 > "{path}"}}\' own.txt',
+            "awk '{{print $0 >> \"{path}\"}}' own.txt",
+        ],
+    )
+    def test_awk_print_redirect_out_of_workspace_rejected(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=str(sibling_file)))
+
+        assert exc_info.value.access == "write"
+
+    def test_awk_print_redirect_inside_workspace_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk '{print $0 > \"own_out.txt\"}' own.txt")
+
+    def test_awk_system_call_fails_closed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("awk '{system(\"rm x\")}' own.txt")
+
+    def test_awk_getline_redirect_out_of_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"awk '{{getline < \"{sibling_file}\"}}' own.txt")
+
+        assert exc_info.value.access == "read"
+
+    def test_awk_getline_inside_workspace_is_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "feed.txt").write_text("data\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk '{getline < \"feed.txt\"}' own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "awk '\"cmd\" | getline' own.txt",
+            "awk '{print | \"cmd\"}' own.txt",
+        ],
+    )
+    def test_awk_pipe_io_fails_closed(self, scoped_command_workspace, command):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_awk_comparison_operator_is_not_misread_as_redirect(
+        self, scoped_command_workspace
+    ):
+        # `print (2 > 1)`: the `>` is a comparison inside parens, not a
+        # redirect, so paren-depth tracking must keep this from being
+        # misread as file I/O.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk 'BEGIN { print (2 > 1) }'")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "awk '{print > $1}' own.txt",
+            "awk -v target=out.txt '{print $0 > target}' own.txt",
+            "awk -v target=out.txt '{print $0 > (target)}' own.txt",
+        ],
+    )
+    def test_awk_dynamic_redirect_target_rejected(
+        self, scoped_command_workspace, command
+    ):
+        # A redirect target is only statically resolvable as a double-quoted
+        # string literal; a field reference (`$1`), a bareword variable, or
+        # a parenthesized expression is dynamic from the lexer's point of
+        # view and must fail closed rather than being silently skipped.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_awk_script_file_inside_workspace_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "safe.awk").write_text(
+            "{ print $0 }\n", encoding="utf-8"
+        )
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk -f safe.awk own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'PROGRAM=\'BEGIN { system("cat own.txt") }\' awk "$PROGRAM"',
+            "PROGRAM='e cat own.txt' sed -e \"$PROGRAM\" own.txt",
+        ],
+    )
+    def test_rejects_dynamic_sed_and_awk_programs(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    @pytest.mark.parametrize(
+        ("script_name", "script_template", "invocation"),
+        [
+            ("dynamic.sed", "w {path}", "sed -f dynamic.sed own.txt"),
+            (
+                "dynamic.awk",
+                '{{print $0 > "{path}"}}',
+                "awk -f dynamic.awk own.txt",
+            ),
+        ],
+    )
+    def test_rejects_scripts_created_earlier_in_the_same_chain(
+        self,
+        scoped_command_workspace,
+        script_name,
+        script_template,
+        invocation,
+    ):
+        # A script written earlier in the same command chain registers a
+        # write on its own path; M4's shared `_read_policy_script` then
+        # refuses to inspect it, exactly like `bash`'s own script reads.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        script = script_template.format(path=sibling_file)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(
+                f"printf '%s\\n' {shlex.quote(script)} > {script_name} && {invocation}"
+            )
+
+    @pytest.mark.parametrize(
+        ("script_name", "safe_script", "unsafe_script", "invocation"),
+        [
+            (
+                "replace.sed",
+                "s/own/own/",
+                "w {path}",
+                "sed -f replace.sed own.txt",
+            ),
+            (
+                "replace.awk",
+                "{ print $0 }",
+                '{{print $0 > "{path}"}}',
+                "awk -f replace.awk own.txt",
+            ),
+        ],
+    )
+    def test_rejects_script_overwritten_before_inspection(
+        self,
+        scoped_command_workspace,
+        script_name,
+        safe_script,
+        unsafe_script,
+        invocation,
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        script_path = workspace.output_dir / script_name
+        script_path.write_text(safe_script, encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        replacement = unsafe_script.format(path=sibling_file)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate(
+                f"printf '%s\\n' {shlex.quote(replacement)} > {script_name} "
+                f"&& {invocation}"
+            )
+
+        assert script_path.read_text(encoding="utf-8") == safe_script
+
+    def test_script_write_tracking_is_scoped_to_one_validation(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "safe.sed").write_text("s/own/safe/", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("printf replacement > safe.sed")
+        guard.validate("sed -f safe.sed own.txt")
+
+    def test_script_inspection_rejects_oversized_regular_file(
+        self, scoped_command_workspace
+    ):
+        # M4: routes through the shared `_read_policy_script`, whose byte
+        # budget (`_MAX_INSPECTED_SCRIPT_BYTES`) and `CommandPolicyViolation`
+        # (not `CommandPathViolation`, reserved for non-regular files) this
+        # test confirms sed/awk inherit rather than reimplement.
+        workspace, _, _ = scoped_command_workspace
+        limit = command_path_guard_module._MAX_INSPECTED_SCRIPT_BYTES
+        script_path = workspace.output_dir / "large.sed"
+        script_path.write_bytes(b"#" * (limit + 1))
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with command_path_guard_module._validation_session_scope():
+            with pytest.raises(
+                CommandPolicyViolation,
+                match=rf"shell policy script exceeds the {limit}-byte inspection limit",
+            ):
+                guard._inspect_script_file(
+                    "sed", str(script_path), workspace.output_dir
+                )

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5126,6 +5126,39 @@ class TestSedAwkCommand:
 
         guard.validate("awk '{getline < \"feed.txt\"}' own.txt")
 
+    def test_awk_parenthesized_getline_read_loop_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # R13: `while ((getline line < "file") > 0)` is the idiomatic awk
+        # file-read loop; the redirect-target trailing-terminator set
+        # previously recognized only `;`, `\n`, `}` after the closing quote,
+        # so the `)` closing the parenthesized `getline` expression fell
+        # through as an unresolvable concatenated remainder and was
+        # rejected outright.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "feed.txt").write_text("data\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            "awk 'BEGIN{while ((getline line < \"feed.txt\") > 0) print line}' own.txt"
+        )
+
+    def test_awk_parenthesized_getline_read_loop_out_of_workspace_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                "awk 'BEGIN{while ((getline line < "
+                f'"{sibling_file}") > 0) print line}}\' own.txt'
+            )
+
+        assert exc_info.value.access == "read"
+
     @pytest.mark.parametrize(
         "command_template",
         [

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4962,12 +4962,81 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         assert exc_info.value.access == "write"
 
-    def test_rsync_log_file_option_still_rejects_out_of_workspace(
+    def test_rsync_backup_dir_requires_write_authorization(
+        self,
+        scoped_command_workspace,
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync -a --backup-dir={shlex.quote(str(external_file.parent))} "
+                "source copied"
+            )
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize("option_spelling", ["--link-des", "--link-dest"])
+    def test_rsync_link_dest_space_separated_form_requires_write_authorization(
+        self, scoped_command_workspace, option_spelling
+    ):
+        # `--link-dest` may hard-link unchanged files straight into the
+        # destination, so a read-only external root (read-allowed, not
+        # write-allowed) is not sufficient authorization for it. Both the
+        # GNU unambiguous-prefix abbreviation and the full spelling must
+        # resolve through `_resolve_long_option` and write-check the
+        # space-separated argument instead of leaking it into the generic
+        # read/write operand list.
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync -a {option_spelling} {shlex.quote(str(external_file))} "
+                "own.txt d"
+            )
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize("option_spelling", ["--backup-di", "--backup-dir"])
+    def test_rsync_backup_dir_space_separated_form_requires_write_authorization(
+        self, scoped_command_workspace, option_spelling
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync -a {option_spelling} {shlex.quote(str(external_file))} "
+                "own.txt d"
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_rsync_benign_local_invocation_is_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "src.txt").write_text("src\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("rsync -a src.txt dst.txt")
+
+    def test_rsync_remote_source_still_rejects_the_whole_invocation(
         self, scoped_command_workspace
     ):
-        # Pin: `rsync --log-file <out> ...` already rejects today (the
-        # unconsumed value becomes an extra read-checked source operand);
-        # this must stay a rejection, not be "fixed" into an ALLOW.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("rsync src host:/x")
+
+    def test_rsync_log_file_option_is_write_checked(self, scoped_command_workspace):
+        # `--log-file` is a modeled write-owning option: its argument must
+        # be write-checked directly, not leaked into the generic
+        # read/write operand list (the prior, coincidental behavior this
+        # test used to pin).
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
         guard = WorkspaceCommandPathGuard(workspace)
@@ -4977,7 +5046,7 @@ class TestDdBase64GzipRemoteTransferCommand:
                 f"rsync --log-file {shlex.quote(str(sibling_file))} own.txt dest.txt"
             )
 
-        assert exc_info.value.access == "read"
+        assert exc_info.value.access == "write"
 
     # -- curl/wget/rsync shared uninspectable-option pins -----------------
 
@@ -4988,6 +5057,7 @@ class TestDdBase64GzipRemoteTransferCommand:
             "wget --config config",
             "rsync host:/secret copied",
             "rsync --files-from=list.txt source copied",
+            "rsync --files-fr list.txt source copied",
         ],
     )
     def test_rejects_uninspectable_new_tool_path_sources(
@@ -5383,23 +5453,38 @@ class TestDdBase64GzipRemoteTransferCommand:
 
 
 class TestBundledAndAbbreviatedPathOptionCoverage:
-    """Recurrence guard for the two bug classes this module's hand-rolled
-    option parsers kept reintroducing: a value-taking option not recognized
-    when bundled behind another short flag (tar's `xfC`, curl's `-sD`,
-    wget's `-qO`, cp/mv/ln's `-rt`), and a GNU-abbreviated long option not
-    resolved to the option it stands for (grep's `--fil=`, cp/mv/ln's
-    `--targ=`, curl's `--dump-hea=`, wget's `--output-docu=`).
+    """Recurrence guard for the bug classes this module's hand-rolled option
+    parsers kept reintroducing: a value-taking option not recognized when
+    bundled behind another short flag (tar's `xfC`, curl's `-sD`, wget's
+    `-qO`, cp/mv/ln's `-rt`), and a GNU-abbreviated long option not resolved
+    to the option it stands for — in EITHER the `=`-attached form (grep's
+    `--fil=`, cp/mv/ln's `--targ=`, curl's `--dump-hea=`, wget's
+    `--output-docu=`) or the space-separated form (rsync's `--link-des
+    <path>`, which is what let the abbreviated-`--link-dest`/`--backup-dir`
+    hole through: the `=`-form was covered here, but the space-separated
+    form was not, so `_check_rsync` fell back to its unmodeled-flag path
+    and swept the value into the generic read/write operand list instead
+    of write-checking it).
 
-    Each row names one path-bearing option a command owns and drives BOTH
-    a bundled-short-cluster form and a GNU-abbreviated long-option form of
-    it against an out-of-workspace path. A command added later that owns a
-    path-bearing option without an entry here has no guarantee either bug
-    class was ever checked for it — that gap is the point of this table,
-    not an oversight to silently fill in.
+    Each row names one path-bearing option a command owns and drives a
+    bundled-short-cluster form (when the option has one; `None` skips it)
+    plus BOTH the `--abbr=value` and `--abbr value` spellings of its
+    GNU-abbreviated long-option form, against an out-of-workspace path.
+    `expected_access` of `None` marks an option this guard denies
+    unconditionally (rsync's `--files-from`, which delegates to an external
+    file list this guard cannot inspect) rather than access-classifies: both
+    spellings must still raise, just without a specific access to assert.
+    A command added later that owns a path-bearing option without an entry
+    here has no guarantee any of these bug classes was ever checked for it
+    — that gap is the point of this table, not an oversight to silently
+    fill in.
     """
 
-    # (label, bundled-short-form template, GNU-abbreviated-long-form template)
-    _BUNDLED_AND_ABBREVIATED_PATH_OPTIONS: list[tuple[str, str, str, str]] = [
+    # (label, bundled-short-form template or None, GNU-abbreviated-long-form
+    # `=`-attached template, expected access or None for unconditional deny)
+    _BUNDLED_AND_ABBREVIATED_PATH_OPTIONS: list[
+        tuple[str, str | None, str, str | None]
+    ] = [
         ("sort -o", "sort -ro{path} own.txt", "sort --out={path} own.txt", "write"),
         ("sort -T", "sort -rT{path} own.txt", "sort --temp={path} own.txt", "write"),
         ("grep -f", "grep -vf {path} own.txt", "grep --fil={path} own.txt", "read"),
@@ -5436,6 +5521,24 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
             "wget -O keep --output-fi={path} https://example.invalid/file",
             "write",
         ),
+        (
+            "rsync --link-dest",
+            None,
+            "rsync -a --link-des={path} own.txt d",
+            "write",
+        ),
+        (
+            "rsync --backup-dir",
+            None,
+            "rsync -a --backup-di={path} own.txt d",
+            "write",
+        ),
+        (
+            "rsync --files-from",
+            None,
+            "rsync -a --files-fr={path} own.txt d",
+            None,
+        ),
     ]
 
     @pytest.mark.parametrize(
@@ -5457,10 +5560,27 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
         guard = WorkspaceCommandPathGuard(workspace)
         outside = shlex.quote(str(sibling_file))
 
-        with pytest.raises(CommandPathViolation) as bundled_exc:
-            guard.validate(bundled_template.format(path=outside))
-        assert bundled_exc.value.access == expected_access
+        if bundled_template is not None:
+            with pytest.raises(CommandPathViolation) as bundled_exc:
+                guard.validate(bundled_template.format(path=outside))
+            assert bundled_exc.value.access == expected_access
 
-        with pytest.raises(CommandPathViolation) as abbreviated_exc:
-            guard.validate(abbreviated_template.format(path=outside))
-        assert abbreviated_exc.value.access == expected_access
+        assert "={path}" in abbreviated_template
+        equals_command = abbreviated_template.format(path=outside)
+        space_command = abbreviated_template.replace("={path}", " {path}").format(
+            path=outside
+        )
+
+        if expected_access is None:
+            with pytest.raises(CommandPolicyViolation):
+                guard.validate(equals_command)
+            with pytest.raises(CommandPolicyViolation):
+                guard.validate(space_command)
+        else:
+            with pytest.raises(CommandPathViolation) as equals_exc:
+                guard.validate(equals_command)
+            assert equals_exc.value.access == expected_access
+
+            with pytest.raises(CommandPathViolation) as space_exc:
+                guard.validate(space_command)
+            assert space_exc.value.access == expected_access

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4003,6 +4003,22 @@ class TestTarCommand:
 
         assert exc_info.value.access == "write"
 
+    def test_dash_prefixed_bundle_gives_each_argument_letter_its_own_token(
+        self, scoped_command_workspace
+    ):
+        # `-xfC archive.tar <dir>`: the GNU dash-prefixed cluster must give
+        # `C` the same own-token treatment the no-dash form gets above.
+        # Misreading `C` as `f`'s attached value would leave the archive and
+        # the directory as unchecked positionals.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside_dir = shlex.quote(str(sibling_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar -xfC archive.tar {outside_dir}")
+
+        assert exc_info.value.access == "write"
+
     def test_rejects_dynamic_short_option_bundle(self, scoped_command_workspace):
         workspace, _, _ = scoped_command_workspace
         guard = WorkspaceCommandPathGuard(workspace)
@@ -4820,6 +4836,36 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         with pytest.raises(CommandPathViolation):
             guard.validate_argv(["base64", "-i", str(sibling_file)])
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "base64 --outp={path} own.txt",
+            "base64 --output={path} own.txt",
+        ],
+    )
+    def test_rejects_base64_output_abbreviation(
+        self, scoped_command_workspace, command_template
+    ):
+        # `--outp=`/`--output=` must resolve through the same GNU
+        # unambiguous-prefix matching `grep`/`curl`/`wget` use: an
+        # unresolved abbreviation must not silently skip the write check.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_base64_benign_invocations_are_allowed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("base64 own.txt")
+        guard.validate("base64 -w0 own.txt")
 
     # -- gzip ----------------------------------------------------------------
 

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2861,13 +2861,15 @@ class TestCommandCoverage:
         "ln": "_check_move_or_link",
         "unlink": "_check_destructive_file_command",
         "shred": "_check_destructive_file_command",
+        "find": "_check_find",
     }
     _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
     _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
     _S2_COMMANDS = _WRITE_CREATE_FAMILY_COMMANDS | frozenset(
         {"cp", "install", "mv", "ln", "unlink", "shred"}
     )
-    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS
+    _S3_COMMANDS = frozenset({"find"})
+    _ALL_COMMANDS = _S1_COMMANDS | _S2_COMMANDS | _S3_COMMANDS
 
     # Each entry: (positive command, negative command template with `{outside}`).
     _REGISTRY: dict[str, tuple[str, str]] = {
@@ -2899,6 +2901,7 @@ class TestCommandCoverage:
         "ln": ("ln own.txt dest.txt", "ln own.txt {outside}"),
         "unlink": ("unlink own.txt", "unlink {outside}"),
         "shred": ("shred own.txt", "shred {outside}"),
+        "find": ("find own.txt -print", "find {outside}"),
     }
 
     def test_registry_covers_every_classified_command(self):
@@ -3149,3 +3152,235 @@ class TestNoEffectCommandClassification:
             match="cannot inspect a script affected by an earlier command",
         ):
             guard.validate("python -c pass && bash safe.sh")
+
+
+class TestFindCommand:
+    """`find`: frozen single-pass, observer-scoped `-exec`/`-execdir` algorithm.
+
+    The searched root's read/write classification comes from a clause-scoped
+    observer that inspects every raw operand of an exec/execdir/ok/okdir
+    clause's real enforcement pass, not from a second throwaway pass and not
+    from inspecting `written_paths` after the fact.
+    """
+
+    def test_exec_write_via_placeholder_marks_root_write(
+        self, scoped_command_workspace
+    ):
+        # The observer fires on the raw "{}" operand before any short-circuit
+        # and marks the searched root write-sensitive; the external directory
+        # is only approved for read, so the write-checked root is rejected.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        external_dir = shlex.quote(str(external_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate("find {ext} -exec rm {{}} \\;".format(ext=external_dir))
+
+        assert exc_info.value.access == "write"
+
+    def test_exec_placeholder_is_arity_preserving_destination_still_checked(
+        self, scoped_command_workspace
+    ):
+        # "{}" stays a real operand (never pre-stripped or substituted before
+        # dispatch), so `cp`'s source/destination split is unaffected and the
+        # fixed destination is still write-checked by the same enforcement
+        # pass that classified "{}".
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate("find . -exec cp {{}} {out} \\;".format(out=outside))
+
+        assert exc_info.value.access == "write"
+
+    def test_exec_write_root_poisons_later_script_inspection(
+        self, scoped_command_workspace
+    ):
+        # A write-root find sets unknown_effect: find's per-match children are
+        # not exact-registerable, so the poison must be session-wide.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "build.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("find . -exec rm {} \\; ; bash build.sh")
+
+    def test_exec_then_execdir_write_or_aggregates_over_all_clauses(
+        self, scoped_command_workspace
+    ):
+        # writes_root is an OR over every clause: a read clause first must not
+        # shadow a write clause that follows it.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        external_dir = shlex.quote(str(external_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                "find {ext} -exec cat {{}} \\; -execdir rm {{}} \\;".format(
+                    ext=external_dir
+                )
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_execdir_then_exec_write_or_aggregates_regardless_of_order(
+        self, scoped_command_workspace
+    ):
+        # Mutation pin for the same invariant in the opposite clause order: a
+        # last-clause-wins bug (assignment instead of OR-accumulate) would let
+        # the later read clause erase the earlier write classification.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        external_dir = shlex.quote(str(external_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                "find {ext} -execdir rm {{}} \\; -exec cat {{}} \\;".format(
+                    ext=external_dir
+                )
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_fprintf_out_of_workspace_destination_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate("find . -fprintf {out} '%p'".format(out=outside))
+
+        assert exc_info.value.access == "write"
+
+    def test_fprintf_in_workspace_registers_on_the_real_effects(
+        self, scoped_command_workspace
+    ):
+        # Fixed path events are checked on the real session effects, not a
+        # throwaway classification pass, so the write is visible to a later
+        # script inspection in the same command chain.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "report.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("find . -fprintf report.sh '%p' && bash report.sh")
+
+    def test_files0_from_fails_closed(self, scoped_command_workspace):
+        # A runtime root list cannot be inspected statically.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("find -files0-from roots.txt")
+
+    @pytest.mark.parametrize("global_option", ["-O2", "-D tree"])
+    def test_global_options_do_not_swallow_the_following_root(
+        self, scoped_command_workspace, global_option
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"find {global_option} {outside}")
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize("global_option", ["-O2", "-D tree"])
+    def test_global_options_root_inside_workspace_is_allowed(
+        self, scoped_command_workspace, global_option
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own_dir").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"find {global_option} own_dir")
+
+    def test_newermt_timestamp_argument_is_not_treated_as_a_path(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("find . -newermt '2026-01-01'")
+
+    def test_samefile_reference_argument_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate("find . -samefile {out}".format(out=outside))
+
+        assert exc_info.value.access == "read"
+
+    def test_delete_marks_root_write(self, scoped_command_workspace):
+        # `-delete` also participates in the writes_root OR, not only
+        # exec/execdir/ok/okdir clauses.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        external_dir = shlex.quote(str(external_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate("find {ext} -delete".format(ext=external_dir))
+
+        assert exc_info.value.access == "write"
+
+    def test_nested_find_sharing_the_outer_terminator_fails_closed(
+        self, scoped_command_workspace
+    ):
+        # `-exec`/`-execdir` consume tokens up to the first bare `;`/`+`
+        # regardless of nesting (matching find's own runtime parser), so an
+        # inner find embedded in an outer clause loses its own terminator to
+        # the outer's. The inner find then raises for its own unterminated
+        # `-execdir`, which is a sound fail-closed outcome, not a corrupted
+        # outer classification.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "a").mkdir()
+        (workspace.output_dir / "a" / "b").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("find a -exec find b -execdir rm {} \\; \\;")
+
+    def test_nested_find_without_further_exec_nesting_leaves_outer_intact(
+        self, scoped_command_workspace
+    ):
+        # A cleanly-terminated nested find (no further -exec inside it) is a
+        # positive control: the inner find's own write classification (via
+        # `-delete`) must reach the real session effects exactly as an outer
+        # command's would, and the outer find's own clause-loop bookkeeping
+        # must not be corrupted by the recursion (the outer clause here is a
+        # plain read of the inner find's stdout, never itself write-flagged).
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "a").mkdir()
+        (workspace.output_dir / "b").mkdir()
+        (workspace.output_dir / "build.sh").write_text(":\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(
+            CommandPolicyViolation,
+            match="cannot inspect a script affected by an earlier command",
+        ):
+            guard.validate("find a -exec find b -delete \\; ; bash build.sh")
+
+    def test_positive_find_inside_workspace_with_exec_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("find . -exec cat {} \\;")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2894,6 +2894,33 @@ class TestCopyInstallMoveLinkDestructive:
 
         assert exc_info.value.access == "write"
 
+    def test_install_bundled_target_directory_short_option_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # `-Dt` bundles the no-value `-D` flag with `-t`'s target-directory
+        # write destination, the same bundling contract `-Dm755` already
+        # covers for the scalar `-m` value.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "destdir").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("install -Dt destdir own.txt")
+
+    def test_install_bundled_target_directory_short_option_outside_workspace_is_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"install -Dt {shlex.quote(str(sibling_file.parent))} own.txt"
+            )
+
+        assert exc_info.value.access == "write"
+
     def test_ln_source_inside_workspace_aliasing_external_read_only_dir_is_rejected(
         self, scoped_command_workspace
     ):
@@ -4573,6 +4600,52 @@ class TestSedAwkCommand:
 
         with pytest.raises(CommandPolicyViolation):
             guard.validate("sed --not-a-sed-option 's/a/b/' own.txt")
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--quiet",
+            "--silent",
+            "--posix",
+            "--sandbox",
+            "--separate",
+            "--null-data",
+            "--zero-terminated",
+            "--unbuffered",
+            "--regexp-extended",
+            "--debug",
+            "--follow-symlinks",
+            "--help",
+            "--version",
+        ],
+    )
+    def test_sed_flag_only_long_options_are_allowed(
+        self, scoped_command_workspace, flag
+    ):
+        # These GNU sed long options never consume a value and never name a
+        # path; before `flag_long_options` existed they fell through to the
+        # unrecognized-long-option fail-closed path (`_check_script_command`
+        # raised on every one of them).
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"sed {flag} 's/x/y/' own.txt")
+
+    def test_sed_unrecognized_long_option_still_fails_closed_ahead_of_a_path(
+        self, scoped_command_workspace
+    ):
+        # `flag_long_options` must only resolve the specific GNU flags it
+        # lists; a genuinely unmodeled long option must still fail closed
+        # instead of the addition making the unknown-long-option path
+        # permissive and letting the following out-of-workspace operand
+        # slip through unclassified.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"sed --bogus {shlex.quote(str(sibling_file))} own.txt")
 
     @pytest.mark.parametrize(
         "command_template",

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2385,6 +2385,35 @@ class TestSortUniqDiffGrepHandlers:
 
         guard.validate(command)
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uniq -c own.txt",
+            "uniq -i own.txt",
+            "uniq -u own.txt",
+            "uniq -d own.txt",
+            "uniq -z own.txt",
+        ],
+    )
+    def test_uniq_allows_recognized_short_flag_options(
+        self, scoped_command_workspace, command
+    ):
+        # R11: the fail-closed short-option flip left `uniq` with an empty
+        # `flag_short_options`, rejecting its own ordinary GNU short flags.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_uniq_rejects_unrecognized_short_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("uniq -@ own.txt")
+
     def test_diff_output_option_registers_write(self, scoped_command_workspace):
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
@@ -2434,6 +2463,46 @@ class TestSortUniqDiffGrepHandlers:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "diff -u own.txt own.txt",
+            "diff -r own.txt own.txt",
+            "diff -q own.txt own.txt",
+            "diff -i own.txt own.txt",
+            "diff -w own.txt own.txt",
+            "diff -b own.txt own.txt",
+            "diff -B own.txt own.txt",
+            "diff -c own.txt own.txt",
+            "diff -y own.txt own.txt",
+            "diff -a own.txt own.txt",
+            "diff -t own.txt own.txt",
+            "diff -T own.txt own.txt",
+            "diff -p own.txt own.txt",
+            "diff -s own.txt own.txt",
+            "diff -e own.txt own.txt",
+            "diff -n own.txt own.txt",
+        ],
+    )
+    def test_diff_allows_recognized_short_flag_options(
+        self, scoped_command_workspace, command
+    ):
+        # R11: the fail-closed short-option flip left `diff` with only `-N`
+        # in `flag_short_options`, rejecting its other ordinary GNU flags.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_diff_rejects_unrecognized_short_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("diff -@ own.txt own.txt")
 
     @pytest.mark.parametrize(
         "command_template",

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2106,7 +2106,7 @@ class TestReadCommandFamily:
     def test_file_and_wc_common_flags_are_allowed(
         self, scoped_command_workspace, command
     ):
-        # R11: the fail-closed short-option flip left `file`/`wc` with an
+        # the fail-closed short-option flip left `file`/`wc` with an
         # empty `flag_short_options`, rejecting their own ordinary GNU flags.
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
@@ -2134,7 +2134,7 @@ class TestReadCommandFamily:
     def test_file_and_wc_post_terminator_operand_is_still_read_checked(
         self, scoped_command_workspace, command_name
     ):
-        # R1: `_partition_path_options` consumes `--` and returns a plain
+        # `_partition_path_options` consumes `--` and returns a plain
         # operand list; routing that list back through `_check_operands`/
         # `_operands` re-applied `_operands`'s own `-`-prefix filter with no
         # memory of the `--` it already passed, silently dropping (and never
@@ -2398,7 +2398,7 @@ class TestSortUniqDiffGrepHandlers:
     def test_uniq_allows_recognized_short_flag_options(
         self, scoped_command_workspace, command
     ):
-        # R11: the fail-closed short-option flip left `uniq` with an empty
+        # the fail-closed short-option flip left `uniq` with an empty
         # `flag_short_options`, rejecting its own ordinary GNU short flags.
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
@@ -2488,7 +2488,7 @@ class TestSortUniqDiffGrepHandlers:
     def test_diff_allows_recognized_short_flag_options(
         self, scoped_command_workspace, command
     ):
-        # R11: the fail-closed short-option flip left `diff` with only `-N`
+        # the fail-closed short-option flip left `diff` with only `-N`
         # in `flag_short_options`, rejecting its other ordinary GNU flags.
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
@@ -2654,7 +2654,7 @@ class TestSortUniqDiffGrepHandlers:
     def test_grep_long_value_option_argument_is_not_treated_as_a_path(
         self, scoped_command_workspace, command_template
     ):
-        # R6: `--label`'s (and `--include`'s/`--context`'s) argument is
+        # `--label`'s (and `--include`'s/`--context`'s) argument is
         # never a filesystem path (a label, glob pattern, or count); an
         # out-of-workspace-looking value must not cause a spurious
         # rejection, and it must not shift the real file operand's
@@ -2860,7 +2860,7 @@ class TestWriteCreateFamily:
     def test_ownership_and_touch_common_short_flags_are_allowed(
         self, scoped_command_workspace, command, monkeypatch
     ):
-        # R11: the fail-closed short-option flip left `chmod`/`chown`/
+        # the fail-closed short-option flip left `chmod`/`chown`/
         # `chgrp`/`touch` with an empty (or narrower) `flag_short_options`,
         # rejecting their own ordinary GNU flags.
         workspace, _, _ = scoped_command_workspace
@@ -2956,7 +2956,7 @@ class TestWriteCreateFamily:
     def test_chmod_bare_terminator_does_not_spuriously_match_reference(
         self, scoped_command_workspace
     ):
-        # R7: `_resolve_long_option` would previously prefix-match a bare
+        # `_resolve_long_option` would previously prefix-match a bare
         # `--` (the operand terminator, not an abbreviation of anything)
         # against the sole `--reference` candidate, so the `has_reference`
         # presence check spuriously believed `--reference` was given. That
@@ -3100,7 +3100,7 @@ class TestCopyInstallMoveLinkDestructive:
     def test_single_operand_is_still_read_checked(
         self, scoped_command_workspace, command_template
     ):
-        # R9: `len(operands) < 2` used to skip ALL containment for a
+        # `len(operands) < 2` used to skip ALL containment for a
         # single-operand invocation; a lone operand is still a real source
         # and must still be read-checked, matching the fix `rsync` already
         # applies to its own single-operand invocation (N1).
@@ -3237,7 +3237,7 @@ class TestCopyInstallMoveLinkDestructive:
     def test_install_target_directory_long_option_abbreviation_is_allowed(
         self, scoped_command_workspace
     ):
-        # R9: `_check_install`'s target-directory extraction used to match
+        # `_check_install`'s target-directory extraction used to match
         # `--target-directory=` as a literal prefix, so a valid GNU
         # unambiguous-prefix abbreviation like `--target-dir=` fell through
         # to the unrecognized-option fail-closed path instead of resolving
@@ -3445,7 +3445,7 @@ class TestCopyInstallMoveLinkDestructive:
     def test_shred_common_short_flags_are_allowed(
         self, scoped_command_workspace, command
     ):
-        # R11: the fail-closed short-option flip left `shred` with an empty
+        # the fail-closed short-option flip left `shred` with an empty
         # `flag_short_options`, rejecting its own ordinary GNU flags.
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
@@ -3454,7 +3454,7 @@ class TestCopyInstallMoveLinkDestructive:
         guard.validate(command)
 
     def test_unlink_rejects_unrecognized_short_option(self, scoped_command_workspace):
-        # R3: `unlink` used to route through the permissive `_operands`
+        # `unlink` used to route through the permissive `_operands`
         # helper (unlike `shred`'s fail-closed `_partition_path_options`),
         # so an unrecognized short option carrying a path (e.g. `-X<path>`)
         # was silently skipped as an ordinary token instead of failing
@@ -3505,7 +3505,7 @@ class TestPathClassificationSubstrate:
         )
 
     def test_resolve_long_option_bare_terminator_returns_none(self):
-        # R7: every known long option starts with `--`, so a bare `--` (the
+        # every known long option starts with `--`, so a bare `--` (the
         # argument-list terminator, never an abbreviation of anything) would
         # otherwise "unambiguously" prefix-match a known set containing
         # exactly one candidate.
@@ -4686,7 +4686,7 @@ class TestTarCommand:
     def test_newer_mtime_option_is_read_checked(
         self, scoped_command_workspace, command_template
     ):
-        # R2: `-N`/`--newer-mtime`/`--after-date`'s DATE-OR-FILE argument can
+        # `-N`/`--newer-mtime`/`--after-date`'s DATE-OR-FILE argument can
         # name a reference file; before this letter was modeled,
         # `_parse_tar_short_events` silently treated an unmodeled short
         # letter as a bare flag, so `-N`'s own argument fell through as an
@@ -5129,7 +5129,7 @@ class TestSedAwkCommand:
     def test_awk_parenthesized_getline_read_loop_is_allowed(
         self, scoped_command_workspace
     ):
-        # R13: `while ((getline line < "file") > 0)` is the idiomatic awk
+        # `while ((getline line < "file") > 0)` is the idiomatic awk
         # file-read loop; the redirect-target trailing-terminator set
         # previously recognized only `;`, `\n`, `}` after the closing quote,
         # so the `)` closing the parenthesized `getline` expression fell

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5334,3 +5334,87 @@ class TestDdBase64GzipRemoteTransferCommand:
             guard.validate(f"rsync {shlex.quote(str(sibling_file))} copied.txt")
 
         assert exc_info.value.access == "read"
+
+
+class TestBundledAndAbbreviatedPathOptionCoverage:
+    """Recurrence guard for the two bug classes this module's hand-rolled
+    option parsers kept reintroducing: a value-taking option not recognized
+    when bundled behind another short flag (tar's `xfC`, curl's `-sD`,
+    wget's `-qO`, cp/mv/ln's `-rt`), and a GNU-abbreviated long option not
+    resolved to the option it stands for (grep's `--fil=`, cp/mv/ln's
+    `--targ=`, curl's `--dump-hea=`, wget's `--output-docu=`).
+
+    Each row names one path-bearing option a command owns and drives BOTH
+    a bundled-short-cluster form and a GNU-abbreviated long-option form of
+    it against an out-of-workspace path. A command added later that owns a
+    path-bearing option without an entry here has no guarantee either bug
+    class was ever checked for it — that gap is the point of this table,
+    not an oversight to silently fill in.
+    """
+
+    # (label, bundled-short-form template, GNU-abbreviated-long-form template)
+    _BUNDLED_AND_ABBREVIATED_PATH_OPTIONS: list[tuple[str, str, str, str]] = [
+        ("sort -o", "sort -ro{path} own.txt", "sort --out={path} own.txt", "write"),
+        ("sort -T", "sort -rT{path} own.txt", "sort --temp={path} own.txt", "write"),
+        ("grep -f", "grep -vf {path} own.txt", "grep --fil={path} own.txt", "read"),
+        ("cp -t", "cp -rt {path} own.txt", "cp own.txt --targ={path}", "write"),
+        ("mv -t", "mv -vt {path} own.txt", "mv own.txt --targ={path}", "write"),
+        ("ln -t", "ln -st {path} own.txt", "ln own.txt --targ={path}", "write"),
+        (
+            "curl -D",
+            "curl -sD {path} https://example.invalid/file",
+            "curl --dump-hea={path} https://example.invalid/file",
+            "write",
+        ),
+        (
+            "curl -c",
+            "curl -sc {path} https://example.invalid/file",
+            "curl --cookie-j={path} https://example.invalid/file",
+            "write",
+        ),
+        (
+            "wget -O",
+            "wget -qO {path} https://example.invalid/file",
+            "wget --output-docu={path} https://example.invalid/file",
+            "write",
+        ),
+        (
+            "wget -P",
+            "wget -qP {path} https://example.invalid/file",
+            "wget --directory-p={path} https://example.invalid/file",
+            "write",
+        ),
+        (
+            "wget -o",
+            "wget -O keep -qo {path} https://example.invalid/file",
+            "wget -O keep --output-fi={path} https://example.invalid/file",
+            "write",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        ("label", "bundled_template", "abbreviated_template", "expected_access"),
+        _BUNDLED_AND_ABBREVIATED_PATH_OPTIONS,
+        ids=[row[0] for row in _BUNDLED_AND_ABBREVIATED_PATH_OPTIONS],
+    )
+    def test_bundled_and_abbreviated_forms_both_reject_out_of_workspace(
+        self,
+        scoped_command_workspace,
+        label,
+        bundled_template,
+        abbreviated_template,
+        expected_access,
+    ):
+        del label  # only used as the parametrize id
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as bundled_exc:
+            guard.validate(bundled_template.format(path=outside))
+        assert bundled_exc.value.access == expected_access
+
+        with pytest.raises(CommandPathViolation) as abbreviated_exc:
+            guard.validate(abbreviated_template.format(path=outside))
+        assert abbreviated_exc.value.access == expected_access

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5141,6 +5141,84 @@ class TestDdBase64GzipRemoteTransferCommand:
                 "https://example.invalid/file"
             )
 
+    def test_wget_save_cookies_write_checked_when_output_is_given(
+        self, scoped_command_workspace
+    ):
+        # With an explicit `-O` the "no output filename" fail-closed reason
+        # above no longer applies; `--save-cookies` must be write-checked
+        # in its own right rather than silently falling through as an
+        # unmodeled option.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"wget -O keep --save-cookies {shlex.quote(str(sibling_file))} "
+                "https://example.invalid/file"
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_wget_save_cookies_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            "wget -O keep --save-cookies cookies.txt https://example.invalid/file"
+        )
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "wget --output-docu={path} https://example.invalid/file",
+            "wget --directory-p={path} https://example.invalid/file",
+            "wget -O keep --output-fi={path} https://example.invalid/file",
+        ],
+    )
+    def test_wget_long_option_abbreviation_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_wget_bundled_output_option_rejects_out_of_workspace(
+        self, scoped_command_workspace
+    ):
+        # `-qO` (quiet + output-document) is a common wget idiom; `-O`'s
+        # write-path argument must still be recognized (and write-checked)
+        # when it is not the leading character of a bundled short-option
+        # cluster.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(sibling_file))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"wget -qO {outside} https://example.invalid/file")
+
+        assert exc_info.value.access == "write"
+
+    def test_wget_bundled_output_option_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("wget -qO out.txt https://example.invalid/file")
+
+    def test_wget_bundled_input_file_flag_fails_closed(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("wget -qi urls.txt")
+
     # -- path-classification bypass regressions -------------------------
 
     @pytest.mark.parametrize(

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2889,16 +2889,37 @@ class TestCopyInstallMoveLinkDestructive:
             "cp -rL . copied",
             "cp --recursive --dereference . copied",
             "cp -rH . copied",
+            "cp --derefe -r . copied",
+            "cp -r --derefe . copied",
+            "cp --recurs --dereference . copied",
+            "cp -r --follow-comm . copied",
         ],
     )
     def test_copy_recursive_symlink_dereference_is_rejected(
         self, scoped_command_workspace, command
     ):
+        # `--derefe`/`--recurs`/`--follow-comm` are GNU unambiguous-prefix
+        # abbreviations of `--dereference`/`--recursive`/
+        # `--follow-command-line-symlink`; an abbreviated spelling of
+        # either flag must be classified identically to the full name so
+        # this hard denial still fires.
         workspace, _, _ = scoped_command_workspace
         guard = WorkspaceCommandPathGuard(workspace)
 
         with pytest.raises(CommandPolicyViolation, match="symbolic links"):
             guard.validate(command)
+
+    def test_copy_dereference_abbreviation_without_recursive_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # The hard denial only fires for the recursive+dereference
+        # combination; an abbreviated `--dereference` alone must not be
+        # misclassified as triggering it.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cp --derefe own.txt copied.txt")
 
     def test_cp_target_directory_bundled_behind_recursive_is_write_checked(
         self, scoped_command_workspace
@@ -3961,6 +3982,8 @@ class TestTarCommand:
         [
             "tar -cf archive.tar -T file-list.txt",
             "tar --create --files-from=file-list.txt -f archive.tar",
+            "tar --create --files-fr=own.txt -f archive.tar",
+            "tar --create --files-fr own.txt -f archive.tar",
             "tar -cf archive.tar --checkpoint-action=exec=sh own.txt",
             "tar -cf archive.tar --checkpoint-action exec=sh own.txt",
             "tar -cf archive.tar -F hook.sh own.txt",
@@ -3975,6 +3998,47 @@ class TestTarCommand:
 
         with pytest.raises(CommandPolicyViolation):
             guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "option_spelling",
+        ["--listed-incr", "--listed-incremental"],
+    )
+    @pytest.mark.parametrize("attach_form", ["=", " "])
+    def test_create_mode_listed_incremental_write_checks_out_of_workspace_path(
+        self, scoped_command_workspace, option_spelling, attach_form
+    ):
+        # `--listed-incr` is the GNU unambiguous-prefix abbreviation of
+        # `--listed-incremental`; both spellings, in both the `=`-attached
+        # and space-separated forms, must resolve to the same
+        # write-checked snapshot-file option, not fall through as an
+        # unchecked (read-checked) source positional.
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside = shlex.quote(str(external_file))
+        option = (
+            f"{option_spelling}={outside}"
+            if attach_form == "="
+            else f"{option_spelling} {outside}"
+        )
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar --create {option} -f a.tar own.txt")
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "option_spelling",
+        ["--listed-incr", "--listed-incremental"],
+    )
+    def test_create_mode_listed_incremental_workspace_path_is_allowed(
+        self, scoped_command_workspace, option_spelling
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"tar --create {option_spelling}=snapshot -f a.tar own.txt")
 
     def test_short_option_bundle_consumes_archive_value(self, scoped_command_workspace):
         # `-xzf archive.tgz`: `x`=extract, `z`=unrecognized flag (skipped),
@@ -4056,19 +4120,27 @@ class TestTarCommand:
 
         guard.validate("tar --index-file listing.txt -xf a.tar")
 
-    @pytest.mark.parametrize("mode_flag", ["-xf", "-tf"])
-    def test_unrecognized_long_option_fails_closed_in_extract_and_list_mode(
+    @pytest.mark.parametrize(
+        "mode_flag", ["-xf", "-tf", "-cf", "-rf", "-uf", "-Af", "-df"]
+    )
+    def test_unrecognized_bare_long_option_fails_closed_in_every_mode(
         self, scoped_command_workspace, mode_flag
     ):
-        # An unrecognized long option with no attached value is ambiguous:
-        # it may take a separated argument this parser cannot identify,
-        # which would otherwise become an unchecked member-selector
-        # positional in extract/list mode.
+        # A bare (argument-free) unrecognized long option is ambiguous: it
+        # may take a separated argument this parser cannot identify, which
+        # would otherwise become an unchecked member-selector positional in
+        # extract/list mode, or an under-strict source/destination
+        # positional in create/append/update/concatenate/compare mode
+        # instead of the write-checked or hard-denied classification the
+        # real option would receive (e.g. `--listed-incremental`/
+        # `--files-from`). It fails closed in every mode, not only
+        # extract/list.
         workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
         guard = WorkspaceCommandPathGuard(workspace)
 
         with pytest.raises(CommandPolicyViolation):
-            guard.validate(f"tar --not-a-tar-option {mode_flag} a.tar")
+            guard.validate(f"tar --not-a-tar-option {mode_flag} a.tar own.txt")
 
     def test_unrecognized_long_option_with_value_fails_closed_regardless_of_mode(
         self, scoped_command_workspace
@@ -4079,19 +4151,6 @@ class TestTarCommand:
 
         with pytest.raises(CommandPolicyViolation):
             guard.validate("tar --not-a-tar-option=value -cf archive.tar own.txt")
-
-    def test_unrecognized_bare_long_option_is_allowed_outside_extract_and_list_mode(
-        self, scoped_command_workspace
-    ):
-        # Create/append/update/concatenate/compare mode already path-checks
-        # every positional as a source, so a bare (argument-free) unmodeled
-        # long option there is not the exploitable ambiguity extract/list
-        # mode has and stays permissive.
-        workspace, _, _ = scoped_command_workspace
-        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
-        guard = WorkspaceCommandPathGuard(workspace)
-
-        guard.validate("tar --not-a-tar-option -cf archive.tar own.txt")
 
 
 class TestSedAwkCommand:
@@ -5464,7 +5523,10 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
     hole through: the `=`-form was covered here, but the space-separated
     form was not, so `_check_rsync` fell back to its unmodeled-flag path
     and swept the value into the generic read/write operand list instead
-    of write-checking it).
+    of write-checking it). tar's `--listed-incr`/`--files-fr` rows cover the
+    same abbreviation gap in create/append/update/concatenate/compare mode
+    specifically, not only extract/list, which is where an earlier revision
+    of this parser left it unguarded.
 
     Each row names one path-bearing option a command owns and drives a
     bundled-short-cluster form (when the option has one; `None` skips it)
@@ -5478,6 +5540,13 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
     here has no guarantee any of these bug classes was ever checked for it
     — that gap is the point of this table, not an oversight to silently
     fill in.
+
+    `TestModeFlagAbbreviationCoverage` below extends the same guard to a
+    different shape of the same bug class: a GNU-abbreviated long option
+    that is a bare mode *flag* rather than a path-bearing option (cp's
+    `--derefe`/`--recurs`), where the recurrence risk is a flag-combination
+    check missing the abbreviated spelling entirely rather than
+    misclassifying a value's read/write access.
     """
 
     # (label, bundled-short-form template or None, GNU-abbreviated-long-form
@@ -5539,6 +5608,18 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
             "rsync -a --files-fr={path} own.txt d",
             None,
         ),
+        (
+            "tar --listed-incremental (create mode)",
+            None,
+            "tar --create --listed-incr={path} -f a.tar own.txt",
+            "write",
+        ),
+        (
+            "tar --files-from (create mode)",
+            None,
+            "tar --create --files-fr={path} -f a.tar",
+            None,
+        ),
     ]
 
     @pytest.mark.parametrize(
@@ -5584,3 +5665,48 @@ class TestBundledAndAbbreviatedPathOptionCoverage:
             with pytest.raises(CommandPathViolation) as space_exc:
                 guard.validate(space_command)
             assert space_exc.value.access == expected_access
+
+
+class TestModeFlagAbbreviationCoverage:
+    """Recurrence guard for a GNU-abbreviated long option that is a bare
+    mode *flag* rather than a path-bearing option.
+
+    `cp`'s `--dereference`/`--recursive`/`--follow-command-line-symlink`
+    carry no value; the bug this covers is a flag-combination check
+    (recursive copy through a dereferenced symlink) matching only the full
+    spelling, so an abbreviated flag silently misses the combination
+    entirely instead of triggering the hard denial. Unlike
+    `TestBundledAndAbbreviatedPathOptionCoverage`'s table, there is no
+    `--abbr=value`/`--abbr value` duality to drive (a bare flag takes no
+    argument), so each row is a single, already fully-formed command.
+    """
+
+    # (label, command using a GNU-abbreviated mode flag that must still
+    # trigger the recursive+dereference hard denial)
+    _ABBREVIATED_MODE_FLAG_COMMANDS: list[tuple[str, str]] = [
+        ("cp --derefe (long, abbreviated) + -r (short)", "cp --derefe -r . copied"),
+        ("cp -r (short) + --derefe (long, abbreviated)", "cp -r --derefe . copied"),
+        (
+            "cp --recurs (long, abbreviated) + --dereference (long, full)",
+            "cp --recurs --dereference . copied",
+        ),
+        (
+            "cp -r (short) + --follow-comm (long, abbreviated)",
+            "cp -r --follow-comm . copied",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        ("label", "command"),
+        _ABBREVIATED_MODE_FLAG_COMMANDS,
+        ids=[row[0] for row in _ABBREVIATED_MODE_FLAG_COMMANDS],
+    )
+    def test_abbreviated_mode_flag_still_triggers_hard_denial(
+        self, scoped_command_workspace, label, command
+    ):
+        del label  # only used as the parametrize id
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation, match="symbolic links"):
+            guard.validate(command)

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3252,62 +3252,90 @@ class TestCommandCoverage:
         "wget": "_check_wget",
     }
 
-    # Each entry: (positive command, negative command template with `{outside}`).
-    _REGISTRY: dict[str, tuple[str, str]] = {
-        "cat": ("cat own.txt", "cat {outside}"),
-        "cmp": ("cmp own.txt own.txt", "cmp own.txt {outside}"),
-        "file": ("file own.txt", "file {outside}"),
-        "head": ("head -n 1 own.txt", "head -n 1 {outside}"),
-        "less": ("less own.txt", "less {outside}"),
-        "ls": ("ls own.txt", "ls {outside}"),
-        "more": ("more own.txt", "more {outside}"),
-        "stat": ("stat own.txt", "stat {outside}"),
-        "tac": ("tac -s , own.txt", "tac -s , {outside}"),
-        "tail": ("tail -n 1 own.txt", "tail -n 1 {outside}"),
-        "wc": ("wc own.txt", "wc {outside}"),
-        "cut": ("cut -d , -f 1 own.txt", "cut -d , -f 1 {outside}"),
-        "sort": ("sort own.txt", "sort {outside}"),
-        "uniq": ("uniq own.txt", "uniq {outside}"),
-        "diff": ("diff own.txt own.txt", "diff own.txt {outside}"),
-        "grep": ("grep pattern own.txt", "grep pattern {outside}"),
-        "chmod": ("chmod 755 own.txt", "chmod 755 {outside}"),
-        "chown": ("chown owner own.txt", "chown owner {outside}"),
-        "chgrp": ("chgrp staff own.txt", "chgrp staff {outside}"),
-        "mkdir": ("mkdir own_new_dir", "mkdir {outside}"),
-        "rm": ("rm own.txt", "rm {outside}"),
-        "rmdir": ("rmdir own_dir", "rmdir {outside}"),
-        "tee": ("tee own.txt", "tee {outside}"),
-        "touch": ("touch own.txt", "touch {outside}"),
-        "truncate": ("truncate -s 1 own.txt", "truncate -s 1 {outside}"),
-        "cp": ("cp own.txt dest.txt", "cp own.txt {outside}"),
-        "install": ("install own.txt dest.txt", "install own.txt {outside}"),
-        "mv": ("mv own.txt dest.txt", "mv own.txt {outside}"),
-        "ln": ("ln own.txt dest.txt", "ln own.txt {outside}"),
-        "unlink": ("unlink own.txt", "unlink {outside}"),
-        "shred": ("shred own.txt", "shred {outside}"),
-        "find": ("find own.txt -print", "find {outside}"),
-        "tar": ("tar -cf archive.tar own.txt", "tar -cf archive.tar {outside}"),
-        "sed": ("sed 's/a/b/' own.txt", "sed 'w {outside}' own.txt"),
+    # Each entry: (positive command, negative command template with
+    # `{outside}`, expected `CommandPathViolation.access` the negative
+    # template's out-of-workspace target is checked as). The expected access
+    # is asserted by both negative-case tests below so a write silently
+    # downgraded to a read (or vice versa) fails the gate mechanically
+    # instead of only being caught by exception type.
+    _REGISTRY: dict[str, tuple[str, str, str]] = {
+        "cat": ("cat own.txt", "cat {outside}", "read"),
+        "cmp": ("cmp own.txt own.txt", "cmp own.txt {outside}", "read"),
+        "file": ("file own.txt", "file {outside}", "read"),
+        "head": ("head -n 1 own.txt", "head -n 1 {outside}", "read"),
+        "less": ("less own.txt", "less {outside}", "read"),
+        "ls": ("ls own.txt", "ls {outside}", "read"),
+        "more": ("more own.txt", "more {outside}", "read"),
+        "stat": ("stat own.txt", "stat {outside}", "read"),
+        "tac": ("tac -s , own.txt", "tac -s , {outside}", "read"),
+        "tail": ("tail -n 1 own.txt", "tail -n 1 {outside}", "read"),
+        "wc": ("wc own.txt", "wc {outside}", "read"),
+        "cut": ("cut -d , -f 1 own.txt", "cut -d , -f 1 {outside}", "read"),
+        "sort": ("sort own.txt", "sort {outside}", "read"),
+        "uniq": ("uniq own.txt", "uniq {outside}", "read"),
+        "diff": ("diff own.txt own.txt", "diff own.txt {outside}", "read"),
+        "grep": ("grep pattern own.txt", "grep pattern {outside}", "read"),
+        "chmod": ("chmod 755 own.txt", "chmod 755 {outside}", "write"),
+        "chown": ("chown owner own.txt", "chown owner {outside}", "write"),
+        "chgrp": ("chgrp staff own.txt", "chgrp staff {outside}", "write"),
+        "mkdir": ("mkdir own_new_dir", "mkdir {outside}", "write"),
+        "rm": ("rm own.txt", "rm {outside}", "write"),
+        "rmdir": ("rmdir own_dir", "rmdir {outside}", "write"),
+        "tee": ("tee own.txt", "tee {outside}", "write"),
+        "touch": ("touch own.txt", "touch {outside}", "write"),
+        "truncate": ("truncate -s 1 own.txt", "truncate -s 1 {outside}", "write"),
+        "cp": ("cp own.txt dest.txt", "cp own.txt {outside}", "write"),
+        "install": (
+            "install own.txt dest.txt",
+            "install own.txt {outside}",
+            "write",
+        ),
+        "mv": ("mv own.txt dest.txt", "mv own.txt {outside}", "write"),
+        "ln": ("ln own.txt dest.txt", "ln own.txt {outside}", "write"),
+        "unlink": ("unlink own.txt", "unlink {outside}", "write"),
+        "shred": ("shred own.txt", "shred {outside}", "write"),
+        "find": ("find own.txt -print", "find {outside}", "read"),
+        "tar": (
+            "tar -cf archive.tar own.txt",
+            "tar -cf archive.tar {outside}",
+            "read",
+        ),
+        "sed": ("sed 's/a/b/' own.txt", "sed 'w {outside}' own.txt", "write"),
         "awk": (
             "awk '{print $0}' own.txt",
             "awk '{{print $0 > \"{outside}\"}}' own.txt",
+            "write",
         ),
-        "dd": ("dd if=own.txt of=dest.bin", "dd if=own.txt of={outside}"),
+        "dd": ("dd if=own.txt of=dest.bin", "dd if=own.txt of={outside}", "write"),
         "base64": (
             "base64 -i own.txt -o own.b64",
             "base64 -i own.txt -o {outside}",
+            "write",
         ),
-        "gzip": ("gzip own.txt", "gzip {outside}"),
-        "rsync": ("rsync own.txt dest.txt", "rsync own.txt {outside}"),
+        "gzip": ("gzip own.txt", "gzip {outside}", "write"),
+        "rsync": ("rsync own.txt dest.txt", "rsync own.txt {outside}", "write"),
         "curl": (
             "curl -o out.bin https://example.invalid/file",
             "curl -o {outside} https://example.invalid/file",
+            "write",
         ),
         "wget": (
             "wget -O out.bin https://example.invalid/file",
             "wget -O {outside} https://example.invalid/file",
+            "write",
         ),
     }
+
+    # Registry entries whose negative case exercises a write-owning slot;
+    # these are also probed against a read-ALLOWED external directory (not
+    # only a fully-out-of-workspace sibling) so a write silently downgraded
+    # to read cannot hide behind a target that both classifications would
+    # reject anyway.
+    _WRITE_ACCESS_COMMANDS = frozenset(
+        command_name
+        for command_name, (_, _, access) in _REGISTRY.items()
+        if access == "write"
+    )
 
     @staticmethod
     def _all_commands() -> frozenset:
@@ -3376,7 +3404,7 @@ class TestCommandCoverage:
         (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
         _trust_locally_shadowed_ownership_commands(monkeypatch)
         guard = WorkspaceCommandPathGuard(workspace)
-        positive_command, _ = self._REGISTRY[command_name]
+        positive_command, _, _ = self._REGISTRY[command_name]
 
         guard.validate(positive_command)
 
@@ -3388,12 +3416,40 @@ class TestCommandCoverage:
         (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
         _trust_locally_shadowed_ownership_commands(monkeypatch)
         guard = WorkspaceCommandPathGuard(workspace)
-        _, negative_template = self._REGISTRY[command_name]
+        _, negative_template, expected_access = self._REGISTRY[command_name]
 
-        with pytest.raises(CommandPathViolation):
+        with pytest.raises(CommandPathViolation) as exc_info:
             guard.validate(
                 negative_template.format(outside=shlex.quote(str(sibling_file)))
             )
+
+        # A write silently downgraded to a read (or vice versa) must not
+        # pass this gate merely because SOME violation was raised.
+        assert exc_info.value.access == expected_access
+
+    @pytest.mark.parametrize("command_name", sorted(_WRITE_ACCESS_COMMANDS))
+    def test_registry_negative_case_rejects_read_allowed_external_dir_as_write(
+        self, scoped_command_workspace, command_name, monkeypatch
+    ):
+        # A write-owning option's target must be rejected even when pointed
+        # at a directory the workspace approves for READ (`external_file`),
+        # not only a fully-out-of-workspace sibling both read and write
+        # already reject alike. This is the read/write-confusion case a
+        # target that is universally denied can never exercise: a write
+        # silently downgraded to a read would otherwise still raise here
+        # (external reads are allowed) and the gate would stay green.
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("data\n", encoding="utf-8")
+        _trust_locally_shadowed_ownership_commands(monkeypatch)
+        guard = WorkspaceCommandPathGuard(workspace)
+        _, negative_template, _ = self._REGISTRY[command_name]
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                negative_template.format(outside=shlex.quote(str(external_file)))
+            )
+
+        assert exc_info.value.access == "write"
 
 
 class TestCdSymlinkTraversal:

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2642,6 +2642,58 @@ class TestSortUniqDiffGrepHandlers:
         with pytest.raises(CommandPolicyViolation):
             guard.validate("grep -@ needle own.txt")
 
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "grep --label {path} needle own.txt",
+            "grep --label={path} needle own.txt",
+            "grep --include={path} needle own.txt",
+            "grep --context 3 needle own.txt",
+        ],
+    )
+    def test_grep_long_value_option_argument_is_not_treated_as_a_path(
+        self, scoped_command_workspace, command_template
+    ):
+        # R6: `--label`'s (and `--include`'s/`--context`'s) argument is
+        # never a filesystem path (a label, glob pattern, or count); an
+        # out-of-workspace-looking value must not cause a spurious
+        # rejection, and it must not shift the real file operand's
+        # classification either.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+    def test_grep_label_value_does_not_spuriously_reject_with_explicit_pattern(
+        self, scoped_command_workspace
+    ):
+        # Before `--label` was modeled, an unrecognized long option was
+        # skipped whole, leaving its own argument in the token stream; once
+        # an explicit `-e` pattern is already present, that stray argument
+        # was misclassified as a file operand and spuriously rejected even
+        # though grep never reads it from disk.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"grep -e needle --label {shlex.quote(str(sibling_file))} own.txt"
+        )
+
+    def test_grep_real_file_operand_after_long_value_option_is_still_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"grep --label harmless needle {shlex.quote(str(sibling_file))}"
+            )
+
+        assert exc_info.value.access == "read"
+
 
 def _trust_locally_shadowed_ownership_commands(monkeypatch):
     """Treat `chown` as a trusted system command regardless of its host path.

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2284,7 +2284,28 @@ class TestSortUniqDiffGrepHandlers:
         guard = WorkspaceCommandPathGuard(workspace)
 
         with pytest.raises(CommandPolicyViolation):
-            guard.validate("uniq --count own.txt")
+            guard.validate("uniq --not-a-uniq-option own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uniq --count own.txt",
+            "uniq --repeated own.txt",
+            "uniq --all-repeated own.txt",
+            "uniq --ignore-case own.txt",
+            "uniq --unique own.txt",
+            "uniq --zero-terminated own.txt",
+            "uniq --group own.txt",
+        ],
+    )
+    def test_uniq_allows_recognized_flag_options(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
 
     def test_diff_output_option_registers_write(self, scoped_command_workspace):
         workspace, _, sibling_file = scoped_command_workspace
@@ -2312,7 +2333,29 @@ class TestSortUniqDiffGrepHandlers:
         guard = WorkspaceCommandPathGuard(workspace)
 
         with pytest.raises(CommandPolicyViolation):
-            guard.validate("diff --brief own.txt own.txt")
+            guard.validate("diff --not-a-diff-option own.txt own.txt")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "diff --brief own.txt own.txt",
+            "diff --unified own.txt own.txt",
+            "diff --recursive own.txt own.txt",
+            "diff --ignore-case own.txt own.txt",
+            "diff --color own.txt own.txt",
+            "diff --color=always own.txt own.txt",
+            "diff --side-by-side own.txt own.txt",
+            "diff --new-file own.txt own.txt",
+        ],
+    )
+    def test_diff_allows_recognized_flag_options(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
 
     @pytest.mark.parametrize(
         "command_template",
@@ -2362,6 +2405,50 @@ class TestSortUniqDiffGrepHandlers:
             guard.validate(f"grep -r needle {shlex.quote(str(sibling_file.parent))}")
 
         assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "grep -if {path} own.txt",
+            "grep -vf {path} own.txt",
+            "grep -nf {path} own.txt",
+        ],
+    )
+    def test_grep_bundled_pattern_file_option_is_read_checked(
+        self, scoped_command_workspace, command_template
+    ):
+        # `-f`'s pattern-file argument must still be read-checked when it is
+        # not the leading character of a bundled short-option cluster.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        ["grep -if pattern.txt own.txt", "grep -vf pattern.txt own.txt"],
+    )
+    def test_grep_bundled_pattern_file_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "pattern.txt").write_text("needle", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_grep_rejects_unmodeled_short_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("grep -@ needle own.txt")
 
 
 def _trust_locally_shadowed_ownership_commands(monkeypatch):
@@ -2506,6 +2593,68 @@ class TestWriteCreateFamily:
 
         guard.validate("chmod --reference=mode.ref own.txt")
 
+    @pytest.mark.parametrize(
+        "command_template",
+        ["touch --reference={path} own.txt", "touch -r {path} own.txt"],
+    )
+    def test_touch_reference_file_is_read_checked(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    def test_touch_reference_file_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "time.ref").write_text("", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("touch --reference=time.ref own.txt")
+        guard.validate("touch -r time.ref own.txt")
+
+    def test_touch_reference_external_read_only_file_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # `-r`/`--reference` only reads the reference file's timestamps, so
+        # a read-only external directory authorizes it even though the same
+        # command's own operand is a write.
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"touch -r {shlex.quote(str(external_file))} own.txt")
+
+    def test_truncate_reference_file_is_read_checked(self, scoped_command_workspace):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"truncate --reference={shlex.quote(str(sibling_file))} own.txt"
+            )
+
+        assert exc_info.value.access == "read"
+
+    def test_truncate_reference_file_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "size.ref").write_text("", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("truncate --reference=size.ref own.txt")
+        guard.validate("truncate -r size.ref own.txt")
+
 
 class TestCopyInstallMoveLinkDestructive:
     """Dedicated handlers for cp/install/mv/ln/unlink/shred.
@@ -2619,6 +2768,42 @@ class TestCopyInstallMoveLinkDestructive:
 
         assert exc_info.value.access == "write"
 
+    def test_install_bundled_flag_and_mode_short_options_are_allowed(
+        self, scoped_command_workspace
+    ):
+        # `-Dm755` bundles the no-value `-D` flag with `-m`'s attached mode
+        # value; only the trailing character may carry a value, matching the
+        # `sort`/`grep` short-option-cluster contract.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("install -Dm755 own.txt dest.txt")
+
+    def test_install_bundled_mode_value_is_not_treated_as_a_path(
+        self, scoped_command_workspace
+    ):
+        # The `-m` mode value is a scalar even when it looks like a path and
+        # even when bundled behind `-D`; an out-of-workspace-looking mode
+        # value does not cause a spurious rejection.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"install -Dm{shlex.quote(str(sibling_file))} own.txt dest.txt")
+
+    def test_install_bundled_flag_and_mode_real_destination_still_rejected(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"install -Dm755 own.txt {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "write"
+
     def test_ln_source_inside_workspace_aliasing_external_read_only_dir_is_rejected(
         self, scoped_command_workspace
     ):
@@ -2649,6 +2834,23 @@ class TestCopyInstallMoveLinkDestructive:
 
         with pytest.raises(CommandPolicyViolation, match="symbolic links"):
             guard.validate(command)
+
+    def test_cp_target_directory_with_recursive_still_rejects_out_of_workspace(
+        self, scoped_command_workspace
+    ):
+        # Pin: `cp -rt <out> own.txt` already rejects today. `-t` bundled
+        # behind `-r` (`-rt`) is not recognized as `--target-directory` (only
+        # a standalone or `-t`-leading token is), so `<out>` instead falls
+        # through as an ordinary source operand and is read-checked; this
+        # must stay a rejection, not be "fixed" into a silent ALLOW.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"cp -rt {shlex.quote(str(sibling_file))} own.txt")
+
+        assert exc_info.value.access == "read"
 
     def test_shred_scalar_options_are_not_treated_as_paths(
         self, scoped_command_workspace
@@ -2820,36 +3022,21 @@ class TestPathClassificationSubstrate:
 class TestCommandCoverage:
     """Mutation-sensitive coverage gate for every classified command.
 
-    Reflects over the guard's live classification sets so a command dropped
-    from dispatch, from the shadow-script set, or left without a test is
-    caught here rather than by chance in an unrelated test.
+    `_ALL_COMMANDS` is derived from the guard's OWN live classification sets
+    (`_READ_COMMANDS`, `_WRITE_COMMANDS`, `_DEDICATED_HANDLER_COMMANDS`),
+    read through the module reference (not a top-level `from ... import`,
+    which would bind an independent copy and stop reflecting a later
+    monkeypatch) so a command added to any of them without a registry entry
+    fails `test_registry_covers_every_classified_command` instead of being
+    silently untested. `test_registry_coverage_is_mutation_sensitive_to_live_classification`
+    proves that sensitivity directly.
     """
 
-    _READ_FAMILY_COMMANDS = frozenset(
-        {
-            "cmp",
-            "file",
-            "head",
-            "less",
-            "ls",
-            "more",
-            "stat",
-            "tac",
-            "tail",
-            "wc",
-            "cut",
-        }
-    )
-    # Flat write/create family: every operand is a plain workspace write, with
-    # at most an option-keyed scalar value skipped (`_COMMAND_VALUE_OPTIONS`)
-    # or, for chmod/chown/chgrp, a leading non-path positional.
-    _WRITE_CREATE_FAMILY_COMMANDS = frozenset(
-        {"chmod", "chown", "chgrp", "rmdir", "tee", "touch", "truncate"}
-    )
-    # Dedicated handlers: each owns a slot (write/read split, target-directory,
-    # every-operand-write-sensitivity, ...) a flat classification cannot
-    # express. Maps command name to the guard method that classifies it; a
-    # method may serve more than one command name (`mv`/`ln`, `unlink`/`shred`).
+    # Maps each dedicated-handler command to the guard method that classifies
+    # it; a method may serve more than one command name (`mv`/`ln`,
+    # `unlink`/`shred`). The key set must equal the live
+    # `_DEDICATED_HANDLER_COMMANDS` (checked below), not be hand-duplicated
+    # against it.
     _DEDICATED_HANDLER_METHODS: dict[str, str] = {
         "sort": "_check_sort",
         "uniq": "_check_uniq",
@@ -2872,26 +3059,10 @@ class TestCommandCoverage:
         "curl": "_check_curl",
         "wget": "_check_wget",
     }
-    _DEDICATED_HANDLER_COMMANDS = frozenset(_DEDICATED_HANDLER_METHODS)
-    _S1_COMMANDS = frozenset({"sort", "uniq", "diff", "grep"}) | _READ_FAMILY_COMMANDS
-    _S2_COMMANDS = _WRITE_CREATE_FAMILY_COMMANDS | frozenset(
-        {"cp", "install", "mv", "ln", "unlink", "shred"}
-    )
-    _S3_COMMANDS = frozenset({"find"})
-    _S4_COMMANDS = frozenset({"tar"})
-    _S5_COMMANDS = frozenset({"sed", "awk"})
-    _S6_COMMANDS = frozenset({"dd", "base64", "gzip", "rsync", "curl", "wget"})
-    _ALL_COMMANDS = (
-        _S1_COMMANDS
-        | _S2_COMMANDS
-        | _S3_COMMANDS
-        | _S4_COMMANDS
-        | _S5_COMMANDS
-        | _S6_COMMANDS
-    )
 
     # Each entry: (positive command, negative command template with `{outside}`).
     _REGISTRY: dict[str, tuple[str, str]] = {
+        "cat": ("cat own.txt", "cat {outside}"),
         "cmp": ("cmp own.txt own.txt", "cmp own.txt {outside}"),
         "file": ("file own.txt", "file {outside}"),
         "head": ("head -n 1 own.txt", "head -n 1 {outside}"),
@@ -2910,6 +3081,8 @@ class TestCommandCoverage:
         "chmod": ("chmod 755 own.txt", "chmod 755 {outside}"),
         "chown": ("chown owner own.txt", "chown owner {outside}"),
         "chgrp": ("chgrp staff own.txt", "chgrp staff {outside}"),
+        "mkdir": ("mkdir own_new_dir", "mkdir {outside}"),
+        "rm": ("rm own.txt", "rm {outside}"),
         "rmdir": ("rmdir own_dir", "rmdir {outside}"),
         "tee": ("tee own.txt", "tee {outside}"),
         "touch": ("touch own.txt", "touch {outside}"),
@@ -2944,16 +3117,34 @@ class TestCommandCoverage:
         ),
     }
 
+    @staticmethod
+    def _all_commands() -> frozenset:
+        """Recompute the live-classified command set from the module.
+
+        Re-reads the module's sets on every call (not a cached class
+        constant) so a test can mutate them first (via `monkeypatch`) and
+        observe the effect, proving the coverage gate actually depends on
+        live classification rather than a frozen snapshot taken at import.
+        """
+        return (
+            frozenset(command_path_guard_module._READ_COMMANDS)
+            | frozenset(command_path_guard_module._WRITE_COMMANDS)
+            | frozenset(command_path_guard_module._DEDICATED_HANDLER_COMMANDS)
+        )
+
+    # A fixed snapshot for parametrization, which pytest evaluates at
+    # collection time; the mutation-sensitivity test below re-derives the
+    # live set independently rather than relying on this constant.
+    _ALL_COMMANDS = _all_commands()
+
     def test_registry_covers_every_classified_command(self):
-        assert set(self._REGISTRY) == self._ALL_COMMANDS
+        assert set(self._REGISTRY) == self._all_commands()
 
-    def test_read_family_commands_are_classified_as_read(self):
-        for command_name in self._READ_FAMILY_COMMANDS:
-            assert command_name in command_path_guard_module._READ_COMMANDS
-
-    def test_write_create_family_commands_are_classified_as_write(self):
-        for command_name in self._WRITE_CREATE_FAMILY_COMMANDS:
-            assert command_name in command_path_guard_module._WRITE_COMMANDS
+    def test_dedicated_handler_registry_matches_live_classification(self):
+        assert (
+            set(self._DEDICATED_HANDLER_METHODS)
+            == command_path_guard_module._DEDICATED_HANDLER_COMMANDS
+        )
 
     def test_dedicated_handlers_are_not_flat_read_or_write(self):
         for command_name, method_name in self._DEDICATED_HANDLER_METHODS.items():
@@ -2962,11 +3153,28 @@ class TestCommandCoverage:
             assert hasattr(WorkspaceCommandPathGuard, method_name)
 
     def test_every_command_is_shadow_script_classified(self):
-        for command_name in self._ALL_COMMANDS:
+        for command_name in self._all_commands():
             assert (
                 command_name
                 in command_path_guard_module._CLASSIFIED_EXECUTABLE_COMMANDS
             )
+
+    def test_registry_coverage_is_mutation_sensitive_to_live_classification(
+        self, monkeypatch
+    ):
+        # Prove the coverage gate actually depends on the live module sets:
+        # injecting a fake command into `_READ_COMMANDS` must desynchronize
+        # it from the (unchanged) registry, which is exactly the condition
+        # `test_registry_covers_every_classified_command` asserts does not
+        # hold. If this stayed equal, that test would stay silently green
+        # after a real command were added without a registry entry.
+        monkeypatch.setattr(
+            command_path_guard_module,
+            "_READ_COMMANDS",
+            command_path_guard_module._READ_COMMANDS | {"__not_a_real_command__"},
+        )
+
+        assert set(self._REGISTRY) != self._all_commands()
 
     @pytest.mark.parametrize("command_name", sorted(_ALL_COMMANDS))
     def test_registry_positive_case_is_accepted(
@@ -3666,6 +3874,66 @@ class TestTarCommand:
         with pytest.raises(CommandPathViolation):
             guard.validate_argv(["tar", "-tf", str(sibling_file)])
 
+    def test_index_file_option_writes_the_verbose_listing(
+        self, scoped_command_workspace
+    ):
+        # `--index-file`'s separated argument must be write-checked, not
+        # returned as an unchecked in-archive member selector.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"tar --index-file {shlex.quote(str(sibling_file))} -xf a.tar"
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_index_file_option_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("tar --index-file listing.txt -xf a.tar")
+
+    @pytest.mark.parametrize("mode_flag", ["-xf", "-tf"])
+    def test_unrecognized_long_option_fails_closed_in_extract_and_list_mode(
+        self, scoped_command_workspace, mode_flag
+    ):
+        # An unrecognized long option with no attached value is ambiguous:
+        # it may take a separated argument this parser cannot identify,
+        # which would otherwise become an unchecked member-selector
+        # positional in extract/list mode.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"tar --not-a-tar-option {mode_flag} a.tar")
+
+    def test_unrecognized_long_option_with_value_fails_closed_regardless_of_mode(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("tar --not-a-tar-option=value -cf archive.tar own.txt")
+
+    def test_unrecognized_bare_long_option_is_allowed_outside_extract_and_list_mode(
+        self, scoped_command_workspace
+    ):
+        # Create/append/update/concatenate/compare mode already path-checks
+        # every positional as a source, so a bare (argument-free) unmodeled
+        # long option there is not the exploitable ambiguity extract/list
+        # mode has and stays permissive.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("tar --not-a-tar-option -cf archive.tar own.txt")
+
 
 class TestSedAwkCommand:
     """`sed`/`awk`: command-slot lexer over the embedded program (I8/I9).
@@ -3823,6 +4091,51 @@ class TestSedAwkCommand:
 
         assert exc_info.value.access == "write"
 
+    def test_sed_long_option_abbreviation_is_resolved(self, scoped_command_workspace):
+        # GNU unambiguous-prefix abbreviation must resolve `--expr=` to
+        # `--expression=` and still write-check its `w` file command, not
+        # silently skip the option as unrecognized.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("sed --expr='w own_out.txt' own.txt")
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"sed --expr='w {sibling_file}' own.txt")
+
+        assert exc_info.value.access == "write"
+
+    def test_sed_in_place_long_option_abbreviation_switches_to_write(
+        self, scoped_command_workspace
+    ):
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"sed --in-pl -e 's/a/b/' {shlex.quote(str(external_file))}")
+
+        assert exc_info.value.access == "write"
+
+    def test_sed_script_file_long_option_abbreviation_is_read_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"sed --fil={shlex.quote(str(sibling_file))} own.txt")
+
+        assert exc_info.value.access == "read"
+
+    def test_sed_rejects_unrecognized_long_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("sed --not-a-sed-option 's/a/b/' own.txt")
+
     @pytest.mark.parametrize(
         "command_template",
         [
@@ -3879,6 +4192,47 @@ class TestSedAwkCommand:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("awk '{getline < \"feed.txt\"}' own.txt")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "awk '{{getline $0 < \"{path}\"}}' own.txt",
+            "awk '{{getline $1 < \"{path}\"}}' own.txt",
+            "awk '{{getline arr[1] < \"{path}\"}}' own.txt",
+        ],
+    )
+    def test_awk_getline_field_and_subscript_targets_are_read_checked(
+        self, scoped_command_workspace, command_template
+    ):
+        # A field reference (`$0`/`$1`) or an array subscript (`arr[1]`)
+        # receiving target must not make the following `< FILE` source
+        # invisible to the read check.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=str(sibling_file)))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "awk '{getline $0 < \"feed.txt\"}' own.txt",
+            "awk '{getline $1 < \"feed.txt\"}' own.txt",
+            "awk '{getline arr[1] < \"feed.txt\"}' own.txt",
+        ],
+    )
+    def test_awk_getline_field_and_subscript_targets_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        (workspace.output_dir / "feed.txt").write_text("data\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
 
     @pytest.mark.parametrize(
         "command",
@@ -3939,6 +4293,105 @@ class TestSedAwkCommand:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("awk -f safe.awk own.txt")
+
+    def test_awk_long_option_abbreviation_is_resolved(self, scoped_command_workspace):
+        # GNU unambiguous-prefix abbreviation must resolve `--sour=` to
+        # `--source=` and still classify its print-redirect write, not
+        # silently skip the option as unrecognized. The whole `--sour=...`
+        # argument is quoted as one shell word (matching how a caller would
+        # protect an embedded double-quoted redirect target).
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("awk '--sour={print $0 > \"own_out.txt\"}' own.txt")
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"awk '--sour={{print $0 > \"{sibling_file}\"}}' own.txt")
+
+        assert exc_info.value.access == "write"
+
+    def test_awk_rejects_unrecognized_long_option(self, scoped_command_workspace):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("awk --not-an-awk-option '{print}' own.txt")
+
+    def test_awk_rejects_unmodeled_short_option(self, scoped_command_workspace):
+        # `-Z` is not a real gawk option; an unmodeled short option must fail
+        # closed rather than being silently skipped.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(
+                f"awk -Z {shlex.quote(str(sibling_file))} '{{print}}' own.txt"
+            )
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "awk -o{path} '{{print}}' own.txt",
+            "awk --pretty-print={path} '{{print}}' own.txt",
+            "awk -p{path} '{{print}}' own.txt",
+            "awk --profile={path} '{{print}}' own.txt",
+            "awk -d{path} '{{print}}' own.txt",
+            "awk --dump-variables={path} '{{print}}' own.txt",
+        ],
+    )
+    def test_awk_optional_write_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "awk -oprof.out '{print}' own.txt",
+            "awk --pretty-print=prof.out '{print}' own.txt",
+            "awk -pprof.out '{print}' own.txt",
+            "awk --profile=prof.out '{print}' own.txt",
+            "awk -dvars.out '{print}' own.txt",
+            "awk --dump-variables=vars.out '{print}' own.txt",
+        ],
+    )
+    def test_awk_optional_write_options_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "awk -o '{print}' own.txt",
+            "awk --pretty-print '{print}' own.txt",
+        ],
+    )
+    def test_awk_optional_write_option_default_filename_is_write_checked(
+        self, scoped_command_workspace, command
+    ):
+        # With no attached argument, gawk writes the fixed default filename
+        # (`awkprof.out`) in the current directory; that default is a
+        # workspace-relative path, so it is allowed without needing an
+        # explicit operand for it.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
 
     @pytest.mark.parametrize(
         "command",
@@ -4187,6 +4640,16 @@ class TestDdBase64GzipRemoteTransferCommand:
         guard.validate(f"gzip -c {shlex.quote(str(external_file))}")
         guard.validate(f"gzip -lt {shlex.quote(str(external_file))}")
 
+    @pytest.mark.parametrize("command", ["gzip --best own.txt", "gzip --fast own.txt"])
+    def test_gzip_allows_recognized_compression_level_flags(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
     def test_gzip_default_mode_poisons_later_script_inspection(
         self, scoped_command_workspace
     ):
@@ -4251,6 +4714,23 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         assert exc_info.value.access == "write"
 
+    def test_rsync_log_file_option_still_rejects_out_of_workspace(
+        self, scoped_command_workspace
+    ):
+        # Pin: `rsync --log-file <out> ...` already rejects today (the
+        # unconsumed value becomes an extra read-checked source operand);
+        # this must stay a rejection, not be "fixed" into an ALLOW.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync --log-file {shlex.quote(str(sibling_file))} own.txt dest.txt"
+            )
+
+        assert exc_info.value.access == "read"
+
     # -- curl/wget/rsync shared uninspectable-option pins -----------------
 
     @pytest.mark.parametrize(
@@ -4294,6 +4774,70 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         assert exc_info.value.access == "write"
 
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "curl -D {path} https://example.invalid/file",
+            "curl --dump-header {path} https://example.invalid/file",
+            "curl -c {path} https://example.invalid/file",
+            "curl --cookie-jar {path} https://example.invalid/file",
+            "curl --trace {path} https://example.invalid/file",
+            "curl --trace-ascii {path} https://example.invalid/file",
+            "curl --stderr {path} https://example.invalid/file",
+        ],
+    )
+    def test_curl_write_output_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl -D headers.txt https://example.invalid/file",
+            "curl --dump-header headers.txt https://example.invalid/file",
+            "curl -c cookies.txt https://example.invalid/file",
+            "curl --cookie-jar cookies.txt https://example.invalid/file",
+            "curl --trace trace.txt https://example.invalid/file",
+            "curl --trace-ascii trace.txt https://example.invalid/file",
+            "curl --stderr err.txt https://example.invalid/file",
+        ],
+    )
+    def test_curl_write_output_options_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_curl_rejects_unrecognized_long_option_with_value(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(
+                "curl --not-a-curl-option=value https://example.invalid/file"
+            )
+
+    def test_curl_allows_unrecognized_bare_long_flag(self, scoped_command_workspace):
+        # A long flag with no attached value cannot be told apart from a
+        # real curl flag this family does not model, so it stays permissive
+        # (over-checked, never under-checked) — only an unmodeled option that
+        # visibly carries a value fails closed.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("curl --location https://example.invalid/file")
+
     # -- wget ------------------------------------------------------------
 
     def test_wget_output_outside_workspace_rejected(self, scoped_command_workspace):
@@ -4305,6 +4849,65 @@ class TestDdBase64GzipRemoteTransferCommand:
             guard.validate(f"wget -O {outside} https://example.invalid/file")
 
         assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "wget -O keep -o {path} https://example.invalid/file",
+            "wget -O keep --output-file {path} https://example.invalid/file",
+        ],
+    )
+    def test_wget_log_file_option_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "wget -O keep -o log.txt https://example.invalid/file",
+            "wget -O keep --output-file log.txt https://example.invalid/file",
+        ],
+    )
+    def test_wget_log_file_option_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_wget_rejects_unrecognized_long_option_with_value(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(
+                "wget --not-a-wget-option=value https://example.invalid/file"
+            )
+
+    def test_wget_save_cookies_still_rejected(self, scoped_command_workspace):
+        # `--save-cookies` is not modeled as a write option; it must not be
+        # "fixed" into an ALLOW. It rejects today because the whole
+        # invocation has no explicit `-O` output, so the remote-derived
+        # output filename fails closed — that reason must not regress into
+        # a silent ALLOW even once `--save-cookies` itself is modeled.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(
+                f"wget --save-cookies {shlex.quote(str(sibling_file))} "
+                "https://example.invalid/file"
+            )
 
     # -- path-classification bypass regressions -------------------------
 

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5412,6 +5412,75 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         guard.validate(command)
 
+    def test_curl_cookie_option_is_read_checked_not_write(
+        self, scoped_command_workspace
+    ):
+        # N2: `--cookie` is a real, distinct curl option (a file curl
+        # *reads* cookies from to send, or an inline `name=value` cookie
+        # list) that this family did not model; before it was added, its
+        # unambiguous-prefix match against the modeled `--cookie-jar` (a
+        # write path) made `_resolve_long_option` snap `--cookie` to
+        # `--cookie-jar` and write-check the argument. A read-only cookie
+        # file the invocation may only read (an approved external
+        # directory) must be allowed, not rejected as a write.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"curl --cookie {shlex.quote(str(external_file))} "
+            "https://example.invalid/file"
+        )
+
+    def test_curl_cookie_abbreviation_is_ambiguous_and_fails_closed(
+        self, scoped_command_workspace
+    ):
+        # Every strict abbreviation of `--cookie` is also a prefix of the
+        # longer `--cookie-jar`, so once both are modeled, only the exact
+        # `--cookie` spelling is unambiguous; a truncated spelling must fail
+        # closed rather than silently snapping to either candidate.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("curl --cooki somefile https://example.invalid/file")
+
+    def test_curl_cookie_option_rejects_out_of_workspace_read(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"curl --cookie {shlex.quote(str(sibling_file))} "
+                "https://example.invalid/file"
+            )
+
+        assert exc_info.value.access == "read"
+
+    def test_curl_cookie_jar_still_write_checked_after_cookie_is_modeled(
+        self, scoped_command_workspace
+    ):
+        # Modeling the exact `--cookie` spelling must not regress
+        # `--cookie-jar`'s own (real write path) check, including its own
+        # unambiguous-prefix abbreviation.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"curl --cookie-jar {shlex.quote(str(sibling_file))} "
+                "https://example.invalid/file"
+            )
+        assert exc_info.value.access == "write"
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"curl --cookie-j={shlex.quote(str(sibling_file))} "
+                "https://example.invalid/file"
+            )
+        assert exc_info.value.access == "write"
+
     def test_curl_rejects_unrecognized_long_option_with_value(
         self, scoped_command_workspace
     ):

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3377,6 +3377,41 @@ class TestCopyInstallMoveLinkDestructive:
 
         assert exc_info.value.access == "read"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "shred -f own.txt",
+            "shred -u own.txt",
+            "shred -v own.txt",
+            "shred -x own.txt",
+            "shred -z own.txt",
+        ],
+    )
+    def test_shred_common_short_flags_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        # R11: the fail-closed short-option flip left `shred` with an empty
+        # `flag_short_options`, rejecting its own ordinary GNU flags.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_unlink_rejects_unrecognized_short_option(self, scoped_command_workspace):
+        # R3: `unlink` used to route through the permissive `_operands`
+        # helper (unlike `shred`'s fail-closed `_partition_path_options`),
+        # so an unrecognized short option carrying a path (e.g. `-X<path>`)
+        # was silently skipped as an ordinary token instead of failing
+        # closed — the same class of bypass the fail-closed flip already
+        # closed for `shred`.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(f"unlink -X{shlex.quote(str(sibling_file))} own.txt")
+
 
 class TestPathClassificationSubstrate:
     """Unit tests for the shared option-classification substrate itself.

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4165,6 +4165,47 @@ class TestTarCommand:
 
         guard.validate("tar --index-file listing.txt -xf a.tar")
 
+    def test_exclude_pattern_is_not_misresolved_as_exclude_from_path(
+        self, scoped_command_workspace
+    ):
+        # N2: `--exclude` is a real, distinct tar option (a glob PATTERN
+        # matched against member names, never a local path) that this
+        # family did not model; before it was added, its unambiguous-prefix
+        # match against the modeled `--exclude-from` (a real path option)
+        # made `_resolve_long_option` snap `--exclude` to `--exclude-from`
+        # and read-check the pattern as if it were a file. An out-of-
+        # workspace-looking pattern must not be rejected as a path, since
+        # it is never opened as one.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(
+            f"tar -cf archive.tar --exclude={shlex.quote(str(sibling_file))} own.txt"
+        )
+
+    def test_exclude_from_still_read_checked_after_exclude_is_modeled(
+        self, scoped_command_workspace
+    ):
+        # Modeling the exact `--exclude` spelling must not regress
+        # `--exclude-from`'s own (real path) read check, including its own
+        # unambiguous-prefix abbreviation.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"tar -cf archive.tar --exclude-from={shlex.quote(str(sibling_file))} own.txt"
+            )
+        assert exc_info.value.access == "read"
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"tar -cf archive.tar --exclude-fr={shlex.quote(str(sibling_file))} own.txt"
+            )
+        assert exc_info.value.access == "read"
+
     @pytest.mark.parametrize(
         "mode_flag", ["-xf", "-tf", "-cf", "-rf", "-uf", "-Af", "-df"]
     )

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2683,6 +2683,23 @@ class TestWriteCreateFamily:
 
         assert exc_info.value.access == "write"
 
+    def test_chmod_bare_terminator_does_not_spuriously_match_reference(
+        self, scoped_command_workspace
+    ):
+        # R7: `_resolve_long_option` would previously prefix-match a bare
+        # `--` (the operand terminator, not an abbreviation of anything)
+        # against the sole `--reference` candidate, so the `has_reference`
+        # presence check spuriously believed `--reference` was given. That
+        # left the leading MODE positional un-stripped and write-checked as
+        # if it were a path, spuriously rejecting an ordinary
+        # `chmod -- MODE file` invocation whose MODE happens to resolve
+        # outside the workspace.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(f"chmod -- {shlex.quote(str(sibling_file))} own.txt")
+
     @pytest.mark.parametrize(
         "command_template",
         ["touch --reference={path} own.txt", "touch -r {path} own.txt"],
@@ -3126,6 +3143,15 @@ class TestPathClassificationSubstrate:
             WorkspaceCommandPathGuard._resolve_long_option("--nonexistent", known)
             is None
         )
+
+    def test_resolve_long_option_bare_terminator_returns_none(self):
+        # R7: every known long option starts with `--`, so a bare `--` (the
+        # argument-list terminator, never an abbreviation of anything) would
+        # otherwise "unambiguously" prefix-match a known set containing
+        # exactly one candidate.
+        known = frozenset({"--reference"})
+
+        assert WorkspaceCommandPathGuard._resolve_long_option("--", known) is None
 
     def test_partition_path_options_drives_the_access_map(
         self, scoped_command_workspace

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3096,6 +3096,32 @@ class TestCopyInstallMoveLinkDestructive:
 
         assert exc_info.value.access == "read"
 
+    @pytest.mark.parametrize("command_template", ["cp {path}", "install {path}"])
+    def test_single_operand_is_still_read_checked(
+        self, scoped_command_workspace, command_template
+    ):
+        # R9: `len(operands) < 2` used to skip ALL containment for a
+        # single-operand invocation; a lone operand is still a real source
+        # and must still be read-checked, matching the fix `rsync` already
+        # applies to its own single-operand invocation (N1).
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize("command", ["cp own.txt", "install own.txt"])
+    def test_single_operand_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
     @pytest.mark.parametrize(
         "command_template",
         [
@@ -3204,6 +3230,35 @@ class TestCopyInstallMoveLinkDestructive:
         with pytest.raises(CommandPathViolation) as exc_info:
             guard.validate(
                 f"install -Dt {shlex.quote(str(sibling_file.parent))} own.txt"
+            )
+
+        assert exc_info.value.access == "write"
+
+    def test_install_target_directory_long_option_abbreviation_is_allowed(
+        self, scoped_command_workspace
+    ):
+        # R9: `_check_install`'s target-directory extraction used to match
+        # `--target-directory=` as a literal prefix, so a valid GNU
+        # unambiguous-prefix abbreviation like `--target-dir=` fell through
+        # to the unrecognized-option fail-closed path instead of resolving
+        # like `cp`'s `--targ=` does.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "out").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("install own.txt --target-dir=out")
+
+    def test_install_target_directory_long_option_abbreviation_rejects_out_of_workspace(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"install own.txt --target-dir={shlex.quote(str(sibling_file))}"
             )
 
         assert exc_info.value.access == "write"

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2371,7 +2371,7 @@ def _trust_locally_shadowed_ownership_commands(monkeypatch):
     executable roots (`/bin`, `/usr/bin`, `/usr/local/bin`,
     `/opt/homebrew/bin`, owned by `command_policy.py`); most Linux
     distributions ship it under `/usr/bin`, already trusted there. This keeps
-    the S2 write-classification tests independent of that host difference
+    the write-classification tests independent of that host difference
     without touching the trusted-roots list itself.
     """
     original = WorkspaceCommandPathGuard._is_trusted_system_command
@@ -2818,7 +2818,7 @@ class TestPathClassificationSubstrate:
 
 
 class TestCommandCoverage:
-    """Mutation-sensitive coverage gate for every classified command (S1+S2).
+    """Mutation-sensitive coverage gate for every classified command.
 
     Reflects over the guard's live classification sets so a command dropped
     from dispatch, from the shadow-script set, or left without a test is
@@ -4306,10 +4306,7 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         assert exc_info.value.access == "write"
 
-    # -- bypass-pin allow-list (ported from the abandoned command-families
-    # branch, re-expressed on the current effect model; the `environment=`
-    # kwarg variants from that branch are not ported — see m2/S6 deviation
-    # notes) ----------------------------------------------------------
+    # -- path-classification bypass regressions -------------------------
 
     @pytest.mark.parametrize(
         "command",

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4676,6 +4676,42 @@ class TestTarCommand:
         assert exc_info.value.access == "read"
 
     @pytest.mark.parametrize(
+        "command_template",
+        [
+            "tar -x -N {path} -f a.tar",
+            "tar --newer-mtime {path} -xf a.tar",
+            "tar --after-date={path} -xf a.tar",
+        ],
+    )
+    def test_newer_mtime_option_is_read_checked(
+        self, scoped_command_workspace, command_template
+    ):
+        # R2: `-N`/`--newer-mtime`/`--after-date`'s DATE-OR-FILE argument can
+        # name a reference file; before this letter was modeled,
+        # `_parse_tar_short_events` silently treated an unmodeled short
+        # letter as a bare flag, so `-N`'s own argument fell through as an
+        # unchecked positional (extract mode never path-checks a
+        # positional).
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "a.tar").write_text("tar", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    def test_newer_mtime_option_workspace_path_is_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "a.tar").write_text("tar", encoding="utf-8")
+        (workspace.output_dir / "reference.txt").write_text("", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("tar -x -N reference.txt -f a.tar")
+
+    @pytest.mark.parametrize(
         "mode_flag", ["-xf", "-tf", "-cf", "-rf", "-uf", "-Af", "-df"]
     )
     def test_unrecognized_bare_long_option_fails_closed_in_every_mode(

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2900,14 +2900,15 @@ class TestCopyInstallMoveLinkDestructive:
         with pytest.raises(CommandPolicyViolation, match="symbolic links"):
             guard.validate(command)
 
-    def test_cp_target_directory_with_recursive_still_rejects_out_of_workspace(
+    def test_cp_target_directory_bundled_behind_recursive_is_write_checked(
         self, scoped_command_workspace
     ):
-        # Pin: `cp -rt <out> own.txt` already rejects today. `-t` bundled
-        # behind `-r` (`-rt`) is not recognized as `--target-directory` (only
-        # a standalone or `-t`-leading token is), so `<out>` instead falls
-        # through as an ordinary source operand and is read-checked; this
-        # must stay a rejection, not be "fixed" into a silent ALLOW.
+        # `-t` bundled behind `-r` (`-rt`) must be recognized as
+        # `--target-directory` through the same bundled-cluster contract
+        # every other family uses, so the directory argument is
+        # write-checked as the actual destination — not misread as an
+        # ordinary source operand and merely read-checked (an inverted,
+        # under-strict classification of the real write target).
         workspace, _, sibling_file = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
         guard = WorkspaceCommandPathGuard(workspace)
@@ -2915,7 +2916,65 @@ class TestCopyInstallMoveLinkDestructive:
         with pytest.raises(CommandPathViolation) as exc_info:
             guard.validate(f"cp -rt {shlex.quote(str(sibling_file))} own.txt")
 
-        assert exc_info.value.access == "read"
+        assert exc_info.value.access == "write"
+
+    def test_cp_target_directory_bundled_behind_recursive_workspace_path_allowed(
+        self, scoped_command_workspace
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "out").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate("cp -rt out own.txt")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "cp own.txt --targ={path}",
+            "mv own.txt --targ={path}",
+            "ln own.txt --targ={path}",
+        ],
+    )
+    def test_target_directory_long_option_abbreviation_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        # `--targ=` is the GNU unambiguous-prefix abbreviation of
+        # `--target-directory`.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        ["cp own.txt --targ=out", "mv own.txt --targ=out", "ln own.txt --targ=out"],
+    )
+    def test_target_directory_long_option_abbreviation_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "out").mkdir()
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    def test_mv_target_directory_bundled_behind_verbose_is_write_checked(
+        self, scoped_command_workspace
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"mv -vt {shlex.quote(str(sibling_file))} own.txt")
+
+        assert exc_info.value.access == "write"
 
     def test_shred_scalar_options_are_not_treated_as_paths(
         self, scoped_command_workspace

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -4994,6 +4994,24 @@ class TestDdBase64GzipRemoteTransferCommand:
         guard.validate(f"gzip -c {shlex.quote(str(external_file))}")
         guard.validate(f"gzip -lt {shlex.quote(str(external_file))}")
 
+    def test_gzip_suffix_value_is_not_misread_as_read_only_mode(
+        self, scoped_command_workspace
+    ):
+        # M3: `-S`'s own (attached-or-separate) suffix argument must not be
+        # misread as the `-t`/`-l`/`-c` read-only-mode flag merely because
+        # it contains that character. `-S -t <path>` here is "-S" with a
+        # SEPARATE suffix argument of literally "-t" — the read-only-mode
+        # classification is option-aware (which characters were parsed as
+        # flags), not a position-independent scan of the raw token text, so
+        # this stays the DEFAULT write-checked mode, not read-only.
+        workspace, external_file, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"gzip -S -t {shlex.quote(str(external_file))}")
+
+        assert exc_info.value.access == "write"
+
     @pytest.mark.parametrize("command", ["gzip --best own.txt", "gzip --fast own.txt"])
     def test_gzip_allows_recognized_compression_level_flags(
         self, scoped_command_workspace, command

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -5172,6 +5172,55 @@ class TestDdBase64GzipRemoteTransferCommand:
 
         assert exc_info.value.access == "write"
 
+    def test_rsync_short_temp_dir_option_requires_write_authorization(
+        self, scoped_command_workspace
+    ):
+        # C2/M4: `-T`/`--temp-dir` had no short-option grammar at all, so
+        # `-T` silently fell through as an unmodeled (ignored) short flag
+        # instead of write-checking its directory argument.
+        workspace, external_file, _ = scoped_command_workspace
+        (workspace.output_dir / "src.txt").write_text("src\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(
+                f"rsync -T {shlex.quote(str(external_file.parent))} src.txt dst.txt"
+            )
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command", ["rsync -K src.txt dst.txt", "rsync -k src.txt dst.txt"]
+    )
+    def test_rsync_keep_or_copy_dirlinks_short_option_fails_closed(
+        self, scoped_command_workspace, command
+    ):
+        # M4: `-K`/`--keep-dirlinks` and `-k`/`--copy-dirlinks` let rsync
+        # write through (or read through) an existing symlink at the
+        # destination/source instead of the literal directory entry, which
+        # can escape the intended root; both must deny outright, matching
+        # `--keep-dirlinks`'s existing long-option denial, instead of
+        # silently falling through as an unmodeled short flag.
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "src.txt").write_text("src\n", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate(command)
+
+    def test_rsync_single_operand_is_still_read_checked(self, scoped_command_workspace):
+        # N1: `len(operands) < 2` used to skip ALL containment (including
+        # the remote-operand check) for a single-operand invocation; a lone
+        # local operand must still be read-checked, not silently exempted
+        # for lack of a second (destination) operand.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"rsync {shlex.quote(str(sibling_file))}")
+
+        assert exc_info.value.access == "read"
+
     # -- curl/wget/rsync shared uninspectable-option pins -----------------
 
     @pytest.mark.parametrize(

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -2442,6 +2442,51 @@ class TestSortUniqDiffGrepHandlers:
 
         guard.validate(command)
 
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "grep --fil={path} own.txt",
+            "grep --reg=sibling {path}",
+            "grep --exclude-fr={path} own.txt",
+        ],
+    )
+    def test_grep_long_option_abbreviation_still_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        # `--fil=`/`--reg=`/`--exclude-fr=` are GNU unambiguous-prefix
+        # abbreviations of `--file`/`--regexp`/`--exclude-from`. An
+        # unrecognized long option is skipped whole (this family's own
+        # documented pure-read permissiveness), so leaving these
+        # unresolved either drops the pattern-file read check entirely or
+        # misclassifies the real file operand as the (excluded) pattern
+        # positional — a silent read-containment bypass, not merely a
+        # missed classification.
+        workspace, _, sibling_file = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "read"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "grep --fil=pattern.txt own.txt",
+            "grep --reg=needle own.txt",
+        ],
+    )
+    def test_grep_long_option_abbreviation_workspace_paths_are_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")
+        (workspace.output_dir / "pattern.txt").write_text("needle", encoding="utf-8")
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
     def test_grep_rejects_unmodeled_short_option(self, scoped_command_workspace):
         workspace, _, _ = scoped_command_workspace
         (workspace.output_dir / "own.txt").write_text("own", encoding="utf-8")

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3860,6 +3860,23 @@ class TestTarCommand:
         with pytest.raises(CommandPathViolation):
             guard.validate(f"tar -xzf {outside}")
 
+    def test_traditional_bundle_gives_each_argument_letter_its_own_token(
+        self, scoped_command_workspace
+    ):
+        # `xfC archive.tar <dir>`: traditional (no-dash) bundled tar syntax
+        # gives each argument-taking letter its own subsequent whitespace
+        # token, in the order the letters appear — `f` takes the archive,
+        # `C` takes the directory. Misreading `C` as `f`'s attached value
+        # would leave the archive and the directory as unchecked positionals.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+        outside_dir = shlex.quote(str(sibling_file.parent))
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(f"tar xfC archive.tar {outside_dir}")
+
+        assert exc_info.value.access == "write"
+
     def test_rejects_dynamic_short_option_bundle(self, scoped_command_workspace):
         workspace, _, _ = scoped_command_workspace
         guard = WorkspaceCommandPathGuard(workspace)

--- a/tests/core/tools/test_command_path_guard_bash.py
+++ b/tests/core/tools/test_command_path_guard_bash.py
@@ -3046,7 +3046,7 @@ class TestPathClassificationSubstrate:
         cwd = guard.execution_cwd
 
         with command_path_guard_module._validation_session_scope():
-            next_index = guard._parse_short_option_cluster(
+            next_index, matched_option, argument = guard._parse_short_option_cluster(
                 ["-nofile.txt"],
                 0,
                 cwd,
@@ -3054,6 +3054,8 @@ class TestPathClassificationSubstrate:
                 value_options={"o": "write"},
             )
         assert next_index == 1
+        assert matched_option == "o"
+        assert argument == "file.txt"
 
         with command_path_guard_module._validation_session_scope():
             with pytest.raises(CommandPathViolation) as exc_info:
@@ -4978,6 +4980,95 @@ class TestDdBase64GzipRemoteTransferCommand:
         guard = WorkspaceCommandPathGuard(workspace)
 
         guard.validate("curl --location https://example.invalid/file")
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "curl -sD {path} https://example.invalid/file",
+            "curl -sLD {path} https://example.invalid/file",
+            "curl -sc {path} https://example.invalid/file",
+        ],
+    )
+    def test_curl_bundled_write_option_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        # `-D`/`-c` must still be recognized (and write-checked) when they
+        # are not the leading character of a bundled short-option cluster
+        # (e.g. `-sD` combines silent mode with dump-header); a hand-rolled
+        # leading-character-only match silently skips the whole token.
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl -sD headers.txt https://example.invalid/file",
+            "curl -sLD headers.txt https://example.invalid/file",
+            "curl -sc cookies.txt https://example.invalid/file",
+        ],
+    )
+    def test_curl_bundled_write_option_workspace_path_is_allowed(
+        self, scoped_command_workspace, command
+    ):
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        guard.validate(command)
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "curl --libcurl {path} https://example.invalid/file",
+            "curl --hsts {path} https://example.invalid/file",
+            "curl --etag-save {path} https://example.invalid/file",
+        ],
+    )
+    def test_curl_new_write_options_reject_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            "curl --dump-hea={path} https://example.invalid/file",
+            "curl --cookie-j={path} https://example.invalid/file",
+        ],
+    )
+    def test_curl_long_option_abbreviation_rejects_out_of_workspace(
+        self, scoped_command_workspace, command_template
+    ):
+        workspace, _, sibling_file = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPathViolation) as exc_info:
+            guard.validate(command_template.format(path=shlex.quote(str(sibling_file))))
+
+        assert exc_info.value.access == "write"
+
+    def test_curl_bundled_remote_output_flag_fails_closed(
+        self, scoped_command_workspace
+    ):
+        # `-sO` (silent + remote-name) is a common curl idiom; `-O`'s output
+        # filename is derived from the remote response and is never
+        # statically knowable, so this must fail closed even bundled behind
+        # another flag, not silently fall through as permissive.
+        workspace, _, _ = scoped_command_workspace
+        guard = WorkspaceCommandPathGuard(workspace)
+
+        with pytest.raises(CommandPolicyViolation):
+            guard.validate("curl -sO https://example.invalid/file")
 
     # -- wget ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extend the cooperative workspace command path guard to classify the path-bearing arguments of file-touching commands against the task workspace, failing closed on grammar it cannot inspect.

Families added:
- read: `cat`, `cmp`, `cut`, `file`, `head`, `less`, `ls`, `more`, `stat`, `tac`, `tail`, `wc`, and `sort`/`uniq`/`diff`/`grep` (which own read-control or write options)
- write/create: `chmod`, `chown`, `chgrp`, `rmdir`, `tee`, `touch`, `truncate`, and `cp`/`install`/`mv`/`ln`/`unlink`/`shred`
- `find`, `tar`, `sed`/`awk`, `dd`, `base64`, `gzip`, and remote transfer `rsync`/`curl`/`wget`

## Behavior

- A path-bearing option value is classified through a per-command option→access map, not skipped; only genuinely non-path option values (e.g. `mkdir -m MODE`, `truncate -s SIZE`) are skipped.
- `ln` treats every operand as write-sensitive, because a hard link inside the workspace aliases the source inode.
- `find` classifies each `-exec`/`-execdir`/`-okdir`/`-delete` clause: the searched root becomes write-sensitive when a clause writes through the `{}` placeholder or an `-execdir` relative operand. The `{}` placeholder stays an arity-preserving no-op scoped to the find invocation. A find that writes also marks the session's effect state, because the per-match targets are not individually enumerable.
- `tar` keeps archive/control paths anchored to the process directory, applies `-C` only to source/member operands, distinguishes compare from delete, and fails closed on stdin/remote archives, absolute extraction, and executable hooks. Extraction marks the session's effect state in addition to validating the extraction root.
- `sed`/`awk` embedded programs are inspected with a command-slot lexer: `w`/`W`/`s///w` write targets and `r`/`R` read targets are path-checked, `print`/`getline` redirections are path-checked, and execute constructs (`sed e`, `awk system()`/pipes) fail closed. `-f` program files go through the shared bounded script reader.
- `gzip` and other writers whose outputs are not individually enumerable mark the session's effect state in addition to validating containment; `gzip -c` stays a plain read.
- `rsync` rejects the whole invocation when any operand is remote; `curl`/`wget` fail closed through their own output/config options.
- Commands with no filesystem write effect, and genuinely unknown commands, keep their existing contracts unchanged.

## Boundary

- Dormant: no production call site injects the guard (unchanged from the previous layer).
- Reuses `TaskWorkspace.resolve_authorized_path` as the single path-authorization owner; `bashlex` stays the optional parser.
- Provides defense in depth; it is not an OS or container isolation boundary.

A coverage test reflects over the live classification sets and asserts every classified command has both a positive and a negative regression, and that every registered command is actually dispatched.

This is the file-command layer for #171, following the command policy foundation and the Bash command boundary. Broader runtime hardening and production activation remain in subsequent PRs.

## Verification

- `uv run pytest -q tests/core/tools/test_command_path_guard_bash.py tests/core/tools/test_command_executor.py tests/core/test_workspace_path_containment.py`
- `uv run mypy src/xagent/core/tools/core/command_path_guard.py`
- `uv run ruff check` and `uv run ruff format --check` on the changed files
- `uv lock --check`
