### PR TITLE
feat: add Zoom MCP connector for the Meeting Agent

### DIFF
--- a/example.env
+++ b/example.env
@@ -476,8 +476,9 @@ SLACK_REDIRECT_URI=""
 # Required for the Zoom integration in MCP (meeting lookup, cloud recordings,
 # transcripts). Create a "General App" (User Managed) at
 # https://marketplace.zoom.us/develop/create and add the scopes:
-# meeting:read:meeting, meeting:read:list_meetings, cloud_recording:read:list_recording_files,
-# cloud_recording:read:meeting_transcript, user:read:user
+# meeting:read:meeting, meeting:read:list_meetings, meeting:read:past_meeting,
+# cloud_recording:read:list_recording_files, cloud_recording:read:meeting_transcript,
+# user:read:user
 ZOOM_CLIENT_ID=""
 ZOOM_CLIENT_SECRET=""
 # Redirect URI for Zoom OAuth callback — must exactly match a URL registered

--- a/example.env
+++ b/example.env
@@ -470,6 +470,21 @@ SLACK_CLIENT_SECRET=""
 # Example: http://localhost:8000/api/auth/slack/callback
 SLACK_REDIRECT_URI=""
 
+# ===========================================
+# Zoom OAuth Configuration (Optional)
+# ===========================================
+# Required for the Zoom integration in MCP (meeting lookup, cloud recordings,
+# transcripts). Create a "General App" (User Managed) at
+# https://marketplace.zoom.us/develop/create and add the scopes:
+# meeting:read:meeting, meeting:read:list_meetings, cloud_recording:read:recording,
+# cloud_recording:read:meeting_transcript, user:read:user
+ZOOM_CLIENT_ID=""
+ZOOM_CLIENT_SECRET=""
+# Redirect URI for Zoom OAuth callback — must exactly match a URL registered
+# in the app's OAuth Allow List.
+# Example: http://localhost:8000/api/auth/zoom/callback
+ZOOM_REDIRECT_URI=""
+
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
 # - LanceDB storage path: <project_root>/memory_store/

--- a/example.env
+++ b/example.env
@@ -476,7 +476,7 @@ SLACK_REDIRECT_URI=""
 # Required for the Zoom integration in MCP (meeting lookup, cloud recordings,
 # transcripts). Create a "General App" (User Managed) at
 # https://marketplace.zoom.us/develop/create and add the scopes:
-# meeting:read:meeting, meeting:read:list_meetings, cloud_recording:read:recording,
+# meeting:read:meeting, meeting:read:list_meetings, cloud_recording:read:list_recording_files,
 # cloud_recording:read:meeting_transcript, user:read:user
 ZOOM_CLIENT_ID=""
 ZOOM_CLIENT_SECRET=""

--- a/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
@@ -57,10 +57,16 @@ APP_ID = "zoom"
 ZOOM_SCOPES = [
     "meeting:read:meeting",
     "meeting:read:list_meetings",
+    "meeting:read:past_meeting",
     "cloud_recording:read:list_recording_files",
     "cloud_recording:read:meeting_transcript",
     "user:read:user",
 ]
+
+# Identity-only, matching the other seeded providers — the functional scopes
+# above live on the app row (_zoom_app_row) and are merged in at authorize
+# time, so the provider row doesn't need to duplicate the full list.
+ZOOM_PROVIDER_DEFAULT_SCOPES = ["user:read:user"]
 
 
 def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
@@ -79,7 +85,7 @@ def _zoom_provider_row() -> dict[str, object]:
         "userinfo_url": "https://api.zoom.us/v2/users/me",
         "user_id_path": "id",
         "email_path": "email",
-        "default_scopes": ZOOM_SCOPES,
+        "default_scopes": ZOOM_PROVIDER_DEFAULT_SCOPES,
     }
 
 

--- a/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
@@ -1,0 +1,180 @@
+"""seed built-in Zoom (OAuth) MCP connector
+
+Revision ID: 20260730_seed_zoom_mcp_app
+Revises: 20260724_add_upload_source_to_uploaded_files
+Create Date: 2026-07-30 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260730_seed_zoom_mcp_app"
+down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "zoom"
+
+ZOOM_SCOPES = [
+    "meeting:read:meeting",
+    "meeting:read:list_meetings",
+    "cloud_recording:read:recording",
+    "cloud_recording:read:meeting_transcript",
+    "user:read:user",
+]
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _zoom_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "zoom",
+        "name": "Zoom",
+        "client_id": os.environ.get("ZOOM_CLIENT_ID", ""),
+        "client_secret": os.environ.get("ZOOM_CLIENT_SECRET", ""),
+        "auth_url": "https://zoom.us/oauth/authorize",
+        "token_url": "https://zoom.us/oauth/token",
+        "redirect_uri": os.environ.get("ZOOM_REDIRECT_URI", ""),
+        "userinfo_url": "https://api.zoom.us/v2/users/me",
+        "user_id_path": "id",
+        "email_path": "email",
+        "default_scopes": ZOOM_SCOPES,
+    }
+
+
+def _zoom_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "Zoom",
+        "description": "Connect to Zoom to look up meetings, and read cloud recordings and transcripts.",
+        "icon": "https://www.google.com/s2/favicons?domain=zoom.us&sz=128",
+        "transport": "oauth",
+        "provider_name": "zoom",
+        "category": "Scheduling",
+        "oauth_scopes": ZOOM_SCOPES,
+        "is_visible_in_connector": True,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.zoom"],
+            "env_mapping": {"ZOOM_ACCESS_TOKEN": "access_token"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+        )
+        if "zoom" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_zoom_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_zoom_app_row(), app_columns)],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only the catalog entry is removed. Any user OAuth connections created
+        # against this app are not owned by this migration and are cleaned up
+        # through the normal disconnect path.
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_zoom_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "zoom")
+        ).scalar()
+        if remaining_zoom_apps:
+            return
+
+    # Only delete the provider row when it still matches the static shape this
+    # migration seeded, so an admin-created "zoom" provider (via
+    # POST /admin/mcp/providers) is preserved. client_id/client_secret are
+    # env-dependent and intentionally not part of the guard.
+    provider_columns = {
+        column["name"] for column in inspector.get_columns("oauth_providers")
+    }
+    seeded_provider = _zoom_provider_row()
+    delete_stmt = sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
+        FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "zoom"
+    )
+    for column in ("name", "auth_url", "token_url"):
+        if column in provider_columns:
+            delete_stmt = delete_stmt.where(
+                FULL_OAUTH_PROVIDERS_TABLE.c[column] == seeded_provider[column]
+            )
+    bind.execute(delete_stmt)

--- a/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Zoom (OAuth) MCP connector
 
 Revision ID: 20260730_seed_zoom_mcp_app
-Revises: 20260724_add_upload_source_to_uploaded_files
+Revises: 20260801_seed_slack_mcp_app
 Create Date: 2026-07-30 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260730_seed_zoom_mcp_app"
-down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+down_revision: Union[str, None] = "20260801_seed_slack_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
@@ -57,7 +57,7 @@ APP_ID = "zoom"
 ZOOM_SCOPES = [
     "meeting:read:meeting",
     "meeting:read:list_meetings",
-    "cloud_recording:read:recording",
+    "cloud_recording:read:list_recording_files",
     "cloud_recording:read:meeting_transcript",
     "user:read:user",
 ]
@@ -164,17 +164,14 @@ def downgrade() -> None:
     # Only delete the provider row when it still matches the static shape this
     # migration seeded, so an admin-created "zoom" provider (via
     # POST /admin/mcp/providers) is preserved. client_id/client_secret are
-    # env-dependent and intentionally not part of the guard.
-    provider_columns = {
-        column["name"] for column in inspector.get_columns("oauth_providers")
-    }
+    # env-dependent and intentionally not part of the guard. name/auth_url/
+    # token_url are NOT NULL core columns present since the table's creation,
+    # so they can be matched unconditionally.
     seeded_provider = _zoom_provider_row()
-    delete_stmt = sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
-        FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "zoom"
+    bind.execute(
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE)
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "zoom")
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.name == seeded_provider["name"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.auth_url == seeded_provider["auth_url"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.token_url == seeded_provider["token_url"])
     )
-    for column in ("name", "auth_url", "token_url"):
-        if column in provider_columns:
-            delete_stmt = delete_stmt.where(
-                FULL_OAUTH_PROVIDERS_TABLE.c[column] == seeded_provider[column]
-            )
-    bind.execute(delete_stmt)

--- a/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Zoom (OAuth) MCP connector
 
 Revision ID: 20260730_seed_zoom_mcp_app
-Revises: 20260801_seed_slack_mcp_app
+Revises: 20260730_seed_google_analytics_mcp_app
 Create Date: 2026-07-30 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260730_seed_zoom_mcp_app"
-down_revision: Union[str, None] = "20260801_seed_slack_mcp_app"
+down_revision: Union[str, None] = "20260730_seed_google_analytics_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/templates/built_in/sales-meeting-agent.yaml
+++ b/src/xagent/templates/built_in/sales-meeting-agent.yaml
@@ -3,18 +3,22 @@ name: Meeting Agent
 category: Sales
 featured: false
 descriptions:
-  en: Turns a meeting transcript you paste or upload into a summary, decisions, action items and a follow-up email draft — grounded in the transcript, nothing invented.
-  zh: 将您粘贴或上传的会议记录转化为摘要、决策、行动项和跟进邮件草稿——完全基于记录内容，不臆造。
+  en: Turns a Zoom meeting — or a transcript you paste or upload — into a summary, decisions, action items and a follow-up email draft, grounded in the transcript, nothing invented.
+  zh: 将 Zoom 会议——或您粘贴/上传的会议记录——转化为摘要、决策、行动项和跟进邮件草稿，完全基于记录内容，不臆造。
 features:
   en:
-  - Reads a pasted or uploaded transcript (.txt, .docx or .pdf) — no meeting-notes platform integration required
+  - Looks up a Zoom meeting by name or date and reads its cloud-recording transcript directly, once Zoom is connected
+  - Also accepts a pasted or uploaded transcript (.txt, .docx or .pdf) if Zoom isn't connected or the meeting wasn't recorded
   - Extracts decisions, owners and due dates from the transcript on request
   - Drafts a follow-up email in Gmail and can log a CRM note to HubSpot after your approval
   zh:
-  - 读取您粘贴或上传的会议记录（.txt、.docx 或 .pdf）——无需接入任何会议记录平台
+  - 连接 Zoom 后，可按名称或日期查找会议，直接读取其云录制转录文本
+  - 若未连接 Zoom 或该场会议没有录制，也可接受您粘贴/上传的会议记录（.txt、.docx 或 .pdf）
   - 按需从记录中提取决策、负责人和截止日期
   - 在 Gmail 中起草跟进邮件，并在您批准后于 HubSpot 中记录 CRM 备注
 connections:
+- name: Zoom
+  logo: https://www.google.com/s2/favicons?domain=zoom.us&sz=64
 - name: HubSpot
   logo: https://www.google.com/s2/favicons?domain=hubspot.com&sz=64
 - name: Gmail
@@ -26,19 +30,19 @@ agent_config:
   instructions: |
     # Role & Purpose
 
-    You are the Meeting Agent. You turn a meeting transcript into a summary, decisions, action items and follow-ups. You work from a transcript the user pastes into chat or uploads as a file (.txt, .docx or .pdf) — you have no live connection to any meeting-notes platform, so you never fetch a meeting on your own.
+    You are the Meeting Agent. You turn a meeting transcript into a summary, decisions, action items and follow-ups. If Zoom is connected, you can look up the meeting and its cloud-recording transcript directly. Otherwise you work from a transcript the user pastes into chat or uploads as a file (.txt, .docx or .pdf) — you never fetch or invent a meeting you have no actual access to.
 
     # Responsibilities
 
-    1. **Get the transcript** — If the user hasn't already pasted or attached one, ask them to paste it or upload it as a file.
+    1. **Get the transcript** — If the user names a meeting (by title, date, or "the latest one") and Zoom is connected, call `zoom_list_meetings` / `zoom_get_meeting` to find it, then `zoom_get_meeting_transcript` to read it. If Zoom isn't connected, the meeting wasn't recorded, or no transcript exists yet, ask the user to paste the transcript or upload it as a file instead.
     2. **Read it fully** — Read the entire transcript before summarizing; don't work from a partial read.
     3. **Extract & decide** — Identify decisions made, item owners, due dates, and any follow-ups that were promised.
     4. **Act on request** — Draft a follow-up email in Gmail, or log a CRM note in HubSpot, when asked.
 
     # Operating Guidelines
 
-    - **Ground everything in the transcript:** Only report content that is actually present in what was pasted or uploaded. Never invent decisions, owners, or action items.
-    - **No transcript, no summary:** If nothing has been provided yet, ask for it rather than guessing which meeting the user means.
+    - **Ground everything in the transcript:** Only report content that is actually present in the Zoom transcript or what was pasted/uploaded. Never invent decisions, owners, or action items.
+    - **No transcript, no summary:** If nothing has been provided or found yet, ask for it rather than guessing which meeting the user means.
     - **Approval required:** Never send an email or log a CRM note without explicit user confirmation of the draft first.
     - **Know your CRM scope:** HubSpot access here covers contacts, companies, deals and notes — there is no HubSpot task object available, so follow-up work items belong in the action-items list and the follow-up email, not a HubSpot task.
     - **Missing data:** If action items or decisions weren't explicitly stated in the transcript, say so rather than inferring them from tone or context.

--- a/src/xagent/templates/built_in/sales-meeting-agent.yaml
+++ b/src/xagent/templates/built_in/sales-meeting-agent.yaml
@@ -34,7 +34,7 @@ agent_config:
 
     # Responsibilities
 
-    1. **Get the transcript** — If the user names a meeting (by title, date, or "the latest one") and Zoom is connected, call `zoom_list_meetings` / `zoom_get_meeting` to find it, then `zoom_get_meeting_transcript` to read it. If Zoom isn't connected, the meeting wasn't recorded, or no transcript exists yet, ask the user to paste the transcript or upload it as a file instead.
+    1. **Get the transcript** — If the user names a meeting (by title, date, or "the latest one") and Zoom is connected, call `zoom_list_meetings` (use `meeting_type="previous_meetings"` for meetings that already happened) / `zoom_get_meeting` to find it, then `zoom_get_meeting_transcript` to read it. If the transcript fetch comes back empty, call `zoom_list_recordings` to tell apart "this meeting was never recorded" from "it was recorded but the transcript isn't ready yet", and say which it is. If Zoom isn't connected or there is genuinely no transcript, ask the user to paste the transcript or upload it as a file instead.
     2. **Read it fully** — Read the entire transcript before summarizing; don't work from a partial read.
     3. **Extract & decide** — Identify decisions made, item owners, due dates, and any follow-ups that were promised.
     4. **Act on request** — Draft a follow-up email in Gmail, or log a CRM note in HubSpot, when asked.

--- a/src/xagent/templates/built_in/sales-meeting-agent.yaml
+++ b/src/xagent/templates/built_in/sales-meeting-agent.yaml
@@ -7,12 +7,12 @@ descriptions:
   zh: 将 Zoom 会议——或您粘贴/上传的会议记录——转化为摘要、决策、行动项和跟进邮件草稿，完全基于记录内容，不臆造。
 features:
   en:
-  - Looks up a Zoom meeting by name or date and reads its cloud-recording transcript directly, once Zoom is connected
+  - Looks up a Zoom meeting by its meeting id and reads its cloud-recording transcript directly, once Zoom is connected
   - Also accepts a pasted or uploaded transcript (.txt, .docx or .pdf) if Zoom isn't connected or the meeting wasn't recorded
   - Extracts decisions, owners and due dates from the transcript on request
   - Drafts a follow-up email in Gmail and can log a CRM note to HubSpot after your approval
   zh:
-  - 连接 Zoom 后，可按名称或日期查找会议，直接读取其云录制转录文本
+  - 连接 Zoom 后，可通过会议 ID 查找会议，直接读取其云录制转录文本
   - 若未连接 Zoom 或该场会议没有录制，也可接受您粘贴/上传的会议记录（.txt、.docx 或 .pdf）
   - 按需从记录中提取决策、负责人和截止日期
   - 在 Gmail 中起草跟进邮件，并在您批准后于 HubSpot 中记录 CRM 备注
@@ -34,7 +34,7 @@ agent_config:
 
     # Responsibilities
 
-    1. **Get the transcript** — If the user names a meeting (by title, date, or "the latest one") and Zoom is connected, call `zoom_list_meetings` (use `meeting_type="previous_meetings"` for meetings that already happened) / `zoom_get_meeting` to find it, then `zoom_get_meeting_transcript` to read it. If the transcript fetch comes back empty, call `zoom_list_recordings` to tell apart "this meeting was never recorded" from "it was recorded but the transcript isn't ready yet", and say which it is. If Zoom isn't connected or there is genuinely no transcript, ask the user to paste the transcript or upload it as a file instead.
+    1. **Get the transcript** — `zoom_list_meetings` only returns scheduled/live/upcoming meetings — it cannot list meetings that already happened. So if the user names a past meeting (by title, date, or "the latest one") and Zoom is connected, ask them for the meeting's id or UUID (from the Zoom invite, calendar event, or meeting history) and call `zoom_get_meeting` with that id to confirm it, then `zoom_get_meeting_transcript` to read it. If the transcript fetch comes back empty, call `zoom_list_recordings` to tell apart "this meeting was never recorded" from "it was recorded but the transcript isn't ready yet", and say which it is. If Zoom isn't connected, there is genuinely no transcript, or the user doesn't have the meeting id handy, ask the user to paste the transcript or upload it as a file instead.
     2. **Read it fully** — Read the entire transcript before summarizing; don't work from a partial read.
     3. **Extract & decide** — Identify decisions made, item owners, due dates, and any follow-ups that were promised.
     4. **Act on request** — Draft a follow-up email in Gmail, or log a CRM note in HubSpot, when asked.

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1325,8 +1325,8 @@ def generic_oauth_callback(
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         auth: tuple[str, str] | None = None
         if provider.lower() == "zoom":
-            # Zoom's token endpoint rejects client_secret in the body; it
-            # requires HTTP Basic Auth (client_id:client_secret, base64).
+            # Zoom's token endpoint requires HTTP Basic Auth for client
+            # credentials (client_id:client_secret, base64).
             auth = (client_id, client_secret)
         else:
             data["client_id"] = client_id

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1320,14 +1320,20 @@ def generic_oauth_callback(
         data = {
             "grant_type": "authorization_code",
             "code": code,
-            "client_id": client_id,
-            "client_secret": client_secret,
             "redirect_uri": redirect_uri,
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        auth: tuple[str, str] | None = None
+        if provider.lower() == "zoom":
+            # Zoom's token endpoint rejects client_secret in the body; it
+            # requires HTTP Basic Auth (client_id:client_secret, base64).
+            auth = (client_id, client_secret)
+        else:
+            data["client_id"] = client_id
+            data["client_secret"] = client_secret
 
         token_response = requests.post(
-            token_url, data=data, headers=headers, timeout=10.0
+            token_url, data=data, headers=headers, timeout=10.0, auth=auth
         )
         token_data = token_response.json()
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -130,6 +130,25 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "email_path": "team",
             "default_scopes": ["chat:write", "chat:write.public", "channels:read"],
         },
+        {
+            "provider_name": "zoom",
+            "name": "Zoom",
+            "client_id": os.environ.get("ZOOM_CLIENT_ID", ""),
+            "client_secret": os.environ.get("ZOOM_CLIENT_SECRET", ""),
+            "auth_url": "https://zoom.us/oauth/authorize",
+            "token_url": "https://zoom.us/oauth/token",
+            "redirect_uri": os.environ.get("ZOOM_REDIRECT_URI", ""),
+            "userinfo_url": "https://api.zoom.us/v2/users/me",
+            "user_id_path": "id",
+            "email_path": "email",
+            "default_scopes": [
+                "meeting:read:meeting",
+                "meeting:read:list_meetings",
+                "cloud_recording:read:recording",
+                "cloud_recording:read:meeting_transcript",
+                "user:read:user",
+            ],
+        },
     ]
 
 
@@ -394,6 +413,28 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "python",
                 "args": ["-m", "xagent.web.tools.mcp.instagram"],
                 "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "zoom",
+            "name": "Zoom",
+            "description": "Connect to Zoom to look up meetings, and read cloud recordings and transcripts.",
+            "icon": "https://www.google.com/s2/favicons?domain=zoom.us&sz=128",
+            "transport": "oauth",
+            "provider_name": "zoom",
+            "category": "Scheduling",
+            "oauth_scopes": [
+                "meeting:read:meeting",
+                "meeting:read:list_meetings",
+                "cloud_recording:read:recording",
+                "cloud_recording:read:meeting_transcript",
+                "user:read:user",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.zoom"],
+                "env_mapping": {"ZOOM_ACCESS_TOKEN": "access_token"},
             },
         },
         {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -144,7 +144,7 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "default_scopes": [
                 "meeting:read:meeting",
                 "meeting:read:list_meetings",
-                "cloud_recording:read:recording",
+                "cloud_recording:read:list_recording_files",
                 "cloud_recording:read:meeting_transcript",
                 "user:read:user",
             ],
@@ -426,7 +426,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "oauth_scopes": [
                 "meeting:read:meeting",
                 "meeting:read:list_meetings",
-                "cloud_recording:read:recording",
+                "cloud_recording:read:list_recording_files",
                 "cloud_recording:read:meeting_transcript",
                 "user:read:user",
             ],

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -141,12 +141,15 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "userinfo_url": "https://api.zoom.us/v2/users/me",
             "user_id_path": "id",
             "email_path": "email",
-            # Identity-only, matching the other providers here (google:
-            # userinfo.email, meta: public_profile) — the functional scopes
-            # this connector actually calls live on the app row's
-            # oauth_scopes below and are merged in at authorize time by
-            # _merge_oauth_scopes, so listing them here too would just be a
-            # second place scope changes have to be kept in sync.
+            # Identity-only for this connector, similar in spirit to google
+            # (userinfo.email/profile) and meta (public_profile) — though
+            # it isn't a strict rule across every provider here (linkedin's
+            # default_scopes includes the functional w_member_social write
+            # scope). The functional scopes this connector actually calls
+            # live on the app row's oauth_scopes below and are merged in at
+            # authorize time by _merge_oauth_scopes, so listing them here
+            # too would just be a second place scope changes have to be
+            # kept in sync.
             "default_scopes": ["user:read:user"],
         },
     ]

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -141,13 +141,13 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "userinfo_url": "https://api.zoom.us/v2/users/me",
             "user_id_path": "id",
             "email_path": "email",
-            "default_scopes": [
-                "meeting:read:meeting",
-                "meeting:read:list_meetings",
-                "cloud_recording:read:list_recording_files",
-                "cloud_recording:read:meeting_transcript",
-                "user:read:user",
-            ],
+            # Identity-only, matching the other providers here (google:
+            # userinfo.email, meta: public_profile) — the functional scopes
+            # this connector actually calls live on the app row's
+            # oauth_scopes below and are merged in at authorize time by
+            # _merge_oauth_scopes, so listing them here too would just be a
+            # second place scope changes have to be kept in sync.
+            "default_scopes": ["user:read:user"],
         },
     ]
 
@@ -426,6 +426,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "oauth_scopes": [
                 "meeting:read:meeting",
                 "meeting:read:list_meetings",
+                "meeting:read:past_meeting",
                 "cloud_recording:read:list_recording_files",
                 "cloud_recording:read:meeting_transcript",
                 "user:read:user",

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -560,7 +560,12 @@ async def refresh_oauth_token_if_needed(
             )
             return False
 
-        if provider_name == "meta":
+        # Normalize once for the special-case comparisons below; DB lookups
+        # and log messages above/below keep using the original provider_name
+        # so an admin-created provider's display casing is unaffected.
+        normalized_provider = provider_name.lower()
+
+        if normalized_provider == "meta":
             async with httpx.AsyncClient() as client:
                 response = await client.get(
                     provider_config.token_url,
@@ -605,10 +610,10 @@ async def refresh_oauth_token_if_needed(
             "refresh_token": oauth_account.refresh_token,
         }
         post_kwargs: dict[str, Any] = {}
-        # .lower() matches the code-exchange branch in api/auth.py: an
-        # admin-created provider named "Zoom" would otherwise connect fine
-        # but silently fail every refresh an hour later.
-        if provider_name.lower() == "zoom":
+        # Matches the code-exchange branch in api/auth.py: an admin-created
+        # provider named "Zoom" would otherwise connect fine but silently
+        # fail every refresh an hour later.
+        if normalized_provider == "zoom":
             # Zoom's token endpoint requires HTTP Basic Auth for client
             # credentials (client_id:client_secret, base64) on every refresh,
             # same as the initial code exchange.
@@ -618,7 +623,7 @@ async def refresh_oauth_token_if_needed(
             data["client_secret"] = client_secret
 
         headers = {}
-        if provider_name == "linkedin":
+        if normalized_provider == "linkedin":
             headers["Content-Type"] = "application/x-www-form-urlencoded"
 
         async with httpx.AsyncClient() as client:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -603,9 +603,16 @@ async def refresh_oauth_token_if_needed(
         data = {
             "grant_type": "refresh_token",
             "refresh_token": oauth_account.refresh_token,
-            "client_id": client_id,
-            "client_secret": client_secret,
         }
+        post_kwargs: dict[str, Any] = {}
+        if provider_name == "zoom":
+            # Zoom's token endpoint rejects client_secret in the body; it
+            # requires HTTP Basic Auth (client_id:client_secret, base64) on
+            # every refresh, same as the initial code exchange.
+            post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
+        else:
+            data["client_id"] = client_id
+            data["client_secret"] = client_secret
 
         headers = {}
         if provider_name == "linkedin":
@@ -613,7 +620,11 @@ async def refresh_oauth_token_if_needed(
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                provider_config.token_url, data=data, headers=headers, timeout=10.0
+                provider_config.token_url,
+                data=data,
+                headers=headers,
+                timeout=10.0,
+                **post_kwargs,
             )
 
         if response.status_code == 200:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -605,10 +605,13 @@ async def refresh_oauth_token_if_needed(
             "refresh_token": oauth_account.refresh_token,
         }
         post_kwargs: dict[str, Any] = {}
-        if provider_name == "zoom":
-            # Zoom's token endpoint rejects client_secret in the body; it
-            # requires HTTP Basic Auth (client_id:client_secret, base64) on
-            # every refresh, same as the initial code exchange.
+        # .lower() matches the code-exchange branch in api/auth.py: an
+        # admin-created provider named "Zoom" would otherwise connect fine
+        # but silently fail every refresh an hour later.
+        if provider_name.lower() == "zoom":
+            # Zoom's token endpoint requires HTTP Basic Auth for client
+            # credentials (client_id:client_secret, base64) on every refresh,
+            # same as the initial code exchange.
             post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
         else:
             data["client_id"] = client_id

--- a/src/xagent/web/tools/mcp/zoom.py
+++ b/src/xagent/web/tools/mcp/zoom.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any
 
@@ -19,6 +20,28 @@ mcp = FastMCP("zoom-mcp")
 
 ZOOM_BASE_URL = "https://api.zoom.us/v2"
 DEFAULT_TIMEOUT_SECONDS = 30
+
+# Documented `type` values for GET /users/{userId}/meetings. "previous_meetings"
+# matters most here: past meetings are the only ones that can have a transcript.
+MEETING_LIST_TYPES = (
+    "scheduled",
+    "live",
+    "upcoming",
+    "upcoming_meetings",
+    "previous_meetings",
+)
+
+_VTT_TIMESTAMP_LINE = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+-->\s+\d{2}:")
+
+
+class _ZoomApiError(RuntimeError):
+    """A Zoom API error carrying the HTTP status code, so callers can branch
+    on 404 precisely instead of substring-matching the message (which could
+    false-positive on an error body that merely mentions "404")."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def _success(**payload: Any) -> str:
@@ -92,11 +115,15 @@ def _request(
             detail = response.text.strip()
         if detail:
             message = f"{message} - {detail}"
-        raise RuntimeError(message) from exc
+        raise _ZoomApiError(message, status_code=response.status_code) from exc
 
     if response.status_code == 204 or not response.content:
         return {}
     return response.json()
+
+
+def _is_not_found(exc: Exception) -> bool:
+    return isinstance(exc, _ZoomApiError) and exc.status_code == 404
 
 
 def _download_text(download_url: str) -> str:
@@ -105,8 +132,35 @@ def _download_text(download_url: str) -> str:
         headers=_headers(),
         timeout=DEFAULT_TIMEOUT_SECONDS,
     )
-    response.raise_for_status()
-    return response.text
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        # Never let the raw HTTPError escape: str(HTTPError) embeds the full
+        # request URL including its query string, and Zoom download URLs can
+        # carry access tokens as query params — keep them out of logs and the
+        # LLM-visible tool response.
+        raise RuntimeError(
+            f"Transcript download failed with HTTP {response.status_code}"
+        ) from exc
+    # Decode explicitly as UTF-8: for a text/* content type without a charset
+    # (a plausible header for a VTT download), requests falls back to
+    # ISO-8859-1, which corrupts non-ASCII (e.g. Chinese) transcripts.
+    return response.content.decode("utf-8", errors="replace")
+
+
+def _vtt_to_text(vtt_text: str) -> str:
+    """Strip WebVTT scaffolding (header, cue numbers, timestamp lines) and
+    return only the spoken lines. Cue timing rarely matters for summarization
+    and roughly doubles the token count of the payload handed to the LLM."""
+    lines: list[str] = []
+    for raw_line in vtt_text.splitlines():
+        line = raw_line.strip()
+        if not line or line == "WEBVTT" or line.isdigit():
+            continue
+        if _VTT_TIMESTAMP_LINE.match(line):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def _find_transcript_file(recording_files: list[Any]) -> dict[str, Any] | None:
@@ -117,20 +171,31 @@ def _find_transcript_file(recording_files: list[Any]) -> dict[str, Any] | None:
 
 
 @mcp.tool()
-def zoom_list_meetings(meeting_type: str = "scheduled") -> str:
+def zoom_list_meetings(meeting_type: str = "scheduled", page_token: str = "") -> str:
     """
     List meetings for the connected Zoom user.
-    meeting_type: one of "scheduled" (default, upcoming + recurring), "live", or "upcoming".
-    Use this to find a meeting_id when the user refers to a meeting by name or "latest".
+    meeting_type: one of "scheduled" (default, unexpired previous + upcoming),
+    "live", "upcoming", "upcoming_meetings", or "previous_meetings".
+    Use "previous_meetings" when looking for a meeting that already happened —
+    e.g. to fetch its transcript ("summarize my latest call").
+    page_token: pass the next_page_token from a previous response to fetch the
+    next page when the result was truncated.
     """
-    try:
-        result = _request(
-            "GET",
-            "/users/me/meetings",
-            params={"type": meeting_type, "page_size": 100},
+    if meeting_type not in MEETING_LIST_TYPES:
+        return _error(
+            f"Invalid meeting_type {meeting_type!r}; expected one of "
+            f"{', '.join(MEETING_LIST_TYPES)}"
         )
-        meetings = result.get("meetings", []) if isinstance(result, dict) else []
-        return _success(meetings=meetings)
+    try:
+        params: dict[str, Any] = {"type": meeting_type, "page_size": 100}
+        if page_token:
+            params["next_page_token"] = page_token
+        result = _request("GET", "/users/me/meetings", params=params)
+        meetings = result.get("meetings") or [] if isinstance(result, dict) else []
+        next_page_token = (
+            result.get("next_page_token", "") if isinstance(result, dict) else ""
+        )
+        return _success(meetings=meetings, next_page_token=next_page_token)
     except Exception as e:
         logger.error(f"Error listing Zoom meetings: {e}")
         return _error(str(e))
@@ -146,10 +211,21 @@ def zoom_get_meeting(meeting_id: str) -> str:
     try:
         try:
             result = _request("GET", f"/meetings/{encoded_id}")
-        except RuntimeError as exc:
-            if "404" not in str(exc):
+        except Exception as exc:
+            if not _is_not_found(exc):
                 raise
-            result = _request("GET", f"/past_meetings/{encoded_id}")
+            try:
+                result = _request("GET", f"/past_meetings/{encoded_id}")
+            except Exception as past_exc:
+                if _is_not_found(past_exc):
+                    # Surface the real situation (unknown id) instead of the
+                    # misleading "past_meetings lookup failed" from the second
+                    # leg alone — the common case here is a typo'd meeting_id.
+                    return _error(
+                        f"Meeting {meeting_id} not found (checked both upcoming "
+                        "and past meetings)"
+                    )
+                raise
         return _success(meeting=result)
     except Exception as e:
         logger.error(f"Error getting Zoom meeting {meeting_id}: {e}")
@@ -167,7 +243,7 @@ def zoom_list_recordings(meeting_id: str) -> str:
     try:
         result = _request("GET", f"/meetings/{encoded_id}/recordings")
         recording_files = (
-            result.get("recording_files", []) if isinstance(result, dict) else []
+            result.get("recording_files") or [] if isinstance(result, dict) else []
         )
         return _success(recording_files=recording_files)
     except Exception as e:
@@ -178,24 +254,40 @@ def zoom_list_recordings(meeting_id: str) -> str:
 @mcp.tool()
 def zoom_get_meeting_transcript(meeting_id: str) -> str:
     """
-    Get the full text of a meeting's cloud-recording transcript (VTT captions), if one exists.
+    Get the spoken text of a meeting's cloud-recording transcript, if one exists
+    (WebVTT scaffolding such as timestamps and cue numbers is stripped).
     """
     encoded_id = _encode_meeting_id(meeting_id)
     try:
+        restriction_reason: str | None = None
         try:
             transcript = _request("GET", f"/meetings/{encoded_id}/transcript")
-            download_url = (
-                transcript.get("download_url") if isinstance(transcript, dict) else None
-            )
-        except RuntimeError as exc:
-            if "404" not in str(exc):
+            if isinstance(transcript, dict):
+                download_url = transcript.get("download_url")
+                restriction_reason = transcript.get("download_restriction_reason")
+            else:
+                download_url = None
+        except Exception as exc:
+            if not _is_not_found(exc):
                 raise
             download_url = None
 
+        if not download_url and restriction_reason:
+            return _error(f"Transcript download is restricted: {restriction_reason}")
+
         if not download_url:
-            recordings = _request("GET", f"/meetings/{encoded_id}/recordings")
+            try:
+                recordings = _request("GET", f"/meetings/{encoded_id}/recordings")
+            except Exception as rec_exc:
+                if _is_not_found(rec_exc):
+                    return _error(
+                        f"Meeting {meeting_id} not found or has no cloud "
+                        "recording (checked both the transcript and recordings "
+                        "endpoints)"
+                    )
+                raise
             recording_files = (
-                recordings.get("recording_files", [])
+                recordings.get("recording_files") or []
                 if isinstance(recordings, dict)
                 else []
             )
@@ -207,7 +299,7 @@ def zoom_get_meeting_transcript(meeting_id: str) -> str:
         if not download_url:
             return _error("Transcript file has no download_url")
 
-        transcript_text = _download_text(download_url)
+        transcript_text = _vtt_to_text(_download_text(download_url))
         return _success(transcript=transcript_text)
     except Exception as e:
         logger.error(f"Error getting Zoom transcript for meeting {meeting_id}: {e}")

--- a/src/xagent/web/tools/mcp/zoom.py
+++ b/src/xagent/web/tools/mcp/zoom.py
@@ -1,0 +1,231 @@
+import json
+import logging
+import os
+import urllib.parse
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("zoom-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("zoom-mcp")
+
+ZOOM_BASE_URL = "https://api.zoom.us/v2"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _encode_meeting_id(meeting_id: str) -> str:
+    """URL-encode a Zoom meeting id or UUID for use in a path segment.
+
+    Per Zoom's API docs, a meeting UUID that starts with a slash (``/``) or
+    contains a double slash (``//``) must be double-encoded, or Zoom's
+    routing mangles the path; a plain numeric meeting id only needs the
+    normal single encoding. Detect on the raw value, since encoding it once
+    would hide the leading-slash/double-slash shape the check depends on.
+    """
+    raw = str(meeting_id)
+    quoted = urllib.parse.quote(raw, safe="")
+    if raw.startswith("/") or "//" in raw:
+        quoted = urllib.parse.quote(quoted, safe="")
+    return quoted
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("ZOOM_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("ZOOM_ACCESS_TOKEN environment variable is missing")
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Zoom error body.
+
+    Zoom error responses are typically ``{"code": ..., "message": ...}``;
+    returning that message alone is more useful to the LLM than the raw
+    body. Returns None if the body isn't in the expected shape, so the
+    caller can fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    message = payload.get("message")
+    return message if isinstance(message, str) and message else None
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=f"{ZOOM_BASE_URL}{path}",
+        headers=_headers(),
+        params=params,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        message = str(exc)
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+        if detail:
+            message = f"{message} - {detail}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _download_text(download_url: str) -> str:
+    response = requests.get(
+        download_url,
+        headers=_headers(),
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def _find_transcript_file(recording_files: list[Any]) -> dict[str, Any] | None:
+    for file_entry in recording_files:
+        if isinstance(file_entry, dict) and file_entry.get("file_type") == "TRANSCRIPT":
+            return file_entry
+    return None
+
+
+@mcp.tool()
+def zoom_list_meetings(meeting_type: str = "scheduled") -> str:
+    """
+    List meetings for the connected Zoom user.
+    meeting_type: one of "scheduled" (default, upcoming + recurring), "live", or "upcoming".
+    Use this to find a meeting_id when the user refers to a meeting by name or "latest".
+    """
+    try:
+        result = _request(
+            "GET",
+            "/users/me/meetings",
+            params={"type": meeting_type, "page_size": 100},
+        )
+        meetings = result.get("meetings", []) if isinstance(result, dict) else []
+        return _success(meetings=meetings)
+    except Exception as e:
+        logger.error(f"Error listing Zoom meetings: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def zoom_get_meeting(meeting_id: str) -> str:
+    """
+    Get details for one meeting by its numeric id or UUID.
+    Falls back to the past-meeting endpoint automatically if the meeting has already ended.
+    """
+    encoded_id = _encode_meeting_id(meeting_id)
+    try:
+        try:
+            result = _request("GET", f"/meetings/{encoded_id}")
+        except RuntimeError as exc:
+            if "404" not in str(exc):
+                raise
+            result = _request("GET", f"/past_meetings/{encoded_id}")
+        return _success(meeting=result)
+    except Exception as e:
+        logger.error(f"Error getting Zoom meeting {meeting_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def zoom_list_recordings(meeting_id: str) -> str:
+    """
+    List cloud recording files for one meeting (audio, video, and transcript files),
+    including each file's type, size, and download_url. Does not download file content —
+    use zoom_get_meeting_transcript to fetch the transcript text itself.
+    """
+    encoded_id = _encode_meeting_id(meeting_id)
+    try:
+        result = _request("GET", f"/meetings/{encoded_id}/recordings")
+        recording_files = (
+            result.get("recording_files", []) if isinstance(result, dict) else []
+        )
+        return _success(recording_files=recording_files)
+    except Exception as e:
+        logger.error(f"Error listing Zoom recordings for meeting {meeting_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def zoom_get_meeting_transcript(meeting_id: str) -> str:
+    """
+    Get the full text of a meeting's cloud-recording transcript (VTT captions), if one exists.
+    """
+    encoded_id = _encode_meeting_id(meeting_id)
+    try:
+        try:
+            transcript = _request("GET", f"/meetings/{encoded_id}/transcript")
+            download_url = (
+                transcript.get("download_url") if isinstance(transcript, dict) else None
+            )
+        except RuntimeError as exc:
+            if "404" not in str(exc):
+                raise
+            download_url = None
+
+        if not download_url:
+            recordings = _request("GET", f"/meetings/{encoded_id}/recordings")
+            recording_files = (
+                recordings.get("recording_files", [])
+                if isinstance(recordings, dict)
+                else []
+            )
+            transcript_file = _find_transcript_file(recording_files)
+            if transcript_file is None:
+                return _error("No transcript found for this meeting")
+            download_url = transcript_file.get("download_url")
+
+        if not download_url:
+            return _error("Transcript file has no download_url")
+
+        transcript_text = _download_text(download_url)
+        return _success(transcript=transcript_text)
+    except Exception as e:
+        logger.error(f"Error getting Zoom transcript for meeting {meeting_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def zoom_get_current_user() -> str:
+    """
+    Get profile info (id, email, name) for the connected Zoom account.
+    """
+    try:
+        result = _request("GET", "/users/me")
+        return _success(user=result)
+    except Exception as e:
+        logger.error(f"Error getting Zoom current user: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/zoom.py
+++ b/src/xagent/web/tools/mcp/zoom.py
@@ -21,14 +21,15 @@ mcp = FastMCP("zoom-mcp")
 ZOOM_BASE_URL = "https://api.zoom.us/v2"
 DEFAULT_TIMEOUT_SECONDS = 30
 
-# Documented `type` values for GET /users/{userId}/meetings. "previous_meetings"
-# matters most here: past meetings are the only ones that can have a transcript.
+# Documented `type` values for GET /users/{userId}/meetings. Zoom staff have
+# confirmed this endpoint only ever returns scheduled/live/upcoming meetings —
+# there is no "previous_meetings" type; past meetings require the separate
+# Reports API (a different OAuth scope this connector doesn't request). See
+# https://devforum.zoom.us/t/get-users-meetings-meetings-past-instances-and-past-meeting-instances-participants/37995
 MEETING_LIST_TYPES = (
     "scheduled",
     "live",
     "upcoming",
-    "upcoming_meetings",
-    "previous_meetings",
 )
 
 _VTT_TIMESTAMP_LINE = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+-->\s+\d{2}:")
@@ -127,21 +128,24 @@ def _is_not_found(exc: Exception) -> bool:
 
 
 def _download_text(download_url: str) -> str:
-    response = requests.get(
-        download_url,
-        headers=_headers(),
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
+    # The request itself (not just a bad status) must stay inside the
+    # try/except: requests.RequestException subclasses like ConnectionError
+    # and Timeout embed the full request URL — including any access_token
+    # query param — in str(exc), so a connection failure must be sanitized
+    # exactly like an HTTP error status is below.
     try:
+        response = requests.get(
+            download_url,
+            headers=_headers(),
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
         response.raise_for_status()
     except requests.HTTPError as exc:
-        # Never let the raw HTTPError escape: str(HTTPError) embeds the full
-        # request URL including its query string, and Zoom download URLs can
-        # carry access tokens as query params — keep them out of logs and the
-        # LLM-visible tool response.
         raise RuntimeError(
-            f"Transcript download failed with HTTP {response.status_code}"
+            f"Transcript download failed with HTTP {exc.response.status_code}"
         ) from exc
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Transcript download failed: {type(exc).__name__}") from exc
     # Decode explicitly as UTF-8: for a text/* content type without a charset
     # (a plausible header for a VTT download), requests falls back to
     # ISO-8859-1, which corrupts non-ASCII (e.g. Chinese) transcripts.
@@ -174,10 +178,12 @@ def _find_transcript_file(recording_files: list[Any]) -> dict[str, Any] | None:
 def zoom_list_meetings(meeting_type: str = "scheduled", page_token: str = "") -> str:
     """
     List meetings for the connected Zoom user.
-    meeting_type: one of "scheduled" (default, unexpired previous + upcoming),
-    "live", "upcoming", "upcoming_meetings", or "previous_meetings".
-    Use "previous_meetings" when looking for a meeting that already happened —
-    e.g. to fetch its transcript ("summarize my latest call").
+    meeting_type: one of "scheduled" (default, unexpired scheduled meetings),
+    "live", or "upcoming". This endpoint never returns meetings that have
+    already ended — Zoom's List Meetings API only covers scheduled/live/
+    upcoming meetings, not history. To look up a meeting that already
+    happened, ask the user for its meeting id or UUID and call
+    zoom_get_meeting / zoom_get_meeting_transcript directly.
     page_token: pass the next_page_token from a previous response to fetch the
     next page when the result was truncated.
     """

--- a/src/xagent/web/tools/mcp/zoom.py
+++ b/src/xagent/web/tools/mcp/zoom.py
@@ -41,7 +41,10 @@ MEETING_LIST_TYPES = (
     "upcoming",
 )
 
-_VTT_TIMESTAMP_LINE = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+-->\s+\d{2}:")
+# Zoom always exports the full HH:MM:SS.mmm form, but WebVTT itself allows
+# the hours group to be omitted (MM:SS.mmm) — match both so a cue-index
+# line preceding a short-form timestamp is still recognized as scaffolding.
+_VTT_TIMESTAMP_LINE = re.compile(r"^(?:\d{2}:)?\d{2}:\d{2}\.\d{3}\s+-->")
 
 
 class _ZoomApiError(RuntimeError):
@@ -181,14 +184,17 @@ def _vtt_to_text(vtt_text: str) -> str:
             continue
         if _VTT_TIMESTAMP_LINE.match(line):
             continue
-        # A cue-index line is digit-only *and* immediately followed by a
-        # timestamp line — checking structure, not just line.isdigit(),
-        # keeps a genuinely spoken digit-only line (a PIN, an order number, a
-        # year read aloud) in the transcript instead of silently dropping it.
-        if (
-            line.isdigit()
-            and index + 1 < len(raw_lines)
-            and _VTT_TIMESTAMP_LINE.match(raw_lines[index + 1])
+        # A cue-index line is digit-only *and* either the last line in the
+        # file or immediately followed by a timestamp line — checking
+        # structure, not just line.isdigit(), keeps a genuinely spoken
+        # digit-only line (a PIN, an order number, a year read aloud) in the
+        # transcript instead of silently dropping it. A trailing bare-digit
+        # line can never be complete spoken content, since a real cue
+        # always requires its own following timestamp and text line, so
+        # it's treated as a (truncated) cue index too.
+        if line.isdigit() and (
+            index + 1 >= len(raw_lines)
+            or _VTT_TIMESTAMP_LINE.match(raw_lines[index + 1])
         ):
             continue
         lines.append(line)
@@ -322,9 +328,6 @@ def zoom_get_meeting_transcript(meeting_id: str) -> str:
                 )
             return _error(f"Transcript download is restricted: {restriction_reason}")
 
-        if not download_url and can_download is False:
-            return _error("Transcript download is restricted")
-
         if not download_url:
             try:
                 recordings = _request("GET", f"/meetings/{encoded_id}/recordings")
@@ -342,9 +345,17 @@ def zoom_get_meeting_transcript(meeting_id: str) -> str:
                 else []
             )
             transcript_file = _find_transcript_file(recording_files)
-            if transcript_file is None:
+            if transcript_file is not None:
+                download_url = transcript_file.get("download_url")
+            elif can_download is False:
+                # The transcript-shortcut endpoint said no, and the
+                # independent recordings listing found no transcript file
+                # either — trust can_download only once both endpoints
+                # agree, rather than short-circuiting on it alone before
+                # ever checking recordings.
+                return _error("Transcript download is restricted")
+            else:
                 return _error("No transcript found for this meeting")
-            download_url = transcript_file.get("download_url")
 
         if not download_url:
             return _error("Transcript file has no download_url")

--- a/src/xagent/web/tools/mcp/zoom.py
+++ b/src/xagent/web/tools/mcp/zoom.py
@@ -20,6 +20,15 @@ mcp = FastMCP("zoom-mcp")
 
 ZOOM_BASE_URL = "https://api.zoom.us/v2"
 DEFAULT_TIMEOUT_SECONDS = 30
+# Matches meta_graph.py's convention: an error body that isn't the expected
+# {"message": ...} shape (e.g. an HTML gateway error page) must not be
+# forwarded to the LLM/logs verbatim and unbounded.
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+# download_url is a Zoom-supplied field, not user input, but _download_text
+# attaches the live Zoom bearer token to it — assert the host before sending
+# credentials as defense-in-depth, since this is the only connector in the
+# package that downloads from a URL rather than a fixed first-party path.
+_ZOOM_DOWNLOAD_HOST_SUFFIX = ".zoom.us"
 
 # Documented `type` values for GET /users/{userId}/meetings. Zoom staff have
 # confirmed this endpoint only ever returns scheduled/live/upcoming meetings —
@@ -114,6 +123,8 @@ def _request(
         detail = _extract_error_detail(response)
         if detail is None:
             detail = response.text.strip()
+            if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+                detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
         if detail:
             message = f"{message} - {detail}"
         raise _ZoomApiError(message, status_code=response.status_code) from exc
@@ -128,11 +139,16 @@ def _is_not_found(exc: Exception) -> bool:
 
 
 def _download_text(download_url: str) -> str:
+    host = urllib.parse.urlparse(download_url).hostname or ""
+    if host != "zoom.us" and not host.endswith(_ZOOM_DOWNLOAD_HOST_SUFFIX):
+        raise RuntimeError("Refusing to send Zoom credentials to an unexpected host")
     # The request itself (not just a bad status) must stay inside the
-    # try/except: requests.RequestException subclasses like ConnectionError
-    # and Timeout embed the full request URL — including any access_token
-    # query param — in str(exc), so a connection failure must be sanitized
-    # exactly like an HTTP error status is below.
+    # try/except: requests.ConnectionError embeds the full request URL —
+    # including any access_token query param — in str(exc), so a connection
+    # failure must be sanitized exactly like an HTTP error status is below.
+    # The broader RequestException handler also covers Timeout and other
+    # request-layer failures defensively, even though a plain read timeout's
+    # message ("Read timed out...") doesn't itself carry the URL.
     try:
         response = requests.get(
             download_url,
@@ -146,22 +162,34 @@ def _download_text(download_url: str) -> str:
         ) from exc
     except requests.RequestException as exc:
         raise RuntimeError(f"Transcript download failed: {type(exc).__name__}") from exc
-    # Decode explicitly as UTF-8: for a text/* content type without a charset
-    # (a plausible header for a VTT download), requests falls back to
-    # ISO-8859-1, which corrupts non-ASCII (e.g. Chinese) transcripts.
-    return response.content.decode("utf-8", errors="replace")
+    # Decode as utf-8-sig rather than plain utf-8: for a text/* content type
+    # without a charset (a plausible header for a VTT download), requests
+    # falls back to ISO-8859-1, which corrupts non-ASCII (e.g. Chinese)
+    # transcripts, and a BOM-prefixed file would otherwise leak into the
+    # first line and fail the "WEBVTT" header check in _vtt_to_text.
+    return response.content.decode("utf-8-sig", errors="replace")
 
 
 def _vtt_to_text(vtt_text: str) -> str:
     """Strip WebVTT scaffolding (header, cue numbers, timestamp lines) and
     return only the spoken lines. Cue timing rarely matters for summarization
     and roughly doubles the token count of the payload handed to the LLM."""
+    raw_lines = [raw_line.strip() for raw_line in vtt_text.splitlines()]
     lines: list[str] = []
-    for raw_line in vtt_text.splitlines():
-        line = raw_line.strip()
-        if not line or line == "WEBVTT" or line.isdigit():
+    for index, line in enumerate(raw_lines):
+        if not line or line == "WEBVTT":
             continue
         if _VTT_TIMESTAMP_LINE.match(line):
+            continue
+        # A cue-index line is digit-only *and* immediately followed by a
+        # timestamp line — checking structure, not just line.isdigit(),
+        # keeps a genuinely spoken digit-only line (a PIN, an order number, a
+        # year read aloud) in the transcript instead of silently dropping it.
+        if (
+            line.isdigit()
+            and index + 1 < len(raw_lines)
+            and _VTT_TIMESTAMP_LINE.match(raw_lines[index + 1])
+        ):
             continue
         lines.append(line)
     return "\n".join(lines)
@@ -232,6 +260,8 @@ def zoom_get_meeting(meeting_id: str) -> str:
                         "and past meetings)"
                     )
                 raise
+        if not result:
+            return _error(f"Meeting {meeting_id} returned no data")
         return _success(meeting=result)
     except Exception as e:
         logger.error(f"Error getting Zoom meeting {meeting_id}: {e}")
@@ -266,11 +296,13 @@ def zoom_get_meeting_transcript(meeting_id: str) -> str:
     encoded_id = _encode_meeting_id(meeting_id)
     try:
         restriction_reason: str | None = None
+        can_download: Any = None
         try:
             transcript = _request("GET", f"/meetings/{encoded_id}/transcript")
             if isinstance(transcript, dict):
                 download_url = transcript.get("download_url")
                 restriction_reason = transcript.get("download_restriction_reason")
+                can_download = transcript.get("can_download")
             else:
                 download_url = None
         except Exception as exc:
@@ -279,7 +311,19 @@ def zoom_get_meeting_transcript(meeting_id: str) -> str:
             download_url = None
 
         if not download_url and restriction_reason:
+            # NOT_READY means the transcript is still processing — a
+            # retry-later condition, not a restriction like DELETED_OR_TRASHED
+            # or UNSUPPORTED. Calling it "restricted" would push the agent to
+            # the paste/upload fallback when waiting would have worked.
+            if restriction_reason == "NOT_READY":
+                return _error(
+                    "Transcript is still processing on Zoom's side; try again "
+                    "in a few minutes."
+                )
             return _error(f"Transcript download is restricted: {restriction_reason}")
+
+        if not download_url and can_download is False:
+            return _error("Transcript download is restricted")
 
         if not download_url:
             try:
@@ -319,6 +363,8 @@ def zoom_get_current_user() -> str:
     """
     try:
         result = _request("GET", "/users/me")
+        if not result:
+            return _error("Zoom returned no user data")
         return _success(user=result)
     except Exception as e:
         logger.error(f"Error getting Zoom current user: {e}")

--- a/tests/alembic/test_20260730_seed_zoom_mcp_app.py
+++ b/tests/alembic/test_20260730_seed_zoom_mcp_app.py
@@ -1,0 +1,208 @@
+"""Tests for the Zoom MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260730_seed_zoom_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_zoom_migration", migration_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "zoom" in _provider_names(connection)
+        assert "zoom" in _app_ids(connection)
+
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='zoom'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "zoom"
+        assert "xagent.web.tools.mcp.zoom" in str(row[2])
+        assert "ZOOM_ACCESS_TOKEN" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='zoom'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='zoom'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    zoom rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "zoom"
+    )
+    assert migration._zoom_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "zoom"
+    )
+    assert migration._zoom_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "zoom" not in _app_ids(connection)
+        assert "zoom" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_zoom_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-zoom', 'Custom Zoom', 'oauth', 'zoom')"
+                )
+            )
+            migration.downgrade()
+        assert "zoom" in _provider_names(connection)
+
+
+def test_downgrade_preserves_admin_created_zoom_provider(tmp_path):
+    """A pre-existing admin-created "zoom" provider (different shape than the
+    seeded row) must survive downgrade even when no zoom apps remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('zoom', 'Custom Zoom', 'cid', 'secret',"
+                " 'https://custom.example.com/authorize',"
+                " 'https://custom.example.com/token')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "zoom" not in _app_ids(connection)
+        assert "zoom" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/test_zoom_oauth.py
+++ b/tests/web/test_zoom_oauth.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.oauth_provider import OAuthProvider
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="zoom",
+            name="Zoom",
+            description="Zoom connector",
+            transport="oauth",
+            provider_name="zoom",
+            category="Scheduling",
+            oauth_scopes=["meeting:read:meeting", "user:read:user"],
+            is_visible_in_connector=True,
+            launch_config={
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.zoom"],
+                "env_mapping": {"ZOOM_ACCESS_TOKEN": "access_token"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _zoom_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="zoom",
+        client_id=encrypt_value("zoom-client-id"),
+        client_secret=encrypt_value("zoom-client-secret"),
+        token_url="https://zoom.us/oauth/token",
+        redirect_uri="https://app.example.com/api/auth/zoom/callback",
+        userinfo_url="https://api.zoom.us/v2/users/me",
+        user_id_path="id",
+        email_path="email",
+        default_scopes=["meeting:read:meeting", "user:read:user"],
+    )
+
+
+def test_zoom_callback_exchanges_code_with_http_basic_auth(db_session, monkeypatch):
+    """Zoom's token endpoint rejects client_secret in the POST body — it requires
+    HTTP Basic Auth. Assert the exchange sends Basic auth and omits the secret
+    (and client_id) from the form body, not just that the call "worked"."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "zoom",
+            "app_id": "zoom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "zoom-code", "state": state})
+
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "zoom-token",
+                "refresh_token": "zoom-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "meeting:read:meeting user:read:user",
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse({"id": "zoom-user-1", "email": "alice@zoom.us"})
+        ),
+    )
+
+    response = generic_oauth_callback("zoom", request, db, _zoom_provider())
+
+    assert response.status_code == 200
+    assert post.call_args.kwargs["auth"] == ("zoom-client-id", "zoom-client-secret")
+    assert "client_id" not in post.call_args.kwargs["data"]
+    assert "client_secret" not in post.call_args.kwargs["data"]
+    assert post.call_args.kwargs["data"]["grant_type"] == "authorization_code"
+
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "zoom")
+        .one()
+    )
+    assert oauth_account.access_token == "zoom-token"
+    assert oauth_account.refresh_token == "zoom-refresh"
+    assert oauth_account.provider_user_id == "zoom-user-1"
+    assert oauth_account.email == "alice@zoom.us"
+
+    server = db.query(MCPServer).filter(MCPServer.name == "Zoom").one()
+    assert server.transport == "oauth"
+    user_mcp = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert user_mcp.is_active is True
+
+
+def test_non_zoom_callback_still_sends_client_secret_in_body(db_session, monkeypatch):
+    """Guard the branch condition: a non-zoom provider must be unaffected by the
+    Zoom-specific Basic-Auth carve-out."""
+    db, user = db_session
+    db.add(
+        PublicMCPApp(
+            app_id="gmail",
+            name="Gmail",
+            transport="oauth",
+            provider_name="google",
+        )
+    )
+    db.commit()
+
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "code", "state": state})
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "tok",
+                "token_type": "Bearer",
+                "scope": "",
+                "expires_in": 3600,
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(return_value=MockResponse({"sub": "u1", "email": "alice@gmail.com"})),
+    )
+
+    google_provider = SimpleNamespace(
+        provider_name="google",
+        client_id=encrypt_value("google-client-id"),
+        client_secret=encrypt_value("google-client-secret"),
+        token_url="https://oauth2.googleapis.com/token",
+        redirect_uri="https://app.example.com/api/auth/google/callback",
+        userinfo_url="https://openidconnect.googleapis.com/v1/userinfo",
+        user_id_path="sub",
+        email_path="email",
+        default_scopes=["https://www.googleapis.com/auth/gmail.modify"],
+    )
+
+    response = generic_oauth_callback("google", request, db, google_provider)
+
+    assert response.status_code == 200
+    assert post.call_args.kwargs.get("auth") is None
+    assert post.call_args.kwargs["data"]["client_id"] == "google-client-id"
+    assert post.call_args.kwargs["data"]["client_secret"] == "google-client-secret"
+
+
+@pytest.mark.asyncio
+async def test_zoom_expired_token_refresh_uses_http_basic_auth(db_session, monkeypatch):
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="zoom",
+            name="Zoom",
+            client_id=encrypt_value("zoom-client-id"),
+            client_secret=encrypt_value("zoom-client-secret"),
+            auth_url="https://zoom.us/oauth/authorize",
+            token_url="https://zoom.us/oauth/token",
+            redirect_uri="https://app.example.com/api/auth/zoom/callback",
+            userinfo_url="https://api.zoom.us/v2/users/me",
+            user_id_path="id",
+            email_path="email",
+            default_scopes=["meeting:read:meeting"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="zoom",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="zoom-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "zoom")
+        is True
+    )
+
+    assert oauth_account.access_token == "new-token"
+    assert oauth_account.refresh_token == "new-refresh"
+    assert len(captured_requests) == 1
+    url, kwargs = captured_requests[0]
+    assert url == "https://zoom.us/oauth/token"
+    assert kwargs["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "old-refresh",
+    }
+    auth = kwargs["auth"]
+    assert isinstance(auth, tool_config.httpx.BasicAuth)

--- a/tests/web/test_zoom_oauth.py
+++ b/tests/web/test_zoom_oauth.py
@@ -277,3 +277,151 @@ async def test_zoom_expired_token_refresh_uses_http_basic_auth(db_session, monke
     }
     auth = kwargs["auth"]
     assert isinstance(auth, tool_config.httpx.BasicAuth)
+    expected_auth = tool_config.httpx.BasicAuth("zoom-client-id", "zoom-client-secret")
+    assert auth._auth_header == expected_auth._auth_header
+
+
+@pytest.mark.asyncio
+async def test_zoom_expired_token_refresh_uses_http_basic_auth_with_capitalized_name(
+    db_session, monkeypatch
+):
+    """An admin-created provider row named "Zoom" (capitalized, e.g. via
+    POST /admin/mcp/providers) must take the same Basic-Auth branch as the
+    lowercase "zoom" — the branch check normalizes case exactly once rather
+    than comparing provider_name verbatim."""
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="Zoom",
+            name="Zoom",
+            client_id=encrypt_value("zoom-client-id"),
+            client_secret=encrypt_value("zoom-client-secret"),
+            auth_url="https://zoom.us/oauth/authorize",
+            token_url="https://zoom.us/oauth/token",
+            redirect_uri="https://app.example.com/api/auth/zoom/callback",
+            userinfo_url="https://api.zoom.us/v2/users/me",
+            user_id_path="id",
+            email_path="email",
+            default_scopes=["meeting:read:meeting"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="Zoom",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="zoom-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "Zoom")
+        is True
+    )
+
+    assert len(captured_requests) == 1
+    _, kwargs = captured_requests[0]
+    assert isinstance(kwargs["auth"], tool_config.httpx.BasicAuth)
+    assert "client_id" not in kwargs["data"]
+    assert "client_secret" not in kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_generic_provider_refresh_sends_client_id_and_secret_in_body(
+    db_session, monkeypatch
+):
+    """The non-special-cased branch of refresh_oauth_token_if_needed (no
+    meta/zoom/linkedin carve-out) must send client_id/client_secret in the
+    POST body on the success path — the existing coverage for this branch
+    only asserted that secrets aren't logged on *failure*."""
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="google",
+            name="Google",
+            client_id=encrypt_value("google-client-id"),
+            client_secret=encrypt_value("google-client-secret"),
+            auth_url="https://accounts.google.com/o/oauth2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            redirect_uri="https://app.example.com/api/auth/google/callback",
+            userinfo_url="https://openidconnect.googleapis.com/v1/userinfo",
+            user_id_path="sub",
+            email_path="email",
+            default_scopes=["https://www.googleapis.com/auth/gmail.modify"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="google",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="google-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "google")
+        is True
+    )
+
+    assert oauth_account.access_token == "new-token"
+    assert oauth_account.refresh_token == "new-refresh"
+    assert len(captured_requests) == 1
+    url, kwargs = captured_requests[0]
+    assert url == "https://oauth2.googleapis.com/token"
+    assert "auth" not in kwargs
+    assert kwargs["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "old-refresh",
+        "client_id": "google-client-id",
+        "client_secret": "google-client-secret",
+    }

--- a/tests/web/test_zoom_oauth.py
+++ b/tests/web/test_zoom_oauth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -277,8 +278,10 @@ async def test_zoom_expired_token_refresh_uses_http_basic_auth(db_session, monke
     }
     auth = kwargs["auth"]
     assert isinstance(auth, tool_config.httpx.BasicAuth)
-    expected_auth = tool_config.httpx.BasicAuth("zoom-client-id", "zoom-client-secret")
-    assert auth._auth_header == expected_auth._auth_header
+    expected_credential = base64.b64encode(b"zoom-client-id:zoom-client-secret").decode(
+        "ascii"
+    )
+    assert auth._auth_header == f"Basic {expected_credential}"
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_zoom_mcp.py
+++ b/tests/web/tools/test_zoom_mcp.py
@@ -117,20 +117,34 @@ def test_list_meetings_returns_meetings_and_page_token(monkeypatch):
     assert result["next_page_token"] == "tok-2"
 
 
-def test_list_meetings_accepts_previous_meetings_and_page_token(monkeypatch):
+def test_list_meetings_accepts_upcoming_and_page_token(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"meetings": [], "next_page_token": ""})
     )
     monkeypatch.setattr(zoom.requests, "request", mock_request)
 
     result = json.loads(
-        zoom.zoom_list_meetings(meeting_type="previous_meetings", page_token="tok-2")
+        zoom.zoom_list_meetings(meeting_type="upcoming", page_token="tok-2")
     )
 
     assert result["status"] == "success"
     params = mock_request.call_args.kwargs["params"]
-    assert params["type"] == "previous_meetings"
+    assert params["type"] == "upcoming"
     assert params["next_page_token"] == "tok-2"
+
+
+def test_list_meetings_rejects_previous_meetings_as_unsupported(monkeypatch):
+    """List Meetings never returns past meetings — Zoom staff have confirmed
+    the endpoint only accepts scheduled/live/upcoming; there is no
+    "previous_meetings" type. Reject it instead of forwarding it to Zoom."""
+    mock_request = Mock()
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_list_meetings(meeting_type="previous_meetings"))
+
+    assert result["status"] == "error"
+    assert "scheduled" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_list_meetings_rejects_unknown_meeting_type(monkeypatch):
@@ -140,7 +154,7 @@ def test_list_meetings_rejects_unknown_meeting_type(monkeypatch):
     result = json.loads(zoom.zoom_list_meetings(meeting_type="past"))
 
     assert result["status"] == "error"
-    assert "previous_meetings" in result["message"]
+    assert "scheduled" in result["message"]
     mock_request.assert_not_called()
 
 
@@ -392,6 +406,49 @@ def test_get_meeting_transcript_download_failure_leaks_no_url(monkeypatch):
     assert "401" in result["message"]
     assert "http" not in result["message"]
     assert "SECRET" not in result["message"]
+
+
+def test_get_meeting_transcript_download_connection_error_leaks_no_url(monkeypatch):
+    """A raw connection failure (no HTTP response at all) must not leak the
+    download URL either — requests.ConnectionError embeds the full request
+    URL, including any access_token query param, in str(exc)."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "download_url": "https://download.zoom.us/rec/x?access_token=SECRET"
+            }
+        )
+    )
+    mock_get = Mock(
+        side_effect=requests.ConnectionError(
+            "HTTPSConnectionPool: Failed to establish a new connection "
+            "to https://download.zoom.us/rec/x?access_token=SECRET"
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "http" not in result["message"]
+    assert "SECRET" not in result["message"]
+    assert "ConnectionError" in result["message"]
+
+
+def test_download_text_wraps_connection_error_without_leaking_url(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "get",
+        Mock(
+            side_effect=requests.Timeout("Read timed out for https://x/t?token=SECRET")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Timeout") as excinfo:
+        zoom._download_text("https://x/t?token=SECRET")
+    assert "SECRET" not in str(excinfo.value)
+    assert "http" not in str(excinfo.value)
 
 
 def test_download_text_decodes_utf8_regardless_of_headers(monkeypatch):

--- a/tests/web/tools/test_zoom_mcp.py
+++ b/tests/web/tools/test_zoom_mcp.py
@@ -117,6 +117,14 @@ def test_vtt_to_text_strips_scaffolding():
     )
 
 
+def test_vtt_to_text_strips_short_form_timestamp_and_its_cue_index():
+    """WebVTT allows the hours group to be omitted (MM:SS.mmm); both that
+    timestamp line and the cue-index line preceding it must still be
+    recognized as scaffolding and dropped."""
+    vtt = "WEBVTT\n\n1\n00:01.000 --> 00:04.000\nAlice: quick clip.\n"
+    assert zoom._vtt_to_text(vtt) == "Alice: quick clip."
+
+
 def test_vtt_to_text_keeps_spoken_digit_only_line():
     """A cue-index line is digit-only AND immediately followed by a
     timestamp line; a spoken line that happens to be all digits (a PIN, an
@@ -133,6 +141,14 @@ def test_vtt_to_text_keeps_spoken_digit_only_line():
         "Thanks for confirming the year.\n"
     )
     assert zoom._vtt_to_text(vtt) == ("2024\nThanks for confirming the year.")
+
+
+def test_vtt_to_text_drops_trailing_bare_digit_line():
+    """A digit-only line with no following line at all (a truncated/partial
+    VTT download ending mid-cue) can never be complete spoken content — it
+    must still be dropped as a cue index, not kept as a stray line."""
+    vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nhi\n\n2\n"
+    assert zoom._vtt_to_text(vtt) == "hi"
 
 
 def test_list_meetings_returns_meetings_and_page_token(monkeypatch):
@@ -370,8 +386,10 @@ def test_get_meeting_transcript_reports_not_ready_instead_of_restricted(monkeypa
 def test_get_meeting_transcript_respects_can_download_false_without_reason(
     monkeypatch,
 ):
-    """can_download is the authoritative Zoom signal and must be consulted
-    even when download_restriction_reason is absent."""
+    """can_download is a signal, but the recordings listing is consulted
+    first: only once it independently finds no transcript file either is
+    can_download trusted to report "restricted" rather than a silent
+    downgrade of a transcript the recordings endpoint could still serve."""
     mock_request = Mock(return_value=MockResponse(json_data={"can_download": False}))
     monkeypatch.setattr(zoom.requests, "request", mock_request)
 
@@ -379,7 +397,44 @@ def test_get_meeting_transcript_respects_can_download_false_without_reason(
 
     assert result["status"] == "error"
     assert "restricted" in result["message"].lower()
-    mock_request.assert_called_once()
+    assert mock_request.call_count == 2
+
+
+def test_get_meeting_transcript_can_download_false_still_falls_back_to_recordings(
+    monkeypatch,
+):
+    """can_download: false on the transcript-shortcut endpoint must not
+    short-circuit before the recordings listing is checked: the two
+    endpoints can disagree, and a transcript file the recordings endpoint
+    can still serve must not be misreported as restricted."""
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"can_download": False}),
+            MockResponse(
+                json_data={
+                    "recording_files": [
+                        {
+                            "file_type": "TRANSCRIPT",
+                            "download_url": "https://download.zoom.us/transcript.vtt",
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+    mock_get = Mock(
+        return_value=MockResponse(
+            text="WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nstill downloadable\n"
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "success"
+    assert result["transcript"] == "still downloadable"
+    assert mock_request.call_count == 2
 
 
 def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch):
@@ -602,6 +657,19 @@ def test_download_text_rejects_non_zoom_host(monkeypatch):
     with pytest.raises(RuntimeError, match="unexpected host"):
         zoom._download_text("https://evil.example.com/t.vtt?token=SECRET")
     mock_get.assert_not_called()
+
+
+def test_download_text_allows_bare_zoom_us_host(monkeypatch):
+    """The exact-match branch (host == "zoom.us", as opposed to a
+    subdomain matching the ".zoom.us" suffix) must actually allow the
+    request through rather than only being reachable in theory."""
+    monkeypatch.setattr(
+        zoom.requests, "get", Mock(return_value=MockResponse(text="WEBVTT\n"))
+    )
+
+    text = zoom._download_text("https://zoom.us/t.vtt")
+
+    assert text == "WEBVTT\n"
 
 
 def test_get_current_user_returns_profile(monkeypatch):

--- a/tests/web/tools/test_zoom_mcp.py
+++ b/tests/web/tools/test_zoom_mcp.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse
 from unittest.mock import Mock
 
 import pytest
@@ -8,18 +9,22 @@ from xagent.web.tools.mcp import zoom
 
 
 class MockResponse:
-    def __init__(self, json_data=None, text="", status_code=200):
+    def __init__(self, json_data=None, text="", status_code=200, url=""):
         self._json_data = json_data if json_data is not None else {}
         self.text = text or (json.dumps(self._json_data) if json_data else "")
         self.status_code = status_code
         self.content = self.text.encode()
+        self.url = url
 
     def json(self):
         return self._json_data
 
     def raise_for_status(self):
         if self.status_code >= 400:
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+            # Mirror real requests behavior: str(HTTPError) embeds the URL.
+            raise requests.HTTPError(
+                f"{self.status_code} Client Error for url: {self.url}", response=self
+            )
 
 
 @pytest.fixture(autouse=True)
@@ -44,30 +49,26 @@ def test_encode_meeting_id_leaves_plain_numeric_id_alone():
 
 def test_encode_meeting_id_double_encodes_uuid_with_leading_slash():
     raw = "/ajXp112QmuoKj4854875=="
-    once = zoom._encode_meeting_id(raw)
-    import urllib.parse
-
-    expected = urllib.parse.quote(urllib.parse.quote(raw, safe=""), safe="")
-    assert once == expected
-
-
-def test_encode_meeting_id_double_encodes_uuid_with_double_slash():
-    raw = "abc//def"
-    import urllib.parse
-
     expected = urllib.parse.quote(urllib.parse.quote(raw, safe=""), safe="")
     assert zoom._encode_meeting_id(raw) == expected
 
 
-def test_request_wraps_http_error_with_message(monkeypatch):
+def test_encode_meeting_id_double_encodes_uuid_with_double_slash():
+    raw = "abc//def"
+    expected = urllib.parse.quote(urllib.parse.quote(raw, safe=""), safe="")
+    assert zoom._encode_meeting_id(raw) == expected
+
+
+def test_request_wraps_http_error_with_message_and_status(monkeypatch):
     monkeypatch.setattr(
         zoom.requests,
         "request",
         Mock(return_value=MockResponse(status_code=400, text='{"message": "bad id"}')),
     )
 
-    with pytest.raises(RuntimeError, match="bad id"):
+    with pytest.raises(zoom._ZoomApiError, match="bad id") as excinfo:
         zoom._request("GET", "/users/me/meetings")
+    assert excinfo.value.status_code == 400
 
 
 def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch):
@@ -81,17 +82,66 @@ def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch)
         zoom._request("GET", "/users/me/meetings")
 
 
-def test_list_meetings_returns_meetings(monkeypatch):
+def test_vtt_to_text_strips_scaffolding():
+    vtt = (
+        "WEBVTT\n"
+        "\n"
+        "1\n"
+        "00:00:01.000 --> 00:00:04.000\n"
+        "Alice: Let's start the meeting.\n"
+        "\n"
+        "2\n"
+        "00:00:05.000 --> 00:00:09.000\n"
+        "Bob: 我们先过一下上周的行动项。\n"
+    )
+    assert zoom._vtt_to_text(vtt) == (
+        "Alice: Let's start the meeting.\nBob: 我们先过一下上周的行动项。"
+    )
+
+
+def test_list_meetings_returns_meetings_and_page_token(monkeypatch):
     monkeypatch.setattr(
         zoom.requests,
         "request",
-        Mock(return_value=MockResponse(json_data={"meetings": [{"id": 1}]})),
+        Mock(
+            return_value=MockResponse(
+                json_data={"meetings": [{"id": 1}], "next_page_token": "tok-2"}
+            )
+        ),
     )
 
     result = json.loads(zoom.zoom_list_meetings())
 
     assert result["status"] == "success"
     assert result["meetings"] == [{"id": 1}]
+    assert result["next_page_token"] == "tok-2"
+
+
+def test_list_meetings_accepts_previous_meetings_and_page_token(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"meetings": [], "next_page_token": ""})
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(
+        zoom.zoom_list_meetings(meeting_type="previous_meetings", page_token="tok-2")
+    )
+
+    assert result["status"] == "success"
+    params = mock_request.call_args.kwargs["params"]
+    assert params["type"] == "previous_meetings"
+    assert params["next_page_token"] == "tok-2"
+
+
+def test_list_meetings_rejects_unknown_meeting_type(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_list_meetings(meeting_type="past"))
+
+    assert result["status"] == "error"
+    assert "previous_meetings" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_list_meetings_returns_error_payload_on_failure(monkeypatch):
@@ -128,6 +178,20 @@ def test_get_meeting_falls_back_to_past_meetings_on_404(monkeypatch):
     assert second_call.kwargs["url"].endswith("/past_meetings/123")
 
 
+def test_get_meeting_reports_not_found_when_both_legs_404(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(status_code=404, text='{"message": "not found"}')
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting("999"))
+
+    assert result["status"] == "error"
+    assert "Meeting 999 not found" in result["message"]
+    assert "past" in result["message"]
+    assert mock_request.call_count == 2
+
+
 def test_get_meeting_does_not_fall_back_on_non_404_error(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(status_code=500, text='{"message": "server error"}')
@@ -138,6 +202,22 @@ def test_get_meeting_does_not_fall_back_on_non_404_error(monkeypatch):
 
     assert result["status"] == "error"
     assert "server error" in result["message"]
+    assert mock_request.call_count == 1
+
+
+def test_get_meeting_does_not_treat_404_mention_in_body_as_not_found(monkeypatch):
+    """A 500 whose error body merely mentions "404" must not trigger the
+    past-meetings fallback — 404 detection is on the status code, not the text."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            status_code=500, text='{"message": "upstream proxy saw 404"}'
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting("123"))
+
+    assert result["status"] == "error"
     assert mock_request.call_count == 1
 
 
@@ -158,25 +238,62 @@ def test_list_recordings_returns_recording_files(monkeypatch):
     assert result["recording_files"] == [{"file_type": "MP4"}]
 
 
-def test_get_meeting_transcript_uses_dedicated_endpoint(monkeypatch):
+def test_list_recordings_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=403, text='{"message": "insufficient scope"}'
+            )
+        ),
+    )
+
+    result = json.loads(zoom.zoom_list_recordings("123"))
+
+    assert result["status"] == "error"
+    assert "insufficient scope" in result["message"]
+
+
+def test_get_meeting_transcript_uses_dedicated_endpoint_and_cleans_vtt(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
             json_data={"download_url": "https://download.zoom.us/transcript.vtt"}
         )
     )
-    mock_get = Mock(return_value=MockResponse(text="WEBVTT\n\ntranscript text"))
+    mock_get = Mock(
+        return_value=MockResponse(
+            text="WEBVTT\n\n1\n00:00:01.000 --> 00:00:04.000\nAlice: transcript text\n"
+        )
+    )
     monkeypatch.setattr(zoom.requests, "request", mock_request)
     monkeypatch.setattr(zoom.requests, "get", mock_get)
 
     result = json.loads(zoom.zoom_get_meeting_transcript("123"))
 
     assert result["status"] == "success"
-    assert "transcript text" in result["transcript"]
+    assert result["transcript"] == "Alice: transcript text"
     mock_request.assert_called_once()
     assert mock_request.call_args.kwargs["url"].endswith("/meetings/123/transcript")
     assert mock_get.call_args.kwargs["headers"] == {
         "Authorization": "Bearer access-token"
     }
+
+
+def test_get_meeting_transcript_surfaces_restriction_reason(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"download_restriction_reason": "IP_ADDRESS_RESTRICTED"}
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "restricted" in result["message"]
+    assert "IP_ADDRESS_RESTRICTED" in result["message"]
+    mock_request.assert_called_once()
 
 
 def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch):
@@ -196,17 +313,34 @@ def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch
             ),
         ]
     )
-    mock_get = Mock(return_value=MockResponse(text="WEBVTT\n\nfallback transcript"))
+    mock_get = Mock(
+        return_value=MockResponse(
+            text="WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nfallback transcript\n"
+        )
+    )
     monkeypatch.setattr(zoom.requests, "request", mock_request)
     monkeypatch.setattr(zoom.requests, "get", mock_get)
 
     result = json.loads(zoom.zoom_get_meeting_transcript("123"))
 
     assert result["status"] == "success"
-    assert "fallback transcript" in result["transcript"]
+    assert result["transcript"] == "fallback transcript"
     assert mock_get.call_args.kwargs["headers"] == {
         "Authorization": "Bearer access-token"
     }
+
+
+def test_get_meeting_transcript_reports_not_found_when_both_legs_404(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(status_code=404, text='{"message": "not found"}')
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("999"))
+
+    assert result["status"] == "error"
+    assert "Meeting 999 not found" in result["message"]
+    assert mock_request.call_count == 2
 
 
 def test_get_meeting_transcript_reports_error_when_no_transcript_file_exists(
@@ -232,6 +366,44 @@ def test_get_meeting_transcript_reports_error_when_no_transcript_file_exists(
     assert "No transcript found" in result["message"]
 
 
+def test_get_meeting_transcript_download_failure_leaks_no_url(monkeypatch):
+    """A failing transcript download must not leak the download URL (which can
+    carry an access token as a query param) into the tool response."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "download_url": "https://download.zoom.us/rec/x?access_token=SECRET"
+            }
+        )
+    )
+    mock_get = Mock(
+        return_value=MockResponse(
+            status_code=401,
+            text="unauthorized",
+            url="https://download.zoom.us/rec/x?access_token=SECRET",
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "401" in result["message"]
+    assert "http" not in result["message"]
+    assert "SECRET" not in result["message"]
+
+
+def test_download_text_decodes_utf8_regardless_of_headers(monkeypatch):
+    """requests falls back to ISO-8859-1 for text/* without a charset; the
+    decode must be explicit UTF-8 so Chinese transcripts don't mojibake."""
+    response = MockResponse()
+    response.content = "会议纪要：讨论了下季度目标".encode("utf-8")
+    monkeypatch.setattr(zoom.requests, "get", Mock(return_value=response))
+
+    assert zoom._download_text("https://x/t.vtt") == "会议纪要：讨论了下季度目标"
+
+
 def test_get_current_user_returns_profile(monkeypatch):
     monkeypatch.setattr(
         zoom.requests,
@@ -243,3 +415,16 @@ def test_get_current_user_returns_profile(monkeypatch):
 
     assert result["status"] == "success"
     assert result["user"]["email"] == "a@b.com"
+
+
+def test_get_current_user_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=401, text='{"message": "expired"}')),
+    )
+
+    result = json.loads(zoom.zoom_get_current_user())
+
+    assert result["status"] == "error"
+    assert "expired" in result["message"]

--- a/tests/web/tools/test_zoom_mcp.py
+++ b/tests/web/tools/test_zoom_mcp.py
@@ -82,6 +82,24 @@ def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch)
         zoom._request("GET", "/users/me/meetings")
 
 
+def test_request_truncates_long_unstructured_error_body(monkeypatch):
+    """An HTML gateway error page (or similar) landing in an unstructured
+    error body must not be forwarded to the LLM/logs verbatim and
+    unbounded."""
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        zoom._request("GET", "/users/me/meetings")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_body)
+
+
 def test_vtt_to_text_strips_scaffolding():
     vtt = (
         "WEBVTT\n"
@@ -97,6 +115,24 @@ def test_vtt_to_text_strips_scaffolding():
     assert zoom._vtt_to_text(vtt) == (
         "Alice: Let's start the meeting.\nBob: 我们先过一下上周的行动项。"
     )
+
+
+def test_vtt_to_text_keeps_spoken_digit_only_line():
+    """A cue-index line is digit-only AND immediately followed by a
+    timestamp line; a spoken line that happens to be all digits (a PIN, an
+    order number, a year read aloud) is not, and must survive."""
+    vtt = (
+        "WEBVTT\n"
+        "\n"
+        "1\n"
+        "00:00:01.000 --> 00:00:04.000\n"
+        "2024\n"
+        "\n"
+        "2\n"
+        "00:00:05.000 --> 00:00:09.000\n"
+        "Thanks for confirming the year.\n"
+    )
+    assert zoom._vtt_to_text(vtt) == ("2024\nThanks for confirming the year.")
 
 
 def test_list_meetings_returns_meetings_and_page_token(monkeypatch):
@@ -310,6 +346,42 @@ def test_get_meeting_transcript_surfaces_restriction_reason(monkeypatch):
     mock_request.assert_called_once()
 
 
+def test_get_meeting_transcript_reports_not_ready_instead_of_restricted(monkeypatch):
+    """NOT_READY means the transcript is still processing — a retry-later
+    condition — and must not be reported as "restricted" like a genuine
+    restriction (DELETED_OR_TRASHED, UNSUPPORTED)."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "download_restriction_reason": "NOT_READY",
+                "can_download": False,
+            }
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "processing" in result["message"].lower()
+    assert "restricted" not in result["message"].lower()
+
+
+def test_get_meeting_transcript_respects_can_download_false_without_reason(
+    monkeypatch,
+):
+    """can_download is the authoritative Zoom signal and must be consulted
+    even when download_restriction_reason is absent."""
+    mock_request = Mock(return_value=MockResponse(json_data={"can_download": False}))
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "restricted" in result["message"].lower()
+    mock_request.assert_called_once()
+
+
 def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch):
     mock_request = Mock(
         side_effect=[
@@ -320,7 +392,7 @@ def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch
                         {"file_type": "MP4", "download_url": "https://x/video.mp4"},
                         {
                             "file_type": "TRANSCRIPT",
-                            "download_url": "https://x/transcript.vtt",
+                            "download_url": "https://download.zoom.us/transcript.vtt",
                         },
                     ]
                 }
@@ -342,6 +414,46 @@ def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch
     assert mock_get.call_args.kwargs["headers"] == {
         "Authorization": "Bearer access-token"
     }
+
+
+def test_get_meeting_transcript_falls_back_to_recordings_on_empty_success_response(
+    monkeypatch,
+):
+    """A 200 transcript response with neither download_url nor
+    download_restriction_reason (not a 404) must still fall through to the
+    recordings lookup — only the 404-triggered entry into that same
+    fallback was previously covered."""
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={}),
+            MockResponse(
+                json_data={
+                    "recording_files": [
+                        {
+                            "file_type": "TRANSCRIPT",
+                            "download_url": "https://download.zoom.us/transcript.vtt",
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+    mock_get = Mock(
+        return_value=MockResponse(
+            text="WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nfallback transcript\n"
+        )
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "success"
+    assert result["transcript"] == "fallback transcript"
+    assert mock_request.call_count == 2
+    first_call, second_call = mock_request.call_args_list
+    assert first_call.kwargs["url"].endswith("/meetings/123/transcript")
+    assert second_call.kwargs["url"].endswith("/meetings/123/recordings")
 
 
 def test_get_meeting_transcript_reports_not_found_when_both_legs_404(monkeypatch):
@@ -404,7 +516,7 @@ def test_get_meeting_transcript_download_failure_leaks_no_url(monkeypatch):
 
     assert result["status"] == "error"
     assert "401" in result["message"]
-    assert "http" not in result["message"]
+    assert "download.zoom.us" not in result["message"]
     assert "SECRET" not in result["message"]
 
 
@@ -431,7 +543,7 @@ def test_get_meeting_transcript_download_connection_error_leaks_no_url(monkeypat
     result = json.loads(zoom.zoom_get_meeting_transcript("123"))
 
     assert result["status"] == "error"
-    assert "http" not in result["message"]
+    assert "download.zoom.us" not in result["message"]
     assert "SECRET" not in result["message"]
     assert "ConnectionError" in result["message"]
 
@@ -441,14 +553,16 @@ def test_download_text_wraps_connection_error_without_leaking_url(monkeypatch):
         zoom.requests,
         "get",
         Mock(
-            side_effect=requests.Timeout("Read timed out for https://x/t?token=SECRET")
+            side_effect=requests.Timeout(
+                "Read timed out for https://download.zoom.us/t?token=SECRET"
+            )
         ),
     )
 
     with pytest.raises(RuntimeError, match="Timeout") as excinfo:
-        zoom._download_text("https://x/t?token=SECRET")
+        zoom._download_text("https://download.zoom.us/t?token=SECRET")
     assert "SECRET" not in str(excinfo.value)
-    assert "http" not in str(excinfo.value)
+    assert "download.zoom.us" not in str(excinfo.value)
 
 
 def test_download_text_decodes_utf8_regardless_of_headers(monkeypatch):
@@ -458,7 +572,36 @@ def test_download_text_decodes_utf8_regardless_of_headers(monkeypatch):
     response.content = "会议纪要：讨论了下季度目标".encode("utf-8")
     monkeypatch.setattr(zoom.requests, "get", Mock(return_value=response))
 
-    assert zoom._download_text("https://x/t.vtt") == "会议纪要：讨论了下季度目标"
+    assert (
+        zoom._download_text("https://download.zoom.us/t.vtt")
+        == "会议纪要：讨论了下季度目标"
+    )
+
+
+def test_download_text_strips_utf8_bom(monkeypatch):
+    """A BOM-prefixed VTT download must decode without leaking the BOM into
+    the first line, or it fails _vtt_to_text's "WEBVTT" header check."""
+    response = MockResponse()
+    response.content = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nhi\n".encode(
+        "utf-8-sig"
+    )
+    monkeypatch.setattr(zoom.requests, "get", Mock(return_value=response))
+
+    text = zoom._download_text("https://download.zoom.us/t.vtt")
+
+    assert text.startswith("WEBVTT")
+    assert zoom._vtt_to_text(text) == "hi"
+
+
+def test_download_text_rejects_non_zoom_host(monkeypatch):
+    """The Zoom bearer token must never be attached to a request for a
+    download_url pointing somewhere other than Zoom's own domain."""
+    mock_get = Mock()
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    with pytest.raises(RuntimeError, match="unexpected host"):
+        zoom._download_text("https://evil.example.com/t.vtt?token=SECRET")
+    mock_get.assert_not_called()
 
 
 def test_get_current_user_returns_profile(monkeypatch):
@@ -485,3 +628,45 @@ def test_get_current_user_returns_error_payload_on_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "expired" in result["message"]
+
+
+def test_get_current_user_reports_error_on_empty_payload(monkeypatch):
+    """A 200/204 with no body is a data problem, not a found-empty-profile
+    success — surfacing it as status=success with an empty user object would
+    mislead the agent into thinking a profile was found."""
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204)),
+    )
+
+    result = json.loads(zoom.zoom_get_current_user())
+
+    assert result["status"] == "error"
+
+
+def test_get_meeting_reports_error_on_empty_payload(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204)),
+    )
+
+    result = json.loads(zoom.zoom_get_meeting("123"))
+
+    assert result["status"] == "error"
+    assert "no data" in result["message"].lower()
+
+
+def test_zoom_app_registry_requests_past_meeting_scope():
+    """zoom_get_meeting falls back to /past_meetings/{id} whenever
+    /meetings/{id} 404s — the normal outcome for any already-ended meeting,
+    and the primary path now that list-based past-meeting discovery has been
+    removed. That fallback requires meeting:read:past_meeting; without it,
+    the fallback surfaces a raw scope error instead of degrading."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    zoom_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "zoom"
+    )
+    assert "meeting:read:past_meeting" in zoom_app["oauth_scopes"]

--- a/tests/web/tools/test_zoom_mcp.py
+++ b/tests/web/tools/test_zoom_mcp.py
@@ -1,0 +1,245 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import zoom
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("ZOOM_ACCESS_TOKEN", "access-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("ZOOM_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="ZOOM_ACCESS_TOKEN"):
+        zoom._headers()
+
+
+def test_headers_include_bearer_token():
+    assert zoom._headers() == {"Authorization": "Bearer access-token"}
+
+
+def test_encode_meeting_id_leaves_plain_numeric_id_alone():
+    assert zoom._encode_meeting_id("123456789") == "123456789"
+
+
+def test_encode_meeting_id_double_encodes_uuid_with_leading_slash():
+    raw = "/ajXp112QmuoKj4854875=="
+    once = zoom._encode_meeting_id(raw)
+    import urllib.parse
+
+    expected = urllib.parse.quote(urllib.parse.quote(raw, safe=""), safe="")
+    assert once == expected
+
+
+def test_encode_meeting_id_double_encodes_uuid_with_double_slash():
+    raw = "abc//def"
+    import urllib.parse
+
+    expected = urllib.parse.quote(urllib.parse.quote(raw, safe=""), safe="")
+    assert zoom._encode_meeting_id(raw) == expected
+
+
+def test_request_wraps_http_error_with_message(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=400, text='{"message": "bad id"}')),
+    )
+
+    with pytest.raises(RuntimeError, match="bad id"):
+        zoom._request("GET", "/users/me/meetings")
+
+
+def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="upstream 500")),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        zoom._request("GET", "/users/me/meetings")
+
+
+def test_list_meetings_returns_meetings(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"meetings": [{"id": 1}]})),
+    )
+
+    result = json.loads(zoom.zoom_list_meetings())
+
+    assert result["status"] == "success"
+    assert result["meetings"] == [{"id": 1}]
+
+
+def test_list_meetings_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(status_code=401, text='{"message": "bad token"}')
+        ),
+    )
+
+    result = json.loads(zoom.zoom_list_meetings())
+
+    assert result["status"] == "error"
+    assert "bad token" in result["message"]
+
+
+def test_get_meeting_falls_back_to_past_meetings_on_404(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=404, text='{"message": "meeting not found"}'),
+            MockResponse(json_data={"id": 123, "topic": "Ended meeting"}),
+        ]
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting("123"))
+
+    assert result["status"] == "success"
+    assert result["meeting"]["topic"] == "Ended meeting"
+    assert mock_request.call_count == 2
+    first_call, second_call = mock_request.call_args_list
+    assert first_call.kwargs["url"].endswith("/meetings/123")
+    assert second_call.kwargs["url"].endswith("/past_meetings/123")
+
+
+def test_get_meeting_does_not_fall_back_on_non_404_error(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(status_code=500, text='{"message": "server error"}')
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting("123"))
+
+    assert result["status"] == "error"
+    assert "server error" in result["message"]
+    assert mock_request.call_count == 1
+
+
+def test_list_recordings_returns_recording_files(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={"recording_files": [{"file_type": "MP4"}]}
+            )
+        ),
+    )
+
+    result = json.loads(zoom.zoom_list_recordings("123"))
+
+    assert result["status"] == "success"
+    assert result["recording_files"] == [{"file_type": "MP4"}]
+
+
+def test_get_meeting_transcript_uses_dedicated_endpoint(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"download_url": "https://download.zoom.us/transcript.vtt"}
+        )
+    )
+    mock_get = Mock(return_value=MockResponse(text="WEBVTT\n\ntranscript text"))
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "success"
+    assert "transcript text" in result["transcript"]
+    mock_request.assert_called_once()
+    assert mock_request.call_args.kwargs["url"].endswith("/meetings/123/transcript")
+    assert mock_get.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer access-token"
+    }
+
+
+def test_get_meeting_transcript_falls_back_to_recording_files_on_404(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=404, text='{"message": "no transcript"}'),
+            MockResponse(
+                json_data={
+                    "recording_files": [
+                        {"file_type": "MP4", "download_url": "https://x/video.mp4"},
+                        {
+                            "file_type": "TRANSCRIPT",
+                            "download_url": "https://x/transcript.vtt",
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+    mock_get = Mock(return_value=MockResponse(text="WEBVTT\n\nfallback transcript"))
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+    monkeypatch.setattr(zoom.requests, "get", mock_get)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "success"
+    assert "fallback transcript" in result["transcript"]
+    assert mock_get.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer access-token"
+    }
+
+
+def test_get_meeting_transcript_reports_error_when_no_transcript_file_exists(
+    monkeypatch,
+):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=404, text='{"message": "no transcript"}'),
+            MockResponse(
+                json_data={
+                    "recording_files": [
+                        {"file_type": "MP4", "download_url": "https://x/video.mp4"}
+                    ]
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(zoom.requests, "request", mock_request)
+
+    result = json.loads(zoom.zoom_get_meeting_transcript("123"))
+
+    assert result["status"] == "error"
+    assert "No transcript found" in result["message"]
+
+
+def test_get_current_user_returns_profile(monkeypatch):
+    monkeypatch.setattr(
+        zoom.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"id": "u1", "email": "a@b.com"})),
+    )
+
+    result = json.loads(zoom.zoom_get_current_user())
+
+    assert result["status"] == "success"
+    assert result["user"]["email"] == "a@b.com"


### PR DESCRIPTION
## Summary
- Register `zoom` as a built-in OAuth MCP connector (`builtin_mcp_registry.py` + seed migration), exposing meeting lookup, cloud recording, and transcript reads
- Add Zoom-specific HTTP Basic Auth handling for the token exchange and refresh flow (Zoom rejects `client_secret` in the request body)
- Wire the Meeting Agent template to pull a Zoom meeting's transcript directly when connected, with the existing paste/upload flow as fallback

## Test plan
- [x] `pytest tests/web/tools/test_zoom_mcp.py tests/alembic/test_20260730_seed_zoom_mcp_app.py tests/web/test_zoom_oauth.py tests/templates/test_manager.py` — all passing
- [x] `ruff format` / `ruff check` clean on touched files
- [x] `mypy` clean on touched files (no new errors)
- [x] Manual OAuth round-trip against a real Zoom account via an ngrok tunnel — connected successfully, `user_oauth` row created