### PR TITLE
ci: pre-pull the sandbox image before docker-backed fast tests

### DIFF
--- a/.github/scripts/docker-pull-retry.sh
+++ b/.github/scripts/docker-pull-retry.sh
@@ -20,7 +20,7 @@ fi
 
 for image in "$@"; do
   pulled=false
-  for i in $(seq 1 "$ATTEMPTS"); do
+  for ((i = 1; i <= ATTEMPTS; i++)); do
     if docker pull "$image"; then
       pulled=true
       break

--- a/.github/scripts/docker-pull-retry.sh
+++ b/.github/scripts/docker-pull-retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Pull one or more images, retrying transient registry failures.
+#
+# CI jobs that drive a real Docker daemon must pre-pull every image their tests
+# need. Otherwise the pull happens inside a test fixture, and a Docker Hub
+# timeout or an anonymous pull rate limit surfaces as a pile of confusing
+# APIError test failures instead of a clearly-named setup failure.
+#
+# Usage: docker-pull-retry.sh IMAGE [IMAGE...]
+
+set -euo pipefail
+
+ATTEMPTS="${PULL_ATTEMPTS:-3}"
+BACKOFF_SECONDS="${PULL_BACKOFF_SECONDS:-15}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 IMAGE [IMAGE...]" >&2
+  exit 2
+fi
+
+for image in "$@"; do
+  pulled=false
+  for i in $(seq 1 "$ATTEMPTS"); do
+    if docker pull "$image"; then
+      pulled=true
+      break
+    fi
+    if [ "$i" -lt "$ATTEMPTS" ]; then
+      echo "Pull attempt $i for $image failed; retrying in ${BACKOFF_SECONDS}s..."
+      sleep "$BACKOFF_SECONDS"
+    fi
+  done
+  if [ "$pulled" != true ]; then
+    echo "Failed to pull $image after $ATTEMPTS attempts" >&2
+    exit 1
+  fi
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,17 @@ jobs:
           set -e
           npm install -g pptxgenjs@4.0.1
 
+      - name: Pre-pull the sandbox image
+        # tests/web/test_sandbox_reconcile_e2e.py drives a real Docker daemon.
+        # Pull with retries here so registry flakes fail in this step instead of
+        # as APIErrors inside the tests (#1099).
+        if: matrix.name == 'web'
+        shell: bash
+        run: |
+          set -e
+          image="$(python3 -m uv run python -c 'from xagent.config import get_sandbox_image; print(get_sandbox_image())')"
+          .github/scripts/docker-pull-retry.sh "$image"
+
       - name: Run tests
         shell: bash
         run: |
@@ -429,6 +440,16 @@ jobs:
         run: |
           set -e
           npm install -g pptxgenjs@4.0.1
+
+      - name: Pre-pull the sandbox image
+        # tests/sandbox drives a real Docker daemon (test_docker_lifecycle_api.py
+        # and friends). Same reasoning as the pytest-fast web leg (#1099).
+        if: matrix.name == 'core'
+        shell: bash
+        run: |
+          set -e
+          image="$(python3 -m uv run python -c 'from xagent.config import get_sandbox_image; print(get_sandbox_image())')"
+          .github/scripts/docker-pull-retry.sh "$image"
 
       - name: Run tests
         shell: bash
@@ -603,21 +624,10 @@ jobs:
       - name: Pull e2e service images
         # Retry service images before pytest so registry failures surface here
         # instead of as confusing Docker daemon errors inside e2e fixtures.
+        shell: bash
         run: |
-          for image in minio/minio postgres:16-bookworm; do
-            pulled=false
-            for i in 1 2 3; do
-              if docker pull "$image"; then
-                pulled=true
-                break
-              fi
-              if [ "$i" -lt 3 ]; then
-                echo "Pull attempt $i for $image failed; retrying in 15s..."
-                sleep 15
-              fi
-            done
-            [ "$pulled" = true ] || exit 1
-          done
+          set -e
+          .github/scripts/docker-pull-retry.sh minio/minio postgres:16-bookworm
 
       - name: Run e2e tests
         shell: bash


### PR DESCRIPTION
Closes #1099.

## Problem

`Pytest Fast (web)` failed on main with `6 failed, 3802 passed`, every failure in
`tests/web/test_sandbox_reconcile_e2e.py` and every one with the same cause:

```
docker.errors.APIError: 500 Server Error for
.../images/create?tag=latest&fromImage=xprobe%2Fxagent-sandbox:
Internal Server Error ("Get "https://registry-1.docker.io/v2/": context deadline exceeded")
```

Those tests drive a real Docker daemon. `_ensure_image()`
(`src/xagent/sandbox/docker_sandbox.py:974`) pulls `xprobe/xagent-sandbox:latest`
when the runner has no local copy, so the pull happens mid-test and a Docker Hub
timeout or an anonymous pull rate limit surfaces as a pile of `APIError` test
failures instead of a clearly-named setup failure. Transient infrastructure, but
structurally guaranteed to recur.

The `e2e` job already guards against this with a retrying pre-pull step; the fast
pytest jobs had no equivalent.

## Change

- Add a "Pre-pull the sandbox image" step to the two legs that drive a real
  daemon: `pytest-fast` / `web` (`tests/web`) and `pytest-fast-deepdoc` / `core`
  (`tests/sandbox`). Both run before pytest.
- Resolve the tag from `get_sandbox_image()` rather than hardcoding it, so the
  pre-pull cannot drift from what `_ensure_image()` actually requests.
- Factor the retry loop the `e2e` job already had into
  `.github/scripts/docker-pull-retry.sh` and share it across all three call
  sites, instead of a third copy of the same twelve lines.

The script takes one or more images, retries `PULL_ATTEMPTS` times (default 3)
with `PULL_BACKOFF_SECONDS` between attempts (default 15), and exits non-zero if
any image cannot be pulled.

## Verification

- `ci.yml` parses; step ordering confirmed — the pre-pull lands between
  "Install pptxgenjs globally" and "Run tests" in both jobs.
- `bash -n` clean. Script exercised against a stub `docker` covering all four
  paths: fail-then-succeed (retry) → 0, multiple images → 0, attempts exhausted
  → 1, no arguments → 2 with usage.
- The image resolver one-liner prints `xprobe/xagent-sandbox:latest` locally.

The real-pull success path is only exercised by CI on this PR — locally it was
covered with a stub daemon.
