### PR TITLE
feat: add Granola as a built-in remote-MCP connector for the Meeting Agent

### DIFF
--- a/example.env
+++ b/example.env
@@ -171,7 +171,10 @@ PORT="80"
 # Public base URL of this backend API. A2A Agent Cards advertise interfaces
 # under this base and MCP OAuth uses it directly; Pub/Sub push callbacks use
 # it only as the fallback when XAGENT_TRIGGER_CALLBACK_BASE_URL is unset.
-# This is NOT the frontend URL (XAGENT_APP_BASE_URL).
+# This is NOT the frontend URL (XAGENT_APP_BASE_URL). When unset, MCP OAuth
+# redirect URIs fall back to XAGENT_APP_BASE_URL — that only works when the
+# frontend origin proxies /api/* to this backend (e.g. the nginx compose
+# setup), so split-port local development must set this explicitly.
 # XAGENT_PUBLIC_API_BASE_URL="https://api.example.com"
 # Base URL for inbound trigger callbacks (Gmail Pub/Sub push, future webhooks).
 # Set this only when server-to-server callbacks must reach a different host

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -195,6 +195,22 @@ function ToolsPageContent() {
   }, [router, searchParams])
 
   useEffect(() => {
+    // The MCP OAuth callback redirects the connect popup here after a
+    // successful authorization. The popup was opened under this window name
+    // by the connect flows; self-close it so the opener's popup-closed poll
+    // refreshes connection state, instead of showing the whole app in the
+    // popup. On error, stay open so the toast above is readable.
+    if (
+      typeof window !== "undefined" &&
+      window.name === "mcp-oauth" &&
+      !searchParams.get("mcp_oauth_error") &&
+      !searchParams.get("mcp_oauth_error_message")
+    ) {
+      window.close()
+    }
+  }, [searchParams])
+
+  useEffect(() => {
     loadTools()
     loadMCPServers()
   }, [])

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -57,6 +57,8 @@ import {
   mcpServerDetailToEditState,
   parseCustomApiDetail,
   parseMcpServerDetail,
+  shouldSelfCloseMcpOauthPopup,
+  MCP_OAUTH_SUCCESS_PARAM,
   type CustomApiDetail,
   type McpServerDetail,
 } from "@/lib/mcp-utils"
@@ -196,19 +198,24 @@ function ToolsPageContent() {
 
   useEffect(() => {
     // The MCP OAuth callback redirects the connect popup here after a
-    // successful authorization. The popup was opened under this window name
-    // by the connect flows; self-close it so the opener's popup-closed poll
-    // refreshes connection state, instead of showing the whole app in the
-    // popup. On error, stay open so the toast above is readable.
-    if (
-      typeof window !== "undefined" &&
-      window.name === "mcp-oauth" &&
-      !searchParams.get("mcp_oauth_error") &&
-      !searchParams.get("mcp_oauth_error_message")
-    ) {
+    // successful authorization, appending mcp_oauth_success=1. The popup was
+    // opened under this window name by the connect flows; self-close it so
+    // the opener's popup-closed poll refreshes connection state, instead of
+    // showing the whole app in the popup. On error the popup stays open so
+    // the toast above is readable. shouldSelfCloseMcpOauthPopup is keyed on
+    // the explicit success param, not the absence of error params, so a
+    // future error param added to the callback can't be mistaken for success.
+    if (!searchParams.get(MCP_OAUTH_SUCCESS_PARAM)) return
+    if (typeof window !== "undefined" && shouldSelfCloseMcpOauthPopup(window.name, searchParams)) {
       window.close()
+      return
     }
-  }, [searchParams])
+    // Not the popup (e.g. the flow ran in a full tab): just tidy the URL.
+    const nextParams = new URLSearchParams(searchParams.toString())
+    nextParams.delete(MCP_OAUTH_SUCCESS_PARAM)
+    const nextQuery = nextParams.toString()
+    router.replace(nextQuery ? `/tools?${nextQuery}` : "/tools", { scroll: false })
+  }, [router, searchParams])
 
   useEffect(() => {
     loadTools()

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -184,16 +184,26 @@ function ToolsPageContent() {
   const { getAppIcon } = useMcpApps()
   const isAdmin = Boolean(user?.is_admin)
 
+  // F8: strip all three mcp_oauth redirect params in both effects below, not
+  // just the one each effect owns. The two backend redirects are mutually
+  // exclusive today (never both present at once), but if that ever changed,
+  // one effect's router.replace could otherwise undo the other's cleanup and
+  // cause a duplicate-toast loop.
+  const stripMcpOauthRedirectParams = (params: URLSearchParams) => {
+    const next = new URLSearchParams(params.toString())
+    next.delete("mcp_oauth_error")
+    next.delete("mcp_oauth_error_message")
+    next.delete(MCP_OAUTH_SUCCESS_PARAM)
+    const nextQuery = next.toString()
+    router.replace(nextQuery ? `/tools?${nextQuery}` : "/tools", { scroll: false })
+  }
+
   useEffect(() => {
     const oauthErrorMessage = searchParams.get("mcp_oauth_error_message")
     if (!oauthErrorMessage) return
 
     toast.error(oauthErrorMessage)
-    const nextParams = new URLSearchParams(searchParams.toString())
-    nextParams.delete("mcp_oauth_error")
-    nextParams.delete("mcp_oauth_error_message")
-    const nextQuery = nextParams.toString()
-    router.replace(nextQuery ? `/tools?${nextQuery}` : "/tools", { scroll: false })
+    stripMcpOauthRedirectParams(searchParams)
   }, [router, searchParams])
 
   useEffect(() => {
@@ -211,10 +221,7 @@ function ToolsPageContent() {
       return
     }
     // Not the popup (e.g. the flow ran in a full tab): just tidy the URL.
-    const nextParams = new URLSearchParams(searchParams.toString())
-    nextParams.delete(MCP_OAUTH_SUCCESS_PARAM)
-    const nextQuery = nextParams.toString()
-    router.replace(nextQuery ? `/tools?${nextQuery}` : "/tools", { scroll: false })
+    stripMcpOauthRedirectParams(searchParams)
   }, [router, searchParams])
 
   useEffect(() => {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -390,7 +390,13 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       await waitFor(() => {
         expect(popup.location.href).toBe("https://auth.granola.ai/authorize?client_id=dyn-1")
       })
-      expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank")
+      // A features string must be passed: without one, browsers open a full
+      // new tab instead of the small centered popup the builtin flow uses.
+      expect(openSpy).toHaveBeenCalledWith(
+        "about:blank",
+        "mcp-oauth",
+        expect.stringContaining("width=600,height=700"),
+      )
       expect(popup.close).not.toHaveBeenCalled()
       expect(toastErrorMock).not.toHaveBeenCalled()
     } finally {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -702,6 +702,49 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     }
   })
 
+  it("removes the builtin_oauth postMessage listener on dialog close, not just its interval (F6)", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const onSuccess = vi.fn()
+    const openSpy = vi.spyOn(window, "open").mockReturnValue({} as Window)
+    try {
+      const { rerender } = render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      fireEvent.click(screen.getByRole("button", { name: "connect-builtin" }))
+
+      // Close the dialog while the popup (and its postMessage listener) is
+      // still outstanding — only clearing the interval (and not this
+      // listener too) would let a real success message fired afterward
+      // still call onSuccess against a dialog the user already closed.
+      rerender(
+        <ConnectMcpDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { type: "oauth-success" } }),
+      )
+
+      expect(onSuccess).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
   it("keeps masked baseline entries in an MCP user-env replacement", async () => {
     apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url.includes("/api/mcp/apps?")) {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -435,6 +435,160 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     }
   })
 
+  it("fires onSuccess and auto-selects only once the closed popup is confirmed connected", async () => {
+    vi.useFakeTimers()
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    const onConnectSelected = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize" }),
+          })
+        }
+        if (url === "http://api.local/api/mcp/apps?location=remote") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ id: "granola", name: "Granola", description: "", icon: "", is_connected: true }],
+          })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+          onConnectSelected={onConnectSelected}
+        />,
+      )
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+      })
+
+      // The popup closes only after the redirect (simulating the user
+      // completing the real authorization in it).
+      popup.closed = true
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+
+      expect(onSuccess).toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not fire onSuccess when the popup closes on a cancelled/failed authorization", async () => {
+    vi.useFakeTimers()
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize" }),
+          })
+        }
+        if (url === "http://api.local/api/mcp/apps?location=remote") {
+          // The user closed the error popup by hand (or cancelled consent) —
+          // the backend never recorded a completed grant, so is_connected
+          // stays false even though the association row already exists (M1).
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ id: "granola", name: "Granola", description: "", icon: "", is_connected: false }],
+          })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+      })
+
+      popup.closed = true
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("stops the loading spinner without firing success after the 5-minute poll timeout", async () => {
+    vi.useFakeTimers()
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize" }),
+          })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+      })
+
+      const callsBeforeTimeout = apiRequestMock.mock.calls.length
+
+      // Popup never closes (user walked away with it open); the poll must
+      // still give up after 5 minutes rather than spinning forever (N3).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+      })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      // The timeout path stops polling without ever issuing the
+      // is-it-really-connected check the popup-closed path makes.
+      expect(apiRequestMock.mock.calls.length).toBe(callsBeforeTimeout)
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("keeps masked baseline entries in an MCP user-env replacement", async () => {
     apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url.includes("/api/mcp/apps?")) {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -93,9 +93,11 @@ vi.mock("./official-mcp-settings-dialog", () => ({
   OfficialMcpSettingsDialog: ({
     onConfigure,
     onOpenChange,
+    onConnectStart,
   }: {
     onConfigure: (app: object) => void
     onOpenChange: (open: boolean) => void
+    onConnectStart: (app: object) => void
   }) => (
     <div>
       <button
@@ -112,6 +114,9 @@ vi.mock("./official-mcp-settings-dialog", () => ({
       </button>
       <button type="button" onClick={() => onConfigure(mcpApp(3, "aggregated-mcp"))}>
         configure-mcp
+      </button>
+      <button type="button" onClick={() => onConnectStart(mcpOauthApp())}>
+        connect-granola
       </button>
       <button type="button" onClick={() => onOpenChange(false)}>
         close-settings
@@ -158,6 +163,20 @@ function mcpApp(id: number, name: string) {
     is_local: true,
     server_id: id,
     transport: "streamable_http",
+  }
+}
+
+// A remote-MCP OAuth (DCR) catalog app, e.g. Granola: no provider, no
+// launch command — connecting must go through /apps/{id}/oauth/connect.
+function mcpOauthApp() {
+  return {
+    id: "granola",
+    name: "Granola",
+    description: "",
+    icon: "",
+    is_connected: false,
+    transport: "streamable_http",
+    auth_type: "mcp_oauth",
   }
 }
 
@@ -344,6 +363,70 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
         description: "Updated MCP description",
       })
     })
+  })
+
+  it("connects a remote-MCP OAuth catalog app through the oauth/connect endpoint", async () => {
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    try {
+      apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          expect(options?.method).toBe("POST")
+          expect((options?.headers as Record<string, string>)?.Accept).toBe("application/json")
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize?client_id=dyn-1" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      renderDialog()
+      fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+
+      await waitFor(() => {
+        expect(popup.location.href).toBe("https://auth.granola.ai/authorize?client_id=dyn-1")
+      })
+      expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank")
+      expect(popup.close).not.toHaveBeenCalled()
+      expect(toastErrorMock).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it("surfaces the backend error and closes the popup when oauth/connect fails", async () => {
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            json: async () => ({ detail: "This app is not a remote-OAuth connector" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      renderDialog()
+      fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+
+      await waitFor(() => {
+        expect(toastErrorMock).toHaveBeenCalledWith("This app is not a remote-OAuth connector")
+      })
+      expect(popup.close).toHaveBeenCalled()
+      expect(popup.location.href).toBe("")
+    } finally {
+      openSpy.mockRestore()
+    }
   })
 
   it("keeps masked baseline entries in an MCP user-env replacement", async () => {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -118,6 +118,9 @@ vi.mock("./official-mcp-settings-dialog", () => ({
       <button type="button" onClick={() => onConnectStart(mcpOauthApp())}>
         connect-granola
       </button>
+      <button type="button" onClick={() => onConnectStart(builtinOauthApp())}>
+        connect-builtin
+      </button>
       <button type="button" onClick={() => onOpenChange(false)}>
         close-settings
       </button>
@@ -177,6 +180,20 @@ function mcpOauthApp() {
     is_connected: false,
     transport: "streamable_http",
     auth_type: "mcp_oauth",
+  }
+}
+
+// A static-provider builtin OAuth catalog app, e.g. Zoom/Gmail.
+function builtinOauthApp() {
+  return {
+    id: "zoom",
+    name: "Zoom",
+    description: "",
+    icon: "",
+    is_connected: false,
+    transport: "oauth",
+    auth_type: "builtin_oauth",
+    provider: "zoom",
   }
 }
 
@@ -583,6 +600,102 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       // The timeout path stops polling without ever issuing the
       // is-it-really-connected check the popup-closed path makes.
       expect(apiRequestMock.mock.calls.length).toBe(callsBeforeTimeout)
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("also times out the sibling builtin_oauth poll after 5 minutes (N3)", async () => {
+    vi.useFakeTimers()
+    const popup = { closed: false, close: vi.fn() }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      fireEvent.click(screen.getByRole("button", { name: "connect-builtin" }))
+
+      // Popup never closes; the builtin_oauth poll previously had no timeout
+      // cap at all (N3), unlike the mcp_oauth handler above.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+      })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("clears the in-flight OAuth poll and loading state when the dialog closes, not just unmounts (F6)", async () => {
+    vi.useFakeTimers()
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize" }),
+          })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      const { rerender } = render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-granola" }))
+      })
+
+      const callsBeforeClose = apiRequestMock.mock.calls.length
+
+      // The parent typically keeps ConnectMcpDialog mounted and just flips
+      // `open` — only the dialog's own content unmounts, not this component,
+      // so the unmount-only cleanup effect alone would miss this (F6).
+      rerender(
+        <ConnectMcpDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+
+      popup.closed = true
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
+
+      expect(onSuccess).not.toHaveBeenCalled()
+      // The poll was already cleared on close, so popup.closed flipping true
+      // afterward must not trigger the is-it-connected follow-up check.
+      expect(apiRequestMock.mock.calls.length).toBe(callsBeforeClose)
     } finally {
       openSpy.mockRestore()
       vi.useRealTimers()

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -132,6 +132,13 @@ export function ConnectMcpDialog({
   // leaking (N3: the poll otherwise has no unmount cleanup, unlike
   // custom-mcp-form's equivalent).
   const mcpOauthPollTimersRef = React.useRef<Set<number>>(new Set())
+  // The builtin_oauth flow's postMessage listener, tracked the same way so a
+  // dialog-close or unmount removes it too — otherwise a genuinely
+  // successful auth completed after the user closed the dialog would still
+  // fire onSuccess/auto-select via a listener nothing else was going to
+  // remove (its own interval, the only thing that used to remove it, is
+  // itself cleared by the same close/unmount cleanup).
+  const mcpOauthMessageListenersRef = React.useRef<Set<(event: MessageEvent) => void>>(new Set())
   // F5: this component instance is commonly kept mounted by the parent
   // across dialog open/close (only the Radix Dialog's own content
   // unmounts), so the unmount-only cleanup above never fires on an ordinary
@@ -231,6 +238,22 @@ export function ConnectMcpDialog({
     }
   }
 
+  // Shared by the dialog-close branch below and the unmount cleanup effect:
+  // stop any in-flight OAuth popup poll and remove the builtin_oauth flow's
+  // postMessage listener (F6) — leaving the listener attached would let a
+  // genuinely successful auth, completed after the user closed the dialog,
+  // still fire onSuccess/auto-select via a listener the (now-cleared)
+  // interval was the only thing that used to remove.
+  const clearMcpOauthPollState = () => {
+    mcpOauthPollTimersRef.current.forEach((timer) => window.clearInterval(timer))
+    mcpOauthPollTimersRef.current.clear()
+    mcpOauthMessageListenersRef.current.forEach((listener) =>
+      window.removeEventListener('message', listener)
+    )
+    mcpOauthMessageListenersRef.current.clear()
+    setLoadingApp(null)
+  }
+
   useEffect(() => {
     if (open) {
       setMcpFormData({
@@ -254,9 +277,7 @@ export function ConnectMcpDialog({
       // in-flight OAuth popup poll — otherwise it can later fire
       // onSuccess/auto-select against a closed dialog, and leaves a stale
       // spinner on the card if the dialog is reopened.
-      mcpOauthPollTimersRef.current.forEach((timer) => window.clearInterval(timer))
-      mcpOauthPollTimersRef.current.clear()
-      setLoadingApp(null)
+      clearMcpOauthPollState()
     }
   }, [open, t, selectedMcpServers])
 
@@ -272,8 +293,7 @@ export function ConnectMcpDialog({
   }, [])
 
   useEffect(() => () => {
-    mcpOauthPollTimersRef.current.forEach((timer) => window.clearInterval(timer))
-    mcpOauthPollTimersRef.current.clear()
+    clearMcpOauthPollState()
   }, [])
 
   useEffect(() => {
@@ -708,6 +728,7 @@ export function ConnectMcpDialog({
       if (event.data?.type === 'oauth-success') {
         setLoadingApp(null)
         window.removeEventListener('message', handleMessage)
+        mcpOauthMessageListenersRef.current.delete(handleMessage)
         window.clearInterval(checkPopup)
         mcpOauthPollTimersRef.current.delete(checkPopup)
 
@@ -724,6 +745,7 @@ export function ConnectMcpDialog({
     };
 
     window.addEventListener('message', handleMessage);
+    mcpOauthMessageListenersRef.current.add(handleMessage)
 
     // Fallback: check if popup was closed without success message, or give up
     // after a timeout (N3: this poll previously had neither an unmount-safe
@@ -737,6 +759,7 @@ export function ConnectMcpDialog({
       window.clearInterval(checkPopup);
       mcpOauthPollTimersRef.current.delete(checkPopup)
       window.removeEventListener('message', handleMessage);
+      mcpOauthMessageListenersRef.current.delete(handleMessage)
       setLoadingApp(null);
     }, 500);
     mcpOauthPollTimersRef.current.add(checkPopup)

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -527,7 +527,17 @@ export function ConnectMcpDialog({
     setLoadingApp(app.id)
     // Open the popup synchronously on the click, before any await — popup
     // blockers reject windows opened outside direct user-gesture handling.
-    const popup = window.open("about:blank", "_blank")
+    // The window-features string matters: without it, browsers open a full
+    // new tab instead of the small centered popup the builtin OAuth flow uses.
+    const width = 600
+    const height = 700
+    const left = window.screenX + (window.outerWidth - width) / 2
+    const top = window.screenY + (window.outerHeight - height) / 2
+    const popup = window.open(
+      "about:blank",
+      "mcp-oauth",
+      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes`,
+    )
     if (!popup) {
       toast.error("Popup blocked. Please allow popups for this site to connect.")
       setLoadingApp(null)

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -43,6 +43,7 @@ import { sanitizeAppIntegrations } from "@/lib/team-sharing-sanitizers"
 import {
   isValidMcpName,
   parseMcpOAuthErrorMessage,
+  MCP_OAUTH_POPUP_WINDOW_NAME,
   type McpOAuthConnectResponse,
   buildCustomApiPayload,
   buildMcpServerPayload,
@@ -126,6 +127,10 @@ export function ConnectMcpDialog({
   const [customApiEditBaseline, setCustomApiEditBaseline] = useState<CustomApiDetail | null>(null)
   const [mcpEditBaseline, setMcpEditBaseline] = useState<McpServerDetail | null>(null)
   const connectorEditRequestRef = React.useRef(0)
+  // Popup-closed poll intervals for in-flight mcp_oauth connects, so they can
+  // be cleared on unmount instead of leaking (N3: the poll otherwise has no
+  // unmount cleanup, unlike custom-mcp-form's equivalent).
+  const mcpOauthPollTimersRef = React.useRef<Set<number>>(new Set())
 
   // Custom MCP Server state
   const [isSavingCustom, setIsSavingCustom] = useState(false)
@@ -242,6 +247,11 @@ export function ConnectMcpDialog({
 
   useEffect(() => () => {
     connectorEditRequestRef.current += 1
+  }, [])
+
+  useEffect(() => () => {
+    mcpOauthPollTimersRef.current.forEach((timer) => window.clearInterval(timer))
+    mcpOauthPollTimersRef.current.clear()
   }, [])
 
   useEffect(() => {
@@ -535,7 +545,7 @@ export function ConnectMcpDialog({
     const top = window.screenY + (window.outerHeight - height) / 2
     const popup = window.open(
       "about:blank",
-      "mcp-oauth",
+      MCP_OAUTH_POPUP_WINDOW_NAME,
       `width=${width},height=${height},left=${left},top=${top},scrollbars=yes`,
     )
     if (!popup) {
@@ -577,20 +587,49 @@ export function ConnectMcpDialog({
       return
     }
 
-    // The OAuth callback lands the popup on the app's own /tools page (no
-    // postMessage like the builtin flow) — so refresh once the popup closes.
-    const checkPopup = setInterval(() => {
-      if (popup.closed) {
-        clearInterval(checkPopup)
-        setLoadingApp(null)
+    // The popup's opener link is severed (popup.opener = null), so unlike the
+    // builtin flow there is no postMessage channel — and a closed popup can
+    // mean success OR a cancelled/denied/failed authorization (the error
+    // redirect leaves the popup open for the user to read, then they close it
+    // by hand). So on close, ask the backend which one actually happened and
+    // gate the success actions on the app really being connected; is_connected
+    // for mcp_oauth apps requires a completed grant, not just the association.
+    const startedAt = Date.now()
+    const maxWaitMs = 5 * 60 * 1000
+    const checkPopup = window.setInterval(() => {
+      const expired = Date.now() - startedAt >= maxWaitMs
+      if (!popup.closed && !expired) return
+      window.clearInterval(checkPopup)
+      mcpOauthPollTimersRef.current.delete(checkPopup)
+      setLoadingApp(null)
+      if (!popup.closed) {
+        // Timed out with the popup still open: stop the spinner. If the user
+        // eventually finishes, the next apps refresh shows the connection.
+        return
+      }
+      void (async () => {
+        let connected = false
+        try {
+          const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=remote`)
+          if (response.ok) {
+            const data = sanitizeAppIntegrations(await response.json())
+            connected = data.some(
+              (candidate) => candidate.id === app.id && candidate.is_connected,
+            )
+          }
+        } catch (error) {
+          console.error("Failed to refresh apps after the OAuth popup closed:", error)
+        }
         loadApps()
+        if (!connected) return
         if (onSuccess) onSuccess()
         if (autoSelect && onConnectSelected) {
           setLocalSelectedServers(prev => prev.includes(app.name) ? prev : [...prev, app.name])
         }
         setSelectedApp(null)
-      }
+      })()
     }, 500)
+    mcpOauthPollTimersRef.current.add(checkPopup)
   }
 
   const handleConnectApp = (app: AppIntegration, autoSelect: boolean = false) => {

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -42,6 +42,8 @@ import { sanitizeAppIntegrations } from "@/lib/team-sharing-sanitizers"
 
 import {
   isValidMcpName,
+  parseMcpOAuthErrorMessage,
+  type McpOAuthConnectResponse,
   buildCustomApiPayload,
   buildMcpServerPayload,
   customApiDetailToEditState,
@@ -516,12 +518,79 @@ export function ConnectMcpDialog({
     }
   }
 
+  // Remote-MCP OAuth catalog app (e.g. Granola): the backend ensures the
+  // shared server row + this user's association, runs Dynamic Client
+  // Registration when the provider has no static client, and returns the
+  // authorization URL. Mirrors custom-mcp-form's handleConnectMcpOAuth,
+  // but keyed by catalog app_id instead of a server id.
+  const handleConnectMcpOAuthApp = async (app: AppIntegration, autoSelect: boolean) => {
+    setLoadingApp(app.id)
+    // Open the popup synchronously on the click, before any await — popup
+    // blockers reject windows opened outside direct user-gesture handling.
+    const popup = window.open("about:blank", "_blank")
+    if (!popup) {
+      toast.error("Popup blocked. Please allow popups for this site to connect.")
+      setLoadingApp(null)
+      return
+    }
+    popup.opener = null
+    try {
+      const response = await apiRequest(`${getApiUrl()}/api/mcp/apps/${app.id}/oauth/connect`, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ redirect_after: "/tools?tab=mcp" }),
+      })
+      if (!response.ok) {
+        popup.close()
+        const message = await parseMcpOAuthErrorMessage(response, t('tools.mcp.dialog.oauthConnectFailed'))
+        toast.error(message)
+        setLoadingApp(null)
+        return
+      }
+      const data = await response.json() as McpOAuthConnectResponse
+      if (!data.authorization_url) {
+        popup.close()
+        toast.error(t('tools.mcp.dialog.oauthConnectFailed'))
+        setLoadingApp(null)
+        return
+      }
+      popup.location.href = data.authorization_url
+    } catch (error) {
+      console.error("Failed to start MCP OAuth connect:", error)
+      popup.close()
+      toast.error(t('tools.mcp.dialog.oauthConnectFailed'))
+      setLoadingApp(null)
+      return
+    }
+
+    // The OAuth callback lands the popup on the app's own /tools page (no
+    // postMessage like the builtin flow) — so refresh once the popup closes.
+    const checkPopup = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(checkPopup)
+        setLoadingApp(null)
+        loadApps()
+        if (onSuccess) onSuccess()
+        if (autoSelect && onConnectSelected) {
+          setLocalSelectedServers(prev => prev.includes(app.name) ? prev : [...prev, app.name])
+        }
+        setSelectedApp(null)
+      }
+    }, 500)
+  }
+
   const handleConnectApp = (app: AppIntegration, autoSelect: boolean = false) => {
     if (app.auth_type !== "builtin_oauth") {
-      // Key-based catalog app: collect the key. Anything else is a mis-authored
-      // entry (neither OAuth nor a launchable key-based command).
+      // Key-based catalog app: collect the key; remote-MCP OAuth app: start
+      // the per-user OAuth (DCR) flow. Anything else is a mis-authored entry.
       if (app.auth_type === "api_key") {
         openKeyConnect(app);
+      } else if (app.auth_type === "mcp_oauth") {
+        handleConnectMcpOAuthApp(app, autoSelect);
       } else {
         toast.error(t('tools.mcp.alerts.notConfigured'));
       }

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -127,10 +127,18 @@ export function ConnectMcpDialog({
   const [customApiEditBaseline, setCustomApiEditBaseline] = useState<CustomApiDetail | null>(null)
   const [mcpEditBaseline, setMcpEditBaseline] = useState<McpServerDetail | null>(null)
   const connectorEditRequestRef = React.useRef(0)
-  // Popup-closed poll intervals for in-flight mcp_oauth connects, so they can
-  // be cleared on unmount instead of leaking (N3: the poll otherwise has no
-  // unmount cleanup, unlike custom-mcp-form's equivalent).
+  // Popup-closed poll intervals for in-flight mcp_oauth/builtin_oauth
+  // connects, so they can be cleared on unmount or dialog-close instead of
+  // leaking (N3: the poll otherwise has no unmount cleanup, unlike
+  // custom-mcp-form's equivalent).
   const mcpOauthPollTimersRef = React.useRef<Set<number>>(new Set())
+  // F5: this component instance is commonly kept mounted by the parent
+  // across dialog open/close (only the Radix Dialog's own content
+  // unmounts), so the unmount-only cleanup above never fires on an ordinary
+  // close. Checked after every await in handleConnectMcpOAuthApp so an
+  // in-flight connect POST that resolves after the dialog (or the whole
+  // component) is gone doesn't register a poll nothing will ever clear.
+  const isMountedRef = React.useRef(true)
 
   // Custom MCP Server state
   const [isSavingCustom, setIsSavingCustom] = useState(false)
@@ -242,11 +250,25 @@ export function ConnectMcpDialog({
       setShareChoice("private")
     } else {
       connectorEditRequestRef.current += 1
+      // F6: closing the dialog (not just unmounting it) must also stop any
+      // in-flight OAuth popup poll — otherwise it can later fire
+      // onSuccess/auto-select against a closed dialog, and leaves a stale
+      // spinner on the card if the dialog is reopened.
+      mcpOauthPollTimersRef.current.forEach((timer) => window.clearInterval(timer))
+      mcpOauthPollTimersRef.current.clear()
+      setLoadingApp(null)
     }
   }, [open, t, selectedMcpServers])
 
   useEffect(() => () => {
     connectorEditRequestRef.current += 1
+  }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
   }, [])
 
   useEffect(() => () => {
@@ -586,6 +608,13 @@ export function ConnectMcpDialog({
       setLoadingApp(null)
       return
     }
+    // F5: if the dialog closed (or this component unmounted) while the
+    // connect POST was in flight, don't register a poll after the cleanup
+    // effects have already run — it would never get cleared. The popup
+    // itself is left navigating to the authorization URL either way; the
+    // user can still complete auth in it, and the next apps refresh (e.g.
+    // reopening the dialog) will reflect it.
+    if (!isMountedRef.current) return
 
     // The popup's opener link is severed (popup.opener = null), so unlike the
     // builtin flow there is no postMessage channel — and a closed popup can
@@ -679,6 +708,8 @@ export function ConnectMcpDialog({
       if (event.data?.type === 'oauth-success') {
         setLoadingApp(null)
         window.removeEventListener('message', handleMessage)
+        window.clearInterval(checkPopup)
+        mcpOauthPollTimersRef.current.delete(checkPopup)
 
         loadApps();
         if (onSuccess) onSuccess();
@@ -694,14 +725,21 @@ export function ConnectMcpDialog({
 
     window.addEventListener('message', handleMessage);
 
-    // Fallback: check if popup was closed without success message
-    const checkPopup = setInterval(() => {
-      if (popup?.closed) {
-        clearInterval(checkPopup);
-        window.removeEventListener('message', handleMessage);
-        setLoadingApp(null);
-      }
+    // Fallback: check if popup was closed without success message, or give up
+    // after a timeout (N3: this poll previously had neither an unmount-safe
+    // cleanup nor a timeout cap, unlike the mcp_oauth handler above and
+    // custom-mcp-form.tsx's equivalent flow).
+    const startedAt = Date.now()
+    const maxWaitMs = 5 * 60 * 1000
+    const checkPopup: number = window.setInterval(() => {
+      const expired = Date.now() - startedAt >= maxWaitMs
+      if (!popup?.closed && !expired) return
+      window.clearInterval(checkPopup);
+      mcpOauthPollTimersRef.current.delete(checkPopup)
+      window.removeEventListener('message', handleMessage);
+      setLoadingApp(null);
     }, 500);
+    mcpOauthPollTimersRef.current.add(checkPopup)
   }
 
   const handleCardClick = (app: AppIntegration, isGloballyConnected: boolean) => {

--- a/frontend/src/components/mcp/custom-mcp-form.tsx
+++ b/frontend/src/components/mcp/custom-mcp-form.tsx
@@ -12,6 +12,10 @@ import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { MCPServerFormData } from "./custom-api-form"
 import {
+  parseMcpOAuthErrorMessage,
+  type McpOAuthConnectResponse,
+} from "@/lib/mcp-utils"
+import {
   RuntimeInputsForm,
   type RuntimeConfigErrorKey,
 } from "./runtime-inputs-form"
@@ -56,27 +60,11 @@ interface McpOAuthDiscoveryResponse {
   scopes: string[]
 }
 
-interface McpOAuthConnectResponse {
-  authorization_url: string
-}
-
 const MASKED_SECRET_VALUE = "********"
 const HTTP_MCP_OAUTH_TRANSPORTS = new Set(["streamable_http", "sse", "websocket"])
 
 export function isHttpMcpOAuthTransport(transport: string): boolean {
   return HTTP_MCP_OAUTH_TRANSPORTS.has(transport)
-}
-
-async function parseMcpOAuthErrorMessage(response: Response, fallback: string): Promise<string> {
-  try {
-    const payload = await response.json()
-    if (typeof payload?.detail === "string") return payload.detail
-    if (payload?.detail?.message) return payload.detail.message
-    if (payload?.detail?.code) return payload.detail.code
-  } catch {
-    // Keep the provided fallback.
-  }
-  return fallback
 }
 
 export function CustomMcpForm({

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -17,7 +17,7 @@ export interface AppIntegration {
   // Canonical connect classification derived on the catalog entry by the
   // backend (mcp_apps.classify_app_auth). Read this instead of re-deriving
   // from provider/required_env so the dialogs can't drift from the backend.
-  auth_type?: "builtin_oauth" | "api_key" | "unconnectable"
+  auth_type?: "builtin_oauth" | "api_key" | "mcp_oauth" | "unconnectable"
   launch_config?: {
     command?: string
     args?: string[]

--- a/frontend/src/lib/mcp-utils.test.ts
+++ b/frontend/src/lib/mcp-utils.test.ts
@@ -5,9 +5,38 @@ import {
   buildMcpServerPayload,
   customApiDetailToEditState,
   mcpServerDetailToEditState,
+  MCP_OAUTH_POPUP_WINDOW_NAME,
+  MCP_OAUTH_SUCCESS_PARAM,
   parseCustomApiDetail,
   parseMcpServerDetail,
+  shouldSelfCloseMcpOauthPopup,
 } from "./mcp-utils"
+
+describe("shouldSelfCloseMcpOauthPopup", () => {
+  it("closes when the success param is present and the window is the mcp_oauth popup", () => {
+    const params = new URLSearchParams({ [MCP_OAUTH_SUCCESS_PARAM]: "1" })
+    expect(shouldSelfCloseMcpOauthPopup(MCP_OAUTH_POPUP_WINDOW_NAME, params)).toBe(true)
+  })
+
+  it("does not close without the success param, even under the popup window name", () => {
+    const params = new URLSearchParams()
+    expect(shouldSelfCloseMcpOauthPopup(MCP_OAUTH_POPUP_WINDOW_NAME, params)).toBe(false)
+  })
+
+  it("does not close on an error redirect, even under the popup window name", () => {
+    const params = new URLSearchParams({
+      mcp_oauth_error: "invalid_resource",
+      mcp_oauth_error_message: "MCP OAuth token_type must be at most 50 characters",
+    })
+    expect(shouldSelfCloseMcpOauthPopup(MCP_OAUTH_POPUP_WINDOW_NAME, params)).toBe(false)
+  })
+
+  it("does not close a differently-named window even with the success param", () => {
+    const params = new URLSearchParams({ [MCP_OAUTH_SUCCESS_PARAM]: "1" })
+    expect(shouldSelfCloseMcpOauthPopup("", params)).toBe(false)
+    expect(shouldSelfCloseMcpOauthPopup("some-other-window", params)).toBe(false)
+  })
+})
 
 const detailPayload = {
   id: 41,

--- a/frontend/src/lib/mcp-utils.ts
+++ b/frontend/src/lib/mcp-utils.ts
@@ -540,3 +540,23 @@ export function buildMcpServerPayload(
   })
   return payload
 }
+
+// --- MCP OAuth (remote server) connect helpers -----------------------------
+
+export interface McpOAuthConnectResponse {
+  authorization_url: string
+}
+
+/** Extract a human-readable message from an MCP OAuth endpoint error body.
+ * Shared by the custom-server form and the catalog connect dialog. */
+export async function parseMcpOAuthErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = await response.json()
+    if (typeof payload?.detail === "string") return payload.detail
+    if (payload?.detail?.message) return payload.detail.message
+    if (payload?.detail?.code) return payload.detail.code
+  } catch {
+    // Keep the provided fallback.
+  }
+  return fallback
+}

--- a/frontend/src/lib/mcp-utils.ts
+++ b/frontend/src/lib/mcp-utils.ts
@@ -560,3 +560,27 @@ export async function parseMcpOAuthErrorMessage(response: Response, fallback: st
   }
   return fallback
 }
+
+/** The window name the mcp_oauth connect popup opens under (connect-mcp-dialog
+ * and custom-mcp-form both use this), and the query param the callback
+ * appends on success. Shared so the popup-open side and the tools page's
+ * self-close guard can't drift apart on either literal. */
+export const MCP_OAUTH_POPUP_WINDOW_NAME = "mcp-oauth"
+export const MCP_OAUTH_SUCCESS_PARAM = "mcp_oauth_success"
+
+/** Whether the tools page, loaded with these search params under this window
+ * name, is the mcp_oauth connect popup landing on a successful callback and
+ * should self-close. Keyed on the explicit success param (not on the absence
+ * of error params) so a future error param added to the callback redirect
+ * can't be mistaken for success here — see the PR review that flagged this
+ * coupling (N5). Extracted as a pure function so it's unit-testable without
+ * mounting the full tools page. */
+export function shouldSelfCloseMcpOauthPopup(
+  windowName: string,
+  searchParams: URLSearchParams,
+): boolean {
+  return (
+    searchParams.get(MCP_OAUTH_SUCCESS_PARAM) !== null &&
+    windowName === MCP_OAUTH_POPUP_WINDOW_NAME
+  )
+}

--- a/frontend/src/lib/mcp-utils.ts
+++ b/frontend/src/lib/mcp-utils.ts
@@ -561,10 +561,15 @@ export async function parseMcpOAuthErrorMessage(response: Response, fallback: st
   return fallback
 }
 
-/** The window name the mcp_oauth connect popup opens under (connect-mcp-dialog
- * and custom-mcp-form both use this), and the query param the callback
- * appends on success. Shared so the popup-open side and the tools page's
- * self-close guard can't drift apart on either literal. */
+/** The window name the mcp_oauth catalog connect popup opens under
+ * (connect-mcp-dialog.tsx), and the query param the callback appends on
+ * success. Shared so that popup-open side and the tools page's self-close
+ * guard can't drift apart on either literal.
+ *
+ * Not (yet) used by custom-mcp-form.tsx's own OAuth flow: that popup still
+ * opens under the reserved target "_blank", so window.name is empty there
+ * and this self-close mechanism never fires for it — a pre-existing gap,
+ * not something this constant's naming implies is already covered. */
 export const MCP_OAUTH_POPUP_WINDOW_NAME = "mcp-oauth"
 export const MCP_OAUTH_SUCCESS_PARAM = "mcp_oauth_success"
 

--- a/src/xagent/migrations/versions/20260731_seed_granola_mcp_app.py
+++ b/src/xagent/migrations/versions/20260731_seed_granola_mcp_app.py
@@ -1,0 +1,81 @@
+"""seed built-in Granola (remote MCP, DCR OAuth) connector
+
+Revision ID: 20260731_seed_granola_mcp_app
+Revises: 20260730_seed_zoom_mcp_app
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260731_seed_granola_mcp_app"
+down_revision: Union[str, None] = "20260730_seed_zoom_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "granola"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Granola",
+    "description": "Connect to Granola to search and read your meeting notes, transcripts and action items through Granola's hosted MCP server.",
+    "icon": "https://www.google.com/s2/favicons?domain=granola.ai&sz=128",
+    "transport": "streamable_http",
+    "provider_name": None,
+    "category": "Productivity",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "url": "https://mcp.granola.ai/mcp",
+        "auth": {"type": "mcp_oauth"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. No oauth_providers row exists for
+    # Granola (auth is per-user Dynamic Client Registration, not a shared
+    # static client), and any MCPServer/UserMCPServer/MCPOAuth* rows created
+    # by users who already connected are intentionally left in place —
+    # connect-driven rows are not owned by this migration and are cleaned up
+    # through the normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/templates/built_in/sales-meeting-agent.yaml
+++ b/src/xagent/templates/built_in/sales-meeting-agent.yaml
@@ -3,22 +3,26 @@ name: Meeting Agent
 category: Sales
 featured: false
 descriptions:
-  en: Turns a Zoom meeting — or a transcript you paste or upload — into a summary, decisions, action items and a follow-up email draft, grounded in the transcript, nothing invented.
-  zh: 将 Zoom 会议——或您粘贴/上传的会议记录——转化为摘要、决策、行动项和跟进邮件草稿，完全基于记录内容，不臆造。
+  en: Turns a meeting — from Zoom, your Granola notes, or a transcript you paste or upload — into a summary, decisions, action items and a follow-up email draft, grounded in the transcript, nothing invented.
+  zh: 将会议——来自 Zoom、您的 Granola 笔记，或您粘贴/上传的会议记录——转化为摘要、决策、行动项和跟进邮件草稿，完全基于记录内容，不臆造。
 features:
   en:
   - Looks up a Zoom meeting by its meeting id and reads its cloud-recording transcript directly, once Zoom is connected
-  - Also accepts a pasted or uploaded transcript (.txt, .docx or .pdf) if Zoom isn't connected or the meeting wasn't recorded
+  - Or finds a meeting in your Granola notes by topic or date and reads its notes and transcript directly, once Granola is connected
+  - Also accepts a pasted or uploaded transcript (.txt, .docx or .pdf) if neither is connected or the meeting isn't available there
   - Extracts decisions, owners and due dates from the transcript on request
   - Drafts a follow-up email in Gmail and can log a CRM note to HubSpot after your approval
   zh:
   - 连接 Zoom 后，可通过会议 ID 查找会议，直接读取其云录制转录文本
-  - 若未连接 Zoom 或该场会议没有录制，也可接受您粘贴/上传的会议记录（.txt、.docx 或 .pdf）
+  - 或连接 Granola 后，可按主题或日期在您的 Granola 笔记中查找会议，直接读取其笔记与转录文本
+  - 若两者均未连接，或该会议在其中不可用，也可接受您粘贴/上传的会议记录（.txt、.docx 或 .pdf）
   - 按需从记录中提取决策、负责人和截止日期
   - 在 Gmail 中起草跟进邮件，并在您批准后于 HubSpot 中记录 CRM 备注
 connections:
 - name: Zoom
   logo: https://www.google.com/s2/favicons?domain=zoom.us&sz=64
+- name: Granola
+  logo: https://www.google.com/s2/favicons?domain=granola.ai&sz=64
 - name: HubSpot
   logo: https://www.google.com/s2/favicons?domain=hubspot.com&sz=64
 - name: Gmail
@@ -30,22 +34,25 @@ agent_config:
   instructions: |
     # Role & Purpose
 
-    You are the Meeting Agent. You turn a meeting transcript into a summary, decisions, action items and follow-ups. If Zoom is connected, you can look up the meeting and its cloud-recording transcript directly. Otherwise you work from a transcript the user pastes into chat or uploads as a file (.txt, .docx or .pdf) — you never fetch or invent a meeting you have no actual access to.
+    You are the Meeting Agent. You turn a meeting's transcript and notes into a summary, decisions, action items and follow-ups. If Zoom or Granola is connected, you can look the meeting up directly. Otherwise you work from a transcript the user pastes into chat or uploads as a file (.txt, .docx or .pdf) — you never fetch or invent a meeting you have no actual access to.
 
     # Responsibilities
 
-    1. **Get the transcript** — `zoom_list_meetings` only returns scheduled/live/upcoming meetings — it cannot list meetings that already happened. So if the user names a past meeting (by title, date, or "the latest one") and Zoom is connected, ask them for the meeting's id or UUID (from the Zoom invite, calendar event, or meeting history) and call `zoom_get_meeting` with that id to confirm it, then `zoom_get_meeting_transcript` to read it. If the transcript fetch comes back empty, call `zoom_list_recordings` to tell apart "this meeting was never recorded" from "it was recorded but the transcript isn't ready yet", and say which it is. If Zoom isn't connected, there is genuinely no transcript, or the user doesn't have the meeting id handy, ask the user to paste the transcript or upload it as a file instead.
+    1. **Get the transcript** — If the user names a meeting (by title, topic, participant, date, or "the latest one"):
+       - If **Zoom** is connected: `zoom_list_meetings` only returns scheduled/live/upcoming meetings — it cannot list meetings that already happened. Ask the user for the meeting's id or UUID (from the Zoom invite, calendar event, or meeting history) and call `zoom_get_meeting` with that id to confirm it, then `zoom_get_meeting_transcript` to read it. If the transcript fetch comes back empty, call `zoom_list_recordings` to tell apart "this meeting was never recorded" from "it was recorded but the transcript isn't ready yet", and say which it is.
+       - If **Granola** is connected: use the Granola tools to find it (list or search the meetings, then read the matching meeting's notes and transcript). If several meetings match, list the candidates and ask which one instead of picking silently.
+       - If neither is connected, the meeting isn't found there, or the user doesn't have the id handy, ask the user to paste the transcript or upload it as a file instead.
     2. **Read it fully** — Read the entire transcript before summarizing; don't work from a partial read.
     3. **Extract & decide** — Identify decisions made, item owners, due dates, and any follow-ups that were promised.
     4. **Act on request** — Draft a follow-up email in Gmail, or log a CRM note in HubSpot, when asked.
 
     # Operating Guidelines
 
-    - **Ground everything in the transcript:** Only report content that is actually present in the Zoom transcript or what was pasted/uploaded. Never invent decisions, owners, or action items.
-    - **No transcript, no summary:** If nothing has been provided or found yet, ask for it rather than guessing which meeting the user means.
+    - **Ground everything in the transcript:** Only report content that is actually present in the Zoom transcript, the Granola notes/transcript, or what was pasted/uploaded. Never invent decisions, owners, or action items.
+    - **No transcript, no summary:** If nothing has been found or provided yet, ask for it rather than guessing which meeting the user means.
     - **Approval required:** Never send an email or log a CRM note without explicit user confirmation of the draft first.
     - **Know your CRM scope:** HubSpot access here covers contacts, companies, deals and notes — there is no HubSpot task object available, so follow-up work items belong in the action-items list and the follow-up email, not a HubSpot task.
-    - **Missing data:** If action items or decisions weren't explicitly stated in the transcript, say so rather than inferring them from tone or context.
+    - **Missing data:** If action items or decisions weren't explicitly stated in the transcript, say so rather than inferring them from tone or context. If the transcript itself is unavailable (e.g. Granola's plan doesn't include transcripts), work from the meeting notes and say that's what you used.
 
     # Tone & Personality
 
@@ -55,6 +62,7 @@ agent_config:
 
     - Structure output as: ## Summary · ## Decisions · ## Action items (owner · due date) · ## Draft email.
     - Never fabricate an owner or due date — mark it "unassigned" / "no date given" if the transcript didn't specify one.
+    - Cite the meeting's title and date in your output when Zoom, Granola, or the user supplied them — never invent one for a pasted/uploaded transcript that didn't include it.
   execution_mode: balanced
   skills: []
   tool_categories:

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -222,9 +222,20 @@ def _public_mcp_app_response(app: PublicMCPApp) -> Dict[str, Any]:
     }
 
 
-def _validate_public_mcp_app_values(values: Dict[str, Any]) -> None:
+def _validate_public_mcp_app_values(
+    values: Dict[str, Any], *, enforce_connect_shape: bool = True
+) -> None:
+    # F4: PublicMCPAppCreate's _enforce_auth_classification rejects a
+    # connect-shape that classifies as "unconnectable" (see that validator's
+    # docstring). Applying it unconditionally on every edit would let a shape
+    # rule added after a row was created (or a row otherwise grandfathered
+    # in) permanently block that row's unrelated fields (e.g. icon) from ever
+    # being edited again. Skip that one check — via PublicMCPAppBase, which
+    # PublicMCPAppCreate extends with no other override — when this edit
+    # doesn't touch the fields the shape check reads (transport/launch_config).
+    model = PublicMCPAppCreate if enforce_connect_shape else PublicMCPAppBase
     try:
-        PublicMCPAppCreate.model_validate(values)
+        model.model_validate(values)
     except ValidationError:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -235,6 +246,7 @@ def _validate_public_mcp_app_values(values: Dict[str, Any]) -> None:
 def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) -> None:
     canonical = get_builtin_public_mcp_app(db_app.app_id)
     persisted = _public_mcp_app_values(db_app)
+    enforce_connect_shape = bool({"transport", "launch_config"} & changes.keys())
 
     if canonical is not None:
         for field in _BUILTIN_PROTECTED_FIELDS.intersection(changes):
@@ -253,7 +265,9 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
             **writable_changes,
             **{field: canonical[field] for field in _BUILTIN_PROTECTED_FIELDS},
         }
-        _validate_public_mcp_app_values(merged)
+        _validate_public_mcp_app_values(
+            merged, enforce_connect_shape=enforce_connect_shape
+        )
     else:
         if "app_id" in changes and changes["app_id"] != db_app.app_id:
             raise HTTPException(
@@ -261,7 +275,9 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
                 detail="MCP app ID is immutable",
             )
         merged = {**persisted, **changes}
-        _validate_public_mcp_app_values(merged)
+        _validate_public_mcp_app_values(
+            merged, enforce_connect_shape=enforce_connect_shape
+        )
         writable_changes = {
             field: value for field, value in changes.items() if field != "app_id"
         }

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -97,19 +97,28 @@ class PublicMCPAppCreate(PublicMCPAppBase):
     def _enforce_auth_classification(self) -> "PublicMCPAppCreate":
         # Reuse the single source of truth (classify_app_auth) rather than
         # re-deriving the rule here. Reject an entry that declares a partial
-        # launch_config (command or required_env) yet still classifies as
-        # "unconnectable" — the write-time constraint issue #764 asked for. This
-        # covers both asymmetric shapes: command-without-required_env and
-        # required_env-without-command.
+        # launch_config (either the key-based or the remote-OAuth shape) yet
+        # still classifies as "unconnectable" — the write-time constraint
+        # issue #764 asked for. Covers four asymmetric shapes:
+        # command-without-required_env, required_env-without-command,
+        # url-without-auth.type=mcp_oauth, and auth.type=mcp_oauth-without-url.
         from ..mcp_apps import classify_app_auth
 
         launch = self.launch_config or {}
-        if (launch.get("command") or launch.get("required_env")) and (
+        declares_key_shape = bool(launch.get("command") or launch.get("required_env"))
+        auth = launch.get("auth")
+        declares_remote_oauth_shape = bool(launch.get("url")) or (
+            isinstance(auth, dict) and auth.get("type") == "mcp_oauth"
+        )
+        if (declares_key_shape or declares_remote_oauth_shape) and (
             classify_app_auth(self.transport, self.launch_config) == "unconnectable"
         ):
             raise ValueError(
                 "A key-based catalog app must declare both launch_config.command "
-                "and launch_config.required_env, otherwise it cannot be connected."
+                "and launch_config.required_env; a remote-OAuth catalog app must "
+                "declare both launch_config.url and launch_config.auth.type == "
+                "'mcp_oauth' (with transport one of sse/websocket/streamable_http), "
+                "otherwise it cannot be connected."
             )
         return self
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2302,6 +2302,97 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
     return server, app_info
 
 
+def _ensure_catalog_mcp_oauth_server(
+    db: Session, app_id: str
+) -> tuple[MCPServer, dict]:
+    """Idempotently ensure the shared server row for a remote-MCP OAuth
+    (DCR-capable) catalog app exists, without creating any per-user
+    association. Returns (server, app_info). Mirrors
+    _ensure_catalog_app_server's hijack guards, but for a streamable_http/
+    sse/websocket server row instead of a stdio one.
+    """
+    from ..mcp_apps import get_app_by_id
+
+    app_info = get_app_by_id(db, app_id)
+    if not app_info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="MCP app not found"
+        )
+    if app_info.get("auth_type") != "mcp_oauth":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This app is not a remote-OAuth connector",
+        )
+    launch = app_info.get("launch_config") or {}
+    url = launch.get("url")
+    auth = launch.get("auth") or {}
+    transport = str(app_info["transport"])
+    server_name = str(app_info["id"])
+
+    server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+    # Same reasoning as _ensure_catalog_app_server: a row under this catalog id
+    # may be a hijack (a custom server someone created with a different remote
+    # URL), so only reuse it if it matches the official configuration.
+    if server:
+        if (
+            str(server.transport or "").lower() != transport.lower()
+            or server.url != url
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A server with this name already exists with a different configuration",
+            )
+        owned = (
+            db.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server.id,
+                UserMCPServer.is_owner.is_(True),
+            )
+            .first()
+        )
+        if owned is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A user-owned server already exists under this catalog id",
+            )
+    if not server:
+        try:
+            config = _build_server_config(
+                MCPServerCreate(
+                    name=server_name,
+                    transport=transport,
+                    description=app_info.get("description"),
+                    config={"url": url, "auth": auth},
+                )
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid app configuration: {str(e)}",
+            )
+        manager = DatabaseMCPServerManager(db)
+        add_error: Exception | None = None
+        try:
+            manager.add_server(config)
+        except (ValueError, IntegrityError) as exc:
+            # A concurrent first-provision loses to the other request, same
+            # recovery as _ensure_catalog_app_server.
+            db.rollback()
+            add_error = exc
+        server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+        if not server:
+            if add_error is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid app configuration: {add_error}",
+                ) from add_error
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create server",
+            )
+    return server, app_info
+
+
 @mcp_router.post("/apps/{app_id}/connect", response_model=MCPServerResponse)
 def connect_mcp_app(
     app_id: str,
@@ -2433,6 +2524,72 @@ def connect_mcp_app(
         manager,
         app_id=str(app_info["id"]),
         is_admin=getattr(current_user, "is_admin", False),
+    )
+
+
+@mcp_router.post("/apps/{app_id}/oauth/connect", response_model=None)
+async def connect_mcp_oauth_app(
+    app_id: str,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    accept: Annotated[str | None, Header()] = None,
+) -> RedirectResponse | JSONResponse:
+    """Connect a remote-MCP OAuth (DCR-capable) catalog app for the current user.
+
+    Ensures the shared server row and this user's association exist, then
+    delegates to connect_mcp_oauth's Authorization Code + PKCE flow — the
+    per-user DCR/token machinery is identical to a self-added custom MCP
+    server; only the server row's origin (catalog vs. a user-typed URL)
+    differs.
+    """
+    server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
+
+    assoc: Any = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == current_user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .first()
+    )
+    if assoc is None:
+        assoc = UserMCPServer(
+            user_id=current_user.id,
+            mcpserver_id=server.id,
+            is_active=True,
+            is_owner=False,
+            can_edit=False,
+            can_delete=True,
+        )
+        db.add(assoc)
+        try:
+            db.commit()
+        except IntegrityError:
+            # Concurrent same-user connect (double-click/client retry): another
+            # request already inserted the (user_id, mcpserver_id) association.
+            db.rollback()
+            assoc = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == current_user.id,
+                    UserMCPServer.mcpserver_id == server.id,
+                )
+                .first()
+            )
+            if assoc is None:
+                raise
+    elif not assoc.is_active:
+        # A reconnect after the user previously disconnected their own
+        # association — re-activate it rather than leaving it dormant.
+        assoc.is_active = True
+        db.commit()
+
+    logger.info(
+        f"User {current_user.id} starting OAuth connect for MCP app '{app_info['id']}'"
+    )
+    return await connect_mcp_oauth(
+        cast(int, server.id), request_data, current_user, db, accept
     )
 
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1817,6 +1817,25 @@ def _connected_non_oauth_server_for_app(
     return cast(int, server.id)
 
 
+def _mcp_oauth_server_is_actually_connected(
+    server: MCPServer, active_grant_server_ids: set[int]
+) -> bool:
+    """An mcp_oauth-shaped server's UserMCPServer association can exist before
+    the user ever completes consent (see connect_mcp_oauth_app), so its mere
+    presence isn't proof of a working connection. Require an active
+    MCPOAuthGrant too, mirroring the check applied in list_mcp_apps' default
+    branch — shared so every code path that reports connection state for an
+    mcp_oauth server (including the location=local/all branch, which used to
+    bypass this check entirely) agrees (F1)."""
+    auth: dict[str, Any] = server.auth if isinstance(server.auth, dict) else {}
+    if (
+        str(server.transport or "").lower() not in HTTP_MCP_TRANSPORTS
+        or auth.get("type") != "mcp_oauth"
+    ):
+        return True
+    return cast(int, server.id) in active_grant_server_ids
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -1911,15 +1930,17 @@ def list_mcp_apps(
                 server_id = _connected_non_oauth_server_for_app(
                     app, non_oauth_server_lookup
                 )
-                if (
-                    app.get("auth_type") == "mcp_oauth"
-                    and server_id is not None
-                    and server_id not in active_grant_server_ids
-                ):
-                    server_id = None
                 connected_account = None
                 # Resolve the shared row once and reuse it for all key-source flags.
                 shared_server = _shared_server_for_app(app, server_by_key)
+                if (
+                    server_id is not None
+                    and shared_server is not None
+                    and not _mcp_oauth_server_is_actually_connected(
+                        shared_server, active_grant_server_ids
+                    )
+                ):
+                    server_id = None
                 app_shared_env = _app_shared_env_available(
                     app, shared_server, shared_env_by_id
                 )
@@ -1996,7 +2017,13 @@ def list_mcp_apps(
                     "icon": "",
                     "users": "1",
                     "transport": server.transport,
-                    "is_connected": True,
+                    # F1: this loop's own membership check above (name-based)
+                    # doesn't gate on a real grant, so a custom mcp_oauth
+                    # server the user abandoned mid-consent must not be
+                    # reported connected just because the row exists.
+                    "is_connected": _mcp_oauth_server_is_actually_connected(
+                        server, active_grant_server_ids
+                    ),
                     "provider": "custom",
                     "category": "Local",
                     "is_local": True,
@@ -2401,8 +2428,14 @@ def _ensure_catalog_mcp_oauth_server(
         if server._decrypt_auth_config(server.auth) != auth:
             encrypted_auth = dict(auth)
             for key in SENSITIVE_AUTH_FIELDS:
-                if key in encrypted_auth and encrypted_auth[key]:
-                    encrypted_auth[key] = encrypt_value(encrypted_auth[key])
+                value = encrypted_auth.get(key)
+                # A mis-authored non-string sensitive field (e.g. a nested
+                # object where a string is expected) must not crash this
+                # user-facing connect request — encrypt_value() calls
+                # .encode() unconditionally. Leave it as-is; that's an admin
+                # authoring bug to catch at write time, not here (F13).
+                if value and isinstance(value, str):
+                    encrypted_auth[key] = encrypt_value(value)
             cast(Any, server).auth = encrypted_auth
             db.commit()
     if not server:
@@ -2951,7 +2984,7 @@ def _catalog_server_has_platform_key(db: Session, server: MCPServer) -> bool:
 
 
 @mcp_router.delete("/servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_mcp_server(
+async def delete_mcp_server(
     server_id: int,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -3062,15 +3095,15 @@ def delete_mcp_server(
                             UserOAuth.provider == provider,
                         ).delete(synchronize_session=False)
 
-        # Revoke this user's MCP OAuth grants for the server. On a shared
-        # (multi-user) row the server outlives this disconnect, so without
-        # this the grant's refresh token would stay usable until the LAST
-        # user disconnects and the cascade finally removes it. Local
-        # revocation is sufficient for the runtime (it only resolves
-        # status == "active" grants); best-effort revocation at the external
-        # provider stays with the per-grant DELETE endpoint, which this sync
-        # handler cannot await.
-        revoked_at = _utc_now()
+        # Revoke and purge this user's MCP OAuth grants for the server. On a
+        # shared (multi-user) row the server outlives this disconnect, so
+        # without this the grant's refresh token would stay usable — and its
+        # row would stay stored — until the LAST user disconnects and the
+        # cascade finally removes it. Best-effort external revocation first
+        # (now awaitable, unlike the previous local-only status flip), then a
+        # hard delete rather than a "revoked" status flip: a revoked grant
+        # row is otherwise never swept, accumulating indefinitely as an
+        # inert but secret-bearing row (F10).
         for grant in (
             db.query(MCPOAuthGrant)
             .filter(
@@ -3080,8 +3113,20 @@ def delete_mcp_server(
             )
             .all()
         ):
-            setattr(grant, "status", "revoked")
-            setattr(grant, "revoked_at", revoked_at)
+            if isinstance(grant.oauth_client, MCPOAuthClient):
+                await _revoke_mcp_oauth_grant_externally(
+                    client=grant.oauth_client, grant=grant
+                )
+            db.delete(grant)
+
+        # This user's own flow-state rows (code_verifier etc.) are per-user,
+        # unlike MCPOAuthClient which a shared server's other users may still
+        # reference — safe to purge outright rather than only on server
+        # deletion's cascade.
+        db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.mcp_server_id == server_id,
+            MCPOAuthFlowState.user_id == user_id,
+        ).delete(synchronize_session=False)
 
         # Remove user-server association
         db.delete(user_mcp)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -452,6 +452,16 @@ def _clear_mcp_oauth_state_cookie(response: Response) -> None:
     response.delete_cookie(MCP_OAUTH_STATE_COOKIE, path="/api/mcp")
 
 
+def _redirect_after_with_params(
+    raw_redirect_after: str | None, params: tuple[tuple[str, str], ...]
+) -> str:
+    redirect_after = _safe_mcp_oauth_redirect_after(raw_redirect_after)
+    parts = urlsplit(redirect_after)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.extend(params)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), ""))
+
+
 def _mcp_oauth_callback_error_redirect(
     flow_state: MCPOAuthFlowState,
     *,
@@ -461,20 +471,15 @@ def _mcp_oauth_callback_error_redirect(
     raw_redirect_after = (
         str(flow_state.redirect_after) if flow_state.redirect_after else None
     )
-    redirect_after = _safe_mcp_oauth_redirect_after(raw_redirect_after)
-    parts = urlsplit(redirect_after)
-    query = parse_qsl(parts.query, keep_blank_values=True)
-    query.extend(
+    redirect_path = _redirect_after_with_params(
+        raw_redirect_after,
         (
             ("mcp_oauth_error", error_code),
             (
                 "mcp_oauth_error_message",
                 oauth_error_message(message, "MCP OAuth authorization failed"),
             ),
-        )
-    )
-    redirect_path = urlunsplit(
-        (parts.scheme, parts.netloc, parts.path, urlencode(query), "")
+        ),
     )
     response = RedirectResponse(_mcp_oauth_redirect_after_url(redirect_path))
     _clear_mcp_oauth_state_cookie(response)
@@ -1876,6 +1881,22 @@ def list_mcp_apps(
 
     shared_env_by_id = load_shared_env_overrides(db, cast(int, current_user.id))
 
+    # mcp_oauth apps: an active association alone is not a connection — the
+    # association is provisioned before the user ever reaches the consent
+    # screen, so an abandoned/denied/failed authorization would otherwise
+    # render as "Connected" forever with no credential behind it. Require an
+    # active grant too, mirroring how builtin_oauth requires a completed
+    # OAuth account. One query for all apps to avoid an N+1.
+    active_grant_server_ids = {
+        row[0]
+        for row in db.query(MCPOAuthGrant.mcp_server_id)
+        .filter(
+            MCPOAuthGrant.user_id == current_user.id,
+            MCPOAuthGrant.status == "active",
+        )
+        .all()
+    }
+
     if location in ["remote", "all"]:
         for app in library_apps:
             if app.get("auth_type") == "builtin_oauth":
@@ -1890,6 +1911,12 @@ def list_mcp_apps(
                 server_id = _connected_non_oauth_server_for_app(
                     app, non_oauth_server_lookup
                 )
+                if (
+                    app.get("auth_type") == "mcp_oauth"
+                    and server_id is not None
+                    and server_id not in active_grant_server_ids
+                ):
+                    server_id = None
                 connected_account = None
                 # Resolve the shared row once and reuse it for all key-source flags.
                 shared_server = _shared_server_for_app(app, server_by_key)
@@ -2197,6 +2224,66 @@ def get_mcp_server(
         )
 
 
+def _reject_user_owned_catalog_squat(db: Session, server: MCPServer) -> None:
+    """409 when the row under a catalog id is owned by a user.
+
+    A matching config is not enough: a row owned by a user is a custom server
+    squatting this catalog id (creatable only before the app was seeded, since
+    create_mcp_server now reserves catalog ids). Its owner keeps edit rights and
+    could later swap in a foreign command/URL that every connected user then
+    uses — refuse to adopt it as the official shared row. The legitimate shared
+    row is created without any association, so it never has an is_owner=True
+    owner. Shared by every catalog-connect shape so a hardening fix here can't
+    land in only one copy.
+    """
+    owned = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.mcpserver_id == server.id,
+            UserMCPServer.is_owner.is_(True),
+        )
+        .first()
+    )
+    if owned is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A user-owned server already exists under this catalog id",
+        )
+
+
+def _add_catalog_server_with_race_recovery(
+    db: Session, config: Any, server_name: str
+) -> MCPServer:
+    """Create the shared catalog server row, tolerating a concurrent first
+    provision. Returns the row (ours or the race winner's); raises 400/500.
+    """
+    manager = DatabaseMCPServerManager(db)
+    add_error: Exception | None = None
+    try:
+        manager.add_server(config)
+    except (ValueError, IntegrityError) as exc:
+        # A concurrent first-provision loses to the other request: add_server's
+        # own duplicate-name check raises ValueError, or the commit trips the
+        # unique constraint (IntegrityError). Either way the row now exists, so
+        # recover by re-reading it below. Any other failure leaves no row.
+        db.rollback()
+        add_error = exc
+    server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+    if not server:
+        # No row after the failure => it was not a race but a genuine error.
+        # Surface it instead of masking it as an opaque 500.
+        if add_error is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid app configuration: {add_error}",
+            ) from add_error
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create server",
+        )
+    return server
+
+
 def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dict]:
     """Idempotently ensure the shared server row for a key-based catalog app
     exists, without creating any per-user association. Returns (server, app_info).
@@ -2222,7 +2309,6 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
         )
     launch = app_info.get("launch_config") or {}
     command = launch.get("command")
-    manager = DatabaseMCPServerManager(db)
     # app_id is the stable catalog key: it passes the server-name validator and
     # is what the connector uses to detect an app as connected.
     server_name = str(app_info["id"])
@@ -2242,25 +2328,7 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                 status_code=status.HTTP_409_CONFLICT,
                 detail="A server with this name already exists with a different configuration",
             )
-        # A matching config is not enough: a row owned by a user is a custom server
-        # squatting this catalog id (creatable only before the app was seeded, since
-        # create_mcp_server now reserves catalog ids). Its owner keeps edit rights and
-        # could later swap in a foreign command that every connected user then runs —
-        # refuse to adopt it as the official shared row. The legitimate shared row is
-        # created without any association, so it never has an is_owner=True owner.
-        owned = (
-            db.query(UserMCPServer)
-            .filter(
-                UserMCPServer.mcpserver_id == server.id,
-                UserMCPServer.is_owner.is_(True),
-            )
-            .first()
-        )
-        if owned is not None:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="A user-owned server already exists under this catalog id",
-            )
+        _reject_user_owned_catalog_squat(db, server)
     if not server:
         try:
             config = _build_server_config(
@@ -2276,29 +2344,7 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid app configuration: {str(e)}",
             )
-        add_error: Exception | None = None
-        try:
-            manager.add_server(config)
-        except (ValueError, IntegrityError) as exc:
-            # A concurrent first-provision loses to the other request: add_server's
-            # own duplicate-name check raises ValueError, or the commit trips the
-            # unique constraint (IntegrityError). Either way the row now exists, so
-            # recover by re-reading it below. Any other failure leaves no row.
-            db.rollback()
-            add_error = exc
-        server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
-        if not server:
-            # No row after the failure => it was not a race but a genuine error.
-            # Surface it instead of masking it as an opaque 500.
-            if add_error is not None:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid app configuration: {add_error}",
-                ) from add_error
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create server",
-            )
+        server = _add_catalog_server_with_race_recovery(db, config, server_name)
     return server, app_info
 
 
@@ -2342,19 +2388,7 @@ def _ensure_catalog_mcp_oauth_server(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="A server with this name already exists with a different configuration",
             )
-        owned = (
-            db.query(UserMCPServer)
-            .filter(
-                UserMCPServer.mcpserver_id == server.id,
-                UserMCPServer.is_owner.is_(True),
-            )
-            .first()
-        )
-        if owned is not None:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="A user-owned server already exists under this catalog id",
-            )
+        _reject_user_owned_catalog_squat(db, server)
         # The catalog stays the source of truth for the row's auth config: if
         # the registry entry's auth changed since this shared row was created
         # (e.g. a scope hint or static client_id was added), sync it so
@@ -2386,26 +2420,7 @@ def _ensure_catalog_mcp_oauth_server(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid app configuration: {str(e)}",
             )
-        manager = DatabaseMCPServerManager(db)
-        add_error: Exception | None = None
-        try:
-            manager.add_server(config)
-        except (ValueError, IntegrityError) as exc:
-            # A concurrent first-provision loses to the other request, same
-            # recovery as _ensure_catalog_app_server.
-            db.rollback()
-            add_error = exc
-        server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
-        if not server:
-            if add_error is not None:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid app configuration: {add_error}",
-                ) from add_error
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create server",
-            )
+        server = _add_catalog_server_with_race_recovery(db, config, server_name)
     return server, app_info
 
 
@@ -3047,6 +3062,27 @@ def delete_mcp_server(
                             UserOAuth.provider == provider,
                         ).delete(synchronize_session=False)
 
+        # Revoke this user's MCP OAuth grants for the server. On a shared
+        # (multi-user) row the server outlives this disconnect, so without
+        # this the grant's refresh token would stay usable until the LAST
+        # user disconnects and the cascade finally removes it. Local
+        # revocation is sufficient for the runtime (it only resolves
+        # status == "active" grants); best-effort revocation at the external
+        # provider stays with the per-grant DELETE endpoint, which this sync
+        # handler cannot await.
+        revoked_at = _utc_now()
+        for grant in (
+            db.query(MCPOAuthGrant)
+            .filter(
+                MCPOAuthGrant.mcp_server_id == server_id,
+                MCPOAuthGrant.user_id == user_id,
+                MCPOAuthGrant.status == "active",
+            )
+            .all()
+        ):
+            setattr(grant, "status", "revoked")
+            setattr(grant, "revoked_at", revoked_at)
+
         # Remove user-server association
         db.delete(user_mcp)
         db.commit()
@@ -3578,8 +3614,17 @@ async def mcp_oauth_callback(
             message="MCP OAuth authorization failed",
         )
 
+    # Positive success signal: the connect popup's self-close logic keys on
+    # this param instead of inferring success from "no error params", so a
+    # future error param added to the error redirect can't be mistaken for
+    # success by an out-of-date guard.
     response = RedirectResponse(
-        _mcp_oauth_redirect_after_url(str(flow_state.redirect_after))
+        _mcp_oauth_redirect_after_url(
+            _redirect_after_with_params(
+                str(flow_state.redirect_after) if flow_state.redirect_after else None,
+                (("mcp_oauth_success", "1"),),
+            )
+        )
     )
     _clear_mcp_oauth_state_cookie(response)
     return response

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2355,6 +2355,22 @@ def _ensure_catalog_mcp_oauth_server(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="A user-owned server already exists under this catalog id",
             )
+        # The catalog stays the source of truth for the row's auth config: if
+        # the registry entry's auth changed since this shared row was created
+        # (e.g. a scope hint or static client_id was added), sync it so
+        # already-connected users don't keep running against stale auth.
+        # Compare on the decrypted form — sensitive auth fields are encrypted
+        # at rest, so comparing the raw stored value against the catalog's
+        # plaintext would spuriously differ on every connect once any secret
+        # is configured. Runs only after the owned-check above: a user-owned
+        # row is rejected, never mutated.
+        if server._decrypt_auth_config(server.auth) != auth:
+            encrypted_auth = dict(auth)
+            for key in SENSITIVE_AUTH_FIELDS:
+                if key in encrypted_auth and encrypted_auth[key]:
+                    encrypted_auth[key] = encrypt_value(encrypted_auth[key])
+            cast(Any, server).auth = encrypted_auth
+            db.commit()
     if not server:
         try:
             config = _build_server_config(

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -475,6 +475,26 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "env_mapping": {"SLACK_ACCESS_TOKEN": "access_token"},
             },
         },
+        {
+            "app_id": "granola",
+            "name": "Granola",
+            "description": "Connect to Granola to search and read your meeting notes, transcripts and action items through Granola's hosted MCP server.",
+            "icon": "https://www.google.com/s2/favicons?domain=granola.ai&sz=128",
+            "transport": "streamable_http",
+            "provider_name": None,
+            "category": "Productivity",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            # Remote MCP (mcp_oauth): Granola hosts the MCP server itself and
+            # exposes its own tools — there is no local module to launch. Users
+            # connect via POST /api/mcp/apps/{id}/oauth/connect (per-user OAuth
+            # Authorization Code + PKCE); Granola issues no static client
+            # credentials, so the flow relies on Dynamic Client Registration.
+            "launch_config": {
+                "url": "https://mcp.granola.ai/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        },
     ]
 
 

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -78,7 +78,6 @@ def restrict_to_app_scoped_oauth_grant(
     ]
 
 
-# Transports for a genuine remote MCP server the platform talks to directly
 def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """Single source of truth for how a catalog app is connected.
 

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -79,13 +79,6 @@ def restrict_to_app_scoped_oauth_grant(
 
 
 # Transports for a genuine remote MCP server the platform talks to directly
-# (as opposed to "oauth", which here means a static-provider redirect wrapping
-# our own stdio module — see classify_app_auth). Mirrors HTTP_MCP_TRANSPORTS
-# in services/mcp_runtime.py and the runtime check in
-# core/tools/core/mcp/manager/db.py's _requires_runtime_mcp_oauth.
-_REMOTE_MCP_TRANSPORTS = frozenset({"sse", "websocket", "streamable_http"})
-
-
 def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """Single source of truth for how a catalog app is connected.
 
@@ -98,6 +91,13 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
           static client_id is configured) — /api/mcp/apps/{id}/oauth/connect
         - "unconnectable": none of the above
     """
+    # Reuses the runtime's notion of which transports are remote ("oauth"
+    # here instead means a static-provider redirect wrapping our own stdio
+    # module). Lowercased like the builtin_oauth check above: an admin PATCH
+    # can store a mixed-case transport, and the two halves of this feature
+    # must not disagree about the same row.
+    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
+
     if str(transport or "").lower() == "oauth":
         return "builtin_oauth"
     launch = launch_config if isinstance(launch_config, dict) else {}
@@ -105,7 +105,7 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
         return "api_key"
     auth = launch.get("auth")
     if (
-        str(transport or "") in _REMOTE_MCP_TRANSPORTS
+        str(transport or "").lower() in HTTP_MCP_TRANSPORTS
         and launch.get("url")
         and isinstance(auth, dict)
         and auth.get("type") == "mcp_oauth"

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -78,6 +78,14 @@ def restrict_to_app_scoped_oauth_grant(
     ]
 
 
+# Transports for a genuine remote MCP server the platform talks to directly
+# (as opposed to "oauth", which here means a static-provider redirect wrapping
+# our own stdio module — see classify_app_auth). Mirrors HTTP_MCP_TRANSPORTS
+# in services/mcp_runtime.py and the runtime check in
+# core/tools/core/mcp/manager/db.py's _requires_runtime_mcp_oauth.
+_REMOTE_MCP_TRANSPORTS = frozenset({"sse", "websocket", "streamable_http"})
+
+
 def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """Single source of truth for how a catalog app is connected.
 
@@ -85,13 +93,24 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     frontend dialogs can't drift apart. Values:
         - "builtin_oauth": provider redirect flow (transport == "oauth")
         - "api_key": static key, connected via /api/mcp/apps/{id}/connect
-        - "unconnectable": neither oauth nor a launchable key-based command
+        - "mcp_oauth": remote MCP server, connected via per-user OAuth
+          Authorization Code + PKCE (Dynamic Client Registration when no
+          static client_id is configured) — /api/mcp/apps/{id}/oauth/connect
+        - "unconnectable": none of the above
     """
     if str(transport or "").lower() == "oauth":
         return "builtin_oauth"
     launch = launch_config if isinstance(launch_config, dict) else {}
     if launch.get("required_env") and launch.get("command"):
         return "api_key"
+    auth = launch.get("auth")
+    if (
+        str(transport or "") in _REMOTE_MCP_TRANSPORTS
+        and launch.get("url")
+        and isinstance(auth, dict)
+        and auth.get("type") == "mcp_oauth"
+    ):
+        return "mcp_oauth"
     return "unconnectable"
 
 

--- a/tests/alembic/test_20260731_seed_granola_mcp_app.py
+++ b/tests/alembic/test_20260731_seed_granola_mcp_app.py
@@ -1,0 +1,122 @@
+"""Tests for the Granola remote-MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260731_seed_granola_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_granola_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_granola(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "granola" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps WHERE app_id='granola'"
+            )
+        ).first()
+        assert row[0] == "streamable_http"
+        assert row[1] is None
+        assert "https://mcp.granola.ai/mcp" in str(row[2])
+        assert "mcp_oauth" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='granola'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    granola row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "granola"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_seed_row_classifies_as_mcp_oauth(tmp_path):
+    """The seeded shape must classify as a remote-MCP OAuth connector — an
+    "unconnectable" classification would make the catalog entry dead on
+    arrival (no connect endpoint accepts it)."""
+    from xagent.web.mcp_apps import classify_app_auth
+
+    migration = _load_migration_module()
+    assert (
+        classify_app_auth(migration.ROW["transport"], migration.ROW["launch_config"])
+        == "mcp_oauth"
+    )
+
+
+def test_downgrade_removes_granola(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "granola" not in _app_ids(connection)

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -132,7 +132,7 @@ def test_reconnect_updates_own_key(test_db):
     assert decrypt_env_dict(assocs[0].env) == {"GOOGLE_MAPS_API_KEY": "new"}
 
 
-def test_disconnect_keeps_shared_server_for_other_users(test_db):
+async def test_disconnect_keeps_shared_server_for_other_users(test_db):
     """A connect user (non-owner) can disconnect their own association; the
     shared server row survives while another user is still connected, and is
     removed only when the last user leaves."""
@@ -159,7 +159,7 @@ def test_disconnect_keeps_shared_server_for_other_users(test_db):
     )
 
     # Alice (non-owner) disconnects — allowed via can_delete, row must survive.
-    delete_mcp_server(server_id, current_user=_user(test_db, 1), db=test_db)
+    await delete_mcp_server(server_id, current_user=_user(test_db, 1), db=test_db)
     assert (
         test_db.query(MCPServer).filter(MCPServer.id == server_id).first() is not None
     )
@@ -171,7 +171,7 @@ def test_disconnect_keeps_shared_server_for_other_users(test_db):
     )
 
     # Last user leaves — shared row is cleaned up.
-    delete_mcp_server(server_id, current_user=_user(test_db, 2), db=test_db)
+    await delete_mcp_server(server_id, current_user=_user(test_db, 2), db=test_db)
     assert test_db.query(MCPServer).filter(MCPServer.id == server_id).first() is None
 
 
@@ -529,7 +529,7 @@ def test_connect_rejects_unconnectable_app(test_db):
     assert exc.value.status_code == 400
 
 
-def test_last_disconnect_keeps_row_with_platform_key(test_db):
+async def test_last_disconnect_keeps_row_with_platform_key(test_db):
     """When a shared catalog row carries the admin's platform fallback key, the
     last user's disconnect must NOT hard-delete the row — that would silently
     wipe the platform key with no signal to the admin. (A row with no platform
@@ -555,7 +555,7 @@ def test_last_disconnect_keeps_row_with_platform_key(test_db):
     server_id = server.id
 
     # The last (only) connected user disconnects.
-    delete_mcp_server(server_id, current_user=_user(test_db, 1), db=test_db)
+    await delete_mcp_server(server_id, current_user=_user(test_db, 1), db=test_db)
 
     kept = test_db.query(MCPServer).filter(MCPServer.id == server_id).first()
     assert kept is not None  # row survives

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1758,6 +1758,44 @@ async def test_mcp_oauth_app_not_connected_until_grant_completes(
 
 
 @pytest.mark.asyncio
+async def test_mcp_oauth_local_listing_also_requires_a_grant(db_session):
+    """F1: the location=local/all branch computed connection state via its
+    own name-based membership check and never consulted the active-grant
+    gate at all — a custom (non-catalog) mcp_oauth server the user abandoned
+    mid-consent rendered as connected there regardless of M1's fix to the
+    default/remote branch."""
+    db, user, _ = db_session
+    # _add_mcp_oauth_server creates a server named "records" with no matching
+    # catalog PublicMCPApp, so it falls into the local/all branch rather than
+    # being excluded as a known catalog app.
+    server = _add_mcp_oauth_server(db, user)
+
+    local_apps_before_grant = list_mcp_apps(location="local", current_user=user, db=db)
+    records_before = next(a for a in local_apps_before_grant if a["id"] == "records")
+    assert records_before["is_connected"] is False
+
+    client = _add_oauth_client(db, server)
+    db.add(
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="",
+            access_token=encrypt_value("records-access-token"),
+            status="active",
+        )
+    )
+    db.commit()
+
+    local_apps_after_grant = list_mcp_apps(location="local", current_user=user, db=db)
+    records_after = next(a for a in local_apps_after_grant if a["id"] == "records")
+    assert records_after["is_connected"] is True
+
+
+@pytest.mark.asyncio
 async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
     db_session, monkeypatch
 ):

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -26,6 +26,7 @@ from xagent.web.api.mcp import (
     MCPOAuthStatusResponse,
     MCPServerUpdate,
     connect_mcp_oauth,
+    connect_mcp_oauth_app,
     delete_mcp_oauth_grant,
     discover_mcp_oauth,
     get_mcp_oauth_status,
@@ -37,6 +38,7 @@ from xagent.web.models import MCPOAuthClient, MCPOAuthFlowState, MCPOAuthGrant
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import mcp_oauth_client_registration_lookup_hash
+from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.services import mcp_oauth as mcp_oauth_service
 from xagent.web.services.mcp_oauth import (
@@ -1230,6 +1232,210 @@ async def test_oauth_routes_reject_inactive_user_mcp_server(db_session, monkeypa
 
     with pytest.raises(mcp_api.HTTPException) as exc:
         await delete_mcp_oauth_grant(server.id, grant.id, user, db)
+    assert exc.value.status_code == 404
+
+
+def _add_remote_oauth_catalog_app(db, *, app_id: str = "granola") -> None:
+    """A built-in catalog row shaped like a real remote-MCP-OAuth connector:
+    only a URL and auth.type — no static client_id, matching a DCR-only
+    provider (e.g. Granola) that never hands out pre-registered credentials."""
+    db.add(
+        PublicMCPApp(
+            app_id=app_id,
+            name=app_id.title(),
+            transport="streamable_http",
+            launch_config={
+                "url": "https://mcp.example.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
+    )
+    db.commit()
+
+
+@pytest.mark.asyncio
+async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    registration_requests: list[httpx.Request] = []
+
+    def registration_handler(request: httpx.Request) -> httpx.Response:
+        registration_requests.append(request)
+        return httpx.Response(
+            201,
+            json={
+                "client_id": "dynamic-client-123",
+                "token_endpoint_auth_method": "none",
+            },
+        )
+
+    registration_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(registration_handler)
+    )
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: registration_client,
+    )
+
+    response = await connect_mcp_oauth_app(
+        "granola",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+    )
+
+    assert response.status_code == 303
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["client_id"] == ["dynamic-client-123"]
+    assert len(registration_requests) == 1
+
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    assert server.transport == "streamable_http"
+    assert server.url == "https://mcp.example.com/mcp"
+    assert server.auth["type"] == "mcp_oauth"
+
+    assoc = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id, UserMCPServer.mcpserver_id == server.id
+        )
+        .one()
+    )
+    assert assoc.is_active is True
+    assert assoc.is_owner is False
+
+
+@pytest.mark.asyncio
+async def test_connect_app_is_idempotent_across_repeated_connects(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    def registration_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "client_id": "dynamic-client-123",
+                "token_endpoint_auth_method": "none",
+            },
+        )
+
+    registration_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(registration_handler)
+    )
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: registration_client,
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    assert db.query(MCPServer).filter(MCPServer.name == "granola").count() == 1
+    assert (
+        db.query(UserMCPServer)
+        .join(MCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
+        .filter(MCPServer.name == "granola", UserMCPServer.user_id == user.id)
+        .count()
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_app_reactivates_a_previously_disconnected_association(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    _set_user_mcp_active(db, user, server, False)
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    assoc = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id, UserMCPServer.mcpserver_id == server.id
+        )
+        .one()
+    )
+    assert assoc.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_connect_app_rejects_non_mcp_oauth_catalog_app(db_session):
+    db, user, _ = db_session
+    db.add(
+        PublicMCPApp(
+            app_id="google-maps",
+            name="Google Maps",
+            transport="stdio",
+            launch_config={"command": "npx", "required_env": ["GOOGLE_MAPS_API_KEY"]},
+        )
+    )
+    db.commit()
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await connect_mcp_oauth_app(
+            "google-maps", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_connect_app_rejects_unknown_app_id(db_session):
+    db, user, _ = db_session
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await connect_mcp_oauth_app(
+            "no-such-app", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        )
     assert exc.value.status_code == 404
 
 

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -28,9 +28,11 @@ from xagent.web.api.mcp import (
     connect_mcp_oauth,
     connect_mcp_oauth_app,
     delete_mcp_oauth_grant,
+    delete_mcp_server,
     discover_mcp_oauth,
     get_mcp_oauth_status,
     get_mcp_server_tools,
+    list_mcp_apps,
     mcp_oauth_callback,
     update_mcp_server,
 )
@@ -1537,6 +1539,268 @@ async def test_connect_app_rejects_unknown_app_id(db_session):
 
 
 @pytest.mark.asyncio
+async def test_connect_app_rejects_hijacked_server_with_foreign_url(db_session):
+    """A pre-existing row under the catalog id with a different remote URL must
+    not be reused — otherwise a victim's DCR/PKCE flow talks to an attacker's
+    MCP server. Mirrors the stdio hijack guard test in test_mcp_apps_connect.py;
+    this shape was previously untested (D1)."""
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    db.add(
+        MCPServer(
+            name="granola",
+            managed="external",
+            transport="streamable_http",
+            url="https://evil.example.com/mcp",
+        )
+    )
+    db.commit()
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await connect_mcp_oauth_app(
+            "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        )
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_connect_app_rejects_user_owned_server_even_with_matching_config(
+    db_session,
+):
+    """A row under the catalog id that a user OWNS is a custom server squatting
+    the id. Even with a config that matches the official launch, it must not be
+    adopted as the shared row (D1's guard, previously untested for mcp_oauth)."""
+    db, user, other_user = db_session
+    _add_remote_oauth_catalog_app(db)
+    server = MCPServer(
+        name="granola",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
+        auth={"type": "mcp_oauth"},
+    )
+    db.add(server)
+    db.commit()
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id, mcpserver_id=server.id, is_owner=True, can_edit=True
+        )
+    )
+    db.commit()
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await connect_mcp_oauth_app(
+            "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        )
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_connect_app_json_accept_returns_authorization_url_in_body(
+    db_session, monkeypatch
+):
+    """The Accept: application/json branch is what the actual frontend popup
+    flow uses; every other test here exercises the 303-redirect branch instead
+    (accept=None)."""
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    response = await connect_mcp_oauth_app(
+        "granola",
+        MCPOAuthConnectRequest(redirect_after="/mcp"),
+        user,
+        db,
+        accept="application/json, text/plain, */*",
+    )
+
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert "authorization_url" in body
+    query = parse_qs(urlparse(body["authorization_url"]).query)
+    assert query["client_id"] == ["dynamic-client-123"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_oauth_app_not_connected_until_grant_completes(
+    db_session, monkeypatch
+):
+    """M1: the UserMCPServer association is created before the user ever
+    reaches the consent screen, so it alone must not mean "connected" — an
+    abandoned/denied/failed authorization must not render as Connected."""
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+
+    apps_before_grant = list_mcp_apps(current_user=user, db=db)
+    granola_before = next(a for a in apps_before_grant if a["id"] == "granola")
+    assert granola_before["is_connected"] is False
+
+    # The DCR flow already registered a client during connect_mcp_oauth_app
+    # above; reuse it rather than registering a second one under the same
+    # (server, issuer) pair, which would trip the unique lookup_hash.
+    client = (
+        db.query(MCPOAuthClient).filter(MCPOAuthClient.mcp_server_id == server.id).one()
+    )
+    db.add(
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="",
+            access_token=encrypt_value("granola-access-token"),
+            status="active",
+        )
+    )
+    db.commit()
+
+    apps_after_grant = list_mcp_apps(current_user=user, db=db)
+    granola_after = next(a for a in apps_after_grant if a["id"] == "granola")
+    assert granola_after["is_connected"] is True
+    assert granola_after["server_id"] == server.id
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
+    db_session, monkeypatch
+):
+    """M3: disconnecting a shared mcp_oauth catalog server must revoke the
+    disconnecting user's own grant immediately, not merely wait for the row to
+    cascade away once the last associated user disconnects — and must leave a
+    still-connected sibling user's grant untouched."""
+    db, user, other_user = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), other_user, db
+    )
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    # Both connects register against the same (server, issuer) pair, so DCR
+    # reuses a single client row (see register_mcp_oauth_public_client).
+    client = (
+        db.query(MCPOAuthClient).filter(MCPOAuthClient.mcp_server_id == server.id).one()
+    )
+
+    own_grant = MCPOAuthGrant(
+        mcp_server_id=server.id,
+        user_id=user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="",
+        access_token=encrypt_value("own-access-token"),
+        status="active",
+    )
+    sibling_grant = MCPOAuthGrant(
+        mcp_server_id=server.id,
+        user_id=other_user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{other_user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="",
+        access_token=encrypt_value("sibling-access-token"),
+        status="active",
+    )
+    db.add_all([own_grant, sibling_grant])
+    db.commit()
+    db.refresh(own_grant)
+    db.refresh(sibling_grant)
+
+    delete_mcp_server(server.id, current_user=user, db=db)
+
+    db.refresh(own_grant)
+    db.refresh(sibling_grant)
+    assert own_grant.status == "revoked"
+    assert own_grant.revoked_at is not None
+    assert sibling_grant.status == "active"
+
+    # The shared row survives (other_user is still associated); only the
+    # disconnecting user's association and grant are gone.
+    assert (
+        db.query(MCPServer).filter(MCPServer.id == server.id).one_or_none() is not None
+    )
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id, UserMCPServer.mcpserver_id == server.id
+        )
+        .one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_callback_exchanges_code_and_stores_encrypted_grant(
     db_session, monkeypatch
 ):
@@ -1596,7 +1860,13 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
     )
 
     assert response.status_code == 307
-    assert response.headers["location"] == "https://app.example.com/mcp"
+    # mcp_oauth_success=1 is the explicit positive signal the connect popup's
+    # self-close effect keys on (N5) instead of inferring success from the
+    # absence of error params.
+    assert (
+        response.headers["location"]
+        == "https://app.example.com/mcp?mcp_oauth_success=1"
+    )
     grant = db.query(MCPOAuthGrant).one()
     assert grant.resource_owner_key == "resource-owner-a"
     assert grant.access_token != "plain-access-token"

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1460,6 +1460,57 @@ async def test_connect_app_syncs_auth_when_catalog_auth_changes(
 
 
 @pytest.mark.asyncio
+async def test_connect_app_auth_sync_tolerates_a_malformed_sensitive_field(
+    db_session, monkeypatch
+):
+    """F13: encrypt_value() calls .encode() unconditionally, so a mis-authored
+    non-string sensitive field (e.g. a nested object where client_secret
+    should be a string) must not crash this user-facing connect request —
+    it's an admin authoring bug to catch at write time, not here."""
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "granola").one()
+    app_row.launch_config = {
+        "url": "https://mcp.example.com/mcp",
+        "auth": {"type": "mcp_oauth", "client_secret": {"nested": "not-a-string"}},
+    }
+    db.commit()
+
+    # Must not raise — the malformed field is left as-is rather than crashing.
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    assert server.auth["client_secret"] == {"nested": "not-a-string"}
+
+
+@pytest.mark.asyncio
 async def test_connect_app_does_not_rewrite_unchanged_auth_with_secret(
     db_session, monkeypatch
 ):
@@ -1777,12 +1828,16 @@ async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
     db.refresh(own_grant)
     db.refresh(sibling_grant)
 
-    delete_mcp_server(server.id, current_user=user, db=db)
+    own_grant_id = own_grant.id
+    await delete_mcp_server(server.id, current_user=user, db=db)
 
-    db.refresh(own_grant)
+    # F10: a disconnected grant must not just flip to "revoked" and linger —
+    # the row itself (still holding the encrypted access token) is purged.
+    assert (
+        db.query(MCPOAuthGrant).filter(MCPOAuthGrant.id == own_grant_id).one_or_none()
+        is None
+    )
     db.refresh(sibling_grant)
-    assert own_grant.status == "revoked"
-    assert own_grant.revoked_at is not None
     assert sibling_grant.status == "active"
 
     # The shared row survives (other_user is still associated); only the
@@ -2599,6 +2654,96 @@ async def test_delete_grant_revokes_external_tokens_when_endpoint_is_advertised(
     db.refresh(grant)
     assert grant.status == "revoked"
     assert grant.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_revokes_external_tokens_when_endpoint_is_advertised(
+    db_session, monkeypatch
+):
+    """M3's remaining half: disconnecting a server must actually reach the
+    provider's revocation_endpoint, not just flip local status (which was
+    already fixed in an earlier round but never called the external API)."""
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(
+        db,
+        server,
+        client_secret=encrypt_value("client-secret"),
+        token_endpoint_auth_method="client_secret_post",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    grant = MCPOAuthGrant(
+        mcp_server_id=server.id,
+        user_id=user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        access_token=encrypt_value("access-token"),
+        refresh_token=encrypt_value("refresh-token"),
+    )
+    db.add(grant)
+    db.commit()
+    db.refresh(grant)
+    grant_id = grant.id
+    requests: list[dict[str, list[str]]] = []
+    real_async_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(parse_qs(request.content.decode()))
+        return httpx.Response(200)
+
+    def async_client_factory(*args, **kwargs):
+        return real_async_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(mcp_api, "create_mcp_oauth_http_client", async_client_factory)
+
+    await delete_mcp_server(server.id, current_user=user, db=db)
+
+    assert [request["token"] for request in requests] == [
+        ["access-token"],
+        ["refresh-token"],
+    ]
+    # Purged outright rather than left as an inert "revoked" row (F10).
+    assert (
+        db.query(MCPOAuthGrant).filter(MCPOAuthGrant.id == grant_id).one_or_none()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_purges_the_users_own_flow_state_rows(db_session):
+    """A leftover MCPOAuthFlowState (e.g. an abandoned/expired connect
+    attempt) carries a per-user code_verifier secret that nothing else
+    sweeps — disconnect must not leave it behind (F10)."""
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    flow_state = MCPOAuthFlowState(
+        state="leftover-state",
+        mcp_server_id=server.id,
+        user_id=user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        code_verifier=encrypt_value("verifier-123"),
+        expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+    )
+    db.add(flow_state)
+    db.commit()
+    flow_state_id = flow_state.id
+
+    await delete_mcp_server(server.id, current_user=user, db=db)
+
+    assert (
+        db.query(MCPOAuthFlowState)
+        .filter(MCPOAuthFlowState.id == flow_state_id)
+        .one_or_none()
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1237,10 +1237,15 @@ async def test_oauth_routes_reject_inactive_user_mcp_server(db_session, monkeypa
     assert exc.value.status_code == 404
 
 
-def _add_remote_oauth_catalog_app(db, *, app_id: str = "granola") -> None:
+def _add_remote_oauth_catalog_app(db, *, app_id: str = "remote-notes") -> None:
     """A built-in catalog row shaped like a real remote-MCP-OAuth connector:
     only a URL and auth.type — no static client_id, matching a DCR-only
-    provider (e.g. Granola) that never hands out pre-registered credentials."""
+    provider (e.g. Granola) that never hands out pre-registered credentials.
+
+    The synthetic app_id must NOT match a real builtin registry entry: the
+    builtin execution overlay (get_builtin_execution_fields) replaces a DB
+    row's execution fields with the canonical registry values for matching
+    app_ids, which would silently override this fixture's url/auth."""
     db.add(
         PublicMCPApp(
             app_id=app_id,
@@ -1289,7 +1294,7 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
     )
 
     response = await connect_mcp_oauth_app(
-        "granola",
+        "remote-notes",
         MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
         user,
         db,
@@ -1300,7 +1305,7 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
     assert query["client_id"] == ["dynamic-client-123"]
     assert len(registration_requests) == 1
 
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     assert server.transport == "streamable_http"
     assert server.url == "https://mcp.example.com/mcp"
     assert server.auth["type"] == "mcp_oauth"
@@ -1347,17 +1352,17 @@ async def test_connect_app_is_idempotent_across_repeated_connects(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
-    assert db.query(MCPServer).filter(MCPServer.name == "granola").count() == 1
+    assert db.query(MCPServer).filter(MCPServer.name == "remote-notes").count() == 1
     assert (
         db.query(UserMCPServer)
         .join(MCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
-        .filter(MCPServer.name == "granola", UserMCPServer.user_id == user.id)
+        .filter(MCPServer.name == "remote-notes", UserMCPServer.user_id == user.id)
         .count()
         == 1
     )
@@ -1391,13 +1396,13 @@ async def test_connect_app_reactivates_a_previously_disconnected_association(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     _set_user_mcp_active(db, user, server, False)
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
     assoc = (
@@ -1441,10 +1446,10 @@ async def test_connect_app_syncs_auth_when_catalog_auth_changes(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
-    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "granola").one()
+    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "remote-notes").one()
     app_row.launch_config = {
         "url": "https://mcp.example.com/mcp",
         "auth": {"type": "mcp_oauth", "scope": "meetings.read"},
@@ -1452,10 +1457,10 @@ async def test_connect_app_syncs_auth_when_catalog_auth_changes(
     db.commit()
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     assert server.auth == {"type": "mcp_oauth", "scope": "meetings.read"}
 
 
@@ -1491,10 +1496,10 @@ async def test_connect_app_auth_sync_tolerates_a_malformed_sensitive_field(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
-    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "granola").one()
+    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "remote-notes").one()
     app_row.launch_config = {
         "url": "https://mcp.example.com/mcp",
         "auth": {"type": "mcp_oauth", "client_secret": {"nested": "not-a-string"}},
@@ -1503,10 +1508,10 @@ async def test_connect_app_auth_sync_tolerates_a_malformed_sensitive_field(
 
     # Must not raise — the malformed field is left as-is rather than crashing.
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     assert server.auth["client_secret"] == {"nested": "not-a-string"}
 
 
@@ -1522,8 +1527,8 @@ async def test_connect_app_does_not_rewrite_unchanged_auth_with_secret(
     db, user, _ = db_session
     db.add(
         PublicMCPApp(
-            app_id="granola",
-            name="Granola",
+            app_id="remote-notes",
+            name="Remote Notes",
             transport="streamable_http",
             launch_config={
                 "url": "https://mcp.example.com/mcp",
@@ -1543,15 +1548,15 @@ async def test_connect_app_does_not_rewrite_unchanged_auth_with_secret(
     monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     stored_secret_ciphertext = server.auth["client_secret"]
     assert stored_secret_ciphertext != "static-secret"  # encrypted at rest
     assert decrypt_value(stored_secret_ciphertext) == "static-secret"
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
 
     db.refresh(server)
@@ -1599,7 +1604,7 @@ async def test_connect_app_rejects_hijacked_server_with_foreign_url(db_session):
     _add_remote_oauth_catalog_app(db)
     db.add(
         MCPServer(
-            name="granola",
+            name="remote-notes",
             managed="external",
             transport="streamable_http",
             url="https://evil.example.com/mcp",
@@ -1609,7 +1614,7 @@ async def test_connect_app_rejects_hijacked_server_with_foreign_url(db_session):
 
     with pytest.raises(mcp_api.HTTPException) as exc:
         await connect_mcp_oauth_app(
-            "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+            "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
         )
     assert exc.value.status_code == 409
 
@@ -1624,7 +1629,7 @@ async def test_connect_app_rejects_user_owned_server_even_with_matching_config(
     db, user, other_user = db_session
     _add_remote_oauth_catalog_app(db)
     server = MCPServer(
-        name="granola",
+        name="remote-notes",
         managed="external",
         transport="streamable_http",
         url="https://mcp.example.com/mcp",
@@ -1641,7 +1646,7 @@ async def test_connect_app_rejects_user_owned_server_even_with_matching_config(
 
     with pytest.raises(mcp_api.HTTPException) as exc:
         await connect_mcp_oauth_app(
-            "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+            "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
         )
     assert exc.value.status_code == 409
 
@@ -1677,7 +1682,7 @@ async def test_connect_app_json_accept_returns_authorization_url_in_body(
     )
 
     response = await connect_mcp_oauth_app(
-        "granola",
+        "remote-notes",
         MCPOAuthConnectRequest(redirect_after="/mcp"),
         user,
         db,
@@ -1722,13 +1727,15 @@ async def test_mcp_oauth_app_not_connected_until_grant_completes(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
 
     apps_before_grant = list_mcp_apps(current_user=user, db=db)
-    granola_before = next(a for a in apps_before_grant if a["id"] == "granola")
-    assert granola_before["is_connected"] is False
+    remote_notes_before = next(
+        a for a in apps_before_grant if a["id"] == "remote-notes"
+    )
+    assert remote_notes_before["is_connected"] is False
 
     # The DCR flow already registered a client during connect_mcp_oauth_app
     # above; reuse it rather than registering a second one under the same
@@ -1745,16 +1752,16 @@ async def test_mcp_oauth_app_not_connected_until_grant_completes(
             issuer="https://auth.example.com",
             resource="https://mcp.example.com/mcp",
             scope="",
-            access_token=encrypt_value("granola-access-token"),
+            access_token=encrypt_value("remote-notes-access-token"),
             status="active",
         )
     )
     db.commit()
 
     apps_after_grant = list_mcp_apps(current_user=user, db=db)
-    granola_after = next(a for a in apps_after_grant if a["id"] == "granola")
-    assert granola_after["is_connected"] is True
-    assert granola_after["server_id"] == server.id
+    remote_notes_after = next(a for a in apps_after_grant if a["id"] == "remote-notes")
+    assert remote_notes_after["is_connected"] is True
+    assert remote_notes_after["server_id"] == server.id
 
 
 @pytest.mark.asyncio
@@ -1827,12 +1834,12 @@ async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
     )
 
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
     )
     await connect_mcp_oauth_app(
-        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), other_user, db
+        "remote-notes", MCPOAuthConnectRequest(redirect_after="/mcp"), other_user, db
     )
-    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    server = db.query(MCPServer).filter(MCPServer.name == "remote-notes").one()
     # Both connects register against the same (server, issuer) pair, so DCR
     # reuses a single client row (see register_mcp_oauth_public_client).
     client = (

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1409,6 +1409,103 @@ async def test_connect_app_reactivates_a_previously_disconnected_association(
 
 
 @pytest.mark.asyncio
+async def test_connect_app_syncs_auth_when_catalog_auth_changes(
+    db_session, monkeypatch
+):
+    """The catalog is the source of truth for the shared row's auth config:
+    a registry change (e.g. adding a scope hint) must propagate to the
+    already-provisioned server row on the next connect, not persist stale."""
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    201,
+                    json={
+                        "client_id": "dynamic-client-123",
+                        "token_endpoint_auth_method": "none",
+                    },
+                )
+            )
+        ),
+    )
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    app_row = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "granola").one()
+    app_row.launch_config = {
+        "url": "https://mcp.example.com/mcp",
+        "auth": {"type": "mcp_oauth", "scope": "meetings.read"},
+    }
+    db.commit()
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    assert server.auth == {"type": "mcp_oauth", "scope": "meetings.read"}
+
+
+@pytest.mark.asyncio
+async def test_connect_app_does_not_rewrite_unchanged_auth_with_secret(
+    db_session, monkeypatch
+):
+    """Auth drift is detected on the DECRYPTED stored value: sensitive auth
+    fields are encrypted at rest, so a raw stored-vs-catalog comparison would
+    spuriously differ on every connect and rewrite the row each time. Fernet
+    ciphertext changes on re-encryption, so an unchanged ciphertext across
+    two connects proves no rewrite happened."""
+    db, user, _ = db_session
+    db.add(
+        PublicMCPApp(
+            app_id="granola",
+            name="Granola",
+            transport="streamable_http",
+            launch_config={
+                "url": "https://mcp.example.com/mcp",
+                "auth": {
+                    "type": "mcp_oauth",
+                    "client_id": "static-client",
+                    "client_secret": "static-secret",
+                },
+            },
+        )
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+    server = db.query(MCPServer).filter(MCPServer.name == "granola").one()
+    stored_secret_ciphertext = server.auth["client_secret"]
+    assert stored_secret_ciphertext != "static-secret"  # encrypted at rest
+    assert decrypt_value(stored_secret_ciphertext) == "static-secret"
+
+    await connect_mcp_oauth_app(
+        "granola", MCPOAuthConnectRequest(redirect_after="/mcp"), user, db
+    )
+
+    db.refresh(server)
+    assert server.auth["client_secret"] == stored_secret_ciphertext
+
+
+@pytest.mark.asyncio
 async def test_connect_app_rejects_non_mcp_oauth_catalog_app(db_session):
     db, user, _ = db_session
     db.add(

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -764,6 +764,24 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
         "required_env": ["GOOGLE_MAPS_API_KEY"],
     }
 
+    # Remote MCP (no local command at all): Granola hosts the server itself.
+    assert rows_by_app_id["granola"]["transport"] == "streamable_http"
+    assert rows_by_app_id["granola"]["launch_config"] == {
+        "url": "https://mcp.granola.ai/mcp",
+        "auth": {"type": "mcp_oauth"},
+    }
+
+
+def test_builtin_registry_classifies_granola_as_mcp_oauth() -> None:
+    """The registry shape must classify as mcp_oauth — anything else means the
+    catalog entry is uninstallable (connect_mcp_app rejects non-api_key apps
+    and generic_oauth_login rejects non-"oauth" transports)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+    from xagent.web.mcp_apps import classify_app_auth
+
+    row = next(r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "granola")
+    assert classify_app_auth(row["transport"], row["launch_config"]) == "mcp_oauth"
+
 
 def test_builtin_registry_helpers_use_exact_ids_and_return_defensive_copies() -> None:
     from xagent.web.builtin_mcp_registry import (

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -1183,6 +1183,82 @@ def test_admin_create_app_rejects_keyless_command_entry() -> None:
             pass
 
 
+def test_admin_create_app_rejects_partial_remote_oauth_entry() -> None:
+    """Same write-time constraint (#764), for the remote-MCP-OAuth shape: a
+    streamable_http/sse/websocket entry needs BOTH launch_config.url and
+    launch_config.auth.type == "mcp_oauth", or it classifies as
+    "unconnectable" and must be rejected rather than silently persisted."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        # Shape 1: url without auth.type=mcp_oauth.
+        resp = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "bad-no-auth-type",
+                "name": "BadNoAuthType",
+                "transport": "streamable_http",
+                "launch_config": {"url": "https://mcp.example.com/mcp"},
+            },
+        )
+        assert resp.status_code == 422
+
+        # Shape 2 (the reverse asymmetric shape): auth.type=mcp_oauth without url.
+        resp = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "bad-no-url",
+                "name": "BadNoUrl",
+                "transport": "streamable_http",
+                "launch_config": {"auth": {"type": "mcp_oauth"}},
+            },
+        )
+        assert resp.status_code == 422
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_admin_create_app_accepts_full_remote_oauth_entry() -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        resp = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "good-remote-oauth",
+                "name": "GoodRemoteOAuth",
+                "transport": "streamable_http",
+                "launch_config": {
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": {"type": "mcp_oauth"},
+                },
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["launch_config"]["url"] == "https://mcp.example.com/mcp"
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
 def test_admin_update_app_enforces_auth_classification() -> None:
     """The write-time constraint fires on PUT too, not just POST (both use the
     same PublicMCPAppCreate model)."""

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -1301,6 +1301,69 @@ def test_admin_update_app_enforces_auth_classification() -> None:
             pass
 
 
+def test_admin_update_grandfathers_a_preexisting_bad_shape_row_for_unrelated_edits() -> (
+    None
+):
+    """F4: a row already in an "unconnectable" partial shape (created directly,
+    simulating one that predates a shape rule tightening) must stay editable
+    for fields the shape check doesn't read — otherwise the write-time
+    constraint permanently locks out even an icon change on that row. A PUT
+    that also touches transport/launch_config must still be rejected."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        db = next(get_db())
+        try:
+            db.add(
+                PublicMCPApp(
+                    app_id="legacy-partial-oauth",
+                    name="LegacyPartialOAuth",
+                    icon="old-icon",
+                    transport="streamable_http",
+                    launch_config={"url": "https://mcp.example.com/mcp"},
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        db = next(get_db())
+        try:
+            app_pk = (
+                db.query(PublicMCPApp)
+                .filter(PublicMCPApp.app_id == "legacy-partial-oauth")
+                .one()
+                .id
+            )
+        finally:
+            db.close()
+
+        unrelated_edit = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"icon": "new-icon"},
+        )
+        assert unrelated_edit.status_code == 200
+        assert unrelated_edit.json()["icon"] == "new-icon"
+
+        shape_touching_edit = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"launch_config": {"url": "https://mcp.example.com/mcp"}},
+        )
+        assert shape_touching_edit.status_code == 422
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
 def test_admin_list_apps_does_not_500_on_partial_launch_config_row() -> None:
     """The write-time validator lives on the create model only, so listing must
     not re-validate on response serialization. A legacy/direct-DB row with a

--- a/tests/web/test_classify_app_auth.py
+++ b/tests/web/test_classify_app_auth.py
@@ -63,6 +63,27 @@ def test_mcp_oauth_requires_both_url_and_auth_type():
     )
 
 
+def test_remote_mcp_oauth_transport_check_is_case_insensitive():
+    # N1: the builtin_oauth check above lowercases ("OAuth" -> "oauth"); the
+    # remote-transport check must be equally forgiving, or an admin PATCH that
+    # stores a mixed-case transport puts the two halves of this feature in
+    # disagreement about the same row.
+    assert (
+        classify_app_auth(
+            "Streamable_HTTP",
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+        )
+        == "mcp_oauth"
+    )
+    assert (
+        classify_app_auth(
+            "SSE",
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+        )
+        == "mcp_oauth"
+    )
+
+
 def test_mcp_oauth_shape_requires_a_remote_transport():
     # Same launch_config shape on a stdio transport must not be misrouted —
     # only sse/websocket/streamable_http describe a genuine remote MCP server.

--- a/tests/web/test_classify_app_auth.py
+++ b/tests/web/test_classify_app_auth.py
@@ -31,6 +31,50 @@ def test_key_based_needs_command_and_required_env():
     )
 
 
+def test_remote_mcp_oauth_shape_is_mcp_oauth():
+    for transport in ("sse", "websocket", "streamable_http"):
+        assert (
+            classify_app_auth(
+                transport,
+                {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+            )
+            == "mcp_oauth"
+        )
+
+
+def test_mcp_oauth_requires_both_url_and_auth_type():
+    # url without auth.type=mcp_oauth -> not launchable via OAuth
+    assert (
+        classify_app_auth("streamable_http", {"url": "https://mcp.example.com/mcp"})
+        == "unconnectable"
+    )
+    # auth.type=mcp_oauth without url -> nothing to connect to
+    assert (
+        classify_app_auth("streamable_http", {"auth": {"type": "mcp_oauth"}})
+        == "unconnectable"
+    )
+    # wrong auth.type is not mcp_oauth
+    assert (
+        classify_app_auth(
+            "streamable_http",
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "bearer"}},
+        )
+        == "unconnectable"
+    )
+
+
+def test_mcp_oauth_shape_requires_a_remote_transport():
+    # Same launch_config shape on a stdio transport must not be misrouted —
+    # only sse/websocket/streamable_http describe a genuine remote MCP server.
+    assert (
+        classify_app_auth(
+            "stdio",
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+        )
+        == "unconnectable"
+    )
+
+
 def test_inconsistent_entries_are_unconnectable_not_misrouted():
     # required_env but no command -> not launchable
     assert classify_app_auth("stdio", {"required_env": ["KEY"]}) == "unconnectable"

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -585,7 +585,7 @@ def test_bare_meta_login_skips_facebook_but_still_connects_instagram(
     assert "Facebook Pages" not in server_names
 
 
-def test_disconnecting_facebook_preserves_shared_bare_meta_grant_for_instagram(
+async def test_disconnecting_facebook_preserves_shared_bare_meta_grant_for_instagram(
     db_session, monkeypatch
 ):
     """UserOAuth has no app_id column: a bare Meta grant (provider="meta")
@@ -671,14 +671,14 @@ def test_disconnecting_facebook_preserves_shared_bare_meta_grant_for_instagram(
     facebook_server = (
         db.query(MCPServer).filter(MCPServer.name == "Facebook Pages").one()
     )
-    delete_mcp_server(facebook_server.id, current_user=user, db=db)
+    await delete_mcp_server(facebook_server.id, current_user=user, db=db)
 
     assert db.query(UserOAuth).filter(UserOAuth.provider == "facebook").count() == 0
     # The shared bare grant Instagram still relies on must survive.
     assert db.query(UserOAuth).filter(UserOAuth.provider == "meta").count() == 1
 
 
-def test_disconnecting_facebook_only_user_also_removes_orphaned_bare_meta_grant(
+async def test_disconnecting_facebook_only_user_also_removes_orphaned_bare_meta_grant(
     db_session,
 ):
     """Mirror of the previous test's opposite case: no Instagram connection
@@ -701,7 +701,7 @@ def test_disconnecting_facebook_only_user_also_removes_orphaned_bare_meta_grant(
 
     from xagent.web.api.mcp import delete_mcp_server
 
-    delete_mcp_server(server.id, current_user=user, db=db)
+    await delete_mcp_server(server.id, current_user=user, db=db)
 
     assert db.query(UserOAuth).filter(UserOAuth.provider == "facebook").count() == 0
     assert db.query(UserOAuth).filter(UserOAuth.provider == "meta").count() == 0


### PR DESCRIPTION
> **Depends on #1096** — this PR is stacked on `feat/remote-mcp-oauth-catalog-connector` and must merge after it. The diff will shrink to the Granola-only commit (`0ed99e03`) once #1096 lands.

## Summary
- Register `granola` in the built-in catalog as the first connector using the remote-MCP OAuth (`mcp_oauth`) shape from #1096: `transport: streamable_http` pointing at Granola's hosted MCP server (`https://mcp.granola.ai/mcp`), `auth.type: mcp_oauth` — Granola issues no static client credentials, so connecting runs the per-user Dynamic Client Registration flow
- No local tool module (unlike the Zoom/AWS-style connectors): Granola's hosted server exposes its own meeting-notes tools (search/list/read meetings, transcripts), so the connector is a catalog row + seed migration only
- Seed migration inserts the catalog row only — no `oauth_providers` row exists for a DCR connector; downgrade removes just the row, leaving connect-driven `MCPServer`/`MCPOAuth*` rows to the normal disconnect path
- Wire the Meeting Agent template (`sales-meeting-agent.yaml`) to Granola per the Advanced Templates spec: `connections` entry, feature copy (EN/ZH), and instructions steering the agent to look meetings up in Granola notes first, falling back to a pasted/uploaded transcript
- Move the oauth-flow test fixture's synthetic app_id from `granola` to `remote-notes`: `granola` is now a real builtin registry entry, and the builtin execution overlay replaces a DB row's execution fields for matching app_ids, which would silently override the fixture's url/auth

## Test plan
- [x] `pytest tests/alembic/test_20260731_seed_granola_mcp_app.py tests/web/api/test_public_mcp_connector_visibility.py tests/templates/test_manager.py tests/web/test_classify_app_auth.py tests/web/api/test_mcp_oauth_flow.py tests/web/api/test_mcp_apps_connect.py` — 161 passed
- [x] New tests: migration upgrade/downgrade round-trip, idempotency, registry-drift guard (migration ROW == registry row), and a classification guard asserting the seeded shape classifies as `mcp_oauth` (an `unconnectable` classification would make the entry dead on arrival)
- [x] Template-connections resolution test passes (Granola resolves against the registry)
- [x] `alembic upgrade head` / `downgrade -1` round-trip verified against a local dev DB — only the `granola` row is added/removed
- [x] `ruff format` / `ruff check` / `mypy` / pre-commit (incl. alembic-check single-head) all clean