### PR TITLE
ref: add Home and Build extension seams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,6 +666,10 @@ jobs:
         working-directory: ./frontend
         run: npm run test:pages
 
+      - name: Run Home and Build page tests
+        working-directory: ./frontend
+        run: npm run test:app-pages
+
       # Static export is the default build (served by FastAPI in the pip/uvx
       # deployment). Verify it produces a servable bundle: index shell plus the
       # dynamic-route __shell__ pages the SPA fallback depends on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,7 @@ jobs:
 
       - name: Run Home and Build page tests
         working-directory: ./frontend
-        run: npm run test:app-pages
+        run: npm run test:home-build-pages
 
       # Static export is the default build (served by FastAPI in the pip/uvx
       # deployment). Verify it produces a servable bundle: index shell plus the

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages",
-    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page.test.tsx src/app/build/page-extension.test.tsx",
+    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages",
-    "test:app-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page.test.tsx",
+    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page-extension.test.tsx",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages",
-    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page-extension.test.tsx",
+    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page.test.tsx src/app/build/page-extension.test.tsx",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages",
+    "test:app-pages": "vitest run --config vitest.config.ts src/app/page.test.tsx src/app/build/page.test.tsx",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/src/app/build/page-default-extension.test.tsx
+++ b/frontend/src/app/build/page-default-extension.test.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  BuildAgentCardExtension,
+  BuildPageExtensionProvider,
+} from "@/lib/build-page-extension"
+
+describe("Build page shipped defaults", () => {
+  afterEach(() => cleanup())
+
+  it("renders Provider children without an extra wrapper", () => {
+    const { container } = render(
+      <BuildPageExtensionProvider>
+        <span data-testid="provider-child" />
+      </BuildPageExtensionProvider>,
+    )
+    const child = screen.getByTestId("provider-child")
+
+    expect(container.childElementCount).toBe(1)
+    expect(container.firstElementChild).toBe(child)
+  })
+
+  it("contributes no card DOM", () => {
+    const { container } = render(<BuildAgentCardExtension agentId={42} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -6,6 +6,8 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const cardRenderMock = vi.hoisted(() => vi.fn())
+const cardPropsMock = vi.hoisted(() => vi.fn())
+const providerLoaderMock = vi.hoisted(() => vi.fn())
 const providerLifetime = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
 
 vi.mock("@/lib/api-wrapper", async () => {
@@ -64,28 +66,57 @@ vi.mock("@/components/voice-input-controller", () => ({
 
 vi.mock("@/lib/build-page-extension", async () => {
   const ReactModule = await vi.importActual<typeof import("react")>("react")
+  const missingProvider = Symbol("missing Build page extension Provider")
+  const BuildPageExtensionContext = ReactModule.createContext<
+    Record<string, string> | null | typeof missingProvider
+  >(missingProvider)
   const BuildPageExtensionProvider = ReactModule.memo(
     ({ children }: { children: React.ReactNode }) => {
+      const [sharedData, setSharedData] = ReactModule.useState<
+        Record<string, string> | null
+      >(null)
       ReactModule.useEffect(() => {
+        let active = true
         providerLifetime.mounts += 1
+        void providerLoaderMock().then((data: Record<string, string>) => {
+          if (active) {
+            setSharedData(data)
+          }
+        })
         return () => {
+          active = false
           providerLifetime.unmounts += 1
         }
       }, [])
       return ReactModule.createElement(
         "div",
         { "data-testid": "build-extension-provider" },
-        children,
+        ReactModule.createElement(
+          BuildPageExtensionContext.Provider,
+          { value: sharedData },
+          children,
+        ),
       )
     },
   )
   const BuildAgentCardExtension = ReactModule.memo(
-    ({ agentId }: { agentId: number }) => {
+    (props: { agentId: number }) => {
       ReactModule.useState(null)
+      const sharedData = ReactModule.useContext(BuildPageExtensionContext)
+      if (sharedData === missingProvider) {
+        throw new Error("Build Agent card extension requires its Provider")
+      }
+      const { agentId } = props
       cardRenderMock(agentId)
-      return ReactModule.createElement("div", {
-        "data-testid": `agent-card-supplement-${agentId}`,
-      })
+      cardPropsMock(props)
+      const supplement = sharedData?.[String(agentId)]
+      return supplement
+        ? ReactModule.createElement(
+          "div",
+          { "data-testid": `agent-card-supplement-${agentId}` },
+          supplement,
+        )
+        : null
     },
   )
   return {
@@ -151,6 +182,9 @@ describe("BuildsPage extension boundaries", () => {
     routerPushMock.mockReset()
     routerReplaceMock.mockReset()
     cardRenderMock.mockClear()
+    cardPropsMock.mockClear()
+    providerLoaderMock.mockReset()
+    providerLoaderMock.mockResolvedValue({ "42": "supplement-42" })
     providerLifetime.mounts = 0
     providerLifetime.unmounts = 0
   })
@@ -163,8 +197,50 @@ describe("BuildsPage extension boundaries", () => {
     render(<BuildsPage />)
 
     await screen.findByText("Research Agent")
-    expect(screen.getByTestId("agent-card-supplement-42")).toBeInTheDocument()
+    expect(await screen.findByTestId("agent-card-supplement-42"))
+      .toBeInTheDocument()
     expect(cardRenderMock).toHaveBeenCalledWith(42)
+    expect(cardPropsMock).toHaveBeenCalledWith({ agentId: 42 })
+  })
+
+  it("shares one provider load across multiple Agent card extensions", async () => {
+    const agents = [1, 2, 3].map((id) => ({
+      ...agent,
+      id,
+      name: `Agent ${id}`,
+    }))
+    const providerLoad = deferred<Record<string, string>>()
+    providerLoaderMock.mockReturnValue(providerLoad.promise)
+    apiRequestMock.mockResolvedValue(jsonResponse(agents))
+
+    render(<BuildsPage />)
+    await screen.findByText("Agent 3")
+
+    for (const id of [1, 2, 3]) {
+      expect(screen.queryByTestId(
+        `agent-card-supplement-${id}`,
+      )).not.toBeInTheDocument()
+    }
+    expect(providerLoaderMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      providerLoad.resolve({
+        "1": "shared-value-1",
+        "2": "shared-value-2",
+        "3": "shared-value-3",
+      })
+      await providerLoad.promise
+    })
+
+    for (const id of [1, 2, 3]) {
+      expect(await screen.findByText(`shared-value-${id}`)).toBeInTheDocument()
+    }
+    expect(providerLoaderMock).toHaveBeenCalledTimes(1)
+    expect(new Set(cardPropsMock.mock.calls.map(([props]) => props.agentId)))
+      .toEqual(new Set([1, 2, 3]))
+    for (const [props] of cardPropsMock.mock.calls) {
+      expect(props).toEqual({ agentId: props.agentId })
+    }
   })
 
   it("keeps the page provider mounted across loading and a real publish refresh", async () => {
@@ -211,73 +287,10 @@ describe("BuildsPage extension boundaries", () => {
     })
     await screen.findByText("builds.emptyState.title")
     expect(providerLifetime).toEqual({ mounts: 1, unmounts: 0 })
+    expect(providerLoaderMock).toHaveBeenCalledTimes(1)
 
     view.unmount()
     expect(providerLifetime).toEqual({ mounts: 1, unmounts: 1 })
   })
 
-  it("renders voice input in the create dialog", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([]))
-
-    render(<BuildsPage />)
-    await waitFor(() => {
-      expect(screen.queryByText("common.loading")).not.toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole("button", {
-      name: "builds.list.header.create",
-    }))
-
-    expect(screen.getByRole("button", {
-      name: "voiceInput.start",
-    })).toBeInTheDocument()
-  })
-
-  it("renders privileged actions for an editable Agent", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
-
-    render(<BuildsPage />)
-    await screen.findByText("Research Agent")
-
-    for (const name of [
-      "builds.list.actions.apiKey",
-      "builds.list.actions.triggers",
-      "builds.list.actions.publish",
-      "builds.list.actions.delete",
-      "builds.list.actions.edit",
-    ]) {
-      expect(screen.getByRole("button", { name })).toBeInTheDocument()
-    }
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.viewConfig",
-    })).not.toBeInTheDocument()
-  })
-
-  it("limits a published read-only Agent to run and view actions", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([{
-      ...agent,
-      status: "published",
-      can_edit: false,
-      can_publish: false,
-      can_delete: false,
-    }]))
-
-    render(<BuildsPage />)
-    await screen.findByText("Research Agent")
-
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.chat",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.viewConfig",
-    })).toBeInTheDocument()
-    for (const name of [
-      "builds.list.actions.apiKey",
-      "builds.list.actions.triggers",
-      "builds.list.actions.publish",
-      "builds.list.actions.delete",
-      "builds.list.actions.edit",
-    ]) {
-      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument()
-    }
-  })
 })

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -1,0 +1,283 @@
+import React from "react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const routerPushMock = vi.hoisted(() => vi.fn())
+const routerReplaceMock = vi.hoisted(() => vi.fn())
+const cardRenderMock = vi.hoisted(() => vi.fn())
+const providerLifetime = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper",
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return { ...actual, getApiUrl: () => "http://api.local" }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock, replace: routerReplaceMock }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    dispatch: vi.fn(),
+    setTaskId: vi.fn(),
+    setPendingMessage: vi.fn(),
+  }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("@/components/voice-input-controller", () => ({
+  useVoiceInputControls: () => ({
+    status: "idle",
+    hasAsrModel: true,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}))
+
+vi.mock("@/lib/build-page-extension", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+  const BuildPageExtensionProvider = ReactModule.memo(
+    ({ children }: { children: React.ReactNode }) => {
+      ReactModule.useEffect(() => {
+        providerLifetime.mounts += 1
+        return () => {
+          providerLifetime.unmounts += 1
+        }
+      }, [])
+      return ReactModule.createElement(
+        "div",
+        { "data-testid": "build-extension-provider" },
+        children,
+      )
+    },
+  )
+  const BuildAgentCardExtension = ReactModule.memo(
+    ({ agentId }: { agentId: number }) => {
+      ReactModule.useState(null)
+      cardRenderMock(agentId)
+      return ReactModule.createElement("div", {
+        "data-testid": `agent-card-supplement-${agentId}`,
+      })
+    },
+  )
+  return {
+    BuildPageExtensionProvider,
+    BuildAgentCardExtension,
+  }
+})
+
+vi.mock("@/components/build/deploy-agent-dialog", () => ({
+  DeployAgentDialog: () => null,
+}))
+
+vi.mock("@/components/build/agent-triggers-dialog", () => ({
+  AgentTriggersDialog: () => null,
+}))
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+import BuildsPage from "./page"
+
+const agent = {
+  id: 42,
+  name: "Research Agent",
+  description: "Researches launch topics",
+  logo_url: null,
+  status: "draft",
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-02T00:00:00Z",
+  widget_enabled: false,
+  allowed_domains: [],
+  can_edit: true,
+  can_publish: true,
+  can_delete: true,
+}
+
+function jsonResponse(data: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe("BuildsPage extension boundaries", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    routerReplaceMock.mockReset()
+    cardRenderMock.mockClear()
+    providerLifetime.mounts = 0
+    providerLifetime.unmounts = 0
+  })
+
+  afterEach(() => cleanup())
+
+  it("renders a hook-bearing supplement for a real Agent card", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+
+    await screen.findByText("Research Agent")
+    expect(screen.getByTestId("agent-card-supplement-42")).toBeInTheDocument()
+    expect(cardRenderMock).toHaveBeenCalledWith(42)
+  })
+
+  it("keeps the page provider mounted across loading and a real publish refresh", async () => {
+    const initialAgents = deferred<Response>()
+    const refreshedAgents = deferred<Response>()
+    let agentListRequests = 0
+
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        agentListRequests += 1
+        return agentListRequests === 1
+          ? initialAgents.promise
+          : refreshedAgents.promise
+      }
+      if (
+        url === "http://api.local/api/agents/42/publish" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    const view = render(<BuildsPage />)
+    expect(screen.getByTestId("build-extension-provider")).toBeInTheDocument()
+    expect(providerLifetime).toEqual({ mounts: 1, unmounts: 0 })
+
+    await act(async () => {
+      initialAgents.resolve(jsonResponse([agent]))
+      await initialAgents.promise
+    })
+    await screen.findByText("Research Agent")
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "builds.list.actions.publish",
+    }))
+    await waitFor(() => expect(agentListRequests).toBe(2))
+    expect(screen.getByText("common.loading")).toBeInTheDocument()
+    expect(providerLifetime).toEqual({ mounts: 1, unmounts: 0 })
+
+    await act(async () => {
+      refreshedAgents.resolve(jsonResponse([]))
+      await refreshedAgents.promise
+    })
+    await screen.findByText("builds.emptyState.title")
+    expect(providerLifetime).toEqual({ mounts: 1, unmounts: 0 })
+
+    view.unmount()
+    expect(providerLifetime).toEqual({ mounts: 1, unmounts: 1 })
+  })
+
+  it("renders voice input in the create dialog", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([]))
+
+    render(<BuildsPage />)
+    await waitFor(() => {
+      expect(screen.queryByText("common.loading")).not.toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", {
+      name: "builds.list.header.create",
+    }))
+
+    expect(screen.getByRole("button", {
+      name: "voiceInput.start",
+    })).toBeInTheDocument()
+  })
+
+  it("renders privileged actions for an editable Agent", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    for (const name of [
+      "builds.list.actions.apiKey",
+      "builds.list.actions.triggers",
+      "builds.list.actions.publish",
+      "builds.list.actions.delete",
+      "builds.list.actions.edit",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument()
+    }
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).not.toBeInTheDocument()
+  })
+
+  it("limits a published read-only Agent to run and view actions", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([{
+      ...agent,
+      status: "published",
+      can_edit: false,
+      can_publish: false,
+      can_delete: false,
+    }]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.chat",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).toBeInTheDocument()
+    for (const name of [
+      "builds.list.actions.apiKey",
+      "builds.list.actions.triggers",
+      "builds.list.actions.publish",
+      "builds.list.actions.delete",
+      "builds.list.actions.edit",
+    ]) {
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument()
+    }
+  })
+})

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -332,10 +332,8 @@ describe("BuildsPage extension boundaries", () => {
     })
     await screen.findByText("builds.emptyState.title")
     expect(providerLifetime).toEqual({ mounts: 1, unmounts: 0 })
-    expect(providerLoaderMock).toHaveBeenCalledTimes(1)
 
     view.unmount()
     expect(providerLifetime).toEqual({ mounts: 1, unmounts: 1 })
   })
-
 })

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -1,5 +1,13 @@
 import React from "react"
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
@@ -233,7 +241,11 @@ describe("BuildsPage extension boundaries", () => {
     })
 
     for (const id of [1, 2, 3]) {
-      expect(await screen.findByText(`shared-value-${id}`)).toBeInTheDocument()
+      const supplement = await screen.findByTestId(
+        `agent-card-supplement-${id}`,
+      )
+      expect(within(supplement).getByText(`shared-value-${id}`))
+        .toBeInTheDocument()
     }
     expect(providerLoaderMock).toHaveBeenCalledTimes(1)
     expect(new Set(cardPropsMock.mock.calls.map(([props]) => props.agentId)))

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -15,6 +15,7 @@ const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const cardRenderMock = vi.hoisted(() => vi.fn())
 const cardPropsMock = vi.hoisted(() => vi.fn())
+const cardActionMock = vi.hoisted(() => vi.fn())
 const providerLoaderMock = vi.hoisted(() => vi.fn())
 const providerLifetime = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
 
@@ -118,13 +119,25 @@ vi.mock("@/lib/build-page-extension", async () => {
       cardRenderMock(agentId)
       cardPropsMock(props)
       const supplement = sharedData?.[String(agentId)]
-      return supplement
-        ? ReactModule.createElement(
-          "div",
-          { "data-testid": `agent-card-supplement-${agentId}` },
-          supplement,
-        )
-        : null
+      return ReactModule.createElement(
+        ReactModule.Fragment,
+        null,
+        supplement
+          ? ReactModule.createElement(
+            "div",
+            { "data-testid": `agent-card-supplement-${agentId}` },
+            supplement,
+          )
+          : null,
+        ReactModule.createElement(
+          "button",
+          {
+            type: "button",
+            onClick: () => cardActionMock(agentId),
+          },
+          `extension-action-${agentId}`,
+        ),
+      )
     },
   )
   return {
@@ -191,6 +204,7 @@ describe("BuildsPage extension boundaries", () => {
     routerReplaceMock.mockReset()
     cardRenderMock.mockClear()
     cardPropsMock.mockClear()
+    cardActionMock.mockClear()
     providerLoaderMock.mockReset()
     providerLoaderMock.mockResolvedValue({ "42": "supplement-42" })
     providerLifetime.mounts = 0
@@ -209,6 +223,25 @@ describe("BuildsPage extension boundaries", () => {
       .toBeInTheDocument()
     expect(cardRenderMock).toHaveBeenCalledWith(42)
     expect(cardPropsMock).toHaveBeenCalledWith({ agentId: 42 })
+  })
+
+  it("keeps interactive extension controls inside the card event boundary", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+
+    const cardTitle = await screen.findByText("Research Agent")
+    fireEvent.click(await screen.findByRole("button", {
+      name: "extension-action-42",
+    }))
+
+    expect(cardActionMock).toHaveBeenCalledOnce()
+    expect(cardActionMock).toHaveBeenCalledWith(42)
+    expect(routerPushMock).not.toHaveBeenCalled()
+
+    fireEvent.click(cardTitle)
+    expect(routerPushMock).toHaveBeenCalledOnce()
+    expect(routerPushMock).toHaveBeenCalledWith("/build/42")
   })
 
   it("shares one provider load across multiple Agent card extensions", async () => {

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -6,18 +6,6 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
-const renderAgentCardSupplementMock = vi.hoisted(() =>
-  vi.fn(({ agentId }: { agentId: number }) =>
-    React.createElement("div", {
-      "data-testid": `agent-card-supplement-${agentId}`,
-    }),
-  ),
-)
-const useBuildPageExtensionMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    renderAgentCardSupplement: renderAgentCardSupplementMock,
-  })),
-)
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -64,14 +52,10 @@ vi.mock("@/lib/branding", () => ({
 vi.mock("@/components/voice-input-controller", () => ({
   useVoiceInputControls: () => ({
     status: "idle",
-    hasAsrModel: true,
+    hasAsrModel: false,
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
   }),
-}))
-
-vi.mock("@/lib/build-page-extension", () => ({
-  useBuildPageExtension: useBuildPageExtensionMock,
 }))
 
 vi.mock("@/components/build/deploy-agent-dialog", () => ({
@@ -143,117 +127,12 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-function resetMocks() {
-  apiRequestMock.mockReset()
-  routerPushMock.mockReset()
-  routerReplaceMock.mockReset()
-  toastErrorMock.mockReset()
-  renderAgentCardSupplementMock.mockClear()
-  useBuildPageExtensionMock.mockClear()
-}
-
-describe("BuildsPage rendering", () => {
-  beforeEach(() => {
-    resetMocks()
-  })
-
-  afterEach(() => cleanup())
-
-  it("renders the configured supplement for a real Agent card", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
-
-    render(<BuildsPage />)
-
-    await screen.findByText("Research Agent")
-    expect(
-      screen.getByTestId("agent-card-supplement-42"),
-    ).toBeInTheDocument()
-    expect(useBuildPageExtensionMock).toHaveBeenCalled()
-    expect(renderAgentCardSupplementMock).toHaveBeenCalledWith({ agentId: 42 })
-  })
-
-  it("renders voice input in the create dialog", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([]))
-
-    render(<BuildsPage />)
-    await waitFor(() => {
-      expect(screen.queryByText("common.loading")).not.toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole("button", {
-      name: "builds.list.header.create",
-    }))
-
-    expect(screen.getByRole("button", {
-      name: "voiceInput.start",
-    })).toBeInTheDocument()
-  })
-
-  it("renders privileged actions for an editable Agent", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
-
-    render(<BuildsPage />)
-    await screen.findByText("Research Agent")
-
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.apiKey",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.triggers",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.publish",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.delete",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.edit",
-    })).toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.viewConfig",
-    })).not.toBeInTheDocument()
-  })
-
-  it("limits a published read-only Agent to run and view actions", async () => {
-    apiRequestMock.mockResolvedValue(jsonResponse([{
-      ...agent,
-      status: "published",
-      can_edit: false,
-      can_publish: false,
-      can_delete: false,
-    }]))
-
-    render(<BuildsPage />)
-    await screen.findByText("Research Agent")
-
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.chat",
-    })).toBeInTheDocument()
-    expect(screen.getByRole("button", {
-      name: "builds.list.actions.viewConfig",
-    })).toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.apiKey",
-    })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.triggers",
-    })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.publish",
-    })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.delete",
-    })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", {
-      name: "builds.list.actions.edit",
-    })).not.toBeInTheDocument()
-  })
-})
-
 describe("BuildsPage Agent deletion", () => {
   beforeEach(() => {
-    resetMocks()
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    routerReplaceMock.mockReset()
+    toastErrorMock.mockReset()
   })
 
   afterEach(() => cleanup())

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -143,14 +143,18 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-describe("BuildsPage Agent deletion", () => {
+function resetMocks() {
+  apiRequestMock.mockReset()
+  routerPushMock.mockReset()
+  routerReplaceMock.mockReset()
+  toastErrorMock.mockReset()
+  renderAgentCardSupplementMock.mockClear()
+  useBuildPageExtensionMock.mockClear()
+}
+
+describe("BuildsPage rendering", () => {
   beforeEach(() => {
-    apiRequestMock.mockReset()
-    routerPushMock.mockReset()
-    routerReplaceMock.mockReset()
-    toastErrorMock.mockReset()
-    renderAgentCardSupplementMock.mockClear()
-    useBuildPageExtensionMock.mockClear()
+    resetMocks()
   })
 
   afterEach(() => cleanup())
@@ -245,6 +249,14 @@ describe("BuildsPage Agent deletion", () => {
       name: "builds.list.actions.edit",
     })).not.toBeInTheDocument()
   })
+})
+
+describe("BuildsPage Agent deletion", () => {
+  beforeEach(() => {
+    resetMocks()
+  })
+
+  afterEach(() => cleanup())
 
   it("discards an eligible draft but waits for explicit Retry Delete", async () => {
     let listRequests = 0

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -6,6 +6,7 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const voiceInputState = vi.hoisted(() => ({ hasAsrModel: false }))
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -52,7 +53,7 @@ vi.mock("@/lib/branding", () => ({
 vi.mock("@/components/voice-input-controller", () => ({
   useVoiceInputControls: () => ({
     status: "idle",
-    hasAsrModel: false,
+    hasAsrModel: voiceInputState.hasAsrModel,
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
   }),
@@ -127,17 +128,93 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-describe("BuildsPage Agent deletion", () => {
-  beforeEach(() => {
-    apiRequestMock.mockReset()
-    routerPushMock.mockReset()
-    routerReplaceMock.mockReset()
-    toastErrorMock.mockReset()
+function resetMocks() {
+  apiRequestMock.mockReset()
+  routerPushMock.mockReset()
+  routerReplaceMock.mockReset()
+  toastErrorMock.mockReset()
+  voiceInputState.hasAsrModel = false
+}
+
+describe("BuildsPage rendering", () => {
+  beforeEach(resetMocks)
+
+  afterEach(() => cleanup())
+
+  it("renders voice input in the create dialog", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([]))
+    voiceInputState.hasAsrModel = true
+
+    render(<BuildsPage />)
+    await waitFor(() => {
+      expect(screen.queryByText("common.loading")).not.toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", {
+      name: "builds.list.header.create",
+    }))
+
+    expect(screen.getByRole("button", {
+      name: "voiceInput.start",
+    })).toBeInTheDocument()
   })
+
+  it("renders privileged actions for an editable Agent", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    for (const name of [
+      "builds.list.actions.apiKey",
+      "builds.list.actions.triggers",
+      "builds.list.actions.publish",
+      "builds.list.actions.delete",
+      "builds.list.actions.edit",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument()
+    }
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).not.toBeInTheDocument()
+  })
+
+  it("limits a published read-only Agent to run and view actions", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([{
+      ...agent,
+      status: "published",
+      can_edit: false,
+      can_publish: false,
+      can_delete: false,
+    }]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.chat",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).toBeInTheDocument()
+    for (const name of [
+      "builds.list.actions.apiKey",
+      "builds.list.actions.triggers",
+      "builds.list.actions.publish",
+      "builds.list.actions.delete",
+      "builds.list.actions.edit",
+    ]) {
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument()
+    }
+  })
+})
+
+describe("BuildsPage Agent deletion", () => {
+  beforeEach(resetMocks)
 
   afterEach(() => cleanup())
 
   it("discards an eligible draft but waits for explicit Retry Delete", async () => {
+    expect(voiceInputState.hasAsrModel).toBe(false)
     let listRequests = 0
     let deleteRequests = 0
 

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -6,6 +6,18 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const renderAgentCardSupplementMock = vi.hoisted(() =>
+  vi.fn(({ agentId }: { agentId: number }) =>
+    React.createElement("div", {
+      "data-testid": `agent-card-supplement-${agentId}`,
+    }),
+  ),
+)
+const useBuildPageExtensionMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    renderAgentCardSupplement: renderAgentCardSupplementMock,
+  })),
+)
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -52,10 +64,14 @@ vi.mock("@/lib/branding", () => ({
 vi.mock("@/components/voice-input-controller", () => ({
   useVoiceInputControls: () => ({
     status: "idle",
-    hasAsrModel: false,
+    hasAsrModel: true,
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
   }),
+}))
+
+vi.mock("@/lib/build-page-extension", () => ({
+  useBuildPageExtension: useBuildPageExtensionMock,
 }))
 
 vi.mock("@/components/build/deploy-agent-dialog", () => ({
@@ -133,9 +149,102 @@ describe("BuildsPage Agent deletion", () => {
     routerPushMock.mockReset()
     routerReplaceMock.mockReset()
     toastErrorMock.mockReset()
+    renderAgentCardSupplementMock.mockClear()
+    useBuildPageExtensionMock.mockClear()
   })
 
   afterEach(() => cleanup())
+
+  it("renders the configured supplement for a real Agent card", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+
+    await screen.findByText("Research Agent")
+    expect(
+      screen.getByTestId("agent-card-supplement-42"),
+    ).toBeInTheDocument()
+    expect(useBuildPageExtensionMock).toHaveBeenCalled()
+    expect(renderAgentCardSupplementMock).toHaveBeenCalledWith({ agentId: 42 })
+  })
+
+  it("renders voice input in the create dialog", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([]))
+
+    render(<BuildsPage />)
+    await waitFor(() => {
+      expect(screen.queryByText("common.loading")).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "builds.list.header.create",
+    }))
+
+    expect(screen.getByRole("button", {
+      name: "voiceInput.start",
+    })).toBeInTheDocument()
+  })
+
+  it("renders privileged actions for an editable Agent", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([agent]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.apiKey",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.triggers",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.publish",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.delete",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.edit",
+    })).toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).not.toBeInTheDocument()
+  })
+
+  it("limits a published read-only Agent to run and view actions", async () => {
+    apiRequestMock.mockResolvedValue(jsonResponse([{
+      ...agent,
+      status: "published",
+      can_edit: false,
+      can_publish: false,
+      can_delete: false,
+    }]))
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.chat",
+    })).toBeInTheDocument()
+    expect(screen.getByRole("button", {
+      name: "builds.list.actions.viewConfig",
+    })).toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.apiKey",
+    })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.triggers",
+    })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.publish",
+    })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.delete",
+    })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "builds.list.actions.edit",
+    })).not.toBeInTheDocument()
+  })
 
   it("discards an eligible draft but waits for explicit Retry Delete", async () => {
     let listRequests = 0

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -39,6 +39,7 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { useVoiceInputControls } from "@/components/voice-input-controller"
+import { useBuildPageExtension } from "@/lib/build-page-extension"
 
 interface LlmModel {
   model_id: string
@@ -82,6 +83,7 @@ export default function BuildsPage() {
   const { dispatch, setTaskId, setPendingMessage } = useApp()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const buildPageExtension = useBuildPageExtension()
   const hasAutoOpenedCreateRef = useRef(false)
   const createPromptRef = useRef<HTMLTextAreaElement | null>(null)
   const isMountedRef = useRef(false)
@@ -651,6 +653,9 @@ export default function BuildsPage() {
                           {t('builds.card.updatedAt')}: {formatDate(agent.updated_at || agent.created_at)}
                         </div>
                       </div>
+                      {buildPageExtension.renderAgentCardSupplement({
+                        agentId: agent.id,
+                      })}
                       <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                         {agent.status === 'published' ? (
                           <>

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -39,7 +39,10 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { useVoiceInputControls } from "@/components/voice-input-controller"
-import { useBuildPageExtension } from "@/lib/build-page-extension"
+import {
+  BuildAgentCardExtension,
+  BuildPageExtensionProvider,
+} from "@/lib/build-page-extension"
 
 interface LlmModel {
   model_id: string
@@ -83,7 +86,6 @@ export default function BuildsPage() {
   const { dispatch, setTaskId, setPendingMessage } = useApp()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const buildPageExtension = useBuildPageExtension()
   const hasAutoOpenedCreateRef = useRef(false)
   const createPromptRef = useRef<HTMLTextAreaElement | null>(null)
   const isMountedRef = useRef(false)
@@ -464,7 +466,8 @@ export default function BuildsPage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-background">
+    <BuildPageExtensionProvider>
+      <div className="flex flex-col h-full bg-background">
       {/* Header */}
       <PageHeader
         title={t("builds.list.header.title")}
@@ -653,9 +656,7 @@ export default function BuildsPage() {
                           {t('builds.card.updatedAt')}: {formatDate(agent.updated_at || agent.created_at)}
                         </div>
                       </div>
-                      {buildPageExtension.renderAgentCardSupplement({
-                        agentId: agent.id,
-                      })}
+                      <BuildAgentCardExtension agentId={agent.id} />
                       <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                         {agent.status === 'published' ? (
                           <>
@@ -893,6 +894,7 @@ export default function BuildsPage() {
           </div>
         </DialogContent>
       </Dialog>
-    </div>
+      </div>
+    </BuildPageExtensionProvider>
   )
 }

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -81,7 +81,7 @@ const isTaskCreateResponse = (value: unknown): value is TaskCreateResponse => {
   return typeof candidate.task_id === "number"
 }
 
-export default function BuildsPage() {
+function BuildsPageContent() {
   const { t } = useI18n()
   const { dispatch, setTaskId, setPendingMessage } = useApp()
   const router = useRouter()
@@ -466,8 +466,7 @@ export default function BuildsPage() {
   }
 
   return (
-    <BuildPageExtensionProvider>
-      <div className="flex flex-col h-full bg-background">
+    <div className="flex flex-col h-full bg-background">
       {/* Header */}
       <PageHeader
         title={t("builds.list.header.title")}
@@ -656,71 +655,73 @@ export default function BuildsPage() {
                           {t('builds.card.updatedAt')}: {formatDate(agent.updated_at || agent.created_at)}
                         </div>
                       </div>
-                      <BuildAgentCardExtension agentId={agent.id} />
-                      <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
-                        {agent.status === 'published' ? (
-                          <>
-                            <Button
-                              variant="default"
-                              className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
-                              onClick={() => router.push(getAgentChatHref(agent))}
-                            >
-                              <MessageSquare className="mr-1.5 h-4 w-4" />
-                              {t('builds.list.actions.chat')}
-                            </Button>
-                            {canEditAgent(agent) ? (
-                              <>
+                      <div className="space-y-4" onClick={(e) => e.stopPropagation()}>
+                        <BuildAgentCardExtension agentId={agent.id} />
+                        <div className="flex gap-2">
+                          {agent.status === 'published' ? (
+                            <>
+                              <Button
+                                variant="default"
+                                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
+                                onClick={() => router.push(getAgentChatHref(agent))}
+                              >
+                                <MessageSquare className="mr-1.5 h-4 w-4" />
+                                {t('builds.list.actions.chat')}
+                              </Button>
+                              {canEditAgent(agent) ? (
+                                <>
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    onClick={() => {
+                                      setDeployAgent(agent);
+                                    }}
+                                    title="Deploy"
+                                  >
+                                    <Rocket className="h-4 w-4" />
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    className="px-4"
+                                    onClick={() => router.push(`/build/${agent.id}`)}
+                                  >
+                                    <Edit className="mr-1.5 h-4 w-4" />
+                                    {t('builds.list.actions.edit')}
+                                  </Button>
+                                </>
+                              ) : (
                                 <Button
                                   variant="outline"
-                                  size="icon"
-                                  onClick={() => {
-                                    setDeployAgent(agent);
-                                  }}
-                                  title="Deploy"
-                                >
-                                  <Rocket className="h-4 w-4" />
-                                </Button>
-                                <Button
-                                  variant="outline"
-                                  className="px-4"
+                                  className={canRunAgent(agent) ? "px-4" : "flex-1 w-full"}
                                   onClick={() => router.push(`/build/${agent.id}`)}
                                 >
-                                  <Edit className="mr-1.5 h-4 w-4" />
-                                  {t('builds.list.actions.edit')}
+                                  <Settings2 className="mr-1.5 h-4 w-4" />
+                                  {t('builds.list.actions.viewConfig')}
                                 </Button>
-                              </>
+                              )}
+                            </>
+                          ) : (
+                            canEditAgent(agent) ? (
+                              <Button
+                                variant="outline"
+                                className="flex-1 w-full"
+                                onClick={() => router.push(`/build/${agent.id}`)}
+                              >
+                                <Edit className="mr-1.5 h-4 w-4" />
+                                {t('builds.list.actions.edit')}
+                              </Button>
                             ) : (
                               <Button
                                 variant="outline"
-                                className={canRunAgent(agent) ? "px-4" : "flex-1 w-full"}
+                                className="flex-1 w-full"
                                 onClick={() => router.push(`/build/${agent.id}`)}
                               >
                                 <Settings2 className="mr-1.5 h-4 w-4" />
                                 {t('builds.list.actions.viewConfig')}
                               </Button>
-                            )}
-                          </>
-                        ) : (
-                          canEditAgent(agent) ? (
-                            <Button
-                              variant="outline"
-                              className="flex-1 w-full"
-                              onClick={() => router.push(`/build/${agent.id}`)}
-                            >
-                              <Edit className="mr-1.5 h-4 w-4" />
-                              {t('builds.list.actions.edit')}
-                            </Button>
-                          ) : (
-                            <Button
-                              variant="outline"
-                              className="flex-1 w-full"
-                              onClick={() => router.push(`/build/${agent.id}`)}
-                            >
-                              <Settings2 className="mr-1.5 h-4 w-4" />
-                              {t('builds.list.actions.viewConfig')}
-                            </Button>
-                          )
-                        )}
+                            )
+                          )}
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -894,7 +895,14 @@ export default function BuildsPage() {
           </div>
         </DialogContent>
       </Dialog>
-      </div>
+    </div>
+  )
+}
+
+export default function BuildsPage() {
+  return (
+    <BuildPageExtensionProvider>
+      <BuildsPageContent />
     </BuildPageExtensionProvider>
   )
 }

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,108 @@
+import React from "react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const homePageExtensionMock = vi.hoisted(() =>
+  vi.fn(() => React.createElement("div", { "data-testid": "home-extension" })),
+)
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper",
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return { ...actual, getApiUrl: () => "http://api.local" }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+  }),
+}))
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    setTaskId: vi.fn(),
+    setPendingMessage: vi.fn(),
+  }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({
+    appName: "Xagent",
+    whiteLogoPath: "/logo-white.png",
+  }),
+}))
+
+vi.mock("@/components/voice-input-controller", () => ({
+  useVoiceInputControls: () => ({
+    status: "idle",
+    hasAsrModel: true,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}))
+
+vi.mock("@/components/welcome-modal", () => ({
+  WelcomeModal: () => null,
+}))
+
+vi.mock("@/lib/home-page-extension", () => ({
+  homePageExtension: homePageExtensionMock,
+}))
+
+import Home from "./page"
+
+function jsonResponse(data: unknown) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("Home", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    homePageExtensionMock.mockClear()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") {
+        return Promise.resolve(jsonResponse({ tasks: [] }))
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  it("renders the voice input and the configured extension exactly once", async () => {
+    render(<Home />)
+
+    expect(screen.getByRole("button", { name: "voiceInput.start" })).toBeInTheDocument()
+    expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
+    expect(screen.getAllByTestId("home-extension")).toHaveLength(1)
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(2))
+  })
+})

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -3,9 +3,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
-const homePageExtensionMock = vi.hoisted(() =>
-  vi.fn(() => React.createElement("div", { "data-testid": "home-extension" })),
-)
+const homeExtensionRenderMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -67,9 +65,17 @@ vi.mock("@/components/welcome-modal", () => ({
   WelcomeModal: () => null,
 }))
 
-vi.mock("@/lib/home-page-extension", () => ({
-  homePageExtension: homePageExtensionMock,
-}))
+vi.mock("@/lib/home-page-extension", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+  const HomePageExtension = ReactModule.memo(() => {
+    ReactModule.useState(null)
+    homeExtensionRenderMock()
+    return ReactModule.createElement("div", { "data-testid": "home-extension" })
+  })
+  return {
+    HomePageExtension,
+  }
+})
 
 import Home from "./page"
 
@@ -83,7 +89,7 @@ function jsonResponse(data: unknown) {
 describe("Home", () => {
   beforeEach(() => {
     apiRequestMock.mockReset()
-    homePageExtensionMock.mockClear()
+    homeExtensionRenderMock.mockClear()
     apiRequestMock.mockImplementation((url: string) => {
       if (url.startsWith("http://api.local/api/templates/")) {
         return Promise.resolve(jsonResponse([]))
@@ -97,12 +103,13 @@ describe("Home", () => {
 
   afterEach(() => cleanup())
 
-  it("renders the voice input and the configured extension exactly once", async () => {
+  it("renders a hook-bearing configured extension as one component", async () => {
     render(<Home />)
 
     expect(screen.getByRole("button", { name: "voiceInput.start" })).toBeInTheDocument()
     expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
     expect(screen.getAllByTestId("home-extension")).toHaveLength(1)
+    expect(homeExtensionRenderMock).toHaveBeenCalled()
     await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(2))
   })
 })

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -129,13 +129,9 @@ describe("Home", () => {
       const slot = container.querySelector('[data-slot="home-page-extension"]')
 
       expect(slot).toBeInTheDocument()
-      expect(slot).toHaveClass("shrink-0")
+      expect(slot).toHaveClass("shrink-0", { exact: true })
+      expect(slot).not.toHaveAttribute("style")
       expect(slot).toBeEmptyDOMElement()
-      expect(
-        Array.from(slot?.classList ?? []).some((className) =>
-          /(?:^|:)(?:p[trblxy]?|m[trblxy]?|min-h)-/.test(className),
-        ),
-      ).toBe(false)
     } finally {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
       vi.resetModules()

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -5,6 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const homeExtensionRenderMock = vi.hoisted(() => vi.fn())
 
+async function createHomeExtensionMock() {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+  const HomePageExtension = ReactModule.memo(() => {
+    ReactModule.useState(null)
+    homeExtensionRenderMock()
+    return ReactModule.createElement("div", { "data-testid": "home-extension" })
+  })
+  return { HomePageExtension }
+}
+
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
     "@/lib/api-wrapper",
@@ -65,17 +75,7 @@ vi.mock("@/components/welcome-modal", () => ({
   WelcomeModal: () => null,
 }))
 
-vi.mock("@/lib/home-page-extension", async () => {
-  const ReactModule = await vi.importActual<typeof import("react")>("react")
-  const HomePageExtension = ReactModule.memo(() => {
-    ReactModule.useState(null)
-    homeExtensionRenderMock()
-    return ReactModule.createElement("div", { "data-testid": "home-extension" })
-  })
-  return {
-    HomePageExtension,
-  }
-})
+vi.mock("@/lib/home-page-extension", createHomeExtensionMock)
 
 import Home from "./page"
 
@@ -107,9 +107,38 @@ describe("Home", () => {
     render(<Home />)
 
     expect(screen.getByRole("button", { name: "voiceInput.start" })).toBeInTheDocument()
-    expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
+    const extension = await screen.findByTestId("home-extension")
+    expect(extension).toBeInTheDocument()
+    expect(extension.parentElement).toHaveAttribute(
+      "data-slot",
+      "home-page-extension",
+    )
+    expect(extension.parentElement).toHaveClass("shrink-0")
     expect(screen.getAllByTestId("home-extension")).toHaveLength(1)
     expect(homeExtensionRenderMock).toHaveBeenCalled()
     await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(2))
+  })
+
+  it("renders the shipped default extension in an inert canonical slot", async () => {
+    vi.doUnmock("@/lib/home-page-extension")
+    vi.resetModules()
+    try {
+      const { default: DefaultHome } = await import("./page")
+
+      const { container } = render(<DefaultHome />)
+      const slot = container.querySelector('[data-slot="home-page-extension"]')
+
+      expect(slot).toBeInTheDocument()
+      expect(slot).toHaveClass("shrink-0")
+      expect(slot).toBeEmptyDOMElement()
+      expect(
+        Array.from(slot?.classList ?? []).some((className) =>
+          /(?:^|:)(?:p[trblxy]?|m[trblxy]?|min-h)-/.test(className),
+        ),
+      ).toBe(false)
+    } finally {
+      vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
+      vi.resetModules()
+    }
   })
 })

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,7 +28,7 @@ import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
-import { homePageExtension } from "@/lib/home-page-extension";
+import { HomePageExtension } from "@/lib/home-page-extension";
 
 interface RecentTask {
   task_id: number | string;
@@ -538,7 +538,7 @@ export default function Home() {
 
         </div>
       </div>
-      {homePageExtension()}
+      <HomePageExtension />
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -538,7 +538,9 @@ export default function Home() {
 
         </div>
       </div>
-      <HomePageExtension />
+      <div data-slot="home-page-extension" className="shrink-0">
+        <HomePageExtension />
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { useRouter } from "next/navigation";
 import {
   ChevronRight, Layers, Bot, Database,
@@ -27,6 +28,7 @@ import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
+import { homePageExtension } from "@/lib/home-page-extension";
 
 interface RecentTask {
   task_id: number | string;
@@ -536,6 +538,7 @@ export default function Home() {
 
         </div>
       </div>
+      {homePageExtension()}
     </div>
   );
 }

--- a/frontend/src/lib/build-page-extension.tsx
+++ b/frontend/src/lib/build-page-extension.tsx
@@ -1,11 +1,13 @@
+import React from "react"
+
 import type {
-  BuildAgentCardExtensionProps,
-  UseBuildPageExtension,
+  BuildAgentCardExtensionComponent,
+  BuildPageExtensionProviderComponent,
 } from "@/lib/page-extension-contracts"
 
-export const useBuildPageExtension = (() => ({
-  renderAgentCardSupplement: (props: BuildAgentCardExtensionProps) => {
-    void props
-    return null
-  },
-})) satisfies UseBuildPageExtension
+export const BuildPageExtensionProvider: BuildPageExtensionProviderComponent = ({
+  children,
+}) => <>{children}</>
+
+export const BuildAgentCardExtension: BuildAgentCardExtensionComponent =
+  () => null

--- a/frontend/src/lib/build-page-extension.tsx
+++ b/frontend/src/lib/build-page-extension.tsx
@@ -1,0 +1,11 @@
+import type {
+  BuildAgentCardExtensionProps,
+  UseBuildPageExtension,
+} from "@/lib/page-extension-contracts"
+
+export const useBuildPageExtension = (() => ({
+  renderAgentCardSupplement: (props: BuildAgentCardExtensionProps) => {
+    void props
+    return null
+  },
+})) satisfies UseBuildPageExtension

--- a/frontend/src/lib/home-page-extension.tsx
+++ b/frontend/src/lib/home-page-extension.tsx
@@ -1,3 +1,3 @@
-import type { HomePageExtension } from "@/lib/page-extension-contracts"
+import type { HomePageExtensionComponent } from "@/lib/page-extension-contracts"
 
-export const homePageExtension = (() => null) satisfies HomePageExtension
+export const HomePageExtension: HomePageExtensionComponent = () => null

--- a/frontend/src/lib/home-page-extension.tsx
+++ b/frontend/src/lib/home-page-extension.tsx
@@ -1,0 +1,3 @@
+import type { HomePageExtension } from "@/lib/page-extension-contracts"
+
+export const homePageExtension = (() => null) satisfies HomePageExtension

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react"
+
+export type HomePageExtension = () => ReactNode
+
+export interface BuildAgentCardExtensionProps {
+  agentId: number
+}
+
+export interface BuildPageExtension {
+  renderAgentCardSupplement:
+    (props: BuildAgentCardExtensionProps) => ReactNode
+}
+
+export type UseBuildPageExtension = () => BuildPageExtension

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -3,7 +3,8 @@ import type { ComponentType, ReactNode } from "react"
 // Embedding distributions may replace default implementation modules during frontend composition.
 export type HomePageExtensionComponent = ComponentType
 
-// A Build replacement must supply the Provider and card extension together from one implementation module.
+// The page guarantees a stable Provider lifetime and agentId join key.
+// The paired replacement implementation owns data loading, sharing, and invalidation.
 export interface BuildAgentCardExtensionProps {
   // Stable key for joining Provider-owned page data to an Agent card.
   agentId: number

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -1,14 +1,18 @@
-import type { ReactNode } from "react"
+import type { ComponentType, ReactNode } from "react"
 
-export type HomePageExtension = () => ReactNode
+// Embedding distributions may replace default implementation modules during frontend composition.
+export type HomePageExtensionComponent = ComponentType
 
 export interface BuildAgentCardExtensionProps {
   agentId: number
 }
 
-export interface BuildPageExtension {
-  renderAgentCardSupplement:
-    (props: BuildAgentCardExtensionProps) => ReactNode
+export interface BuildPageExtensionProviderProps {
+  children: ReactNode
 }
 
-export type UseBuildPageExtension = () => BuildPageExtension
+export type BuildPageExtensionProviderComponent =
+  ComponentType<BuildPageExtensionProviderProps>
+
+export type BuildAgentCardExtensionComponent =
+  ComponentType<BuildAgentCardExtensionProps>

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -3,6 +3,7 @@ import type { ComponentType, ReactNode } from "react"
 // Embedding distributions may replace default implementation modules during frontend composition.
 export type HomePageExtensionComponent = ComponentType
 
+// A Build replacement must supply the Provider and card extension together from one implementation module.
 export interface BuildAgentCardExtensionProps {
   // Stable key for joining Provider-owned page data to an Agent card.
   agentId: number

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -4,6 +4,7 @@ import type { ComponentType, ReactNode } from "react"
 export type HomePageExtensionComponent = ComponentType
 
 export interface BuildAgentCardExtensionProps {
+  // Stable key for joining Provider-owned page data to an Agent card.
   agentId: number
 }
 


### PR DESCRIPTION
## Summary

- add neutral component contracts for Home and Build page extensions
- render Home and per-Agent Build extensions through real React component boundaries
- keep a stable Build page Provider mounted across loading, refresh, empty, and populated states
- demonstrate one Provider-owned shared load across multiple `agentId`-only card extensions
- keep general Build page behavior tests separate from extension-boundary tests
- run Home, Build page, and Build extension suites in focused frontend CI

## Why

Embedding distributions need to add small page-specific UI without copying and maintaining complete route implementations. These no-op-by-default seams keep the canonical Home and Build pages owned by Xagent while allowing replacement modules to supply components that can safely use React hooks.

The Build contract separates a page-level Provider from an `agentId`-only card component. The Provider and card exports form one replaceable module pair: the Provider can load shared page data once, while each card joins that data by the stable Agent ID without coupling the extension contract to the page-local Agent model.

## Validation

- `npm run test:home-build-pages` — 3 files, 14 tests passed
- `npm run type-check`
- targeted ESLint — 0 errors
- `pre-commit run --files ...`
- mutations confirm the focused scope fails when the canonical Build suite is removed, card/value joins are mismatched, or the deletion suite loses its default ASR input
- `git diff --check 4b42e977...2e4c00ff`
