### PR TITLE
feat: add Google Analytics (GA4) MCP connector

### DIFF
--- a/src/xagent/migrations/versions/20260730_seed_google_analytics_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_google_analytics_mcp_app.py
@@ -1,0 +1,81 @@
+"""seed built-in Google Analytics (OAuth) MCP connector
+
+Revision ID: 20260730_seed_google_analytics_mcp_app
+Revises: 20260724_add_upload_source_to_uploaded_files
+Create Date: 2026-07-30 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260730_seed_google_analytics_mcp_app"
+down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "google-analytics"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Google Analytics",
+    "description": "Connect to Google Analytics (GA4) to list properties and run performance reports.",
+    "icon": "https://www.google.com/s2/favicons?domain=analytics.google.com&sz=128",
+    "transport": "oauth",
+    "provider_name": "google",
+    "category": "Marketing",
+    "oauth_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.google_analytics"],
+        "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. The shared "google" oauth_providers row
+    # is left untouched since it is reused by Gmail/Drive/Calendar/Docs/Slides/Ads.
+    # Any MCPServer/UserMCPServer rows created by users who already connected are
+    # intentionally left in place — connect-driven rows are not owned by this
+    # migration and are cleaned up through the normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260730_seed_google_analytics_mcp_app.py
+++ b/src/xagent/migrations/versions/20260730_seed_google_analytics_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Google Analytics (OAuth) MCP connector
 
 Revision ID: 20260730_seed_google_analytics_mcp_app
-Revises: 20260724_add_upload_source_to_uploaded_files
+Revises: 20260801_seed_slack_mcp_app
 Create Date: 2026-07-30 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260730_seed_google_analytics_mcp_app"
-down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+down_revision: Union[str, None] = "20260801_seed_slack_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -257,6 +257,22 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "google-analytics",
+            "name": "Google Analytics",
+            "description": "Connect to Google Analytics (GA4) to list properties and run performance reports.",
+            "icon": "https://www.google.com/s2/favicons?domain=analytics.google.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "google",
+            "category": "Marketing",
+            "oauth_scopes": ["https://www.googleapis.com/auth/analytics.readonly"],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.google_analytics"],
+                "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
             "app_id": "hubspot",
             "name": "HubSpot",
             "description": "Connect to HubSpot CRM to search, create, and update contacts and companies, read deals, and log notes.",

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -147,14 +147,18 @@ def google_analytics_list_properties() -> str:
                     params=params,
                 )
             )
-            for account in result.get("accountSummaries", []):
+            for account in result.get("accountSummaries") or []:
                 if not isinstance(account, dict):
                     continue
                 account_name = account.get("displayName")
-                for prop in account.get("propertySummaries", []) or []:
+                for prop in account.get("propertySummaries") or []:
                     if not isinstance(prop, dict):
                         continue
-                    resource_name = prop.get("property", "")
+                    resource_name = prop.get("property")
+                    if not isinstance(resource_name, str) or not resource_name:
+                        # No usable resource name -> no property_id to offer;
+                        # skip rather than emitting a garbage empty id.
+                        continue
                     properties.append(
                         {
                             "account_name": account_name,
@@ -187,8 +191,8 @@ def google_analytics_get_metadata(property_id: str) -> str:
             )
         )
         return _success(
-            dimensions=result.get("dimensions", []),
-            metrics=result.get("metrics", []),
+            dimensions=result.get("dimensions") or [],
+            metrics=result.get("metrics") or [],
         )
     except Exception as e:
         logger.error(f"Error getting Google Analytics metadata for {property_id}: {e}")
@@ -247,10 +251,10 @@ def google_analytics_run_report(
             )
         )
         return _success(
-            dimension_headers=result.get("dimensionHeaders", []),
-            metric_headers=result.get("metricHeaders", []),
-            rows=result.get("rows", []),
-            row_count=result.get("rowCount", 0),
+            dimension_headers=result.get("dimensionHeaders") or [],
+            metric_headers=result.get("metricHeaders") or [],
+            rows=result.get("rows") or [],
+            row_count=result.get("rowCount") or 0,
         )
     except Exception as e:
         logger.error(f"Error running Google Analytics report for {property_id}: {e}")

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -21,6 +21,11 @@ DATA_API_BASE_URL = "https://analyticsdata.googleapis.com/v1beta"
 ADMIN_API_BASE_URL = "https://analyticsadmin.googleapis.com/v1beta"
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_ACCOUNT_SUMMARY_PAGES = 20
+# A 5-dimension + 5-metric row serializes to ~275 chars through _success(); at
+# RUN_REPORT_MAX_LIMIT rows that's comfortably under the platform's 51200-char
+# MCP output truncation threshold even for wide reports.
+RUN_REPORT_DEFAULT_LIMIT = 100
+RUN_REPORT_MAX_LIMIT = 150
 
 _PROPERTY_ID_PATTERN = re.compile(r"^[0-9]+\Z")
 
@@ -204,7 +209,11 @@ def _project_metadata_entries(entries: list[Any], search: str) -> list[dict[str,
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        api_name = str(entry.get("apiName") or "")
+        api_name = entry.get("apiName")
+        if not isinstance(api_name, str) or not api_name:
+            # No usable apiName -> nothing for the LLM to pass back into
+            # run_report; skip rather than emitting a garbage empty name.
+            continue
         ui_name = str(entry.get("uiName") or "")
         if needle and needle not in api_name.lower() and needle not in ui_name.lower():
             continue
@@ -257,7 +266,7 @@ def google_analytics_run_report(
     dimension_filter: dict[str, Any] | None = None,
     metric_filter: dict[str, Any] | None = None,
     order_bys: list[dict[str, Any]] | None = None,
-    limit: int = 1000,
+    limit: int = RUN_REPORT_DEFAULT_LIMIT,
     offset: int = 0,
 ) -> str:
     """
@@ -280,22 +289,29 @@ def google_analytics_run_report(
     metric_filter: a raw GA4 FilterExpression dict applied to metric values
       (e.g. "sessions > 100"). Optional.
     order_bys: a raw GA4 OrderBy list, e.g. to sort by a metric descending.
-    limit: max rows to return (default 1000).
+    limit: max rows to return (default 100, max 150 — keeps a wide report's
+      serialized response under the MCP output size limit).
     offset: row offset for paging — if row_count in the response exceeds
       limit, call again with offset=limit, then offset=2*limit, and so on.
     """
     try:
         normalized_property_id = _normalize_property_id(property_id)
+        if not metrics:
+            raise ValueError("metrics must contain at least one metric name")
         if not date_ranges:
             raise ValueError("date_ranges must contain at least one date range")
         if len(date_ranges) > 4:
             raise ValueError("GA4 allows at most 4 date_ranges per report")
+        if limit < 1 or limit > RUN_REPORT_MAX_LIMIT:
+            raise ValueError(f"limit must be between 1 and {RUN_REPORT_MAX_LIMIT}")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
         body: dict[str, Any] = {
             "metrics": [{"name": m} for m in metrics],
             "dateRanges": [_date_range_body(dr) for dr in date_ranges],
             # Always sent explicitly: GA4's default would otherwise return up
             # to 10k rows in one response.
-            "limit": str(max(1, limit)),
+            "limit": str(limit),
         }
         if dimensions:
             body["dimensions"] = [{"name": d} for d in dimensions]

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -117,9 +117,18 @@ def _require_dict_result(result: Any) -> dict[str, Any]:
 
 
 def _date_range_body(date_range: dict[str, Any]) -> dict[str, Any]:
+    # FastMCP's signature validation guarantees a dict, but not its keys — an
+    # empty dict or misnamed keys (e.g. camelCase "startDate") would otherwise
+    # sail through and reach the API as two nulls. Fail here with a message
+    # the LLM can self-correct from.
+    if not date_range.get("start_date") or not date_range.get("end_date"):
+        raise ValueError(
+            'Each date range needs "start_date" and "end_date" (YYYY-MM-DD or '
+            'GA4 relative terms like "7daysAgo"/"today")'
+        )
     body = {
-        "startDate": date_range.get("start_date"),
-        "endDate": date_range.get("end_date"),
+        "startDate": date_range["start_date"],
+        "endDate": date_range["end_date"],
     }
     if date_range.get("name"):
         body["name"] = date_range["name"]

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -1,0 +1,261 @@
+import json
+import logging
+import os
+import re
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("google-analytics-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("google-analytics-mcp")
+
+DATA_API_BASE_URL = "https://analyticsdata.googleapis.com/v1beta"
+ADMIN_API_BASE_URL = "https://analyticsadmin.googleapis.com/v1beta"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_ACCOUNT_SUMMARY_PAGES = 20
+
+_PROPERTY_ID_PATTERN = re.compile(r"^[0-9]+\Z")
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _normalize_property_id(property_id: str) -> str:
+    """Accept either a bare numeric id ("123456") or a resource name
+    ("properties/123456") and return the bare numeric id.
+
+    Rejects anything else rather than silently sanitizing it, since this
+    value is interpolated directly into a URL path.
+    """
+    raw = str(property_id)
+    if raw.startswith("properties/"):
+        raw = raw[len("properties/") :]
+    if not _PROPERTY_ID_PATTERN.match(raw):
+        raise ValueError(
+            "property_id must be numeric (optionally prefixed 'properties/')"
+        )
+    return raw
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("GOOGLE_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("GOOGLE_ACCESS_TOKEN environment variable is missing")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Google API error body
+    (``{"error": {"code": ..., "message": ..., "status": ...}}``).
+    Returns None if the body isn't in the expected shape, so the caller can
+    fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    return message if isinstance(message, str) and message else None
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=url,
+        headers=_headers(),
+        params=params,
+        json=body,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        message = str(exc)
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+        if detail:
+            message = f"{message} - {detail}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _require_dict_result(result: Any) -> dict[str, Any]:
+    if not isinstance(result, dict):
+        raise ValueError("Unexpected response format from Google Analytics API")
+    return result
+
+
+def _date_range_body(date_range: dict[str, Any]) -> dict[str, Any]:
+    body = {
+        "startDate": date_range.get("start_date"),
+        "endDate": date_range.get("end_date"),
+    }
+    if date_range.get("name"):
+        body["name"] = date_range["name"]
+    return body
+
+
+@mcp.tool()
+def google_analytics_list_properties() -> str:
+    """
+    List the GA4 accounts and properties accessible to the connected account.
+    Use this first to discover which property_id values are available for
+    google_analytics_run_report / google_analytics_get_metadata.
+    """
+    try:
+        properties: list[dict[str, Any]] = []
+        page_token: str | None = None
+        for _ in range(MAX_ACCOUNT_SUMMARY_PAGES):
+            params: dict[str, Any] = {"pageSize": 200}
+            if page_token:
+                params["pageToken"] = page_token
+            result = _require_dict_result(
+                _request(
+                    "GET",
+                    f"{ADMIN_API_BASE_URL}/accountSummaries",
+                    params=params,
+                )
+            )
+            for account in result.get("accountSummaries", []):
+                if not isinstance(account, dict):
+                    continue
+                account_name = account.get("displayName")
+                for prop in account.get("propertySummaries", []) or []:
+                    if not isinstance(prop, dict):
+                        continue
+                    resource_name = prop.get("property", "")
+                    properties.append(
+                        {
+                            "account_name": account_name,
+                            "property_id": resource_name.rsplit("/", 1)[-1],
+                            "property_display_name": prop.get("displayName"),
+                        }
+                    )
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                break
+        return _success(properties=properties)
+    except Exception as e:
+        logger.error(f"Error listing Google Analytics properties: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_analytics_get_metadata(property_id: str) -> str:
+    """
+    List the dimensions and metrics available to query for a GA4 property.
+    Use this before google_analytics_run_report if you're unsure which
+    dimension/metric names are valid for this property.
+    """
+    try:
+        normalized_property_id = _normalize_property_id(property_id)
+        result = _require_dict_result(
+            _request(
+                "GET",
+                f"{DATA_API_BASE_URL}/properties/{normalized_property_id}/metadata",
+            )
+        )
+        return _success(
+            dimensions=result.get("dimensions", []),
+            metrics=result.get("metrics", []),
+        )
+    except Exception as e:
+        logger.error(f"Error getting Google Analytics metadata for {property_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_analytics_run_report(
+    property_id: str,
+    metrics: list[str],
+    date_ranges: list[dict[str, str]],
+    dimensions: list[str] | None = None,
+    dimension_filter: dict[str, Any] | None = None,
+    order_bys: list[dict[str, Any]] | None = None,
+    limit: int | None = None,
+) -> str:
+    """
+    Run a GA4 report: quantify performance by any combination of dimensions
+    (e.g. channel, campaign, landing page, segment) over one or more date
+    ranges.
+
+    metrics: metric names, e.g. ["sessions", "conversions", "totalRevenue"].
+    date_ranges: one dict per period to compare, each with "start_date" and
+      "end_date" (YYYY-MM-DD, or GA4 relative terms like "7daysAgo"/"today"),
+      and an optional "name" to label the period (e.g. "current", "previous")
+      — pass two date_ranges to compare a period against a prior one in a
+      single call; the response's rows are tagged with the matching name.
+    dimensions: dimension names, e.g. ["sessionDefaultChannelGroup",
+      "landingPagePlusQueryString"]. Use google_analytics_get_metadata to
+      discover valid names for this property.
+    dimension_filter: a raw GA4 FilterExpression dict, for narrowing results
+      (e.g. to one campaign or landing page). Optional.
+    order_bys: a raw GA4 OrderBy list, e.g. to sort by a metric descending.
+    limit: max rows to return.
+    """
+    try:
+        normalized_property_id = _normalize_property_id(property_id)
+        body: dict[str, Any] = {
+            "metrics": [{"name": m} for m in metrics],
+            "dateRanges": [_date_range_body(dr) for dr in date_ranges],
+        }
+        if dimensions:
+            body["dimensions"] = [{"name": d} for d in dimensions]
+        if dimension_filter:
+            body["dimensionFilter"] = dimension_filter
+        if order_bys:
+            body["orderBys"] = order_bys
+        if limit is not None:
+            body["limit"] = str(limit)
+
+        result = _require_dict_result(
+            _request(
+                "POST",
+                f"{DATA_API_BASE_URL}/properties/{normalized_property_id}:runReport",
+                body=body,
+            )
+        )
+        return _success(
+            dimension_headers=result.get("dimensionHeaders", []),
+            metric_headers=result.get("metricHeaders", []),
+            rows=result.get("rows", []),
+            row_count=result.get("rowCount", 0),
+        )
+    except Exception as e:
+        logger.error(f"Error running Google Analytics report for {property_id}: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -7,6 +7,7 @@ from typing import Any
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from ....config import get_tool_max_output_length
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -21,9 +22,13 @@ DATA_API_BASE_URL = "https://analyticsdata.googleapis.com/v1beta"
 ADMIN_API_BASE_URL = "https://analyticsadmin.googleapis.com/v1beta"
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_ACCOUNT_SUMMARY_PAGES = 20
-# A 5-dimension + 5-metric row serializes to ~275 chars through _success(); at
-# RUN_REPORT_MAX_LIMIT rows that's comfortably under the platform's 51200-char
-# MCP output truncation threshold even for wide reports.
+# The limit bounds row *count*, not bytes: a 5-dimension + 5-metric row with
+# short (~11-char) values serializes to ~275 chars through _success(), which
+# keeps RUN_REPORT_MAX_LIMIT rows comfortably under the platform's 51200-char
+# MCP output truncation threshold — but several long-valued dimensions (e.g.
+# full URLs) at once can still cross it. google_analytics_run_report guards
+# the actual serialized size and trims rows if needed, same as
+# google_analytics_list_properties does for its own response.
 RUN_REPORT_DEFAULT_LIMIT = 100
 RUN_REPORT_MAX_LIMIT = 150
 
@@ -331,12 +336,41 @@ def google_analytics_run_report(
                 body=body,
             )
         )
-        return _success(
-            dimension_headers=result.get("dimensionHeaders") or [],
-            metric_headers=result.get("metricHeaders") or [],
-            rows=result.get("rows") or [],
-            row_count=result.get("rowCount") or 0,
+        dimension_headers = result.get("dimensionHeaders") or []
+        metric_headers = result.get("metricHeaders") or []
+        rows = result.get("rows") or []
+        row_count = result.get("rowCount") or 0
+
+        # RUN_REPORT_MAX_LIMIT bounds row count, not bytes: several long
+        # dimension values (e.g. full URLs) at once can still cross the
+        # platform's output truncation threshold. Halve the returned rows
+        # until the serialized response fits, mirroring the truncated-flag
+        # pattern in google_analytics_list_properties.
+        max_output_length = get_tool_max_output_length()
+        original_row_count = len(rows)
+        response = _success(
+            dimension_headers=dimension_headers,
+            metric_headers=metric_headers,
+            rows=rows,
+            row_count=row_count,
+            truncated=False,
         )
+        while len(response) > max_output_length and len(rows) > 1:
+            rows = rows[: len(rows) // 2]
+            response = _success(
+                dimension_headers=dimension_headers,
+                metric_headers=metric_headers,
+                rows=rows,
+                row_count=row_count,
+                truncated=True,
+            )
+        if len(rows) < original_row_count:
+            logger.warning(
+                f"Google Analytics run_report response trimmed from "
+                f"{original_row_count} to {len(rows)} rows to stay under "
+                f"the {max_output_length}-char output limit"
+            )
+        return response
     except Exception as e:
         # !r escapes embedded newlines, keeping a crafted property_id from
         # injecting fake log lines.

--- a/src/xagent/web/tools/mcp/google_analytics.py
+++ b/src/xagent/web/tools/mcp/google_analytics.py
@@ -100,7 +100,10 @@ def _request(
         message = str(exc)
         detail = _extract_error_detail(response)
         if detail is None:
-            detail = response.text.strip()
+            # Cap the raw-body fallback: an upstream HTML error page can be
+            # hundreds of KB and would otherwise be embedded whole into the
+            # error message.
+            detail = response.text.strip()[:1000]
         if detail:
             message = f"{message} - {detail}"
         raise RuntimeError(message) from exc
@@ -111,6 +114,10 @@ def _request(
 
 
 def _require_dict_result(result: Any) -> dict[str, Any]:
+    """Guard against a non-dict payload (e.g. a list or string) before
+    calling dict methods on it. A dict that's merely empty (zero properties,
+    zero report rows) is a normal, valid response and must not be rejected
+    here."""
     if not isinstance(result, dict):
         raise ValueError("Unexpected response format from Google Analytics API")
     return result
@@ -178,18 +185,47 @@ def google_analytics_list_properties() -> str:
             page_token = result.get("nextPageToken")
             if not page_token:
                 break
-        return _success(properties=properties)
+        # page_token still set here means MAX_ACCOUNT_SUMMARY_PAGES ran out
+        # with more pages pending — tell the caller the list is incomplete.
+        return _success(properties=properties, truncated=bool(page_token))
     except Exception as e:
         logger.error(f"Error listing Google Analytics properties: {e}")
         return _error(str(e))
 
 
+def _project_metadata_entries(entries: list[Any], search: str) -> list[dict[str, Any]]:
+    """Project metadata entries down to the fields the LLM needs to pick a
+    name (apiName/uiName/category), optionally filtered by a case-insensitive
+    substring. The full GA4 metadata document (200-350+ entries with
+    descriptions) serializes to 50-140KB, which would be hard-truncated by
+    the platform output filter into broken JSON."""
+    needle = search.strip().lower()
+    projected = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        api_name = str(entry.get("apiName") or "")
+        ui_name = str(entry.get("uiName") or "")
+        if needle and needle not in api_name.lower() and needle not in ui_name.lower():
+            continue
+        projected.append(
+            {
+                "apiName": api_name,
+                "uiName": ui_name,
+                "category": entry.get("category"),
+            }
+        )
+    return projected
+
+
 @mcp.tool()
-def google_analytics_get_metadata(property_id: str) -> str:
+def google_analytics_get_metadata(property_id: str, search: str = "") -> str:
     """
-    List the dimensions and metrics available to query for a GA4 property.
-    Use this before google_analytics_run_report if you're unsure which
-    dimension/metric names are valid for this property.
+    List the dimension and metric names available to query for a GA4 property
+    (apiName, uiName, category). Use this before google_analytics_run_report
+    if you're unsure which dimension/metric names are valid for this property.
+    search: optional case-insensitive substring filter on the name, e.g.
+    "session" or "conversion" — prefer it over listing everything.
     """
     try:
         normalized_property_id = _normalize_property_id(property_id)
@@ -200,11 +236,15 @@ def google_analytics_get_metadata(property_id: str) -> str:
             )
         )
         return _success(
-            dimensions=result.get("dimensions") or [],
-            metrics=result.get("metrics") or [],
+            dimensions=_project_metadata_entries(
+                result.get("dimensions") or [], search
+            ),
+            metrics=_project_metadata_entries(result.get("metrics") or [], search),
         )
     except Exception as e:
-        logger.error(f"Error getting Google Analytics metadata for {property_id}: {e}")
+        logger.error(
+            f"Error getting Google Analytics metadata for {property_id!r}: {e}"
+        )
         return _error(str(e))
 
 
@@ -215,8 +255,10 @@ def google_analytics_run_report(
     date_ranges: list[dict[str, str]],
     dimensions: list[str] | None = None,
     dimension_filter: dict[str, Any] | None = None,
+    metric_filter: dict[str, Any] | None = None,
     order_bys: list[dict[str, Any]] | None = None,
-    limit: int | None = None,
+    limit: int = 1000,
+    offset: int = 0,
 ) -> str:
     """
     Run a GA4 report: quantify performance by any combination of dimensions
@@ -224,33 +266,47 @@ def google_analytics_run_report(
     ranges.
 
     metrics: metric names, e.g. ["sessions", "conversions", "totalRevenue"].
-    date_ranges: one dict per period to compare, each with "start_date" and
-      "end_date" (YYYY-MM-DD, or GA4 relative terms like "7daysAgo"/"today"),
-      and an optional "name" to label the period (e.g. "current", "previous")
-      — pass two date_ranges to compare a period against a prior one in a
-      single call; the response's rows are tagged with the matching name.
+    date_ranges: one dict per period to compare (max 4), each with
+      "start_date" and "end_date" (YYYY-MM-DD, or GA4 relative terms like
+      "7daysAgo"/"today"), and an optional "name" to label the period
+      (e.g. "current", "previous") — pass two date_ranges to compare a
+      period against a prior one in a single call; the response's rows are
+      tagged with the matching name.
     dimensions: dimension names, e.g. ["sessionDefaultChannelGroup",
       "landingPagePlusQueryString"]. Use google_analytics_get_metadata to
       discover valid names for this property.
     dimension_filter: a raw GA4 FilterExpression dict, for narrowing results
       (e.g. to one campaign or landing page). Optional.
+    metric_filter: a raw GA4 FilterExpression dict applied to metric values
+      (e.g. "sessions > 100"). Optional.
     order_bys: a raw GA4 OrderBy list, e.g. to sort by a metric descending.
-    limit: max rows to return.
+    limit: max rows to return (default 1000).
+    offset: row offset for paging — if row_count in the response exceeds
+      limit, call again with offset=limit, then offset=2*limit, and so on.
     """
     try:
         normalized_property_id = _normalize_property_id(property_id)
+        if not date_ranges:
+            raise ValueError("date_ranges must contain at least one date range")
+        if len(date_ranges) > 4:
+            raise ValueError("GA4 allows at most 4 date_ranges per report")
         body: dict[str, Any] = {
             "metrics": [{"name": m} for m in metrics],
             "dateRanges": [_date_range_body(dr) for dr in date_ranges],
+            # Always sent explicitly: GA4's default would otherwise return up
+            # to 10k rows in one response.
+            "limit": str(max(1, limit)),
         }
         if dimensions:
             body["dimensions"] = [{"name": d} for d in dimensions]
         if dimension_filter:
             body["dimensionFilter"] = dimension_filter
+        if metric_filter:
+            body["metricFilter"] = metric_filter
         if order_bys:
             body["orderBys"] = order_bys
-        if limit is not None:
-            body["limit"] = str(limit)
+        if offset > 0:
+            body["offset"] = str(offset)
 
         result = _require_dict_result(
             _request(
@@ -266,7 +322,9 @@ def google_analytics_run_report(
             row_count=result.get("rowCount") or 0,
         )
     except Exception as e:
-        logger.error(f"Error running Google Analytics report for {property_id}: {e}")
+        # !r escapes embedded newlines, keeping a crafted property_id from
+        # injecting fake log lines.
+        logger.error(f"Error running Google Analytics report for {property_id!r}: {e}")
         return _error(str(e))
 
 

--- a/tests/alembic/test_20260730_seed_google_analytics_mcp_app.py
+++ b/tests/alembic/test_20260730_seed_google_analytics_mcp_app.py
@@ -1,0 +1,126 @@
+"""Tests for the Google Analytics MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260730_seed_google_analytics_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_google_analytics_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_google_analytics(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "google-analytics" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='google-analytics'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "google"
+        assert "xagent.web.tools.mcp.google_analytics" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='google-analytics'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    google-analytics row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r
+        for r in get_builtin_public_mcp_app_rows()
+        if r["app_id"] == "google-analytics"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_google_analytics(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "google-analytics" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -716,6 +716,10 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
             "xagent.web.tools.mcp.google_slides",
             {"GOOGLE_ACCESS_TOKEN": "access_token"},
         ),
+        "google-analytics": (
+            "xagent.web.tools.mcp.google_analytics",
+            {"GOOGLE_ACCESS_TOKEN": "access_token"},
+        ),
         "hubspot": (
             "xagent.web.tools.mcp.hubspot",
             {"HUBSPOT_ACCESS_TOKEN": "access_token"},

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -1,0 +1,373 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import google_analytics
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ACCESS_TOKEN"):
+        google_analytics._headers()
+
+
+def test_headers_include_bearer_token():
+    headers = google_analytics._headers()
+
+    assert headers["Authorization"] == "Bearer access-token"
+
+
+def test_normalize_property_id_accepts_bare_numeric():
+    assert google_analytics._normalize_property_id("123456") == "123456"
+
+
+def test_normalize_property_id_strips_resource_prefix():
+    assert google_analytics._normalize_property_id("properties/123456") == "123456"
+
+
+def test_normalize_property_id_rejects_non_numeric():
+    with pytest.raises(ValueError, match="property_id"):
+        google_analytics._normalize_property_id("123/../456")
+
+
+def test_normalize_property_id_rejects_empty_after_prefix():
+    with pytest.raises(ValueError, match="property_id"):
+        google_analytics._normalize_property_id("properties/")
+
+
+def test_request_wraps_http_error_with_google_error_message(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "error": {
+                        "code": 400,
+                        "message": "Field sessions is not a valid metric.",
+                        "status": "INVALID_ARGUMENT",
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="not a valid metric"):
+        google_analytics._request(
+            "POST", f"{google_analytics.DATA_API_BASE_URL}/properties/1:runReport"
+        )
+
+
+def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="upstream 500")),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        google_analytics._request(
+            "GET", f"{google_analytics.ADMIN_API_BASE_URL}/accountSummaries"
+        )
+
+
+def test_list_properties_flattens_account_summaries(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "accountSummaries": [
+                        {
+                            "displayName": "Acme Inc",
+                            "propertySummaries": [
+                                {
+                                    "property": "properties/111",
+                                    "displayName": "Acme Website",
+                                },
+                                {
+                                    "property": "properties/222",
+                                    "displayName": "Acme App",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert result["status"] == "success"
+    assert result["properties"] == [
+        {
+            "account_name": "Acme Inc",
+            "property_id": "111",
+            "property_display_name": "Acme Website",
+        },
+        {
+            "account_name": "Acme Inc",
+            "property_id": "222",
+            "property_display_name": "Acme App",
+        },
+    ]
+
+
+def test_list_properties_follows_pagination(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(
+                json_data={
+                    "accountSummaries": [
+                        {
+                            "displayName": "Acme Inc",
+                            "propertySummaries": [
+                                {"property": "properties/111", "displayName": "Site A"}
+                            ],
+                        }
+                    ],
+                    "nextPageToken": "page-2",
+                }
+            ),
+            MockResponse(
+                json_data={
+                    "accountSummaries": [
+                        {
+                            "displayName": "Acme Inc",
+                            "propertySummaries": [
+                                {"property": "properties/222", "displayName": "Site B"}
+                            ],
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert result["status"] == "success"
+    assert [p["property_id"] for p in result["properties"]] == ["111", "222"]
+    assert mock_request.call_count == 2
+    second_call = mock_request.call_args_list[1]
+    assert second_call.kwargs["params"]["pageToken"] == "page-2"
+
+
+def test_list_properties_handles_account_without_properties(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={"accountSummaries": [{"displayName": "Empty Account"}]}
+            )
+        ),
+    )
+
+    result = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert result["status"] == "success"
+    assert result["properties"] == []
+
+
+def test_list_properties_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=403,
+                json_data={"error": {"message": "insufficient permissions"}},
+            )
+        ),
+    )
+
+    result = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert result["status"] == "error"
+    assert "insufficient permissions" in result["message"]
+
+
+def test_get_metadata_returns_dimensions_and_metrics(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensions": [{"apiName": "country"}],
+                "metrics": [{"apiName": "sessions"}],
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(google_analytics.google_analytics_get_metadata("properties/42"))
+
+    assert result["status"] == "success"
+    assert result["dimensions"] == [{"apiName": "country"}]
+    assert result["metrics"] == [{"apiName": "sessions"}]
+    assert mock_request.call_args.kwargs["url"].endswith("/properties/42/metadata")
+
+
+def test_get_metadata_rejects_invalid_property_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(google_analytics.google_analytics_get_metadata("not-a-number"))
+
+    assert result["status"] == "error"
+    assert "property_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_run_report_builds_body_and_returns_rows(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensionHeaders": [{"name": "sessionDefaultChannelGroup"}],
+                "metricHeaders": [{"name": "sessions", "type": "TYPE_INTEGER"}],
+                "rows": [
+                    {
+                        "dimensionValues": [{"value": "Organic Search"}],
+                        "metricValues": [{"value": "1200"}],
+                    }
+                ],
+                "rowCount": 1,
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "properties/42",
+            metrics=["sessions", "conversions"],
+            date_ranges=[
+                {
+                    "start_date": "2026-07-01",
+                    "end_date": "2026-07-28",
+                    "name": "current",
+                },
+                {
+                    "start_date": "2026-06-03",
+                    "end_date": "2026-06-30",
+                    "name": "previous",
+                },
+            ],
+            dimensions=["sessionDefaultChannelGroup"],
+            limit=50,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["row_count"] == 1
+    assert result["rows"][0]["metricValues"] == [{"value": "1200"}]
+
+    call_kwargs = mock_request.call_args.kwargs
+    assert call_kwargs["url"].endswith("/properties/42:runReport")
+    body = call_kwargs["json"]
+    assert body["metrics"] == [{"name": "sessions"}, {"name": "conversions"}]
+    assert body["dateRanges"] == [
+        {"startDate": "2026-07-01", "endDate": "2026-07-28", "name": "current"},
+        {"startDate": "2026-06-03", "endDate": "2026-06-30", "name": "previous"},
+    ]
+    assert body["dimensions"] == [{"name": "sessionDefaultChannelGroup"}]
+    assert body["limit"] == "50"
+    assert "dimensionFilter" not in body
+    assert "orderBys" not in body
+
+
+def test_run_report_passes_through_filter_and_order(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"rowCount": 0}))
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    dimension_filter = {
+        "filter": {
+            "fieldName": "sessionCampaignName",
+            "stringFilter": {"value": "summer-sale"},
+        }
+    }
+    order_bys = [{"metric": {"metricName": "sessions"}, "desc": True}]
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42",
+            metrics=["sessions"],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+            dimension_filter=dimension_filter,
+            order_bys=order_bys,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["rows"] == []
+    body = mock_request.call_args.kwargs["json"]
+    assert body["dimensionFilter"] == dimension_filter
+    assert body["orderBys"] == order_bys
+    assert body["dateRanges"] == [{"startDate": "7daysAgo", "endDate": "today"}]
+
+
+def test_run_report_rejects_invalid_property_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42; DROP TABLE",
+            metrics=["sessions"],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "property_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_run_report_returns_error_payload_on_api_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={"error": {"message": "bad metric name"}},
+            )
+        ),
+    )
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42",
+            metrics=["not-real"],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "bad metric name" in result["message"]

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -248,12 +248,30 @@ def test_list_properties_returns_error_payload_on_failure(monkeypatch):
     assert "insufficient permissions" in result["message"]
 
 
-def test_get_metadata_returns_dimensions_and_metrics(monkeypatch):
+def test_get_metadata_projects_entries_to_name_fields(monkeypatch):
+    """The full GA4 metadata document (with descriptions) can exceed the
+    platform output filter's truncation threshold; only the name-picking
+    fields survive the projection."""
     mock_request = Mock(
         return_value=MockResponse(
             json_data={
-                "dimensions": [{"apiName": "country"}],
-                "metrics": [{"apiName": "sessions"}],
+                "dimensions": [
+                    {
+                        "apiName": "country",
+                        "uiName": "Country",
+                        "category": "Geography",
+                        "description": "x" * 500,
+                        "customDefinition": False,
+                    }
+                ],
+                "metrics": [
+                    {
+                        "apiName": "sessions",
+                        "uiName": "Sessions",
+                        "category": "Session",
+                        "description": "y" * 500,
+                    }
+                ],
             }
         )
     )
@@ -262,9 +280,39 @@ def test_get_metadata_returns_dimensions_and_metrics(monkeypatch):
     result = json.loads(google_analytics.google_analytics_get_metadata("properties/42"))
 
     assert result["status"] == "success"
-    assert result["dimensions"] == [{"apiName": "country"}]
-    assert result["metrics"] == [{"apiName": "sessions"}]
+    assert result["dimensions"] == [
+        {"apiName": "country", "uiName": "Country", "category": "Geography"}
+    ]
+    assert result["metrics"] == [
+        {"apiName": "sessions", "uiName": "Sessions", "category": "Session"}
+    ]
     assert mock_request.call_args.kwargs["url"].endswith("/properties/42/metadata")
+
+
+def test_get_metadata_search_filters_by_name(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensions": [
+                    {"apiName": "country", "uiName": "Country"},
+                    {"apiName": "sessionSource", "uiName": "Session source"},
+                ],
+                "metrics": [
+                    {"apiName": "sessions", "uiName": "Sessions"},
+                    {"apiName": "totalRevenue", "uiName": "Total revenue"},
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_get_metadata("42", search="SESSION")
+    )
+
+    assert result["status"] == "success"
+    assert [d["apiName"] for d in result["dimensions"]] == ["sessionSource"]
+    assert [m["apiName"] for m in result["metrics"]] == ["sessions"]
 
 
 def test_get_metadata_rejects_invalid_property_id(monkeypatch):
@@ -363,6 +411,119 @@ def test_run_report_passes_through_filter_and_order(monkeypatch):
     assert body["dimensionFilter"] == dimension_filter
     assert body["orderBys"] == order_bys
     assert body["dateRanges"] == [{"startDate": "7daysAgo", "endDate": "today"}]
+
+
+def test_run_report_sends_default_limit_and_omits_zero_offset(monkeypatch):
+    """GA4's own default returns up to 10k rows; the tool must always send an
+    explicit limit."""
+    mock_request = Mock(return_value=MockResponse(json_data={"rowCount": 0}))
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    google_analytics.google_analytics_run_report(
+        "42",
+        metrics=["sessions"],
+        date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+    )
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["limit"] == "1000"
+    assert "offset" not in body
+
+
+def test_run_report_passes_metric_filter_and_offset(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"rowCount": 0}))
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    metric_filter = {
+        "filter": {
+            "fieldName": "sessions",
+            "numericFilter": {
+                "operation": "GREATER_THAN",
+                "value": {"int64Value": "100"},
+            },
+        }
+    }
+
+    google_analytics.google_analytics_run_report(
+        "42",
+        metrics=["sessions"],
+        date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        metric_filter=metric_filter,
+        offset=1000,
+    )
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["metricFilter"] == metric_filter
+    assert body["offset"] == "1000"
+
+
+@pytest.mark.parametrize(
+    ("bad_ranges", "expected_fragment"),
+    [
+        ([], "at least one"),
+        (
+            [{"start_date": "7daysAgo", "end_date": "today"}] * 5,
+            "at most 4",
+        ),
+    ],
+)
+def test_run_report_rejects_bad_date_range_counts(
+    monkeypatch, bad_ranges, expected_fragment
+):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42", metrics=["sessions"], date_ranges=bad_ranges
+        )
+    )
+
+    assert result["status"] == "error"
+    assert expected_fragment in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_list_properties_flags_truncation_when_pages_run_out(monkeypatch):
+    monkeypatch.setattr(google_analytics, "MAX_ACCOUNT_SUMMARY_PAGES", 1)
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "accountSummaries": [
+                        {
+                            "displayName": "Acme Inc",
+                            "propertySummaries": [
+                                {"property": "properties/111", "displayName": "Site A"}
+                            ],
+                        }
+                    ],
+                    "nextPageToken": "page-2",
+                }
+            )
+        ),
+    )
+
+    result = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_request_caps_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        google_analytics.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=502, text="x" * 5000)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        google_analytics._request(
+            "GET", f"{google_analytics.ADMIN_API_BASE_URL}/accountSummaries"
+        )
+    assert len(str(excinfo.value)) < 1200
 
 
 def test_run_report_rejects_date_range_missing_required_keys(monkeypatch):

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 import requests
 
+from xagent.config import get_tool_max_output_length
 from xagent.web.tools.mcp import google_analytics
 
 
@@ -475,7 +476,7 @@ def test_run_report_rejects_empty_metrics(monkeypatch):
 
 @pytest.mark.parametrize(
     "bad_limit",
-    [0, -1, google_analytics.RUN_REPORT_MAX_LIMIT + 1],
+    [0, google_analytics.RUN_REPORT_MAX_LIMIT + 1],
 )
 def test_run_report_rejects_out_of_range_limit(monkeypatch, bad_limit):
     mock_request = Mock()
@@ -513,18 +514,25 @@ def test_run_report_rejects_negative_offset(monkeypatch):
     mock_request.assert_not_called()
 
 
-def test_run_report_default_limit_keeps_serialized_response_under_truncation_threshold(
-    monkeypatch,
+@pytest.mark.parametrize(
+    "limit",
+    [google_analytics.RUN_REPORT_DEFAULT_LIMIT, google_analytics.RUN_REPORT_MAX_LIMIT],
+)
+def test_run_report_keeps_serialized_response_under_truncation_threshold(
+    monkeypatch, limit
 ):
-    """Regression for the sizing bug: a realistic 5-dimension + 5-metric report
-    at the tool's own default limit must serialize to well under the 51200-char
-    MCP output truncation threshold enforced by
-    src/xagent/core/tools/adapters/vibe/output_filter.py."""
+    """Regression for the sizing bug: a report at both the tool's default and
+    max row limit must serialize to under the MCP output truncation threshold
+    enforced by src/xagent/core/tools/adapters/vibe/output_filter.py, even
+    with dimension values wide enough (~30-40 chars, e.g. a landing-page path)
+    to actually stress the boundary — not just the narrow 11-char case."""
     row = {
-        "dimensionValues": [{"value": f"dim-value-{i}"} for i in range(5)],
+        "dimensionValues": [
+            {"value": f"dim-value-{i:02d}".ljust(35, "x")} for i in range(5)
+        ],
         "metricValues": [{"value": str(1000 + i)} for i in range(5)],
     }
-    rows = [row] * google_analytics.RUN_REPORT_DEFAULT_LIMIT
+    rows = [row] * limit
     mock_request = Mock(
         return_value=MockResponse(
             json_data={
@@ -542,11 +550,52 @@ def test_run_report_default_limit_keeps_serialized_response_under_truncation_thr
         metrics=[f"metric{i}" for i in range(5)],
         date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
         dimensions=[f"dim{i}" for i in range(5)],
+        limit=limit,
     )
 
     result = json.loads(response)
     assert result["status"] == "success"
-    assert len(response) < 51200
+    assert len(response) < get_tool_max_output_length()
+
+
+def test_run_report_trims_rows_and_flags_truncated_when_still_over_budget(monkeypatch):
+    """Several long-valued dimensions at once (all 5 padded to 35 chars) at
+    RUN_REPORT_MAX_LIMIT rows crosses the output threshold even after the
+    default/max regression test's mix stays under it. The tool must trim
+    rows and set truncated=True rather than return an oversized payload that
+    the platform would hard-truncate into invalid JSON."""
+    row = {
+        "dimensionValues": [
+            {"value": f"dim-value-{i:02d}".ljust(35, "x")} for i in range(5)
+        ],
+        "metricValues": [{"value": str(1000 + i)} for i in range(5)],
+    }
+    rows = [row] * google_analytics.RUN_REPORT_MAX_LIMIT
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensionHeaders": [{"name": f"dim{i}"} for i in range(5)],
+                "metricHeaders": [{"name": f"metric{i}"} for i in range(5)],
+                "rows": rows,
+                "rowCount": len(rows),
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    response = google_analytics.google_analytics_run_report(
+        "42",
+        metrics=[f"metric{i}" for i in range(5)],
+        date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        dimensions=[f"dim{i}" for i in range(5)],
+        limit=google_analytics.RUN_REPORT_MAX_LIMIT,
+    )
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["rows"]) < google_analytics.RUN_REPORT_MAX_LIMIT
+    assert len(response) < get_tool_max_output_length()
 
 
 def test_run_report_passes_metric_filter_and_offset(monkeypatch):

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -289,6 +289,30 @@ def test_get_metadata_projects_entries_to_name_fields(monkeypatch):
     assert mock_request.call_args.kwargs["url"].endswith("/properties/42/metadata")
 
 
+def test_get_metadata_skips_entries_without_usable_api_name(monkeypatch):
+    """An entry with no apiName (or a non-string one) can't be passed back into
+    run_report's metrics/dimensions, so it must be dropped rather than
+    projected with an empty name."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensions": [
+                    {"apiName": None, "uiName": "broken"},
+                    {"uiName": "also broken"},
+                    {"apiName": "country", "uiName": "Country"},
+                ],
+                "metrics": [],
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(google_analytics.google_analytics_get_metadata("42"))
+
+    assert result["status"] == "success"
+    assert [d["apiName"] for d in result["dimensions"]] == ["country"]
+
+
 def test_get_metadata_search_filters_by_name(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -415,7 +439,9 @@ def test_run_report_passes_through_filter_and_order(monkeypatch):
 
 def test_run_report_sends_default_limit_and_omits_zero_offset(monkeypatch):
     """GA4's own default returns up to 10k rows; the tool must always send an
-    explicit limit."""
+    explicit limit, and the default itself must stay small enough that a wide
+    report's serialized response doesn't cross the MCP output truncation
+    threshold."""
     mock_request = Mock(return_value=MockResponse(json_data={"rowCount": 0}))
     monkeypatch.setattr(google_analytics.requests, "request", mock_request)
 
@@ -426,8 +452,101 @@ def test_run_report_sends_default_limit_and_omits_zero_offset(monkeypatch):
     )
 
     body = mock_request.call_args.kwargs["json"]
-    assert body["limit"] == "1000"
+    assert body["limit"] == str(google_analytics.RUN_REPORT_DEFAULT_LIMIT)
     assert "offset" not in body
+
+
+def test_run_report_rejects_empty_metrics(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42",
+            metrics=[],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "metrics" in result["message"]
+    mock_request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_limit",
+    [0, -1, google_analytics.RUN_REPORT_MAX_LIMIT + 1],
+)
+def test_run_report_rejects_out_of_range_limit(monkeypatch, bad_limit):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42",
+            metrics=["sessions"],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+            limit=bad_limit,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "limit" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_run_report_rejects_negative_offset(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    result = json.loads(
+        google_analytics.google_analytics_run_report(
+            "42",
+            metrics=["sessions"],
+            date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+            offset=-1,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "offset" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_run_report_default_limit_keeps_serialized_response_under_truncation_threshold(
+    monkeypatch,
+):
+    """Regression for the sizing bug: a realistic 5-dimension + 5-metric report
+    at the tool's own default limit must serialize to well under the 51200-char
+    MCP output truncation threshold enforced by
+    src/xagent/core/tools/adapters/vibe/output_filter.py."""
+    row = {
+        "dimensionValues": [{"value": f"dim-value-{i}"} for i in range(5)],
+        "metricValues": [{"value": str(1000 + i)} for i in range(5)],
+    }
+    rows = [row] * google_analytics.RUN_REPORT_DEFAULT_LIMIT
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "dimensionHeaders": [{"name": f"dim{i}"} for i in range(5)],
+                "metricHeaders": [{"name": f"metric{i}"} for i in range(5)],
+                "rows": rows,
+                "rowCount": len(rows),
+            }
+        )
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    response = google_analytics.google_analytics_run_report(
+        "42",
+        metrics=[f"metric{i}" for i in range(5)],
+        date_ranges=[{"start_date": "7daysAgo", "end_date": "today"}],
+        dimensions=[f"dim{i}" for i in range(5)],
+    )
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert len(response) < 51200
 
 
 def test_run_report_passes_metric_filter_and_offset(monkeypatch):

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -365,6 +365,24 @@ def test_run_report_passes_through_filter_and_order(monkeypatch):
     assert body["dateRanges"] == [{"startDate": "7daysAgo", "endDate": "today"}]
 
 
+def test_run_report_rejects_date_range_missing_required_keys(monkeypatch):
+    """An empty dict or misnamed keys (e.g. camelCase "startDate") pass the
+    tool-signature validation but must fail here with an actionable message
+    instead of sending nulls to the API."""
+    mock_request = Mock()
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    for bad_range in [{}, {"startDate": "7daysAgo", "endDate": "today"}]:
+        result = json.loads(
+            google_analytics.google_analytics_run_report(
+                "42", metrics=["sessions"], date_ranges=[bad_range]
+            )
+        )
+        assert result["status"] == "error"
+        assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_run_report_rejects_invalid_property_id(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(google_analytics.requests, "request", mock_request)

--- a/tests/web/tools/test_google_analytics_mcp.py
+++ b/tests/web/tools/test_google_analytics_mcp.py
@@ -197,6 +197,39 @@ def test_list_properties_handles_account_without_properties(monkeypatch):
     assert result["properties"] == []
 
 
+def test_list_properties_tolerates_null_values_in_response(monkeypatch):
+    """Keys present with an explicit null (accountSummaries, property) must not
+    crash iteration/rsplit; entries without a usable property resource name are
+    skipped rather than emitted with an empty property_id."""
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"accountSummaries": None}),
+            MockResponse(
+                json_data={
+                    "accountSummaries": [
+                        {
+                            "displayName": "Acme Inc",
+                            "propertySummaries": [
+                                {"property": None, "displayName": "broken"},
+                                {"property": "properties/111", "displayName": "ok"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(google_analytics.requests, "request", mock_request)
+
+    first = json.loads(google_analytics.google_analytics_list_properties())
+    second = json.loads(google_analytics.google_analytics_list_properties())
+
+    assert first["status"] == "success"
+    assert first["properties"] == []
+    assert second["status"] == "success"
+    assert [p["property_id"] for p in second["properties"]] == ["111"]
+
+
 def test_list_properties_returns_error_payload_on_failure(monkeypatch):
     monkeypatch.setattr(
         google_analytics.requests,


### PR DESCRIPTION
## Summary
- Register `google-analytics` as a built-in OAuth MCP connector (`builtin_mcp_registry.py` + seed migration), reusing the shared `google` OAuth provider with the `analytics.readonly` scope — no new client credentials needed
- New `xagent.web.tools.mcp.google_analytics` MCP module with three tools:
  - `google_analytics_list_properties` — list accessible GA4 properties via the Admin API (handles pagination)
  - `google_analytics_get_metadata` — list a property's available dimensions/metrics
  - `google_analytics_run_report` — Data API `runReport` with multi-date-range comparison, dimension filters, ordering and row limits
- Deployment prerequisite: enable the Google Analytics Data API and Admin API in the Google Cloud project, and add the `analytics.readonly` scope to the OAuth consent screen

## Test plan
- [x] `pytest tests/web/tools/test_google_analytics_mcp.py tests/alembic/test_20260730_seed_google_analytics_mcp_app.py tests/templates/test_manager.py` — all passing
- [x] `ruff format` / `ruff check` clean, `mypy` clean on touched files
- [x] Manual end-to-end against a real GA4 property: OAuth connect, list properties, metadata lookup, and a period-over-period channel report all working