### PR TITLE
feat: add AWS MCP connector

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -776,4 +776,24 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       })
     })
   })
+
+  it("filters by the Operations category sidebar entry (PR review: AWS connector had no way to be found except via All)", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalled())
+    apiRequestMock.mockClear()
+
+    fireEvent.click(screen.getByRole("button", { name: "Operations" }))
+
+    await waitFor(() => {
+      const url = apiRequestMock.mock.calls.at(-1)?.[0] as string
+      expect(new URLSearchParams(url.split("?")[1]).get("category")).toBe("Operations")
+    })
+  })
 })

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -978,6 +978,12 @@ export function ConnectMcpDialog({
                     >
                       <BarChart3 className="h-4 w-4" /> Analytics
                     </button>
+                    <button
+                      className={`w-full flex items-center gap-3 px-2 py-1.5 text-sm font-medium rounded-md ${activeCategory === 'Operations' ? 'bg-blue-100/50 text-blue-700' : 'text-slate-600 hover:bg-slate-100'}`}
+                      onClick={() => setActiveCategory('Operations')}
+                    >
+                      <Settings className="h-4 w-4" /> Operations
+                    </button>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/pages/admin-mcp.tsx
+++ b/frontend/src/components/pages/admin-mcp.tsx
@@ -828,6 +828,7 @@ export default function AdminMcpPage() {
                               <SelectItem value="Scheduling">Scheduling</SelectItem>
                               <SelectItem value="Payments">Payments</SelectItem>
                               <SelectItem value="Analytics">Analytics</SelectItem>
+                              <SelectItem value="Operations">Operations</SelectItem>
                               <SelectItem value="Other">Other</SelectItem>
                             </SelectContent>
                           </Select>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "mcp>=1.12.4",
   "asyncssh>=2.14.0",  # SSH MCP runner (production runtime, not just tests)
   "requests >= 2.32.0",
+  "boto3 >= 1.34.0",  # AWS built-in MCP connector (CloudWatch/DynamoDB/SQS, read-only)
   "celery[redis]>=5.4.0,<6.0.0",
   "redis>=5.0.0",
   "pillow >= 10.0.0",
@@ -314,6 +315,8 @@ module = [
   "xrouter_llm",
   "xrouter_llm.*",
   "google.pubsub_v1",
+  "boto3",
+  "botocore.*",
 ]
 ignore_missing_imports = true
 

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -1,0 +1,85 @@
+"""seed built-in AWS (key-based) MCP connector
+
+Revision ID: 20260731_seed_aws_mcp_app
+Revises: 20260724_add_upload_source_to_uploaded_files
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260731_seed_aws_mcp_app"
+down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "aws"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "AWS",
+    "description": "Connect to AWS to read CloudWatch alarms, metrics and logs, DynamoDB table health, and SQS queue depth for diagnostics. Read-only — pair with a read-only IAM policy.",
+    "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
+    "transport": "stdio",
+    "provider_name": None,
+    "category": "Operations",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.aws"],
+        "required_env": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_REGION",
+        ],
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. AWS has no oauth_providers row (it is
+    # key-based). Any MCPServer/UserMCPServer rows created by users who already
+    # connected are intentionally left in place — connect-driven rows are not
+    # owned by this migration and are cleaned up through the normal disconnect
+    # path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in AWS (key-based) MCP connector
 
 Revision ID: 20260731_seed_aws_mcp_app
-Revises: 20260730_seed_google_analytics_mcp_app
+Revises: 20260730_seed_zoom_mcp_app
 Create Date: 2026-07-31 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260731_seed_aws_mcp_app"
-down_revision: Union[str, None] = "20260730_seed_google_analytics_mcp_app"
+down_revision: Union[str, None] = "20260730_seed_zoom_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -36,7 +36,7 @@ APP_ID = "aws"
 ROW = {
     "app_id": APP_ID,
     "name": "AWS",
-    "description": "Read-only for the credentials you provide — but the optional role_arn tool parameter lets the model assume ANY IAM role those credentials are permitted to assume, with no allowlist. Restrict sts:AssumeRole on your base principal's own policy if you don't want cross-account access; the assumed session itself is still capped to this connector's own read-only calls. Reads CloudWatch alarms/metrics/logs, DynamoDB table health, and SQS queue depth for diagnostics.",
+    "description": "Connect to AWS to check CloudWatch alarms/metrics, DynamoDB health, and SQS queue depth.",
     "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
     "transport": "stdio",
     "provider_name": None,

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in AWS (key-based) MCP connector
 
 Revision ID: 20260731_seed_aws_mcp_app
-Revises: 20260730_seed_zoom_mcp_app
+Revises: 20260728_add_agent_template_id_and_name_uniqueness
 Create Date: 2026-07-31 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260731_seed_aws_mcp_app"
-down_revision: Union[str, None] = "20260730_seed_zoom_mcp_app"
+down_revision: Union[str, None] = "20260728_add_agent_template_id_and_name_uniqueness"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -36,7 +36,7 @@ APP_ID = "aws"
 ROW = {
     "app_id": APP_ID,
     "name": "AWS",
-    "description": "Connect to AWS to check CloudWatch alarms/metrics, DynamoDB health, and SQS queue depth.",
+    "description": "Connect to AWS to check CloudWatch alarms/metrics/logs, DynamoDB health, and SQS queue depth.",
     "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
     "transport": "stdio",
     "provider_name": None,

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -36,7 +36,7 @@ APP_ID = "aws"
 ROW = {
     "app_id": APP_ID,
     "name": "AWS",
-    "description": "Connect to AWS to read CloudWatch alarms, metrics and logs, DynamoDB table health, and SQS queue depth for diagnostics. Read-only — pair with a read-only IAM policy.",
+    "description": "Read-only for the credentials you provide — but the optional role_arn tool parameter lets the model assume ANY IAM role those credentials are permitted to assume, with no allowlist. Restrict sts:AssumeRole on your base principal's own policy if you don't want cross-account access; the assumed session itself is still capped to this connector's own read-only calls. Reads CloudWatch alarms/metrics/logs, DynamoDB table health, and SQS queue depth for diagnostics.",
     "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
     "transport": "stdio",
     "provider_name": None,

--- a/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in AWS (key-based) MCP connector
 
 Revision ID: 20260731_seed_aws_mcp_app
-Revises: 20260724_add_upload_source_to_uploaded_files
+Revises: 20260730_seed_google_analytics_mcp_app
 Create Date: 2026-07-31 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260731_seed_aws_mcp_app"
-down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+down_revision: Union[str, None] = "20260730_seed_google_analytics_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -498,7 +498,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "aws",
             "name": "AWS",
-            "description": "Connect to AWS to read CloudWatch alarms, metrics and logs, DynamoDB table health, and SQS queue depth for diagnostics. Read-only — pair with a read-only IAM policy.",
+            "description": "Read-only for the credentials you provide — but the optional role_arn tool parameter lets the model assume ANY IAM role those credentials are permitted to assume, with no allowlist. Restrict sts:AssumeRole on your base principal's own policy if you don't want cross-account access; the assumed session itself is still capped to this connector's own read-only calls. Reads CloudWatch alarms/metrics/logs, DynamoDB table health, and SQS queue depth for diagnostics.",
             "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
             "transport": "stdio",
             "provider_name": None,

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -498,7 +498,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "aws",
             "name": "AWS",
-            "description": "Connect to AWS to check CloudWatch alarms/metrics, DynamoDB health, and SQS queue depth.",
+            "description": "Connect to AWS to check CloudWatch alarms/metrics/logs, DynamoDB health, and SQS queue depth.",
             "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
             "transport": "stdio",
             "provider_name": None,

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -498,7 +498,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "aws",
             "name": "AWS",
-            "description": "Read-only for the credentials you provide — but the optional role_arn tool parameter lets the model assume ANY IAM role those credentials are permitted to assume, with no allowlist. Restrict sts:AssumeRole on your base principal's own policy if you don't want cross-account access; the assumed session itself is still capped to this connector's own read-only calls. Reads CloudWatch alarms/metrics/logs, DynamoDB table health, and SQS queue depth for diagnostics.",
+            "description": "Connect to AWS to check CloudWatch alarms/metrics, DynamoDB health, and SQS queue depth.",
             "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
             "transport": "stdio",
             "provider_name": None,

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -495,6 +495,30 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "auth": {"type": "mcp_oauth"},
             },
         },
+        {
+            "app_id": "aws",
+            "name": "AWS",
+            "description": "Connect to AWS to read CloudWatch alarms, metrics and logs, DynamoDB table health, and SQS queue depth for diagnostics. Read-only — pair with a read-only IAM policy.",
+            "icon": "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=128",
+            "transport": "stdio",
+            "provider_name": None,
+            "category": "Operations",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            # Key-based (non-oauth), like google-maps: the user supplies an
+            # access key at connect time. Cross-account access goes through the
+            # per-call role_arn tool parameter (STS AssumeRole inside the MCP
+            # module), not a fourth env key — required_env has no optional slots.
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.aws"],
+                "required_env": [
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                    "AWS_REGION",
+                ],
+            },
+        },
     ]
 
 

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -110,7 +110,7 @@ def caller_id_env(user_id: int | None) -> dict[str, str]:
     AssumeRole session name) to a specific user in the target system's own
     audit trail, instead of every user's calls being indistinguishable.
     """
-    if user_id is None:
+    if not isinstance(user_id, int):
         return {}
     return {CALLER_ID_ENV_VAR: str(user_id)}
 
@@ -148,6 +148,12 @@ def resolve_stdio_env(
 
     The stored own key is never deleted when another source is picked — it is
     simply not merged — so switching back to "own" needs no re-entry.
+
+    This governs only the shared/own/global layers above. The caller-id layer
+    (see caller_id_env, applied in build_mcp_runtime_connection after this
+    function returns) is appended unconditionally for every stdio server
+    regardless of env_source — it identifies the calling user, not a
+    connector-owned credential, so it is not subject to this precedence.
     """
     if env_source == "platform":
         return global_env
@@ -190,6 +196,10 @@ async def build_mcp_runtime_connection(
                 )
                 if merged:
                     connection["env"] = merged
+        # Applied to every stdio server unconditionally — including
+        # arbitrary third-party stdio commands a user registers directly via
+        # create_mcp_server, not just catalog connectors — since the value
+        # is only an opaque internal xagent user id, not a credential or PII.
         caller_env = caller_id_env(user_id)
         if caller_env:
             connection["env"] = {**(connection.get("env") or {}), **caller_env}

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -98,6 +98,23 @@ def load_shared_env_overrides(db: Any, user_id: int | None) -> dict[int, dict]:
         return {}
 
 
+CALLER_ID_ENV_VAR = "XAGENT_MCP_CALLER_ID"
+
+
+def caller_id_env(user_id: int | None) -> dict[str, str]:
+    """Env layer identifying which xagent user triggered this stdio MCP call.
+
+    A stdio connector runs as a short-lived per-call subprocess with no other
+    way to learn who invoked it. Exposing the caller's user id lets a
+    connector attribute its own external API calls (e.g. an AWS STS
+    AssumeRole session name) to a specific user in the target system's own
+    audit trail, instead of every user's calls being indistinguishable.
+    """
+    if user_id is None:
+        return {}
+    return {CALLER_ID_ENV_VAR: str(user_id)}
+
+
 def merge_stdio_env(
     global_env: dict[str, Any] | None,
     *layers: dict[str, Any] | None,
@@ -161,19 +178,21 @@ async def build_mcp_runtime_connection(
     # Resolve which env layer to apply for this user, per their env_source pick
     # (stdio only; global env is the fallback). Overrides are prefetched by the
     # caller (see load_user_env_overrides / load_user_env_sources) to avoid N+1.
-    if connection.get("transport") == "stdio" and (
-        user_env_overrides or shared_env_overrides or env_source_overrides
-    ):
-        server_id = getattr(server, "id", None)
-        if isinstance(server_id, int):
-            merged = resolve_stdio_env(
-                (env_source_overrides or {}).get(server_id),
-                connection.get("env"),
-                (shared_env_overrides or {}).get(server_id),
-                (user_env_overrides or {}).get(server_id),
-            )
-            if merged:
-                connection["env"] = merged
+    if connection.get("transport") == "stdio":
+        if user_env_overrides or shared_env_overrides or env_source_overrides:
+            server_id = getattr(server, "id", None)
+            if isinstance(server_id, int):
+                merged = resolve_stdio_env(
+                    (env_source_overrides or {}).get(server_id),
+                    connection.get("env"),
+                    (shared_env_overrides or {}).get(server_id),
+                    (user_env_overrides or {}).get(server_id),
+                )
+                if merged:
+                    connection["env"] = merged
+        caller_env = caller_id_env(user_id)
+        if caller_env:
+            connection["env"] = {**(connection.get("env") or {}), **caller_env}
 
     auth_config = server._decrypt_auth_config(getattr(server, "auth", None))
     if not _is_mcp_oauth_http_server(server, auth_config):

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3123,7 +3123,7 @@ class WebToolConfig(BaseToolConfig):
                 transport_config["args"] = server.args
             # Decrypt global env and merge per-user override (user wins).
             from ...core.utils.encryption import decrypt_env_dict
-            from ..services.mcp_runtime import resolve_stdio_env
+            from ..services.mcp_runtime import caller_id_env, resolve_stdio_env
 
             merged_env = resolve_stdio_env(
                 env_source_by_id.get(server.id),
@@ -3131,8 +3131,9 @@ class WebToolConfig(BaseToolConfig):
                 shared_env_by_id.get(server.id),
                 user_env_by_id.get(server.id),
             )
-            if merged_env:
-                transport_config["env"] = merged_env
+            combined_env = {**(merged_env or {}), **caller_id_env(self._user_id)}
+            if combined_env:
+                transport_config["env"] = combined_env
             if server.cwd:
                 transport_config["cwd"] = server.cwd
 

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -252,6 +252,9 @@ def aws_cloudwatch_describe_log_groups(
     discover where a service's logs live before searching them.
     """
     try:
+        # 50, not 100 like the other list-style tools: DescribeLogGroups'
+        # `limit` has a hard server-side max of 50 (unlike, e.g., MaxRecords
+        # on describe_alarms), so 100 here would fail remotely.
         kwargs: dict[str, Any] = {"limit": 50}
         if name_prefix:
             kwargs["logGroupNamePrefix"] = name_prefix

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -194,6 +194,11 @@ def aws_cloudwatch_get_metric_data(
                     },
                 }
             ],
+            # botocore natively accepts ISO 8601 strings for timestamp
+            # params (same as the AWS CLI); an unparsable string raises
+            # ParamValidationError (a BotoCoreError), which the except
+            # below already surfaces. Converting via datetime.fromisoformat
+            # here would only narrow the accepted formats.
             StartTime=start_time,
             EndTime=end_time,
         )

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import os
-import time
 from typing import Any
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 from mcp.server.fastmcp import FastMCP
 
@@ -18,14 +18,19 @@ setup_proxy_env()
 
 mcp = FastMCP("aws-mcp")
 
-# Refresh assumed-role credentials this many seconds before they expire, so a
-# long-running tool call never starts with credentials about to lapse.
-ASSUME_ROLE_EXPIRY_MARGIN_SECONDS = 300
 ASSUME_ROLE_SESSION_NAME = "xagent-aws-mcp"
 MAX_LOG_EVENTS = 100
+# CloudWatch's own server-side default (100,800) is far more than an LLM
+# needs handed back in one response; cap to roughly a day of 1-minute data.
+MAX_METRIC_DATAPOINTS = 1440
 
-# role_arn -> (credentials dict, unix expiry timestamp)
-_assumed_role_cache: dict[str, tuple[dict[str, str], float]] = {}
+# boto3 defaults (60s connect/read timeout, up to 5 legacy retries) are too
+# generous for a synchronous tool call the LLM is waiting on.
+DEFAULT_CLIENT_CONFIG = Config(
+    connect_timeout=10,
+    read_timeout=30,
+    retries={"max_attempts": 3, "mode": "standard"},
+)
 
 
 def _success(**payload: Any) -> str:
@@ -51,24 +56,22 @@ def _resolve_region(region: str | None) -> str:
 
 
 def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
-    cached = _assumed_role_cache.get(role_arn)
-    now = time.time()
-    if cached and cached[1] - ASSUME_ROLE_EXPIRY_MARGIN_SECONDS > now:
-        return cached[0]
-
-    sts = boto3.Session().client("sts", region_name=region)
+    # No caching: each MCP tool call runs in its own short-lived subprocess
+    # (see _execute_mcp_call in mcp_adapter.py, which opens and tears down a
+    # fresh stdio session per call), so a module-level cache never survives
+    # past the single call that populated it.
+    sts = boto3.Session().client(
+        "sts", region_name=region, config=DEFAULT_CLIENT_CONFIG
+    )
     response = sts.assume_role(
         RoleArn=role_arn, RoleSessionName=ASSUME_ROLE_SESSION_NAME
     )
     creds = response["Credentials"]
-    credentials = {
+    return {
         "aws_access_key_id": creds["AccessKeyId"],
         "aws_secret_access_key": creds["SecretAccessKey"],
         "aws_session_token": creds["SessionToken"],
     }
-    expiry = creds["Expiration"].timestamp()
-    _assumed_role_cache[role_arn] = (credentials, expiry)
-    return credentials
 
 
 def _client(
@@ -77,9 +80,10 @@ def _client(
     """Build a boto3 client from the connector's env credentials.
 
     With role_arn set, base credentials are exchanged for temporary
-    assumed-role credentials first (cached per ARN until shortly before
-    expiry) — this is how cross-account read access works without storing a
-    second key set.
+    assumed-role credentials first — this is how cross-account read access
+    works without storing a second key set. The exchange happens on every
+    call: see the comment on _assume_role_credentials for why caching it
+    would be dead code.
 
     A fresh boto3.Session per call, rather than the module-level
     boto3.client shortcut: the default shared session is documented as not
@@ -91,8 +95,15 @@ def _client(
     session = boto3.Session()
     if role_arn:
         credentials = _assume_role_credentials(role_arn, resolved_region)
-        return session.client(service, region_name=resolved_region, **credentials)
-    return session.client(service, region_name=resolved_region)
+        return session.client(
+            service,
+            region_name=resolved_region,
+            config=DEFAULT_CLIENT_CONFIG,
+            **credentials,
+        )
+    return session.client(
+        service, region_name=resolved_region, config=DEFAULT_CLIENT_CONFIG
+    )
 
 
 def _aws_error_message(exc: Exception) -> str:
@@ -184,6 +195,8 @@ def aws_cloudwatch_get_metric_data(
     start_time / end_time: ISO 8601 timestamps, e.g. "2026-07-30T00:00:00Z".
     stat: one of "Average", "Sum", "Minimum", "Maximum", "SampleCount".
     dimensions: e.g. [{"Name": "QueueName", "Value": "my-queue"}].
+    Returns at most 1440 datapoints — narrow the time range or widen
+    period_seconds rather than expecting more in one call.
     """
     try:
         metric: dict[str, Any] = {"Namespace": namespace, "MetricName": metric_name}
@@ -207,13 +220,21 @@ def aws_cloudwatch_get_metric_data(
             # here would only narrow the accepted formats.
             StartTime=start_time,
             EndTime=end_time,
+            MaxDatapoints=MAX_METRIC_DATAPOINTS,
         )
         series = result.get("MetricDataResults") or []
         first = (series[0] or {}) if series else {}
+        status_code = first.get("StatusCode")
         return _success(
             timestamps=first.get("Timestamps", []),
             values=first.get("Values", []),
             label=first.get("Label"),
+            status_code=status_code,
+            # PartialData/InternalError mean CloudWatch could not fully
+            # answer this query — surface that distinctly from "no data".
+            partial=status_code is not None and status_code != "Complete",
+            messages=result.get("Messages") or [],
+            truncated="NextToken" in result,
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error getting CloudWatch metric data: {e}")

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -37,6 +37,46 @@ MAX_METRIC_DATAPOINTS = 1440
 # while keeping a full batch's worst case bounded.
 MAX_LOG_MESSAGE_CHARS = 4000
 
+# role_arn is a model-supplied ARN with no operator-side allowlist, so an
+# assumed session's actual permissions could otherwise be as broad as
+# whatever policy the target role happens to carry -- there's no IAM-level
+# guarantee that role is itself read-only. An inline session policy caps
+# what the *assumed* session can do to exactly the API calls this module
+# makes, regardless of the target role's own permissions: read-only becomes
+# an enforced property of every role_arn call, not just a documentation
+# convention the operator has to trust. Session policies never grant more
+# than the target role's own policy already allows; they only narrow it.
+_READ_ONLY_SESSION_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sts:GetCallerIdentity",
+                    "cloudwatch:DescribeAlarms",
+                    "cloudwatch:GetMetricData",
+                    "logs:DescribeLogGroups",
+                    "logs:FilterLogEvents",
+                    "dynamodb:ListTables",
+                    "dynamodb:DescribeTable",
+                    "sqs:ListQueues",
+                    "sqs:GetQueueAttributes",
+                    # Reading from a CloudWatch Logs group encrypted with a
+                    # customer-managed KMS key requires these in addition to
+                    # logs:FilterLogEvents -- without them, this session
+                    # policy would regress an existing role_arn caller's
+                    # access to an encrypted log group even though the
+                    # target role's own permissions are unchanged.
+                    "kms:Decrypt",
+                    "kms:DescribeKey",
+                ],
+                "Resource": "*",
+            }
+        ],
+    }
+)
+
 # boto3 defaults (60s connect/read timeout, up to 5 legacy retries) are too
 # generous for a synchronous tool call the LLM is waiting on.
 DEFAULT_CLIENT_CONFIG = Config(
@@ -102,7 +142,11 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str | None
     sts = boto3.Session().client(
         "sts", region_name=region, config=DEFAULT_CLIENT_CONFIG
     )
-    response = sts.assume_role(RoleArn=role_arn, RoleSessionName=_role_session_name())
+    response = sts.assume_role(
+        RoleArn=role_arn,
+        RoleSessionName=_role_session_name(),
+        Policy=_READ_ONLY_SESSION_POLICY,
+    )
     creds = response.get("Credentials") or {}
     access_key_id = creds.get("AccessKeyId")
     secret_access_key = creds.get("SecretAccessKey")
@@ -191,7 +235,10 @@ def aws_get_caller_identity(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         result = _client("sts", region, role_arn).get_caller_identity()
@@ -221,7 +268,10 @@ def aws_cloudwatch_describe_alarms(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         kwargs: dict[str, Any] = {"MaxRecords": 100}
@@ -288,12 +338,21 @@ def aws_cloudwatch_get_metric_data(
     start_time / end_time: ISO 8601 timestamps, e.g. "2026-07-30T00:00:00Z".
     stat: one of "Average", "Sum", "Minimum", "Maximum", "SampleCount".
     dimensions: e.g. [{"Name": "QueueName", "Value": "my-queue"}].
+    period_seconds: CloudWatch's own retention tiers cap the resolution
+    actually available for older data regardless of this value -- 1-minute
+    for the last 15 days, 5-minute for 15-63 days, 1-hour beyond that --
+    and CloudWatch rounds start_time down to align with whichever tier
+    applies, so a small period_seconds for an old start_time won't add
+    resolution back that was never retained.
     Returns at most 1440 datapoints — narrow the time range or widen
     period_seconds rather than expecting more in one call.
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         metric: dict[str, Any] = {"Namespace": namespace, "MetricName": metric_name}
@@ -350,7 +409,10 @@ def aws_cloudwatch_describe_log_groups(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         # 50, not 100 like the other list-style tools: DescribeLogGroups'
@@ -394,7 +456,10 @@ def aws_cloudwatch_filter_log_events(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         kwargs: dict[str, Any] = {
@@ -433,7 +498,10 @@ def aws_dynamodb_list_tables(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
@@ -456,7 +524,10 @@ def aws_dynamodb_describe_table(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         result = _client("dynamodb", region, role_arn).describe_table(
@@ -498,7 +569,10 @@ def aws_sqs_list_queues(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         kwargs: dict[str, Any] = {"MaxResults": 100}
@@ -525,7 +599,10 @@ def aws_sqs_get_queue_attributes(
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
-    the call.
+    the call -- reachable with no operator-side allowlist if the base
+    credentials permit sts:AssumeRole, but the assumed session is scoped to
+    this connector's own read-only calls regardless of the target role's
+    own permissions.
     """
     try:
         result = _client("sqs", region, role_arn).get_queue_attributes(

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -91,7 +91,7 @@ def _client(
 
 def _aws_error_message(exc: Exception) -> str:
     if isinstance(exc, ClientError):
-        error = exc.response.get("Error", {})
+        error = exc.response.get("Error") or {}
         code = error.get("Code", "")
         message = error.get("Message", "")
         if code or message:
@@ -151,7 +151,7 @@ def aws_cloudwatch_describe_alarms(
                 "threshold": alarm.get("Threshold"),
                 "comparison": alarm.get("ComparisonOperator"),
             }
-            for alarm in result.get("MetricAlarms", [])
+            for alarm in (result.get("MetricAlarms") or [])
         ]
         return _success(alarms=alarms)
     except (ClientError, BotoCoreError, ValueError) as e:
@@ -202,8 +202,8 @@ def aws_cloudwatch_get_metric_data(
             StartTime=start_time,
             EndTime=end_time,
         )
-        series = result.get("MetricDataResults", [])
-        first = series[0] if series else {}
+        series = result.get("MetricDataResults") or []
+        first = (series[0] or {}) if series else {}
         return _success(
             timestamps=first.get("Timestamps", []),
             values=first.get("Values", []),
@@ -235,7 +235,7 @@ def aws_cloudwatch_describe_log_groups(
                 "stored_bytes": group.get("storedBytes"),
                 "retention_days": group.get("retentionInDays"),
             }
-            for group in result.get("logGroups", [])
+            for group in (result.get("logGroups") or [])
         ]
         return _success(log_groups=groups)
     except (ClientError, BotoCoreError, ValueError) as e:
@@ -278,7 +278,7 @@ def aws_cloudwatch_filter_log_events(
                 "log_stream": event.get("logStreamName"),
                 "message": event.get("message"),
             }
-            for event in result.get("events", [])
+            for event in (result.get("events") or [])
         ]
         return _success(events=events, truncated="nextToken" in result)
     except (ClientError, BotoCoreError, ValueError) as e:
@@ -295,7 +295,7 @@ def aws_dynamodb_list_tables(
     """
     try:
         result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
-        return _success(tables=result.get("TableNames", []))
+        return _success(tables=result.get("TableNames") or [])
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing DynamoDB tables: {e}")
         return _error(_aws_error_message(e))
@@ -313,7 +313,7 @@ def aws_dynamodb_describe_table(
         result = _client("dynamodb", region, role_arn).describe_table(
             TableName=table_name
         )
-        table = result.get("Table", {})
+        table = result.get("Table") or {}
         return _success(
             table={
                 "name": table.get("TableName"),
@@ -329,7 +329,7 @@ def aws_dynamodb_describe_table(
                         "name": index.get("IndexName"),
                         "status": index.get("IndexStatus"),
                     }
-                    for index in table.get("GlobalSecondaryIndexes", [])
+                    for index in (table.get("GlobalSecondaryIndexes") or [])
                 ],
             }
         )
@@ -352,7 +352,7 @@ def aws_sqs_list_queues(
         if name_prefix:
             kwargs["QueueNamePrefix"] = name_prefix
         result = _client("sqs", region, role_arn).list_queues(**kwargs)
-        return _success(queue_urls=result.get("QueueUrls", []))
+        return _success(queue_urls=result.get("QueueUrls") or [])
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing SQS queues: {e}")
         return _error(_aws_error_message(e))
@@ -371,7 +371,7 @@ def aws_sqs_get_queue_attributes(
         result = _client("sqs", region, role_arn).get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["All"]
         )
-        return _success(attributes=result.get("Attributes", {}))
+        return _success(attributes=result.get("Attributes") or {})
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error getting SQS queue attributes for {queue_url}: {e}")
         return _error(_aws_error_message(e))

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import boto3
@@ -19,6 +20,12 @@ setup_proxy_env()
 mcp = FastMCP("aws-mcp")
 
 ASSUME_ROLE_SESSION_NAME = "xagent-aws-mcp"
+# Set by xagent.web.services.mcp_runtime.caller_id_env for every stdio MCP
+# connector — kept as a literal here (not imported) since this module runs as
+# a standalone subprocess entrypoint.
+CALLER_ID_ENV_VAR = "XAGENT_MCP_CALLER_ID"
+# RoleSessionName's allowed charset per AWS STS: [\w+=,.@-], max 64 chars.
+_SESSION_NAME_UNSAFE_CHARS = re.compile(r"[^\w+=,.@-]")
 MAX_LOG_EVENTS = 100
 # CloudWatch's own server-side default (100,800) is far more than an LLM
 # needs handed back in one response; cap to roughly a day of 1-minute data.
@@ -55,6 +62,19 @@ def _resolve_region(region: str | None) -> str:
     return region or os.environ.get("AWS_REGION", "")
 
 
+def _role_session_name() -> str:
+    """Build a RoleSessionName that attributes an AssumeRole call to the
+    xagent user who triggered it, so the target account's CloudTrail can tell
+    different users' cross-account reads apart. Falls back to the bare
+    connector name if the caller id wasn't threaded through (e.g. a manual
+    `python -m xagent.web.tools.mcp.aws` invocation outside the platform)."""
+    caller_id = os.environ.get(CALLER_ID_ENV_VAR)
+    if not caller_id:
+        return ASSUME_ROLE_SESSION_NAME
+    sanitized = _SESSION_NAME_UNSAFE_CHARS.sub("_", caller_id)
+    return f"{ASSUME_ROLE_SESSION_NAME}-{sanitized}"[:64]
+
+
 def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
     # No caching: each MCP tool call runs in its own short-lived subprocess
     # (see _execute_mcp_call in mcp_adapter.py, which opens and tears down a
@@ -63,9 +83,7 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
     sts = boto3.Session().client(
         "sts", region_name=region, config=DEFAULT_CLIENT_CONFIG
     )
-    response = sts.assume_role(
-        RoleArn=role_arn, RoleSessionName=ASSUME_ROLE_SESSION_NAME
-    )
+    response = sts.assume_role(RoleArn=role_arn, RoleSessionName=_role_session_name())
     creds = response["Credentials"]
     return {
         "aws_access_key_id": creds["AccessKeyId"],

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -67,7 +67,14 @@ def _role_session_name() -> str:
     xagent user who triggered it, so the target account's CloudTrail can tell
     different users' cross-account reads apart. Falls back to the bare
     connector name if the caller id wasn't threaded through (e.g. a manual
-    `python -m xagent.web.tools.mcp.aws` invocation outside the platform)."""
+    `python -m xagent.web.tools.mcp.aws` invocation outside the platform).
+
+    This only covers the role_arn (cross-account) path — see _client. A call
+    without role_arn goes straight through the connector's own base
+    credentials, one shared IAM principal with no per-call session name, so
+    same-account calls remain indistinguishable from each other in
+    CloudTrail.
+    """
     caller_id = os.environ.get(CALLER_ID_ENV_VAR)
     if not caller_id:
         return ASSUME_ROLE_SESSION_NAME
@@ -75,7 +82,7 @@ def _role_session_name() -> str:
     return f"{ASSUME_ROLE_SESSION_NAME}-{sanitized}"[:64]
 
 
-def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
+def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str | None]:
     # No caching: each MCP tool call runs in its own short-lived subprocess
     # (see _execute_mcp_call in mcp_adapter.py, which opens and tears down a
     # fresh stdio session per call), so a module-level cache never survives
@@ -84,11 +91,11 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
         "sts", region_name=region, config=DEFAULT_CLIENT_CONFIG
     )
     response = sts.assume_role(RoleArn=role_arn, RoleSessionName=_role_session_name())
-    creds = response["Credentials"]
+    creds = response.get("Credentials") or {}
     return {
-        "aws_access_key_id": creds["AccessKeyId"],
-        "aws_secret_access_key": creds["SecretAccessKey"],
-        "aws_session_token": creds["SessionToken"],
+        "aws_access_key_id": creds.get("AccessKeyId"),
+        "aws_secret_access_key": creds.get("SecretAccessKey"),
+        "aws_session_token": creds.get("SessionToken"),
     }
 
 
@@ -104,9 +111,9 @@ def _client(
     would be dead code.
 
     A fresh boto3.Session per call, rather than the module-level
-    boto3.client shortcut: the default shared session is documented as not
-    thread-safe for concurrent client creation, and FastMCP runs sync tools
-    in a thread pool.
+    boto3.client shortcut: boto3 Sessions are documented as not safe to
+    share across concurrent client creation, so a fresh one per call is a
+    low-cost precaution regardless of how this module happens to be invoked.
     """
     _require_base_credentials()
     resolved_region = _resolve_region(region)
@@ -164,6 +171,8 @@ def aws_cloudwatch_describe_alarms(
 ) -> str:
     """
     List CloudWatch alarms — the triage entry point for "what is wrong right now".
+    Returns both metric alarms and composite alarms (account-level rollups
+    aggregating other alarms) separately.
     state: optional filter, one of "ALARM", "OK", "INSUFFICIENT_DATA".
     alarm_name_prefix: optional name prefix filter.
     """
@@ -188,7 +197,26 @@ def aws_cloudwatch_describe_alarms(
             }
             for alarm in (result.get("MetricAlarms") or [])
         ]
-        return _success(alarms=alarms, truncated="NextToken" in result)
+        # DescribeAlarms returns composite alarms (account-level "is the
+        # service healthy" rollups aggregating leaf alarms) in a separate
+        # top-level field sharing the same MaxRecords budget. Omitting them
+        # would let this triage tool report "nothing is wrong" while the
+        # account's top rollup alarm is firing.
+        composite_alarms = [
+            {
+                "name": alarm.get("AlarmName"),
+                "state": alarm.get("StateValue"),
+                "state_reason": alarm.get("StateReason"),
+                "state_updated": alarm.get("StateUpdatedTimestamp"),
+                "alarm_rule": alarm.get("AlarmRule"),
+            }
+            for alarm in (result.get("CompositeAlarms") or [])
+        ]
+        return _success(
+            alarms=alarms,
+            composite_alarms=composite_alarms,
+            truncated="NextToken" in result,
+        )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing CloudWatch alarms: {e}")
         return _error(_aws_error_message(e))

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -1,0 +1,376 @@
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("aws-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("aws-mcp")
+
+# Refresh assumed-role credentials this many seconds before they expire, so a
+# long-running tool call never starts with credentials about to lapse.
+ASSUME_ROLE_EXPIRY_MARGIN_SECONDS = 300
+ASSUME_ROLE_SESSION_NAME = "xagent-aws-mcp"
+MAX_LOG_EVENTS = 100
+
+# role_arn -> (credentials dict, unix expiry timestamp)
+_assumed_role_cache: dict[str, tuple[dict[str, str], float]] = {}
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False, default=str)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _require_base_credentials() -> None:
+    missing = [
+        name
+        for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
+        if not os.environ.get(name)
+    ]
+    if missing:
+        raise ValueError(f"Missing environment variable(s): {', '.join(missing)}")
+
+
+def _resolve_region(region: str | None) -> str:
+    return region or os.environ.get("AWS_REGION", "")
+
+
+def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
+    cached = _assumed_role_cache.get(role_arn)
+    now = time.time()
+    if cached and cached[1] - ASSUME_ROLE_EXPIRY_MARGIN_SECONDS > now:
+        return cached[0]
+
+    sts = boto3.client("sts", region_name=region)
+    response = sts.assume_role(
+        RoleArn=role_arn, RoleSessionName=ASSUME_ROLE_SESSION_NAME
+    )
+    creds = response["Credentials"]
+    credentials = {
+        "aws_access_key_id": creds["AccessKeyId"],
+        "aws_secret_access_key": creds["SecretAccessKey"],
+        "aws_session_token": creds["SessionToken"],
+    }
+    expiry = creds["Expiration"].timestamp()
+    _assumed_role_cache[role_arn] = (credentials, expiry)
+    return credentials
+
+
+def _client(
+    service: str, region: str | None = None, role_arn: str | None = None
+) -> Any:
+    """Build a boto3 client from the connector's env credentials.
+
+    With role_arn set, base credentials are exchanged for temporary
+    assumed-role credentials first (cached per ARN until shortly before
+    expiry) — this is how cross-account read access works without storing a
+    second key set.
+    """
+    _require_base_credentials()
+    resolved_region = _resolve_region(region)
+    if role_arn:
+        credentials = _assume_role_credentials(role_arn, resolved_region)
+        return boto3.client(service, region_name=resolved_region, **credentials)
+    return boto3.client(service, region_name=resolved_region)
+
+
+def _aws_error_message(exc: Exception) -> str:
+    if isinstance(exc, ClientError):
+        error = exc.response.get("Error", {})
+        code = error.get("Code", "")
+        message = error.get("Message", "")
+        if code or message:
+            return f"{code}: {message}" if code else message
+    return str(exc)
+
+
+@mcp.tool()
+def aws_get_caller_identity(
+    region: str | None = None, role_arn: str | None = None
+) -> str:
+    """
+    Verify AWS connectivity and show which account/principal the connector is
+    acting as. Use this first if any other AWS call fails with access errors.
+    Optional role_arn assumes that IAM role (cross-account) before the call.
+    """
+    try:
+        result = _client("sts", region, role_arn).get_caller_identity()
+        return _success(
+            account=result.get("Account"),
+            arn=result.get("Arn"),
+            user_id=result.get("UserId"),
+        )
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error getting caller identity: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_cloudwatch_describe_alarms(
+    state: str | None = None,
+    alarm_name_prefix: str | None = None,
+    region: str | None = None,
+    role_arn: str | None = None,
+) -> str:
+    """
+    List CloudWatch alarms — the triage entry point for "what is wrong right now".
+    state: optional filter, one of "ALARM", "OK", "INSUFFICIENT_DATA".
+    alarm_name_prefix: optional name prefix filter.
+    """
+    try:
+        kwargs: dict[str, Any] = {"MaxRecords": 100}
+        if state:
+            kwargs["StateValue"] = state
+        if alarm_name_prefix:
+            kwargs["AlarmNamePrefix"] = alarm_name_prefix
+        result = _client("cloudwatch", region, role_arn).describe_alarms(**kwargs)
+        alarms = [
+            {
+                "name": alarm.get("AlarmName"),
+                "state": alarm.get("StateValue"),
+                "state_reason": alarm.get("StateReason"),
+                "state_updated": alarm.get("StateUpdatedTimestamp"),
+                "metric": alarm.get("MetricName"),
+                "namespace": alarm.get("Namespace"),
+                "dimensions": alarm.get("Dimensions"),
+                "threshold": alarm.get("Threshold"),
+                "comparison": alarm.get("ComparisonOperator"),
+            }
+            for alarm in result.get("MetricAlarms", [])
+        ]
+        return _success(alarms=alarms)
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error describing CloudWatch alarms: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_cloudwatch_get_metric_data(
+    namespace: str,
+    metric_name: str,
+    start_time: str,
+    end_time: str,
+    period_seconds: int = 300,
+    stat: str = "Average",
+    dimensions: list[dict[str, str]] | None = None,
+    region: str | None = None,
+    role_arn: str | None = None,
+) -> str:
+    """
+    Fetch a CloudWatch metric timeseries, e.g. CPUUtilization or queue depth over time.
+    namespace: e.g. "AWS/EC2", "AWS/SQS", "AWS/DynamoDB".
+    metric_name: e.g. "CPUUtilization", "ApproximateNumberOfMessagesVisible".
+    start_time / end_time: ISO 8601 timestamps, e.g. "2026-07-30T00:00:00Z".
+    stat: one of "Average", "Sum", "Minimum", "Maximum", "SampleCount".
+    dimensions: e.g. [{"Name": "QueueName", "Value": "my-queue"}].
+    """
+    try:
+        metric: dict[str, Any] = {"Namespace": namespace, "MetricName": metric_name}
+        if dimensions:
+            metric["Dimensions"] = dimensions
+        result = _client("cloudwatch", region, role_arn).get_metric_data(
+            MetricDataQueries=[
+                {
+                    "Id": "m1",
+                    "MetricStat": {
+                        "Metric": metric,
+                        "Period": period_seconds,
+                        "Stat": stat,
+                    },
+                }
+            ],
+            StartTime=start_time,
+            EndTime=end_time,
+        )
+        series = result.get("MetricDataResults", [])
+        first = series[0] if series else {}
+        return _success(
+            timestamps=first.get("Timestamps", []),
+            values=first.get("Values", []),
+            label=first.get("Label"),
+        )
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error getting CloudWatch metric data: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_cloudwatch_describe_log_groups(
+    name_prefix: str | None = None,
+    region: str | None = None,
+    role_arn: str | None = None,
+) -> str:
+    """
+    List CloudWatch Logs log groups (optionally filtered by name prefix), to
+    discover where a service's logs live before searching them.
+    """
+    try:
+        kwargs: dict[str, Any] = {"limit": 50}
+        if name_prefix:
+            kwargs["logGroupNamePrefix"] = name_prefix
+        result = _client("logs", region, role_arn).describe_log_groups(**kwargs)
+        groups = [
+            {
+                "name": group.get("logGroupName"),
+                "stored_bytes": group.get("storedBytes"),
+                "retention_days": group.get("retentionInDays"),
+            }
+            for group in result.get("logGroups", [])
+        ]
+        return _success(log_groups=groups)
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error describing log groups: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_cloudwatch_filter_log_events(
+    log_group_name: str,
+    filter_pattern: str | None = None,
+    start_time_ms: int | None = None,
+    end_time_ms: int | None = None,
+    limit: int = MAX_LOG_EVENTS,
+    region: str | None = None,
+    role_arn: str | None = None,
+) -> str:
+    """
+    Search a CloudWatch Logs group for matching events, e.g. errors during an incident window.
+    filter_pattern: CloudWatch filter syntax, e.g. "ERROR" or "{ $.level = \"error\" }".
+    start_time_ms / end_time_ms: unix epoch milliseconds bounding the search window.
+    Returns at most `limit` events (default 100) — narrow the window or pattern rather
+    than raising the limit.
+    """
+    try:
+        kwargs: dict[str, Any] = {
+            "logGroupName": log_group_name,
+            "limit": min(int(limit), MAX_LOG_EVENTS),
+        }
+        if filter_pattern:
+            kwargs["filterPattern"] = filter_pattern
+        if start_time_ms is not None:
+            kwargs["startTime"] = int(start_time_ms)
+        if end_time_ms is not None:
+            kwargs["endTime"] = int(end_time_ms)
+        result = _client("logs", region, role_arn).filter_log_events(**kwargs)
+        events = [
+            {
+                "timestamp_ms": event.get("timestamp"),
+                "log_stream": event.get("logStreamName"),
+                "message": event.get("message"),
+            }
+            for event in result.get("events", [])
+        ]
+        return _success(events=events, truncated="nextToken" in result)
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error filtering log events: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_dynamodb_list_tables(
+    region: str | None = None, role_arn: str | None = None
+) -> str:
+    """
+    List DynamoDB table names in the region.
+    """
+    try:
+        result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
+        return _success(tables=result.get("TableNames", []))
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error listing DynamoDB tables: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_dynamodb_describe_table(
+    table_name: str, region: str | None = None, role_arn: str | None = None
+) -> str:
+    """
+    Get a DynamoDB table's status and health signals: state, item count, size,
+    billing mode, and provisioned throughput (for throttling diagnostics).
+    """
+    try:
+        result = _client("dynamodb", region, role_arn).describe_table(
+            TableName=table_name
+        )
+        table = result.get("Table", {})
+        return _success(
+            table={
+                "name": table.get("TableName"),
+                "status": table.get("TableStatus"),
+                "item_count": table.get("ItemCount"),
+                "size_bytes": table.get("TableSizeBytes"),
+                "billing_mode": (table.get("BillingModeSummary") or {}).get(
+                    "BillingMode"
+                ),
+                "provisioned_throughput": table.get("ProvisionedThroughput"),
+                "global_secondary_indexes": [
+                    {
+                        "name": index.get("IndexName"),
+                        "status": index.get("IndexStatus"),
+                    }
+                    for index in table.get("GlobalSecondaryIndexes", [])
+                ],
+            }
+        )
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error describing DynamoDB table {table_name}: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_sqs_list_queues(
+    name_prefix: str | None = None,
+    region: str | None = None,
+    role_arn: str | None = None,
+) -> str:
+    """
+    List SQS queue URLs in the region (optionally filtered by name prefix).
+    """
+    try:
+        kwargs: dict[str, Any] = {"MaxResults": 100}
+        if name_prefix:
+            kwargs["QueueNamePrefix"] = name_prefix
+        result = _client("sqs", region, role_arn).list_queues(**kwargs)
+        return _success(queue_urls=result.get("QueueUrls", []))
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error listing SQS queues: {e}")
+        return _error(_aws_error_message(e))
+
+
+@mcp.tool()
+def aws_sqs_get_queue_attributes(
+    queue_url: str, region: str | None = None, role_arn: str | None = None
+) -> str:
+    """
+    Get an SQS queue's attributes — most importantly backlog depth
+    (ApproximateNumberOfMessages), in-flight count, oldest message age, and
+    the redrive/DLQ policy — the key signals for "is this queue backed up".
+    """
+    try:
+        result = _client("sqs", region, role_arn).get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["All"]
+        )
+        return _success(attributes=result.get("Attributes", {}))
+    except (ClientError, BotoCoreError, ValueError) as e:
+        logger.error(f"Error getting SQS queue attributes for {queue_url}: {e}")
+        return _error(_aws_error_message(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -153,7 +153,7 @@ def aws_cloudwatch_describe_alarms(
             }
             for alarm in (result.get("MetricAlarms") or [])
         ]
-        return _success(alarms=alarms)
+        return _success(alarms=alarms, truncated="NextToken" in result)
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing CloudWatch alarms: {e}")
         return _error(_aws_error_message(e))
@@ -237,7 +237,7 @@ def aws_cloudwatch_describe_log_groups(
             }
             for group in (result.get("logGroups") or [])
         ]
-        return _success(log_groups=groups)
+        return _success(log_groups=groups, truncated="nextToken" in result)
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing log groups: {e}")
         return _error(_aws_error_message(e))
@@ -295,7 +295,10 @@ def aws_dynamodb_list_tables(
     """
     try:
         result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
-        return _success(tables=result.get("TableNames") or [])
+        return _success(
+            tables=result.get("TableNames") or [],
+            truncated="LastEvaluatedTableName" in result,
+        )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing DynamoDB tables: {e}")
         return _error(_aws_error_message(e))
@@ -352,7 +355,10 @@ def aws_sqs_list_queues(
         if name_prefix:
             kwargs["QueueNamePrefix"] = name_prefix
         result = _client("sqs", region, role_arn).list_queues(**kwargs)
-        return _success(queue_urls=result.get("QueueUrls") or [])
+        return _success(
+            queue_urls=result.get("QueueUrls") or [],
+            truncated="NextToken" in result,
+        )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing SQS queues: {e}")
         return _error(_aws_error_message(e))

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -30,6 +30,12 @@ MAX_LOG_EVENTS = 100
 # CloudWatch's own server-side default (100,800) is far more than an LLM
 # needs handed back in one response; cap to roughly a day of 1-minute data.
 MAX_METRIC_DATAPOINTS = 1440
+# CloudWatch log messages routinely carry a full stack trace or a serialized
+# payload; MAX_LOG_EVENTS bounds event *count* but not size, so up to 100
+# uncapped messages could still produce a multi-megabyte tool result that
+# blows out the model's context. ~4000 chars is generous for a log line
+# while keeping a full batch's worst case bounded.
+MAX_LOG_MESSAGE_CHARS = 4000
 
 # boto3 defaults (60s connect/read timeout, up to 5 legacy retries) are too
 # generous for a synchronous tool call the LLM is waiting on.
@@ -48,12 +54,18 @@ def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
-def _require_base_credentials() -> None:
+def _require_base_credentials(resolved_region: str) -> None:
     missing = [
         name
-        for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
+        for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
         if not os.environ.get(name)
     ]
+    # AWS_REGION is only required when the caller didn't already supply an
+    # explicit region= argument - resolved_region already reflects that
+    # override (see _resolve_region), so checking the env var directly here
+    # would make an explicit region unable to satisfy the requirement.
+    if not resolved_region:
+        missing.append("AWS_REGION")
     if missing:
         raise ValueError(f"Missing environment variable(s): {', '.join(missing)}")
 
@@ -92,10 +104,27 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str | None
     )
     response = sts.assume_role(RoleArn=role_arn, RoleSessionName=_role_session_name())
     creds = response.get("Credentials") or {}
+    access_key_id = creds.get("AccessKeyId")
+    secret_access_key = creds.get("SecretAccessKey")
+    session_token = creds.get("SessionToken")
+    # A 200 response with Credentials present but AccessKeyId/SecretAccessKey
+    # both absent would otherwise spread as **{..., "aws_access_key_id": None,
+    # "aws_secret_access_key": None, ...} into session.client(), which
+    # botocore treats as "no explicit credentials supplied" and silently
+    # falls back to the connector's own base/ambient credentials -- a
+    # cross-account call would then run under the wrong identity with no
+    # error at all. AWS's documented AssumeRole contract says this can't
+    # happen on a 200, but failing loudly here costs nothing and closes the
+    # gap if it ever does (a partial response, e.g. only one field missing,
+    # already raises botocore's own PartialCredentialsError upstream).
+    if not access_key_id or not secret_access_key or not session_token:
+        raise ValueError(
+            f"AssumeRole for {role_arn!r} returned an incomplete credential set"
+        )
     return {
-        "aws_access_key_id": creds.get("AccessKeyId"),
-        "aws_secret_access_key": creds.get("SecretAccessKey"),
-        "aws_session_token": creds.get("SessionToken"),
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_access_key,
+        "aws_session_token": session_token,
     }
 
 
@@ -115,8 +144,8 @@ def _client(
     share across concurrent client creation, so a fresh one per call is a
     low-cost precaution regardless of how this module happens to be invoked.
     """
-    _require_base_credentials()
     resolved_region = _resolve_region(region)
+    _require_base_credentials(resolved_region)
     session = boto3.Session()
     if role_arn:
         credentials = _assume_role_credentials(role_arn, resolved_region)
@@ -141,6 +170,17 @@ def _aws_error_message(exc: Exception) -> str:
     return str(exc)
 
 
+def _truncate_message(
+    message: str | None, max_chars: int = MAX_LOG_MESSAGE_CHARS
+) -> str | None:
+    # CloudWatch Logs documents `message` as always a string, but guard the
+    # type anyway rather than let a TypeError from `+` on a non-str value
+    # escape uncaught (the caller's except clause doesn't include TypeError).
+    if message is None or not isinstance(message, str) or len(message) <= max_chars:
+        return message
+    return message[:max_chars] + f"...[truncated, {len(message)} chars total]"
+
+
 @mcp.tool()
 def aws_get_caller_identity(
     region: str | None = None, role_arn: str | None = None
@@ -148,7 +188,10 @@ def aws_get_caller_identity(
     """
     Verify AWS connectivity and show which account/principal the connector is
     acting as. Use this first if any other AWS call fails with access errors.
-    Optional role_arn assumes that IAM role (cross-account) before the call.
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         result = _client("sts", region, role_arn).get_caller_identity()
@@ -175,6 +218,10 @@ def aws_cloudwatch_describe_alarms(
     aggregating other alarms) separately.
     state: optional filter, one of "ALARM", "OK", "INSUFFICIENT_DATA".
     alarm_name_prefix: optional name prefix filter.
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         kwargs: dict[str, Any] = {"MaxRecords": 100}
@@ -243,6 +290,10 @@ def aws_cloudwatch_get_metric_data(
     dimensions: e.g. [{"Name": "QueueName", "Value": "my-queue"}].
     Returns at most 1440 datapoints — narrow the time range or widen
     period_seconds rather than expecting more in one call.
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         metric: dict[str, Any] = {"Namespace": namespace, "MetricName": metric_name}
@@ -296,6 +347,10 @@ def aws_cloudwatch_describe_log_groups(
     """
     List CloudWatch Logs log groups (optionally filtered by name prefix), to
     discover where a service's logs live before searching them.
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         # 50, not 100 like the other list-style tools: DescribeLogGroups'
@@ -334,7 +389,12 @@ def aws_cloudwatch_filter_log_events(
     filter_pattern: CloudWatch filter syntax, e.g. "ERROR" or "{ $.level = \"error\" }".
     start_time_ms / end_time_ms: unix epoch milliseconds bounding the search window.
     Returns at most `limit` events (default 100) — narrow the window or pattern rather
-    than raising the limit.
+    than raising the limit. Each event's message is truncated past 4000 characters
+    (MAX_LOG_MESSAGE_CHARS).
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         kwargs: dict[str, Any] = {
@@ -354,7 +414,7 @@ def aws_cloudwatch_filter_log_events(
             {
                 "timestamp_ms": event.get("timestamp"),
                 "log_stream": event.get("logStreamName"),
-                "message": event.get("message"),
+                "message": _truncate_message(event.get("message")),
             }
             for event in (result.get("events") or [])
         ]
@@ -370,6 +430,10 @@ def aws_dynamodb_list_tables(
 ) -> str:
     """
     List DynamoDB table names in the region.
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
@@ -389,6 +453,10 @@ def aws_dynamodb_describe_table(
     """
     Get a DynamoDB table's status and health signals: state, item count, size,
     billing mode, and provisioned throughput (for throttling diagnostics).
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         result = _client("dynamodb", region, role_arn).describe_table(
@@ -427,6 +495,10 @@ def aws_sqs_list_queues(
 ) -> str:
     """
     List SQS queue URLs in the region (optionally filtered by name prefix).
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         kwargs: dict[str, Any] = {"MaxResults": 100}
@@ -450,6 +522,10 @@ def aws_sqs_get_queue_attributes(
     Get an SQS queue's attributes — most importantly backlog depth
     (ApproximateNumberOfMessages), in-flight count, oldest message age, and
     the redrive/DLQ policy — the key signals for "is this queue backed up".
+    region: optional AWS region override; defaults to the connector's
+    configured AWS_REGION.
+    role_arn: optional IAM role ARN to assume (cross-account access) before
+    the call.
     """
     try:
         result = _client("sqs", region, role_arn).get_queue_attributes(

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -56,7 +56,7 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str]:
     if cached and cached[1] - ASSUME_ROLE_EXPIRY_MARGIN_SECONDS > now:
         return cached[0]
 
-    sts = boto3.client("sts", region_name=region)
+    sts = boto3.Session().client("sts", region_name=region)
     response = sts.assume_role(
         RoleArn=role_arn, RoleSessionName=ASSUME_ROLE_SESSION_NAME
     )
@@ -80,13 +80,19 @@ def _client(
     assumed-role credentials first (cached per ARN until shortly before
     expiry) — this is how cross-account read access works without storing a
     second key set.
+
+    A fresh boto3.Session per call, rather than the module-level
+    boto3.client shortcut: the default shared session is documented as not
+    thread-safe for concurrent client creation, and FastMCP runs sync tools
+    in a thread pool.
     """
     _require_base_credentials()
     resolved_region = _resolve_region(region)
+    session = boto3.Session()
     if role_arn:
         credentials = _assume_role_credentials(role_arn, resolved_region)
-        return boto3.client(service, region_name=resolved_region, **credentials)
-    return boto3.client(service, region_name=resolved_region)
+        return session.client(service, region_name=resolved_region, **credentials)
+    return session.client(service, region_name=resolved_region)
 
 
 def _aws_error_message(exc: Exception) -> str:
@@ -263,7 +269,9 @@ def aws_cloudwatch_filter_log_events(
     try:
         kwargs: dict[str, Any] = {
             "logGroupName": log_group_name,
-            "limit": min(int(limit), MAX_LOG_EVENTS),
+            # Clamp to [1, MAX_LOG_EVENTS]: a zero/negative limit passes the
+            # int signature validation but AWS rejects it remotely.
+            "limit": max(1, min(int(limit), MAX_LOG_EVENTS)),
         }
         if filter_pattern:
             kwargs["filterPattern"] = filter_pattern

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -62,17 +62,28 @@ _READ_ONLY_SESSION_POLICY = json.dumps(
                     "dynamodb:DescribeTable",
                     "sqs:ListQueues",
                     "sqs:GetQueueAttributes",
-                    # Reading from a CloudWatch Logs group encrypted with a
-                    # customer-managed KMS key requires these in addition to
-                    # logs:FilterLogEvents -- without them, this session
-                    # policy would regress an existing role_arn caller's
-                    # access to an encrypted log group even though the
-                    # target role's own permissions are unchanged.
+                ],
+                "Resource": "*",
+            },
+            {
+                # Reading from a CloudWatch Logs group encrypted with a
+                # customer-managed KMS key requires these in addition to
+                # logs:FilterLogEvents -- without them, this session policy
+                # would regress an existing role_arn caller's access to an
+                # encrypted log group even though the target role's own
+                # permissions are unchanged. Split into its own
+                # conditioned statement (rather than folded into the
+                # Resource: "*" statement above) so the grant only ever
+                # applies to a KMS call made on logs' behalf, not a bare
+                # kms:Decrypt/DescribeKey call against an unrelated key.
+                "Effect": "Allow",
+                "Action": [
                     "kms:Decrypt",
                     "kms:DescribeKey",
                 ],
                 "Resource": "*",
-            }
+                "Condition": {"StringLike": {"kms:ViaService": "logs.*.amazonaws.com"}},
+            },
         ],
     }
 )
@@ -165,6 +176,11 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str | None
         raise ValueError(
             f"AssumeRole for {role_arn!r} returned an incomplete credential set"
         )
+    # Local audit trail: CloudTrail on the *target* account already
+    # attributes the call via RoleSessionName, but xagent's own logs
+    # otherwise have no record of which caller assumed which role_arn.
+    caller_id = os.environ.get(CALLER_ID_ENV_VAR, "<unknown>")
+    logger.info(f"caller {caller_id} assumed role {role_arn}")
     return {
         "aws_access_key_id": access_key_id,
         "aws_secret_access_key": secret_access_key,
@@ -204,13 +220,39 @@ def _client(
     )
 
 
-def _aws_error_message(exc: Exception) -> str:
+def _aws_error_message(exc: Exception, used_role_arn: bool = False) -> str:
     if isinstance(exc, ClientError):
         error = exc.response.get("Error") or {}
         code = error.get("Code", "")
         message = error.get("Message", "")
         if code or message:
-            return f"{code}: {message}" if code else message
+            result = f"{code}: {message}" if code else message
+            # AccessDenied on a role_arn call's *downstream* service call
+            # (e.g. cloudwatch:DescribeAlarms) could mean the target role
+            # itself doesn't grant the action, OR that this connector's own
+            # inline session policy doesn't include it (see
+            # _READ_ONLY_SESSION_POLICY) -- the two look identical from the
+            # response alone, so name the second possibility explicitly
+            # rather than leaving it read as only a target-role problem.
+            # Excluded when the denial is on AssumeRole itself: at that
+            # point no session has been created yet, so there is nothing
+            # for the session policy to have restricted -- the actual cause
+            # is the target role's trust policy or the base credentials'
+            # own sts:AssumeRole permission, and the hint would misdirect
+            # the operator toward the wrong fix.
+            operation_name = getattr(exc, "operation_name", None)
+            if (
+                used_role_arn
+                and code == "AccessDenied"
+                and operation_name != "AssumeRole"
+            ):
+                result += (
+                    " (this connector's assumed session is restricted to its "
+                    "own read-only calls regardless of the target role's own "
+                    "permissions -- confirm the action is one of the ones "
+                    "this connector makes, not just permitted by role_arn)"
+                )
+            return result
     return str(exc)
 
 
@@ -249,7 +291,7 @@ def aws_get_caller_identity(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error getting caller identity: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -316,7 +358,7 @@ def aws_cloudwatch_describe_alarms(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing CloudWatch alarms: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -394,7 +436,7 @@ def aws_cloudwatch_get_metric_data(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error getting CloudWatch metric data: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -433,7 +475,7 @@ def aws_cloudwatch_describe_log_groups(
         return _success(log_groups=groups, truncated="nextToken" in result)
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing log groups: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -486,7 +528,7 @@ def aws_cloudwatch_filter_log_events(
         return _success(events=events, truncated="nextToken" in result)
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error filtering log events: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -511,7 +553,7 @@ def aws_dynamodb_list_tables(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing DynamoDB tables: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -555,7 +597,7 @@ def aws_dynamodb_describe_table(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing DynamoDB table {table_name}: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -585,7 +627,7 @@ def aws_sqs_list_queues(
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing SQS queues: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 @mcp.tool()
@@ -611,7 +653,7 @@ def aws_sqs_get_queue_attributes(
         return _success(attributes=result.get("Attributes") or {})
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error getting SQS queue attributes for {queue_url}: {e}")
-        return _error(_aws_error_message(e))
+        return _error(_aws_error_message(e, bool(role_arn)))
 
 
 if __name__ == "__main__":

--- a/src/xagent/web/tools/mcp/aws.py
+++ b/src/xagent/web/tools/mcp/aws.py
@@ -26,6 +26,14 @@ ASSUME_ROLE_SESSION_NAME = "xagent-aws-mcp"
 CALLER_ID_ENV_VAR = "XAGENT_MCP_CALLER_ID"
 # RoleSessionName's allowed charset per AWS STS: [\w+=,.@-], max 64 chars.
 _SESSION_NAME_UNSAFE_CHARS = re.compile(r"[^\w+=,.@-]")
+# Bounded pagination cap for the list/describe tools below -- mirrors the
+# same pattern already used by slack.py's channel listing. Each of these
+# AWS list/describe APIs can return a page that's partially full (or even
+# empty) with more matching data on a later page, so fetching exactly one
+# page and reporting `truncated` with no way to continue can silently miss
+# data (worst case: a log search during an incident reporting "no errors
+# found" when errors exist past the first page).
+MAX_PAGES = 20
 MAX_LOG_EVENTS = 100
 # CloudWatch's own server-side default (100,800) is far more than an LLM
 # needs handed back in one response; cap to roughly a day of 1-minute data.
@@ -36,6 +44,30 @@ MAX_METRIC_DATAPOINTS = 1440
 # blows out the model's context. ~4000 chars is generous for a log line
 # while keeping a full batch's worst case bounded.
 MAX_LOG_MESSAGE_CHARS = 4000
+
+# AttributeNames=["All"] on GetQueueAttributes also returns the queue's
+# resource Policy document (account IDs, principal ARNs, cross-account
+# trust conditions) and KmsMasterKeyId -- neither is a diagnostic signal
+# this tool's docstring promises, and IAM can't restrict which
+# AttributeNames come back, so this connector enumerates only the
+# diagnostic attributes itself instead of asking for everything.
+SQS_DIAGNOSTIC_ATTRIBUTES = [
+    "ApproximateNumberOfMessages",
+    "ApproximateNumberOfMessagesNotVisible",
+    "ApproximateNumberOfMessagesDelayed",
+    "CreatedTimestamp",
+    "LastModifiedTimestamp",
+    "VisibilityTimeout",
+    "MaximumMessageSize",
+    "MessageRetentionPeriod",
+    "DelaySeconds",
+    "ReceiveMessageWaitTimeSeconds",
+    "RedrivePolicy",
+    "RedriveAllowPolicy",
+    "QueueArn",
+    "FifoQueue",
+    "ContentBasedDeduplication",
+]
 
 # role_arn is a model-supplied ARN with no operator-side allowlist, so an
 # assumed session's actual permissions could otherwise be as broad as
@@ -150,8 +182,17 @@ def _assume_role_credentials(role_arn: str, region: str) -> dict[str, str | None
     # (see _execute_mcp_call in mcp_adapter.py, which opens and tears down a
     # fresh stdio session per call), so a module-level cache never survives
     # past the single call that populated it.
+    #
+    # Explicit credentials here too (see the matching comment in _client):
+    # this is the cross-account AssumeRole call, the most sensitive path in
+    # the module, so it shouldn't be the one place still leaning on boto3's
+    # ambient provider chain instead of the connector's own env credentials.
     sts = boto3.Session().client(
-        "sts", region_name=region, config=DEFAULT_CLIENT_CONFIG
+        "sts",
+        region_name=region,
+        config=DEFAULT_CLIENT_CONFIG,
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
     )
     response = sts.assume_role(
         RoleArn=role_arn,
@@ -215,8 +256,19 @@ def _client(
             config=DEFAULT_CLIENT_CONFIG,
             **credentials,
         )
+    # Pass the connector's own credentials explicitly rather than letting
+    # boto3's ambient provider chain pick them up: _require_base_credentials
+    # above already guarantees these two env vars are set and boto3's chain
+    # would resolve the same values today, but naming them here removes any
+    # dependency on that chain ever consulting a ~/.aws/credentials file at
+    # all -- reachable via the inherited HOME env var -- as a fallback,
+    # rather than trusting it never will.
     return session.client(
-        service, region_name=resolved_region, config=DEFAULT_CLIENT_CONFIG
+        service,
+        region_name=resolved_region,
+        config=DEFAULT_CLIENT_CONFIG,
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
     )
 
 
@@ -321,7 +373,28 @@ def aws_cloudwatch_describe_alarms(
             kwargs["StateValue"] = state
         if alarm_name_prefix:
             kwargs["AlarmNamePrefix"] = alarm_name_prefix
-        result = _client("cloudwatch", region, role_arn).describe_alarms(**kwargs)
+        client = _client("cloudwatch", region, role_arn)
+        # Bounded pagination (MAX_PAGES): a single DescribeAlarms page can
+        # come back with NextToken set even when this page alone answered
+        # "nothing is wrong" -- fetching only one page could hide a firing
+        # alarm sitting on the next one.
+        raw_alarms: list[dict[str, Any]] = []
+        raw_composite_alarms: list[dict[str, Any]] = []
+        next_token: str | None = None
+        for _ in range(MAX_PAGES):
+            if next_token:
+                kwargs["NextToken"] = next_token
+            result = client.describe_alarms(**kwargs)
+            raw_alarms.extend(result.get("MetricAlarms") or [])
+            # DescribeAlarms returns composite alarms (account-level "is the
+            # service healthy" rollups aggregating leaf alarms) in a separate
+            # top-level field sharing the same page/cursor. Omitting them
+            # would let this triage tool report "nothing is wrong" while the
+            # account's top rollup alarm is firing.
+            raw_composite_alarms.extend(result.get("CompositeAlarms") or [])
+            next_token = result.get("NextToken")
+            if not next_token:
+                break
         alarms = [
             {
                 "name": alarm.get("AlarmName"),
@@ -334,13 +407,8 @@ def aws_cloudwatch_describe_alarms(
                 "threshold": alarm.get("Threshold"),
                 "comparison": alarm.get("ComparisonOperator"),
             }
-            for alarm in (result.get("MetricAlarms") or [])
+            for alarm in raw_alarms
         ]
-        # DescribeAlarms returns composite alarms (account-level "is the
-        # service healthy" rollups aggregating leaf alarms) in a separate
-        # top-level field sharing the same MaxRecords budget. Omitting them
-        # would let this triage tool report "nothing is wrong" while the
-        # account's top rollup alarm is firing.
         composite_alarms = [
             {
                 "name": alarm.get("AlarmName"),
@@ -349,12 +417,12 @@ def aws_cloudwatch_describe_alarms(
                 "state_updated": alarm.get("StateUpdatedTimestamp"),
                 "alarm_rule": alarm.get("AlarmRule"),
             }
-            for alarm in (result.get("CompositeAlarms") or [])
+            for alarm in raw_composite_alarms
         ]
         return _success(
             alarms=alarms,
             composite_alarms=composite_alarms,
-            truncated="NextToken" in result,
+            truncated=bool(next_token),
         )
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing CloudWatch alarms: {e}")
@@ -463,16 +531,26 @@ def aws_cloudwatch_describe_log_groups(
         kwargs: dict[str, Any] = {"limit": 50}
         if name_prefix:
             kwargs["logGroupNamePrefix"] = name_prefix
-        result = _client("logs", region, role_arn).describe_log_groups(**kwargs)
+        client = _client("logs", region, role_arn)
+        raw_groups: list[dict[str, Any]] = []
+        next_token: str | None = None
+        for _ in range(MAX_PAGES):
+            if next_token:
+                kwargs["nextToken"] = next_token
+            result = client.describe_log_groups(**kwargs)
+            raw_groups.extend(result.get("logGroups") or [])
+            next_token = result.get("nextToken")
+            if not next_token:
+                break
         groups = [
             {
                 "name": group.get("logGroupName"),
                 "stored_bytes": group.get("storedBytes"),
                 "retention_days": group.get("retentionInDays"),
             }
-            for group in (result.get("logGroups") or [])
+            for group in raw_groups
         ]
-        return _success(log_groups=groups, truncated="nextToken" in result)
+        return _success(log_groups=groups, truncated=bool(next_token))
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error describing log groups: {e}")
         return _error(_aws_error_message(e, bool(role_arn)))
@@ -504,11 +582,12 @@ def aws_cloudwatch_filter_log_events(
     own permissions.
     """
     try:
+        max_events = max(1, min(int(limit), MAX_LOG_EVENTS))
         kwargs: dict[str, Any] = {
             "logGroupName": log_group_name,
             # Clamp to [1, MAX_LOG_EVENTS]: a zero/negative limit passes the
             # int signature validation but AWS rejects it remotely.
-            "limit": max(1, min(int(limit), MAX_LOG_EVENTS)),
+            "limit": max_events,
         }
         if filter_pattern:
             kwargs["filterPattern"] = filter_pattern
@@ -516,16 +595,36 @@ def aws_cloudwatch_filter_log_events(
             kwargs["startTime"] = int(start_time_ms)
         if end_time_ms is not None:
             kwargs["endTime"] = int(end_time_ms)
-        result = _client("logs", region, role_arn).filter_log_events(**kwargs)
+        client = _client("logs", region, role_arn)
+        # Bounded pagination (MAX_PAGES): FilterLogEvents can come back with
+        # a partially-full (or even empty) page and nextToken still set, so
+        # stopping after one page could report "no matches" during an
+        # incident while matching events sit on a later page.
+        raw_events: list[dict[str, Any]] = []
+        next_token: str | None = None
+        for _ in range(MAX_PAGES):
+            if next_token:
+                kwargs["nextToken"] = next_token
+            # Shrink the per-page request to the remaining budget: without
+            # this, a page could return more than what's left toward
+            # max_events, requiring the surplus to be discarded below and
+            # muddying "truncated" into a len(raw_events) > max_events check
+            # instead of simply "is there still a next_token".
+            kwargs["limit"] = max_events - len(raw_events)
+            result = client.filter_log_events(**kwargs)
+            raw_events.extend(result.get("events") or [])
+            next_token = result.get("nextToken")
+            if len(raw_events) >= max_events or not next_token:
+                break
         events = [
             {
                 "timestamp_ms": event.get("timestamp"),
                 "log_stream": event.get("logStreamName"),
                 "message": _truncate_message(event.get("message")),
             }
-            for event in (result.get("events") or [])
+            for event in raw_events
         ]
-        return _success(events=events, truncated="nextToken" in result)
+        return _success(events=events, truncated=bool(next_token))
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error filtering log events: {e}")
         return _error(_aws_error_message(e, bool(role_arn)))
@@ -546,11 +645,22 @@ def aws_dynamodb_list_tables(
     own permissions.
     """
     try:
-        result = _client("dynamodb", region, role_arn).list_tables(Limit=100)
-        return _success(
-            tables=result.get("TableNames") or [],
-            truncated="LastEvaluatedTableName" in result,
-        )
+        client = _client("dynamodb", region, role_arn)
+        kwargs: dict[str, Any] = {"Limit": 100}
+        raw_tables: list[str] = []
+        # ListTables' own pagination cursor: ExclusiveStartTableName on the
+        # request, LastEvaluatedTableName on the response (unlike the
+        # NextToken/nextToken name shared by every other tool here).
+        next_token: str | None = None
+        for _ in range(MAX_PAGES):
+            if next_token:
+                kwargs["ExclusiveStartTableName"] = next_token
+            result = client.list_tables(**kwargs)
+            raw_tables.extend(result.get("TableNames") or [])
+            next_token = result.get("LastEvaluatedTableName")
+            if not next_token:
+                break
+        return _success(tables=raw_tables, truncated=bool(next_token))
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing DynamoDB tables: {e}")
         return _error(_aws_error_message(e, bool(role_arn)))
@@ -617,14 +727,21 @@ def aws_sqs_list_queues(
     own permissions.
     """
     try:
+        client = _client("sqs", region, role_arn)
         kwargs: dict[str, Any] = {"MaxResults": 100}
         if name_prefix:
             kwargs["QueueNamePrefix"] = name_prefix
-        result = _client("sqs", region, role_arn).list_queues(**kwargs)
-        return _success(
-            queue_urls=result.get("QueueUrls") or [],
-            truncated="NextToken" in result,
-        )
+        raw_queue_urls: list[str] = []
+        next_token: str | None = None
+        for _ in range(MAX_PAGES):
+            if next_token:
+                kwargs["NextToken"] = next_token
+            result = client.list_queues(**kwargs)
+            raw_queue_urls.extend(result.get("QueueUrls") or [])
+            next_token = result.get("NextToken")
+            if not next_token:
+                break
+        return _success(queue_urls=raw_queue_urls, truncated=bool(next_token))
     except (ClientError, BotoCoreError, ValueError) as e:
         logger.error(f"Error listing SQS queues: {e}")
         return _error(_aws_error_message(e, bool(role_arn)))
@@ -636,8 +753,11 @@ def aws_sqs_get_queue_attributes(
 ) -> str:
     """
     Get an SQS queue's attributes — most importantly backlog depth
-    (ApproximateNumberOfMessages), in-flight count, oldest message age, and
-    the redrive/DLQ policy — the key signals for "is this queue backed up".
+    (ApproximateNumberOfMessages), in-flight count, and the redrive/DLQ
+    policy — the key signals for "is this queue backed up". For oldest
+    message age (not one of GetQueueAttributes' own attributes), use
+    aws_cloudwatch_get_metric_data with namespace "AWS/SQS" and metric_name
+    "ApproximateAgeOfOldestMessage" instead.
     region: optional AWS region override; defaults to the connector's
     configured AWS_REGION.
     role_arn: optional IAM role ARN to assume (cross-account access) before
@@ -648,7 +768,7 @@ def aws_sqs_get_queue_attributes(
     """
     try:
         result = _client("sqs", region, role_arn).get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["All"]
+            QueueUrl=queue_url, AttributeNames=SQS_DIAGNOSTIC_ATTRIBUTES
         )
         return _success(attributes=result.get("Attributes") or {})
     except (ClientError, BotoCoreError, ValueError) as e:

--- a/tests/alembic/test_20260731_seed_aws_mcp_app.py
+++ b/tests/alembic/test_20260731_seed_aws_mcp_app.py
@@ -86,7 +86,7 @@ def test_upgrade_is_idempotent(tmp_path):
         assert rows == 1
 
 
-def test_seed_row_matches_registry(tmp_path):
+def test_seed_row_matches_registry():
     """The migration snapshot and the runtime registry must define the same
     aws row (the migration is a frozen copy; this catches drift)."""
     from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows

--- a/tests/alembic/test_20260731_seed_aws_mcp_app.py
+++ b/tests/alembic/test_20260731_seed_aws_mcp_app.py
@@ -1,0 +1,124 @@
+"""Tests for the AWS MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260731_seed_aws_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_aws_migration", migration_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_aws(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "aws" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='aws'"
+            )
+        ).first()
+        assert row[0] == "stdio"
+        assert row[1] is None
+        assert "xagent.web.tools.mcp.aws" in str(row[2])
+        for env_key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"):
+            assert env_key in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='aws'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    aws row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "aws"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_aws(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "aws" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -771,6 +771,12 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
         "auth": {"type": "mcp_oauth"},
     }
 
+    assert rows_by_app_id["aws"]["launch_config"] == {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.aws"],
+        "required_env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"],
+    }
+
 
 def test_builtin_registry_classifies_granola_as_mcp_oauth() -> None:
     """The registry shape must classify as mcp_oauth — anything else means the
@@ -781,6 +787,7 @@ def test_builtin_registry_classifies_granola_as_mcp_oauth() -> None:
 
     row = next(r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "granola")
     assert classify_app_auth(row["transport"], row["launch_config"]) == "mcp_oauth"
+
 
 
 def test_builtin_registry_helpers_use_exact_ids_and_return_defensive_copies() -> None:

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -789,7 +789,6 @@ def test_builtin_registry_classifies_granola_as_mcp_oauth() -> None:
     assert classify_app_auth(row["transport"], row["launch_config"]) == "mcp_oauth"
 
 
-
 def test_builtin_registry_helpers_use_exact_ids_and_return_defensive_copies() -> None:
     from xagent.web.builtin_mcp_registry import (
         get_builtin_execution_fields,

--- a/tests/web/services/test_mcp_shared_env_hook.py
+++ b/tests/web/services/test_mcp_shared_env_hook.py
@@ -98,6 +98,17 @@ def test_caller_id_env_empty_without_user_id():
     assert mcp_runtime.caller_id_env(None) == {}
 
 
+def test_caller_id_env_var_name_matches_aws_connector_literal():
+    """CALLER_ID_ENV_VAR is duplicated as an independent literal in
+    xagent.web.tools.mcp.aws (a standalone subprocess entrypoint that can't
+    import this module), with no other check tying the two together. A
+    rename on either side would silently degrade attribution back to the
+    un-attributed default without failing any other test."""
+    from xagent.web.tools.mcp import aws
+
+    assert aws.CALLER_ID_ENV_VAR == mcp_runtime.CALLER_ID_ENV_VAR
+
+
 class _FakeStdioServer:
     """Minimal stand-in for MCPServer: just enough for the stdio branch of
     build_mcp_runtime_connection (transport check + auth decrypt call)."""
@@ -138,8 +149,12 @@ def test_build_mcp_runtime_connection_omits_caller_id_without_user():
 
 
 def test_build_mcp_runtime_connection_caller_id_wins_over_user_overrides():
-    """Overrides still apply, but the caller-id layer is merged in last so it
-    can never be shadowed by a stale/forged XAGENT_MCP_CALLER_ID override."""
+    """When a real user_id is present, overrides still apply, but the
+    caller-id layer is merged in last so it can never be shadowed by a
+    stale/forged XAGENT_MCP_CALLER_ID override. This guarantee is
+    conditional on user_id being set — see the user_id=None test below,
+    where caller_id_env contributes nothing and a forged override passes
+    through unchanged."""
     server = _FakeStdioServer({"transport": "stdio", "env": {"FOO": "global"}})
 
     build = asyncio.run(
@@ -152,3 +167,22 @@ def test_build_mcp_runtime_connection_caller_id_wins_over_user_overrides():
     )
 
     assert build.connection["env"]["XAGENT_MCP_CALLER_ID"] == "42"
+
+
+def test_build_mcp_runtime_connection_without_user_id_does_not_scrub_forged_override():
+    """Without a user_id, caller_id_env returns {} and contributes nothing —
+    a pre-existing or forged XAGENT_MCP_CALLER_ID override passes through to
+    the subprocess env unchanged. The "can never be shadowed" guarantee in
+    the test above only holds once user_id is set."""
+    server = _FakeStdioServer({"transport": "stdio", "env": {"FOO": "global"}})
+
+    build = asyncio.run(
+        mcp_runtime.build_mcp_runtime_connection(
+            db=None,
+            server=server,
+            user_id=None,
+            user_env_overrides={5: {"XAGENT_MCP_CALLER_ID": "spoofed"}},
+        )
+    )
+
+    assert build.connection["env"]["XAGENT_MCP_CALLER_ID"] == "spoofed"

--- a/tests/web/services/test_mcp_shared_env_hook.py
+++ b/tests/web/services/test_mcp_shared_env_hook.py
@@ -1,5 +1,7 @@
 """Tests for the shared (app-injected) MCP env hook and layered merge."""
 
+import asyncio
+
 from xagent.web.services import mcp_runtime
 
 
@@ -86,3 +88,67 @@ def test_shared_env_hook_failure_degrades_to_empty():
         assert mcp_runtime.load_shared_env_overrides("db", 7) == {}
     finally:
         mcp_runtime.set_mcp_shared_env_hook(None)
+
+
+def test_caller_id_env_returns_user_id_keyed_var():
+    assert mcp_runtime.caller_id_env(42) == {"XAGENT_MCP_CALLER_ID": "42"}
+
+
+def test_caller_id_env_empty_without_user_id():
+    assert mcp_runtime.caller_id_env(None) == {}
+
+
+class _FakeStdioServer:
+    """Minimal stand-in for MCPServer: just enough for the stdio branch of
+    build_mcp_runtime_connection (transport check + auth decrypt call)."""
+
+    def __init__(self, connection, server_id=5):
+        self._connection = connection
+        self.id = server_id
+        self.transport = connection.get("transport")
+
+    def to_connection_dict(self):
+        return dict(self._connection)
+
+    def _decrypt_auth_config(self, auth):
+        return {}
+
+
+def test_build_mcp_runtime_connection_injects_caller_id_for_stdio():
+    """Every stdio connection gets the caller's user id, even with no other
+    env overrides present — this is what lets a connector like the AWS MCP
+    module attribute its own external calls to a specific xagent user."""
+    server = _FakeStdioServer({"transport": "stdio", "env": {"FOO": "bar"}})
+
+    build = asyncio.run(
+        mcp_runtime.build_mcp_runtime_connection(db=None, server=server, user_id=42)
+    )
+
+    assert build.connection["env"] == {"FOO": "bar", "XAGENT_MCP_CALLER_ID": "42"}
+
+
+def test_build_mcp_runtime_connection_omits_caller_id_without_user():
+    server = _FakeStdioServer({"transport": "stdio", "env": {"FOO": "bar"}})
+
+    build = asyncio.run(
+        mcp_runtime.build_mcp_runtime_connection(db=None, server=server, user_id=None)
+    )
+
+    assert build.connection["env"] == {"FOO": "bar"}
+
+
+def test_build_mcp_runtime_connection_caller_id_wins_over_user_overrides():
+    """Overrides still apply, but the caller-id layer is merged in last so it
+    can never be shadowed by a stale/forged XAGENT_MCP_CALLER_ID override."""
+    server = _FakeStdioServer({"transport": "stdio", "env": {"FOO": "global"}})
+
+    build = asyncio.run(
+        mcp_runtime.build_mcp_runtime_connection(
+            db=None,
+            server=server,
+            user_id=42,
+            user_env_overrides={5: {"XAGENT_MCP_CALLER_ID": "spoofed"}},
+        )
+    )
+
+    assert build.connection["env"]["XAGENT_MCP_CALLER_ID"] == "42"

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -310,22 +310,30 @@ def _sts_with_assume_role(expires_in_seconds: int) -> Mock:
     return sts
 
 
+def _patch_boto3_session(monkeypatch, client_factory) -> Mock:
+    """Patch boto3.Session so every new session's .client() delegates to
+    client_factory; returns the shared client Mock for call assertions."""
+    session_client = Mock(side_effect=client_factory)
+    session = Mock()
+    session.client = session_client
+    monkeypatch.setattr(aws.boto3, "Session", Mock(return_value=session))
+    return session_client
+
+
 def test_client_with_role_arn_assumes_role_and_caches(monkeypatch):
     sts = _sts_with_assume_role(expires_in_seconds=3600)
     service_client = Mock()
-    boto3_client = Mock(
-        side_effect=lambda service, **kwargs: (
-            sts if service == "sts" else service_client
-        )
+    session_client = _patch_boto3_session(
+        monkeypatch,
+        lambda service, **kwargs: sts if service == "sts" else service_client,
     )
-    monkeypatch.setattr(aws.boto3, "client", boto3_client)
 
     first = aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
     second = aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
 
     assert first is service_client and second is service_client
     assert sts.assume_role.call_count == 1  # cached on second call
-    sqs_calls = [c for c in boto3_client.call_args_list if c.args[0] == "sqs"]
+    sqs_calls = [c for c in session_client.call_args_list if c.args[0] == "sqs"]
     assert sqs_calls[0].kwargs["aws_access_key_id"] == "ASIA-temp"
     assert sqs_calls[0].kwargs["aws_session_token"] == "temp-token"
 
@@ -334,10 +342,9 @@ def test_client_with_role_arn_refreshes_near_expiry(monkeypatch):
     sts = _sts_with_assume_role(
         expires_in_seconds=aws.ASSUME_ROLE_EXPIRY_MARGIN_SECONDS - 10
     )
-    boto3_client = Mock(
-        side_effect=lambda service, **kwargs: sts if service == "sts" else Mock()
+    _patch_boto3_session(
+        monkeypatch, lambda service, **kwargs: sts if service == "sts" else Mock()
     )
-    monkeypatch.setattr(aws.boto3, "client", boto3_client)
 
     aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
     aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
@@ -346,10 +353,34 @@ def test_client_with_role_arn_refreshes_near_expiry(monkeypatch):
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):
-    boto3_client = Mock(return_value=Mock())
-    monkeypatch.setattr(aws.boto3, "client", boto3_client)
+    session_client = _patch_boto3_session(monkeypatch, lambda service, **kwargs: Mock())
 
     aws._client("cloudwatch")
 
-    kwargs = boto3_client.call_args.kwargs
+    kwargs = session_client.call_args.kwargs
     assert kwargs == {"region_name": "us-east-1"}  # no explicit creds → env chain
+
+
+def test_client_creates_a_fresh_session_per_call(monkeypatch):
+    """The default shared boto3 session is not thread-safe for concurrent
+    client creation; each _client call must build its own Session."""
+    session_factory = Mock(side_effect=lambda: Mock(client=Mock(return_value=Mock())))
+    monkeypatch.setattr(aws.boto3, "Session", session_factory)
+
+    aws._client("cloudwatch")
+    aws._client("sqs")
+
+    assert session_factory.call_count == 2
+
+
+def test_filter_log_events_clamps_non_positive_limit(monkeypatch):
+    logs = Mock()
+    logs.filter_log_events.return_value = {"events": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod", limit=0)
+    )
+
+    assert result["status"] == "success"
+    assert logs.filter_log_events.call_args.kwargs["limit"] == 1

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -95,6 +94,35 @@ def test_describe_alarms_flags_truncated_when_next_token_present(monkeypatch):
     result = json.loads(aws.aws_cloudwatch_describe_alarms())
 
     assert result["truncated"] is True
+
+
+def test_describe_alarms_surfaces_composite_alarms(monkeypatch):
+    """DescribeAlarms returns composite (rollup) alarms in a separate
+    top-level field from MetricAlarms; a firing composite alarm must not be
+    silently dropped from this triage tool's output."""
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.return_value = {
+        "MetricAlarms": [],
+        "CompositeAlarms": [
+            {
+                "AlarmName": "service-health-rollup",
+                "StateValue": "ALARM",
+                "StateReason": "1 out of 3 alarms in ALARM",
+                "AlarmRule": "ALARM(high-cpu) OR ALARM(high-latency)",
+            }
+        ],
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(aws.aws_cloudwatch_describe_alarms())
+
+    assert result["status"] == "success"
+    assert result["alarms"] == []
+    assert result["composite_alarms"][0]["name"] == "service-health-rollup"
+    assert result["composite_alarms"][0]["state"] == "ALARM"
+    assert result["composite_alarms"][0]["alarm_rule"] == (
+        "ALARM(high-cpu) OR ALARM(high-latency)"
+    )
 
 
 def test_describe_alarms_omits_filters_when_not_given(monkeypatch):
@@ -403,15 +431,13 @@ def test_sqs_get_queue_attributes_requests_all(monkeypatch):
 # --- assume-role plumbing -------------------------------------------------
 
 
-def _sts_with_assume_role(expires_in_seconds: int) -> Mock:
+def _sts_with_assume_role() -> Mock:
     sts = Mock()
     sts.assume_role.return_value = {
         "Credentials": {
             "AccessKeyId": "ASIA-temp",
             "SecretAccessKey": "temp-secret",
             "SessionToken": "temp-token",
-            "Expiration": datetime.now(timezone.utc)
-            + timedelta(seconds=expires_in_seconds),
         }
     }
     return sts
@@ -431,7 +457,7 @@ def test_client_with_role_arn_assumes_role_on_every_call(monkeypatch):
     """Each MCP tool call runs in its own short-lived subprocess, so there is
     no in-process caching layer to test — every _client() call with a
     role_arn must exchange it for fresh temporary credentials."""
-    sts = _sts_with_assume_role(expires_in_seconds=3600)
+    sts = _sts_with_assume_role()
     service_client = Mock()
     session_client = _patch_boto3_session(
         monkeypatch,
@@ -484,7 +510,7 @@ def test_role_session_name_truncates_to_64_chars(monkeypatch):
 
 def test_assume_role_credentials_uses_caller_attributed_session_name(monkeypatch):
     monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "7")
-    sts = _sts_with_assume_role(expires_in_seconds=3600)
+    sts = _sts_with_assume_role()
     _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
 
     aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
@@ -518,6 +544,44 @@ def test_client_creates_a_fresh_session_per_call(monkeypatch):
     aws._client("sqs")
 
     assert session_factory.call_count == 2
+
+
+def test_client_creates_independent_sessions_for_sts_and_service_on_role_arn_path(
+    monkeypatch,
+):
+    """On the role_arn (cross-account) path, a single _client() call must
+    create two independent boto3.Session objects -- one for the STS
+    assume_role exchange (inside _assume_role_credentials), one for the
+    final service client -- neither reused from the other.
+    test_client_creates_a_fresh_session_per_call never passes role_arn, and
+    _patch_boto3_session's shared-Session mock can't tell "one Session
+    reused across both calls" from "two independent Sessions"."""
+    sessions: list[Mock] = []
+
+    def make_client(service: str, **kwargs) -> Mock:
+        client = Mock()
+        if service == "sts":
+            client.assume_role.return_value = {
+                "Credentials": {
+                    "AccessKeyId": "ASIA-temp",
+                    "SecretAccessKey": "temp-secret",
+                    "SessionToken": "temp-token",
+                }
+            }
+        return client
+
+    def session_factory() -> Mock:
+        session = Mock()
+        session.client = Mock(side_effect=make_client)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(aws.boto3, "Session", Mock(side_effect=session_factory))
+
+    aws._client("cloudwatch", role_arn="arn:aws:iam::2:role/read")
+
+    assert len(sessions) == 2
+    assert sessions[0] is not sessions[1]
 
 
 def test_filter_log_events_clamps_non_positive_limit(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -81,6 +81,7 @@ def test_describe_alarms_passes_state_filter_and_shapes_output(monkeypatch):
     assert result["status"] == "success"
     assert result["alarms"][0]["name"] == "high-cpu"
     assert result["alarms"][0]["state"] == "ALARM"
+    assert result["truncated"] is False
     assert cloudwatch.describe_alarms.call_args.kwargs["StateValue"] == "ALARM"
 
 
@@ -223,13 +224,17 @@ def test_describe_log_groups_filters_by_prefix(monkeypatch):
 
 def test_dynamodb_list_tables(monkeypatch):
     dynamodb = Mock()
-    dynamodb.list_tables.return_value = {"TableNames": ["orders", "users"]}
+    dynamodb.list_tables.return_value = {
+        "TableNames": ["orders", "users"],
+        "LastEvaluatedTableName": "users",
+    }
     monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
 
     result = json.loads(aws.aws_dynamodb_list_tables())
 
     assert result["status"] == "success"
     assert result["tables"] == ["orders", "users"]
+    assert result["truncated"] is True
 
 
 def test_dynamodb_describe_table_shapes_health_fields(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -13,7 +13,6 @@ def _credentials(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-test")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-test")
     monkeypatch.setenv("AWS_REGION", "us-east-1")
-    aws._assumed_role_cache.clear()
 
 
 def _client_error(code: str, message: str, operation: str = "Op") -> ClientError:
@@ -107,6 +106,7 @@ def test_get_metric_data_builds_query_and_returns_series(monkeypatch):
                 "Label": "CPUUtilization",
                 "Timestamps": ["2026-07-30T00:00:00Z"],
                 "Values": [42.5],
+                "StatusCode": "Complete",
             }
         ]
     }
@@ -125,11 +125,17 @@ def test_get_metric_data_builds_query_and_returns_series(monkeypatch):
 
     assert result["status"] == "success"
     assert result["values"] == [42.5]
+    assert result["status_code"] == "Complete"
+    assert result["partial"] is False
     query = cloudwatch.get_metric_data.call_args.kwargs["MetricDataQueries"][0]
     assert query["MetricStat"]["Stat"] == "Maximum"
     assert query["MetricStat"]["Metric"]["Dimensions"] == [
         {"Name": "InstanceId", "Value": "i-123"}
     ]
+    assert (
+        cloudwatch.get_metric_data.call_args.kwargs["MaxDatapoints"]
+        == aws.MAX_METRIC_DATAPOINTS
+    )
 
 
 def test_get_metric_data_handles_empty_series(monkeypatch):
@@ -149,6 +155,44 @@ def test_get_metric_data_handles_empty_series(monkeypatch):
     assert result["status"] == "success"
     assert result["timestamps"] == []
     assert result["values"] == []
+    assert result["partial"] is False
+
+
+def test_get_metric_data_flags_partial_data_and_surfaces_messages(monkeypatch):
+    """StatusCode other than "Complete" (PartialData/InternalError) means
+    CloudWatch could not fully answer the query — this must be distinguishable
+    from a clean "no data in this range" result."""
+    cloudwatch = Mock()
+    cloudwatch.get_metric_data.return_value = {
+        "MetricDataResults": [
+            {
+                "Label": "CPUUtilization",
+                "Timestamps": [],
+                "Values": [],
+                "StatusCode": "PartialData",
+            }
+        ],
+        "Messages": [{"Code": "PartialData", "Value": "Some data unavailable"}],
+        "NextToken": "next-page",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(
+        aws.aws_cloudwatch_get_metric_data(
+            namespace="AWS/EC2",
+            metric_name="CPUUtilization",
+            start_time="2026-07-30T00:00:00Z",
+            end_time="2026-07-30T01:00:00Z",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["status_code"] == "PartialData"
+    assert result["partial"] is True
+    assert result["messages"] == [
+        {"Code": "PartialData", "Value": "Some data unavailable"}
+    ]
+    assert result["truncated"] is True
 
 
 def test_tools_tolerate_explicit_none_values_in_responses(monkeypatch):
@@ -320,7 +364,10 @@ def _patch_boto3_session(monkeypatch, client_factory) -> Mock:
     return session_client
 
 
-def test_client_with_role_arn_assumes_role_and_caches(monkeypatch):
+def test_client_with_role_arn_assumes_role_on_every_call(monkeypatch):
+    """Each MCP tool call runs in its own short-lived subprocess, so there is
+    no in-process caching layer to test — every _client() call with a
+    role_arn must exchange it for fresh temporary credentials."""
     sts = _sts_with_assume_role(expires_in_seconds=3600)
     service_client = Mock()
     session_client = _patch_boto3_session(
@@ -332,24 +379,13 @@ def test_client_with_role_arn_assumes_role_and_caches(monkeypatch):
     second = aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
 
     assert first is service_client and second is service_client
-    assert sts.assume_role.call_count == 1  # cached on second call
+    assert sts.assume_role.call_count == 2
     sqs_calls = [c for c in session_client.call_args_list if c.args[0] == "sqs"]
     assert sqs_calls[0].kwargs["aws_access_key_id"] == "ASIA-temp"
     assert sqs_calls[0].kwargs["aws_session_token"] == "temp-token"
-
-
-def test_client_with_role_arn_refreshes_near_expiry(monkeypatch):
-    sts = _sts_with_assume_role(
-        expires_in_seconds=aws.ASSUME_ROLE_EXPIRY_MARGIN_SECONDS - 10
-    )
-    _patch_boto3_session(
-        monkeypatch, lambda service, **kwargs: sts if service == "sts" else Mock()
-    )
-
-    aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
-    aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
-
-    assert sts.assume_role.call_count == 2  # inside margin → refreshed
+    assert sqs_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
+    sts_calls = [c for c in session_client.call_args_list if c.args[0] == "sts"]
+    assert sts_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):
@@ -358,7 +394,11 @@ def test_client_without_role_arn_uses_env_credentials(monkeypatch):
     aws._client("cloudwatch")
 
     kwargs = session_client.call_args.kwargs
-    assert kwargs == {"region_name": "us-east-1"}  # no explicit creds → env chain
+    # no explicit creds → env chain; a timeout/retry config is still applied
+    assert kwargs == {
+        "region_name": "us-east-1",
+        "config": aws.DEFAULT_CLIENT_CONFIG,
+    }
 
 
 def test_client_creates_a_fresh_session_per_call(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -595,3 +595,186 @@ def test_filter_log_events_clamps_non_positive_limit(monkeypatch):
 
     assert result["status"] == "success"
     assert logs.filter_log_events.call_args.kwargs["limit"] == 1
+
+
+def test_filter_log_events_truncates_oversized_messages(monkeypatch):
+    """CloudWatch messages can carry a full stack trace or serialized
+    payload; MAX_LOG_EVENTS bounds count but not size, so an individual
+    message must still be capped to keep a full batch's worst case
+    bounded (PR review finding R3-m2)."""
+    long_message = "x" * (aws.MAX_LOG_MESSAGE_CHARS + 500)
+    logs = Mock()
+    logs.filter_log_events.return_value = {
+        "events": [{"timestamp": 1, "logStreamName": "s1", "message": long_message}]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod")
+    )
+
+    message = result["events"][0]["message"]
+    assert len(message) < len(long_message)
+    assert message.startswith("x" * 100)
+    assert "truncated" in message
+
+
+def test_filter_log_events_leaves_short_messages_untouched(monkeypatch):
+    logs = Mock()
+    logs.filter_log_events.return_value = {
+        "events": [{"timestamp": 1, "logStreamName": "s1", "message": "short"}]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod")
+    )
+
+    assert result["events"][0]["message"] == "short"
+
+
+def test_truncate_message_passes_through_non_str_without_raising():
+    """CloudWatch Logs documents `message` as always a string, but
+    _truncate_message must not raise TypeError on a non-str value - the
+    caller's except clause doesn't include TypeError, so an uncaught one
+    would crash the tool call instead of degrading gracefully."""
+    assert aws._truncate_message(None) is None
+    assert aws._truncate_message(12345) == 12345
+
+
+# --- server-side page-size caps (PR review finding R3-m6) -----------------
+
+
+def test_describe_log_groups_sends_the_50_item_hard_cap(monkeypatch):
+    logs = Mock()
+    logs.describe_log_groups.return_value = {"logGroups": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    aws.aws_cloudwatch_describe_log_groups()
+
+    assert logs.describe_log_groups.call_args.kwargs["limit"] == 50
+
+
+def test_describe_alarms_sends_the_100_record_cap(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.return_value = {"MetricAlarms": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    aws.aws_cloudwatch_describe_alarms()
+
+    assert cloudwatch.describe_alarms.call_args.kwargs["MaxRecords"] == 100
+
+
+def test_dynamodb_list_tables_sends_the_100_item_cap(monkeypatch):
+    dynamodb = Mock()
+    dynamodb.list_tables.return_value = {"TableNames": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
+
+    aws.aws_dynamodb_list_tables()
+
+    assert dynamodb.list_tables.call_args.kwargs["Limit"] == 100
+
+
+def test_sqs_list_queues_sends_the_100_result_cap(monkeypatch):
+    sqs = Mock()
+    sqs.list_queues.return_value = {"QueueUrls": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sqs))
+
+    aws.aws_sqs_list_queues()
+
+    assert sqs.list_queues.call_args.kwargs["MaxResults"] == 100
+
+
+# --- explicit region= plumbing (PR review finding R3-m6) -------------------
+
+
+def test_client_passes_explicit_region_to_boto3(monkeypatch):
+    session_client = _patch_boto3_session(monkeypatch, lambda service, **kwargs: Mock())
+
+    aws._client("cloudwatch", region="eu-west-1")
+
+    assert session_client.call_args.kwargs["region_name"] == "eu-west-1"
+
+
+def test_tool_call_with_explicit_region_reaches_boto3(monkeypatch):
+    """Regression test for R3-m6: an explicit region= argument passed to a
+    real tool function (not just _client() directly) must reach the
+    eventual boto3 client call. The no-AWS_REGION-env case is covered
+    separately by
+    test_explicit_region_satisfies_the_region_requirement_without_env_var."""
+    dynamodb = Mock()
+    dynamodb.list_tables.return_value = {"TableNames": []}
+    session_client = _patch_boto3_session(
+        monkeypatch, lambda service, **kwargs: dynamodb
+    )
+
+    result = json.loads(aws.aws_dynamodb_list_tables(region="ap-southeast-2"))
+
+    assert result["status"] == "success"
+    assert session_client.call_args.kwargs["region_name"] == "ap-southeast-2"
+
+
+def test_explicit_region_satisfies_the_region_requirement_without_env_var(monkeypatch):
+    """Regression test for R3-m1: _require_base_credentials used to check
+    the AWS_REGION env var directly, so an explicit region= argument could
+    not satisfy it - _client would raise even though the caller supplied
+    everything it needed."""
+    monkeypatch.delenv("AWS_REGION")
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: Mock())
+
+    # Must not raise.
+    aws._client("sts", region="us-west-2")
+
+
+def test_missing_region_without_explicit_override_still_reported(monkeypatch):
+    monkeypatch.delenv("AWS_REGION")
+
+    result = json.loads(aws.aws_get_caller_identity())
+
+    assert result["status"] == "error"
+    assert "AWS_REGION" in result["message"]
+
+
+# --- malformed AssumeRole response (PR review finding R3-M1) ---------------
+
+
+def test_assume_role_credentials_rejects_null_credential_fields(monkeypatch):
+    """AWS's documented AssumeRole contract says a 200 always returns a
+    complete Credentials block, but if it ever didn't, spreading
+    {"aws_access_key_id": None, ...} into session.client() would make
+    botocore silently fall back to the connector's own base/ambient
+    credentials - a cross-account call would then run under the wrong
+    identity with no error at all. Must fail loudly instead."""
+    sts = Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": None,
+            "SecretAccessKey": None,
+            "SessionToken": None,
+        }
+    }
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
+
+    with pytest.raises(ValueError, match="incomplete credential set"):
+        aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
+
+
+def test_client_with_role_arn_surfaces_null_credentials_as_a_clean_error(monkeypatch):
+    """End-to-end: a tool call must translate the malformed-response
+    ValueError into the standard error envelope, not an unhandled crash."""
+    sts = Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": None,
+            "SecretAccessKey": "temp-secret",
+            "SessionToken": "temp-token",
+        }
+    }
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
+
+    result = json.loads(
+        aws.aws_get_caller_identity(role_arn="arn:aws:iam::2:role/read")
+    )
+
+    assert result["status"] == "error"
+    assert "incomplete credential set" in result["message"]

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -57,6 +57,49 @@ def test_client_error_surfaces_code_and_message(monkeypatch):
     assert "not authorized" in result["message"]
 
 
+def test_access_denied_via_role_arn_gets_a_disambiguating_hint():
+    """PR review finding m5: AccessDenied on a role_arn call could mean the
+    target role's own policy denies the action, OR that this connector's own
+    session policy (_READ_ONLY_SESSION_POLICY) doesn't include it - the raw
+    ClientError looks identical either way, so the role_arn path should name
+    the second possibility explicitly."""
+    exc = _client_error("AccessDenied", "User is not authorized")
+
+    assert "session" in aws._aws_error_message(exc, True).lower()
+
+
+def test_access_denied_without_role_arn_has_no_session_hint():
+    exc = _client_error("AccessDenied", "User is not authorized")
+
+    message = aws._aws_error_message(exc, False)
+
+    assert message == "AccessDenied: User is not authorized"
+
+
+def test_non_access_denied_error_via_role_arn_has_no_session_hint():
+    exc = _client_error("ThrottlingException", "Rate exceeded")
+
+    message = aws._aws_error_message(exc, True)
+
+    assert message == "ThrottlingException: Rate exceeded"
+
+
+def test_access_denied_on_assume_role_itself_has_no_session_hint():
+    """Adversarial-review catch: an AccessDenied raised by the AssumeRole
+    call itself (e.g. the target role's trust policy doesn't allow this
+    principal, or the base credentials lack sts:AssumeRole on that ARN)
+    happens before any session exists, so _READ_ONLY_SESSION_POLICY was
+    never in play. Appending the session-restriction hint here would
+    misdirect an operator toward the wrong fix."""
+    exc = _client_error(
+        "AccessDenied", "not authorized to perform: sts:AssumeRole", "AssumeRole"
+    )
+
+    message = aws._aws_error_message(exc, True)
+
+    assert message == "AccessDenied: not authorized to perform: sts:AssumeRole"
+
+
 def test_describe_alarms_passes_state_filter_and_shapes_output(monkeypatch):
     cloudwatch = Mock()
     cloudwatch.describe_alarms.return_value = {
@@ -522,6 +565,23 @@ def test_assume_role_credentials_uses_caller_attributed_session_name(monkeypatch
     )
 
 
+def test_assume_role_credentials_logs_caller_and_role_for_audit(monkeypatch, caplog):
+    """PR review finding m6: CloudTrail on the *target* account attributes an
+    AssumeRole call via RoleSessionName, but xagent's own logs otherwise have
+    no local record of which caller assumed which role_arn."""
+    monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "7")
+    sts = _sts_with_assume_role()
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
+
+    with caplog.at_level("INFO", logger=aws.logger.name):
+        aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
+
+    assert any(
+        "7" in record.message and "arn:aws:iam::2:role/read" in record.message
+        for record in caplog.records
+    )
+
+
 def test_assume_role_credentials_scopes_the_session_to_read_only_actions(monkeypatch):
     """PR review finding NEW-M1: role_arn is a model-supplied ARN with no
     operator-side allowlist, so the assumed session's actual permissions
@@ -535,9 +595,9 @@ def test_assume_role_credentials_scopes_the_session_to_read_only_actions(monkeyp
     aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
 
     policy = json.loads(sts.assume_role.call_args.kwargs["Policy"])
-    statement = policy["Statement"][0]
-    assert statement["Effect"] == "Allow"
-    assert statement["Resource"] == "*"
+    main_statement, kms_statement = policy["Statement"]
+    assert main_statement["Effect"] == "Allow"
+    assert main_statement["Resource"] == "*"
     # Exact equality, not just a subset check: a subset check alone would
     # still pass if a future tool's action were added to the connector's
     # boto3 calls but never added here, silently leaving that tool
@@ -554,12 +614,28 @@ def test_assume_role_credentials_scopes_the_session_to_read_only_actions(monkeyp
         "dynamodb:DescribeTable",
         "sqs:ListQueues",
         "sqs:GetQueueAttributes",
-        # Required alongside logs:FilterLogEvents to read from a log group
-        # encrypted with a customer-managed KMS key.
-        "kms:Decrypt",
-        "kms:DescribeKey",
     }
-    assert set(statement["Action"]) == expected_actions
+    assert set(main_statement["Action"]) == expected_actions
+
+    # PR review finding M2: kms:Decrypt/kms:DescribeKey (required alongside
+    # logs:FilterLogEvents to read from a log group encrypted with a
+    # customer-managed KMS key) live in their own statement, conditioned to
+    # only apply when the KMS call is made on CloudWatch Logs' behalf --
+    # otherwise this would be the one un-conditioned Resource: "*" grant in
+    # an otherwise tightly-scoped policy.
+    assert kms_statement["Effect"] == "Allow"
+    assert kms_statement["Resource"] == "*"
+    assert set(kms_statement["Action"]) == {"kms:Decrypt", "kms:DescribeKey"}
+    assert kms_statement["Condition"] == {
+        "StringLike": {"kms:ViaService": "logs.*.amazonaws.com"}
+    }
+
+
+def test_read_only_session_policy_stays_under_the_sts_inline_policy_limit():
+    """PR review finding n7: AssumeRole's Policy= parameter has a documented
+    ~2048-character limit; a regression guard here catches the policy
+    growing past it before a real AssumeRole call would reject it."""
+    assert len(aws._READ_ONLY_SESSION_POLICY) < 2048
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -1,0 +1,322 @@
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from xagent.web.tools.mcp import aws
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-test")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    aws._assumed_role_cache.clear()
+
+
+def _client_error(code: str, message: str, operation: str = "Op") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, operation)
+
+
+def test_missing_credentials_reported(monkeypatch):
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY")
+
+    result = json.loads(aws.aws_get_caller_identity())
+
+    assert result["status"] == "error"
+    assert "AWS_SECRET_ACCESS_KEY" in result["message"]
+
+
+def test_get_caller_identity_returns_account_and_arn(monkeypatch):
+    sts = Mock()
+    sts.get_caller_identity.return_value = {
+        "Account": "123456789012",
+        "Arn": "arn:aws:iam::123456789012:user/devops-readonly",
+        "UserId": "AIDATEST",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sts))
+
+    result = json.loads(aws.aws_get_caller_identity())
+
+    assert result["status"] == "success"
+    assert result["account"] == "123456789012"
+    assert "devops-readonly" in result["arn"]
+
+
+def test_client_error_surfaces_code_and_message(monkeypatch):
+    sts = Mock()
+    sts.get_caller_identity.side_effect = _client_error(
+        "AccessDenied", "User is not authorized"
+    )
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sts))
+
+    result = json.loads(aws.aws_get_caller_identity())
+
+    assert result["status"] == "error"
+    assert "AccessDenied" in result["message"]
+    assert "not authorized" in result["message"]
+
+
+def test_describe_alarms_passes_state_filter_and_shapes_output(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.return_value = {
+        "MetricAlarms": [
+            {
+                "AlarmName": "high-cpu",
+                "StateValue": "ALARM",
+                "StateReason": "Threshold crossed",
+                "MetricName": "CPUUtilization",
+                "Namespace": "AWS/EC2",
+                "Threshold": 90.0,
+                "ComparisonOperator": "GreaterThanThreshold",
+            }
+        ]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(aws.aws_cloudwatch_describe_alarms(state="ALARM"))
+
+    assert result["status"] == "success"
+    assert result["alarms"][0]["name"] == "high-cpu"
+    assert result["alarms"][0]["state"] == "ALARM"
+    assert cloudwatch.describe_alarms.call_args.kwargs["StateValue"] == "ALARM"
+
+
+def test_describe_alarms_omits_filters_when_not_given(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.return_value = {"MetricAlarms": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(aws.aws_cloudwatch_describe_alarms())
+
+    assert result["status"] == "success"
+    assert result["alarms"] == []
+    kwargs = cloudwatch.describe_alarms.call_args.kwargs
+    assert "StateValue" not in kwargs
+    assert "AlarmNamePrefix" not in kwargs
+
+
+def test_get_metric_data_builds_query_and_returns_series(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.get_metric_data.return_value = {
+        "MetricDataResults": [
+            {
+                "Label": "CPUUtilization",
+                "Timestamps": ["2026-07-30T00:00:00Z"],
+                "Values": [42.5],
+            }
+        ]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(
+        aws.aws_cloudwatch_get_metric_data(
+            namespace="AWS/EC2",
+            metric_name="CPUUtilization",
+            start_time="2026-07-30T00:00:00Z",
+            end_time="2026-07-30T01:00:00Z",
+            stat="Maximum",
+            dimensions=[{"Name": "InstanceId", "Value": "i-123"}],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["values"] == [42.5]
+    query = cloudwatch.get_metric_data.call_args.kwargs["MetricDataQueries"][0]
+    assert query["MetricStat"]["Stat"] == "Maximum"
+    assert query["MetricStat"]["Metric"]["Dimensions"] == [
+        {"Name": "InstanceId", "Value": "i-123"}
+    ]
+
+
+def test_get_metric_data_handles_empty_series(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.get_metric_data.return_value = {"MetricDataResults": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(
+        aws.aws_cloudwatch_get_metric_data(
+            namespace="AWS/EC2",
+            metric_name="CPUUtilization",
+            start_time="2026-07-30T00:00:00Z",
+            end_time="2026-07-30T01:00:00Z",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["timestamps"] == []
+    assert result["values"] == []
+
+
+def test_filter_log_events_caps_limit_and_passes_window(monkeypatch):
+    logs = Mock()
+    logs.filter_log_events.return_value = {
+        "events": [
+            {"timestamp": 1753900000000, "logStreamName": "s1", "message": "ERROR boom"}
+        ],
+        "nextToken": "more",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(
+            log_group_name="/app/prod",
+            filter_pattern="ERROR",
+            start_time_ms=1753890000000,
+            end_time_ms=1753900000000,
+            limit=5000,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["events"][0]["message"] == "ERROR boom"
+    assert result["truncated"] is True
+    kwargs = logs.filter_log_events.call_args.kwargs
+    assert kwargs["limit"] == aws.MAX_LOG_EVENTS  # capped, not 5000
+    assert kwargs["filterPattern"] == "ERROR"
+    assert kwargs["startTime"] == 1753890000000
+
+
+def test_describe_log_groups_filters_by_prefix(monkeypatch):
+    logs = Mock()
+    logs.describe_log_groups.return_value = {
+        "logGroups": [{"logGroupName": "/app/prod", "storedBytes": 1024}]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(aws.aws_cloudwatch_describe_log_groups(name_prefix="/app"))
+
+    assert result["status"] == "success"
+    assert result["log_groups"][0]["name"] == "/app/prod"
+    assert logs.describe_log_groups.call_args.kwargs["logGroupNamePrefix"] == "/app"
+
+
+def test_dynamodb_list_tables(monkeypatch):
+    dynamodb = Mock()
+    dynamodb.list_tables.return_value = {"TableNames": ["orders", "users"]}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
+
+    result = json.loads(aws.aws_dynamodb_list_tables())
+
+    assert result["status"] == "success"
+    assert result["tables"] == ["orders", "users"]
+
+
+def test_dynamodb_describe_table_shapes_health_fields(monkeypatch):
+    dynamodb = Mock()
+    dynamodb.describe_table.return_value = {
+        "Table": {
+            "TableName": "orders",
+            "TableStatus": "ACTIVE",
+            "ItemCount": 12345,
+            "TableSizeBytes": 987654,
+            "BillingModeSummary": {"BillingMode": "PAY_PER_REQUEST"},
+            "GlobalSecondaryIndexes": [
+                {"IndexName": "by-user", "IndexStatus": "ACTIVE"}
+            ],
+        }
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
+
+    result = json.loads(aws.aws_dynamodb_describe_table("orders"))
+
+    assert result["status"] == "success"
+    assert result["table"]["status"] == "ACTIVE"
+    assert result["table"]["billing_mode"] == "PAY_PER_REQUEST"
+    assert result["table"]["global_secondary_indexes"] == [
+        {"name": "by-user", "status": "ACTIVE"}
+    ]
+
+
+def test_sqs_list_queues_passes_prefix(monkeypatch):
+    sqs = Mock()
+    sqs.list_queues.return_value = {
+        "QueueUrls": ["https://sqs.us-east-1.amazonaws.com/1/jobs"]
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sqs))
+
+    result = json.loads(aws.aws_sqs_list_queues(name_prefix="jobs"))
+
+    assert result["status"] == "success"
+    assert result["queue_urls"] == ["https://sqs.us-east-1.amazonaws.com/1/jobs"]
+    assert sqs.list_queues.call_args.kwargs["QueueNamePrefix"] == "jobs"
+
+
+def test_sqs_get_queue_attributes_requests_all(monkeypatch):
+    sqs = Mock()
+    sqs.get_queue_attributes.return_value = {
+        "Attributes": {"ApproximateNumberOfMessages": "42"}
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sqs))
+
+    result = json.loads(
+        aws.aws_sqs_get_queue_attributes("https://sqs.us-east-1.amazonaws.com/1/jobs")
+    )
+
+    assert result["status"] == "success"
+    assert result["attributes"]["ApproximateNumberOfMessages"] == "42"
+    assert sqs.get_queue_attributes.call_args.kwargs["AttributeNames"] == ["All"]
+
+
+# --- assume-role plumbing -------------------------------------------------
+
+
+def _sts_with_assume_role(expires_in_seconds: int) -> Mock:
+    sts = Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ASIA-temp",
+            "SecretAccessKey": "temp-secret",
+            "SessionToken": "temp-token",
+            "Expiration": datetime.now(timezone.utc)
+            + timedelta(seconds=expires_in_seconds),
+        }
+    }
+    return sts
+
+
+def test_client_with_role_arn_assumes_role_and_caches(monkeypatch):
+    sts = _sts_with_assume_role(expires_in_seconds=3600)
+    service_client = Mock()
+    boto3_client = Mock(
+        side_effect=lambda service, **kwargs: (
+            sts if service == "sts" else service_client
+        )
+    )
+    monkeypatch.setattr(aws.boto3, "client", boto3_client)
+
+    first = aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
+    second = aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
+
+    assert first is service_client and second is service_client
+    assert sts.assume_role.call_count == 1  # cached on second call
+    sqs_calls = [c for c in boto3_client.call_args_list if c.args[0] == "sqs"]
+    assert sqs_calls[0].kwargs["aws_access_key_id"] == "ASIA-temp"
+    assert sqs_calls[0].kwargs["aws_session_token"] == "temp-token"
+
+
+def test_client_with_role_arn_refreshes_near_expiry(monkeypatch):
+    sts = _sts_with_assume_role(
+        expires_in_seconds=aws.ASSUME_ROLE_EXPIRY_MARGIN_SECONDS - 10
+    )
+    boto3_client = Mock(
+        side_effect=lambda service, **kwargs: sts if service == "sts" else Mock()
+    )
+    monkeypatch.setattr(aws.boto3, "client", boto3_client)
+
+    aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
+    aws._client("sqs", role_arn="arn:aws:iam::2:role/read")
+
+    assert sts.assume_role.call_count == 2  # inside margin → refreshed
+
+
+def test_client_without_role_arn_uses_env_credentials(monkeypatch):
+    boto3_client = Mock(return_value=Mock())
+    monkeypatch.setattr(aws.boto3, "client", boto3_client)
+
+    aws._client("cloudwatch")
+
+    kwargs = boto3_client.call_args.kwargs
+    assert kwargs == {"region_name": "us-east-1"}  # no explicit creds → env chain

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -471,6 +471,7 @@ def test_client_with_role_arn_assumes_role_on_every_call(monkeypatch):
     assert sts.assume_role.call_count == 2
     sqs_calls = [c for c in session_client.call_args_list if c.args[0] == "sqs"]
     assert sqs_calls[0].kwargs["aws_access_key_id"] == "ASIA-temp"
+    assert sqs_calls[0].kwargs["aws_secret_access_key"] == "temp-secret"
     assert sqs_calls[0].kwargs["aws_session_token"] == "temp-token"
     assert sqs_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
     sts_calls = [c for c in session_client.call_args_list if c.args[0] == "sts"]
@@ -519,6 +520,46 @@ def test_assume_role_credentials_uses_caller_attributed_session_name(monkeypatch
         sts.assume_role.call_args.kwargs["RoleSessionName"]
         == f"{aws.ASSUME_ROLE_SESSION_NAME}-7"
     )
+
+
+def test_assume_role_credentials_scopes_the_session_to_read_only_actions(monkeypatch):
+    """PR review finding NEW-M1: role_arn is a model-supplied ARN with no
+    operator-side allowlist, so the assumed session's actual permissions
+    otherwise depend entirely on the target role's own policy - there's no
+    IAM-level guarantee it's read-only. The inline session policy must
+    scope the assumed session to exactly this module's read actions,
+    regardless of what the target role itself allows."""
+    sts = _sts_with_assume_role()
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
+
+    aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
+
+    policy = json.loads(sts.assume_role.call_args.kwargs["Policy"])
+    statement = policy["Statement"][0]
+    assert statement["Effect"] == "Allow"
+    assert statement["Resource"] == "*"
+    # Exact equality, not just a subset check: a subset check alone would
+    # still pass if a future tool's action were added to the connector's
+    # boto3 calls but never added here, silently leaving that tool
+    # unusable under role_arn. This still can't catch a 10th tool's action
+    # being omitted from *both* the implementation and this expected set
+    # at once, but it does catch drift in either alone.
+    expected_actions = {
+        "sts:GetCallerIdentity",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:GetMetricData",
+        "logs:DescribeLogGroups",
+        "logs:FilterLogEvents",
+        "dynamodb:ListTables",
+        "dynamodb:DescribeTable",
+        "sqs:ListQueues",
+        "sqs:GetQueueAttributes",
+        # Required alongside logs:FilterLogEvents to read from a log group
+        # encrypted with a customer-managed KMS key.
+        "kms:Decrypt",
+        "kms:DescribeKey",
+    }
+    assert set(statement["Action"]) == expected_actions
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -84,6 +84,19 @@ def test_describe_alarms_passes_state_filter_and_shapes_output(monkeypatch):
     assert cloudwatch.describe_alarms.call_args.kwargs["StateValue"] == "ALARM"
 
 
+def test_describe_alarms_flags_truncated_when_next_token_present(monkeypatch):
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.return_value = {
+        "MetricAlarms": [{"AlarmName": "high-cpu"}],
+        "NextToken": "more",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=cloudwatch))
+
+    result = json.loads(aws.aws_cloudwatch_describe_alarms())
+
+    assert result["truncated"] is True
+
+
 def test_describe_alarms_omits_filters_when_not_given(monkeypatch):
     cloudwatch = Mock()
     cloudwatch.describe_alarms.return_value = {"MetricAlarms": []}
@@ -252,6 +265,18 @@ def test_filter_log_events_caps_limit_and_passes_window(monkeypatch):
     assert kwargs["startTime"] == 1753890000000
 
 
+def test_filter_log_events_not_truncated_without_next_token(monkeypatch):
+    logs = Mock()
+    logs.filter_log_events.return_value = {"events": []}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod")
+    )
+
+    assert result["truncated"] is False
+
+
 def test_describe_log_groups_filters_by_prefix(monkeypatch):
     logs = Mock()
     logs.describe_log_groups.return_value = {
@@ -263,7 +288,21 @@ def test_describe_log_groups_filters_by_prefix(monkeypatch):
 
     assert result["status"] == "success"
     assert result["log_groups"][0]["name"] == "/app/prod"
+    assert result["truncated"] is False
     assert logs.describe_log_groups.call_args.kwargs["logGroupNamePrefix"] == "/app"
+
+
+def test_describe_log_groups_flags_truncated_when_next_token_present(monkeypatch):
+    logs = Mock()
+    logs.describe_log_groups.return_value = {
+        "logGroups": [{"logGroupName": "/app/prod"}],
+        "nextToken": "more",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(aws.aws_cloudwatch_describe_log_groups())
+
+    assert result["truncated"] is True
 
 
 def test_dynamodb_list_tables(monkeypatch):
@@ -279,6 +318,16 @@ def test_dynamodb_list_tables(monkeypatch):
     assert result["status"] == "success"
     assert result["tables"] == ["orders", "users"]
     assert result["truncated"] is True
+
+
+def test_dynamodb_list_tables_not_truncated_without_last_evaluated_key(monkeypatch):
+    dynamodb = Mock()
+    dynamodb.list_tables.return_value = {"TableNames": ["orders"]}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
+
+    result = json.loads(aws.aws_dynamodb_list_tables())
+
+    assert result["truncated"] is False
 
 
 def test_dynamodb_describe_table_shapes_health_fields(monkeypatch):
@@ -318,7 +367,21 @@ def test_sqs_list_queues_passes_prefix(monkeypatch):
 
     assert result["status"] == "success"
     assert result["queue_urls"] == ["https://sqs.us-east-1.amazonaws.com/1/jobs"]
+    assert result["truncated"] is False
     assert sqs.list_queues.call_args.kwargs["QueueNamePrefix"] == "jobs"
+
+
+def test_sqs_list_queues_flags_truncated_when_next_token_present(monkeypatch):
+    sqs = Mock()
+    sqs.list_queues.return_value = {
+        "QueueUrls": ["https://sqs.us-east-1.amazonaws.com/1/jobs"],
+        "NextToken": "more",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sqs))
+
+    result = json.loads(aws.aws_sqs_list_queues())
+
+    assert result["truncated"] is True
 
 
 def test_sqs_get_queue_attributes_requests_all(monkeypatch):
@@ -386,6 +449,50 @@ def test_client_with_role_arn_assumes_role_on_every_call(monkeypatch):
     assert sqs_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
     sts_calls = [c for c in session_client.call_args_list if c.args[0] == "sts"]
     assert sts_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
+
+
+def test_role_session_name_falls_back_without_caller_id(monkeypatch):
+    monkeypatch.delenv(aws.CALLER_ID_ENV_VAR, raising=False)
+
+    assert aws._role_session_name() == aws.ASSUME_ROLE_SESSION_NAME
+
+
+def test_role_session_name_includes_sanitized_caller_id(monkeypatch):
+    monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "42")
+
+    assert aws._role_session_name() == f"{aws.ASSUME_ROLE_SESSION_NAME}-42"
+
+
+def test_role_session_name_sanitizes_unsafe_characters(monkeypatch):
+    """RoleSessionName's allowed charset is [\\w+=,.@-]; anything else (e.g. a
+    slash or space) would make sts.assume_role reject the call outright."""
+    monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "weird/id with space")
+
+    name = aws._role_session_name()
+
+    assert "/" not in name and " " not in name
+    assert name.startswith(f"{aws.ASSUME_ROLE_SESSION_NAME}-")
+
+
+def test_role_session_name_truncates_to_64_chars(monkeypatch):
+    monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "x" * 100)
+
+    name = aws._role_session_name()
+
+    assert len(name) == 64
+
+
+def test_assume_role_credentials_uses_caller_attributed_session_name(monkeypatch):
+    monkeypatch.setenv(aws.CALLER_ID_ENV_VAR, "7")
+    sts = _sts_with_assume_role(expires_in_seconds=3600)
+    _patch_boto3_session(monkeypatch, lambda service, **kwargs: sts)
+
+    aws._assume_role_credentials("arn:aws:iam::2:role/read", "us-east-1")
+
+    assert (
+        sts.assume_role.call_args.kwargs["RoleSessionName"]
+        == f"{aws.ASSUME_ROLE_SESSION_NAME}-7"
+    )
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -127,6 +127,9 @@ def test_describe_alarms_passes_state_filter_and_shapes_output(monkeypatch):
 
 
 def test_describe_alarms_flags_truncated_when_next_token_present(monkeypatch):
+    """A cursor that never runs out must not spin forever -- MAX_PAGES caps
+    it, and the result is still reported truncated=True since data was left
+    on the table."""
     cloudwatch = Mock()
     cloudwatch.describe_alarms.return_value = {
         "MetricAlarms": [{"AlarmName": "high-cpu"}],
@@ -137,6 +140,42 @@ def test_describe_alarms_flags_truncated_when_next_token_present(monkeypatch):
     result = json.loads(aws.aws_cloudwatch_describe_alarms())
 
     assert result["truncated"] is True
+    assert cloudwatch.describe_alarms.call_count == aws.MAX_PAGES
+
+
+def test_describe_alarms_paginates_across_pages(monkeypatch):
+    """PR review finding (round 6, major): DescribeAlarms fetching exactly
+    one page and reporting `truncated` with no way to continue could let
+    this triage tool report "nothing is wrong" while a firing alarm sits on
+    a later page. Both MetricAlarms and CompositeAlarms share the same
+    NextToken cursor and must both accumulate across pages."""
+    cloudwatch = Mock()
+    cloudwatch.describe_alarms.side_effect = [
+        {
+            "MetricAlarms": [{"AlarmName": "high-cpu"}],
+            "CompositeAlarms": [{"AlarmName": "rollup-1"}],
+            "NextToken": "page2",
+        },
+        {
+            "MetricAlarms": [{"AlarmName": "high-latency"}],
+            "CompositeAlarms": [{"AlarmName": "rollup-2"}],
+        },
+    ]
+    client_factory = Mock(return_value=cloudwatch)
+    monkeypatch.setattr(aws, "_client", client_factory)
+
+    result = json.loads(
+        aws.aws_cloudwatch_describe_alarms(role_arn="arn:aws:iam::2:role/read")
+    )
+
+    assert [a["name"] for a in result["alarms"]] == ["high-cpu", "high-latency"]
+    assert [a["name"] for a in result["composite_alarms"]] == ["rollup-1", "rollup-2"]
+    assert result["truncated"] is False
+    assert cloudwatch.describe_alarms.call_args_list[1].kwargs["NextToken"] == "page2"
+    # The client (and, under role_arn, its one-time AssumeRole exchange) must
+    # be built once per tool call, not once per page -- otherwise pagination
+    # would multiply STS AssumeRole calls by the number of pages fetched.
+    assert client_factory.call_count == 1
 
 
 def test_describe_alarms_surfaces_composite_alarms(monkeypatch):
@@ -308,6 +347,9 @@ def test_tools_tolerate_explicit_none_values_in_responses(monkeypatch):
 
 
 def test_filter_log_events_caps_limit_and_passes_window(monkeypatch):
+    """A cursor that never runs out (and never reaches max_events, since
+    each page only carries one event) must not spin forever -- MAX_PAGES
+    caps it, and the result is still reported truncated=True."""
     logs = Mock()
     logs.filter_log_events.return_value = {
         "events": [
@@ -330,10 +372,72 @@ def test_filter_log_events_caps_limit_and_passes_window(monkeypatch):
     assert result["status"] == "success"
     assert result["events"][0]["message"] == "ERROR boom"
     assert result["truncated"] is True
-    kwargs = logs.filter_log_events.call_args.kwargs
-    assert kwargs["limit"] == aws.MAX_LOG_EVENTS  # capped, not 5000
-    assert kwargs["filterPattern"] == "ERROR"
-    assert kwargs["startTime"] == 1753890000000
+    assert logs.filter_log_events.call_count == aws.MAX_PAGES
+    first_call_kwargs = logs.filter_log_events.call_args_list[0].kwargs
+    assert first_call_kwargs["limit"] == aws.MAX_LOG_EVENTS  # capped, not 5000
+    assert first_call_kwargs["filterPattern"] == "ERROR"
+    assert first_call_kwargs["startTime"] == 1753890000000
+    # The per-page limit shrinks to the remaining budget on later pages
+    # (one event accumulated per page here) rather than staying fixed.
+    assert (
+        logs.filter_log_events.call_args_list[1].kwargs["limit"]
+        == aws.MAX_LOG_EVENTS - 1
+    )
+
+
+def test_filter_log_events_follows_an_empty_page_to_find_matches(monkeypatch):
+    """PR review finding (round 6, major, worst case): botocore's own
+    FilterLogEvents docs say a page can be partially full or even empty
+    while more matching events exist on a later page -- fetching exactly
+    one page and stopping would report "no errors found" during an
+    incident when errors actually exist past that first, empty page."""
+    logs = Mock()
+    logs.filter_log_events.side_effect = [
+        {"events": [], "nextToken": "page2"},
+        {"events": [{"timestamp": 1, "logStreamName": "s1", "message": "ERROR boom"}]},
+    ]
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod")
+    )
+
+    assert result["events"] == [
+        {"timestamp_ms": 1, "log_stream": "s1", "message": "ERROR boom"}
+    ]
+    assert result["truncated"] is False
+    assert logs.filter_log_events.call_count == 2
+
+
+def test_filter_log_events_stops_once_limit_reached_across_pages(monkeypatch):
+    """Pagination must stop as soon as `limit` events are gathered, not
+    keep fetching pages the caller didn't ask for."""
+    logs = Mock()
+    logs.filter_log_events.side_effect = [
+        {
+            "events": [
+                {"timestamp": 1, "logStreamName": "s1", "message": "one"},
+                {"timestamp": 2, "logStreamName": "s1", "message": "two"},
+            ],
+            "nextToken": "page2",
+        },
+        {
+            "events": [{"timestamp": 3, "logStreamName": "s1", "message": "three"}],
+            "nextToken": "page3",
+        },
+    ]
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(
+        aws.aws_cloudwatch_filter_log_events(log_group_name="/app/prod", limit=3)
+    )
+
+    assert [e["message"] for e in result["events"]] == ["one", "two", "three"]
+    assert result["truncated"] is True  # page3 still pending beyond the 3 requested
+    assert logs.filter_log_events.call_count == 2
+    # Page 2 asks for only the remaining budget (3 - 2 already fetched = 1),
+    # not the full limit again.
+    assert logs.filter_log_events.call_args_list[1].kwargs["limit"] == 1
 
 
 def test_filter_log_events_not_truncated_without_next_token(monkeypatch):
@@ -364,6 +468,9 @@ def test_describe_log_groups_filters_by_prefix(monkeypatch):
 
 
 def test_describe_log_groups_flags_truncated_when_next_token_present(monkeypatch):
+    """A cursor that never runs out must not spin forever -- MAX_PAGES caps
+    it, and the result is still reported truncated=True since data was left
+    on the table."""
     logs = Mock()
     logs.describe_log_groups.return_value = {
         "logGroups": [{"logGroupName": "/app/prod"}],
@@ -374,21 +481,70 @@ def test_describe_log_groups_flags_truncated_when_next_token_present(monkeypatch
     result = json.loads(aws.aws_cloudwatch_describe_log_groups())
 
     assert result["truncated"] is True
+    assert logs.describe_log_groups.call_count == aws.MAX_PAGES
+
+
+def test_describe_log_groups_paginates_across_pages(monkeypatch):
+    """PR review finding (round 6, major): DescribeLogGroups fetching
+    exactly one page and reporting `truncated` with no way to continue
+    could hide a log group living past the first page."""
+    logs = Mock()
+    logs.describe_log_groups.side_effect = [
+        {"logGroups": [{"logGroupName": "/app/prod"}], "nextToken": "page2"},
+        {"logGroups": [{"logGroupName": "/app/staging"}]},
+    ]
+    monkeypatch.setattr(aws, "_client", Mock(return_value=logs))
+
+    result = json.loads(aws.aws_cloudwatch_describe_log_groups())
+
+    assert [g["name"] for g in result["log_groups"]] == ["/app/prod", "/app/staging"]
+    assert result["truncated"] is False
+    assert logs.describe_log_groups.call_args_list[1].kwargs["nextToken"] == "page2"
 
 
 def test_dynamodb_list_tables(monkeypatch):
+    """PR review finding (round 6, major): a single ListTables page fetched
+    with no way to continue could silently under-report the table list.
+    ListTables' own cursor names differ request-vs-response
+    (ExclusiveStartTableName / LastEvaluatedTableName), unlike every other
+    tool here sharing a single NextToken/nextToken name — covered here
+    specifically since a wrong field name would silently stop pagination
+    after page one."""
     dynamodb = Mock()
-    dynamodb.list_tables.return_value = {
-        "TableNames": ["orders", "users"],
-        "LastEvaluatedTableName": "users",
-    }
+    dynamodb.list_tables.side_effect = [
+        {"TableNames": ["orders"], "LastEvaluatedTableName": "orders"},
+        {"TableNames": ["users"]},
+    ]
     monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
 
     result = json.loads(aws.aws_dynamodb_list_tables())
 
     assert result["status"] == "success"
     assert result["tables"] == ["orders", "users"]
+    assert result["truncated"] is False
+    assert dynamodb.list_tables.call_count == 2
+    assert (
+        dynamodb.list_tables.call_args_list[1].kwargs["ExclusiveStartTableName"]
+        == "orders"
+    )
+
+
+def test_dynamodb_list_tables_stops_at_max_pages_with_token_still_pending(monkeypatch):
+    """Bounded pagination guard: a cursor that never runs out (e.g. an API
+    quirk or a bug in this loop) must not spin forever -- MAX_PAGES caps it,
+    and the result is still reported truncated=True since data was left on
+    the table."""
+    dynamodb = Mock()
+    dynamodb.list_tables.return_value = {
+        "TableNames": ["orders"],
+        "LastEvaluatedTableName": "orders",
+    }
+    monkeypatch.setattr(aws, "_client", Mock(return_value=dynamodb))
+
+    result = json.loads(aws.aws_dynamodb_list_tables())
+
     assert result["truncated"] is True
+    assert dynamodb.list_tables.call_count == aws.MAX_PAGES
 
 
 def test_dynamodb_list_tables_not_truncated_without_last_evaluated_key(monkeypatch):
@@ -443,6 +599,9 @@ def test_sqs_list_queues_passes_prefix(monkeypatch):
 
 
 def test_sqs_list_queues_flags_truncated_when_next_token_present(monkeypatch):
+    """A cursor that never runs out must not spin forever -- MAX_PAGES caps
+    it, and the result is still reported truncated=True since data was left
+    on the table."""
     sqs = Mock()
     sqs.list_queues.return_value = {
         "QueueUrls": ["https://sqs.us-east-1.amazonaws.com/1/jobs"],
@@ -453,9 +612,40 @@ def test_sqs_list_queues_flags_truncated_when_next_token_present(monkeypatch):
     result = json.loads(aws.aws_sqs_list_queues())
 
     assert result["truncated"] is True
+    assert sqs.list_queues.call_count == aws.MAX_PAGES
 
 
-def test_sqs_get_queue_attributes_requests_all(monkeypatch):
+def test_sqs_list_queues_paginates_across_pages(monkeypatch):
+    """PR review finding (round 6, major): ListQueues fetching exactly one
+    page and reporting `truncated` with no way to continue could hide a
+    queue living past the first page."""
+    sqs = Mock()
+    sqs.list_queues.side_effect = [
+        {
+            "QueueUrls": ["https://sqs.us-east-1.amazonaws.com/1/a"],
+            "NextToken": "page2",
+        },
+        {"QueueUrls": ["https://sqs.us-east-1.amazonaws.com/1/b"]},
+    ]
+    monkeypatch.setattr(aws, "_client", Mock(return_value=sqs))
+
+    result = json.loads(aws.aws_sqs_list_queues())
+
+    assert result["queue_urls"] == [
+        "https://sqs.us-east-1.amazonaws.com/1/a",
+        "https://sqs.us-east-1.amazonaws.com/1/b",
+    ]
+    assert result["truncated"] is False
+    assert sqs.list_queues.call_args_list[1].kwargs["NextToken"] == "page2"
+
+
+def test_sqs_get_queue_attributes_requests_only_diagnostic_attributes(monkeypatch):
+    """PR review finding (round 6, minor): AttributeNames=["All"] also
+    returns the queue's resource Policy document (account IDs, principal
+    ARNs, cross-account trust conditions) and KmsMasterKeyId, neither of
+    which this tool's docstring promises - IAM can't restrict which
+    AttributeNames come back, so this connector must enumerate only the
+    diagnostic attributes itself instead of asking for everything."""
     sqs = Mock()
     sqs.get_queue_attributes.return_value = {
         "Attributes": {"ApproximateNumberOfMessages": "42"}
@@ -468,7 +658,21 @@ def test_sqs_get_queue_attributes_requests_all(monkeypatch):
 
     assert result["status"] == "success"
     assert result["attributes"]["ApproximateNumberOfMessages"] == "42"
-    assert sqs.get_queue_attributes.call_args.kwargs["AttributeNames"] == ["All"]
+    requested = sqs.get_queue_attributes.call_args.kwargs["AttributeNames"]
+    assert requested == aws.SQS_DIAGNOSTIC_ATTRIBUTES
+    assert "Policy" not in requested
+    assert "KmsMasterKeyId" not in requested
+    assert "All" not in requested
+    # Comparing only against the constant itself can't catch the constant
+    # being wrong/incomplete relative to what the docstring promises -- this
+    # asserts the actual attributes the docstring claims are present.
+    for promised in (
+        "ApproximateNumberOfMessages",
+        "ApproximateNumberOfMessagesNotVisible",
+        "RedrivePolicy",
+        "RedriveAllowPolicy",
+    ):
+        assert promised in requested
 
 
 # --- assume-role plumbing -------------------------------------------------
@@ -519,6 +723,11 @@ def test_client_with_role_arn_assumes_role_on_every_call(monkeypatch):
     assert sqs_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
     sts_calls = [c for c in session_client.call_args_list if c.args[0] == "sts"]
     assert sts_calls[0].kwargs["config"] == aws.DEFAULT_CLIENT_CONFIG
+    # PR review finding (round 6, minor): the AssumeRole call itself must
+    # not lean on boto3's ambient credential chain either -- it's the most
+    # sensitive (cross-account) path in the module.
+    assert sts_calls[0].kwargs["aws_access_key_id"] == "AKIA-test"
+    assert sts_calls[0].kwargs["aws_secret_access_key"] == "secret-test"
 
 
 def test_role_session_name_falls_back_without_caller_id(monkeypatch):
@@ -639,15 +848,22 @@ def test_read_only_session_policy_stays_under_the_sts_inline_policy_limit():
 
 
 def test_client_without_role_arn_uses_env_credentials(monkeypatch):
+    """PR review finding (round 6, minor): pass the connector's own
+    credentials explicitly instead of leaning on boto3's ambient provider
+    chain, which could otherwise fall back to a ~/.aws/credentials file
+    (reachable via the inherited HOME env var) -- naming the credentials
+    here removes any dependency on that chain never doing so, rather than
+    trusting it won't."""
     session_client = _patch_boto3_session(monkeypatch, lambda service, **kwargs: Mock())
 
     aws._client("cloudwatch")
 
     kwargs = session_client.call_args.kwargs
-    # no explicit creds → env chain; a timeout/retry config is still applied
     assert kwargs == {
         "region_name": "us-east-1",
         "config": aws.DEFAULT_CLIENT_CONFIG,
+        "aws_access_key_id": "AKIA-test",
+        "aws_secret_access_key": "secret-test",
     }
 
 

--- a/tests/web/tools/test_aws_mcp.py
+++ b/tests/web/tools/test_aws_mcp.py
@@ -150,6 +150,34 @@ def test_get_metric_data_handles_empty_series(monkeypatch):
     assert result["values"] == []
 
 
+def test_tools_tolerate_explicit_none_values_in_responses(monkeypatch):
+    """Keys present with an explicit None value (as opposed to absent) must
+    not crash list/dict handling — the `or []` / `or {}` fallbacks apply."""
+    client = Mock()
+    client.describe_alarms.return_value = {"MetricAlarms": None}
+    client.get_metric_data.return_value = {"MetricDataResults": None}
+    client.list_tables.return_value = {"TableNames": None}
+    client.describe_table.return_value = {"Table": None}
+    client.list_queues.return_value = {"QueueUrls": None}
+    client.get_queue_attributes.return_value = {"Attributes": None}
+    monkeypatch.setattr(aws, "_client", Mock(return_value=client))
+
+    assert json.loads(aws.aws_cloudwatch_describe_alarms())["alarms"] == []
+    metric = json.loads(
+        aws.aws_cloudwatch_get_metric_data(
+            namespace="AWS/EC2",
+            metric_name="CPUUtilization",
+            start_time="2026-07-30T00:00:00Z",
+            end_time="2026-07-30T01:00:00Z",
+        )
+    )
+    assert metric["status"] == "success" and metric["values"] == []
+    assert json.loads(aws.aws_dynamodb_list_tables())["tables"] == []
+    assert json.loads(aws.aws_dynamodb_describe_table("orders"))["status"] == "success"
+    assert json.loads(aws.aws_sqs_list_queues())["queue_urls"] == []
+    assert json.loads(aws.aws_sqs_get_queue_attributes("https://q"))["attributes"] == {}
+
+
 def test_filter_log_events_caps_limit_and_passes_window(monkeypatch):
     logs = Mock()
     logs.filter_log_events.return_value = {

--- a/tests/web/tools/test_webtoolconfig_stdio_caller_id.py
+++ b/tests/web/tools/test_webtoolconfig_stdio_caller_id.py
@@ -1,0 +1,75 @@
+"""Coverage for the caller-id env injection site inside
+WebToolConfig._build_mcp_server_config's plain-stdio branch.
+
+Every other test of this mechanism exercises
+mcp_runtime.build_mcp_runtime_connection only; this file targets the
+independent injection at config.py's stdio branch, whose only other caller
+is _build_oauth_mcp_stdio_transport_config (a different code path). Deleting
+that line previously failed nothing in the suite."""
+
+import asyncio
+from types import SimpleNamespace
+
+from xagent.web.tools.config import WebToolConfig
+
+
+def _stdio_server(**overrides):
+    defaults = dict(
+        id=5,
+        name="Test Stdio Server",
+        transport="stdio",
+        description="",
+        command="python",
+        args=["-m", "xagent.web.tools.mcp.aws"],
+        env={"FOO": "bar"},
+        cwd=None,
+        managed="external",
+        docker_url=None,
+        docker_image=None,
+        docker_environment=None,
+        docker_working_dir=None,
+        volumes=None,
+        bind_ports=None,
+        restart_policy=None,
+        auto_start=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_build_mcp_server_config_injects_caller_id_for_plain_stdio():
+    cfg = WebToolConfig(db=None, request=None, user_id=42)
+    server = _stdio_server()
+
+    config = asyncio.run(
+        cfg._build_mcp_server_config(
+            server=server,
+            user_env_by_id={},
+            shared_env_by_id={},
+            env_source_by_id={},
+        )
+    )
+
+    assert config["config"]["env"] == {"FOO": "bar", "XAGENT_MCP_CALLER_ID": "42"}
+
+
+def test_build_mcp_server_config_merges_env_overrides_before_caller_id():
+    """The user-env override layer still applies; caller-id is merged in
+    after, matching build_mcp_runtime_connection's precedence."""
+    cfg = WebToolConfig(db=None, request=None, user_id=7)
+    server = _stdio_server(id=9)
+
+    config = asyncio.run(
+        cfg._build_mcp_server_config(
+            server=server,
+            user_env_by_id={9: {"OVERRIDE": "own"}},
+            shared_env_by_id={},
+            env_source_by_id={9: "own"},
+        )
+    )
+
+    assert config["config"]["env"] == {
+        "FOO": "bar",
+        "OVERRIDE": "own",
+        "XAGENT_MCP_CALLER_ID": "7",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,20 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/65/47670987f2f9e181397872c7ee6415b7b95156d711b7eab6c55f66e575bc/boto3-1.43.0.tar.gz", hash = "sha256:80d44a943ef90aba7958ab31d30c155c198acc8a9581b5846b3878b2c8951086", size = 113143, upload-time = "2026-04-29T22:07:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/a0/3e6a0b1c1ea6bec76f71473727ef27abf3cd40e9709b3ebcbfbcfaae6f79/boto3-1.43.0-py3-none-any.whl", hash = "sha256:8ebe03754a4b73a5cb6ec2f14cca03ac33bd4760d0adea53da4724845130258b", size = 140497, upload-time = "2026-04-29T22:07:46.216Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6315,6 +6329,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7745,6 +7771,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "beartype" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "boxlite", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "byteplus-python-sdk-v2" },
     { name = "cairosvg" },
@@ -7957,6 +7984,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "beartype", specifier = ">=0.18.5" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
+    { name = "boto3", specifier = ">=1.34.0" },
     { name = "boxlite", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.6.0" },
     { name = "boxlite", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=0.6.0" },
     { name = "byteplus-python-sdk-v2", specifier = ">=3.0.52" },


### PR DESCRIPTION
## Summary
- Register `aws` as a built-in key-based MCP connector (`builtin_mcp_registry.py` + seed migration) — access-key auth via the connect dialog (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION`), mirroring the `google-maps` pattern since AWS isn't OAuth
- Add `boto3` as a core dependency (`pyproject.toml` + `uv.lock` regenerated) — no existing SigV4 code in the repo, and the SDK covers CloudWatch/Logs/DynamoDB/SQS's differing wire protocols
- New `xagent.web.tools.mcp.aws` module, nine read-only tools:
  - STS: `aws_get_caller_identity`
  - CloudWatch: `aws_cloudwatch_describe_alarms`, `aws_cloudwatch_get_metric_data`, `aws_cloudwatch_describe_log_groups`, `aws_cloudwatch_filter_log_events`
  - DynamoDB: `aws_dynamodb_list_tables`, `aws_dynamodb_describe_table`
  - SQS: `aws_sqs_list_queues`, `aws_sqs_get_queue_attributes`
- Read-only is enforced by construction — only read/describe/list APIs are implemented, no write calls exist in the module
- Cross-account access via an optional `role_arn` parameter on every tool (STS AssumeRole exchanged fresh on every call — each MCP tool call runs in its own short-lived subprocess, so there's no in-process layer where caching credentials would help) rather than a connection-time field, since the platform's `required_env` has no optional-key concept

## Test plan
- [x] `pytest tests/web/tools/test_aws_mcp.py tests/alembic/test_20260731_seed_aws_mcp_app.py tests/templates/test_manager.py` — all passing
- [x] `ruff format` / `ruff check` clean, `mypy` clean on touched files
- [x] `uv lock` / `uv sync --locked` succeed (Docker build parity)
- [x] `alembic upgrade head` / `downgrade -1` round-trip verified locally — only the `aws` row is added/removed
- [x] Manual end-to-end with a real read-only IAM key: connected via the connector UI, verified `aws_get_caller_identity`, CloudWatch alarms, log search, DynamoDB table lookup, and SQS queue attributes all working
