### PR TITLE
fix(widget): require a published agent on every widget entry point (#1055)

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -166,14 +166,19 @@ def ensure_widget_agent_available(
     Mirrors :func:`ensure_share_agent_available` for the widget channel. The
     guest JWT is long-lived (30-day TTL), so access is re-derived from the
     agent's *current* widget state on every request rather than trusted from
-    the token alone: disabling the widget (``widget_enabled = False``) or
-    rotating ``widget_key`` cuts off outstanding guest tokens on their next
-    request.
+    the token alone. Three owner-side levers cut off outstanding guest tokens
+    on their next request: disabling the widget (``widget_enabled = False``),
+    rotating ``widget_key``, and unpublishing the agent (#1055).
+
+    Publication is checked here rather than by having ``unpublish_agent`` clear
+    ``widget_enabled``, so that the gate is re-derived per request and covers
+    every code path that takes an agent out of ``PUBLISHED`` — and so that
+    re-publishing restores the widget without the owner re-deploying it.
 
     ``expected_widget_key`` is the key carried by the guest JWT; when present
     it must still match the agent's live key. Tokens minted before the key was
     embedded carry no key and skip that comparison — they stay gated on
-    ``widget_enabled`` so the disable path still revokes them.
+    ``widget_enabled`` and publication so those paths still revoke them.
     """
     agent = db.query(Agent).filter(Agent.id == widget_agent_id).first()
     if (
@@ -182,6 +187,7 @@ def ensure_widget_agent_available(
         or agent.user_id != user_id
         or not agent.widget_enabled
         or not agent.widget_key
+        or agent.status != AgentStatus.PUBLISHED
         or (expected_widget_key is not None and agent.widget_key != expected_widget_key)
     ):
         raise HTTPException(status_code=403, detail="Widget is unavailable")

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
-from ..models.agent import Agent, is_workforce_generated_manager_agent
+from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.database import get_db
 from ..models.deployment import DeploymentOwnerType
 from ..models.user import User
@@ -117,21 +117,38 @@ class ResolvedWidgetOwner:
     workforce: Workforce | None = None
 
 
-def _get_widget_enabled_agent(db: Session, agent_id: int) -> Agent:
-    """Load a widget-enabled agent or raise the matching HTTP error."""
+def _get_live_widget_agent(db: Session, agent_id: int) -> Agent:
+    """Load an agent whose widget is actually serving, or raise the matching
+    HTTP error.
+
+    "Live" is three conditions, not just ``widget_enabled``: a real non-manager
+    agent, its widget enabled, and the agent still published.
+
+    External access requires the agent to still be published, mirroring
+    ``_workforce_owner_from_ticket``'s ``status == "active"`` check: a ticket
+    minted before an unpublish must not still redeem inside its TTL (#1055).
+    Unpublished collapses into the same "disabled" 403 so the ticket path does
+    not leak an agent's publication state.
+    """
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if agent is None or is_workforce_generated_manager_agent(agent):
         raise HTTPException(
             status_code=401, detail="Widget owner not found or invalid agent_id"
         )
-    if not agent.widget_enabled:
+    if not agent.widget_enabled or agent.status != AgentStatus.PUBLISHED:
         raise HTTPException(status_code=403, detail="Widget is disabled for this agent")
     return agent
 
 
 def _resolve_widget_agent_by_key(db: Session, widget_key: str) -> Agent | None:
     """Return a widget-enabled agent for the key, or ``None`` if no eligible
-    agent matches (unknown key, disabled widget, or a workforce-manager agent).
+    agent matches (unknown key, disabled widget, unpublished agent, or a
+    workforce-manager agent).
+
+    External access requires the agent to still be published, mirroring the
+    workforce branch of :func:`_resolve_widget_owner_by_key` (#1055). Agents are
+    created ``widget_enabled=True`` with a key already minted, so without this
+    a never-published draft would serve its widget too.
 
     Returning ``None`` — rather than raising — lets the caller fall through to
     the workforce lookup; every real failure still collapses to a single 403
@@ -143,6 +160,7 @@ def _resolve_widget_agent_by_key(db: Session, widget_key: str) -> Agent | None:
         or not agent.widget_key
         or is_workforce_generated_manager_agent(agent)
         or not agent.widget_enabled
+        or agent.status != AgentStatus.PUBLISHED
     ):
         return None
     return agent
@@ -317,7 +335,7 @@ def _owner_from_embed_ticket(db: Session, embed_ticket: str) -> ResolvedWidgetOw
     ticket_agent_id = claims.get("agent_id")
     if not isinstance(ticket_agent_id, int):
         raise HTTPException(status_code=403, detail="Invalid or expired embed ticket")
-    agent = _get_widget_enabled_agent(db, ticket_agent_id)
+    agent = _get_live_widget_agent(db, ticket_agent_id)
     allowed_domains = agent.allowed_domains
     # Re-check so tickets die immediately if the allowlist shrinks.
     require_domain_allowed(

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -121,21 +121,34 @@ def _get_live_widget_agent(db: Session, agent_id: int) -> Agent:
     """Load an agent whose widget is actually serving, or raise the matching
     HTTP error.
 
-    "Live" is three conditions, not just ``widget_enabled``: a real non-manager
-    agent, its widget enabled, and the agent still published.
+    "Live" is four conditions, not just ``widget_enabled``: a real non-manager
+    agent, its widget enabled, a widget key still minted, and the agent still
+    published.
 
     External access requires the agent to still be published, mirroring
     ``_workforce_owner_from_ticket``'s ``status == "active"`` check: a ticket
     minted before an unpublish must not still redeem inside its TTL (#1055).
     Unpublished collapses into the same "disabled" 403 so the ticket path does
     not leak an agent's publication state.
+
+    ``widget_key`` is checked for parity with the three sibling gates
+    (:func:`_resolve_widget_agent_by_key`, ``ensure_widget_agent_available``,
+    :func:`_workforce_owner_from_ticket`). No path produces
+    ``widget_enabled=True`` with no key today, but nothing at the schema level
+    forbids it either; without this check such a row would redeem a ticket into
+    a guest token that then 403s on its first real request instead of failing
+    here.
     """
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if agent is None or is_workforce_generated_manager_agent(agent):
         raise HTTPException(
             status_code=401, detail="Widget owner not found or invalid agent_id"
         )
-    if not agent.widget_enabled or agent.status != AgentStatus.PUBLISHED:
+    if (
+        not agent.widget_enabled
+        or not agent.widget_key
+        or agent.status != AgentStatus.PUBLISHED
+    ):
         raise HTTPException(status_code=403, detail="Widget is disabled for this agent")
     return agent
 

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -1203,6 +1203,174 @@ def test_rotated_widget_key_invalidates_existing_guest_tokens() -> None:
     assert response.json()["detail"] == "Widget is unavailable"
 
 
+def test_unpublishing_agent_invalidates_existing_widget_guest_tokens() -> None:
+    """Unpublishing an agent must invalidate already-issued guest JWTs on their
+    next request — the third revocation lever alongside disable and rotate.
+
+    ``unpublish_agent`` only flips ``status``; it leaves ``widget_enabled`` and
+    ``widget_key`` intact on purpose, so that re-publishing restores the same
+    embed snippet. That makes the per-request check in
+    ``ensure_widget_agent_available`` the thing that has to enforce this (#1055).
+    """
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Unpublish Invalidate Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+
+    # Sanity: the guest token works while the agent is published.
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
+def test_republishing_agent_restores_widget_access_for_existing_tokens() -> None:
+    """Unpublish is a reversible lever: re-publishing revives the same guest
+    token, because the widget key it pins was never rotated. Locks in why the
+    status check lives in the availability helper rather than in
+    ``unpublish_agent`` clearing ``widget_enabled`` (#1055)."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Republish Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+    key_before = _widget_key_for(agent_id)
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+    assert _create_widget_task(guest_headers, agent_id).status_code == 403
+
+    republished = client.post(f"/api/agents/{agent_id}/publish", headers=headers)
+    assert republished.status_code == 200, republished.text
+
+    assert _widget_key_for(agent_id) == key_before
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+
+def test_widget_auth_rejects_unpublished_agent_key() -> None:
+    """An unpublished agent's widget key must stop minting guest tokens at all,
+    rather than handing out a token that dies on its first real request. Mirrors
+    the workforce branch, which resolves keys only for ``status == 'active'``."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Unpublish Auth Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    widget_key = _widget_key_for(agent_id)
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"widget_key": widget_key, "guest_id": "guest-1"},
+    )
+    assert response.status_code == 403, response.text
+    # Same detail as an unknown key: publication state must not be probeable.
+    assert response.json()["detail"] == "Invalid widget key"
+
+
+@pytest.mark.parametrize("status", [AgentStatus.DRAFT, AgentStatus.ARCHIVED])
+def test_widget_auth_rejects_agent_that_is_not_published(status: AgentStatus) -> None:
+    """Agents are created ``widget_enabled=True`` with a key already minted, so
+    a never-published draft carries a live widget credential. External access
+    requires publication, so that key must not authenticate either (#1055).
+
+    Parametrized over both non-published states to pin the gate as
+    ``!= PUBLISHED`` rather than ``== DRAFT``; ``ARCHIVED`` is not reachable
+    through the web API today, so nothing else would catch a narrowing."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name=f"Unpublished Widget Agent ({status.value})",
+        status=status,
+        widget_enabled=True,
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"widget_key": _widget_key_for(agent_id), "guest_id": "guest-1"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Invalid widget key"
+
+
+def test_embed_ticket_rejects_unpublished_agent_like_an_unknown_key() -> None:
+    """The embedding page cannot obtain a fresh ticket for an unpublished agent;
+    unpublished and unknown-key collapse to the same 403."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Unpublish Embed Ticket Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+    widget_key = _widget_key_for(agent_id)
+    assert _issue_embed_ticket(agent_id, "https://trusted-site.com").status_code == 200
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+
+    response = client.post(
+        "/api/widget/embed-ticket",
+        json={"widget_key": widget_key},
+        headers={"origin": "https://trusted-site.com"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Invalid widget key"
+
+
+def test_embed_ticket_stops_authenticating_once_agent_is_unpublished() -> None:
+    """A ticket minted while the agent was published must not survive an
+    unpublish inside its 60s TTL: redemption re-derives the agent from live
+    state, mirroring ``_workforce_owner_from_ticket``'s ``active`` check.
+
+    The denial reuses the disabled-widget detail so a caller holding a valid
+    ticket cannot tell the two revocation levers apart."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Unpublish Ticket Redemption Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+    ticket_response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+    assert ticket_response.status_code == 200, ticket_response.text
+    ticket = ticket_response.json()["ticket"]
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+        headers={"origin": "https://xagent-host.example"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is disabled for this agent"
+
+
 def test_widget_guest_token_rejected_when_agent_becomes_generated_manager() -> None:
     """``ensure_widget_agent_available`` must reject a live guest token once the
     backing agent is a workforce-generated manager, tripping the check at the

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -210,6 +210,22 @@ def _widget_key_for(agent_id: int) -> str:
         db.close()
 
 
+def _set_agent_status(agent_id: int, status: AgentStatus) -> None:
+    """Write a status straight to the row.
+
+    Only needed for ``ARCHIVED``: no web API route assigns it, so the
+    ``!= PUBLISHED`` shape of the widget gates cannot be exercised through the
+    real ``/unpublish`` endpoint, which hardcodes ``DRAFT``.
+    """
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.status = status
+        db.commit()
+    finally:
+        db.close()
+
+
 def _user_id(username: str) -> int:
     db = _direct_db_session()
     try:
@@ -1369,6 +1385,148 @@ def test_embed_ticket_stops_authenticating_once_agent_is_unpublished() -> None:
     )
     assert response.status_code == 403, response.text
     assert response.json()["detail"] == "Widget is disabled for this agent"
+
+
+def test_widget_guest_token_rejected_when_agent_is_archived() -> None:
+    """``ensure_widget_agent_available`` gates on ``!= PUBLISHED``, not
+    ``== DRAFT``.
+
+    ``test_unpublishing_agent_invalidates_existing_widget_guest_tokens`` covers
+    the DRAFT half, but only through the real ``/unpublish`` endpoint, which
+    hardcodes ``AgentStatus.DRAFT`` and can never produce ``ARCHIVED`` — so a
+    narrowed gate would still pass it. Hence the direct status write."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Archived Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+    assert _create_widget_task(guest_headers, agent_id).status_code == 200
+
+    _set_agent_status(agent_id, AgentStatus.ARCHIVED)
+
+    response = _create_widget_task(guest_headers, agent_id)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is unavailable"
+
+
+def test_embed_ticket_rejects_widget_enabled_agent_with_no_widget_key() -> None:
+    """``_get_live_widget_agent`` also requires a live ``widget_key``, matching
+    its three sibling gates.
+
+    Nothing produces ``widget_enabled=True, widget_key=None`` today — creation
+    always mints a key, the update path re-mints one if the flag is toggled on
+    without it, and rotation never nulls it — but no schema constraint forbids
+    the row either. Written directly so the check is pinned: such an agent must
+    fail here rather than redeem the ticket into a guest token that 403s on its
+    first real request."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Keyless Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+    ticket_response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+    assert ticket_response.status_code == 200, ticket_response.text
+    ticket = ticket_response.json()["ticket"]
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.widget_key = None
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+        headers={"origin": "https://xagent-host.example"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is disabled for this agent"
+
+
+def test_embed_ticket_stops_authenticating_once_agent_is_archived() -> None:
+    """``_get_live_widget_agent`` gates on ``!= PUBLISHED``, not ``== DRAFT``.
+
+    Same reasoning as ``test_widget_guest_token_rejected_when_agent_is_archived``
+    one gate over: the sibling unpublish test can only reach DRAFT."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Archived Ticket Redemption Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+    ticket_response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+    assert ticket_response.status_code == 200, ticket_response.text
+    ticket = ticket_response.json()["ticket"]
+
+    _set_agent_status(agent_id, AgentStatus.ARCHIVED)
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+        headers={"origin": "https://xagent-host.example"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Widget is disabled for this agent"
+
+
+def test_unpublishing_agent_revokes_widget_guest_access_to_task_files() -> None:
+    """The publication gate reaches further than the chat/WS routes: the public
+    file endpoints resolve a guest token through ``get_public_chat_user``
+    (``_validate_public_task_file_access``), which calls the same
+    ``ensure_widget_agent_available``. So unpublishing also cuts a widget guest
+    off from its own task's attachments — part of the shipped blast radius of
+    #1055, and the only widget/guest file-access assertion in the suite."""
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Unpublish Widget File Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+    access_token = guest_headers["Authorization"].removeprefix("Bearer ")
+
+    created = _create_widget_task(guest_headers, agent_id)
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task_id"]
+
+    uploaded = client.post(
+        "/api/widget/files/upload",
+        headers=guest_headers,
+        data={"task_type": "task", "task_id": str(task_id)},
+        files={"file": ("widget-note.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    file_id = uploaded.json()["file_id"]
+
+    allowed = client.get(
+        f"/api/files/public/download/{file_id}", params={"token": access_token}
+    )
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.content == b"hello"
+
+    unpublished = client.post(f"/api/agents/{agent_id}/unpublish", headers=headers)
+    assert unpublished.status_code == 200, unpublished.text
+
+    denied = client.get(
+        f"/api/files/public/download/{file_id}", params={"token": access_token}
+    )
+    assert denied.status_code == 403, denied.text
+    assert denied.json()["detail"] == "Widget is unavailable"
 
 
 def test_widget_guest_token_rejected_when_agent_becomes_generated_manager() -> None:

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -9,8 +9,9 @@ the socket, and no test in the suite even reached
 ``/api/widget/chat/ws/{task_id}``.
 
 These tests drive the real endpoint end to end: a guest with a valid token holds
-a live socket, the owner revokes the widget (disable or key rotation), and the
-next inbound message must drop the connection with ``4003``. Unlike
+a live socket, the owner revokes the widget (disable, key rotation, or
+unpublishing the owner — #1055), and the next inbound message must drop the
+connection with ``4003``. Unlike
 ``test_public_chat_websocket_db_boundary.py`` — which mocks
 ``_authorize_public_chat_websocket`` to prove the close *plumbing* — nothing is
 stubbed on the auth path here, so the revocation checks in
@@ -31,7 +32,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 import pytest
 from starlette.testclient import WebSocketTestSession
@@ -177,9 +178,11 @@ class _WidgetGuest:
 
     token: str
     task_id: int
-    # Owner-side revocations, each of which must invalidate ``token``.
-    disable: Callable[[], None]
-    rotate: Callable[[], None]
+    # Owner-side revocation levers keyed by the ``revocation`` parametrize id,
+    # each of which must invalidate ``token``. A mapping rather than one field
+    # per lever so adding a lever touches the two builders and the parametrize
+    # list, not every call site in between.
+    revocations: Mapping[str, Callable[[], None]]
 
 
 def _agent_widget_guest() -> _WidgetGuest:
@@ -208,11 +211,16 @@ def _agent_widget_guest() -> _WidgetGuest:
         )
         assert response.status_code == 200, response.text
 
+    def unpublish() -> None:
+        response = client.post(
+            f"/api/agents/{agent_id}/unpublish", headers=_admin_headers()
+        )
+        assert response.status_code == 200, response.text
+
     return _WidgetGuest(
         token=token,
         task_id=int(created.json()["task_id"]),
-        disable=disable,
-        rotate=rotate,
+        revocations={"disable": disable, "rotate": rotate, "unpublish": unpublish},
     )
 
 
@@ -243,11 +251,16 @@ def _workforce_widget_guest(monkeypatch: pytest.MonkeyPatch) -> _WidgetGuest:
         )
         assert response.status_code == 200, response.text
 
+    def unpublish() -> None:
+        response = client.post(
+            f"/api/workforces/{workforce_id}/unpublish", headers=_admin_headers()
+        )
+        assert response.status_code == 200, response.text
+
     return _WidgetGuest(
         token=token,
         task_id=int(created.json()["task_id"]),
-        disable=disable,
-        rotate=rotate,
+        revocations={"disable": disable, "rotate": rotate, "unpublish": unpublish},
     )
 
 
@@ -289,7 +302,7 @@ def _drain_until_disconnect(ws: WebSocketTestSession) -> WebSocketDisconnect:
 # instead of failing it (there is no global pytest timeout).
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize("channel", ["agent", "workforce"])
-@pytest.mark.parametrize("revocation", ["disable", "rotate"])
+@pytest.mark.parametrize("revocation", ["disable", "rotate", "unpublish"])
 def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
     monkeypatch: pytest.MonkeyPatch,
     channel: str,
@@ -299,8 +312,11 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
 
     The guest JWT has a 30-day TTL and the socket outlives any single request,
     so the receive loop — not the token — is what enforces revocation here.
-    Both revocation levers are covered: disabling the widget, and rotating its
-    key (which the guest token pins via its ``widget_key`` claim).
+    All three revocation levers are covered: disabling the widget, rotating its
+    key (which the guest token pins via its ``widget_key`` claim), and
+    unpublishing the owner — taking an agent/workforce out of service must stop
+    its embedded widget from serving, not just hide it from the product surfaces
+    (#1055).
     """
     guest = _build_guest(channel, monkeypatch)
     url = f"/api/widget/chat/ws/{guest.task_id}?token={guest.token}"
@@ -315,8 +331,7 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
         ws.send_text(json.dumps({"type": "intervention", "action": "noop"}))
         assert _receive_until(ws, "intervention_processed")
 
-        revoke = guest.disable if revocation == "disable" else guest.rotate
-        revoke()
+        guest.revocations[revocation]()
 
         ws.send_text(json.dumps({"type": "chat", "message": "still there?"}))
         denied = _drain_until_disconnect(ws)

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 
 import pytest
 from starlette.testclient import WebSocketTestSession
@@ -178,11 +178,12 @@ class _WidgetGuest:
 
     token: str
     task_id: int
-    # Owner-side revocation levers keyed by the ``revocation`` parametrize id,
-    # each of which must invalidate ``token``. A mapping rather than one field
-    # per lever so adding a lever touches the two builders and the parametrize
-    # list, not every call site in between.
-    revocations: Mapping[str, Callable[[], None]]
+    # Owner-side revocations, each of which must invalidate ``token``. Field
+    # names match the ``revocation`` parametrize ids so the test can dispatch
+    # by id without a lookup table.
+    disable: Callable[[], None]
+    rotate: Callable[[], None]
+    unpublish: Callable[[], None]
 
 
 def _agent_widget_guest() -> _WidgetGuest:
@@ -220,7 +221,9 @@ def _agent_widget_guest() -> _WidgetGuest:
     return _WidgetGuest(
         token=token,
         task_id=int(created.json()["task_id"]),
-        revocations={"disable": disable, "rotate": rotate, "unpublish": unpublish},
+        disable=disable,
+        rotate=rotate,
+        unpublish=unpublish,
     )
 
 
@@ -260,7 +263,9 @@ def _workforce_widget_guest(monkeypatch: pytest.MonkeyPatch) -> _WidgetGuest:
     return _WidgetGuest(
         token=token,
         task_id=int(created.json()["task_id"]),
-        revocations={"disable": disable, "rotate": rotate, "unpublish": unpublish},
+        disable=disable,
+        rotate=rotate,
+        unpublish=unpublish,
     )
 
 
@@ -331,7 +336,8 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
         ws.send_text(json.dumps({"type": "intervention", "action": "noop"}))
         assert _receive_until(ws, "intervention_processed")
 
-        guest.revocations[revocation]()
+        revoke: Callable[[], None] = getattr(guest, revocation)
+        revoke()
 
         ws.send_text(json.dumps({"type": "chat", "message": "still there?"}))
         denied = _drain_until_disconnect(ws)


### PR DESCRIPTION
Closes #1055.

## Problem

The agent widget channel was never gated on publication state. `AgentStore.unpublish_agent` only flips `status` — it deliberately leaves `widget_enabled` and `widget_key` intact — so an unpublished agent stayed fully reachable through its existing widget key: `/api/widget/auth` kept minting guest tokens, and outstanding guest JWTs kept working on both the HTTP and WS paths.

The workforce widget channel already gates on `status == "active"` at two layers, and the agent *share* channel gates on `PUBLISHED`. Only the agent widget channel did not — at any layer.

## Fix

All three agent-widget entry points now require `AgentStatus.PUBLISHED`:

| entry point | endpoints it guards |
| --- | --- |
| `ensure_widget_agent_available` | `/chat/task/create`, `/files/upload`, `/chat/ws/{task_id}` (per request, and per inbound WS message), plus the public file routes (see below) |
| `_resolve_widget_agent_by_key` | `/api/widget/auth` (direct visit), `/api/widget/embed-ticket` |
| `_get_widget_enabled_agent` → renamed `_get_live_widget_agent` | `/api/widget/auth` (embed-ticket redemption) |

The issue only called for the first. The other two matter because fixing the revalidation helper alone would still let `/api/widget/auth` mint a guest token for an unpublished agent that then 403s on its first real message — and would leave a live embed ticket redeemable inside its 60s TTL.

`_get_live_widget_agent` also gained a non-null `widget_key` check, for parity with its three sibling gates (`_resolve_widget_agent_by_key`, `ensure_widget_agent_available`, `_workforce_owner_from_ticket`), which all had one. Nothing produces `widget_enabled=True, widget_key=None` today and no schema constraint forbids it either; without the check such a row would redeem a ticket into a guest token carrying `widget_key: null` that then 403s on its first real request instead of failing cleanly at redemption.

### Why the helper-side lever

Publication is checked in the availability helpers rather than by having `unpublish_agent` clear `widget_enabled`:

- it is re-derived per request, so it covers every code path that takes an agent out of `PUBLISHED`, not just this one function;
- a state-clearing approach structurally cannot cover a never-published draft, which never passes through `unpublish_agent` at all (see below);
- it does not destroy the owner's widget configuration — re-publishing restores the same embed snippet with no re-deploy;
- it matches how the share channel already does it.

Denials reuse the existing `"Invalid widget key"` / `"Widget is disabled for this agent"` details, so publication state stays unprobeable.

## Behaviour change beyond the issue text

**Never-published drafts.** Agents are created `widget_enabled=True` with a key already minted (`agent_store.py`), so a never-published draft also carried a live widget credential. Those keys stop authenticating too. No supported flow distributed such a key — the embed snippet is only reachable from the Deploy dialog, which opens only for published agents (`frontend/src/app/build/page.tsx`) — but it is a real change in what the API accepts, so calling it out explicitly.

**Public file routes.** `ensure_widget_agent_available` is also reached transitively from the public file preview/download/open routes, via `_validate_public_task_file_access` (`files.py`) → `get_public_chat_user`. So unpublishing additionally cuts a widget guest off from that task's file attachments. Correct and fail-safe — the attachments belong to a channel that is no longer serving — but it is part of the shipped blast radius, so it is now called out here and covered by a test.

**WS timing, unchanged.** For an already-connected WS guest, revocation lands on the guest's next *inbound* message: an unpublished agent's socket keeps receiving outbound/broadcast frames and in-flight runs keep executing until the guest speaks. That is the contract the existing disable/rotate levers already have, so this is consistent with prior behaviour rather than a new gap — but "owner clicks Unpublish" reads as *stop now*, and closing that delta for all three levers at once is worth a follow-up issue.

## Tests

- Unpublish revokes an existing guest token on its next HTTP request; re-publishing revives the same token (pins the reversibility the helper-side lever buys).
- `/api/widget/auth` and `/api/widget/embed-ticket` reject an unpublished agent's key, and a never-published agent's key — parametrized over `DRAFT` and `ARCHIVED` to pin the gate as `!= PUBLISHED` rather than `== DRAFT`.
- An embed ticket minted while published no longer redeems after an unpublish.
- `ARCHIVED` variants for the other two gates as well (`ensure_widget_agent_available` and `_get_live_widget_agent`). Both are otherwise only reached through the real `/unpublish` endpoint, which hardcodes `DRAFT` and can never produce `ARCHIVED`, so a narrowed `== DRAFT` gate would have passed. Written via a direct status write, since no route assigns `ARCHIVED`.
- A `widget_enabled=True, widget_key=None` agent fails embed-ticket redemption rather than minting a keyless guest token.
- A widget guest's file download 403s after the agent is unpublished — the first widget/guest file-access assertion in the suite.
- `unpublish` added as a third case to the WS `4003` revalidation matrix in `test_widget_ws_revalidation.py`, for both the agent and workforce channels (the workforce case exercises pre-existing behaviour and keeps the `channel × revocation` matrix square).

Each of the four source-side checks was verified to be independently pinned: removing any one of them fails at least one test.

## Not in this PR

The Deploy dialog gates its **Share link** tab on publication but not its **Embed** tab. That state is unreachable today (the dialog only opens for published agents), so the missing notice is defence-in-depth rather than a live gap — left as a follow-up.

## Verification

`tests/web` passes in full. Whole-repo runs on this machine show pre-existing order-dependent `caplog` failures (including four widget-allowlist tests whose behavioural assertions pass and only whose log capture is empty); all pass in isolation. `ruff`, `ruff format`, `mypy`, `isort`, `codespell`, `npm lint`, `npm type-check` all pass.
