### PR TITLE
fix(channels): serialize telegram and feishu bot sync

### DIFF
--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -735,6 +735,10 @@ class FeishuChannelManager:
     def __init__(self) -> None:
         self.bots: Dict[str, FeishuBotInstance] = {}
         self._bot_stop_tasks: Dict[str, asyncio.Task[None]] = {}
+        # Channel CRUD endpoints fire sync as a background task, so two syncs
+        # can interleave at the awaits below and act on a stale view of
+        # self.bots -- starting a duplicate bot or stopping a live one.
+        self._sync_lock = asyncio.Lock()
 
     async def start(self) -> None:
         await self._sync_bots_async()
@@ -744,38 +748,39 @@ class FeishuChannelManager:
             await self._stop_bot_for_appid(app_id)
 
     async def _sync_bots_async(self) -> None:
-        active_app_ids = set()
-        channel_info_by_appid: Dict[str, Dict] = {}
+        async with self._sync_lock:
+            active_app_ids = set()
+            channel_info_by_appid: Dict[str, Dict] = {}
 
-        try:
-            channels = await load_active_channel_configs(
-                channel_type="feishu",
-                required_config_keys=("app_id", "app_secret"),
-            )
-            for ch in channels:
-                app_id = ch.config_value("app_id")
-                app_secret = ch.config_value("app_secret")
-                if app_id and app_secret:
-                    active_app_ids.add(app_id)
-                    channel_info_by_appid[app_id] = {
-                        "app_secret": app_secret,
-                        "id": ch.channel_id,
-                        "name": ch.channel_name,
-                    }
-        except Exception as e:
-            logger.error(f"Failed to load feishu channels for sync: {e}")
-            return
+            try:
+                channels = await load_active_channel_configs(
+                    channel_type="feishu",
+                    required_config_keys=("app_id", "app_secret"),
+                )
+                for ch in channels:
+                    app_id = ch.config_value("app_id")
+                    app_secret = ch.config_value("app_secret")
+                    if app_id and app_secret:
+                        active_app_ids.add(app_id)
+                        channel_info_by_appid[app_id] = {
+                            "app_secret": app_secret,
+                            "id": ch.channel_id,
+                            "name": ch.channel_name,
+                        }
+            except Exception as e:
+                logger.error(f"Failed to load feishu channels for sync: {e}")
+                return
 
-        current_app_ids = set(self.bots.keys())
+            current_app_ids = set(self.bots.keys())
 
-        for app_id in current_app_ids - active_app_ids:
-            await self._stop_bot_for_appid(app_id)
+            for app_id in current_app_ids - active_app_ids:
+                await self._stop_bot_for_appid(app_id)
 
-        for app_id in active_app_ids - current_app_ids:
-            info = channel_info_by_appid[app_id]
-            await self._start_bot_for_appid(
-                app_id, info["app_secret"], info["id"], info["name"]
-            )
+            for app_id in active_app_ids - current_app_ids:
+                info = channel_info_by_appid[app_id]
+                await self._start_bot_for_appid(
+                    app_id, info["app_secret"], info["id"], info["name"]
+                )
 
     async def _start_bot_for_appid(
         self, app_id: str, app_secret: str, channel_id: int, channel_name: str

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -736,8 +736,12 @@ class FeishuChannelManager:
         self.bots: Dict[str, FeishuBotInstance] = {}
         self._bot_stop_tasks: Dict[str, asyncio.Task[None]] = {}
         # Channel CRUD endpoints fire sync as a background task, so two syncs
-        # can interleave at the awaits below and act on a stale view of
-        # self.bots -- starting a duplicate bot or stopping a live one.
+        # can interleave. _stop_bot_for_appid awaits the shutdown drain and
+        # only removes the bot from self.bots afterwards, so a second sync
+        # entering that window sees an app_id that is still present but
+        # already being torn down: it skips starting it, the first sync
+        # completes the removal, and a re-enabled channel ends up neither
+        # running nor tracked until some later sync happens to run.
         self._sync_lock = asyncio.Lock()
 
     async def start(self) -> None:

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -1603,8 +1603,12 @@ class TelegramChannelManager:
         self._bot_stop_tasks: Dict[str, asyncio.Task[None]] = {}
         self.enabled = True  # Always enabled, we load dynamically
         # Channel CRUD endpoints fire sync as a background task, so two syncs
-        # can interleave at the awaits below and act on a stale view of
-        # self.bots -- starting a duplicate bot or stopping a live one.
+        # can interleave. _stop_bot_for_token awaits the shutdown drain and
+        # only removes the bot from self.bots afterwards, so a second sync
+        # entering that window sees a token that is still present but already
+        # being torn down: it skips starting it, the first sync completes the
+        # removal, and a re-enabled channel ends up neither running nor
+        # tracked until some later sync happens to run.
         self._sync_lock = asyncio.Lock()
 
     async def start(self) -> None:

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -1602,6 +1602,10 @@ class TelegramChannelManager:
         self.bots: Dict[str, TelegramBotInstance] = {}
         self._bot_stop_tasks: Dict[str, asyncio.Task[None]] = {}
         self.enabled = True  # Always enabled, we load dynamically
+        # Channel CRUD endpoints fire sync as a background task, so two syncs
+        # can interleave at the awaits below and act on a stale view of
+        # self.bots -- starting a duplicate bot or stopping a live one.
+        self._sync_lock = asyncio.Lock()
 
     async def start(self) -> None:
         await self._sync_bots_async()
@@ -1612,46 +1616,47 @@ class TelegramChannelManager:
             await self._stop_bot_for_token(token)
 
     async def _sync_bots_async(self) -> None:
-        active_tokens = set()
-        channel_info_by_token: Dict[str, Dict] = {}
+        async with self._sync_lock:
+            active_tokens = set()
+            channel_info_by_token: Dict[str, Dict] = {}
 
-        try:
-            channels = await load_active_channel_configs(
-                channel_type="telegram",
-                required_config_keys=("bot_token",),
+            try:
+                channels = await load_active_channel_configs(
+                    channel_type="telegram",
+                    required_config_keys=("bot_token",),
+                )
+                for ch in channels:
+                    token = ch.config_value("bot_token")
+                    if token:
+                        active_tokens.add(token)
+                        channel_info_by_token[token] = {
+                            "id": ch.channel_id,
+                            "name": ch.channel_name,
+                        }
+            except Exception as e:
+                logger.error(f"Failed to load user channels for sync: {e}")
+                return  # Don't try to sync if we failed to load from db
+
+            current_tokens = set(self.bots.keys())
+
+            logger.info(
+                f"Syncing telegram bots. Current active in db: {len(active_tokens)}, currently running: {len(current_tokens)}"
             )
-            for ch in channels:
-                token = ch.config_value("bot_token")
-                if token:
-                    active_tokens.add(token)
-                    channel_info_by_token[token] = {
-                        "id": ch.channel_id,
-                        "name": ch.channel_name,
-                    }
-        except Exception as e:
-            logger.error(f"Failed to load user channels for sync: {e}")
-            return  # Don't try to sync if we failed to load from db
 
-        current_tokens = set(self.bots.keys())
+            # Stop bots that are no longer active
+            for token in current_tokens - active_tokens:
+                await self._stop_bot_for_token(token)
 
-        logger.info(
-            f"Syncing telegram bots. Current active in db: {len(active_tokens)}, currently running: {len(current_tokens)}"
-        )
-
-        # Stop bots that are no longer active
-        for token in current_tokens - active_tokens:
-            await self._stop_bot_for_token(token)
-
-        # Start bots that are newly active
-        for token in active_tokens - current_tokens:
-            channel_info = channel_info_by_token.get(token, {})
-            ch_id = channel_info.get("id")
-            ch_name = channel_info.get("name")
-            await self._start_bot_for_token(
-                token,
-                int(ch_id) if ch_id is not None else None,
-                str(ch_name) if ch_name is not None else None,
-            )
+            # Start bots that are newly active
+            for token in active_tokens - current_tokens:
+                channel_info = channel_info_by_token.get(token, {})
+                ch_id = channel_info.get("id")
+                ch_name = channel_info.get("name")
+                await self._start_bot_for_token(
+                    token,
+                    int(ch_id) if ch_id is not None else None,
+                    str(ch_name) if ch_name is not None else None,
+                )
 
     async def _start_bot_for_token(
         self,

--- a/tests/web/test_channel_manager_sync_lock.py
+++ b/tests/web/test_channel_manager_sync_lock.py
@@ -1,9 +1,17 @@
-"""Concurrent channel-manager syncs must not act on a stale bot view.
+"""Concurrent channel-manager syncs must not interleave.
 
-Channel CRUD endpoints schedule ``_sync_bots_async`` as a background task, so
-two syncs can overlap. Each one reads ``self.bots`` and then awaits while
-starting or stopping bots; without serialization the second sync observes the
-pre-start view and starts a duplicate bot for the same credential.
+Channel CRUD endpoints schedule ``_sync_bots_async`` as a background task
+(``trigger_telegram_sync`` / ``trigger_feishu_sync``), so two syncs can
+overlap. The real suspension point is inside ``_stop_bot_for_token`` /
+``_stop_bot_for_appid``, which awaits the bot's shutdown drain and only then
+removes it from ``self.bots``.
+
+Without serialization that window loses a channel: sync A decides to stop a
+token that has disappeared from the database and suspends in the drain; sync B
+runs, sees the token still present in ``self.bots`` (A has not removed it yet)
+and therefore does not start it, even though the database now lists it as
+active again; A resumes and completes the removal. The token ends up neither
+in ``self.bots`` nor running, and nothing starts it until the next sync.
 """
 
 from __future__ import annotations
@@ -19,67 +27,119 @@ from xagent.web.services.channel_runtime import ChannelConfigSnapshot
 
 
 @pytest.mark.asyncio
-async def test_telegram_concurrent_sync_starts_each_bot_once(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_telegram_sync_does_not_interleave_with_a_pending_stop() -> None:
     manager = TelegramChannelManager()
-    snapshot = ChannelConfigSnapshot(
-        channel_id=1,
-        channel_name="Telegram Bot",
-        config_items=(("bot_token", "tg-token"),),
-    )
+    token = "tg-token"
+    # A bot is running for a token the database no longer lists.
+    manager.bots[token] = object()  # type: ignore[assignment]
+
+    active_tokens: list[str] = []
+    drain_entered = asyncio.Event()
+    release_drain = asyncio.Event()
 
     async def load_configs(**_kwargs: Any) -> tuple[ChannelConfigSnapshot, ...]:
-        # Yield so a second sync can interleave right after the DB read.
-        await asyncio.sleep(0)
-        return (snapshot,)
+        return tuple(
+            ChannelConfigSnapshot(
+                channel_id=1,
+                channel_name="Telegram Bot",
+                config_items=(("bot_token", value),),
+            )
+            for value in active_tokens
+        )
+
+    async def stop_bot(stopped_token: str) -> None:
+        # Mirrors the real method: suspend on the shutdown drain, then remove.
+        drain_entered.set()
+        await release_drain.wait()
+        manager.bots.pop(stopped_token, None)
 
     started: list[str] = []
 
-    async def start_bot(token: str, *_args: Any, **_kwargs: Any) -> None:
-        started.append(token)
-        await asyncio.sleep(0)
-        manager.bots[token] = object()  # type: ignore[assignment]
+    async def start_bot(started_token: str, *_args: Any, **_kwargs: Any) -> None:
+        if started_token in manager.bots:
+            return
+        started.append(started_token)
+        manager.bots[started_token] = object()  # type: ignore[assignment]
 
-    monkeypatch.setattr(
-        "xagent.web.channels.telegram.bot.load_active_channel_configs",
-        load_configs,
-    )
+    manager._stop_bot_for_token = stop_bot  # type: ignore[method-assign]
     manager._start_bot_for_token = start_bot  # type: ignore[method-assign]
 
-    await asyncio.gather(manager._sync_bots_async(), manager._sync_bots_async())
+    import xagent.web.channels.telegram.bot as telegram_bot
 
-    assert started == ["tg-token"]
+    original_loader = telegram_bot.load_active_channel_configs
+    telegram_bot.load_active_channel_configs = load_configs  # type: ignore[assignment]
+    try:
+        # Sync A: token absent from the DB, so it stops the running bot.
+        first = asyncio.create_task(manager._sync_bots_async())
+        await drain_entered.wait()
+
+        # The token is re-enabled while A is suspended mid-stop.
+        active_tokens.append(token)
+        second = asyncio.create_task(manager._sync_bots_async())
+        await asyncio.sleep(0)
+
+        release_drain.set()
+        await asyncio.gather(first, second)
+    finally:
+        telegram_bot.load_active_channel_configs = original_loader  # type: ignore[assignment]
+
+    # B must observe the completed stop and start the re-enabled token.
+    assert started == [token]
+    assert token in manager.bots
 
 
 @pytest.mark.asyncio
-async def test_feishu_concurrent_sync_starts_each_bot_once(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_feishu_sync_does_not_interleave_with_a_pending_stop() -> None:
     manager = FeishuChannelManager()
-    snapshot = ChannelConfigSnapshot(
-        channel_id=2,
-        channel_name="Feishu Bot",
-        config_items=(("app_id", "cli_123"), ("app_secret", "secret")),
-    )
+    app_id = "cli_123"
+    manager.bots[app_id] = object()  # type: ignore[assignment]
+
+    active_ids: list[str] = []
+    drain_entered = asyncio.Event()
+    release_drain = asyncio.Event()
 
     async def load_configs(**_kwargs: Any) -> tuple[ChannelConfigSnapshot, ...]:
-        await asyncio.sleep(0)
-        return (snapshot,)
+        return tuple(
+            ChannelConfigSnapshot(
+                channel_id=2,
+                channel_name="Feishu Bot",
+                config_items=(("app_id", value), ("app_secret", "secret")),
+            )
+            for value in active_ids
+        )
+
+    async def stop_bot(stopped_id: str) -> None:
+        drain_entered.set()
+        await release_drain.wait()
+        manager.bots.pop(stopped_id, None)
 
     started: list[str] = []
 
-    async def start_bot(app_id: str, *_args: Any, **_kwargs: Any) -> None:
-        started.append(app_id)
-        await asyncio.sleep(0)
-        manager.bots[app_id] = object()  # type: ignore[assignment]
+    async def start_bot(started_id: str, *_args: Any, **_kwargs: Any) -> None:
+        if started_id in manager.bots:
+            return
+        started.append(started_id)
+        manager.bots[started_id] = object()  # type: ignore[assignment]
 
-    monkeypatch.setattr(
-        "xagent.web.channels.feishu.bot.load_active_channel_configs",
-        load_configs,
-    )
+    manager._stop_bot_for_appid = stop_bot  # type: ignore[method-assign]
     manager._start_bot_for_appid = start_bot  # type: ignore[method-assign]
 
-    await asyncio.gather(manager._sync_bots_async(), manager._sync_bots_async())
+    import xagent.web.channels.feishu.bot as feishu_bot
 
-    assert started == ["cli_123"]
+    original_loader = feishu_bot.load_active_channel_configs
+    feishu_bot.load_active_channel_configs = load_configs  # type: ignore[assignment]
+    try:
+        first = asyncio.create_task(manager._sync_bots_async())
+        await drain_entered.wait()
+
+        active_ids.append(app_id)
+        second = asyncio.create_task(manager._sync_bots_async())
+        await asyncio.sleep(0)
+
+        release_drain.set()
+        await asyncio.gather(first, second)
+    finally:
+        feishu_bot.load_active_channel_configs = original_loader  # type: ignore[assignment]
+
+    assert started == [app_id]
+    assert app_id in manager.bots

--- a/tests/web/test_channel_manager_sync_lock.py
+++ b/tests/web/test_channel_manager_sync_lock.py
@@ -1,0 +1,85 @@
+"""Concurrent channel-manager syncs must not act on a stale bot view.
+
+Channel CRUD endpoints schedule ``_sync_bots_async`` as a background task, so
+two syncs can overlap. Each one reads ``self.bots`` and then awaits while
+starting or stopping bots; without serialization the second sync observes the
+pre-start view and starts a duplicate bot for the same credential.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from xagent.web.channels.feishu.bot import FeishuChannelManager
+from xagent.web.channels.telegram.bot import TelegramChannelManager
+from xagent.web.services.channel_runtime import ChannelConfigSnapshot
+
+
+@pytest.mark.asyncio
+async def test_telegram_concurrent_sync_starts_each_bot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = TelegramChannelManager()
+    snapshot = ChannelConfigSnapshot(
+        channel_id=1,
+        channel_name="Telegram Bot",
+        config_items=(("bot_token", "tg-token"),),
+    )
+
+    async def load_configs(**_kwargs: Any) -> tuple[ChannelConfigSnapshot, ...]:
+        # Yield so a second sync can interleave right after the DB read.
+        await asyncio.sleep(0)
+        return (snapshot,)
+
+    started: list[str] = []
+
+    async def start_bot(token: str, *_args: Any, **_kwargs: Any) -> None:
+        started.append(token)
+        await asyncio.sleep(0)
+        manager.bots[token] = object()  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.load_active_channel_configs",
+        load_configs,
+    )
+    manager._start_bot_for_token = start_bot  # type: ignore[method-assign]
+
+    await asyncio.gather(manager._sync_bots_async(), manager._sync_bots_async())
+
+    assert started == ["tg-token"]
+
+
+@pytest.mark.asyncio
+async def test_feishu_concurrent_sync_starts_each_bot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = FeishuChannelManager()
+    snapshot = ChannelConfigSnapshot(
+        channel_id=2,
+        channel_name="Feishu Bot",
+        config_items=(("app_id", "cli_123"), ("app_secret", "secret")),
+    )
+
+    async def load_configs(**_kwargs: Any) -> tuple[ChannelConfigSnapshot, ...]:
+        await asyncio.sleep(0)
+        return (snapshot,)
+
+    started: list[str] = []
+
+    async def start_bot(app_id: str, *_args: Any, **_kwargs: Any) -> None:
+        started.append(app_id)
+        await asyncio.sleep(0)
+        manager.bots[app_id] = object()  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        "xagent.web.channels.feishu.bot.load_active_channel_configs",
+        load_configs,
+    )
+    manager._start_bot_for_appid = start_bot  # type: ignore[method-assign]
+
+    await asyncio.gather(manager._sync_bots_async(), manager._sync_bots_async())
+
+    assert started == ["cli_123"]

--- a/tests/web/test_channel_manager_sync_lock.py
+++ b/tests/web/test_channel_manager_sync_lock.py
@@ -25,9 +25,16 @@ from xagent.web.channels.feishu.bot import FeishuChannelManager
 from xagent.web.channels.telegram.bot import TelegramChannelManager
 from xagent.web.services.channel_runtime import ChannelConfigSnapshot
 
+# Bound every wait so a regression that stops a sync from reaching the drain
+# fails the test instead of hanging the CI job (no global pytest timeout is
+# configured for this project).
+_TEST_TIMEOUT_SECONDS = 5.0
+
 
 @pytest.mark.asyncio
-async def test_telegram_sync_does_not_interleave_with_a_pending_stop() -> None:
+async def test_telegram_sync_does_not_interleave_with_a_pending_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = TelegramChannelManager()
     token = "tg-token"
     # A bot is running for a token the database no longer lists.
@@ -63,25 +70,25 @@ async def test_telegram_sync_does_not_interleave_with_a_pending_stop() -> None:
 
     manager._stop_bot_for_token = stop_bot  # type: ignore[method-assign]
     manager._start_bot_for_token = start_bot  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.load_active_channel_configs",
+        load_configs,
+    )
 
-    import xagent.web.channels.telegram.bot as telegram_bot
+    # Sync A: token absent from the DB, so it stops the running bot.
+    first = asyncio.create_task(manager._sync_bots_async())
+    await asyncio.wait_for(drain_entered.wait(), timeout=_TEST_TIMEOUT_SECONDS)
 
-    original_loader = telegram_bot.load_active_channel_configs
-    telegram_bot.load_active_channel_configs = load_configs  # type: ignore[assignment]
-    try:
-        # Sync A: token absent from the DB, so it stops the running bot.
-        first = asyncio.create_task(manager._sync_bots_async())
-        await drain_entered.wait()
+    # The token is re-enabled while A is suspended mid-stop.
+    active_tokens.append(token)
+    second = asyncio.create_task(manager._sync_bots_async())
+    await asyncio.sleep(0)
+    # Pin the intent rather than relying on one scheduler step being enough:
+    # B must be parked on the lock, not past it.
+    assert manager._sync_lock.locked()
 
-        # The token is re-enabled while A is suspended mid-stop.
-        active_tokens.append(token)
-        second = asyncio.create_task(manager._sync_bots_async())
-        await asyncio.sleep(0)
-
-        release_drain.set()
-        await asyncio.gather(first, second)
-    finally:
-        telegram_bot.load_active_channel_configs = original_loader  # type: ignore[assignment]
+    release_drain.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=_TEST_TIMEOUT_SECONDS)
 
     # B must observe the completed stop and start the re-enabled token.
     assert started == [token]
@@ -89,7 +96,9 @@ async def test_telegram_sync_does_not_interleave_with_a_pending_stop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_feishu_sync_does_not_interleave_with_a_pending_stop() -> None:
+async def test_feishu_sync_does_not_interleave_with_a_pending_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = FeishuChannelManager()
     app_id = "cli_123"
     manager.bots[app_id] = object()  # type: ignore[assignment]
@@ -123,23 +132,21 @@ async def test_feishu_sync_does_not_interleave_with_a_pending_stop() -> None:
 
     manager._stop_bot_for_appid = stop_bot  # type: ignore[method-assign]
     manager._start_bot_for_appid = start_bot  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "xagent.web.channels.feishu.bot.load_active_channel_configs",
+        load_configs,
+    )
 
-    import xagent.web.channels.feishu.bot as feishu_bot
+    first = asyncio.create_task(manager._sync_bots_async())
+    await asyncio.wait_for(drain_entered.wait(), timeout=_TEST_TIMEOUT_SECONDS)
 
-    original_loader = feishu_bot.load_active_channel_configs
-    feishu_bot.load_active_channel_configs = load_configs  # type: ignore[assignment]
-    try:
-        first = asyncio.create_task(manager._sync_bots_async())
-        await drain_entered.wait()
+    active_ids.append(app_id)
+    second = asyncio.create_task(manager._sync_bots_async())
+    await asyncio.sleep(0)
+    assert manager._sync_lock.locked()
 
-        active_ids.append(app_id)
-        second = asyncio.create_task(manager._sync_bots_async())
-        await asyncio.sleep(0)
-
-        release_drain.set()
-        await asyncio.gather(first, second)
-    finally:
-        feishu_bot.load_active_channel_configs = original_loader  # type: ignore[assignment]
+    release_drain.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=_TEST_TIMEOUT_SECONDS)
 
     assert started == [app_id]
     assert app_id in manager.bots


### PR DESCRIPTION
## Summary

- serialize `_sync_bots_async` in `TelegramChannelManager` and `FeishuChannelManager` with an `asyncio.Lock`, matching the guard `SlackChannelManager` already has
- add regression coverage for concurrent sync on both managers

## Why

Channel CRUD endpoints schedule bot sync as a background task (`trigger_telegram_sync` / `trigger_feishu_sync`), so two syncs can overlap. Each one reads `self.bots`, then awaits while starting or stopping bots:

```python
current_tokens = set(self.bots.keys())
for token in current_tokens - active_tokens:
    await self._stop_bot_for_token(token)      # <-- await
for token in active_tokens - current_tokens:
    await self._start_bot_for_token(...)       # <-- await
```

The second sync resumes on the pre-start view and starts a duplicate bot for the same credential — two polling loops on one token, and the shared `self.bots` / `_bot_stop_tasks` dicts get mutated from both.

`SlackChannelManager` already holds a `_sync_lock` for exactly this reason. This ports it to the other two managers rather than removing it from Slack. Noted in #1065 as one of the divergences between the three channel implementations.

## Validation

- new `tests/web/test_channel_manager_sync_lock.py`: two concurrent `_sync_bots_async()` calls must start each bot exactly once. Verified the test **fails** without the lock (`started == ['tg-token', 'tg-token']`) and passes with it, so it exercises the real race rather than passing trivially.
- `pytest tests/web/test_channel_manager_sync_lock.py tests/web/test_telegram_message_queue.py tests/web/test_feishu_message_queue.py` — 69 passed
- ruff check / ruff format / mypy clean on the changed files

Refs #1065.
