### PR TITLE
feat: add browser computer use loop

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -12,6 +12,7 @@ from ...context_ref import (
     ContextReference,
     normalize_context_references,
     split_tool_result_context_references,
+    split_tool_result_supersedes_scope,
 )
 from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS
 from ...tools.artifacts import (
@@ -166,7 +167,10 @@ class ExecutionContext:
         *,
         context_refs: Any = (),
     ) -> Message:
-        public_result, embedded_refs = split_tool_result_context_references(result)
+        public_result, supersedes_scope = split_tool_result_supersedes_scope(result)
+        public_result, embedded_refs = split_tool_result_context_references(
+            public_result
+        )
         explicit_refs = normalize_context_references(context_refs)
         all_context_refs = []
         seen_context_refs: set[str] = set()
@@ -181,7 +185,7 @@ class ExecutionContext:
             tool_name, public_result
         )
         content = self._format_tool_result(tool_name, context_result)
-        metadata = {
+        metadata: dict[str, Any] = {
             "tool_name": tool_name,
             "raw_result": context_result,
             "workspace_id": self.workspace_id,
@@ -189,12 +193,58 @@ class ExecutionContext:
             "cwd": self.cwd,
             "memory_session_id": self.memory_session_id,
         }
+        if supersedes_scope:
+            metadata["supersedes_scope"] = supersedes_scope
+            self._compact_superseded_tool_messages(supersedes_scope)
         return self.add_message(
             "tool",
             content,
             tool_call_id=tool_call_id,
             metadata=metadata,
             context_refs=tuple(all_context_refs),
+        )
+
+    def _compact_superseded_tool_messages(self, scope: str) -> None:
+        """Keep stale observations durable while removing them from live prompts."""
+
+        for index, message in enumerate(self.messages):
+            metadata = message.metadata or {}
+            if metadata.get("supersedes_scope") != scope:
+                continue
+            if metadata.get("superseded"):
+                continue
+            self.messages[index] = replace(
+                message,
+                content=self._superseded_tool_summary(message),
+                metadata={
+                    **metadata,
+                    "superseded": True,
+                    "raw_result": None,
+                },
+            )
+
+    @staticmethod
+    def _superseded_tool_summary(message: Message) -> str:
+        metadata = message.metadata or {}
+        tool_name = str(metadata.get("tool_name") or "tool")
+        raw_result = metadata.get("raw_result")
+        details: list[str] = []
+        if isinstance(raw_result, dict):
+            observation = raw_result.get("observation")
+            for key in ("frame_id", "active_url", "title"):
+                value = raw_result.get(key)
+                if not value and isinstance(observation, dict):
+                    value = observation.get(key)
+                if value:
+                    details.append(f"{key}={value}")
+        if message.context_refs:
+            details.append(
+                "file_id=" + ",".join(ref.file_id for ref in message.context_refs)
+            )
+        suffix = f" ({', '.join(details)})" if details else ""
+        return (
+            f"[{tool_name} result superseded by a later observation{suffix}. "
+            "The page state it described no longer applies.]"
         )
 
     def attach_workspace(

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -219,7 +219,7 @@ class ExecutionContext:
                 metadata={
                     **metadata,
                     "superseded": True,
-                    "raw_result": None,
+                    "raw_result": {"success": True, "superseded": True},
                 },
             )
 
@@ -1218,7 +1218,9 @@ class ExecutionContext:
                 )
             chunks.append(message.content)
             if message.context_refs:
-                chunks.append(message.context_refs_text())
+                context_refs_text = message.context_refs_text()
+                if context_refs_text:
+                    chunks.append(context_refs_text)
         return "\n".join(chunks)
 
     def _compact_response_text(self, response: Any) -> str:

--- a/src/xagent/core/agent/context/message.py
+++ b/src/xagent/core/agent/context/message.py
@@ -60,7 +60,7 @@ class Message:
             result["tool_call_id"] = self.tool_call_id
         if self.hidden:
             result["hidden"] = True
-        if self.context_refs:
+        if self.context_refs and not self.metadata.get("superseded"):
             result[CONTEXT_REFS_KEY] = [
                 reference.durable_dict() for reference in self.context_refs
             ]
@@ -92,9 +92,13 @@ class Message:
         )
 
     def context_refs_text(self) -> str:
+        if self.metadata.get("superseded"):
+            return ""
         return "\n".join(reference.compact_text() for reference in self.context_refs)
 
     def context_refs_token_estimate(self) -> int:
+        if self.metadata.get("superseded"):
+            return 0
         return sum(reference.estimated_tokens() for reference in self.context_refs)
 
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -3028,7 +3028,7 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         args = self._tool_call_args_dict(tool_call, require_mapping=True)
         tool_name = self._tool_name(tool)
-        if not tool_name.startswith("browser_"):
+        if not (tool_name.startswith("browser_") or tool_name == "computer"):
             return args
 
         step_id = tool_call.get("dag_step_id") or tool_call.get("step_id")

--- a/src/xagent/core/computer/browser.py
+++ b/src/xagent/core/computer/browser.py
@@ -6,8 +6,14 @@ from typing import Any, cast
 from urllib.parse import urlsplit
 from uuid import uuid4
 
+from pydantic import TypeAdapter, ValidationError
+
 from ..tools.core.browser_use import BrowserSessionManager, get_browser_manager
-from .environment import ComputerEnvironment, ComputerTargetNotFoundError
+from .environment import (
+    ComputerEnvironment,
+    ComputerFrameMismatchError,
+    ComputerTargetNotFoundError,
+)
 from .schema import (
     ELEMENT_EXTRACTION_FAILED_KEY,
     ELEMENT_EXTRACTION_INCOMPLETE_KEY,
@@ -21,11 +27,14 @@ from .schema import (
     ComputerEnvironmentType,
     ComputerObservation,
     NormalizedPoint,
+    ObservedUrl,
     Viewport,
 )
 from .store import ObservationStore
 
 logger = logging.getLogger(__name__)
+
+_OBSERVED_URL_ADAPTER = TypeAdapter(ObservedUrl)
 
 _INTERACTIVE_ELEMENTS_SCRIPT = """
 (limit) => {
@@ -77,8 +86,7 @@ _INTERACTIVE_ELEMENTS_SCRIPT = """
       autocomplete === "webauthn" ||
       autocomplete.startsWith("cc-")
     );
-    const safeValue = sensitive ? "" : String(node.value || "");
-    const text = String(node.innerText || safeValue).trim().slice(0, 240);
+    const text = String(node.innerText || "").trim().slice(0, 240);
     const label = String(
       node.getAttribute("aria-label") ||
       node.getAttribute("title") ||
@@ -133,12 +141,25 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         self.headless = headless
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height
+        self._manager_session_id = f"computer:{self.session_id}"
+        self._browser_session: Any | None = None
 
-    async def _get_page(self) -> Any:
+    async def _get_page(self, *, reject_recreated_session: bool) -> Any:
         session = await self.manager.get_or_create(
-            self.session_id,
+            self._manager_session_id,
             headless=self.headless,
         )
+        recreated = (
+            self._browser_session is not None and session is not self._browser_session
+        )
+        self._browser_session = session
+        if recreated:
+            self._invalidate_observation()
+            if reject_recreated_session:
+                raise ComputerFrameMismatchError(
+                    "browser session changed after the expected frame was captured; "
+                    "request a fresh screenshot before another action"
+                )
         page = await session.get_page()
         requested = {
             "width": self.viewport_width,
@@ -149,13 +170,16 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         return page
 
     async def _close(self) -> None:
-        await self.manager.close(self.session_id)
+        await self.manager.close(self._manager_session_id)
+        self._browser_session = None
 
     async def _observe(self) -> ComputerObservation:
-        return await self._capture_observation(await self._get_page())
+        return await self._capture_observation(
+            await self._get_page(reject_recreated_session=False)
+        )
 
     async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
-        page = await self._get_page()
+        page = await self._get_page(reject_recreated_session=True)
         action = batch.actions[0]
         await self._execute_action(page, action)
         if action.type not in {
@@ -205,7 +229,13 @@ class BrowserComputerEnvironment(ComputerEnvironment):
             # screenshot remains authoritative for cross-origin child frames.
             metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
 
-        active_url = str(getattr(page, "url", "") or "").strip() or None
+        raw_active_url = str(getattr(page, "url", "") or "").strip() or None
+        active_url: str | None = None
+        if raw_active_url is not None:
+            try:
+                active_url = _OBSERVED_URL_ADAPTER.validate_python(raw_active_url)
+            except ValidationError:
+                metadata["active_url_unavailable"] = True
         return ComputerObservation(
             session_id=self.session_id,
             frame_id=frame_id,
@@ -296,6 +326,18 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         if action.type is ComputerActionType.REPLACE_TEXT:
             x, y = self._target_pixels(action)
             await page.mouse.click(x, y)
+            editable = await page.evaluate(
+                """() => {
+                  const node = document.activeElement;
+                  if (!node) return false;
+                  if (node.isContentEditable) return true;
+                  const tag = String(node.tagName || "").toLowerCase();
+                  return (tag === "input" || tag === "textarea") &&
+                    !node.disabled && !node.readOnly;
+                }"""
+            )
+            if not editable:
+                raise ValueError("replace_text target is not an editable element")
             modifier = "Meta" if sys.platform == "darwin" else "Control"
             await page.keyboard.press(f"{modifier}+A")
             await page.keyboard.insert_text(action.text or "")
@@ -404,4 +446,10 @@ class BrowserComputerEnvironment(ComputerEnvironment):
             "SPACE": "Space",
             "TAB": "Tab",
         }
-        return "+".join(aliases.get(key.upper(), key) for key in keys)
+        normalized = [aliases.get(key.upper(), key) for key in keys]
+        modifiers = {"Alt", "Control", "Meta", "Shift"}
+        if len(normalized) > 1 and any(key not in modifiers for key in normalized[:-1]):
+            raise ValueError(
+                "keypress accepts one key chord; send sequential keys as separate actions"
+            )
+        return "+".join(normalized)

--- a/src/xagent/core/computer/browser.py
+++ b/src/xagent/core/computer/browser.py
@@ -36,6 +36,28 @@ logger = logging.getLogger(__name__)
 
 _OBSERVED_URL_ADAPTER = TypeAdapter(ObservedUrl)
 
+_EDITABLE_ACTIVE_ELEMENT_SCRIPT = """() => {
+  let currentDocument = document;
+  const visited = new Set();
+  while (currentDocument && !visited.has(currentDocument)) {
+    visited.add(currentDocument);
+    const node = currentDocument.activeElement;
+    if (!node) return false;
+    if (node.isContentEditable) return true;
+    const tag = String(node.tagName || "").toLowerCase();
+    if (tag === "input" || tag === "textarea") {
+      return !node.disabled && !node.readOnly;
+    }
+    if (tag !== "iframe" && tag !== "frame") return false;
+    try {
+      currentDocument = node.contentDocument;
+    } catch (_) {
+      return false;
+    }
+  }
+  return false;
+}"""
+
 _INTERACTIVE_ELEMENTS_SCRIPT = """
 (limit) => {
   const selector = [
@@ -141,7 +163,7 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         self.headless = headless
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height
-        self._manager_session_id = f"computer:{self.session_id}"
+        self._manager_session_id = f"{self.session_id}:computer"
         self._browser_session: Any | None = None
 
     async def _get_page(self, *, reject_recreated_session: bool) -> Any:
@@ -326,16 +348,7 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         if action.type is ComputerActionType.REPLACE_TEXT:
             x, y = self._target_pixels(action)
             await page.mouse.click(x, y)
-            editable = await page.evaluate(
-                """() => {
-                  const node = document.activeElement;
-                  if (!node) return false;
-                  if (node.isContentEditable) return true;
-                  const tag = String(node.tagName || "").toLowerCase();
-                  return (tag === "input" || tag === "textarea") &&
-                    !node.disabled && !node.readOnly;
-                }"""
-            )
+            editable = await page.evaluate(_EDITABLE_ACTIVE_ELEMENT_SCRIPT)
             if not editable:
                 raise ValueError("replace_text target is not an editable element")
             modifier = "Meta" if sys.platform == "darwin" else "Control"

--- a/src/xagent/core/computer/browser.py
+++ b/src/xagent/core/computer/browser.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, cast
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from ..tools.core.browser_use import BrowserSessionManager, get_browser_manager
+from .environment import ComputerEnvironment
+from .schema import (
+    ELEMENT_EXTRACTION_FAILED_KEY,
+    ELEMENT_EXTRACTION_INCOMPLETE_KEY,
+    ELEMENTS_TRUNCATED_KEY,
+    MAX_OBSERVATION_ELEMENTS,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerElement,
+    ComputerElementSource,
+    ComputerEnvironmentType,
+    ComputerObservation,
+    NormalizedPoint,
+    Viewport,
+)
+from .store import ObservationStore
+
+logger = logging.getLogger(__name__)
+
+_INTERACTIVE_ELEMENTS_SCRIPT = """
+(limit) => {
+  const selector = [
+    "a[href]", "button", "input", "textarea", "select", "summary",
+    "[role='button']", "[role='link']", "[role='checkbox']", "[role='radio']",
+    "[role='tab']", "[role='menuitem']", "[role='textbox']", "[onclick]",
+    "[tabindex]", "[contenteditable='true']"
+  ].join(",");
+  const width = Math.max(1, window.innerWidth);
+  const height = Math.max(1, window.innerHeight);
+  const elements = [];
+  let truncated = false;
+  for (const node of document.querySelectorAll(selector)) {
+    if (elements.length >= limit) {
+      truncated = true;
+      break;
+    }
+    const rect = node.getBoundingClientRect();
+    const style = window.getComputedStyle(node);
+    if (
+      style.visibility === "hidden" ||
+      style.visibility === "collapse" ||
+      style.display === "none" ||
+      Number(style.opacity) === 0 ||
+      rect.width < 2 ||
+      rect.height < 2 ||
+      rect.right <= 0 ||
+      rect.bottom <= 0 ||
+      rect.left >= width ||
+      rect.top >= height
+    ) {
+      continue;
+    }
+    const left = Math.max(0, rect.left);
+    const top = Math.max(0, rect.top);
+    const right = Math.min(width, rect.right);
+    const bottom = Math.min(height, rect.bottom);
+    const inputType = String(node.getAttribute("type") || "").toLowerCase();
+    const autocomplete = String(
+      node.getAttribute("autocomplete") || ""
+    ).toLowerCase();
+    const sensitive = (
+      inputType === "password" ||
+      inputType === "hidden" ||
+      autocomplete === "current-password" ||
+      autocomplete === "new-password" ||
+      autocomplete === "one-time-code" ||
+      autocomplete === "webauthn" ||
+      autocomplete.startsWith("cc-")
+    );
+    const safeValue = sensitive ? "" : String(node.value || "");
+    const text = String(node.innerText || safeValue).trim().slice(0, 240);
+    const label = String(
+      node.getAttribute("aria-label") ||
+      node.getAttribute("title") ||
+      node.getAttribute("placeholder") ||
+      text
+    ).trim().slice(0, 240);
+    elements.push({
+      bounds: {
+        x: left / width,
+        y: top / height,
+        width: Math.max(0.000001, (right - left) / width),
+        height: Math.max(0.000001, (bottom - top) / height)
+      },
+      label: label || null,
+      role: node.getAttribute("role") || node.tagName.toLowerCase(),
+      text: text || null,
+      metadata: {
+        tag: node.tagName.toLowerCase(),
+        input_type: inputType || null,
+        autocomplete: autocomplete || null,
+        sensitive,
+        disabled: Boolean(node.disabled),
+        focused: node === document.activeElement
+      }
+    });
+  }
+  return {elements, truncated};
+}
+"""
+
+
+class BrowserComputerEnvironment(ComputerEnvironment):
+    """Ephemeral Playwright implementation of a computer environment."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        workspace: Any,
+        manager: BrowserSessionManager | None = None,
+        observation_store: ObservationStore | None = None,
+        headless: bool = True,
+        viewport_width: int = 1280,
+        viewport_height: int = 720,
+    ) -> None:
+        super().__init__(session_id)
+        if viewport_width <= 0 or viewport_height <= 0:
+            raise ValueError("viewport dimensions must be positive")
+        self.workspace = workspace
+        self.manager = manager or get_browser_manager()
+        self.observation_store = observation_store or ObservationStore(workspace)
+        self.headless = headless
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
+
+    async def _get_page(self) -> Any:
+        session = await self.manager.get_or_create(
+            self.session_id,
+            headless=self.headless,
+        )
+        page = await session.get_page()
+        requested = {
+            "width": self.viewport_width,
+            "height": self.viewport_height,
+        }
+        if page.viewport_size != requested:
+            await page.set_viewport_size(cast(Any, requested))
+        return page
+
+    async def _close(self) -> None:
+        await self.manager.close(self.session_id)
+
+    async def _observe(self) -> ComputerObservation:
+        return await self._capture_observation(await self._get_page())
+
+    async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
+        page = await self._get_page()
+        action = batch.actions[0]
+        await self._execute_action(page, action)
+        if action.type not in {
+            ComputerActionType.SCREENSHOT,
+            ComputerActionType.WAIT,
+        }:
+            await page.wait_for_timeout(250)
+        return await self._capture_observation(page)
+
+    async def _capture_observation(self, page: Any) -> ComputerObservation:
+        viewport = await self._read_viewport(page)
+        frame_id = f"frame-{uuid4().hex}"
+        screenshot_bytes = await page.screenshot(full_page=False, type="png")
+        screenshot = await self.observation_store.save_screenshot(
+            session_id=self.session_id,
+            frame_id=frame_id,
+            image_bytes=screenshot_bytes,
+            mime_type="image/png",
+            viewport=viewport,
+            text_fallback="Current browser viewport screenshot.",
+        )
+        try:
+            title = await page.title()
+        except Exception:  # noqa: BLE001 - title is optional observation metadata.
+            title = None
+
+        metadata: dict[str, Any] = {
+            "browser_runtime_kind": "ephemeral_playwright",
+            "supported_actions": [action.value for action in ComputerActionType],
+        }
+        try:
+            elements, truncated = await self._read_interactive_elements(page)
+        except Exception:  # noqa: BLE001 - screenshots remain useful without DOM hints.
+            logger.warning(
+                "Failed to collect interactive browser elements for %s",
+                self.session_id,
+                exc_info=True,
+            )
+            elements = []
+            truncated = False
+            metadata[ELEMENT_EXTRACTION_FAILED_KEY] = True
+        if truncated:
+            metadata[ELEMENTS_TRUNCATED_KEY] = True
+        frames = getattr(page, "frames", ())
+        if isinstance(frames, (list, tuple)) and len(frames) > 1:
+            # This adapter intentionally reports only top-level DOM hints. The
+            # screenshot remains authoritative for cross-origin child frames.
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+
+        active_url = str(getattr(page, "url", "") or "").strip() or None
+        return ComputerObservation(
+            session_id=self.session_id,
+            frame_id=frame_id,
+            environment=ComputerEnvironmentType.BROWSER,
+            viewport=viewport,
+            screenshot=screenshot,
+            elements=elements,
+            active_url=active_url,
+            title=str(title) if title else None,
+            metadata=metadata,
+        )
+
+    async def _read_viewport(self, page: Any) -> Viewport:
+        size = page.viewport_size
+        if not size:
+            size = await page.evaluate(
+                "() => ({width: window.innerWidth, height: window.innerHeight})"
+            )
+        try:
+            device_pixel_ratio = float(
+                await page.evaluate("() => window.devicePixelRatio || 1")
+            )
+        except Exception:  # noqa: BLE001 - DPR defaults safely.
+            device_pixel_ratio = 1.0
+        return Viewport(
+            width=int(size["width"]),
+            height=int(size["height"]),
+            device_pixel_ratio=device_pixel_ratio,
+        )
+
+    async def _read_interactive_elements(
+        self,
+        page: Any,
+    ) -> tuple[list[ComputerElement], bool]:
+        payload = await page.evaluate(
+            _INTERACTIVE_ELEMENTS_SCRIPT,
+            MAX_OBSERVATION_ELEMENTS,
+        )
+        if not isinstance(payload, dict):
+            return [], False
+        raw_elements = payload.get("elements")
+        if not isinstance(raw_elements, list):
+            return [], bool(payload.get("truncated"))
+        elements: list[ComputerElement] = []
+        for index, raw_element in enumerate(
+            raw_elements[:MAX_OBSERVATION_ELEMENTS],
+            start=1,
+        ):
+            if not isinstance(raw_element, dict):
+                continue
+            try:
+                elements.append(
+                    ComputerElement(
+                        element_id=f"dom-{index}",
+                        source=ComputerElementSource.DOM,
+                        bounds=raw_element["bounds"],
+                        label=raw_element.get("label"),
+                        role=raw_element.get("role"),
+                        text=raw_element.get("text"),
+                        metadata=raw_element.get("metadata") or {},
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                logger.debug("Skipping invalid DOM element payload", exc_info=True)
+        return elements, bool(payload.get("truncated"))
+
+    async def _execute_action(self, page: Any, action: ComputerAction) -> None:
+        if action.type is ComputerActionType.SCREENSHOT:
+            return
+        if action.type is ComputerActionType.NAVIGATE:
+            assert action.url is not None
+            await page.goto(
+                self._resolve_navigation_url(action.url),
+                wait_until="domcontentloaded",
+                timeout=30_000,
+            )
+            return
+        if action.type is ComputerActionType.WAIT:
+            await page.wait_for_timeout(action.duration_ms)
+            return
+        if action.type is ComputerActionType.KEYPRESS:
+            await page.keyboard.press(self._playwright_key_chord(action.keys))
+            return
+        if action.type is ComputerActionType.TYPE:
+            await page.keyboard.insert_text(action.text or "")
+            return
+        if action.type is ComputerActionType.REPLACE_TEXT:
+            x, y = self._target_pixels(action)
+            await page.mouse.click(x, y)
+            modifier = "Meta" if sys.platform == "darwin" else "Control"
+            await page.keyboard.press(f"{modifier}+A")
+            await page.keyboard.insert_text(action.text or "")
+            return
+        if action.type is ComputerActionType.SCROLL:
+            viewport = self._current_viewport()
+            await page.mouse.wheel(
+                action.delta_x * viewport.width,
+                action.delta_y * viewport.height,
+            )
+            return
+        if action.type is ComputerActionType.DRAG:
+            assert action.start is not None and action.end is not None
+            start_x, start_y = self._point_pixels(action.start)
+            end_x, end_y = self._point_pixels(action.end)
+            await page.mouse.move(start_x, start_y)
+            await page.mouse.down()
+            await page.mouse.move(end_x, end_y, steps=10)
+            await page.mouse.up()
+            return
+
+        x, y = self._target_pixels(action)
+        if action.type is ComputerActionType.CLICK:
+            await page.mouse.click(x, y)
+        elif action.type is ComputerActionType.DOUBLE_CLICK:
+            await page.mouse.dblclick(x, y)
+        elif action.type is ComputerActionType.MOVE:
+            await page.mouse.move(x, y)
+        else:  # pragma: no cover - schema and supported action list stay aligned.
+            raise ValueError(
+                f"unsupported browser computer action: {action.type.value}"
+            )
+
+    def _target_pixels(self, action: ComputerAction) -> tuple[float, float]:
+        if action.target is None:
+            raise ValueError(f"{action.type.value} requires a target")
+        if action.target.point is not None:
+            return self._point_pixels(action.target.point)
+        target_id = action.target.element_id
+        observation = self.current_observation
+        if target_id is None or observation is None:
+            raise ValueError("element target requires a current observation")
+        element = next(
+            element
+            for element in observation.elements
+            if element.element_id == target_id
+        )
+        return self._point_pixels(
+            NormalizedPoint(
+                x=element.bounds.x + element.bounds.width / 2,
+                y=element.bounds.y + element.bounds.height / 2,
+            )
+        )
+
+    def _point_pixels(self, point: NormalizedPoint) -> tuple[float, float]:
+        viewport = self._current_viewport()
+        return (
+            min(point.x * viewport.width, viewport.width - 1),
+            min(point.y * viewport.height, viewport.height - 1),
+        )
+
+    def _current_viewport(self) -> Viewport:
+        observation = self.current_observation
+        if observation is None:
+            raise RuntimeError("computer action requires a current observation")
+        return observation.viewport
+
+    @staticmethod
+    def _resolve_navigation_url(raw_url: str) -> str:
+        url = raw_url.strip()
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+            raise ValueError("navigate URL must use absolute HTTP or HTTPS")
+        return url
+
+    @staticmethod
+    def _playwright_key_chord(keys: list[str]) -> str:
+        aliases = {
+            "ALT": "Alt",
+            "ARROWDOWN": "ArrowDown",
+            "ARROWLEFT": "ArrowLeft",
+            "ARROWRIGHT": "ArrowRight",
+            "ARROWUP": "ArrowUp",
+            "BACKSPACE": "Backspace",
+            "CMD": "Meta",
+            "COMMAND": "Meta",
+            "CTRL": "Control",
+            "DELETE": "Delete",
+            "END": "End",
+            "ENTER": "Enter",
+            "ESC": "Escape",
+            "ESCAPE": "Escape",
+            "HOME": "Home",
+            "META": "Meta",
+            "PAGEDOWN": "PageDown",
+            "PAGEUP": "PageUp",
+            "SHIFT": "Shift",
+            "SPACE": "Space",
+            "TAB": "Tab",
+        }
+        return "+".join(aliases.get(key.upper(), key) for key in keys)

--- a/src/xagent/core/computer/browser.py
+++ b/src/xagent/core/computer/browser.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 from uuid import uuid4
 
 from ..tools.core.browser_use import BrowserSessionManager, get_browser_manager
-from .environment import ComputerEnvironment
+from .environment import ComputerEnvironment, ComputerTargetNotFoundError
 from .schema import (
     ELEMENT_EXTRACTION_FAILED_KEY,
     ELEMENT_EXTRACTION_INCOMPLETE_KEY,
@@ -276,7 +276,8 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         if action.type is ComputerActionType.SCREENSHOT:
             return
         if action.type is ComputerActionType.NAVIGATE:
-            assert action.url is not None
+            if action.url is None:
+                raise ValueError("navigate action requires a URL")
             await page.goto(
                 self._resolve_navigation_url(action.url),
                 wait_until="domcontentloaded",
@@ -307,7 +308,8 @@ class BrowserComputerEnvironment(ComputerEnvironment):
             )
             return
         if action.type is ComputerActionType.DRAG:
-            assert action.start is not None and action.end is not None
+            if action.start is None or action.end is None:
+                raise ValueError("drag action requires start and end points")
             start_x, start_y = self._point_pixels(action.start)
             end_x, end_y = self._point_pixels(action.end)
             await page.mouse.move(start_x, start_y)
@@ -338,10 +340,17 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         if target_id is None or observation is None:
             raise ValueError("element target requires a current observation")
         element = next(
-            element
-            for element in observation.elements
-            if element.element_id == target_id
+            (
+                element
+                for element in observation.elements
+                if element.element_id == target_id
+            ),
+            None,
         )
+        if element is None:
+            raise ComputerTargetNotFoundError(
+                f"element {target_id!r} is not present in the current observation"
+            )
         return self._point_pixels(
             NormalizedPoint(
                 x=element.bounds.x + element.bounds.width / 2,

--- a/src/xagent/core/context_ref.py
+++ b/src/xagent/core/context_ref.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from .file_ref import sanitize_file_ref_for_context
 
 CONTEXT_REFS_KEY = "_xagent_context_refs"
+SUPERSEDES_SCOPE_KEY = "_xagent_supersedes_scope"
 
 _PATH_METADATA_PARTS = {
     "cwd",
@@ -245,3 +246,18 @@ def split_tool_result_context_references(
     public_result = dict(result)
     raw_refs = public_result.pop(CONTEXT_REFS_KEY)
     return public_result, normalize_context_references(raw_refs)
+
+
+def split_tool_result_supersedes_scope(result: Any) -> tuple[Any, str | None]:
+    """Detach a bounded internal scope used to supersede stale tool output."""
+
+    if not isinstance(result, dict) or SUPERSEDES_SCOPE_KEY not in result:
+        return result, None
+    public_result = dict(result)
+    raw_scope = public_result.pop(SUPERSEDES_SCOPE_KEY)
+    scope = str(raw_scope).strip() if raw_scope is not None else ""
+    if not scope:
+        return public_result, None
+    if len(scope) > 512 or any(ord(character) < 0x20 for character in scope):
+        raise ValueError("tool result supersedes scope is invalid")
+    return public_result, scope

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -1135,7 +1135,10 @@ def create_browser_tools(
     Returns:
         List of browser tool instances
     """
+    from .computer import ComputerTool
+
     tools = [
+        ComputerTool(task_id=task_id, workspace=workspace),
         BrowserNavigateTool(task_id=task_id, workspace=workspace),
         BrowserClickTool(task_id=task_id),
         BrowserFillTool(task_id=task_id),

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from ....computer.browser import BrowserComputerEnvironment
+from ....computer.environment import (
+    ComputerEnvironment,
+    ComputerEnvironmentError,
+)
+from ....computer.schema import (
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerObservation,
+)
+from ....context_ref import (
+    CONTEXT_REFS_KEY,
+    SUPERSEDES_SCOPE_KEY,
+)
+from ....workspace import TaskWorkspace
+from .base import AbstractBaseTool, ToolCategory, ToolVisibility
+from .browser_use import BrowserTaskSessionMixin
+
+logger = logging.getLogger(__name__)
+
+ComputerEnvironmentFactory = Callable[..., ComputerEnvironment]
+_STEP_SESSION_ARG = "_xagent_step_id"
+
+
+def _initial_screenshot_actions() -> list[ComputerAction]:
+    return [ComputerAction(type=ComputerActionType.SCREENSHOT)]
+
+
+class ComputerToolArgs(BaseModel):
+    expected_frame_id: str | None = Field(
+        default=None,
+        description=(
+            "Frame ID that the action was planned against. Required for every "
+            "state-changing call; omit only when requesting a fresh screenshot."
+        ),
+    )
+    actions: list[ComputerAction] = Field(
+        default_factory=_initial_screenshot_actions,
+        min_length=1,
+        max_length=1,
+        description=(
+            "One browser action. Coordinates are normalized from 0 to 1. Every "
+            "call returns a fresh observation before another action is planned."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_action_scoped_frame_id(cls, value: Any) -> Any:
+        """Normalize a common tool-call shape without weakening frame checks."""
+
+        if not isinstance(value, Mapping):
+            return value
+        raw_actions = value.get("actions")
+        if (
+            not isinstance(raw_actions, list)
+            or len(raw_actions) != 1
+            or not isinstance(raw_actions[0], Mapping)
+            or "expected_frame_id" not in raw_actions[0]
+        ):
+            return value
+
+        action = dict(raw_actions[0])
+        nested_frame_id = action.pop("expected_frame_id")
+        normalized = dict(value)
+        normalized["actions"] = [action]
+        if nested_frame_id is None:
+            return normalized
+        top_level_frame_id = normalized.get("expected_frame_id")
+        if top_level_frame_id is None:
+            normalized["expected_frame_id"] = nested_frame_id
+        elif top_level_frame_id != nested_frame_id:
+            raise ValueError(
+                "action expected_frame_id conflicts with the top-level value"
+            )
+        return normalized
+
+
+class ComputerToolResult(BaseModel):
+    success: bool
+    session_id: str
+    frame_id: str | None = None
+    observation: ComputerObservation | None = None
+    message: str = ""
+    error: str = ""
+
+
+class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
+    """Screenshot/action loop for ordinary tool-calling vision models."""
+
+    category = ToolCategory.BROWSER
+    decision_group = "computer"
+
+    def __init__(
+        self,
+        *,
+        task_id: str | None = None,
+        workspace: TaskWorkspace | None = None,
+        environment_factory: ComputerEnvironmentFactory = BrowserComputerEnvironment,
+        headless: bool = True,
+    ) -> None:
+        self._visibility = ToolVisibility.PUBLIC
+        self._task_id = task_id
+        self._workspace = workspace
+        self._environment_factory = environment_factory
+        self._headless = headless
+        self._environments: dict[str, ComputerEnvironment] = {}
+
+    @property
+    def name(self) -> str:
+        return "computer"
+
+    @property
+    def description(self) -> str:
+        return """Inspect and control an isolated temporary browser through screenshots.
+
+        First request a screenshot without expected_frame_id. Inspect the returned
+        image, then send exactly one action with that frame_id as expected_frame_id.
+        Every successful call returns a fresh screenshot and frame_id; do not request
+        a second screenshot after an action.
+
+        Coordinates are normalized: (0, 0) is the viewport top-left and (1, 1)
+        is the bottom-right. Prefer element_id when the observation exposes one.
+        Use `type` to insert at the current caret and `replace_text` with a target
+        to replace a field. Keyboard chords use keys such as ["CTRL", "A"].
+
+        This is a new ephemeral browser. It does not inherit the user's existing
+        browser profile or signed-in sessions.
+        """
+
+    @property
+    def tags(self) -> list[str]:
+        return ["browser", "computer-use", "vision", "automation"]
+
+    def args_type(self) -> type[BaseModel]:
+        return ComputerToolArgs
+
+    def return_type(self) -> type[BaseModel]:
+        return ComputerToolResult
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        raise NotImplementedError("computer is async-only")
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> dict[str, Any]:
+        raw_args = dict(args)
+        step_id = raw_args.pop(_STEP_SESSION_ARG, None)
+        # The session is an execution-scoped resource. Never let model output
+        # select another task's browser, even if it invents a session_id field.
+        raw_args.pop("session_id", None)
+        parsed = ComputerToolArgs.model_validate(raw_args)
+        session_id = self._default_session_id(step_id)
+        if not session_id:
+            return self._error_result(
+                session_id="",
+                error="Computer tool requires a task-scoped browser session.",
+            )
+        if self._workspace is None:
+            return self._error_result(
+                session_id=session_id,
+                error="Computer tool requires a task workspace for observations.",
+            )
+
+        environment = self._environments.get(session_id)
+        if environment is None:
+            environment = self._environment_factory(
+                session_id=session_id,
+                workspace=self._workspace,
+                headless=self._headless,
+            )
+            self._environments[session_id] = environment
+
+        action = parsed.actions[0]
+        screenshot_only = action.type is ComputerActionType.SCREENSHOT
+        try:
+            current = environment.current_observation
+            if current is None:
+                if not screenshot_only:
+                    return self._error_result(
+                        session_id=session_id,
+                        error=(
+                            "No browser frame exists yet. Request a screenshot "
+                            "before planning another action."
+                        ),
+                    )
+                observation = await environment.observe()
+            elif screenshot_only:
+                observation = await environment.observe()
+            elif parsed.expected_frame_id is None:
+                return self._error_result(
+                    session_id=session_id,
+                    frame_id=current.frame_id,
+                    error=(
+                        "expected_frame_id is required for state-changing "
+                        "computer actions."
+                    ),
+                )
+            else:
+                observation = await environment.execute(
+                    ComputerActionBatch(
+                        session_id=session_id,
+                        expected_frame_id=parsed.expected_frame_id,
+                        actions=parsed.actions,
+                    )
+                )
+        except (
+            ComputerEnvironmentError,
+            FileNotFoundError,
+            RuntimeError,
+            ValueError,
+        ) as exc:
+            current = environment.current_observation
+            return self._error_result(
+                session_id=session_id,
+                frame_id=current.frame_id if current else None,
+                error=str(exc),
+            )
+        except Exception as exc:  # noqa: BLE001 - provider failures become tool results.
+            current = environment.current_observation
+            return self._error_result(
+                session_id=session_id,
+                frame_id=current.frame_id if current else None,
+                error=f"Browser computer action failed: {exc}",
+            )
+
+        result = ComputerToolResult(
+            success=True,
+            session_id=session_id,
+            frame_id=observation.frame_id,
+            observation=observation,
+            message=(
+                f"Browser observation captured for frame {observation.frame_id}. "
+                "Use this exact frame_id for the next state-changing action."
+            ),
+        ).model_dump(mode="json", exclude_none=True)
+        result[CONTEXT_REFS_KEY] = [observation.screenshot.durable_dict()]
+        result[SUPERSEDES_SCOPE_KEY] = f"{self.name}:{session_id}"
+        return result
+
+    async def teardown(self, task_id: str | None = None) -> None:
+        environments = list(self._environments.values())
+        self._environments.clear()
+        for environment in environments:
+            try:
+                await environment.close()
+            except Exception:  # noqa: BLE001 - teardown must continue.
+                logger.warning(
+                    "Failed to close computer environment %s",
+                    environment.session_id,
+                    exc_info=True,
+                )
+        await self._close_task_sessions(task_id)
+
+    @staticmethod
+    def _error_result(
+        *,
+        session_id: str,
+        error: str,
+        frame_id: str | None = None,
+    ) -> dict[str, Any]:
+        return ComputerToolResult(
+            success=False,
+            session_id=session_id,
+            frame_id=frame_id,
+            error=error,
+        ).model_dump(mode="json", exclude_none=True)

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from ....computer.browser import BrowserComputerEnvironment
 from ....computer.environment import (
@@ -156,7 +156,6 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         # The session is an execution-scoped resource. Never let model output
         # select another task's browser, even if it invents a session_id field.
         raw_args.pop("session_id", None)
-        parsed = ComputerToolArgs.model_validate(raw_args)
         session_id = self._default_session_id(step_id)
         if not session_id:
             return self._error_result(
@@ -167,6 +166,16 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             return self._error_result(
                 session_id=session_id,
                 error="Computer tool requires a task workspace for observations.",
+            )
+        try:
+            parsed = ComputerToolArgs.model_validate(raw_args)
+        except ValidationError as exc:
+            environment = self._environments.get(session_id)
+            current = environment.current_observation if environment else None
+            return self._error_result(
+                session_id=session_id,
+                frame_id=current.frame_id if current else None,
+                error=f"Invalid computer action: {exc}",
             )
 
         environment = self._environments.get(session_id)

--- a/tests/core/agent/test_browser_tools.py
+++ b/tests/core/agent/test_browser_tools.py
@@ -24,6 +24,7 @@ def test_browser_debug_tools_are_opt_in() -> None:
 
     assert "browser_list_sessions" not in default_names
     assert "browser_list_sessions" in debug_names
+    assert "computer" in default_names
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -1547,6 +1547,42 @@ async def test_react_passes_runtime_step_to_browser_tool_call() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_passes_runtime_step_to_computer_tool_call() -> None:
+    class FakeComputerTool:
+        name = "computer"
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def run_json_async(self, args: dict[str, Any]) -> dict[str, Any]:
+            self.calls.append(args)
+            return {"success": True}
+
+    pattern = ReActPattern()
+    runtime = PatternRuntime()
+    runtime.active_react_step_id = "inspect_browser"
+    tool = FakeComputerTool()
+
+    result = await pattern._execute_tool_safely(
+        {
+            "id": "call-computer",
+            "name": "computer",
+            "args": {"actions": [{"type": "screenshot"}]},
+        },
+        [tool],
+        runtime,
+    )
+
+    assert result["success"] is True
+    assert tool.calls == [
+        {
+            "actions": [{"type": "screenshot"}],
+            "_xagent_step_id": "inspect_browser",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_react_interrupt_cancels_in_flight_tool() -> None:
     class SlowVisionTool:
         name = "understand_images"

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from xagent.core.computer.browser import BrowserComputerEnvironment
+from xagent.core.computer.environment import ComputerTargetNotFoundError
 from xagent.core.computer.schema import (
     COMPUTER_FRAME_ID_METADATA_KEY,
     COMPUTER_SESSION_ID_METADATA_KEY,
@@ -258,6 +259,21 @@ async def test_browser_point_click_uses_normalized_viewport(
     )
 
     assert page.mouse.calls[0] == ("click", 640.0, 360.0)
+
+
+@pytest.mark.asyncio
+async def test_browser_element_lookup_fails_with_clear_target_error(
+    browser_environment,
+) -> None:
+    environment, _page, _store = browser_environment
+    await environment.observe()
+    action = ComputerAction(
+        type=ComputerActionType.CLICK,
+        target=ComputerTarget(element_id="missing-element"),
+    )
+
+    with pytest.raises(ComputerTargetNotFoundError, match="missing-element"):
+        environment._target_pixels(action)
 
 
 @pytest.mark.asyncio

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.browser import BrowserComputerEnvironment
+from xagent.core.computer.schema import (
+    COMPUTER_FRAME_ID_METADATA_KEY,
+    COMPUTER_SESSION_ID_METADATA_KEY,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerTarget,
+    NormalizedPoint,
+)
+from xagent.core.context_ref import ContextReference
+
+
+class FakeObservationStore:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def save_screenshot(self, **kwargs: Any) -> ContextReference:
+        self.calls.append(kwargs)
+        return ContextReference(
+            file_ref={
+                "file_id": f"image-{len(self.calls)}",
+                "filename": f"{kwargs['frame_id']}.png",
+                "mime_type": "image/png",
+            },
+            metadata={
+                COMPUTER_SESSION_ID_METADATA_KEY: kwargs["session_id"],
+                COMPUTER_FRAME_ID_METADATA_KEY: kwargs["frame_id"],
+            },
+        )
+
+
+class FakeMouse:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+
+    async def click(self, x: float, y: float) -> None:
+        self.calls.append(("click", x, y))
+
+    async def dblclick(self, x: float, y: float) -> None:
+        self.calls.append(("dblclick", x, y))
+
+    async def move(self, x: float, y: float, **kwargs: Any) -> None:
+        self.calls.append(("move", x, y, kwargs))
+
+    async def wheel(self, x: float, y: float) -> None:
+        self.calls.append(("wheel", x, y))
+
+    async def down(self) -> None:
+        self.calls.append(("down",))
+
+    async def up(self) -> None:
+        self.calls.append(("up",))
+
+
+class FakeKeyboard:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def press(self, keys: str) -> None:
+        self.calls.append(("press", keys))
+
+    async def insert_text(self, text: str) -> None:
+        self.calls.append(("insert_text", text))
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.viewport_size = {"width": 1280, "height": 720}
+        self.url = "about:blank"
+        self.frames: list[Any] = [object()]
+        self.mouse = FakeMouse()
+        self.keyboard = FakeKeyboard()
+        self.goto_calls: list[tuple[str, str, int]] = []
+        self.wait_calls: list[int] = []
+        self.element_payload: Any = {
+            "elements": [
+                {
+                    "bounds": {
+                        "x": 0.1,
+                        "y": 0.2,
+                        "width": 0.2,
+                        "height": 0.1,
+                    },
+                    "label": "Continue",
+                    "role": "button",
+                    "text": "Continue",
+                    "metadata": {"tag": "button", "sensitive": False},
+                }
+            ],
+            "truncated": False,
+        }
+
+    async def set_viewport_size(self, viewport: dict[str, int]) -> None:
+        self.viewport_size = viewport
+
+    async def screenshot(self, **kwargs: Any) -> bytes:
+        assert kwargs == {"full_page": False, "type": "png"}
+        return b"browser-png"
+
+    async def title(self) -> str:
+        return "Browser page"
+
+    async def evaluate(self, script: str, arg: Any = None) -> Any:
+        if "devicePixelRatio" in script:
+            return 2
+        if "querySelectorAll" in script:
+            assert arg == 100
+            if isinstance(self.element_payload, BaseException):
+                raise self.element_payload
+            return self.element_payload
+        raise AssertionError(f"unexpected evaluate script: {script}")
+
+    async def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
+        self.goto_calls.append((url, wait_until, timeout))
+        self.url = url
+
+    async def wait_for_timeout(self, duration_ms: int) -> None:
+        self.wait_calls.append(duration_ms)
+
+
+class FakeSession:
+    def __init__(self, page: FakePage) -> None:
+        self.page = page
+
+    async def get_page(self) -> FakePage:
+        return self.page
+
+
+class FakeManager:
+    def __init__(self, page: FakePage) -> None:
+        self.page = page
+        self.calls: list[tuple[str, bool]] = []
+        self.closed: list[str] = []
+
+    async def get_or_create(self, session_id: str, headless: bool) -> FakeSession:
+        self.calls.append((session_id, headless))
+        return FakeSession(self.page)
+
+    async def close(self, session_id: str) -> None:
+        self.closed.append(session_id)
+
+
+@pytest.fixture
+def browser_environment() -> tuple[
+    BrowserComputerEnvironment,
+    FakePage,
+    FakeObservationStore,
+]:
+    page = FakePage()
+    store = FakeObservationStore()
+    environment = BrowserComputerEnvironment(
+        session_id="browser-1",
+        workspace=object(),
+        manager=FakeManager(page),  # type: ignore[arg-type]
+        observation_store=store,  # type: ignore[arg-type]
+    )
+    return environment, page, store
+
+
+@pytest.mark.asyncio
+async def test_browser_observation_captures_screenshot_and_dom_elements(
+    browser_environment,
+) -> None:
+    environment, _page, store = browser_environment
+
+    observation = await environment.observe()
+
+    assert observation.active_url == "about:blank"
+    assert observation.title == "Browser page"
+    assert observation.viewport.model_dump() == {
+        "width": 1280,
+        "height": 720,
+        "device_pixel_ratio": 2.0,
+    }
+    assert observation.elements[0].element_id == "dom-1"
+    assert observation.elements[0].label == "Continue"
+    assert store.calls[0]["image_bytes"] == b"browser-png"
+    assert observation.metadata["browser_runtime_kind"] == "ephemeral_playwright"
+    assert environment.current_observation == observation
+
+
+@pytest.mark.asyncio
+async def test_browser_actions_use_fresh_normalized_coordinates(
+    browser_environment,
+) -> None:
+    environment, page, _store = browser_environment
+    first = await environment.observe()
+
+    clicked = await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=first.frame_id,
+            actions=[
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="dom-1"),
+                )
+            ],
+        )
+    )
+    typed = await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=clicked.frame_id,
+            actions=[ComputerAction(type=ComputerActionType.TYPE, text="hello")],
+        )
+    )
+    scrolled = await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=typed.frame_id,
+            actions=[ComputerAction(type=ComputerActionType.SCROLL, delta_y=0.5)],
+        )
+    )
+    await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=scrolled.frame_id,
+            actions=[
+                ComputerAction(type=ComputerActionType.KEYPRESS, keys=["CTRL", "A"])
+            ],
+        )
+    )
+
+    assert page.mouse.calls[0] == ("click", 256.0, 180.0)
+    assert page.mouse.calls[1] == ("wheel", 0, 360.0)
+    assert page.keyboard.calls == [
+        ("insert_text", "hello"),
+        ("press", "Control+A"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_browser_point_click_uses_normalized_viewport(
+    browser_environment,
+) -> None:
+    environment, page, _store = browser_environment
+    first = await environment.observe()
+
+    await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=first.frame_id,
+            actions=[
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(point=NormalizedPoint(x=0.5, y=0.5)),
+                )
+            ],
+        )
+    )
+
+    assert page.mouse.calls[0] == ("click", 640.0, 360.0)
+
+
+@pytest.mark.asyncio
+async def test_browser_navigation_returns_new_observation(browser_environment) -> None:
+    environment, page, _store = browser_environment
+    first = await environment.observe()
+
+    observation = await environment.execute(
+        ComputerActionBatch(
+            session_id="browser-1",
+            expected_frame_id=first.frame_id,
+            actions=[
+                ComputerAction(
+                    type=ComputerActionType.NAVIGATE,
+                    url="https://example.com",
+                )
+            ],
+        )
+    )
+
+    assert page.goto_calls == [("https://example.com", "domcontentloaded", 30_000)]
+    assert observation.active_url == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_browser_reports_incomplete_or_failed_element_extraction(
+    browser_environment,
+) -> None:
+    environment, page, _store = browser_environment
+    page.frames.append(object())
+
+    incomplete = await environment.observe()
+    assert incomplete.metadata["element_extraction_incomplete"] is True
+
+    page.element_payload = RuntimeError("detached document")
+    failed = await environment.observe()
+    assert failed.elements == []
+    assert failed.metadata["element_extraction_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_environment_closes_its_session(browser_environment) -> None:
+    environment, _page, _store = browser_environment
+
+    await environment.close()
+
+    assert environment.manager.closed == ["browser-1"]  # type: ignore[attr-defined]

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from xagent.core.computer.browser import (
+    _EDITABLE_ACTIVE_ELEMENT_SCRIPT,
     _INTERACTIVE_ELEMENTS_SCRIPT,
     BrowserComputerEnvironment,
 )
@@ -123,7 +124,7 @@ class FakePage:
             if isinstance(self.element_payload, BaseException):
                 raise self.element_payload
             return self.element_payload
-        if "document.activeElement" in script:
+        if "currentDocument.activeElement" in script:
             return self.active_element_editable
         raise AssertionError(f"unexpected evaluate script: {script}")
 
@@ -196,12 +197,16 @@ async def test_browser_observation_captures_screenshot_and_dom_elements(
     assert observation.metadata["browser_runtime_kind"] == "ephemeral_playwright"
     assert environment.current_observation == observation
     assert environment.manager.calls == [  # type: ignore[attr-defined]
-        ("computer:browser-1", True)
+        ("browser-1:computer", True)
     ]
 
 
 def test_browser_element_script_never_reads_input_values() -> None:
     assert "node.value" not in _INTERACTIVE_ELEMENTS_SCRIPT
+
+
+def test_editable_check_descends_into_same_origin_frames() -> None:
+    assert "node.contentDocument" in _EDITABLE_ACTIVE_ELEMENT_SCRIPT
 
 
 @pytest.mark.asyncio
@@ -411,5 +416,5 @@ async def test_browser_environment_closes_its_session(browser_environment) -> No
     await environment.close()
 
     assert environment.manager.closed == [  # type: ignore[attr-defined]
-        "computer:browser-1"
+        "browser-1:computer"
     ]

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -4,8 +4,14 @@ from typing import Any
 
 import pytest
 
-from xagent.core.computer.browser import BrowserComputerEnvironment
-from xagent.core.computer.environment import ComputerTargetNotFoundError
+from xagent.core.computer.browser import (
+    _INTERACTIVE_ELEMENTS_SCRIPT,
+    BrowserComputerEnvironment,
+)
+from xagent.core.computer.environment import (
+    ComputerFrameMismatchError,
+    ComputerTargetNotFoundError,
+)
 from xagent.core.computer.schema import (
     COMPUTER_FRAME_ID_METADATA_KEY,
     COMPUTER_SESSION_ID_METADATA_KEY,
@@ -80,6 +86,7 @@ class FakePage:
         self.keyboard = FakeKeyboard()
         self.goto_calls: list[tuple[str, str, int]] = []
         self.wait_calls: list[int] = []
+        self.active_element_editable = True
         self.element_payload: Any = {
             "elements": [
                 {
@@ -116,6 +123,8 @@ class FakePage:
             if isinstance(self.element_payload, BaseException):
                 raise self.element_payload
             return self.element_payload
+        if "document.activeElement" in script:
+            return self.active_element_editable
         raise AssertionError(f"unexpected evaluate script: {script}")
 
     async def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
@@ -137,12 +146,13 @@ class FakeSession:
 class FakeManager:
     def __init__(self, page: FakePage) -> None:
         self.page = page
+        self.session = FakeSession(page)
         self.calls: list[tuple[str, bool]] = []
         self.closed: list[str] = []
 
     async def get_or_create(self, session_id: str, headless: bool) -> FakeSession:
         self.calls.append((session_id, headless))
-        return FakeSession(self.page)
+        return self.session
 
     async def close(self, session_id: str) -> None:
         self.closed.append(session_id)
@@ -185,6 +195,13 @@ async def test_browser_observation_captures_screenshot_and_dom_elements(
     assert store.calls[0]["image_bytes"] == b"browser-png"
     assert observation.metadata["browser_runtime_kind"] == "ephemeral_playwright"
     assert environment.current_observation == observation
+    assert environment.manager.calls == [  # type: ignore[attr-defined]
+        ("computer:browser-1", True)
+    ]
+
+
+def test_browser_element_script_never_reads_input_values() -> None:
+    assert "node.value" not in _INTERACTIVE_ELEMENTS_SCRIPT
 
 
 @pytest.mark.asyncio
@@ -299,6 +316,79 @@ async def test_browser_navigation_returns_new_observation(browser_environment) -
 
 
 @pytest.mark.asyncio
+async def test_browser_omits_unsupported_active_url(browser_environment) -> None:
+    environment, page, _store = browser_environment
+    page.url = "data:text/html,secret"
+
+    observation = await environment.observe()
+
+    assert observation.active_url is None
+    assert observation.metadata["active_url_unavailable"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_recreated_session_requires_fresh_frame(
+    browser_environment,
+) -> None:
+    environment, _page, _store = browser_environment
+    first = await environment.observe()
+    manager = environment.manager
+    replacement_page = FakePage()
+    manager.session = FakeSession(replacement_page)  # type: ignore[attr-defined]
+
+    with pytest.raises(ComputerFrameMismatchError, match="session changed"):
+        await environment.execute(
+            ComputerActionBatch(
+                session_id="browser-1",
+                expected_frame_id=first.frame_id,
+                actions=[
+                    ComputerAction(
+                        type=ComputerActionType.CLICK,
+                        target=ComputerTarget(point=NormalizedPoint(x=0.5, y=0.5)),
+                    )
+                ],
+            )
+        )
+
+    assert replacement_page.mouse.calls == []
+    assert environment.current_observation is None
+    refreshed = await environment.observe()
+    assert refreshed.frame_id != first.frame_id
+
+
+@pytest.mark.asyncio
+async def test_replace_text_rejects_non_editable_target(browser_environment) -> None:
+    environment, page, _store = browser_environment
+    first = await environment.observe()
+    page.active_element_editable = False
+
+    with pytest.raises(ValueError, match="not an editable element"):
+        await environment.execute(
+            ComputerActionBatch(
+                session_id="browser-1",
+                expected_frame_id=first.frame_id,
+                actions=[
+                    ComputerAction(
+                        type=ComputerActionType.REPLACE_TEXT,
+                        target=ComputerTarget(point=NormalizedPoint(x=0.5, y=0.5)),
+                        text="replacement",
+                    )
+                ],
+            )
+        )
+
+    assert page.keyboard.calls == []
+
+
+def test_keypress_rejects_non_modifier_sequences() -> None:
+    assert BrowserComputerEnvironment._playwright_key_chord(["CTRL", "A"]) == (
+        "Control+A"
+    )
+    with pytest.raises(ValueError, match="one key chord"):
+        BrowserComputerEnvironment._playwright_key_chord(["ArrowDown", "Enter"])
+
+
+@pytest.mark.asyncio
 async def test_browser_reports_incomplete_or_failed_element_extraction(
     browser_environment,
 ) -> None:
@@ -320,4 +410,6 @@ async def test_browser_environment_closes_its_session(browser_environment) -> No
 
     await environment.close()
 
-    assert environment.manager.closed == ["browser-1"]  # type: ignore[attr-defined]
+    assert environment.manager.closed == [  # type: ignore[attr-defined]
+        "computer:browser-1"
+    ]

--- a/tests/core/computer/test_computer_tool.py
+++ b/tests/core/computer/test_computer_tool.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import ExecutionContext
+from xagent.core.computer.environment import ComputerEnvironment
+from xagent.core.computer.schema import (
+    COMPUTER_FRAME_ID_METADATA_KEY,
+    COMPUTER_SESSION_ID_METADATA_KEY,
+    ComputerActionBatch,
+    ComputerEnvironmentType,
+    ComputerObservation,
+    Viewport,
+)
+from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
+from xagent.core.tools.adapters.vibe.computer import ComputerTool
+
+
+def make_observation(session_id: str, index: int) -> ComputerObservation:
+    frame_id = f"frame-{index}"
+    return ComputerObservation(
+        session_id=session_id,
+        frame_id=frame_id,
+        environment=ComputerEnvironmentType.BROWSER,
+        viewport=Viewport(width=1280, height=720),
+        screenshot=ContextReference(
+            file_ref={
+                "file_id": f"image-{index}",
+                "filename": f"{frame_id}.png",
+                "mime_type": "image/png",
+            },
+            metadata={
+                COMPUTER_SESSION_ID_METADATA_KEY: session_id,
+                COMPUTER_FRAME_ID_METADATA_KEY: frame_id,
+            },
+        ),
+        active_url="about:blank",
+    )
+
+
+class FakeComputerEnvironment(ComputerEnvironment):
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id)
+        self.observe_count = 0
+        self.executed: list[ComputerActionBatch] = []
+        self.close_count = 0
+
+    async def _observe(self) -> ComputerObservation:
+        self.observe_count += 1
+        return make_observation(self.session_id, self.observe_count)
+
+    async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
+        self.executed.append(batch)
+        self.observe_count += 1
+        return make_observation(self.session_id, self.observe_count)
+
+    async def _close(self) -> None:
+        self.close_count += 1
+
+
+class EnvironmentFactory:
+    def __init__(self) -> None:
+        self.environments: list[FakeComputerEnvironment] = []
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> FakeComputerEnvironment:
+        self.calls.append(kwargs)
+        environment = FakeComputerEnvironment(kwargs["session_id"])
+        self.environments.append(environment)
+        return environment
+
+
+@pytest.mark.asyncio
+async def test_computer_tool_requires_initial_screenshot_then_expected_frame() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+
+    initial = await tool.run_json_async({})
+
+    assert initial["success"] is True
+    assert initial["session_id"] == "task-1"
+    assert initial["frame_id"] == "frame-1"
+    assert initial[CONTEXT_REFS_KEY][0]["file_ref"]["file_id"] == "image-1"
+
+    missing_frame = await tool.run_json_async(
+        {
+            "actions": [
+                {
+                    "type": "click",
+                    "target": {"point": {"x": 0.5, "y": 0.5}},
+                }
+            ]
+        }
+    )
+    assert missing_frame["success"] is False
+    assert "expected_frame_id" in missing_frame["error"]
+
+    acted = await tool.run_json_async(
+        {
+            "expected_frame_id": "frame-1",
+            "actions": [
+                {
+                    "type": "click",
+                    "target": {"point": {"x": 0.5, "y": 0.5}},
+                }
+            ],
+        }
+    )
+
+    assert acted["success"] is True
+    assert acted["frame_id"] == "frame-2"
+    assert factory.environments[0].executed[0].expected_frame_id == "frame-1"
+
+
+@pytest.mark.asyncio
+async def test_computer_tool_derives_session_from_task_and_step() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+
+    result = await tool.run_json_async(
+        {
+            "session_id": "invented-by-model",
+            "_xagent_step_id": "inspect page",
+        }
+    )
+
+    assert result["session_id"] == "task-1:inspect_page"
+    assert factory.calls[0]["session_id"] == "task-1:inspect_page"
+
+
+@pytest.mark.asyncio
+async def test_computer_tool_lifts_action_scoped_expected_frame_id() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+    await tool.run_json_async({})
+
+    result = await tool.run_json_async(
+        {
+            "actions": [
+                {
+                    "type": "click",
+                    "expected_frame_id": "frame-1",
+                    "target": {"point": {"x": 0.5, "y": 0.5}},
+                }
+            ]
+        }
+    )
+
+    assert result["success"] is True
+    assert factory.environments[0].executed[0].expected_frame_id == "frame-1"
+
+
+@pytest.mark.asyncio
+async def test_computer_tool_rejects_action_before_first_observation() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+
+    result = await tool.run_json_async(
+        {"actions": [{"type": "navigate", "url": "https://example.com"}]}
+    )
+
+    assert result["success"] is False
+    assert "screenshot" in result["error"]
+    assert factory.environments[0].current_observation is None
+
+
+def test_computer_tool_accepts_only_one_action_per_observation() -> None:
+    with pytest.raises(ValueError, match="at most 1"):
+        ComputerTool(
+            task_id="task-1",
+            workspace=object(),  # type: ignore[arg-type]
+            environment_factory=EnvironmentFactory(),
+        ).args_type().model_validate(
+            {"actions": [{"type": "screenshot"}, {"type": "screenshot"}]}
+        )
+
+
+@pytest.mark.asyncio
+async def test_computer_tool_teardown_closes_created_environments(
+    monkeypatch,
+) -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+    await tool.run_json_async({})
+
+    async def no_browser_sessions(_task_id: str | None = None) -> None:
+        return None
+
+    monkeypatch.setattr(tool, "_close_task_sessions", no_browser_sessions)
+    await tool.teardown()
+
+    assert factory.environments[0].close_count == 1
+    assert tool._environments == {}
+
+
+def test_new_computer_observation_supersedes_stale_live_context() -> None:
+    context = ExecutionContext()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=EnvironmentFactory(),
+    )
+    first = make_observation("task-1", 1)
+    second = make_observation("task-1", 2)
+
+    for observation in (first, second):
+        result = {
+            "success": True,
+            "frame_id": observation.frame_id,
+            "observation": observation.model_dump(mode="json"),
+            CONTEXT_REFS_KEY: [observation.screenshot.durable_dict()],
+            "_xagent_supersedes_scope": f"{tool.name}:task-1",
+        }
+        context.add_tool_result("computer", result)
+
+    old_message, current_message = context.messages
+    assert old_message.metadata["superseded"] is True
+    assert old_message.context_refs
+    assert CONTEXT_REFS_KEY not in old_message.to_dict()
+    assert old_message.context_refs_token_estimate() == 0
+    assert "superseded by a later observation" in old_message.content
+    assert CONTEXT_REFS_KEY in current_message.to_dict()

--- a/tests/core/computer/test_computer_tool.py
+++ b/tests/core/computer/test_computer_tool.py
@@ -182,6 +182,27 @@ async def test_computer_tool_rejects_action_before_first_observation() -> None:
     assert factory.environments[0].current_observation is None
 
 
+@pytest.mark.asyncio
+async def test_computer_tool_returns_validation_error_with_current_frame() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+    )
+    await tool.run_json_async({})
+
+    result = await tool.run_json_async(
+        {"actions": [{"type": "click", "target": {"point": {"x": 2, "y": 0}}}]}
+    )
+
+    assert result["success"] is False
+    assert result["session_id"] == "task-1"
+    assert result["frame_id"] == "frame-1"
+    assert "Invalid computer action" in result["error"]
+    assert len(factory.environments) == 1
+
+
 def test_computer_tool_accepts_only_one_action_per_observation() -> None:
     with pytest.raises(ValueError, match="at most 1"):
         ComputerTool(
@@ -237,6 +258,10 @@ def test_new_computer_observation_supersedes_stale_live_context() -> None:
 
     old_message, current_message = context.messages
     assert old_message.metadata["superseded"] is True
+    assert old_message.metadata["raw_result"] == {
+        "success": True,
+        "superseded": True,
+    }
     assert old_message.context_refs
     assert CONTEXT_REFS_KEY not in old_message.to_dict()
     assert old_message.context_refs_token_estimate() == 0


### PR DESCRIPTION
## Scope

This PR is the **ephemeral Playwright browser loop** built on top of the provider-neutral Computer Use foundation merged in #1098. It is deliberately a focused implementation slice, not the complete Browser Use or Computer Use product.

## What this PR does

- implements `BrowserComputerEnvironment` with a new isolated Playwright browser session
- captures each viewport as an internal screenshot FileRef and returns the current URL, title, viewport, and bounded DOM hints
- supports one action per observed frame, followed by a mandatory fresh observation
- preserves the foundation stale-frame and task/session isolation guarantees
- exposes one `computer` tool through the existing browser tool category
- connects the tool to the existing ReAct loop and task/step-scoped browser lifecycle
- supersedes stale browser observations in the live model prompt while retaining their durable FileRefs in execution state
- redacts sensitive input values from DOM hints

## Explicitly out of scope

This PR does **not** implement or change:

- persistent Playwright profiles or reused login state
- control of an existing local Chrome window through `cua-driver`
- Chrome extension takeover of a user-authorized signed-in tab
- WebSocket or Redis browser relay, pairing, or distributed routing
- macOS desktop relay, window control, or whole-computer control
- product UI, settings, target selection, pairing flows, or confirmation UX
- native OpenAI, Claude, or Gemini computer-use model protocols
- router/model-selection policy beyond exposing the ordinary `computer` tool
- iframe-wide or closed-shadow-root DOM extraction; screenshots remain authoritative when structural hints are incomplete

Those capabilities should be reviewed in their own follow-up PRs with their own security and lifecycle boundaries. They should not be required to merge this foundational browser-loop slice.

## Review focus

Review in this PR should stay focused on:

1. conformance with the #1098 Computer Use schema and environment contracts
2. stale-frame enforcement and one-action-per-observation behavior
3. task/step session isolation and deterministic teardown
4. Playwright action and screenshot correctness
5. safe FileRef/context handling and bounded prompt growth
6. regressions to the existing browser tools and ReAct loop

Suggestions that require persistent profiles, local-browser ownership, relays, desktop control, product authorization, or new provider-specific protocols are intentionally follow-up work rather than blockers for this PR.

## Validation

- `pre-commit run --files ...`
- `pytest -q tests/core/computer tests/core/agent/test_browser_tools.py`
- `pytest -q tests/core/test_context_ref.py tests/core/test_context_materializer.py tests/core/agent/test_context.py tests/core/agent/test_react.py`
- real headless Chromium smoke: screenshot, navigate to Example Domain, capture a fresh observation, and teardown