### PR TITLE
feat: add Slack MCP connector

### DIFF
--- a/example.env
+++ b/example.env
@@ -460,6 +460,8 @@ META_CONFIG_ID=""
 # Required for the Slack integration in MCP (list channels, post messages)
 # Create an app at https://api.slack.com/apps, add these scopes under
 # "OAuth & Permissions": chat:write, chat:write.public, channels:read
+# Note: chat:write.public also lets the bot post into any public channel
+# without being invited — it bypasses Slack's invite gate.
 # Leave "Token Rotation" off — bot tokens don't expire, so no refresh is needed.
 SLACK_CLIENT_ID=""
 SLACK_CLIENT_SECRET=""

--- a/example.env
+++ b/example.env
@@ -454,6 +454,20 @@ META_REDIRECT_URI=""
 # users who authorize via config_id will not grant it.
 META_CONFIG_ID=""
 
+# ===========================================
+# Slack OAuth Configuration (Optional)
+# ===========================================
+# Required for the Slack integration in MCP (list channels, post messages)
+# Create an app at https://api.slack.com/apps, add these scopes under
+# "OAuth & Permissions": chat:write, chat:write.public, channels:read
+# Leave "Token Rotation" off — bot tokens don't expire, so no refresh is needed.
+SLACK_CLIENT_ID=""
+SLACK_CLIENT_SECRET=""
+# Redirect URI for Slack OAuth callback — must also be added under the app's
+# "OAuth & Permissions" > "Redirect URLs".
+# Example: http://localhost:8000/api/auth/slack/callback
+SLACK_REDIRECT_URI=""
+
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
 # - LanceDB storage path: <project_root>/memory_store/

--- a/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
+++ b/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
@@ -1,0 +1,174 @@
+"""seed built-in Slack (OAuth) MCP connector
+
+Revision ID: 20260801_seed_slack_mcp_app
+Revises: 20260724_add_upload_source_to_uploaded_files
+Create Date: 2026-08-01 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260801_seed_slack_mcp_app"
+down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "slack"
+
+SLACK_SCOPES = ["chat:write", "chat:write.public", "channels:read"]
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _slack_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "slack",
+        "name": "Slack",
+        "client_id": os.environ.get("SLACK_CLIENT_ID", ""),
+        "client_secret": os.environ.get("SLACK_CLIENT_SECRET", ""),
+        "auth_url": "https://slack.com/oauth/v2/authorize",
+        "token_url": "https://slack.com/api/oauth.v2.access",
+        "redirect_uri": os.environ.get("SLACK_REDIRECT_URI", ""),
+        "userinfo_url": "https://slack.com/api/auth.test",
+        "user_id_path": "team_id",
+        "email_path": "team",
+        "default_scopes": SLACK_SCOPES,
+    }
+
+
+def _slack_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "Slack",
+        "description": "Connect to Slack to list channels and post messages, e.g. incident summaries and recommended fixes.",
+        "icon": "https://www.google.com/s2/favicons?domain=slack.com&sz=128",
+        "transport": "oauth",
+        "provider_name": "slack",
+        "category": "Communication",
+        "oauth_scopes": SLACK_SCOPES,
+        "is_visible_in_connector": True,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.slack"],
+            "env_mapping": {"SLACK_ACCESS_TOKEN": "access_token"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+        )
+        if "slack" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_slack_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_slack_app_row(), app_columns)],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only the catalog entry is removed. Any user OAuth connections created
+        # against this app are not owned by this migration and are cleaned up
+        # through the normal disconnect path.
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_slack_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "slack")
+        ).scalar()
+        if remaining_slack_apps:
+            return
+
+    # Only delete the provider row when it still matches the static shape this
+    # migration seeded, so an admin-created "slack" provider (via
+    # POST /admin/mcp/providers) is preserved. client_id/client_secret are
+    # env-dependent and intentionally not part of the guard.
+    provider_columns = {
+        column["name"] for column in inspector.get_columns("oauth_providers")
+    }
+    seeded_provider = _slack_provider_row()
+    delete_stmt = sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
+        FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "slack"
+    )
+    for column in ("name", "auth_url", "token_url"):
+        if column in provider_columns:
+            delete_stmt = delete_stmt.where(
+                FULL_OAUTH_PROVIDERS_TABLE.c[column] == seeded_provider[column]
+            )
+    bind.execute(delete_stmt)

--- a/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
+++ b/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Slack (OAuth) MCP connector
 
 Revision ID: 20260801_seed_slack_mcp_app
-Revises: 20260724_add_upload_source_to_uploaded_files
+Revises: 20260728_add_facebook_pages_read_user_content_scope
 Create Date: 2026-08-01 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260801_seed_slack_mcp_app"
-down_revision: Union[str, None] = "20260724_add_upload_source_to_uploaded_files"
+down_revision: Union[str, None] = "20260728_add_facebook_pages_read_user_content_scope"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
+++ b/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Slack (OAuth) MCP connector
 
 Revision ID: 20260801_seed_slack_mcp_app
-Revises: 20260728_add_facebook_pages_read_user_content_scope
+Revises: 20260730_add_slack_oauth_flow_states
 Create Date: 2026-08-01 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260801_seed_slack_mcp_app"
-down_revision: Union[str, None] = "20260728_add_facebook_pages_read_user_content_scope"
+down_revision: Union[str, None] = "20260730_add_slack_oauth_flow_states"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
+++ b/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
@@ -71,6 +71,11 @@ def _slack_provider_row() -> dict[str, object]:
         "token_url": "https://slack.com/api/oauth.v2.access",
         "redirect_uri": os.environ.get("SLACK_REDIRECT_URI", ""),
         "userinfo_url": "https://slack.com/api/auth.test",
+        # auth.test never returns an email for a bot token; the workspace
+        # name ("team") is deliberately stored in the email slot because
+        # UserOAuth.email is only consumed as the "connected account" display
+        # label for non-gmail providers — without it the Slack connection
+        # would show up unlabeled in the connector UI.
         "user_id_path": "team_id",
         "email_path": "team",
         "default_scopes": SLACK_SCOPES,

--- a/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
+++ b/src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py
@@ -33,11 +33,6 @@ FULL_OAUTH_PROVIDERS_TABLE = sa.table(
     sa.column("default_scopes", sa.JSON),
 )
 
-OAUTH_PROVIDERS_TABLE = sa.table(
-    "oauth_providers",
-    sa.column("provider_name", sa.String),
-)
-
 PUBLIC_MCP_APPS_TABLE = sa.table(
     "public_mcp_apps",
     sa.column("app_id", sa.String),
@@ -111,7 +106,9 @@ def upgrade() -> None:
             column["name"] for column in inspector.get_columns("oauth_providers")
         }
         existing_provider_names = set(
-            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+            bind.execute(
+                sa.select(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name)
+            ).scalars()
         )
         if "slack" not in existing_provider_names:
             bind.execute(
@@ -160,20 +157,13 @@ def downgrade() -> None:
         if remaining_slack_apps:
             return
 
-    # Only delete the provider row when it still matches the static shape this
-    # migration seeded, so an admin-created "slack" provider (via
-    # POST /admin/mcp/providers) is preserved. client_id/client_secret are
-    # env-dependent and intentionally not part of the guard.
-    provider_columns = {
-        column["name"] for column in inspector.get_columns("oauth_providers")
-    }
-    seeded_provider = _slack_provider_row()
-    delete_stmt = sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
-        FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "slack"
+    # Delete unconditionally by provider_name, matching the sibling seed
+    # migrations (meta, google-maps). A shape-matching guard would protect
+    # the wrong thing: an admin recreating the *real* Slack provider enters
+    # Slack's canonical URLs, which would match the guard and be deleted
+    # anyway — only a differently-shaped row would survive.
+    bind.execute(
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
+            FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "slack"
+        )
     )
-    for column in ("name", "auth_url", "token_url"):
-        if column in provider_columns:
-            delete_stmt = delete_stmt.where(
-                FULL_OAUTH_PROVIDERS_TABLE.c[column] == seeded_provider[column]
-            )
-    bind.execute(delete_stmt)

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1354,6 +1354,25 @@ def generic_oauth_callback(
             info_response = requests.get(actual_url, headers=info_headers, timeout=10.0)
             if info_response.status_code == 200:
                 info_data = info_response.json()
+                if isinstance(info_data, dict) and info_data.get("ok") is False:
+                    # Slack-style APIs answer HTTP 200 with {"ok": false,
+                    # "error": ...} on failure; a status check alone would
+                    # treat a bad/revoked token as success and persist a
+                    # "connected" account with no identity. Fail the
+                    # callback instead. Providers without Slack semantics
+                    # never carry an "ok" key, so they are unaffected.
+                    import html
+
+                    escaped_error = html.escape(
+                        str(info_data.get("error") or "unknown error")
+                    )
+                    return HTMLResponse(
+                        content=(
+                            "<h1>Error verifying the connected account</h1>"
+                            f"<p>The provider reported: {escaped_error}</p>"
+                        ),
+                        status_code=400,
+                    )
                 provider_user_id = info_data.get(db_provider.user_id_path or "id")
                 email = info_data.get(db_provider.email_path or "email")
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -121,6 +121,11 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "token_url": "https://slack.com/api/oauth.v2.access",
             "redirect_uri": os.environ.get("SLACK_REDIRECT_URI", ""),
             "userinfo_url": "https://slack.com/api/auth.test",
+            # auth.test never returns an email for a bot token; the workspace
+            # name ("team") is deliberately stored in the email slot because
+            # UserOAuth.email is only consumed as the "connected account"
+            # display label for non-gmail providers — without it the Slack
+            # connection would show up unlabeled in the connector UI.
             "user_id_path": "team_id",
             "email_path": "team",
             "default_scopes": ["chat:write", "chat:write.public", "channels:read"],

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -112,6 +112,19 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "email_path": "email",
             "default_scopes": ["public_profile"],
         },
+        {
+            "provider_name": "slack",
+            "name": "Slack",
+            "client_id": os.environ.get("SLACK_CLIENT_ID", ""),
+            "client_secret": os.environ.get("SLACK_CLIENT_SECRET", ""),
+            "auth_url": "https://slack.com/oauth/v2/authorize",
+            "token_url": "https://slack.com/api/oauth.v2.access",
+            "redirect_uri": os.environ.get("SLACK_REDIRECT_URI", ""),
+            "userinfo_url": "https://slack.com/api/auth.test",
+            "user_id_path": "team_id",
+            "email_path": "team",
+            "default_scopes": ["chat:write", "chat:write.public", "channels:read"],
+        },
     ]
 
 
@@ -378,6 +391,22 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "npx",
                 "args": ["-y", "@cablate/mcp-google-map", "--stdio"],
                 "required_env": ["GOOGLE_MAPS_API_KEY"],
+            },
+        },
+        {
+            "app_id": "slack",
+            "name": "Slack",
+            "description": "Connect to Slack to list channels and post messages, e.g. incident summaries and recommended fixes.",
+            "icon": "https://www.google.com/s2/favicons?domain=slack.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "slack",
+            "category": "Communication",
+            "oauth_scopes": ["chat:write", "chat:write.public", "channels:read"],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.slack"],
+                "env_mapping": {"SLACK_ACCESS_TOKEN": "access_token"},
             },
         },
     ]

--- a/src/xagent/web/tools/mcp/slack.py
+++ b/src/xagent/web/tools/mcp/slack.py
@@ -41,18 +41,24 @@ def _request(
     path: str,
     *,
     params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Call a Slack Web API method.
 
     Slack always answers with HTTP 200, even on failure — success/failure is
     only signalled by the body's "ok" boolean plus an "error" code, so error
     detection here is on that field, not on raise_for_status().
+
+    Write calls pass json_data rather than params: message text can exceed
+    URL length limits, and query strings are commonly logged in plaintext by
+    proxies/load balancers, which would leak message content.
     """
     response = requests.request(
         method=method,
         url=f"{SLACK_BASE_URL}/{path}",
         headers=_headers(),
         params=params,
+        json=json_data,
         timeout=DEFAULT_TIMEOUT_SECONDS,
     )
     response.raise_for_status()
@@ -75,7 +81,10 @@ def slack_list_channels(exclude_archived: bool = True) -> str:
         for _ in range(MAX_PAGES):
             params: dict[str, Any] = {
                 "types": "public_channel",
-                "exclude_archived": exclude_archived,
+                # Slack expects a lowercase "true"/"false" string; requests
+                # would otherwise serialize the Python bool as "True"/"False",
+                # which Slack's parser doesn't recognize as a boolean.
+                "exclude_archived": "true" if exclude_archived else "false",
                 "limit": 200,
             }
             if cursor:
@@ -109,7 +118,7 @@ def slack_post_message(channel: str, text: str) -> str:
         result = _request(
             "POST",
             "chat.postMessage",
-            params={"channel": channel, "text": text},
+            json_data={"channel": channel, "text": text},
         )
         return _success(channel=result.get("channel"), ts=result.get("ts"))
     except Exception as e:

--- a/src/xagent/web/tools/mcp/slack.py
+++ b/src/xagent/web/tools/mcp/slack.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("slack-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("slack-mcp")
+
+SLACK_BASE_URL = "https://slack.com/api"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_PAGES = 20
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("SLACK_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("SLACK_ACCESS_TOKEN environment variable is missing")
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Slack Web API method.
+
+    Slack always answers with HTTP 200, even on failure — success/failure is
+    only signalled by the body's "ok" boolean plus an "error" code, so error
+    detection here is on that field, not on raise_for_status().
+    """
+    response = requests.request(
+        method=method,
+        url=f"{SLACK_BASE_URL}/{path}",
+        headers=_headers(),
+        params=params,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    payload: dict[str, Any] = response.json()
+    if not payload.get("ok"):
+        raise RuntimeError(payload.get("error") or "Unknown Slack API error")
+    return payload
+
+
+@mcp.tool()
+def slack_list_channels(exclude_archived: bool = True) -> str:
+    """
+    List public channels in the connected Slack workspace (id, name, is_archived).
+    Use this to resolve a channel name to an id before posting, or to find the
+    right channel when the user names one imprecisely.
+    """
+    try:
+        channels: list[dict[str, Any]] = []
+        cursor: str | None = None
+        for _ in range(MAX_PAGES):
+            params: dict[str, Any] = {
+                "types": "public_channel",
+                "exclude_archived": exclude_archived,
+                "limit": 200,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            result = _request("GET", "conversations.list", params=params)
+            channels.extend(
+                {
+                    "id": channel.get("id"),
+                    "name": channel.get("name"),
+                    "is_archived": channel.get("is_archived", False),
+                }
+                for channel in result.get("channels", [])
+            )
+            cursor = (result.get("response_metadata") or {}).get("next_cursor")
+            if not cursor:
+                break
+        return _success(channels=channels)
+    except Exception as e:
+        logger.error(f"Error listing Slack channels: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def slack_post_message(channel: str, text: str) -> str:
+    """
+    Post a message to a Slack channel.
+    channel: a channel id (e.g. "C0123456789") or name (e.g. "#incidents" or "incidents").
+    text: the message body (plain text or Slack mrkdwn).
+    """
+    try:
+        result = _request(
+            "POST",
+            "chat.postMessage",
+            params={"channel": channel, "text": text},
+        )
+        return _success(channel=result.get("channel"), ts=result.get("ts"))
+    except Exception as e:
+        logger.error(f"Error posting Slack message to {channel}: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/slack.py
+++ b/src/xagent/web/tools/mcp/slack.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import re
+import time
 from typing import Any
 
 import requests
@@ -19,6 +21,15 @@ mcp = FastMCP("slack-mcp")
 SLACK_BASE_URL = "https://slack.com/api"
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_PAGES = 20
+MAX_CHANNELS = 1000
+# conversations.list is Tier-2 rate-limited (~20 req/min); on a 429 with a
+# small Retry-After we wait once and retry rather than failing the page.
+MAX_RETRY_AFTER_SECONDS = 30
+
+# Slack channel/user/group ids are uppercase alphanumerics with a letter
+# prefix; channel *names* are forced lowercase by Slack, so this can't
+# misclassify a name as an id.
+_SLACK_ID_PATTERN = re.compile(r"^[A-Z][A-Z0-9]{5,}$")
 
 
 def _success(**payload: Any) -> str:
@@ -34,6 +45,16 @@ def _headers() -> dict[str, str]:
     if not access_token:
         raise ValueError("SLACK_ACCESS_TOKEN environment variable is missing")
     return {"Authorization": f"Bearer {access_token}"}
+
+
+def _normalize_channel(channel: str) -> str:
+    """Accept a channel id ("C0123456789") or a name with or without the
+    leading "#"; bare names get the "#" prepended so all three documented
+    forms reach the API in a shape it accepts."""
+    value = channel.strip()
+    if value.startswith("#") or _SLACK_ID_PATTERN.match(value):
+        return value
+    return f"#{value}"
 
 
 def _request(
@@ -52,15 +73,28 @@ def _request(
     Write calls pass json_data rather than params: message text can exceed
     URL length limits, and query strings are commonly logged in plaintext by
     proxies/load balancers, which would leak message content.
+
+    Rate limiting is the one non-200 case worth special handling: on a 429
+    with a small Retry-After, wait once and retry instead of failing.
     """
-    response = requests.request(
-        method=method,
-        url=f"{SLACK_BASE_URL}/{path}",
-        headers=_headers(),
-        params=params,
-        json=json_data,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
+    for attempt in (0, 1):
+        response = requests.request(
+            method=method,
+            url=f"{SLACK_BASE_URL}/{path}",
+            headers=_headers(),
+            params=params,
+            json=json_data,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 429 and attempt == 0:
+            try:
+                retry_after = int(response.headers.get("Retry-After", "0"))
+            except ValueError:
+                retry_after = 0
+            if 0 < retry_after <= MAX_RETRY_AFTER_SECONDS:
+                time.sleep(retry_after)
+                continue
+        break
     response.raise_for_status()
     payload: dict[str, Any] = response.json()
     if not payload.get("ok"):
@@ -69,16 +103,29 @@ def _request(
 
 
 @mcp.tool()
-def slack_list_channels(exclude_archived: bool = True) -> str:
+def slack_list_channels(
+    exclude_archived: bool = True,
+    name_contains: str = "",
+    limit: int = MAX_CHANNELS,
+) -> str:
     """
     List public channels in the connected Slack workspace (id, name, is_archived).
-    Use this to resolve a channel name to an id before posting, or to find the
-    right channel when the user names one imprecisely.
+    Use this to resolve a channel name to an id before posting.
+    name_contains: optional case-insensitive substring filter on the channel
+    name — pass it when looking for a specific channel in a large workspace
+    instead of listing everything.
+    limit: maximum channels to return (default 1000).
+    The response includes truncated=true when there were more channels than
+    returned (more pages, the limit was hit, or a page failed mid-way — a
+    partial list is returned rather than discarded).
     """
+    channels: list[dict[str, Any]] = []
+    needle = name_contains.strip().lower()
+    max_channels = max(1, min(int(limit), MAX_CHANNELS))
+    cursor: str | None = None
+    truncated = False
     try:
-        channels: list[dict[str, Any]] = []
-        cursor: str | None = None
-        for _ in range(MAX_PAGES):
+        for page_index in range(MAX_PAGES):
             params: dict[str, Any] = {
                 "types": "public_channel",
                 # Slack expects a lowercase "true"/"false" string; requests
@@ -89,19 +136,36 @@ def slack_list_channels(exclude_archived: bool = True) -> str:
             }
             if cursor:
                 params["cursor"] = cursor
-            result = _request("GET", "conversations.list", params=params)
-            channels.extend(
-                {
-                    "id": channel.get("id"),
-                    "name": channel.get("name"),
-                    "is_archived": channel.get("is_archived", False),
-                }
-                for channel in result.get("channels", [])
-            )
+            try:
+                result = _request("GET", "conversations.list", params=params)
+            except Exception as page_exc:
+                if not channels:
+                    raise
+                # A mid-pagination failure (e.g. a rate limit that outlived
+                # the single retry) must not discard the pages already
+                # fetched — return the partial list with a marker instead.
+                logger.warning(f"Slack channel pagination stopped early: {page_exc}")
+                return _success(channels=channels, truncated=True, error=str(page_exc))
+            for channel in result.get("channels") or []:
+                name = str(channel.get("name") or "")
+                if needle and needle not in name.lower():
+                    continue
+                channels.append(
+                    {
+                        "id": channel.get("id"),
+                        "name": channel.get("name"),
+                        "is_archived": channel.get("is_archived", False),
+                    }
+                )
+                if len(channels) >= max_channels:
+                    return _success(channels=channels, truncated=True)
             cursor = (result.get("response_metadata") or {}).get("next_cursor")
             if not cursor:
                 break
-        return _success(channels=channels)
+        else:
+            # MAX_PAGES exhausted with a cursor still pending.
+            truncated = bool(cursor)
+        return _success(channels=channels, truncated=truncated)
     except Exception as e:
         logger.error(f"Error listing Slack channels: {e}")
         return _error(str(e))
@@ -111,14 +175,15 @@ def slack_list_channels(exclude_archived: bool = True) -> str:
 def slack_post_message(channel: str, text: str) -> str:
     """
     Post a message to a Slack channel.
-    channel: a channel id (e.g. "C0123456789") or name (e.g. "#incidents" or "incidents").
+    channel: a channel id (e.g. "C0123456789") or name (e.g. "#incidents" or
+    "incidents" — a bare name is normalized to "#incidents").
     text: the message body (plain text or Slack mrkdwn).
     """
     try:
         result = _request(
             "POST",
             "chat.postMessage",
-            json_data={"channel": channel, "text": text},
+            json_data={"channel": _normalize_channel(channel), "text": text},
         )
         return _success(channel=result.get("channel"), ts=result.get("ts"))
     except Exception as e:

--- a/src/xagent/web/tools/mcp/slack.py
+++ b/src/xagent/web/tools/mcp/slack.py
@@ -124,8 +124,9 @@ def slack_list_channels(
     max_channels = max(1, min(int(limit), MAX_CHANNELS))
     cursor: str | None = None
     truncated = False
+    pages_scanned = 0
     try:
-        for page_index in range(MAX_PAGES):
+        for _ in range(MAX_PAGES):
             params: dict[str, Any] = {
                 "types": "public_channel",
                 # Slack expects a lowercase "true"/"false" string; requests
@@ -139,14 +140,18 @@ def slack_list_channels(
             try:
                 result = _request("GET", "conversations.list", params=params)
             except Exception as page_exc:
-                if not channels:
+                if not pages_scanned:
                     raise
                 # A mid-pagination failure (e.g. a rate limit that outlived
                 # the single retry) must not discard the pages already
                 # fetched — return the partial list with a marker instead.
+                # This can legitimately be an empty list when name_contains
+                # filtered out everything scanned so far.
                 logger.warning(f"Slack channel pagination stopped early: {page_exc}")
                 return _success(channels=channels, truncated=True, error=str(page_exc))
-            for channel in result.get("channels") or []:
+            pages_scanned += 1
+            raw_channels = result.get("channels") or []
+            for index, channel in enumerate(raw_channels):
                 name = str(channel.get("name") or "")
                 if needle and needle not in name.lower():
                     continue
@@ -158,7 +163,17 @@ def slack_list_channels(
                     }
                 )
                 if len(channels) >= max_channels:
-                    return _success(channels=channels, truncated=True)
+                    # Only truncated if there is actually more data: more raw
+                    # results left in this page, or another page pending —
+                    # hitting the limit on the very last item of the very
+                    # last page is not truncation.
+                    more_in_page = index + 1 < len(raw_channels)
+                    more_pages = bool(
+                        (result.get("response_metadata") or {}).get("next_cursor")
+                    )
+                    return _success(
+                        channels=channels, truncated=more_in_page or more_pages
+                    )
             cursor = (result.get("response_metadata") or {}).get("next_cursor")
             if not cursor:
                 break

--- a/tests/alembic/test_20260801_seed_slack_mcp_app.py
+++ b/tests/alembic/test_20260801_seed_slack_mcp_app.py
@@ -119,7 +119,7 @@ def test_upgrade_is_idempotent(tmp_path):
         assert provider_count == 1
 
 
-def test_seed_rows_match_registry(tmp_path):
+def test_seed_rows_match_registry():
     """The migration snapshot and the runtime registry must define the same
     slack rows (the migration is a frozen copy; this catches drift)."""
     from xagent.web.builtin_mcp_registry import (
@@ -171,9 +171,11 @@ def test_downgrade_keeps_provider_when_custom_slack_app_exists(tmp_path):
         assert "slack" in _provider_names(connection)
 
 
-def test_downgrade_preserves_admin_created_slack_provider(tmp_path):
-    """A pre-existing admin-created "slack" provider (different shape than the
-    seeded row) must survive downgrade even when no slack apps remain."""
+def test_downgrade_deletes_provider_unconditionally_by_name(tmp_path):
+    """The downgrade deletes the slack provider row by provider_name alone,
+    matching the sibling seed migrations (meta, google-maps): a shape-matching
+    guard would protect the wrong thing, since an admin recreating the real
+    Slack provider would enter the canonical URLs and match the guard anyway."""
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
@@ -191,7 +193,7 @@ def test_downgrade_preserves_admin_created_slack_provider(tmp_path):
             migration.upgrade()
             migration.downgrade()
         assert "slack" not in _app_ids(connection)
-        assert "slack" in _provider_names(connection)
+        assert "slack" not in _provider_names(connection)
 
 
 def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):

--- a/tests/alembic/test_20260801_seed_slack_mcp_app.py
+++ b/tests/alembic/test_20260801_seed_slack_mcp_app.py
@@ -1,0 +1,210 @@
+"""Tests for the Slack MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260801_seed_slack_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_slack_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "slack" in _provider_names(connection)
+        assert "slack" in _app_ids(connection)
+
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='slack'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "slack"
+        assert "xagent.web.tools.mcp.slack" in str(row[2])
+        assert "SLACK_ACCESS_TOKEN" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='slack'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='slack'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    slack rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "slack"
+    )
+    assert migration._slack_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "slack"
+    )
+    assert migration._slack_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "slack" not in _app_ids(connection)
+        assert "slack" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_slack_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-slack', 'Custom Slack', 'oauth', 'slack')"
+                )
+            )
+            migration.downgrade()
+        assert "slack" in _provider_names(connection)
+
+
+def test_downgrade_preserves_admin_created_slack_provider(tmp_path):
+    """A pre-existing admin-created "slack" provider (different shape than the
+    seeded row) must survive downgrade even when no slack apps remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('slack', 'Custom Slack', 'cid', 'secret',"
+                " 'https://custom.example.com/authorize',"
+                " 'https://custom.example.com/token')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "slack" not in _app_ids(connection)
+        assert "slack" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -740,6 +740,10 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
             "xagent.web.tools.mcp.instagram",
             {"META_ACCESS_TOKEN": "access_token"},
         ),
+        "slack": (
+            "xagent.web.tools.mcp.slack",
+            {"SLACK_ACCESS_TOKEN": "access_token"},
+        ),
     }
     rows_by_app_id = {row["app_id"]: row for row in get_builtin_public_mcp_app_rows()}
 

--- a/tests/web/test_slack_oauth.py
+++ b/tests/web/test_slack_oauth.py
@@ -89,20 +89,17 @@ def _callback_request(db, user) -> SimpleNamespace:
 
 def test_slack_callback_persists_workspace_identity(db_session, monkeypatch):
     db, user = db_session
-    monkeypatch.setattr(
-        auth_api.requests,
-        "post",
-        Mock(
-            return_value=MockResponse(
-                {
-                    "ok": True,
-                    "access_token": "xoxb-token",
-                    "token_type": "bot",
-                    "scope": "chat:write,chat:write.public,channels:read",
-                }
-            )
-        ),
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "ok": True,
+                "access_token": "xoxb-token",
+                "token_type": "bot",
+                "scope": "chat:write,chat:write.public,channels:read",
+            }
+        )
     )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
     monkeypatch.setattr(
         auth_api.requests,
         "get",
@@ -126,6 +123,19 @@ def test_slack_callback_persists_workspace_identity(db_session, monkeypatch):
     assert oauth_account.access_token == "xoxb-token"
     assert oauth_account.provider_user_id == "T0123"
     assert oauth_account.email == "acme-workspace"
+
+    # Slack (unlike some OAuth providers) accepts client_id/client_secret in
+    # the token-exchange POST body rather than requiring HTTP Basic auth —
+    # this PR relies on that to avoid a Slack-specific token-exchange path,
+    # so pin the request shape rather than leaving it unverified.
+    assert mock_post.call_args.args[0] == "https://slack.com/api/oauth.v2.access"
+    assert mock_post.call_args.kwargs["data"] == {
+        "grant_type": "authorization_code",
+        "code": "slack-code",
+        "client_id": "slack-client-id",
+        "client_secret": "slack-client-secret",
+        "redirect_uri": "https://app.example.com/api/auth/slack/callback",
+    }
 
 
 def test_slack_callback_fails_when_auth_test_reports_ok_false(db_session, monkeypatch):

--- a/tests/web/test_slack_oauth.py
+++ b/tests/web/test_slack_oauth.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import (
+    _merge_oauth_scopes,
+    _oauth_scope_separator,
+    create_access_token,
+    generic_oauth_callback,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="slack",
+            name="Slack",
+            transport="oauth",
+            provider_name="slack",
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _slack_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="slack",
+        client_id=encrypt_value("slack-client-id"),
+        client_secret=encrypt_value("slack-client-secret"),
+        token_url="https://slack.com/api/oauth.v2.access",
+        redirect_uri="https://app.example.com/api/auth/slack/callback",
+        userinfo_url="https://slack.com/api/auth.test",
+        user_id_path="team_id",
+        email_path="team",
+        default_scopes=["chat:write", "chat:write.public", "channels:read"],
+    )
+
+
+def _callback_request(db, user) -> SimpleNamespace:
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "slack",
+            "app_id": "slack",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    return SimpleNamespace(query_params={"code": "slack-code", "state": state})
+
+
+def test_slack_callback_persists_workspace_identity(db_session, monkeypatch):
+    db, user = db_session
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "ok": True,
+                    "access_token": "xoxb-token",
+                    "token_type": "bot",
+                    "scope": "chat:write,chat:write.public,channels:read",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"ok": True, "team_id": "T0123", "team": "acme-workspace"}
+            )
+        ),
+    )
+
+    response = generic_oauth_callback(
+        "slack", _callback_request(db, user), db, _slack_provider()
+    )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "slack")
+        .one()
+    )
+    assert oauth_account.access_token == "xoxb-token"
+    assert oauth_account.provider_user_id == "T0123"
+    assert oauth_account.email == "acme-workspace"
+
+
+def test_slack_callback_fails_when_auth_test_reports_ok_false(db_session, monkeypatch):
+    """Slack answers HTTP 200 with {"ok": false} for a bad/revoked token; the
+    callback must fail visibly instead of persisting a dead "connected"
+    account with no identity."""
+    db, user = db_session
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {"ok": True, "access_token": "xoxb-token", "token_type": "bot"}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(return_value=MockResponse({"ok": False, "error": "invalid_auth"})),
+    )
+
+    response = generic_oauth_callback(
+        "slack", _callback_request(db, user), db, _slack_provider()
+    )
+
+    assert response.status_code == 400
+    assert "invalid_auth" in response.body.decode()
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "slack")
+        .first()
+        is None
+    )
+
+
+def test_slack_scopes_join_with_spaces():
+    """Regression pin for the scope-string form: Slack's docs describe
+    comma-separated scopes, but the space-joined form produced by the generic
+    separator was verified working end-to-end against a real workspace. A
+    refactor of _oauth_scope_separator must not silently change this."""
+    assert _oauth_scope_separator("slack") == " "
+    provider = _slack_provider()
+    joined = _oauth_scope_separator("slack").join(
+        _merge_oauth_scopes(provider.default_scopes, None)
+    )
+    assert joined == "chat:write chat:write.public channels:read"

--- a/tests/web/tools/test_slack_mcp.py
+++ b/tests/web/tools/test_slack_mcp.py
@@ -206,6 +206,37 @@ def test_list_channels_stops_at_limit_and_flags_truncation(monkeypatch):
     assert result["truncated"] is True
 
 
+def test_list_channels_limit_matching_last_item_of_last_page_is_not_truncated(
+    monkeypatch,
+):
+    """Hitting the limit exactly on the last channel of the last page (no
+    more raw results in this page, no next_cursor) means there is nothing
+    left — truncated must be False, not a false positive from the limit
+    check alone."""
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "ok": True,
+                    "channels": [
+                        {"id": f"C{i}", "name": f"chan-{i}", "is_archived": False}
+                        for i in range(3)
+                    ],
+                    "response_metadata": {"next_cursor": ""},
+                }
+            )
+        ),
+    )
+
+    result = json.loads(slack.slack_list_channels(limit=3))
+
+    assert result["status"] == "success"
+    assert len(result["channels"]) == 3
+    assert result["truncated"] is False
+
+
 def test_list_channels_follows_pagination(monkeypatch):
     mock_request = Mock(
         side_effect=[
@@ -260,6 +291,36 @@ def test_list_channels_returns_partial_results_when_a_later_page_fails(monkeypat
 
     assert result["status"] == "success"
     assert [c["id"] for c in result["channels"]] == ["C1"]
+    assert result["truncated"] is True
+    assert "ratelimited" in result["error"]
+
+
+def test_list_channels_returns_partial_results_when_filter_matched_nothing_yet(
+    monkeypatch,
+):
+    """A name_contains filter that matched nothing on page 1 must not be
+    confused with "no page fetched yet": a page-2 failure should still
+    return the (empty) partial result rather than raising."""
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(
+                {
+                    "ok": True,
+                    "channels": [{"id": "C1", "name": "general", "is_archived": False}],
+                    "response_metadata": {"next_cursor": "page-2"},
+                }
+            ),
+            MockResponse({"ok": False, "error": "ratelimited"}),
+        ]
+    )
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    result = json.loads(
+        slack.slack_list_channels(name_contains="no-such-channel-matches")
+    )
+
+    assert result["status"] == "success"
+    assert result["channels"] == []
     assert result["truncated"] is True
     assert "ratelimited" in result["error"]
 
@@ -342,7 +403,7 @@ def test_post_message_returns_error_payload_on_slack_error(monkeypatch, error_co
         Mock(return_value=MockResponse({"ok": False, "error": error_code})),
     )
 
-    result = json.loads(slack.slack_post_message("C0123", "hi"))
+    result = json.loads(slack.slack_post_message("C0123456789", "hi"))
 
     assert result["status"] == "error"
     assert error_code in result["message"]
@@ -355,7 +416,7 @@ def test_post_message_reports_http_error_through_the_tool(monkeypatch):
         Mock(return_value=MockResponse({}, status_code=500)),
     )
 
-    result = json.loads(slack.slack_post_message("C0123", "hi"))
+    result = json.loads(slack.slack_post_message("C0123456789", "hi"))
 
     assert result["status"] == "error"
     assert "500" in result["message"]
@@ -364,7 +425,7 @@ def test_post_message_reports_http_error_through_the_tool(monkeypatch):
 def test_post_message_reports_missing_token_through_the_tool(monkeypatch):
     monkeypatch.delenv("SLACK_ACCESS_TOKEN")
 
-    result = json.loads(slack.slack_post_message("C0123", "hi"))
+    result = json.loads(slack.slack_post_message("C0123456789", "hi"))
 
     assert result["status"] == "error"
     assert "SLACK_ACCESS_TOKEN" in result["message"]

--- a/tests/web/tools/test_slack_mcp.py
+++ b/tests/web/tools/test_slack_mcp.py
@@ -8,9 +8,10 @@ from xagent.web.tools.mcp import slack
 
 
 class MockResponse:
-    def __init__(self, json_data=None, status_code=200):
+    def __init__(self, json_data=None, status_code=200, headers=None):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
+        self.headers = headers or {}
 
     def json(self):
         return self._json_data
@@ -34,6 +35,19 @@ def test_headers_require_access_token(monkeypatch):
 
 def test_headers_include_bearer_token():
     assert slack._headers() == {"Authorization": "Bearer xoxb-test-token"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "normalized"),
+    [
+        ("C0123456789", "C0123456789"),  # channel id, untouched
+        ("#incidents", "#incidents"),  # already hash-prefixed
+        ("incidents", "#incidents"),  # bare name gets the hash
+        (" incidents ", "#incidents"),  # whitespace trimmed first
+    ],
+)
+def test_normalize_channel(raw, normalized):
+    assert slack._normalize_channel(raw) == normalized
 
 
 def test_request_raises_on_slack_ok_false(monkeypatch):
@@ -69,6 +83,39 @@ def test_request_raises_on_http_error_status(monkeypatch):
         slack._request("GET", "auth.test")
 
 
+def test_request_retries_once_on_rate_limit_with_small_retry_after(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse({}, status_code=429, headers={"Retry-After": "2"}),
+            MockResponse({"ok": True, "channels": []}),
+        ]
+    )
+    sleep = Mock()
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+    monkeypatch.setattr(slack.time, "sleep", sleep)
+
+    result = slack._request("GET", "conversations.list")
+
+    assert result["ok"] is True
+    assert mock_request.call_count == 2
+    sleep.assert_called_once_with(2)
+
+
+def test_request_does_not_retry_on_large_retry_after(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse({}, status_code=429, headers={"Retry-After": "120"})
+    )
+    sleep = Mock()
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+    monkeypatch.setattr(slack.time, "sleep", sleep)
+
+    with pytest.raises(requests.HTTPError):
+        slack._request("GET", "conversations.list")
+
+    assert mock_request.call_count == 1
+    sleep.assert_not_called()
+
+
 def test_list_channels_returns_flat_list(monkeypatch):
     monkeypatch.setattr(
         slack.requests,
@@ -93,18 +140,70 @@ def test_list_channels_returns_flat_list(monkeypatch):
         {"id": "C1", "name": "general", "is_archived": False},
         {"id": "C2", "name": "incidents", "is_archived": False},
     ]
+    assert result["truncated"] is False
 
 
-def test_list_channels_passes_exclude_archived_and_types(monkeypatch):
+@pytest.mark.parametrize(("value", "serialized"), [(True, "true"), (False, "false")])
+def test_list_channels_serializes_exclude_archived_lowercase(
+    monkeypatch, value, serialized
+):
     mock_request = Mock(return_value=MockResponse({"ok": True, "channels": []}))
     monkeypatch.setattr(slack.requests, "request", mock_request)
 
-    slack.slack_list_channels(exclude_archived=False)
+    slack.slack_list_channels(exclude_archived=value)
 
     params = mock_request.call_args.kwargs["params"]
-    assert params["exclude_archived"] == "false"
+    assert params["exclude_archived"] == serialized
     assert params["types"] == "public_channel"
     assert "cursor" not in params
+
+
+def test_list_channels_filters_by_name_contains(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "ok": True,
+                    "channels": [
+                        {"id": "C1", "name": "general", "is_archived": False},
+                        {"id": "C2", "name": "prod-incidents", "is_archived": False},
+                    ],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(slack.slack_list_channels(name_contains="INCIDENT"))
+
+    assert result["status"] == "success"
+    assert [c["id"] for c in result["channels"]] == ["C2"]
+
+
+def test_list_channels_stops_at_limit_and_flags_truncation(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "ok": True,
+                    "channels": [
+                        {"id": f"C{i}", "name": f"chan-{i}", "is_archived": False}
+                        for i in range(5)
+                    ],
+                    "response_metadata": {"next_cursor": "more"},
+                }
+            )
+        ),
+    )
+
+    result = json.loads(slack.slack_list_channels(limit=3))
+
+    assert result["status"] == "success"
+    assert len(result["channels"]) == 3
+    assert result["truncated"] is True
 
 
 def test_list_channels_follows_pagination(monkeypatch):
@@ -134,12 +233,38 @@ def test_list_channels_follows_pagination(monkeypatch):
 
     assert result["status"] == "success"
     assert [c["id"] for c in result["channels"]] == ["C1", "C2"]
+    assert result["truncated"] is False
     assert mock_request.call_count == 2
     second_call_params = mock_request.call_args_list[1].kwargs["params"]
     assert second_call_params["cursor"] == "page-2"
 
 
-def test_list_channels_returns_error_payload_on_failure(monkeypatch):
+def test_list_channels_returns_partial_results_when_a_later_page_fails(monkeypatch):
+    """conversations.list is Tier-2 rate-limited; a failure on page N must not
+    discard the N-1 pages already fetched."""
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(
+                {
+                    "ok": True,
+                    "channels": [{"id": "C1", "name": "general", "is_archived": False}],
+                    "response_metadata": {"next_cursor": "page-2"},
+                }
+            ),
+            MockResponse({"ok": False, "error": "ratelimited"}),
+        ]
+    )
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "success"
+    assert [c["id"] for c in result["channels"]] == ["C1"]
+    assert result["truncated"] is True
+    assert "ratelimited" in result["error"]
+
+
+def test_list_channels_returns_error_payload_when_first_page_fails(monkeypatch):
     monkeypatch.setattr(
         slack.requests,
         "request",
@@ -152,6 +277,28 @@ def test_list_channels_returns_error_payload_on_failure(monkeypatch):
     assert "missing_scope" in result["message"]
 
 
+def test_list_channels_tolerates_missing_channels_key(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": True})),
+    )
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "success"
+    assert result["channels"] == []
+
+
+def test_list_channels_reports_missing_token_through_the_tool(monkeypatch):
+    monkeypatch.delenv("SLACK_ACCESS_TOKEN")
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "error"
+    assert "SLACK_ACCESS_TOKEN" in result["message"]
+
+
 def test_post_message_returns_channel_and_ts(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -160,48 +307,64 @@ def test_post_message_returns_channel_and_ts(monkeypatch):
     )
     monkeypatch.setattr(slack.requests, "request", mock_request)
 
-    result = json.loads(slack.slack_post_message("C0123", "Incident detected"))
+    result = json.loads(slack.slack_post_message("C0123456789", "Incident detected"))
 
     assert result["status"] == "success"
     assert result["channel"] == "C0123"
     assert result["ts"] == "1753900000.000100"
     call_kwargs = mock_request.call_args.kwargs
     assert call_kwargs["url"].endswith("/chat.postMessage")
-    assert call_kwargs["json"] == {"channel": "C0123", "text": "Incident detected"}
+    assert call_kwargs["json"] == {
+        "channel": "C0123456789",
+        "text": "Incident detected",
+    }
 
 
-def test_post_message_accepts_channel_name(monkeypatch):
+@pytest.mark.parametrize(
+    ("raw", "sent"), [("#incidents", "#incidents"), ("incidents", "#incidents")]
+)
+def test_post_message_normalizes_channel_names(monkeypatch, raw, sent):
     mock_request = Mock(
         return_value=MockResponse({"ok": True, "channel": "C0123", "ts": "1.1"})
     )
     monkeypatch.setattr(slack.requests, "request", mock_request)
 
-    json.loads(slack.slack_post_message("#incidents", "hello"))
+    json.loads(slack.slack_post_message(raw, "hello"))
 
-    assert mock_request.call_args.kwargs["json"]["channel"] == "#incidents"
+    assert mock_request.call_args.kwargs["json"]["channel"] == sent
 
 
-def test_post_message_returns_error_payload_on_channel_not_found(monkeypatch):
+@pytest.mark.parametrize("error_code", ["channel_not_found", "not_in_channel"])
+def test_post_message_returns_error_payload_on_slack_error(monkeypatch, error_code):
     monkeypatch.setattr(
         slack.requests,
         "request",
-        Mock(return_value=MockResponse({"ok": False, "error": "channel_not_found"})),
-    )
-
-    result = json.loads(slack.slack_post_message("C_missing", "hi"))
-
-    assert result["status"] == "error"
-    assert "channel_not_found" in result["message"]
-
-
-def test_post_message_returns_error_payload_on_not_in_channel(monkeypatch):
-    monkeypatch.setattr(
-        slack.requests,
-        "request",
-        Mock(return_value=MockResponse({"ok": False, "error": "not_in_channel"})),
+        Mock(return_value=MockResponse({"ok": False, "error": error_code})),
     )
 
     result = json.loads(slack.slack_post_message("C0123", "hi"))
 
     assert result["status"] == "error"
-    assert "not_in_channel" in result["message"]
+    assert error_code in result["message"]
+
+
+def test_post_message_reports_http_error_through_the_tool(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({}, status_code=500)),
+    )
+
+    result = json.loads(slack.slack_post_message("C0123", "hi"))
+
+    assert result["status"] == "error"
+    assert "500" in result["message"]
+
+
+def test_post_message_reports_missing_token_through_the_tool(monkeypatch):
+    monkeypatch.delenv("SLACK_ACCESS_TOKEN")
+
+    result = json.loads(slack.slack_post_message("C0123", "hi"))
+
+    assert result["status"] == "error"
+    assert "SLACK_ACCESS_TOKEN" in result["message"]

--- a/tests/web/tools/test_slack_mcp.py
+++ b/tests/web/tools/test_slack_mcp.py
@@ -102,7 +102,7 @@ def test_list_channels_passes_exclude_archived_and_types(monkeypatch):
     slack.slack_list_channels(exclude_archived=False)
 
     params = mock_request.call_args.kwargs["params"]
-    assert params["exclude_archived"] is False
+    assert params["exclude_archived"] == "false"
     assert params["types"] == "public_channel"
     assert "cursor" not in params
 
@@ -167,7 +167,7 @@ def test_post_message_returns_channel_and_ts(monkeypatch):
     assert result["ts"] == "1753900000.000100"
     call_kwargs = mock_request.call_args.kwargs
     assert call_kwargs["url"].endswith("/chat.postMessage")
-    assert call_kwargs["params"] == {"channel": "C0123", "text": "Incident detected"}
+    assert call_kwargs["json"] == {"channel": "C0123", "text": "Incident detected"}
 
 
 def test_post_message_accepts_channel_name(monkeypatch):
@@ -178,7 +178,7 @@ def test_post_message_accepts_channel_name(monkeypatch):
 
     json.loads(slack.slack_post_message("#incidents", "hello"))
 
-    assert mock_request.call_args.kwargs["params"]["channel"] == "#incidents"
+    assert mock_request.call_args.kwargs["json"]["channel"] == "#incidents"
 
 
 def test_post_message_returns_error_payload_on_channel_not_found(monkeypatch):

--- a/tests/web/tools/test_slack_mcp.py
+++ b/tests/web/tools/test_slack_mcp.py
@@ -1,0 +1,207 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import slack
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code=200):
+        self._json_data = json_data if json_data is not None else {}
+        self.status_code = status_code
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("SLACK_ACCESS_TOKEN", "xoxb-test-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("SLACK_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="SLACK_ACCESS_TOKEN"):
+        slack._headers()
+
+
+def test_headers_include_bearer_token():
+    assert slack._headers() == {"Authorization": "Bearer xoxb-test-token"}
+
+
+def test_request_raises_on_slack_ok_false(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": False, "error": "invalid_auth"})),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid_auth"):
+        slack._request("GET", "auth.test")
+
+
+def test_request_raises_generic_message_when_error_field_absent(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": False})),
+    )
+
+    with pytest.raises(RuntimeError, match="Unknown Slack API error"):
+        slack._request("GET", "auth.test")
+
+
+def test_request_raises_on_http_error_status(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({}, status_code=500)),
+    )
+
+    with pytest.raises(requests.HTTPError):
+        slack._request("GET", "auth.test")
+
+
+def test_list_channels_returns_flat_list(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "ok": True,
+                    "channels": [
+                        {"id": "C1", "name": "general", "is_archived": False},
+                        {"id": "C2", "name": "incidents", "is_archived": False},
+                    ],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "success"
+    assert result["channels"] == [
+        {"id": "C1", "name": "general", "is_archived": False},
+        {"id": "C2", "name": "incidents", "is_archived": False},
+    ]
+
+
+def test_list_channels_passes_exclude_archived_and_types(monkeypatch):
+    mock_request = Mock(return_value=MockResponse({"ok": True, "channels": []}))
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    slack.slack_list_channels(exclude_archived=False)
+
+    params = mock_request.call_args.kwargs["params"]
+    assert params["exclude_archived"] is False
+    assert params["types"] == "public_channel"
+    assert "cursor" not in params
+
+
+def test_list_channels_follows_pagination(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(
+                {
+                    "ok": True,
+                    "channels": [{"id": "C1", "name": "general", "is_archived": False}],
+                    "response_metadata": {"next_cursor": "page-2"},
+                }
+            ),
+            MockResponse(
+                {
+                    "ok": True,
+                    "channels": [
+                        {"id": "C2", "name": "incidents", "is_archived": False}
+                    ],
+                    "response_metadata": {"next_cursor": ""},
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "success"
+    assert [c["id"] for c in result["channels"]] == ["C1", "C2"]
+    assert mock_request.call_count == 2
+    second_call_params = mock_request.call_args_list[1].kwargs["params"]
+    assert second_call_params["cursor"] == "page-2"
+
+
+def test_list_channels_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": False, "error": "missing_scope"})),
+    )
+
+    result = json.loads(slack.slack_list_channels())
+
+    assert result["status"] == "error"
+    assert "missing_scope" in result["message"]
+
+
+def test_post_message_returns_channel_and_ts(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            {"ok": True, "channel": "C0123", "ts": "1753900000.000100"}
+        )
+    )
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    result = json.loads(slack.slack_post_message("C0123", "Incident detected"))
+
+    assert result["status"] == "success"
+    assert result["channel"] == "C0123"
+    assert result["ts"] == "1753900000.000100"
+    call_kwargs = mock_request.call_args.kwargs
+    assert call_kwargs["url"].endswith("/chat.postMessage")
+    assert call_kwargs["params"] == {"channel": "C0123", "text": "Incident detected"}
+
+
+def test_post_message_accepts_channel_name(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse({"ok": True, "channel": "C0123", "ts": "1.1"})
+    )
+    monkeypatch.setattr(slack.requests, "request", mock_request)
+
+    json.loads(slack.slack_post_message("#incidents", "hello"))
+
+    assert mock_request.call_args.kwargs["params"]["channel"] == "#incidents"
+
+
+def test_post_message_returns_error_payload_on_channel_not_found(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": False, "error": "channel_not_found"})),
+    )
+
+    result = json.loads(slack.slack_post_message("C_missing", "hi"))
+
+    assert result["status"] == "error"
+    assert "channel_not_found" in result["message"]
+
+
+def test_post_message_returns_error_payload_on_not_in_channel(monkeypatch):
+    monkeypatch.setattr(
+        slack.requests,
+        "request",
+        Mock(return_value=MockResponse({"ok": False, "error": "not_in_channel"})),
+    )
+
+    result = json.loads(slack.slack_post_message("C0123", "hi"))
+
+    assert result["status"] == "error"
+    assert "not_in_channel" in result["message"]


### PR DESCRIPTION
## Summary
- Register `slack` as a built-in OAuth MCP connector (`builtin_mcp_registry.py` + seed migration) — new provider (own client_id/secret), since Slack isn't a workspace shared with any existing OAuth provider
- New `xagent.web.tools.mcp.slack` module, two tools:
  - `slack_list_channels` — paginated `conversations.list`, resolves a channel name to an id
  - `slack_post_message` — `chat.postMessage`, accepts either a channel id or `#name`
- Scope: `chat:write` + `chat:write.public` (post to any public channel without a manual bot invite) + `channels:read` — matches the PDF DevOps Agent spec, which only requires posting incident findings (summary, evidence, root-cause hypothesis, recommended fix, severity), not reading or reacting to messages
- No changes needed in `auth.py`/`config.py`: confirmed via Slack's official docs that `oauth.v2.access` accepts `client_id`/`client_secret` in the POST body (Basic Auth is only recommended, not enforced, unlike Zoom), and bot tokens don't expire unless token rotation is explicitly enabled on the Slack app (left off) — the existing generic exchange/refresh code handles both cases already
- Slack's Web API always returns HTTP 200 even on failure, signalling errors via `{"ok": false, "error": "..."}` in the body — the connector's `_request` helper checks `ok`/`error` explicitly rather than relying on `raise_for_status()`

## Test plan
- [x] `pytest tests/web/tools/test_slack_mcp.py tests/alembic/test_20260801_seed_slack_mcp_app.py tests/templates/test_manager.py` — all passing
- [x] `ruff format` / `ruff check` clean, `mypy` clean on touched files
- [x] `alembic upgrade head` / `downgrade -1` round-trip verified against a scratch DB — only the `slack` rows are added/removed, single head
- [x] Manual end-to-end via a real Slack workspace (OAuth connect through an ngrok tunnel, since the Slack app requires a public HTTPS redirect): connected successfully, `slack_list_channels` and `slack_post_message` both verified working, including posting a structured incident message (summary/evidence/root-cause/fix/severity) matching the DevOps Agent's target output format