### PR TITLE
fix(widget): include session error reason in diagnostics

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -28,6 +28,7 @@
     identity_mismatch: true,
     rate_limited: true
   };
+  // Only diagnostic reasons defined by public issue #983 may be logged.
   var SESSION_ERROR_REASONS = {
     agent_not_granted: {
       origin_not_allowed: true
@@ -57,7 +58,7 @@
   }
 
   function isPlainSessionErrorObject(value) {
-    if (!value || Object.prototype.toString.call(value) !== '[object Object]') return false;
+    if (!value || typeof value !== 'object') return false;
     var prototype = Object.getPrototypeOf(value);
     return prototype === Object.prototype || prototype === null;
   }
@@ -69,9 +70,7 @@
   }
 
   function sessionErrorEnvelope(result) {
-    if (!isPlainSessionErrorObject(result) ||
-        !Object.prototype.hasOwnProperty.call(result, 'data') ||
-        !isPlainSessionErrorObject(result.data) ||
+    if (!isPlainSessionErrorObject(result.data) ||
         !Object.prototype.hasOwnProperty.call(result.data, 'error') ||
         !isPlainSessionErrorObject(result.data.error)) {
       return { code: null, reason: null };
@@ -754,7 +753,8 @@
     }
 
     function classifySessionFailure(result) {
-      if (result && result.syntheticCode) return { code: result.syntheticCode, reason: null };
+      var syntheticCode = ownSessionErrorString(result, 'syntheticCode');
+      if (syntheticCode) return { code: syntheticCode, reason: null };
       var envelope = sessionErrorEnvelope(result);
       if (isKnownSessionErrorCode(envelope.code)) return envelope;
       if (result.status >= 500) return { code: 'network_unavailable', reason: null };

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -59,8 +59,9 @@
 
   function isPlainSessionErrorObject(value) {
     if (!value || typeof value !== 'object') return false;
+    // Prototype identity is not affected by host-page Symbol.toStringTag pollution.
     var prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
+    return prototype === Object.prototype;
   }
 
   function ownSessionErrorString(value, key) {

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -28,7 +28,7 @@
     identity_mismatch: true,
     rate_limited: true
   };
-  // Only diagnostic reasons defined by public issue #983 may be logged.
+  // Only diagnostic reasons registered for their session error code may be logged.
   var SESSION_ERROR_REASONS = {
     agent_not_granted: {
       origin_not_allowed: true

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -28,6 +28,11 @@
     identity_mismatch: true,
     rate_limited: true
   };
+  var SESSION_ERROR_REASONS = {
+    agent_not_granted: {
+      origin_not_allowed: true
+    }
+  };
   function sessionAbortError() {
     return new DOMException('session request superseded', 'AbortError');
   }
@@ -51,9 +56,38 @@
     });
   }
 
-  function sessionErrorCode(result) {
-    var code = result && result.data && result.data.error && result.data.error.code;
-    return typeof code === 'string' ? code : null;
+  function isPlainSessionErrorObject(value) {
+    if (!value || Object.prototype.toString.call(value) !== '[object Object]') return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function ownSessionErrorString(value, key) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) return null;
+    var candidate = value[key];
+    return typeof candidate === 'string' ? candidate : null;
+  }
+
+  function sessionErrorEnvelope(result) {
+    if (!isPlainSessionErrorObject(result) ||
+        !Object.prototype.hasOwnProperty.call(result, 'data') ||
+        !isPlainSessionErrorObject(result.data) ||
+        !Object.prototype.hasOwnProperty.call(result.data, 'error') ||
+        !isPlainSessionErrorObject(result.data.error)) {
+      return { code: null, reason: null };
+    }
+    var error = result.data.error;
+    var code = ownSessionErrorString(error, 'code');
+    var reason = ownSessionErrorString(error, 'reason');
+    var allowedReasons = code && Object.prototype.hasOwnProperty.call(SESSION_ERROR_REASONS, code)
+      ? SESSION_ERROR_REASONS[code]
+      : null;
+    return {
+      code: code,
+      reason: allowedReasons && reason && Object.prototype.hasOwnProperty.call(allowedReasons, reason)
+        ? reason
+        : null
+    };
   }
 
   function isKnownSessionErrorCode(code) {
@@ -140,7 +174,7 @@
       retry.attempts += 1;
       return makeRequest(requestTimeoutMs).then(function (result) {
         if (signal.aborted) throw sessionAbortError();
-        var code = sessionErrorCode(result);
+        var code = sessionErrorEnvelope(result).code;
         if (code === 'rate_limited') {
           if (retry.rateLimited >= policy.maxRateLimitRetries) return result;
           retry.rateLimited += 1;
@@ -386,9 +420,10 @@
     return 'g' + hash.toString(16);
   }
 
-  function logSession(level, text, code, status) {
+  function logSession(level, text, code, status, reason) {
     var suffix = status ? ' (HTTP ' + status + ')' : '';
-    console[level]('Xagent Widget: ' + text + ' [' + code + ']' + suffix + '.');
+    var diagnostic = reason ? code + '/' + reason : code;
+    console[level]('Xagent Widget: ' + text + ' [' + diagnostic + ']' + suffix + '.');
   }
 
   function createSessionMode(scriptTag, host) {
@@ -710,20 +745,20 @@
       flush();
     }
 
-    function recordFailure(code, status) {
+    function recordFailure(code, status, reason) {
       if (state.terminalCode) return;
       state.terminalCode = code;
       state.recoverableCode = null;
-      logSession('error', 'chat unavailable', code, status);
+      logSession('error', 'chat unavailable', code, status, reason);
       flush();
     }
 
     function classifySessionFailure(result) {
-      if (result && result.syntheticCode) return result.syntheticCode;
-      var code = sessionErrorCode(result);
-      if (isKnownSessionErrorCode(code)) return code;
-      if (result.status >= 500) return 'network_unavailable';
-      return 'unexpected_error';
+      if (result && result.syntheticCode) return { code: result.syntheticCode, reason: null };
+      var envelope = sessionErrorEnvelope(result);
+      if (isKnownSessionErrorCode(envelope.code)) return envelope;
+      if (result.status >= 500) return { code: 'network_unavailable', reason: null };
+      return { code: 'unexpected_error', reason: null };
     }
 
     function handleResult(result, phase) {
@@ -739,8 +774,8 @@
         return;
       }
 
-      var code = classifySessionFailure(result);
-      recordFailure(code, result.status);
+      var failure = classifySessionFailure(result);
+      recordFailure(failure.code, result.status, failure.reason);
     }
 
     function postJson(url, body, timeoutMs, operationSignal) {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -17,12 +17,7 @@ const RECONNECT_URL = `${HOST}/v1/external/chat/sessions/reconnect`
 
 const fetchMock = vi.fn()
 
-type SessionFailureTestSeam = {
-  parse: (result: unknown) => { code: string | null; reason: string | null }
-  classify: (result: unknown) => { code: string; reason: string | null }
-}
-
-function runWidget(attributes: Record<string, string>, exposeClassifier = false) {
+function runWidget(attributes: Record<string, string>) {
   const script = document.createElement("script")
   script.src = `${HOST}/widget.js`
   for (const [name, value] of Object.entries(attributes)) {
@@ -30,13 +25,7 @@ function runWidget(attributes: Record<string, string>, exposeClassifier = false)
   }
   document.body.appendChild(script)
   Object.defineProperty(document, "currentScript", { configurable: true, value: script })
-  const executable = exposeClassifier
-    ? widgetScript.replace(
-      "    return { attach: attach };",
-      "    window.__xagentWidgetTestSessionFailure = { parse: sessionErrorEnvelope, classify: classifySessionFailure };\n    return { attach: attach };",
-    )
-    : widgetScript
-  window.eval(`${executable}\n//# sourceURL=${widgetScriptUrl}`)
+  window.eval(`${widgetScript}\n//# sourceURL=${widgetScriptUrl}`)
   return script
 }
 
@@ -104,14 +93,6 @@ function directJsonResponse(status: number, data: unknown): Response {
     headers: new Headers(),
     json: () => Promise.resolve(data),
   } as Response
-}
-
-function exposedSessionFailureTestSeam(): SessionFailureTestSeam {
-  const seam = (window as unknown as {
-    __xagentWidgetTestSessionFailure?: SessionFailureTestSeam
-  }).__xagentWidgetTestSessionFailure
-  if (!seam) throw new Error("session failure test seam was not exposed")
-  return seam
 }
 
 function proxyWithInheritedValue(target: Record<string, unknown>, key: string, value: unknown) {
@@ -194,7 +175,6 @@ describe("widget session mode", () => {
     localStorage.clear()
     // The grant dedupe registry lives on window and survives between tests in a file.
     Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetGrants")
-    Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetTestSessionFailure")
     vi.stubGlobal("fetch", fetchMock)
     fetchMock.mockReset()
 
@@ -219,8 +199,6 @@ describe("widget session mode", () => {
       window.removeEventListener(type, listener)
     }
     windowListeners = []
-    Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetTestSessionFailure")
-
     if (currentScriptDescriptor) {
       Object.defineProperty(document, "currentScript", currentScriptDescriptor)
     } else {
@@ -818,6 +796,70 @@ describe("widget session mode", () => {
     })
   })
 
+  it("ignores an inherited synthetic session failure code", async () => {
+    const syntheticCodeDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "syntheticCode")
+    Object.defineProperty(Object.prototype, "syntheticCode", {
+      configurable: true,
+      value: "network_unavailable",
+    })
+    try {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+      fetchMock.mockResolvedValueOnce(jsonResponse(403, {
+        error: {
+          code: "agent_not_granted",
+          reason: "origin_not_allowed",
+        },
+      }))
+      runWidget({ "data-encrypted-context": GRANT })
+      const post = spyOnIframePostMessage()
+
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+        "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
+      ))
+      fromIframe("ready")
+
+      expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: "agent_not_granted" })
+    } finally {
+      if (syntheticCodeDescriptor) {
+        Object.defineProperty(Object.prototype, "syntheticCode", syntheticCodeDescriptor)
+      } else {
+        Reflect.deleteProperty(Object.prototype, "syntheticCode")
+      }
+    }
+  })
+
+  it("keeps a registered diagnostic intact when Object.prototype has a toString tag", async () => {
+    const toStringTagDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, Symbol.toStringTag)
+    Object.defineProperty(Object.prototype, Symbol.toStringTag, {
+      configurable: true,
+      value: "polluted",
+    })
+    try {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+      fetchMock.mockResolvedValueOnce(jsonResponse(403, {
+        error: {
+          code: "agent_not_granted",
+          reason: "origin_not_allowed",
+        },
+      }))
+      runWidget({ "data-encrypted-context": GRANT })
+      const post = spyOnIframePostMessage()
+
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+        "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
+      ))
+      fromIframe("ready")
+
+      expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: "agent_not_granted" })
+    } finally {
+      if (toStringTagDescriptor) {
+        Object.defineProperty(Object.prototype, Symbol.toStringTag, toStringTagDescriptor)
+      } else {
+        Reflect.deleteProperty(Object.prototype, Symbol.toStringTag)
+      }
+    }
+  })
+
   it("keeps the existing exchange diagnostic unchanged when the reason is absent", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     fetchMock.mockResolvedValueOnce(errorResponse(403, "agent_not_granted"))
@@ -859,117 +901,79 @@ describe("widget session mode", () => {
   })
 
   it.each([
+    ["root array", () => ["agent_not_granted", "origin_not_allowed"], "unexpected_error"],
+    ["missing error", () => ({}), "unexpected_error"],
+    ["null error", () => ({ error: null }), "unexpected_error"],
+    ["error array", () => ({ error: ["agent_not_granted", "origin_not_allowed"] }), "unexpected_error"],
+    ["non-string code", () => ({ error: { code: 42, reason: "origin_not_allowed", message: "sentinel" } }), "unexpected_error"],
+    ["non-string code array", () => ({ error: { code: ["agent_not_granted"], reason: "origin_not_allowed", message: "sentinel" } }), "unexpected_error"],
     ["missing reason", () => ({ error: { code: "agent_not_granted", message: "sentinel" } }), "agent_not_granted"],
     ["null reason", () => ({ error: { code: "agent_not_granted", reason: null, message: "sentinel" } }), "agent_not_granted"],
     ["non-string reason", () => ({ error: { code: "agent_not_granted", reason: 42, message: "sentinel" } }), "agent_not_granted"],
+    ["non-string reason array", () => ({ error: { code: "agent_not_granted", reason: ["origin_not_allowed"], message: "sentinel" } }), "agent_not_granted"],
     ["unregistered reason", () => ({ error: { code: "agent_not_granted", reason: "future_reason", message: "sentinel" } }), "agent_not_granted"],
     ["prototype-key reason", () => ({ error: { code: "agent_not_granted", reason: "toString", message: "sentinel" } }), "agent_not_granted"],
-    ["malformed error", () => ({ error: ["agent_not_granted", "origin_not_allowed"] }), "unexpected_error"],
-  ])("suppresses an untrusted %s diagnostic component", async (_case, makeData, expectedCode) => {
+  ])("suppresses an untrusted %s diagnostic component from a JSON response", async (_case, makeData, expectedCode) => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    fetchMock.mockResolvedValueOnce(directJsonResponse(403, makeData()))
+    fetchMock.mockResolvedValueOnce(jsonResponse(403, makeData()))
     runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
 
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
       `Xagent Widget: chat unavailable [${expectedCode}] (HTTP 403).`,
     ))
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("origin_not_allowed"))
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("sentinel"))
-  })
+    fromIframe("ready")
 
-  it("accepts the registered diagnostic pair from null-prototype envelope objects", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    const error = Object.assign(Object.create(null), {
-      code: "agent_not_granted",
-      reason: "origin_not_allowed",
-    })
-    const data = Object.assign(Object.create(null), { error })
-    fetchMock.mockResolvedValueOnce(directJsonResponse(403, data))
-    runWidget({ "data-encrypted-context": GRANT })
-
-    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
-      "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
-    ))
-  })
-
-  it("gives synthetic session failures precedence over a registered server diagnostic", () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
-    runWidget({ "data-encrypted-context": GRANT }, true)
-    const { classify } = exposedSessionFailureTestSeam()
-
-    expect(classify({
-      syntheticCode: "network_unavailable",
-      status: 403,
-      data: { error: { code: "agent_not_granted", reason: "origin_not_allowed" } },
-    })).toEqual({ code: "network_unavailable", reason: null })
+    expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: expectedCode })
   })
 
   it.each([
     [
-      "result.data",
-      () => proxyWithInheritedValue(
-        { status: 403 },
-        "data",
-        { error: { code: "agent_not_granted", reason: "origin_not_allowed" } },
-      ),
-      { code: null, reason: null },
-    ],
-    [
       "data.error",
-      () => ({
-        status: 403,
-        data: proxyWithInheritedValue(
-          {},
-          "error",
-          { code: "agent_not_granted", reason: "origin_not_allowed" },
-        ),
-      }),
-      { code: null, reason: null },
+      () => proxyWithInheritedValue(
+        {},
+        "error",
+        { code: "agent_not_granted", reason: "origin_not_allowed" },
+      ),
+      "unexpected_error",
     ],
     [
       "error.code",
       () => ({
-        status: 403,
-        data: {
-          error: proxyWithInheritedValue(
-            { reason: "origin_not_allowed" },
-            "code",
-            "agent_not_granted",
-          ),
-        },
+        error: proxyWithInheritedValue(
+          { reason: "origin_not_allowed" },
+          "code",
+          "agent_not_granted",
+        ),
       }),
-      { code: null, reason: null },
+      "unexpected_error",
     ],
     [
       "error.reason",
       () => ({
-        status: 403,
-        data: {
-          error: proxyWithInheritedValue(
-            { code: "agent_not_granted" },
-            "reason",
-            "origin_not_allowed",
-          ),
-        },
+        error: proxyWithInheritedValue(
+          { code: "agent_not_granted" },
+          "reason",
+          "origin_not_allowed",
+        ),
       }),
-      { code: "agent_not_granted", reason: null },
+      "agent_not_granted",
     ],
-  ])("rejects the inherited %s boundary without short-circuiting an outer parser guard", (_boundary, makeResult, expected) => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
-    runWidget({ "data-encrypted-context": GRANT }, true)
+  ])("suppresses an inherited %s diagnostic component", async (_boundary, makeData, expectedCode) => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(directJsonResponse(403, makeData()))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
 
-    expect(exposedSessionFailureTestSeam().parse(makeResult())).toEqual(expected)
-  })
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      `Xagent Widget: chat unavailable [${expectedCode}] (HTTP 403).`,
+    ))
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("origin_not_allowed"))
+    fromIframe("ready")
 
-  it.each([
-    ["missing error", { status: 403, data: {} }],
-    ["null error", { status: 403, data: { error: null } }],
-    ["non-string code", { status: 403, data: { error: { code: 42, reason: "origin_not_allowed" } } }],
-  ])("rejects a %s envelope component", (_case, result) => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
-    runWidget({ "data-encrypted-context": GRANT }, true)
-
-    expect(exposedSessionFailureTestSeam().parse(result)).toEqual({ code: null, reason: null })
+    expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: expectedCode })
   })
 
   it("does not retry a coded 4xx and reports unexpected_error for an uncoded one", async () => {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -1165,7 +1165,7 @@ describe("widget session mode", () => {
     vi.useFakeTimers()
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    fetchMock.mockImplementation(() => Promise.resolve(directJsonResponse(503, {
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(503, {
       error: {
         code: "future_server_code",
         reason: "origin_not_allowed",

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -17,7 +17,12 @@ const RECONNECT_URL = `${HOST}/v1/external/chat/sessions/reconnect`
 
 const fetchMock = vi.fn()
 
-function runWidget(attributes: Record<string, string>) {
+type SessionFailureTestSeam = {
+  parse: (result: unknown) => { code: string | null; reason: string | null }
+  classify: (result: unknown) => { code: string; reason: string | null }
+}
+
+function runWidget(attributes: Record<string, string>, exposeClassifier = false) {
   const script = document.createElement("script")
   script.src = `${HOST}/widget.js`
   for (const [name, value] of Object.entries(attributes)) {
@@ -25,7 +30,13 @@ function runWidget(attributes: Record<string, string>) {
   }
   document.body.appendChild(script)
   Object.defineProperty(document, "currentScript", { configurable: true, value: script })
-  window.eval(`${widgetScript}\n//# sourceURL=${widgetScriptUrl}`)
+  const executable = exposeClassifier
+    ? widgetScript.replace(
+      "    return { attach: attach };",
+      "    window.__xagentWidgetTestSessionFailure = { parse: sessionErrorEnvelope, classify: classifySessionFailure };\n    return { attach: attach };",
+    )
+    : widgetScript
+  window.eval(`${executable}\n//# sourceURL=${widgetScriptUrl}`)
   return script
 }
 
@@ -83,6 +94,31 @@ function jsonResponse(status: number, body: unknown, headers: Record<string, str
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json", ...headers },
+  })
+}
+
+function directJsonResponse(status: number, data: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    json: () => Promise.resolve(data),
+  } as Response
+}
+
+function exposedSessionFailureTestSeam(): SessionFailureTestSeam {
+  const seam = (window as unknown as {
+    __xagentWidgetTestSessionFailure?: SessionFailureTestSeam
+  }).__xagentWidgetTestSessionFailure
+  if (!seam) throw new Error("session failure test seam was not exposed")
+  return seam
+}
+
+function proxyWithInheritedValue(target: Record<string, unknown>, key: string, value: unknown) {
+  return new Proxy(target, {
+    get(current, property, receiver) {
+      return property === key ? value : Reflect.get(current, property, receiver)
+    },
   })
 }
 
@@ -158,6 +194,7 @@ describe("widget session mode", () => {
     localStorage.clear()
     // The grant dedupe registry lives on window and survives between tests in a file.
     Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetGrants")
+    Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetTestSessionFailure")
     vi.stubGlobal("fetch", fetchMock)
     fetchMock.mockReset()
 
@@ -182,6 +219,7 @@ describe("widget session mode", () => {
       window.removeEventListener(type, listener)
     }
     windowListeners = []
+    Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__xagentWidgetTestSessionFailure")
 
     if (currentScriptDescriptor) {
       Object.defineProperty(document, "currentScript", currentScriptDescriptor)
@@ -755,6 +793,185 @@ describe("widget session mode", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it("logs the registered exchange diagnostic reason without forwarding it to the iframe", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(jsonResponse(403, {
+      error: {
+        code: "agent_not_granted",
+        reason: "origin_not_allowed",
+        message: "remote diagnostic must not be logged",
+      },
+    }))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
+    ))
+    fromIframe("ready")
+
+    expect(post.mock.calls[0][0]).toEqual({
+      xagent: true,
+      v: 1,
+      type: "session_terminal",
+      code: "agent_not_granted",
+    })
+  })
+
+  it("keeps the existing exchange diagnostic unchanged when the reason is absent", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(errorResponse(403, "agent_not_granted"))
+    runWidget({ "data-encrypted-context": GRANT })
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      "Xagent Widget: chat unavailable [agent_not_granted] (HTTP 403).",
+    ))
+  })
+
+  it("logs the registered reconnect diagnostic reason without forwarding it to the iframe", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+      .mockResolvedValueOnce(jsonResponse(403, {
+        error: {
+          code: "agent_not_granted",
+          reason: "origin_not_allowed",
+          message: "remote diagnostic must not be logged",
+        },
+      }))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
+    await flushAsync()
+    fromIframe("ready")
+    post.mockClear()
+
+    fromIframe("reconnect_request", { reason: "ws_closed" })
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
+    ))
+    expect(post).toHaveBeenCalledWith({
+      xagent: true,
+      v: 1,
+      type: "session_terminal",
+      code: "agent_not_granted",
+    }, HOST)
+  })
+
+  it.each([
+    ["missing reason", () => ({ error: { code: "agent_not_granted", message: "sentinel" } }), "agent_not_granted"],
+    ["null reason", () => ({ error: { code: "agent_not_granted", reason: null, message: "sentinel" } }), "agent_not_granted"],
+    ["non-string reason", () => ({ error: { code: "agent_not_granted", reason: 42, message: "sentinel" } }), "agent_not_granted"],
+    ["unregistered reason", () => ({ error: { code: "agent_not_granted", reason: "future_reason", message: "sentinel" } }), "agent_not_granted"],
+    ["prototype-key reason", () => ({ error: { code: "agent_not_granted", reason: "toString", message: "sentinel" } }), "agent_not_granted"],
+    ["malformed error", () => ({ error: ["agent_not_granted", "origin_not_allowed"] }), "unexpected_error"],
+  ])("suppresses an untrusted %s diagnostic component", async (_case, makeData, expectedCode) => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(directJsonResponse(403, makeData()))
+    runWidget({ "data-encrypted-context": GRANT })
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      `Xagent Widget: chat unavailable [${expectedCode}] (HTTP 403).`,
+    ))
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("origin_not_allowed"))
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("sentinel"))
+  })
+
+  it("accepts the registered diagnostic pair from null-prototype envelope objects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const error = Object.assign(Object.create(null), {
+      code: "agent_not_granted",
+      reason: "origin_not_allowed",
+    })
+    const data = Object.assign(Object.create(null), { error })
+    fetchMock.mockResolvedValueOnce(directJsonResponse(403, data))
+    runWidget({ "data-encrypted-context": GRANT })
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
+    ))
+  })
+
+  it("gives synthetic session failures precedence over a registered server diagnostic", () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+    runWidget({ "data-encrypted-context": GRANT }, true)
+    const { classify } = exposedSessionFailureTestSeam()
+
+    expect(classify({
+      syntheticCode: "network_unavailable",
+      status: 403,
+      data: { error: { code: "agent_not_granted", reason: "origin_not_allowed" } },
+    })).toEqual({ code: "network_unavailable", reason: null })
+  })
+
+  it.each([
+    [
+      "result.data",
+      () => proxyWithInheritedValue(
+        { status: 403 },
+        "data",
+        { error: { code: "agent_not_granted", reason: "origin_not_allowed" } },
+      ),
+      { code: null, reason: null },
+    ],
+    [
+      "data.error",
+      () => ({
+        status: 403,
+        data: proxyWithInheritedValue(
+          {},
+          "error",
+          { code: "agent_not_granted", reason: "origin_not_allowed" },
+        ),
+      }),
+      { code: null, reason: null },
+    ],
+    [
+      "error.code",
+      () => ({
+        status: 403,
+        data: {
+          error: proxyWithInheritedValue(
+            { reason: "origin_not_allowed" },
+            "code",
+            "agent_not_granted",
+          ),
+        },
+      }),
+      { code: null, reason: null },
+    ],
+    [
+      "error.reason",
+      () => ({
+        status: 403,
+        data: {
+          error: proxyWithInheritedValue(
+            { code: "agent_not_granted" },
+            "reason",
+            "origin_not_allowed",
+          ),
+        },
+      }),
+      { code: "agent_not_granted", reason: null },
+    ],
+  ])("rejects the inherited %s boundary without short-circuiting an outer parser guard", (_boundary, makeResult, expected) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+    runWidget({ "data-encrypted-context": GRANT }, true)
+
+    expect(exposedSessionFailureTestSeam().parse(makeResult())).toEqual(expected)
+  })
+
+  it.each([
+    ["missing error", { status: 403, data: {} }],
+    ["null error", { status: 403, data: { error: null } }],
+    ["non-string code", { status: 403, data: { error: { code: 42, reason: "origin_not_allowed" } } }],
+  ])("rejects a %s envelope component", (_case, result) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+    runWidget({ "data-encrypted-context": GRANT }, true)
+
+    expect(exposedSessionFailureTestSeam().parse(result)).toEqual({ code: null, reason: null })
+  })
+
   it("does not retry a coded 4xx and reports unexpected_error for an uncoded one", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     fetchMock.mockResolvedValueOnce(new Response("<html>payload too large</html>", { status: 413 }))
@@ -894,6 +1111,39 @@ describe("widget session mode", () => {
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("[future_server_code]"))
   })
 
+  it("keeps unknown-5xx retry warnings and terminal frames code-only", async () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockImplementation(() => Promise.resolve(directJsonResponse(503, {
+      error: {
+        code: "future_server_code",
+        reason: "origin_not_allowed",
+        message: "retry diagnostic must not be logged",
+      },
+    })))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
+    fromIframe("ready")
+
+    await vi.advanceTimersByTimeAsync(7_000)
+
+    expect(warnSpy.mock.calls).toEqual([
+      ["Xagent Widget: session recovery is retrying [network_unavailable]."],
+      ["Xagent Widget: session recovery is retrying [network_unavailable]."],
+      ["Xagent Widget: session recovery is retrying [network_unavailable]."],
+    ])
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Xagent Widget: chat unavailable [network_unavailable] (HTTP 503).",
+    )
+    expect(post.mock.calls.map(([message]) => message)).toEqual([
+      { xagent: true, v: 1, type: "session_degraded", code: "network_unavailable" },
+      { xagent: true, v: 1, type: "session_degraded", code: "network_unavailable" },
+      { xagent: true, v: 1, type: "session_degraded", code: "network_unavailable" },
+      { xagent: true, v: 1, type: "session_terminal", code: "network_unavailable" },
+    ])
+  })
+
   it("retries a server-supplied network_unavailable 5xx as an unknown transport failure", async () => {
     vi.useFakeTimers()
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
@@ -1011,6 +1261,31 @@ describe("widget session mode", () => {
     await vi.advanceTimersByTimeAsync(3000)
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[rate_limited] (HTTP 429)"))
+  })
+
+  it("keeps rate-limit retry warnings and degraded frames code-only", async () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(429, {
+      error: {
+        code: "rate_limited",
+        reason: "origin_not_allowed",
+        message: "retry diagnostic must not be logged",
+      },
+    }, { "Retry-After": "1" })))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
+    fromIframe("ready")
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Xagent Widget: session recovery is retrying [rate_limited].",
+    )
+    expect(post).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "session_degraded", code: "rate_limited" },
+      HOST,
+    )
   })
 
   it("honors an HTTP-date Retry-After value", async () => {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -95,14 +95,6 @@ function directJsonResponse(status: number, data: unknown): Response {
   } as Response
 }
 
-function proxyWithInheritedValue(target: Record<string, unknown>, key: string, value: unknown) {
-  return new Proxy(target, {
-    get(current, property, receiver) {
-      return property === key ? value : Reflect.get(current, property, receiver)
-    },
-  })
-}
-
 function errorResponse(status: number, code: string) {
   return jsonResponse(status, { error: { code, message: "nope" } })
 }
@@ -813,9 +805,9 @@ describe("widget session mode", () => {
       runWidget({ "data-encrypted-context": GRANT })
       const post = spyOnIframePostMessage()
 
-      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      await vi.waitFor(() => expect(errorSpy.mock.calls).toEqual([[
         "Xagent Widget: chat unavailable [agent_not_granted/origin_not_allowed] (HTTP 403).",
-      ))
+      ]]))
       fromIframe("ready")
 
       expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: "agent_not_granted" })
@@ -929,51 +921,81 @@ describe("widget session mode", () => {
     expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: expectedCode })
   })
 
-  it.each([
-    [
-      "data.error",
-      () => proxyWithInheritedValue(
-        {},
-        "error",
-        { code: "agent_not_granted", reason: "origin_not_allowed" },
-      ),
-      "unexpected_error",
-    ],
-    [
-      "error.code",
-      () => ({
-        error: proxyWithInheritedValue(
-          { reason: "origin_not_allowed" },
-          "code",
-          "agent_not_granted",
-        ),
-      }),
-      "unexpected_error",
-    ],
-    [
-      "error.reason",
-      () => ({
-        error: proxyWithInheritedValue(
-          { code: "agent_not_granted" },
-          "reason",
-          "origin_not_allowed",
-        ),
-      }),
-      "agent_not_granted",
-    ],
-  ])("suppresses an inherited %s diagnostic component", async (_boundary, makeData, expectedCode) => {
+  it("fails closed on null-prototype response objects", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    fetchMock.mockResolvedValueOnce(directJsonResponse(403, makeData()))
+    const error = Object.assign(Object.create(null), {
+      code: "agent_not_granted",
+      reason: "origin_not_allowed",
+    })
+    const data = Object.assign(Object.create(null), { error })
+    fetchMock.mockResolvedValueOnce(directJsonResponse(403, data))
     runWidget({ "data-encrypted-context": GRANT })
     const post = spyOnIframePostMessage()
 
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
-      `Xagent Widget: chat unavailable [${expectedCode}] (HTTP 403).`,
+      "Xagent Widget: chat unavailable [unexpected_error] (HTTP 403).",
     ))
     expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("origin_not_allowed"))
     fromIframe("ready")
 
-    expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: expectedCode })
+    expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: "unexpected_error" })
+  })
+
+  it.each([
+    [
+      "data.error",
+      "error",
+      { code: "agent_not_granted", reason: "origin_not_allowed" },
+      () => ({}),
+      "unexpected_error",
+    ],
+    [
+      "error.code",
+      "code",
+      "agent_not_granted",
+      () => ({ error: { reason: "origin_not_allowed" } }),
+      "unexpected_error",
+    ],
+    [
+      "error.reason",
+      "reason",
+      "origin_not_allowed",
+      () => ({ error: { code: "agent_not_granted" } }),
+      "agent_not_granted",
+    ],
+  ])("suppresses an inherited %s diagnostic component from Object.prototype", async (
+    _boundary,
+    property,
+    inheritedValue,
+    makeData,
+    expectedCode,
+  ) => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, property)
+    Object.defineProperty(Object.prototype, property, {
+      configurable: true,
+      writable: true,
+      value: inheritedValue,
+    })
+    try {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+      fetchMock.mockResolvedValueOnce(jsonResponse(403, makeData()))
+      runWidget({ "data-encrypted-context": GRANT })
+      const post = spyOnIframePostMessage()
+
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+        `Xagent Widget: chat unavailable [${expectedCode}] (HTTP 403).`,
+      ))
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("origin_not_allowed"))
+      fromIframe("ready")
+
+      expect(post.mock.calls[0][0]).toMatchObject({ type: "session_terminal", code: expectedCode })
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Object.prototype, property, descriptor)
+      } else {
+        Reflect.deleteProperty(Object.prototype, property)
+      }
+    }
   })
 
   it("does not retry a coded 4xx and reports unexpected_error for an uncoded one", async () => {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -191,6 +191,7 @@ describe("widget session mode", () => {
       window.removeEventListener(type, listener)
     }
     windowListeners = []
+
     if (currentScriptDescriptor) {
       Object.defineProperty(document, "currentScript", currentScriptDescriptor)
     } else {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -788,6 +788,30 @@ describe("widget session mode", () => {
     })
   })
 
+  it("scopes a registered diagnostic reason to its owning terminal code", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, {
+      error: {
+        code: "session_expired",
+        reason: "origin_not_allowed",
+      },
+    }))
+    runWidget({ "data-encrypted-context": GRANT })
+    const post = spyOnIframePostMessage()
+
+    await vi.waitFor(() => expect(errorSpy.mock.calls).toEqual([[
+      "Xagent Widget: chat unavailable [session_expired] (HTTP 401).",
+    ]]))
+    fromIframe("ready")
+
+    expect(post.mock.calls[0][0]).toEqual({
+      xagent: true,
+      v: 1,
+      type: "session_terminal",
+      code: "session_expired",
+    })
+  })
+
   it("ignores an inherited synthetic session failure code", async () => {
     const syntheticCodeDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "syntheticCode")
     Object.defineProperty(Object.prototype, "syntheticCode", {


### PR DESCRIPTION
## Summary

Adds safe error-reason diagnostics to delegated Widget Session exchange and reconnect failures.

- Parses the documented error envelope through one shared helper.
- Logs `agent_not_granted/origin_not_allowed` as `[agent_not_granted/origin_not_allowed]` so Allowed Domains configuration failures are distinguishable from missing agent grants.
- Keeps retry decisions, terminal/degraded state, and iframe `postMessage` payloads code-only.
- Rejects inherited error fields and synthetic failure codes, so host-page prototype pollution cannot alter retry or terminal classification.
- Ignores malformed, non-string, inherited, unknown, and unregistered reasons without logging the remote error message.

## Why

The session API intentionally uses `agent_not_granted` for both missing grants and Origin × `allowed_domains` denials. Without the optional `origin_not_allowed` diagnostic, partner developers are directed toward agent registration even when the actual problem is the Allowed Domains configuration.

The reason catalog is fail-closed: new server reasons must be registered deliberately and the hosted `widget.js` redeployed before they can appear in browser diagnostics.

## Verification

- `npm run test:widget:coverage` — 705/705 tests passed across 31 files
- `public/widget.js` coverage — 97.23% statements/lines, 93.03% branches, 98.30% functions
- `npx eslint src/components/widget/widget-session.test.ts public/widget.js`
- `npx tsc --noEmit`
- `node --check public/widget.js`
- `pre-commit run --files frontend/public/widget.js frontend/src/components/widget/widget-session.test.ts`

Refs #983

