### PR TITLE
feat: add local computer use via cua-driver

### DIFF
--- a/example.env
+++ b/example.env
@@ -362,17 +362,16 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # XAGENT_TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS="30"
 
 # ===========================================
-# Local browser Computer Use
+# Local computer use
 # ===========================================
-# Controls one visible browser window on the same host as the Xagent backend
-# through `cua-driver mcp`. Keep disabled on shared/cloud hosts unless backend
-# administrators are explicitly allowed to operate that host browser.
-# XAGENT_NATIVE_BROWSER_ENABLED="false"
-# XAGENT_NATIVE_BROWSER_APP_NAME="Google Chrome"
-# XAGENT_BROWSER_CUA_DRIVER_COMMAND="cua-driver"
-# XAGENT_BROWSER_CUA_DRIVER_SOCKET=""
-# XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS="30"
-# XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS="100"
+# Controls one visible application window on the same host as the Xagent
+# backend through `cua-driver mcp`. The first observation binds the task to the
+# frontmost visible window. Keep disabled on shared/cloud hosts.
+# XAGENT_LOCAL_COMPUTER_ENABLED="false"
+# XAGENT_CUA_DRIVER_COMMAND="cua-driver"
+# XAGENT_CUA_DRIVER_SOCKET=""
+# XAGENT_CUA_DRIVER_TIMEOUT_SECONDS="30"
+# XAGENT_CUA_DRIVER_MAX_ELEMENTS="100"
 
 # Context compaction: the conversation is compacted when the estimated context
 # size reaches (model context window * ratio). Set a model's context window in

--- a/example.env
+++ b/example.env
@@ -361,6 +361,19 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # XAGENT_TASK_RUNTIME_HOOK_MAX_WORKERS="8"
 # XAGENT_TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS="30"
 
+# ===========================================
+# Local browser Computer Use
+# ===========================================
+# Controls one visible browser window on the same host as the Xagent backend
+# through `cua-driver mcp`. Keep disabled on shared/cloud hosts unless backend
+# administrators are explicitly allowed to operate that host browser.
+# XAGENT_NATIVE_BROWSER_ENABLED="false"
+# XAGENT_NATIVE_BROWSER_APP_NAME="Google Chrome"
+# XAGENT_BROWSER_CUA_DRIVER_COMMAND="cua-driver"
+# XAGENT_BROWSER_CUA_DRIVER_SOCKET=""
+# XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS="30"
+# XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS="100"
+
 # Context compaction: the conversation is compacted when the estimated context
 # size reaches (model context window * ratio). Set a model's context window in
 # the model config; models without one fall back to the default below.

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -117,6 +117,52 @@ describe("ChatInput", () => {
     expect(onSend).not.toHaveBeenCalled()
   })
 
+  it("binds a new task to the ready local browser from the add menu", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            ready: true,
+            connected: true,
+            attached: true,
+            application: "Google Chrome",
+            title: "GitHub",
+            permissions: {},
+            issues: [],
+            message: "",
+          }), { status: 200, headers: { "Content-Type": "application/json" } })
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect this page"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    await screen.findByText("Google Chrome · GitHub")
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+
+    expect(screen.getByText("chatPage.input.localBrowser.chipLabel")).toBeInTheDocument()
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "inspect this page",
+        expect.objectContaining({
+          runtimeExtensions: { local_browser: {} },
+        }),
+      )
+    })
+  })
+
   it("suppresses preseeded files and restored file previews when files are disabled", () => {
     const onSend = vi.fn()
     const onFilesChange = vi.fn()

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -117,9 +117,9 @@ describe("ChatInput", () => {
     expect(onSend).not.toHaveBeenCalled()
   })
 
-  it("binds a new task to the ready local browser from the add menu", async () => {
+  it("binds a new task to a selected local computer window", async () => {
     apiRequestMock.mockImplementation((url: string) => {
-      if (url === "http://api.local/api/computer/local-browser/readiness") {
+      if (url === "http://api.local/api/computer/local-computer/readiness") {
         return Promise.resolve(
           new Response(JSON.stringify({
             ready: true,
@@ -127,6 +127,14 @@ describe("ChatInput", () => {
             attached: true,
             application: "Google Chrome",
             title: "GitHub",
+            windows: [
+              {
+                pid: 100,
+                window_id: 20,
+                application: "Google Chrome",
+                title: "GitHub",
+              },
+            ],
             permissions: {},
             issues: [],
             message: "",
@@ -147,17 +155,27 @@ describe("ChatInput", () => {
     )
 
     fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
-    await screen.findByText("Google Chrome · GitHub")
-    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+    fireEvent.click(await screen.findByText("GitHub"))
 
-    expect(screen.getByText("chatPage.input.localBrowser.chipLabel")).toBeInTheDocument()
-    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+    expect(screen.queryByText("chatPage.input.localComputer.chipLabel")).not.toBeInTheDocument()
+    expect(screen.getByRole("status", { name: "Google Chrome · GitHub" })).toBeInTheDocument()
+    const form = container.querySelector("form") as HTMLFormElement
+    expect(form).toHaveClass("rounded-2xl")
+    expect(form).not.toHaveClass("rounded-tl-none")
+    fireEvent.submit(form)
 
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledWith(
         "inspect this page",
         expect.objectContaining({
-          runtimeExtensions: { local_browser: {} },
+          runtimeExtensions: {
+            local_computer: {
+              pid: 100,
+              window_id: 20,
+              application: "Google Chrome",
+              title: "GitHub",
+            },
+          },
         }),
       )
     })

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -14,6 +14,7 @@ import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "@/components/ui/sonner";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
+import { LocalBrowserMenu } from "./LocalBrowserMenu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -111,6 +112,7 @@ interface AgentConfig {
   memorySimilarityThreshold?: number;
   executionMode?: ExecutionModeConfig;
   clientMessageId?: string;
+  runtimeExtensions?: Record<string, Record<string, unknown>>;
 }
 
 interface ModelRecord {
@@ -158,6 +160,7 @@ export function ChatInput({
   const [isFocused, setIsFocused] = useState(false);
   const [showNoModelAlert, setShowNoModelAlert] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [localBrowserSelected, setLocalBrowserSelected] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -676,6 +679,7 @@ export function ChatInput({
       const executionMode = taskConfig?.executionMode;
       const deliveryKey = JSON.stringify([
         messageToSend,
+        localBrowserSelected,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -691,6 +695,14 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
+        ...(localBrowserSelected
+          ? {
+              runtimeExtensions: {
+                ...(agentConfig.runtimeExtensions || {}),
+                local_browser: {},
+              },
+            }
+          : {}),
         ...(executionMode
           ? {
               executionMode:
@@ -703,6 +715,7 @@ export function ChatInput({
 
       await onSend(messageToSend, configToSend);
       deliveryAttemptRef.current = null;
+      setLocalBrowserSelected(false);
       fileMention.resetMention();
 
       if (isControlled) {
@@ -855,7 +868,8 @@ export function ChatInput({
     }
   }, [filesDisabled, message, promptHighlightTerms]);
 
-  const hasTopChip = selectedAgents.length > 0 || !!selectedTemplate;
+  const hasTopChip =
+    selectedAgents.length > 0 || !!selectedTemplate || localBrowserSelected;
 
   return (
     <div className="space-y-3">
@@ -891,6 +905,14 @@ export function ChatInput({
                 label={t("chatPage.templateQuickAccess.usingTemplateLabel")}
                 value={selectedTemplate.name}
                 onRemove={onRemoveSelectedTemplate}
+                removeLabel={t("common.remove")}
+              />
+            )}
+            {localBrowserSelected && (
+              <SelectionChip
+                label={t("chatPage.input.localBrowser.chipLabel")}
+                value={t("chatPage.input.localBrowser.label")}
+                onRemove={() => setLocalBrowserSelected(false)}
                 removeLabel={t("common.remove")}
               />
             )}
@@ -1098,30 +1120,32 @@ export function ChatInput({
                     )}
                   </>
                 )}
-                {/* Upload button - adjacent to bottom toolbar */}
-                {!hideFileUpload && !filesDisabled && (
+                {/* Add files or bind this new task to the local host browser. */}
+                {(!hideFileUpload && !filesDisabled) || (!readOnlyConfig && !hideConfig) ? (
                   <>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      multiple
-                      onChange={handleFileSelect}
-                      className="hidden"
-                      accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground hover:bg-secondary/80 rounded-full"
-                      onClick={() => fileInputRef.current?.click()}
+                    {!hideFileUpload && !filesDisabled && (
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        onChange={handleFileSelect}
+                        className="hidden"
+                        accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
+                      />
+                    )}
+                    <LocalBrowserMenu
                       disabled={isInputBusy}
-                      title={t("chatPage.input.actions.upload")}
-                    >
-                      <Paperclip className="h-4 w-4" />
-                    </Button>
+                      selected={localBrowserSelected}
+                      onSelectedChange={setLocalBrowserSelected}
+                      onAddFiles={
+                        !hideFileUpload && !filesDisabled
+                          ? () => fileInputRef.current?.click()
+                          : undefined
+                      }
+                      showLocalBrowser={!readOnlyConfig && !hideConfig}
+                    />
                   </>
-                )}
+                ) : null}
               </div>
 
               <div className="flex items-center gap-2">

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -14,7 +14,7 @@ import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "@/components/ui/sonner";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
-import { LocalBrowserMenu } from "./LocalBrowserMenu";
+import { LocalComputerMenu, type LocalComputerTarget } from "./LocalBrowserMenu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -160,7 +160,8 @@ export function ChatInput({
   const [isFocused, setIsFocused] = useState(false);
   const [showNoModelAlert, setShowNoModelAlert] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
-  const [localBrowserSelected, setLocalBrowserSelected] = useState(false);
+  const [localComputerTarget, setLocalComputerTarget] =
+    useState<LocalComputerTarget | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -679,7 +680,7 @@ export function ChatInput({
       const executionMode = taskConfig?.executionMode;
       const deliveryKey = JSON.stringify([
         messageToSend,
-        localBrowserSelected,
+        localComputerTarget,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -695,11 +696,11 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
-        ...(localBrowserSelected
+        ...(localComputerTarget
           ? {
               runtimeExtensions: {
                 ...(agentConfig.runtimeExtensions || {}),
-                local_browser: {},
+                local_computer: { ...localComputerTarget },
               },
             }
           : {}),
@@ -715,7 +716,7 @@ export function ChatInput({
 
       await onSend(messageToSend, configToSend);
       deliveryAttemptRef.current = null;
-      setLocalBrowserSelected(false);
+      setLocalComputerTarget(null);
       fileMention.resetMention();
 
       if (isControlled) {
@@ -868,8 +869,7 @@ export function ChatInput({
     }
   }, [filesDisabled, message, promptHighlightTerms]);
 
-  const hasTopChip =
-    selectedAgents.length > 0 || !!selectedTemplate || localBrowserSelected;
+  const hasTopChip = selectedAgents.length > 0 || !!selectedTemplate;
 
   return (
     <div className="space-y-3">
@@ -905,14 +905,6 @@ export function ChatInput({
                 label={t("chatPage.templateQuickAccess.usingTemplateLabel")}
                 value={selectedTemplate.name}
                 onRemove={onRemoveSelectedTemplate}
-                removeLabel={t("common.remove")}
-              />
-            )}
-            {localBrowserSelected && (
-              <SelectionChip
-                label={t("chatPage.input.localBrowser.chipLabel")}
-                value={t("chatPage.input.localBrowser.label")}
-                onRemove={() => setLocalBrowserSelected(false)}
                 removeLabel={t("common.remove")}
               />
             )}
@@ -1120,7 +1112,7 @@ export function ChatInput({
                     )}
                   </>
                 )}
-                {/* Add files or bind this new task to the local host browser. */}
+                {/* Add files or bind this new task to a local host window. */}
                 {(!hideFileUpload && !filesDisabled) || (!readOnlyConfig && !hideConfig) ? (
                   <>
                     {!hideFileUpload && !filesDisabled && (
@@ -1133,16 +1125,16 @@ export function ChatInput({
                         accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
                       />
                     )}
-                    <LocalBrowserMenu
+                    <LocalComputerMenu
                       disabled={isInputBusy}
-                      selected={localBrowserSelected}
-                      onSelectedChange={setLocalBrowserSelected}
+                      selectedTarget={localComputerTarget}
+                      onTargetChange={setLocalComputerTarget}
                       onAddFiles={
                         !hideFileUpload && !filesDisabled
                           ? () => fileInputRef.current?.click()
                           : undefined
                       }
-                      showLocalBrowser={!readOnlyConfig && !hideConfig}
+                      showLocalComputer={!readOnlyConfig && !hideConfig}
                     />
                   </>
                 ) : null}

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import { Check, Laptop, Loader2, Paperclip, Plus } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useI18n } from "@/contexts/i18n-context";
+import { apiRequest } from "@/lib/api-wrapper";
+import { cn, getApiUrl } from "@/lib/utils";
+
+interface ReadinessIssue {
+  code: string;
+  message: string;
+}
+
+interface LocalBrowserReadiness {
+  ready: boolean;
+  application: string;
+  title?: string | null;
+  issues: ReadinessIssue[];
+  message: string;
+}
+
+interface LocalBrowserMenuProps {
+  disabled: boolean;
+  selected: boolean;
+  onSelectedChange: (selected: boolean) => void;
+  onAddFiles?: () => void;
+  showLocalBrowser: boolean;
+}
+
+export function LocalBrowserMenu({
+  disabled,
+  selected,
+  onSelectedChange,
+  onAddFiles,
+  showLocalBrowser,
+}: LocalBrowserMenuProps) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [readiness, setReadiness] = useState<LocalBrowserReadiness | null>(null);
+
+  const refreshReadiness = useCallback(async () => {
+    if (!showLocalBrowser) return;
+    setLoading(true);
+    try {
+      const response = await apiRequest(
+        `${getApiUrl()}/api/computer/local-browser/readiness`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) throw new Error("readiness request failed");
+      setReadiness(await response.json());
+    } catch {
+      setReadiness({
+        ready: false,
+        application: "Local browser",
+        issues: [],
+        message: t("chatPage.input.localBrowser.unavailable"),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [showLocalBrowser, t]);
+
+  const localBrowserDisabled = disabled || loading || readiness?.ready !== true;
+  const status = loading
+    ? t("chatPage.input.localBrowser.checking")
+    : readiness?.ready
+      ? [readiness.application, readiness.title].filter(Boolean).join(" · ")
+      : readiness?.message || t("chatPage.input.localBrowser.unavailable");
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (nextOpen && showLocalBrowser) void refreshReadiness();
+      }}
+    >
+      <PopoverTrigger
+        type="button"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full p-0 text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+        disabled={disabled}
+        title={t("chatPage.input.actions.add")}
+        aria-label={t("chatPage.input.actions.add")}
+      >
+        <Plus className="h-4 w-4" />
+      </PopoverTrigger>
+      <PopoverContent align="start" side="top" className="w-80 space-y-1 p-1.5">
+        {onAddFiles && (
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              onAddFiles();
+            }}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
+          >
+            <Paperclip className="h-4 w-4 shrink-0" />
+            <span>{t("chatPage.input.actions.upload")}</span>
+          </button>
+        )}
+        {showLocalBrowser && (
+          <button
+            type="button"
+            disabled={localBrowserDisabled}
+            onClick={() => {
+              onSelectedChange(!selected);
+              setOpen(false);
+            }}
+            className={cn(
+              "flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors",
+              localBrowserDisabled
+                ? "cursor-not-allowed opacity-55"
+                : "hover:bg-muted",
+              selected && "bg-primary/5",
+            )}
+          >
+            {loading ? (
+              <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
+            ) : (
+              <Laptop className="mt-0.5 h-4 w-4 shrink-0" />
+            )}
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-medium">
+                {t("chatPage.input.localBrowser.label")}
+              </span>
+              <span className="block truncate text-xs text-muted-foreground" title={status}>
+                {status}
+              </span>
+            </span>
+            {selected && <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />}
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useState } from "react";
-import { Check, Laptop, Loader2, Paperclip, Plus } from "lucide-react";
+import { Check, Laptop, Loader2, Paperclip, Plus, X } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useI18n } from "@/contexts/i18n-context";
@@ -13,40 +13,48 @@ interface ReadinessIssue {
   message: string;
 }
 
-interface LocalBrowserReadiness {
+export interface LocalComputerTarget {
+  pid: number;
+  window_id: number;
+  application: string;
+  title?: string | null;
+}
+
+interface LocalComputerReadiness {
   ready: boolean;
   application: string;
   title?: string | null;
+  windows: LocalComputerTarget[];
   issues: ReadinessIssue[];
   message: string;
 }
 
-interface LocalBrowserMenuProps {
+interface LocalComputerMenuProps {
   disabled: boolean;
-  selected: boolean;
-  onSelectedChange: (selected: boolean) => void;
+  selectedTarget: LocalComputerTarget | null;
+  onTargetChange: (target: LocalComputerTarget | null) => void;
   onAddFiles?: () => void;
-  showLocalBrowser: boolean;
+  showLocalComputer: boolean;
 }
 
-export function LocalBrowserMenu({
+export function LocalComputerMenu({
   disabled,
-  selected,
-  onSelectedChange,
+  selectedTarget,
+  onTargetChange,
   onAddFiles,
-  showLocalBrowser,
-}: LocalBrowserMenuProps) {
+  showLocalComputer,
+}: LocalComputerMenuProps) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [readiness, setReadiness] = useState<LocalBrowserReadiness | null>(null);
+  const [readiness, setReadiness] = useState<LocalComputerReadiness | null>(null);
 
   const refreshReadiness = useCallback(async () => {
-    if (!showLocalBrowser) return;
+    if (!showLocalComputer) return;
     setLoading(true);
     try {
       const response = await apiRequest(
-        `${getApiUrl()}/api/computer/local-browser/readiness`,
+        `${getApiUrl()}/api/computer/local-computer/readiness`,
         { cache: "no-store" },
       );
       if (!response.ok) throw new Error("readiness request failed");
@@ -54,86 +62,143 @@ export function LocalBrowserMenu({
     } catch {
       setReadiness({
         ready: false,
-        application: "Local browser",
+        application: "Local computer",
+        windows: [],
         issues: [],
-        message: t("chatPage.input.localBrowser.unavailable"),
+        message: t("chatPage.input.localComputer.unavailable"),
       });
     } finally {
       setLoading(false);
     }
-  }, [showLocalBrowser, t]);
+  }, [showLocalComputer, t]);
 
-  const localBrowserDisabled = disabled || loading || readiness?.ready !== true;
+  const localComputerDisabled = disabled || loading || readiness?.ready !== true;
+  const selected = selectedTarget !== null;
   const status = loading
-    ? t("chatPage.input.localBrowser.checking")
+    ? t("chatPage.input.localComputer.checking")
     : readiness?.ready
-      ? [readiness.application, readiness.title].filter(Boolean).join(" · ")
-      : readiness?.message || t("chatPage.input.localBrowser.unavailable");
+      ? selectedTarget
+        ? [selectedTarget.application, selectedTarget.title].filter(Boolean).join(" · ")
+        : t("chatPage.input.localComputer.chooseWindow")
+      : readiness?.message || t("chatPage.input.localComputer.unavailable");
 
   return (
-    <Popover
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        if (nextOpen && showLocalBrowser) void refreshReadiness();
-      }}
-    >
-      <PopoverTrigger
-        type="button"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full p-0 text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-        disabled={disabled}
-        title={t("chatPage.input.actions.add")}
-        aria-label={t("chatPage.input.actions.add")}
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (nextOpen && showLocalComputer) void refreshReadiness();
+        }}
       >
-        <Plus className="h-4 w-4" />
-      </PopoverTrigger>
-      <PopoverContent align="start" side="top" className="w-80 space-y-1 p-1.5">
-        {onAddFiles && (
-          <button
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              onAddFiles();
-            }}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
-          >
-            <Paperclip className="h-4 w-4 shrink-0" />
-            <span>{t("chatPage.input.actions.upload")}</span>
-          </button>
-        )}
-        {showLocalBrowser && (
-          <button
-            type="button"
-            disabled={localBrowserDisabled}
-            onClick={() => {
-              onSelectedChange(!selected);
-              setOpen(false);
-            }}
+        <PopoverTrigger
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full p-0 text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          disabled={disabled}
+          title={t("chatPage.input.actions.add")}
+          aria-label={t("chatPage.input.actions.add")}
+        >
+          <Plus className="h-4 w-4" />
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" className="w-80 space-y-1 p-1.5">
+          {onAddFiles && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onAddFiles();
+              }}
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
+            >
+              <Paperclip className="h-4 w-4 shrink-0" />
+              <span>{t("chatPage.input.actions.upload")}</span>
+            </button>
+          )}
+          {showLocalComputer && (
+            <div className="rounded-lg px-1 py-1">
+              <div className="flex items-start gap-3 px-2 py-1.5">
+                {loading ? (
+                  <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
+                ) : (
+                  <Laptop className="mt-0.5 h-4 w-4 shrink-0" />
+                )}
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">
+                    {t("chatPage.input.localComputer.label")}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground" title={status}>
+                    {status}
+                  </span>
+                </span>
+              </div>
+              {!loading && readiness?.ready && readiness.windows.length > 0 && (
+                <div className="max-h-56 space-y-0.5 overflow-y-auto pl-7">
+                  {readiness.windows.map((window) => {
+                    const isSelected = selectedTarget?.pid === window.pid
+                      && selectedTarget?.window_id === window.window_id;
+                    return (
+                      <button
+                        type="button"
+                        key={`${window.pid}:${window.window_id}`}
+                        disabled={localComputerDisabled}
+                        onClick={() => {
+                          onTargetChange(window);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-muted",
+                          isSelected && "bg-primary/5",
+                        )}
+                      >
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm">{window.application}</span>
+                          {window.title && (
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {window.title}
+                            </span>
+                          )}
+                        </span>
+                        {isSelected && <Check className="h-4 w-4 shrink-0 text-primary" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {selected && (
+        <div
+          className="inline-flex h-8 min-w-0 max-w-[180px] items-center gap-1.5 rounded-lg border border-border bg-secondary/70 px-2.5 text-xs text-foreground"
+          title={status}
+        >
+          <Laptop className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{t("chatPage.input.localComputer.label")}</span>
+          <span
+            role="status"
+            aria-label={status}
             className={cn(
-              "flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors",
-              localBrowserDisabled
-                ? "cursor-not-allowed opacity-55"
-                : "hover:bg-muted",
-              selected && "bg-primary/5",
+              "h-2 w-2 shrink-0 rounded-full",
+              readiness?.ready
+                ? "bg-emerald-500"
+                : readiness
+                  ? "bg-amber-500"
+                  : "bg-muted-foreground/35",
             )}
+          />
+          <button
+            type="button"
+            aria-label={t("common.remove")}
+            title={t("common.remove")}
+            className="ml-0.5 rounded-sm p-0.5 hover:bg-foreground/10"
+            onClick={() => onTargetChange(null)}
           >
-            {loading ? (
-              <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
-            ) : (
-              <Laptop className="mt-0.5 h-4 w-4 shrink-0" />
-            )}
-            <span className="min-w-0 flex-1">
-              <span className="block text-sm font-medium">
-                {t("chatPage.input.localBrowser.label")}
-              </span>
-              <span className="block truncate text-xs text-muted-foreground" title={status}>
-                {status}
-              </span>
-            </span>
-            {selected && <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />}
+            <X className="h-3 w-3" />
           </button>
-        )}
-      </PopoverContent>
-    </Popover>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -990,7 +990,7 @@ describe("AppProvider websocket message routing", () => {
       const { sendMessage } = useApp()
       send = () => sendMessage("inspect browser", {
         clientMessageId: "turn-local-browser",
-        runtimeExtensions: { local_browser: {} },
+        runtimeExtensions: { local_computer: {} },
       })
       return null
     }
@@ -1010,7 +1010,7 @@ describe("AppProvider websocket message routing", () => {
 
     expect(createBody).toEqual(
       expect.objectContaining({
-        runtime_extensions: { local_browser: {} },
+        runtime_extensions: { local_computer: {} },
       })
     )
 

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -965,6 +965,65 @@ describe("AppProvider websocket message routing", () => {
     ])
   })
 
+  it("sends selected task runtime extensions in the create request", async () => {
+    let createBody: Record<string, unknown> | undefined
+    apiRequestMock.mockImplementation(
+      async (url: string, options?: RequestInit) => {
+        if (url.endsWith("/api/chat/task/create")) {
+          createBody = JSON.parse(String(options?.body || "{}"))
+          return {
+            ok: true,
+            json: async () => ({
+              task_id: 8,
+              title: "inspect browser",
+              description: "inspect browser",
+              status: "pending",
+            }),
+          }
+        }
+        return { ok: true, json: async () => ({}) }
+      },
+    )
+
+    let send: (() => Promise<void>) | undefined
+    function RuntimeExtensionProbe() {
+      const { sendMessage } = useApp()
+      send = () => sendMessage("inspect browser", {
+        clientMessageId: "turn-local-browser",
+        runtimeExtensions: { local_browser: {} },
+      })
+      return null
+    }
+
+    wsHarness.isConnected = false
+    render(
+      <AppProvider token="token">
+        <RuntimeExtensionProbe />
+      </AppProvider>
+    )
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = send?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(createBody).toEqual(
+      expect.objectContaining({
+        runtime_extensions: { local_browser: {} },
+      })
+    )
+
+    await act(async () => {
+      wsHarness.isConnected = true
+      webSocketOptions.current?.onConnect?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await act(async () => {
+      await delivery
+    })
+  })
+
   it("does not crash on a trace event without data", () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5587,6 +5587,9 @@ export function AppProvider({
         if (config?.agentConfig) {
           requestBody.agent_config = config.agentConfig
         }
+        if (config?.runtimeExtensions) {
+          requestBody.runtime_extensions = config.runtimeExtensions
+        }
 
         const response = await apiRequest(`${apiUrl}/api/chat/task/create`, {
           method: 'POST',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -238,10 +238,11 @@ const en = {
         config: "Configure Model",
         upload: "Upload",
       },
-      localBrowser: {
-        label: "Local browser",
+      localComputer: {
+        label: "Local computer",
         chipLabel: "Computer use",
         checking: "Checking the Xagent host...",
+        chooseWindow: "Choose an application window",
         unavailable: "Not available on this Xagent host",
       },
       noModel: "No Model",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -234,8 +234,15 @@ const en = {
       processing: "Processing",
       usingAgentLabel: "Using",
       actions: {
+        add: "Add",
         config: "Configure Model",
         upload: "Upload",
+      },
+      localBrowser: {
+        label: "Local browser",
+        chipLabel: "Computer use",
+        checking: "Checking the Xagent host...",
+        unavailable: "Not available on this Xagent host",
       },
       noModel: "No Model",
       noModelAlert: "No model configured. Please configure a model first.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -234,8 +234,15 @@ const zh = {
       processing: "处理中",
       usingAgentLabel: "使用",
       actions: {
+        add: "添加",
         config: "配置模型",
         upload: "上传文件",
+      },
+      localBrowser: {
+        label: "本地浏览器",
+        chipLabel: "操作电脑",
+        checking: "正在检查 Xagent 主机...",
+        unavailable: "此 Xagent 主机不可用",
       },
       noModel: "暂无模型",
       noModelAlert: "暂无模型，请先配置模型",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -238,10 +238,11 @@ const zh = {
         config: "配置模型",
         upload: "上传文件",
       },
-      localBrowser: {
-        label: "本地浏览器",
+      localComputer: {
+        label: "本机电脑",
         chipLabel: "操作电脑",
         checking: "正在检查 Xagent 主机...",
+        chooseWindow: "选择一个应用窗口",
         unavailable: "此 Xagent 主机不可用",
       },
       noModel: "暂无模型",

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -47,6 +47,13 @@ UPLOADED_FILE_RECOVERY_INTERVAL_SECONDS = (
 UPLOADED_FILE_RECOVERY_STALE_SECONDS = "XAGENT_UPLOADED_FILE_RECOVERY_STALE_SECONDS"
 UPLOADED_FILE_RECOVERY_BATCH_SIZE = "XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
+LOCAL_COMPUTER_ENABLED = "XAGENT_LOCAL_COMPUTER_ENABLED"
+CUA_DRIVER_COMMAND = "XAGENT_CUA_DRIVER_COMMAND"
+CUA_DRIVER_SOCKET = "XAGENT_CUA_DRIVER_SOCKET"
+CUA_DRIVER_TIMEOUT_SECONDS = "XAGENT_CUA_DRIVER_TIMEOUT_SECONDS"
+CUA_DRIVER_MAX_ELEMENTS = "XAGENT_CUA_DRIVER_MAX_ELEMENTS"
+# Compatibility with the short-lived Local browser preview. New deployments
+# should use the Local computer names above.
 NATIVE_BROWSER_ENABLED = "XAGENT_NATIVE_BROWSER_ENABLED"
 NATIVE_BROWSER_APP_NAME = "XAGENT_NATIVE_BROWSER_APP_NAME"
 BROWSER_CUA_DRIVER_COMMAND = "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
@@ -570,37 +577,68 @@ def get_task_runtime_hook_queue_timeout_seconds() -> int:
     return _get_positive_int_env(TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS, 30)
 
 
-def get_native_browser_enabled() -> bool:
-    """Whether tasks may control a browser running on the Xagent host."""
+def get_local_computer_enabled() -> bool:
+    """Whether tasks may control the interactive Xagent host through cua-driver."""
 
+    if os.getenv(LOCAL_COMPUTER_ENABLED) is not None:
+        return _get_bool_env(LOCAL_COMPUTER_ENABLED, False)
     return _get_bool_env(NATIVE_BROWSER_ENABLED, False)
 
 
+def get_native_browser_enabled() -> bool:
+    """Compatibility alias for :func:`get_local_computer_enabled`."""
+
+    return get_local_computer_enabled()
+
+
 def get_native_browser_app_name() -> str:
-    """Application name used to select the local browser window."""
+    """Legacy preferred application used by older Local browser bindings."""
 
     return (
         os.getenv(NATIVE_BROWSER_APP_NAME, "Google Chrome").strip() or "Google Chrome"
     )
 
 
-def get_browser_cua_driver_command() -> str:
+def get_cua_driver_command() -> str:
     """Executable used to start the local cua-driver MCP server."""
 
-    return os.getenv(BROWSER_CUA_DRIVER_COMMAND, "cua-driver").strip() or "cua-driver"
+    return (
+        os.getenv(CUA_DRIVER_COMMAND)
+        or os.getenv(BROWSER_CUA_DRIVER_COMMAND)
+        or "cua-driver"
+    ).strip() or "cua-driver"
 
 
-def get_browser_cua_driver_socket() -> str | None:
+def get_browser_cua_driver_command() -> str:
+    """Compatibility alias for :func:`get_cua_driver_command`."""
+
+    return get_cua_driver_command()
+
+
+def get_cua_driver_socket() -> str | None:
     """Optional cua-driver daemon socket endpoint."""
 
-    value = os.getenv(BROWSER_CUA_DRIVER_SOCKET, "").strip()
+    value = (
+        os.getenv(CUA_DRIVER_SOCKET) or os.getenv(BROWSER_CUA_DRIVER_SOCKET) or ""
+    ).strip()
     return value or None
 
 
-def get_browser_cua_driver_timeout_seconds() -> float:
-    """Per-call timeout for the local browser driver."""
+def get_browser_cua_driver_socket() -> str | None:
+    """Compatibility alias for :func:`get_cua_driver_socket`."""
 
-    raw_value = os.getenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "30").strip()
+    return get_cua_driver_socket()
+
+
+def get_cua_driver_timeout_seconds() -> float:
+    """Per-call timeout for the local computer driver."""
+
+    source_name = (
+        CUA_DRIVER_TIMEOUT_SECONDS
+        if os.getenv(CUA_DRIVER_TIMEOUT_SECONDS) is not None
+        else BROWSER_CUA_DRIVER_TIMEOUT_SECONDS
+    )
+    raw_value = os.getenv(source_name, "30").strip()
     try:
         value = float(raw_value)
     except ValueError:
@@ -609,16 +647,33 @@ def get_browser_cua_driver_timeout_seconds() -> float:
         return value
     logger.warning(
         "Invalid %s=%r; falling back to 30 seconds",
-        BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
+        source_name,
         raw_value,
     )
     return 30.0
 
 
-def get_browser_cua_driver_max_elements() -> int:
+def get_browser_cua_driver_timeout_seconds() -> float:
+    """Compatibility alias for :func:`get_cua_driver_timeout_seconds`."""
+
+    return get_cua_driver_timeout_seconds()
+
+
+def get_cua_driver_max_elements() -> int:
     """Maximum AX elements requested from cua-driver per observation."""
 
-    return _get_positive_int_env(BROWSER_CUA_DRIVER_MAX_ELEMENTS, 100)
+    source_name = (
+        CUA_DRIVER_MAX_ELEMENTS
+        if os.getenv(CUA_DRIVER_MAX_ELEMENTS) is not None
+        else BROWSER_CUA_DRIVER_MAX_ELEMENTS
+    )
+    return _get_positive_int_env(source_name, 100)
+
+
+def get_browser_cua_driver_max_elements() -> int:
+    """Compatibility alias for :func:`get_cua_driver_max_elements`."""
+
+    return get_cua_driver_max_elements()
 
 
 def get_checkpoint_encoding_v2_enabled() -> bool:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -47,6 +47,12 @@ UPLOADED_FILE_RECOVERY_INTERVAL_SECONDS = (
 UPLOADED_FILE_RECOVERY_STALE_SECONDS = "XAGENT_UPLOADED_FILE_RECOVERY_STALE_SECONDS"
 UPLOADED_FILE_RECOVERY_BATCH_SIZE = "XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
+NATIVE_BROWSER_ENABLED = "XAGENT_NATIVE_BROWSER_ENABLED"
+NATIVE_BROWSER_APP_NAME = "XAGENT_NATIVE_BROWSER_APP_NAME"
+BROWSER_CUA_DRIVER_COMMAND = "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
+BROWSER_CUA_DRIVER_SOCKET = "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
+BROWSER_CUA_DRIVER_TIMEOUT_SECONDS = "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
+BROWSER_CUA_DRIVER_MAX_ELEMENTS = "XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS"
 MAX_UPLOAD_SIZE = "XAGENT_MAX_UPLOAD_SIZE"
 FILE_STORAGE_URI = "XAGENT_FILE_STORAGE_URI"
 FILE_STORAGE_OPTIONS = "XAGENT_FILE_STORAGE_OPTIONS"
@@ -562,6 +568,57 @@ def get_task_runtime_hook_queue_timeout_seconds() -> int:
     """Seconds a provider hook may wait for a runtime worker before starting."""
 
     return _get_positive_int_env(TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS, 30)
+
+
+def get_native_browser_enabled() -> bool:
+    """Whether tasks may control a browser running on the Xagent host."""
+
+    return _get_bool_env(NATIVE_BROWSER_ENABLED, False)
+
+
+def get_native_browser_app_name() -> str:
+    """Application name used to select the local browser window."""
+
+    return (
+        os.getenv(NATIVE_BROWSER_APP_NAME, "Google Chrome").strip() or "Google Chrome"
+    )
+
+
+def get_browser_cua_driver_command() -> str:
+    """Executable used to start the local cua-driver MCP server."""
+
+    return os.getenv(BROWSER_CUA_DRIVER_COMMAND, "cua-driver").strip() or "cua-driver"
+
+
+def get_browser_cua_driver_socket() -> str | None:
+    """Optional cua-driver daemon socket endpoint."""
+
+    value = os.getenv(BROWSER_CUA_DRIVER_SOCKET, "").strip()
+    return value or None
+
+
+def get_browser_cua_driver_timeout_seconds() -> float:
+    """Per-call timeout for the local browser driver."""
+
+    raw_value = os.getenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "30").strip()
+    try:
+        value = float(raw_value)
+    except ValueError:
+        value = 30.0
+    if value > 0:
+        return value
+    logger.warning(
+        "Invalid %s=%r; falling back to 30 seconds",
+        BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
+        raw_value,
+    )
+    return 30.0
+
+
+def get_browser_cua_driver_max_elements() -> int:
+    """Maximum AX elements requested from cua-driver per observation."""
+
+    return _get_positive_int_env(BROWSER_CUA_DRIVER_MAX_ELEMENTS, 100)
 
 
 def get_checkpoint_encoding_v2_enabled() -> bool:

--- a/src/xagent/core/computer/cua_driver.py
+++ b/src/xagent/core/computer/cua_driver.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
-import io
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -15,9 +14,9 @@ from mcp.client.stdio import stdio_client
 from mcp.types import CallToolResult, ImageContent, TextContent
 
 from ...config import (
-    get_browser_cua_driver_command,
-    get_browser_cua_driver_socket,
-    get_browser_cua_driver_timeout_seconds,
+    get_cua_driver_command,
+    get_cua_driver_socket,
+    get_cua_driver_timeout_seconds,
 )
 
 
@@ -62,14 +61,12 @@ class CuaDriverMCPClient:
         socket: str | None = None,
         timeout_seconds: float | None = None,
     ) -> None:
-        self.command = command or get_browser_cua_driver_command()
+        self.command = command or get_cua_driver_command()
         self.socket = (
-            get_browser_cua_driver_socket()
-            if socket is None
-            else socket.strip() or None
+            get_cua_driver_socket() if socket is None else socket.strip() or None
         )
         self.timeout_seconds = (
-            get_browser_cua_driver_timeout_seconds()
+            get_cua_driver_timeout_seconds()
             if timeout_seconds is None
             else timeout_seconds
         )
@@ -220,37 +217,38 @@ class CuaDriverMCPClient:
         )
         failure: BaseException | None = None
         try:
-            async with (
-                stdio_client(parameters, errlog=io.StringIO()) as (
-                    read_stream,
-                    write_stream,
-                ),
-                ClientSession(
-                    read_stream,
-                    write_stream,
-                    read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
-                ) as session,
-            ):
-                await session.initialize()
-                if not ready.done():
-                    ready.set_result(None)
-                while True:
-                    request = await queue.get()
-                    if request is None:
-                        break
-                    if request.future.done():
-                        continue
-                    try:
-                        response = await session.call_tool(
-                            request.name,
-                            request.arguments,
-                        )
-                    except Exception as exc:
-                        if not request.future.done():
-                            request.future.set_exception(exc)
-                    else:
-                        if not request.future.done():
-                            request.future.set_result(response)
+            with open(os.devnull, "w", encoding="utf-8") as errlog:
+                async with (
+                    stdio_client(parameters, errlog=errlog) as (
+                        read_stream,
+                        write_stream,
+                    ),
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
+                    ) as session,
+                ):
+                    await session.initialize()
+                    if not ready.done():
+                        ready.set_result(None)
+                    while True:
+                        request = await queue.get()
+                        if request is None:
+                            break
+                        if request.future.done():
+                            continue
+                        try:
+                            response = await session.call_tool(
+                                request.name,
+                                request.arguments,
+                            )
+                        except Exception as exc:
+                            if not request.future.done():
+                                request.future.set_exception(exc)
+                        else:
+                            if not request.future.done():
+                                request.future.set_result(response)
         except FileNotFoundError as exc:
             failure = CuaDriverError(
                 f"cua-driver executable was not found: {self.command!r}"

--- a/src/xagent/core/computer/cua_driver.py
+++ b/src/xagent/core/computer/cua_driver.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import io
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Protocol
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from ...config import (
+    get_browser_cua_driver_command,
+    get_browser_cua_driver_socket,
+    get_browser_cua_driver_timeout_seconds,
+)
+
+
+class CuaDriverError(RuntimeError):
+    """Raised when the local cua-driver process cannot satisfy a tool call."""
+
+
+@dataclass(frozen=True)
+class CuaDriverResult:
+    """Provider-neutral subset of one cua-driver MCP tool response."""
+
+    structured: dict[str, Any] = field(default_factory=dict)
+    text: str = ""
+    image_bytes: bytes | None = None
+    image_mime_type: str | None = None
+
+
+class CuaDriverClientProtocol(Protocol):
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+    ) -> CuaDriverResult: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class _ToolCallRequest:
+    name: str
+    arguments: dict[str, Any]
+    future: asyncio.Future[CallToolResult]
+
+
+class CuaDriverMCPClient:
+    """Lazy, task-scoped stdio MCP client for the native cua-driver runtime."""
+
+    def __init__(
+        self,
+        *,
+        command: str | None = None,
+        socket: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self.command = command or get_browser_cua_driver_command()
+        self.socket = (
+            get_browser_cua_driver_socket()
+            if socket is None
+            else socket.strip() or None
+        )
+        self.timeout_seconds = (
+            get_browser_cua_driver_timeout_seconds()
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if not self.command.strip():
+            raise ValueError("cua-driver command must not be empty")
+        if self.timeout_seconds <= 0:
+            raise ValueError("cua-driver timeout must be positive")
+        self._worker: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[_ToolCallRequest | None] | None = None
+        self._ready: asyncio.Future[None] | None = None
+        self._lifecycle_lock = asyncio.Lock()
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+    ) -> CuaDriverResult:
+        if not name.strip():
+            raise ValueError("cua-driver tool name must not be empty")
+        queue = await self._ensure_worker()
+        future: asyncio.Future[CallToolResult] = (
+            asyncio.get_running_loop().create_future()
+        )
+        await queue.put(
+            _ToolCallRequest(
+                name=name,
+                arguments=dict(arguments or {}),
+                future=future,
+            )
+        )
+        try:
+            response = await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise CuaDriverError(
+                f"cua-driver tool {name!r} timed out after "
+                f"{self.timeout_seconds:g} seconds"
+            ) from exc
+        except Exception as exc:
+            raise CuaDriverError(f"cua-driver tool {name!r} failed: {exc}") from exc
+        finally:
+            if not future.done():
+                future.cancel()
+
+        text_parts = [
+            item.text for item in response.content if isinstance(item, TextContent)
+        ]
+        image_parts = [
+            item for item in response.content if isinstance(item, ImageContent)
+        ]
+        message = "\n".join(text_parts).strip()
+        if response.isError:
+            raise CuaDriverError(message or f"cua-driver tool {name!r} failed")
+
+        image_bytes: bytes | None = None
+        image_mime_type: str | None = None
+        if image_parts:
+            image = image_parts[0]
+            try:
+                image_bytes = base64.b64decode(image.data, validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise CuaDriverError(
+                    f"cua-driver tool {name!r} returned invalid image data"
+                ) from exc
+            image_mime_type = image.mimeType
+
+        structured = response.structuredContent
+        return CuaDriverResult(
+            structured=dict(structured) if isinstance(structured, dict) else {},
+            text=message,
+            image_bytes=image_bytes,
+            image_mime_type=image_mime_type,
+        )
+
+    async def close(self) -> None:
+        async with self._lifecycle_lock:
+            worker = self._worker
+            queue = self._queue
+            self._worker = None
+            self._queue = None
+            self._ready = None
+        if worker is None:
+            return
+        if queue is not None and not worker.done():
+            await queue.put(None)
+        try:
+            await asyncio.wait_for(worker, timeout=self.timeout_seconds)
+        except TimeoutError:
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+        except Exception:
+            # Callers already receive the specific transport failure from their
+            # request future. Teardown remains best-effort and idempotent.
+            pass
+
+    async def _ensure_worker(
+        self,
+    ) -> asyncio.Queue[_ToolCallRequest | None]:
+        async with self._lifecycle_lock:
+            if self._worker is None or self._worker.done():
+                loop = asyncio.get_running_loop()
+                self._queue = asyncio.Queue()
+                self._ready = loop.create_future()
+                self._worker = asyncio.create_task(
+                    self._run_worker(self._queue, self._ready),
+                    name="xagent-cua-driver-mcp",
+                )
+            queue = self._queue
+            ready = self._ready
+        assert queue is not None and ready is not None
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(ready),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise CuaDriverError(
+                "cua-driver MCP initialization timed out after "
+                f"{self.timeout_seconds:g} seconds"
+            ) from exc
+        except Exception as exc:
+            if isinstance(exc, CuaDriverError):
+                raise
+            raise CuaDriverError(f"could not initialize cua-driver MCP: {exc}") from exc
+        return queue
+
+    async def _run_worker(
+        self,
+        queue: asyncio.Queue[_ToolCallRequest | None],
+        ready: asyncio.Future[None],
+    ) -> None:
+        args = ["mcp"]
+        if self.socket is not None:
+            args.extend(["--socket", self.socket])
+        parameters = StdioServerParameters(
+            command=self.command,
+            args=args,
+            env={
+                # The MCP SDK inherits only a safe environment allowlist. Keep
+                # driver telemetry disabled unless the host explicitly opted in.
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED": os.getenv(
+                    "CUA_DRIVER_RS_TELEMETRY_ENABLED",
+                    "0",
+                ),
+            },
+        )
+        failure: BaseException | None = None
+        try:
+            async with (
+                stdio_client(parameters, errlog=io.StringIO()) as (
+                    read_stream,
+                    write_stream,
+                ),
+                ClientSession(
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
+                ) as session,
+            ):
+                await session.initialize()
+                if not ready.done():
+                    ready.set_result(None)
+                while True:
+                    request = await queue.get()
+                    if request is None:
+                        break
+                    if request.future.done():
+                        continue
+                    try:
+                        response = await session.call_tool(
+                            request.name,
+                            request.arguments,
+                        )
+                    except Exception as exc:
+                        if not request.future.done():
+                            request.future.set_exception(exc)
+                    else:
+                        if not request.future.done():
+                            request.future.set_result(response)
+        except FileNotFoundError as exc:
+            failure = CuaDriverError(
+                f"cua-driver executable was not found: {self.command!r}"
+            )
+            failure.__cause__ = exc
+        except asyncio.CancelledError:
+            failure = CuaDriverError("cua-driver MCP worker was cancelled")
+            raise
+        except Exception as exc:
+            failure = CuaDriverError(f"could not initialize cua-driver MCP: {exc}")
+            failure.__cause__ = exc
+        finally:
+            if failure is not None and not ready.done():
+                ready.set_exception(failure)
+            while not queue.empty():
+                request = queue.get_nowait()
+                if request is not None and not request.future.done():
+                    request.future.set_exception(
+                        failure or CuaDriverError("cua-driver MCP worker stopped")
+                    )

--- a/src/xagent/core/computer/input_platform.py
+++ b/src/xagent/core/computer/input_platform.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import Any
+
+
+class ComputerInputPlatform(str, Enum):
+    MACOS = "macos"
+    WINDOWS = "windows"
+    LINUX = "linux"
+    CHROMEOS = "chromeos"
+    ANDROID = "android"
+    UNKNOWN = "unknown"
+
+
+class ComputerPrimaryModifier(str, Enum):
+    META = "META"
+    CTRL = "CTRL"
+
+
+def normalize_computer_input_platform(value: str | None) -> ComputerInputPlatform:
+    normalized = str(value or "").strip().lower()
+    aliases = {
+        "darwin": ComputerInputPlatform.MACOS,
+        "mac": ComputerInputPlatform.MACOS,
+        "macos": ComputerInputPlatform.MACOS,
+        "win": ComputerInputPlatform.WINDOWS,
+        "win32": ComputerInputPlatform.WINDOWS,
+        "windows": ComputerInputPlatform.WINDOWS,
+        "linux": ComputerInputPlatform.LINUX,
+        "openbsd": ComputerInputPlatform.LINUX,
+        "chromeos": ComputerInputPlatform.CHROMEOS,
+        "android": ComputerInputPlatform.ANDROID,
+    }
+    return aliases.get(normalized, ComputerInputPlatform.UNKNOWN)
+
+
+def host_computer_input_platform() -> ComputerInputPlatform:
+    return normalize_computer_input_platform(sys.platform)
+
+
+def primary_modifier_for_platform(
+    platform: ComputerInputPlatform | str,
+) -> ComputerPrimaryModifier:
+    normalized = (
+        platform
+        if isinstance(platform, ComputerInputPlatform)
+        else normalize_computer_input_platform(platform)
+    )
+    if normalized is ComputerInputPlatform.MACOS:
+        return ComputerPrimaryModifier.META
+    return ComputerPrimaryModifier.CTRL
+
+
+def computer_input_metadata(
+    platform: ComputerInputPlatform | str,
+) -> dict[str, Any]:
+    normalized = (
+        platform
+        if isinstance(platform, ComputerInputPlatform)
+        else normalize_computer_input_platform(platform)
+    )
+    return {
+        "platform": normalized.value,
+        "primary_modifier": primary_modifier_for_platform(normalized).value,
+    }

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -1,0 +1,832 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import struct
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from ...config import (
+    get_browser_cua_driver_max_elements,
+    get_native_browser_app_name,
+    get_native_browser_enabled,
+)
+from .cua_driver import (
+    CuaDriverClientProtocol,
+    CuaDriverError,
+    CuaDriverMCPClient,
+    CuaDriverResult,
+)
+from .environment import ComputerEnvironment, ComputerTargetNotFoundError
+from .input_platform import (
+    ComputerInputPlatform,
+    computer_input_metadata,
+    host_computer_input_platform,
+)
+from .schema import (
+    ELEMENT_EXTRACTION_FAILED_KEY,
+    ELEMENT_EXTRACTION_INCOMPLETE_KEY,
+    ELEMENTS_TRUNCATED_KEY,
+    MAX_OBSERVATION_ELEMENTS,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerElement,
+    ComputerElementSource,
+    ComputerEnvironmentType,
+    ComputerObservation,
+    NormalizedPoint,
+    NormalizedRect,
+    Viewport,
+)
+from .store import ObservationStore
+
+_SUPPORTED_ACTIONS = tuple(
+    action for action in ComputerActionType if action is not ComputerActionType.MOVE
+)
+_ACTION_RESULT_FIELDS = (
+    "path",
+    "effect",
+    "verified",
+    "escalation",
+    "status",
+    "code",
+)
+
+CuaDriverClientFactory = Callable[[], CuaDriverClientProtocol]
+LOCAL_BROWSER_TASK_EXTENSION = "local_browser"
+
+
+@dataclass(frozen=True)
+class NativeBrowserWindow:
+    pid: int
+    window_id: int
+    app_name: str
+    title: str | None
+    x: float
+    y: float
+    width: float
+    height: float
+    z_index: int
+    is_on_screen: bool
+    on_current_space: bool
+
+
+class NativeBrowserEnvironment(ComputerEnvironment):
+    """Control one local browser window through cua-driver's native MCP tools.
+
+    The first observation binds the task to one concrete ``(pid, window_id)``.
+    That binding is intentionally sticky: if the window closes, the environment
+    fails instead of silently taking over another browser window.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        workspace: Any,
+        driver: CuaDriverClientProtocol | None = None,
+        driver_factory: CuaDriverClientFactory | None = None,
+        observation_store: ObservationStore | None = None,
+        browser_app_name: str | None = None,
+        navigation_allowlist: Sequence[str] | None = None,
+        navigation_denylist: Sequence[str] | None = None,
+        max_elements: int | None = None,
+        headless: bool = False,
+    ) -> None:
+        del headless
+        super().__init__(session_id)
+        if driver is not None and driver_factory is not None:
+            raise ValueError("provide either driver or driver_factory, not both")
+        if driver is None and not get_native_browser_enabled():
+            raise RuntimeError(
+                "Native browser access is disabled. Set "
+                "XAGENT_NATIVE_BROWSER_ENABLED=true only on a trusted "
+                "interactive Xagent host."
+            )
+        self.workspace = workspace
+        self.observation_store = observation_store or ObservationStore(workspace)
+        self.browser_app_name = (
+            browser_app_name or get_native_browser_app_name()
+        ).strip()
+        if not self.browser_app_name:
+            raise ValueError("native browser application name must not be empty")
+        self.navigation_allowlist = _normalize_host_patterns(navigation_allowlist)
+        self.navigation_denylist = _normalize_host_patterns(navigation_denylist)
+        self.max_elements = (
+            get_browser_cua_driver_max_elements()
+            if max_elements is None
+            else max_elements
+        )
+        if self.max_elements <= 0:
+            raise ValueError("native browser max_elements must be positive")
+        self._driver = driver
+        self._driver_factory = driver_factory or CuaDriverMCPClient
+        self._target: NativeBrowserWindow | None = None
+        self._session_started = False
+        self._last_action_result: dict[str, Any] | None = None
+
+    async def _close(self) -> None:
+        driver = self._driver
+        self._driver = None
+        if driver is None:
+            return
+        if self._session_started:
+            try:
+                await driver.call_tool("end_session", {"session": self.session_id})
+            except Exception:
+                # Closing stdin still tears down process-owned driver state.
+                pass
+        await driver.close()
+        self._session_started = False
+
+    async def health_report(self) -> dict[str, Any]:
+        """Return cua-driver's stable structured diagnostics contract."""
+
+        result = await self._get_driver().call_tool("health_report", {})
+        return result.structured
+
+    async def _observe(self) -> ComputerObservation:
+        await self._ensure_session()
+        if self._target is None:
+            self._target = await self._select_target()
+        return await self._capture_observation()
+
+    async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
+        if len(batch.actions) != 1:
+            raise ValueError("native browser executes exactly one action per frame")
+        action = batch.actions[0]
+        supported_actions = (
+            self.current_observation.metadata.get("supported_actions")
+            if self.current_observation is not None
+            else None
+        )
+        if self.current_observation is not None and (
+            not isinstance(supported_actions, list)
+            or action.type.value not in supported_actions
+        ):
+            raise ValueError(
+                f"{action.type.value} is not supported by the native browser runtime"
+            )
+        await self._execute_action(action)
+        if action.type not in {ComputerActionType.SCREENSHOT, ComputerActionType.WAIT}:
+            await asyncio.sleep(0.25)
+        return await self._capture_observation()
+
+    async def _ensure_session(self) -> None:
+        if self._session_started:
+            return
+        await self._get_driver().call_tool(
+            "start_session",
+            {
+                "session": self.session_id,
+                "capture_scope": "window",
+            },
+        )
+        self._session_started = True
+
+    def _get_driver(self) -> CuaDriverClientProtocol:
+        if self._driver is None:
+            self._driver = self._driver_factory()
+        return self._driver
+
+    async def _select_target(self) -> NativeBrowserWindow:
+        result = await self._get_driver().call_tool(
+            "list_windows",
+            {"on_screen_only": False},
+        )
+        raw_windows = result.structured.get("windows")
+        if not isinstance(raw_windows, list):
+            raise CuaDriverError("cua-driver list_windows returned no window list")
+        windows = [
+            parsed
+            for raw in raw_windows
+            if isinstance(raw, Mapping)
+            and (parsed := self._parse_window(raw)) is not None
+        ]
+        app_name = self.browser_app_name.casefold()
+        matches = [
+            window for window in windows if window.app_name.casefold() == app_name
+        ]
+        if not matches:
+            raise ComputerTargetNotFoundError(
+                f"No local {self.browser_app_name!r} window is running. Open the "
+                "browser on the Xagent host, then request a fresh screenshot."
+            )
+        visible_matches = [
+            window
+            for window in matches
+            if window.on_current_space and window.is_on_screen
+        ]
+        if not visible_matches:
+            raise ComputerTargetNotFoundError(
+                f"No visible {self.browser_app_name!r} window is on the current "
+                "desktop. Restore and show the intended window, then request a "
+                "fresh screenshot."
+            )
+        return max(visible_matches, key=lambda window: window.z_index)
+
+    @staticmethod
+    def _parse_window(raw: Mapping[str, Any]) -> NativeBrowserWindow | None:
+        bounds = raw.get("bounds")
+        if not isinstance(bounds, Mapping):
+            return None
+        try:
+            width = float(bounds["width"])
+            height = float(bounds["height"])
+            if width <= 0 or height <= 0:
+                return None
+            return NativeBrowserWindow(
+                pid=int(raw["pid"]),
+                window_id=int(raw["window_id"]),
+                app_name=str(raw["app_name"]),
+                title=(
+                    str(raw["title"]).strip()
+                    if raw.get("title") is not None and str(raw["title"]).strip()
+                    else None
+                ),
+                x=float(bounds["x"]),
+                y=float(bounds["y"]),
+                width=width,
+                height=height,
+                z_index=int(raw.get("z_index") or 0),
+                is_on_screen=raw.get("is_on_screen") is True,
+                on_current_space=raw.get("on_current_space") is True,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    async def _capture_observation(self) -> ComputerObservation:
+        target = self._require_target()
+        requested_max_elements = min(self.max_elements, MAX_OBSERVATION_ELEMENTS)
+        result = await self._get_driver().call_tool(
+            "get_window_state",
+            {
+                "session": self.session_id,
+                "pid": target.pid,
+                "window_id": target.window_id,
+                "include_screenshot": True,
+                "max_elements": requested_max_elements,
+            },
+        )
+        if not result.image_bytes:
+            raise CuaDriverError(
+                "cua-driver could not capture the bound browser window. Check "
+                "Screen Recording permission with `cua-driver health_report`."
+            )
+        mime_type = result.image_mime_type or str(
+            result.structured.get("screenshot_mime_type") or "image/png"
+        )
+        if mime_type not in {"image/png", "image/jpeg", "image/webp"}:
+            raise CuaDriverError(
+                f"cua-driver returned unsupported screenshot type {mime_type!r}"
+            )
+        width, height = self._screenshot_size(result)
+        viewport = Viewport(width=width, height=height, device_pixel_ratio=1.0)
+        frame_id = f"frame-{uuid4().hex}"
+        screenshot = await self.observation_store.save_screenshot(
+            session_id=self.session_id,
+            frame_id=frame_id,
+            image_bytes=result.image_bytes,
+            mime_type=mime_type,
+            viewport=viewport,
+            text_fallback=(f"Current local {target.app_name} window screenshot."),
+            metadata={
+                "browser_runtime_kind": "native_browser",
+                "pid": target.pid,
+                "window_id": target.window_id,
+            },
+        )
+        raw_elements = result.structured.get("elements")
+        elements = self._build_elements(
+            raw_elements if isinstance(raw_elements, list) else [],
+            target=target,
+        )
+        raw_element_count = self._optional_int(result.structured.get("element_count"))
+        metadata: dict[str, Any] = {
+            "browser_runtime_kind": "native_browser",
+            "native_driver": "cua-driver",
+            "application": target.app_name,
+            "pid": target.pid,
+            "window_id": target.window_id,
+            "user_takeover_available": True,
+            "delivery_mode": "background",
+            **computer_input_metadata(host_computer_input_platform()),
+            "supported_actions": [action.value for action in _SUPPORTED_ACTIONS],
+        }
+        if result.structured.get("degraded") is True:
+            metadata[ELEMENT_EXTRACTION_FAILED_KEY] = True
+            metadata["driver_degraded_reason"] = str(
+                result.structured.get("degraded_reason") or ""
+            )
+        if raw_element_count is not None and raw_element_count > len(elements):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+        if isinstance(raw_elements, list) and len(elements) < len(raw_elements):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+        if (
+            raw_element_count is not None and raw_element_count > requested_max_elements
+        ) or (
+            isinstance(raw_elements, list)
+            and len(raw_elements) >= requested_max_elements
+        ):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+            metadata[ELEMENTS_TRUNCATED_KEY] = True
+        escalation = result.structured.get("escalation")
+        if isinstance(escalation, Mapping):
+            metadata["driver_escalation"] = dict(escalation)
+        if self._last_action_result is not None:
+            metadata["last_action_result"] = self._last_action_result
+            self._last_action_result = None
+        return ComputerObservation(
+            session_id=self.session_id,
+            frame_id=frame_id,
+            environment=ComputerEnvironmentType.BROWSER,
+            viewport=viewport,
+            screenshot=screenshot,
+            elements=elements,
+            active_url=_optional_active_url(result.structured),
+            title=target.title,
+            metadata=metadata,
+        )
+
+    def _screenshot_size(self, result: CuaDriverResult) -> tuple[int, int]:
+        width = self._optional_int(result.structured.get("screenshot_width"))
+        height = self._optional_int(result.structured.get("screenshot_height"))
+        if width and height:
+            return width, height
+        image = result.image_bytes or b""
+        if image.startswith(b"\x89PNG\r\n\x1a\n") and len(image) >= 24:
+            parsed_width, parsed_height = struct.unpack(">II", image[16:24])
+            if parsed_width > 0 and parsed_height > 0:
+                return parsed_width, parsed_height
+        raise CuaDriverError("cua-driver screenshot dimensions are missing")
+
+    def _build_elements(
+        self,
+        raw_elements: list[Any],
+        *,
+        target: NativeBrowserWindow,
+    ) -> list[ComputerElement]:
+        elements: list[ComputerElement] = []
+        for raw in raw_elements[:MAX_OBSERVATION_ELEMENTS]:
+            if not isinstance(raw, Mapping):
+                continue
+            frame = raw.get("frame")
+            if not isinstance(frame, Mapping):
+                continue
+            bounds = self._normalize_element_bounds(frame, target=target)
+            if bounds is None:
+                continue
+            token = str(raw.get("element_token") or "").strip()
+            index = self._optional_int(raw.get("element_index"))
+            if not token and index is None:
+                continue
+            element_id = token or f"cua-index:{index}"
+            role = str(raw.get("role") or "").strip() or None
+            label = str(raw.get("label") or "").strip() or None
+            sensitive = self._is_sensitive_element(
+                raw,
+                role=role,
+                label=label,
+            )
+            value = str(raw.get("value") or "").strip() or None
+            metadata = {
+                "element_index": index,
+                "element_token": token or None,
+                "depth": self._optional_int(raw.get("depth")),
+                "parent_index": self._optional_int(raw.get("parent_index")),
+                "enabled": raw.get("enabled"),
+                "selected": raw.get("selected"),
+                "sensitive": sensitive,
+            }
+            return_metadata = {
+                key: value for key, value in metadata.items() if value is not None
+            }
+            elements.append(
+                ComputerElement(
+                    element_id=element_id,
+                    source=ComputerElementSource.ACCESSIBILITY,
+                    bounds=bounds,
+                    label="Sensitive input" if sensitive else label,
+                    role=role,
+                    text=None if sensitive else value,
+                    metadata=return_metadata,
+                )
+            )
+        return elements
+
+    @staticmethod
+    def _is_sensitive_element(
+        raw: Mapping[str, Any],
+        *,
+        role: str | None,
+        label: str | None,
+    ) -> bool:
+        role_text = " ".join(
+            str(value or "").casefold()
+            for value in (role, raw.get("subrole"), raw.get("input_type"))
+        )
+        if any(marker in role_text for marker in ("secure", "password")):
+            return True
+        if any(
+            raw.get(flag) is True for flag in ("sensitive", "protected", "is_password")
+        ):
+            return True
+        is_text_input = any(
+            marker in role_text for marker in ("text", "input", "field", "edit")
+        )
+        label_text = (label or "").casefold()
+        return is_text_input and any(
+            marker in label_text
+            for marker in ("password", "passcode", "security code", "verification code")
+        )
+
+    @staticmethod
+    def _normalize_element_bounds(
+        raw: Mapping[str, Any],
+        *,
+        target: NativeBrowserWindow,
+    ) -> NormalizedRect | None:
+        try:
+            x = float(raw["x"])
+            y = float(raw["y"])
+            width = float(raw["w"])
+            height = float(raw["h"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if width <= 0 or height <= 0:
+            return None
+
+        # AX frames are normally screen-relative. Some platform backends emit
+        # window-local frames, so accept that shape when subtracting the native
+        # window origin would put the entire element outside the screenshot.
+        local_x = x - target.x
+        local_y = y - target.y
+        if (
+            (
+                local_x + width <= 0
+                or local_y + height <= 0
+                or local_x >= target.width
+                or local_y >= target.height
+            )
+            and 0 <= x < target.width
+            and 0 <= y < target.height
+        ):
+            local_x = x
+            local_y = y
+
+        left = max(0.0, local_x)
+        top = max(0.0, local_y)
+        right = min(target.width, local_x + width)
+        bottom = min(target.height, local_y + height)
+        if right <= left or bottom <= top:
+            return None
+        return NormalizedRect(
+            x=left / target.width,
+            y=top / target.height,
+            width=(right - left) / target.width,
+            height=(bottom - top) / target.height,
+        )
+
+    async def _execute_action(self, action: ComputerAction) -> None:
+        if action.type is ComputerActionType.SCREENSHOT:
+            return
+        if action.type is ComputerActionType.WAIT:
+            duration_ms = action.duration_ms or 1_000
+            await asyncio.sleep(duration_ms / 1_000)
+            self._last_action_result = {
+                "effect": "confirmed",
+                "verified": True,
+            }
+            return
+        if action.type is ComputerActionType.NAVIGATE:
+            await self._navigate(action.url or "")
+            return
+
+        target = self._require_target()
+        common: dict[str, Any] = {
+            "session": self.session_id,
+            "pid": target.pid,
+            "window_id": target.window_id,
+            "delivery_mode": self._delivery_mode(action),
+        }
+        if action.type in {
+            ComputerActionType.CLICK,
+            ComputerActionType.DOUBLE_CLICK,
+        }:
+            arguments = {**common, **self._action_target_arguments(action)}
+            tool_name = (
+                "double_click"
+                if action.type is ComputerActionType.DOUBLE_CLICK
+                else "click"
+            )
+            await self._call_action(tool_name, arguments)
+            return
+        if action.type is ComputerActionType.TYPE:
+            arguments = {**common, "text": action.text or ""}
+            await self._call_action("type_text", arguments)
+            return
+        if action.type is ComputerActionType.REPLACE_TEXT:
+            x, y = self._action_point_pixels(action)
+            modifier = self._primary_driver_modifier()
+            await self._call_action(
+                "hotkey",
+                {
+                    **common,
+                    "keys": [modifier, "a"],
+                    "x": x,
+                    "y": y,
+                },
+                remember=False,
+            )
+            await self._call_action(
+                "type_text",
+                {
+                    **common,
+                    "text": action.text or "",
+                },
+            )
+            return
+        if action.type is ComputerActionType.KEYPRESS:
+            keys = [self._driver_key(key) for key in action.keys]
+            if len(keys) == 1:
+                arguments = {**common, "key": keys[0]}
+                tool_name = "press_key"
+            else:
+                arguments = {**common, "keys": keys}
+                tool_name = "hotkey"
+            await self._call_action(tool_name, arguments)
+            return
+        if action.type is ComputerActionType.SCROLL:
+            horizontal = abs(action.delta_x) > abs(action.delta_y)
+            delta = action.delta_x if horizontal else action.delta_y
+            direction = (
+                ("right" if delta > 0 else "left")
+                if horizontal
+                else ("down" if delta > 0 else "up")
+            )
+            arguments = {
+                **common,
+                "direction": direction,
+                "amount": max(1, min(20, math.ceil(abs(delta) * 10))),
+                "by": "line",
+            }
+            if action.target is not None:
+                arguments.update(self._action_target_arguments(action))
+            await self._call_action("scroll", arguments)
+            return
+        if action.type is ComputerActionType.DRAG:
+            if action.start is None or action.end is None:
+                raise ValueError("drag requires start and end points")
+            from_x, from_y = self._point_pixels(action.start)
+            to_x, to_y = self._point_pixels(action.end)
+            await self._call_action(
+                "drag",
+                {
+                    **common,
+                    "from_x": from_x,
+                    "from_y": from_y,
+                    "to_x": to_x,
+                    "to_y": to_y,
+                    "duration_ms": action.duration_ms or 500,
+                    "steps": max(
+                        1,
+                        min(50, (action.duration_ms or 500) // 25),
+                    ),
+                },
+            )
+            return
+        raise ValueError(f"unsupported native browser action: {action.type.value}")
+
+    async def _navigate(self, raw_url: str) -> None:
+        url = self._validate_navigation_url(raw_url)
+        target = self._require_target()
+        common = {
+            "session": self.session_id,
+            "pid": target.pid,
+            "window_id": target.window_id,
+            "delivery_mode": "foreground",
+        }
+        await self._call_action(
+            "hotkey",
+            {**common, "keys": [self._primary_driver_modifier(), "l"]},
+            remember=False,
+        )
+        await self._call_action(
+            "type_text",
+            {**common, "text": url},
+            remember=False,
+        )
+        await self._call_action(
+            "press_key",
+            {**common, "key": "return"},
+        )
+
+    async def _call_action(
+        self,
+        name: str,
+        arguments: Mapping[str, Any],
+        *,
+        remember: bool = True,
+    ) -> CuaDriverResult:
+        result = await self._get_driver().call_tool(name, arguments)
+        status = str(result.structured.get("status") or "").strip().lower()
+        if status in {"refused", "failed", "error"}:
+            refusal = result.structured.get("refusal")
+            detail = (
+                refusal.get("message")
+                if isinstance(refusal, Mapping)
+                else result.structured.get("message")
+            )
+            raise CuaDriverError(
+                str(detail or result.text or f"cua-driver {name} was {status}")
+            )
+        if remember:
+            metadata = {
+                field: result.structured[field]
+                for field in _ACTION_RESULT_FIELDS
+                if field in result.structured
+            }
+            if result.text:
+                metadata["summary"] = result.text[:500]
+            self._last_action_result = metadata or {
+                "effect": "unverifiable",
+                "verified": False,
+            }
+        return result
+
+    def _action_target_arguments(self, action: ComputerAction) -> dict[str, Any]:
+        target = action.target
+        if target is None:
+            return {}
+        if target.element_id is not None:
+            element = self._find_element(target.element_id)
+            token = str(element.metadata.get("element_token") or "").strip()
+            if token:
+                return {"element_token": token}
+            index = element.metadata.get("element_index")
+            if isinstance(index, int):
+                return {"element_index": index}
+        x, y = self._action_point_pixels(action)
+        return {"x": x, "y": y}
+
+    def _action_point_pixels(self, action: ComputerAction) -> tuple[float, float]:
+        target = action.target
+        if target is None:
+            raise ValueError(f"{action.type.value} requires a target")
+        if target.point is not None:
+            return self._point_pixels(target.point)
+        element = self._find_element(target.element_id or "")
+        return self._point_pixels(
+            NormalizedPoint(
+                x=element.bounds.x + element.bounds.width / 2,
+                y=element.bounds.y + element.bounds.height / 2,
+            )
+        )
+
+    def _point_pixels(self, point: NormalizedPoint) -> tuple[float, float]:
+        observation = self.current_observation
+        if observation is None:
+            raise RuntimeError("native browser action requires a current observation")
+        return (
+            point.x * observation.viewport.width,
+            point.y * observation.viewport.height,
+        )
+
+    def _find_element(self, element_id: str) -> ComputerElement:
+        observation = self.current_observation
+        if observation is None:
+            raise RuntimeError("element target requires a current observation")
+        element = next(
+            (item for item in observation.elements if item.element_id == element_id),
+            None,
+        )
+        if element is None:
+            raise ComputerTargetNotFoundError(
+                f"element {element_id!r} is not present in frame "
+                f"{observation.frame_id!r}"
+            )
+        return element
+
+    def _require_target(self) -> NativeBrowserWindow:
+        if self._target is None:
+            raise RuntimeError("native browser window has not been selected")
+        return self._target
+
+    def _validate_navigation_url(self, raw_url: str) -> str:
+        url = raw_url.strip()
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+            raise ValueError("native browser navigation requires an absolute HTTP URL")
+        reason = _navigation_block_reason(
+            url,
+            allowlist=self.navigation_allowlist,
+            denylist=self.navigation_denylist,
+        )
+        if reason is not None:
+            raise ValueError(reason)
+        return url
+
+    def _delivery_mode(self, action: ComputerAction) -> str:
+        requested = str(action.metadata.get("delivery_mode") or "").strip().lower()
+        if requested != "foreground":
+            return "background"
+        observation = self.current_observation
+        metadata = observation.metadata if observation is not None else {}
+        last_result = metadata.get("last_action_result")
+        escalations = [
+            last_result.get("escalation") if isinstance(last_result, Mapping) else None,
+            metadata.get("driver_escalation"),
+        ]
+        for escalation in escalations:
+            if (
+                isinstance(escalation, Mapping)
+                and str(escalation.get("recommended") or "").strip().lower()
+                == "foreground"
+            ):
+                return "foreground"
+        raise ValueError(
+            "foreground delivery requires a cua-driver escalation recommendation "
+            "from the current observation"
+        )
+
+    @staticmethod
+    def _driver_key(key: str) -> str:
+        normalized = key.strip().lower()
+        aliases = {
+            "meta": "cmd",
+            "command": "cmd",
+            "alt": "option",
+            "enter": "return",
+            "esc": "escape",
+            "arrowup": "up",
+            "arrowdown": "down",
+            "arrowleft": "left",
+            "arrowright": "right",
+            "page_up": "pageup",
+            "page_down": "pagedown",
+        }
+        return aliases.get(normalized, normalized)
+
+    @staticmethod
+    def _primary_driver_modifier() -> str:
+        if host_computer_input_platform() is ComputerInputPlatform.MACOS:
+            return "cmd"
+        return "ctrl"
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+
+def _normalize_host_patterns(patterns: Sequence[str] | None) -> tuple[str, ...]:
+    if not patterns:
+        return ()
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for pattern in patterns
+            if (normalized := str(pattern).strip().lower().lstrip("."))
+        )
+    )
+
+
+def _host_matches(host: str, patterns: Sequence[str]) -> bool:
+    candidate = host.strip().lower().rstrip(".")
+    return any(
+        candidate == pattern or candidate.endswith(f".{pattern}")
+        for pattern in patterns
+    )
+
+
+def _navigation_block_reason(
+    raw_url: str,
+    *,
+    allowlist: Sequence[str],
+    denylist: Sequence[str],
+) -> str | None:
+    host = urlsplit(raw_url).hostname
+    if host is None:
+        return "Native browser navigation requires a network host."
+    if _host_matches(host, denylist):
+        return f"Navigation to {host} is blocked by the configured policy."
+    if allowlist and not _host_matches(host, allowlist):
+        return f"Navigation to {host} is outside the configured allowlist."
+    return None
+
+
+def _optional_active_url(structured: Mapping[str, Any]) -> str | None:
+    for key in ("active_url", "url"):
+        value = structured.get(key)
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip()
+        if normalized.startswith(("http://", "https://", "about:")):
+            return normalized
+    return None

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import asyncio
 import math
 import struct
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlsplit
 from uuid import uuid4
 
 from ...config import (
-    get_browser_cua_driver_max_elements,
-    get_native_browser_app_name,
-    get_native_browser_enabled,
+    get_cua_driver_max_elements,
+    get_local_computer_enabled,
 )
 from .cua_driver import (
     CuaDriverClientProtocol,
@@ -45,7 +43,9 @@ from .schema import (
 from .store import ObservationStore
 
 _SUPPORTED_ACTIONS = tuple(
-    action for action in ComputerActionType if action is not ComputerActionType.MOVE
+    action
+    for action in ComputerActionType
+    if action not in {ComputerActionType.MOVE, ComputerActionType.NAVIGATE}
 )
 _ACTION_RESULT_FIELDS = (
     "path",
@@ -57,11 +57,14 @@ _ACTION_RESULT_FIELDS = (
 )
 
 CuaDriverClientFactory = Callable[[], CuaDriverClientProtocol]
-LOCAL_BROWSER_TASK_EXTENSION = "local_browser"
+LOCAL_COMPUTER_TASK_EXTENSION = "local_computer"
+LEGACY_LOCAL_BROWSER_TASK_EXTENSION = "local_browser"
+# Import compatibility for code written against the preview name.
+LOCAL_BROWSER_TASK_EXTENSION = LEGACY_LOCAL_BROWSER_TASK_EXTENSION
 
 
 @dataclass(frozen=True)
-class NativeBrowserWindow:
+class NativeComputerWindow:
     pid: int
     window_id: int
     app_name: str
@@ -72,15 +75,16 @@ class NativeBrowserWindow:
     height: float
     z_index: int
     is_on_screen: bool
-    on_current_space: bool
+    on_current_space: bool | None
 
 
-class NativeBrowserEnvironment(ComputerEnvironment):
-    """Control one local browser window through cua-driver's native MCP tools.
+class NativeComputerEnvironment(ComputerEnvironment):
+    """Control one local application window through cua-driver's native tools.
 
-    The first observation binds the task to one concrete ``(pid, window_id)``.
-    That binding is intentionally sticky: if the window closes, the environment
-    fails instead of silently taking over another browser window.
+    A caller may provide one exact ``(pid, window_id)`` selected by the user.
+    Otherwise the first observation chooses the frontmost visible window. The
+    resulting binding is sticky: if the window closes, the environment fails
+    instead of silently taking over another application.
     """
 
     def __init__(
@@ -91,9 +95,9 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         driver: CuaDriverClientProtocol | None = None,
         driver_factory: CuaDriverClientFactory | None = None,
         observation_store: ObservationStore | None = None,
+        target_pid: int | None = None,
+        target_window_id: int | None = None,
         browser_app_name: str | None = None,
-        navigation_allowlist: Sequence[str] | None = None,
-        navigation_denylist: Sequence[str] | None = None,
         max_elements: int | None = None,
         headless: bool = False,
     ) -> None:
@@ -101,31 +105,32 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         super().__init__(session_id)
         if driver is not None and driver_factory is not None:
             raise ValueError("provide either driver or driver_factory, not both")
-        if driver is None and not get_native_browser_enabled():
+        if driver is None and not get_local_computer_enabled():
             raise RuntimeError(
-                "Native browser access is disabled. Set "
-                "XAGENT_NATIVE_BROWSER_ENABLED=true only on a trusted "
+                "Local computer access is disabled. Set "
+                "XAGENT_LOCAL_COMPUTER_ENABLED=true only on a trusted "
                 "interactive Xagent host."
             )
         self.workspace = workspace
         self.observation_store = observation_store or ObservationStore(workspace)
-        self.browser_app_name = (
-            browser_app_name or get_native_browser_app_name()
-        ).strip()
-        if not self.browser_app_name:
-            raise ValueError("native browser application name must not be empty")
-        self.navigation_allowlist = _normalize_host_patterns(navigation_allowlist)
-        self.navigation_denylist = _normalize_host_patterns(navigation_denylist)
+        if (target_pid is None) != (target_window_id is None):
+            raise ValueError(
+                "target_pid and target_window_id must be provided together"
+            )
+        self.target_pid = target_pid
+        self.target_window_id = target_window_id
+        # Only legacy callers pass this value. Canonical Local computer tasks
+        # select an exact window or use the frontmost visible application.
+        self.preferred_app_name = (browser_app_name or "").strip() or None
         self.max_elements = (
-            get_browser_cua_driver_max_elements()
-            if max_elements is None
-            else max_elements
+            get_cua_driver_max_elements() if max_elements is None else max_elements
         )
         if self.max_elements <= 0:
-            raise ValueError("native browser max_elements must be positive")
+            raise ValueError("local computer max_elements must be positive")
         self._driver = driver
         self._driver_factory = driver_factory or CuaDriverMCPClient
-        self._target: NativeBrowserWindow | None = None
+        self._target: NativeComputerWindow | None = None
+        self._visible_windows: list[NativeComputerWindow] = []
         self._session_started = False
         self._last_action_result: dict[str, Any] | None = None
 
@@ -157,7 +162,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
 
     async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
         if len(batch.actions) != 1:
-            raise ValueError("native browser executes exactly one action per frame")
+            raise ValueError("local computer executes exactly one action per frame")
         action = batch.actions[0]
         supported_actions = (
             self.current_observation.metadata.get("supported_actions")
@@ -169,7 +174,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             or action.type.value not in supported_actions
         ):
             raise ValueError(
-                f"{action.type.value} is not supported by the native browser runtime"
+                f"{action.type.value} is not supported by the local computer runtime"
             )
         await self._execute_action(action)
         if action.type not in {ComputerActionType.SCREENSHOT, ComputerActionType.WAIT}:
@@ -193,10 +198,10 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             self._driver = self._driver_factory()
         return self._driver
 
-    async def _select_target(self) -> NativeBrowserWindow:
+    async def _select_target(self) -> NativeComputerWindow:
         result = await self._get_driver().call_tool(
             "list_windows",
-            {"on_screen_only": False},
+            {"on_screen_only": True},
         )
         raw_windows = result.structured.get("windows")
         if not isinstance(raw_windows, list):
@@ -207,30 +212,44 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             if isinstance(raw, Mapping)
             and (parsed := self._parse_window(raw)) is not None
         ]
-        app_name = self.browser_app_name.casefold()
-        matches = [
-            window for window in windows if window.app_name.casefold() == app_name
-        ]
-        if not matches:
-            raise ComputerTargetNotFoundError(
-                f"No local {self.browser_app_name!r} window is running. Open the "
-                "browser on the Xagent host, then request a fresh screenshot."
-            )
-        visible_matches = [
+        visible = [
             window
-            for window in matches
-            if window.on_current_space and window.is_on_screen
+            for window in windows
+            if window.is_on_screen and window.on_current_space is not False
         ]
-        if not visible_matches:
-            raise ComputerTargetNotFoundError(
-                f"No visible {self.browser_app_name!r} window is on the current "
-                "desktop. Restore and show the intended window, then request a "
-                "fresh screenshot."
+        self._visible_windows = visible
+        if self.target_pid is not None and self.target_window_id is not None:
+            exact = next(
+                (
+                    window
+                    for window in visible
+                    if window.pid == self.target_pid
+                    and window.window_id == self.target_window_id
+                ),
+                None,
             )
-        return max(visible_matches, key=lambda window: window.z_index)
+            if exact is None:
+                raise ComputerTargetNotFoundError(
+                    "The selected local computer window is no longer visible. "
+                    "Choose the window again before starting a new task."
+                )
+            return exact
+        if self.preferred_app_name:
+            preferred = [
+                window
+                for window in visible
+                if window.app_name.casefold() == self.preferred_app_name.casefold()
+            ]
+            if preferred:
+                return max(preferred, key=lambda window: window.z_index)
+        if not visible:
+            raise ComputerTargetNotFoundError(
+                "No visible application window is available on the Xagent host."
+            )
+        return max(visible, key=lambda window: window.z_index)
 
     @staticmethod
-    def _parse_window(raw: Mapping[str, Any]) -> NativeBrowserWindow | None:
+    def _parse_window(raw: Mapping[str, Any]) -> NativeComputerWindow | None:
         bounds = raw.get("bounds")
         if not isinstance(bounds, Mapping):
             return None
@@ -239,7 +258,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             height = float(bounds["height"])
             if width <= 0 or height <= 0:
                 return None
-            return NativeBrowserWindow(
+            return NativeComputerWindow(
                 pid=int(raw["pid"]),
                 window_id=int(raw["window_id"]),
                 app_name=str(raw["app_name"]),
@@ -254,7 +273,11 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 height=height,
                 z_index=int(raw.get("z_index") or 0),
                 is_on_screen=raw.get("is_on_screen") is True,
-                on_current_space=raw.get("on_current_space") is True,
+                on_current_space=(
+                    raw.get("on_current_space")
+                    if isinstance(raw.get("on_current_space"), bool)
+                    else None
+                ),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -274,7 +297,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         )
         if not result.image_bytes:
             raise CuaDriverError(
-                "cua-driver could not capture the bound browser window. Check "
+                "cua-driver could not capture the bound application window. Check "
                 "Screen Recording permission with `cua-driver health_report`."
             )
         mime_type = result.image_mime_type or str(
@@ -295,7 +318,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             viewport=viewport,
             text_fallback=(f"Current local {target.app_name} window screenshot."),
             metadata={
-                "browser_runtime_kind": "native_browser",
+                "computer_runtime_kind": "local_computer",
                 "pid": target.pid,
                 "window_id": target.window_id,
             },
@@ -307,7 +330,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         )
         raw_element_count = self._optional_int(result.structured.get("element_count"))
         metadata: dict[str, Any] = {
-            "browser_runtime_kind": "native_browser",
+            "computer_runtime_kind": "local_computer",
             "native_driver": "cua-driver",
             "application": target.app_name,
             "pid": target.pid,
@@ -316,6 +339,15 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             "delivery_mode": "background",
             **computer_input_metadata(host_computer_input_platform()),
             "supported_actions": [action.value for action in _SUPPORTED_ACTIONS],
+            "available_windows": [
+                {
+                    "pid": window.pid,
+                    "window_id": window.window_id,
+                    "application": window.app_name,
+                    "title": window.title,
+                }
+                for window in self._visible_windows[:20]
+            ],
         }
         if result.structured.get("degraded") is True:
             metadata[ELEMENT_EXTRACTION_FAILED_KEY] = True
@@ -343,7 +375,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         return ComputerObservation(
             session_id=self.session_id,
             frame_id=frame_id,
-            environment=ComputerEnvironmentType.BROWSER,
+            environment=ComputerEnvironmentType.DESKTOP,
             viewport=viewport,
             screenshot=screenshot,
             elements=elements,
@@ -368,7 +400,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         self,
         raw_elements: list[Any],
         *,
-        target: NativeBrowserWindow,
+        target: NativeComputerWindow,
     ) -> list[ComputerElement]:
         elements: list[ComputerElement] = []
         for raw in raw_elements[:MAX_OBSERVATION_ELEMENTS]:
@@ -448,7 +480,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
     def _normalize_element_bounds(
         raw: Mapping[str, Any],
         *,
-        target: NativeBrowserWindow,
+        target: NativeComputerWindow,
     ) -> NormalizedRect | None:
         try:
             x = float(raw["x"])
@@ -502,10 +534,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 "verified": True,
             }
             return
-        if action.type is ComputerActionType.NAVIGATE:
-            await self._navigate(action.url or "")
-            return
-
         target = self._require_target()
         common: dict[str, Any] = {
             "session": self.session_id,
@@ -599,31 +627,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 },
             )
             return
-        raise ValueError(f"unsupported native browser action: {action.type.value}")
-
-    async def _navigate(self, raw_url: str) -> None:
-        url = self._validate_navigation_url(raw_url)
-        target = self._require_target()
-        common = {
-            "session": self.session_id,
-            "pid": target.pid,
-            "window_id": target.window_id,
-            "delivery_mode": "foreground",
-        }
-        await self._call_action(
-            "hotkey",
-            {**common, "keys": [self._primary_driver_modifier(), "l"]},
-            remember=False,
-        )
-        await self._call_action(
-            "type_text",
-            {**common, "text": url},
-            remember=False,
-        )
-        await self._call_action(
-            "press_key",
-            {**common, "key": "return"},
-        )
+        raise ValueError(f"unsupported local computer action: {action.type.value}")
 
     async def _call_action(
         self,
@@ -690,7 +694,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
     def _point_pixels(self, point: NormalizedPoint) -> tuple[float, float]:
         observation = self.current_observation
         if observation is None:
-            raise RuntimeError("native browser action requires a current observation")
+            raise RuntimeError("local computer action requires a current observation")
         return (
             point.x * observation.viewport.width,
             point.y * observation.viewport.height,
@@ -711,24 +715,10 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             )
         return element
 
-    def _require_target(self) -> NativeBrowserWindow:
+    def _require_target(self) -> NativeComputerWindow:
         if self._target is None:
-            raise RuntimeError("native browser window has not been selected")
+            raise RuntimeError("local computer window has not been selected")
         return self._target
-
-    def _validate_navigation_url(self, raw_url: str) -> str:
-        url = raw_url.strip()
-        parsed = urlsplit(url)
-        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
-            raise ValueError("native browser navigation requires an absolute HTTP URL")
-        reason = _navigation_block_reason(
-            url,
-            allowlist=self.navigation_allowlist,
-            denylist=self.navigation_denylist,
-        )
-        if reason is not None:
-            raise ValueError(reason)
-        return url
 
     def _delivery_mode(self, action: ComputerAction) -> str:
         requested = str(action.metadata.get("delivery_mode") or "").strip().lower()
@@ -785,42 +775,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             return None
 
 
-def _normalize_host_patterns(patterns: Sequence[str] | None) -> tuple[str, ...]:
-    if not patterns:
-        return ()
-    return tuple(
-        dict.fromkeys(
-            normalized
-            for pattern in patterns
-            if (normalized := str(pattern).strip().lower().lstrip("."))
-        )
-    )
-
-
-def _host_matches(host: str, patterns: Sequence[str]) -> bool:
-    candidate = host.strip().lower().rstrip(".")
-    return any(
-        candidate == pattern or candidate.endswith(f".{pattern}")
-        for pattern in patterns
-    )
-
-
-def _navigation_block_reason(
-    raw_url: str,
-    *,
-    allowlist: Sequence[str],
-    denylist: Sequence[str],
-) -> str | None:
-    host = urlsplit(raw_url).hostname
-    if host is None:
-        return "Native browser navigation requires a network host."
-    if _host_matches(host, denylist):
-        return f"Navigation to {host} is blocked by the configured policy."
-    if allowlist and not _host_matches(host, allowlist):
-        return f"Navigation to {host} is outside the configured allowlist."
-    return None
-
-
 def _optional_active_url(structured: Mapping[str, Any]) -> str | None:
     for key in ("active_url", "url"):
         value = structured.get(key)
@@ -830,3 +784,9 @@ def _optional_active_url(structured: Mapping[str, Any]) -> str | None:
         if normalized.startswith(("http://", "https://", "about:")):
             return normalized
     return None
+
+
+# Compatibility aliases for the preview API. They intentionally point to the
+# generalized implementation instead of preserving Chrome-only semantics.
+NativeBrowserWindow = NativeComputerWindow
+NativeBrowserEnvironment = NativeComputerEnvironment

--- a/src/xagent/core/computer/native_browser_readiness.py
+++ b/src/xagent/core/computer/native_browser_readiness.py
@@ -8,29 +8,38 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ...config import get_native_browser_app_name
 from .cua_driver import CuaDriverError, CuaDriverMCPClient
 
 _READINESS_CACHE_SECONDS = 10.0
 
 
-class NativeBrowserReadinessIssue(BaseModel):
+class LocalComputerReadinessIssue(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     code: str
     message: str
 
 
-class NativeBrowserReadiness(BaseModel):
+class LocalComputerWindowSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pid: int
+    window_id: int
+    application: str
+    title: str | None = None
+
+
+class LocalComputerReadiness(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     ready: bool
     connected: bool
     attached: bool
-    application: str
+    application: str = "Local computer"
     title: str | None = None
+    windows: list[LocalComputerWindowSummary] = Field(default_factory=list)
     permissions: dict[str, bool] = Field(default_factory=dict)
-    issues: list[NativeBrowserReadinessIssue] = Field(default_factory=list)
+    issues: list[LocalComputerReadinessIssue] = Field(default_factory=list)
     message: str = ""
 
 
@@ -38,14 +47,14 @@ class NativeBrowserReadiness(BaseModel):
 class _ReadinessCache:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     expires_at: float = 0
-    value: NativeBrowserReadiness | None = None
+    value: LocalComputerReadiness | None = None
 
 
 _cache = _ReadinessCache()
 
 
-async def get_native_browser_readiness() -> NativeBrowserReadiness:
-    """Probe cua-driver and the configured browser with a short polling cache."""
+async def get_local_computer_readiness() -> LocalComputerReadiness:
+    """Probe cua-driver and visible application windows with a short cache."""
 
     now = time.monotonic()
     if _cache.value is not None and _cache.expires_at > now:
@@ -54,35 +63,33 @@ async def get_native_browser_readiness() -> NativeBrowserReadiness:
         now = time.monotonic()
         if _cache.value is not None and _cache.expires_at > now:
             return _cache.value.model_copy(deep=True)
-        value = await _probe_native_browser_readiness()
+        value = await _probe_local_computer_readiness()
         _cache.value = value
         _cache.expires_at = time.monotonic() + _READINESS_CACHE_SECONDS
         return value.model_copy(deep=True)
 
 
-def reset_native_browser_readiness_cache() -> None:
+def reset_local_computer_readiness_cache() -> None:
     _cache.value = None
     _cache.expires_at = 0
 
 
-async def _probe_native_browser_readiness() -> NativeBrowserReadiness:
-    application = get_native_browser_app_name()
+async def _probe_local_computer_readiness() -> LocalComputerReadiness:
     client = CuaDriverMCPClient()
     try:
         health, windows_result = await asyncio.gather(
             client.call_tool("health_report", {}),
-            client.call_tool("list_windows", {"on_screen_only": False}),
+            client.call_tool("list_windows", {"on_screen_only": True}),
         )
     except (CuaDriverError, FileNotFoundError, OSError) as exc:
-        issue = NativeBrowserReadinessIssue(
+        issue = LocalComputerReadinessIssue(
             code="driver_unavailable",
             message=f"cua-driver is unavailable on this Xagent host: {exc}",
         )
-        return NativeBrowserReadiness(
+        return LocalComputerReadiness(
             ready=False,
             connected=False,
             attached=False,
-            application=application,
             issues=[issue],
             message=issue.message,
         )
@@ -93,50 +100,51 @@ async def _probe_native_browser_readiness() -> NativeBrowserReadiness:
     overall = str(report.get("overall") or "").strip().lower()
     connected = overall in {"ok", "degraded"}
     permissions = _health_permissions(report)
-    window = _select_browser_window(
-        windows_result.structured.get("windows"),
-        app_name=application,
-    )
-    issues: list[NativeBrowserReadinessIssue] = []
+    windows = _visible_windows(windows_result.structured.get("windows"))
+    window = windows[0] if windows else None
+    issues: list[LocalComputerReadinessIssue] = []
     if not connected:
         issues.append(
-            NativeBrowserReadinessIssue(
+            LocalComputerReadinessIssue(
                 code="driver_unhealthy",
                 message=_health_failure_message(report),
             )
         )
     if permissions.get("screen_recording") is False:
         issues.append(
-            NativeBrowserReadinessIssue(
+            LocalComputerReadinessIssue(
                 code="screen_recording_permission_missing",
                 message="cua-driver needs Screen Recording permission.",
             )
         )
     if permissions.get("accessibility") is False:
         issues.append(
-            NativeBrowserReadinessIssue(
+            LocalComputerReadinessIssue(
                 code="accessibility_permission_missing",
                 message="cua-driver needs Accessibility permission.",
             )
         )
     if window is None:
         issues.append(
-            NativeBrowserReadinessIssue(
-                code="browser_not_found",
-                message=(
-                    f"No visible {application!r} window is on the current desktop "
-                    "of the Xagent host."
-                ),
+            LocalComputerReadinessIssue(
+                code="window_not_found",
+                message="No visible application window is available on the Xagent host.",
             )
         )
 
     title = _optional_string(window.get("title")) if window is not None else None
-    return NativeBrowserReadiness(
+    application = (
+        _optional_string(window.get("app_name"))
+        if window is not None
+        else "Local computer"
+    ) or "Local computer"
+    return LocalComputerReadiness(
         ready=not issues,
         connected=connected,
         attached=window is not None,
         application=application,
         title=title,
+        windows=[_window_summary(item) for item in windows],
         permissions=permissions,
         issues=issues,
         message=" ".join(issue.message for issue in issues),
@@ -184,25 +192,33 @@ def _health_failure_message(report: Mapping[str, Any]) -> str:
     return "cua-driver health checks failed on the Xagent host."
 
 
-def _select_browser_window(
-    raw_windows: Any,
-    *,
-    app_name: str,
-) -> Mapping[str, Any] | None:
+def _visible_windows(raw_windows: Any) -> list[Mapping[str, Any]]:
     if not isinstance(raw_windows, list):
-        return None
-    normalized = app_name.casefold()
+        return []
     matches = [
         item
         for item in raw_windows
         if isinstance(item, Mapping)
-        and str(item.get("app_name") or "").casefold() == normalized
-        and item.get("on_current_space") is True
+        and item.get("on_current_space") is not False
         and item.get("is_on_screen") is True
+        and _safe_int(item.get("pid")) > 0
+        and _safe_int(item.get("window_id")) > 0
+        and bool(_optional_string(item.get("app_name")))
     ]
-    if not matches:
-        return None
-    return max(matches, key=lambda item: _safe_int(item.get("z_index")))
+    return sorted(
+        matches,
+        key=lambda item: _safe_int(item.get("z_index")),
+        reverse=True,
+    )[:50]
+
+
+def _window_summary(window: Mapping[str, Any]) -> LocalComputerWindowSummary:
+    return LocalComputerWindowSummary(
+        pid=_safe_int(window.get("pid")),
+        window_id=_safe_int(window.get("window_id")),
+        application=_optional_string(window.get("app_name")) or "Application",
+        title=_optional_string(window.get("title")),
+    )
 
 
 def _safe_int(value: Any) -> int:
@@ -215,3 +231,11 @@ def _safe_int(value: Any) -> int:
 def _optional_string(value: Any) -> str | None:
     text = str(value).strip() if value is not None else ""
     return text or None
+
+
+# Compatibility aliases retained for code and tasks created under the preview
+# Local browser name.
+NativeBrowserReadinessIssue = LocalComputerReadinessIssue
+NativeBrowserReadiness = LocalComputerReadiness
+get_native_browser_readiness = get_local_computer_readiness
+reset_native_browser_readiness_cache = reset_local_computer_readiness_cache

--- a/src/xagent/core/computer/native_browser_readiness.py
+++ b/src/xagent/core/computer/native_browser_readiness.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...config import get_native_browser_app_name
+from .cua_driver import CuaDriverError, CuaDriverMCPClient
+
+_READINESS_CACHE_SECONDS = 10.0
+
+
+class NativeBrowserReadinessIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str
+    message: str
+
+
+class NativeBrowserReadiness(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    ready: bool
+    connected: bool
+    attached: bool
+    application: str
+    title: str | None = None
+    permissions: dict[str, bool] = Field(default_factory=dict)
+    issues: list[NativeBrowserReadinessIssue] = Field(default_factory=list)
+    message: str = ""
+
+
+@dataclass
+class _ReadinessCache:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    expires_at: float = 0
+    value: NativeBrowserReadiness | None = None
+
+
+_cache = _ReadinessCache()
+
+
+async def get_native_browser_readiness() -> NativeBrowserReadiness:
+    """Probe cua-driver and the configured browser with a short polling cache."""
+
+    now = time.monotonic()
+    if _cache.value is not None and _cache.expires_at > now:
+        return _cache.value.model_copy(deep=True)
+    async with _cache.lock:
+        now = time.monotonic()
+        if _cache.value is not None and _cache.expires_at > now:
+            return _cache.value.model_copy(deep=True)
+        value = await _probe_native_browser_readiness()
+        _cache.value = value
+        _cache.expires_at = time.monotonic() + _READINESS_CACHE_SECONDS
+        return value.model_copy(deep=True)
+
+
+def reset_native_browser_readiness_cache() -> None:
+    _cache.value = None
+    _cache.expires_at = 0
+
+
+async def _probe_native_browser_readiness() -> NativeBrowserReadiness:
+    application = get_native_browser_app_name()
+    client = CuaDriverMCPClient()
+    try:
+        health, windows_result = await asyncio.gather(
+            client.call_tool("health_report", {}),
+            client.call_tool("list_windows", {"on_screen_only": False}),
+        )
+    except (CuaDriverError, FileNotFoundError, OSError) as exc:
+        issue = NativeBrowserReadinessIssue(
+            code="driver_unavailable",
+            message=f"cua-driver is unavailable on this Xagent host: {exc}",
+        )
+        return NativeBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=application,
+            issues=[issue],
+            message=issue.message,
+        )
+    finally:
+        await client.close()
+
+    report = health.structured
+    overall = str(report.get("overall") or "").strip().lower()
+    connected = overall in {"ok", "degraded"}
+    permissions = _health_permissions(report)
+    window = _select_browser_window(
+        windows_result.structured.get("windows"),
+        app_name=application,
+    )
+    issues: list[NativeBrowserReadinessIssue] = []
+    if not connected:
+        issues.append(
+            NativeBrowserReadinessIssue(
+                code="driver_unhealthy",
+                message=_health_failure_message(report),
+            )
+        )
+    if permissions.get("screen_recording") is False:
+        issues.append(
+            NativeBrowserReadinessIssue(
+                code="screen_recording_permission_missing",
+                message="cua-driver needs Screen Recording permission.",
+            )
+        )
+    if permissions.get("accessibility") is False:
+        issues.append(
+            NativeBrowserReadinessIssue(
+                code="accessibility_permission_missing",
+                message="cua-driver needs Accessibility permission.",
+            )
+        )
+    if window is None:
+        issues.append(
+            NativeBrowserReadinessIssue(
+                code="browser_not_found",
+                message=(
+                    f"No visible {application!r} window is on the current desktop "
+                    "of the Xagent host."
+                ),
+            )
+        )
+
+    title = _optional_string(window.get("title")) if window is not None else None
+    return NativeBrowserReadiness(
+        ready=not issues,
+        connected=connected,
+        attached=window is not None,
+        application=application,
+        title=title,
+        permissions=permissions,
+        issues=issues,
+        message=" ".join(issue.message for issue in issues),
+    )
+
+
+def _health_permissions(report: Mapping[str, Any]) -> dict[str, bool]:
+    permissions: dict[str, bool] = {}
+    checks = report.get("checks")
+    if not isinstance(checks, list):
+        return permissions
+    names = {
+        "tcc_accessibility": "accessibility",
+        "ax_capability": "accessibility",
+        "tcc_screen_recording": "screen_recording",
+        "screen_capture_capability": "screen_recording",
+    }
+    for check in checks:
+        if not isinstance(check, Mapping):
+            continue
+        permission = names.get(str(check.get("name") or ""))
+        status = str(check.get("status") or "").strip().lower()
+        if permission is None or status not in {"pass", "fail"}:
+            continue
+        passed = status == "pass"
+        current = permissions.get(permission)
+        permissions[permission] = passed if current is None else current and passed
+    return permissions
+
+
+def _health_failure_message(report: Mapping[str, Any]) -> str:
+    checks = report.get("checks")
+    if isinstance(checks, list):
+        for check in checks:
+            if not isinstance(check, Mapping):
+                continue
+            if str(check.get("status") or "").lower() != "fail":
+                continue
+            message = _optional_string(check.get("message"))
+            hint = _optional_string(check.get("hint"))
+            if message and hint:
+                return f"cua-driver is unhealthy: {message} {hint}"
+            if message:
+                return f"cua-driver is unhealthy: {message}"
+    return "cua-driver health checks failed on the Xagent host."
+
+
+def _select_browser_window(
+    raw_windows: Any,
+    *,
+    app_name: str,
+) -> Mapping[str, Any] | None:
+    if not isinstance(raw_windows, list):
+        return None
+    normalized = app_name.casefold()
+    matches = [
+        item
+        for item in raw_windows
+        if isinstance(item, Mapping)
+        and str(item.get("app_name") or "").casefold() == normalized
+        and item.get("on_current_space") is True
+        and item.get("is_on_screen") is True
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda item: _safe_int(item.get("z_index")))
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _optional_string(value: Any) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ROUTER_ABILITIES = ["chat", "tool_calling"]
 _UNROUTED_ROUTER_ABILITIES = {"vision", "thinking_mode"}
 _DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
+_ENABLE_DOWNSTREAM_THINKING = {"type": "enabled", "enable": True}
 _CONTENT_PART_MODALITIES = {
     "audio": "audio",
     "audio_url": "audio",
@@ -69,6 +70,23 @@ _MODALITY_ABILITIES = {
 
 class RouterModalityRoutingError(RuntimeError):
     """The installed router cannot enforce required input modalities."""
+
+
+def _should_retry_with_thinking(
+    exc: Exception,
+    *,
+    thinking: dict[str, Any] | None,
+) -> bool:
+    if thinking is None or not (
+        thinking.get("type") == "disabled" or thinking.get("enable") is False
+    ):
+        return False
+
+    # OpenRouter currently exposes this provider constraint only through an
+    # untyped 400 response. Retry the same selected model once with reasoning
+    # enabled instead of repeating the rejected payload or rerouting.
+    exc_msg = str(exc).lower()
+    return "reasoning is mandatory" in exc_msg and "cannot be disabled" in exc_msg
 
 
 def _should_retry_without_thinking(
@@ -114,6 +132,14 @@ def _next_retry_state(
     thinking: dict[str, Any] | None,
     tool_choice: str | dict[str, Any] | None,
 ) -> tuple[str | dict[str, Any] | None, dict[str, Any] | None, str, str] | None:
+    if _should_retry_with_thinking(exc, thinking=thinking):
+        return (
+            tool_choice,
+            _ENABLE_DOWNSTREAM_THINKING,
+            "selected model requires reasoning; retrying with thinking enabled",
+            "enable_thinking",
+        )
+
     if _should_retry_without_thinking(exc, thinking=thinking, tool_choice=tool_choice):
         return (
             tool_choice,

--- a/src/xagent/core/tools/adapters/vibe/browser_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_tools.py
@@ -11,8 +11,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _has_local_browser_runtime(contribution: Any) -> bool:
-    from ....computer.native_browser import LOCAL_BROWSER_TASK_EXTENSION
+def _has_local_computer_runtime(contribution: Any) -> bool:
+    from ....computer.native_browser import (
+        LEGACY_LOCAL_BROWSER_TASK_EXTENSION,
+        LOCAL_COMPUTER_TASK_EXTENSION,
+    )
     from ....task_runtime import (
         TaskRuntimeContribution,
         full_task_runtime_contribution,
@@ -22,7 +25,8 @@ def _has_local_browser_runtime(contribution: Any) -> bool:
         return False
     full_contribution = full_task_runtime_contribution(contribution)
     return any(
-        provider_name == LOCAL_BROWSER_TASK_EXTENSION
+        provider_name
+        in {LOCAL_COMPUTER_TASK_EXTENSION, LEGACY_LOCAL_BROWSER_TASK_EXTENSION}
         and any(
             getattr(tool, "name", None) == "computer"
             for tool in provider_contribution.tools
@@ -39,12 +43,12 @@ async def create_browser_tools(config: "BaseToolConfig") -> List[Any]:
     if not config.get_browser_tools_enabled():
         return []
 
-    # A bound Local browser task contributes its own ``computer`` instance.
+    # A bound Local computer task contributes its own ``computer`` instance.
     # Suppress the Playwright browser family as one unit so the runtime tool
     # does not collide with the core tool or accidentally expose a second,
     # unrelated browser to the model.
     contribution = config.get_task_runtime_contribution()
-    if _has_local_browser_runtime(contribution):
+    if _has_local_computer_runtime(contribution):
         return []
 
     task_id = config.get_task_id()
@@ -57,3 +61,6 @@ async def create_browser_tools(config: "BaseToolConfig") -> List[Any]:
     except Exception as e:
         logger.warning(f"Failed to create browser tools: {e}")
         return []
+
+
+_has_local_browser_runtime = _has_local_computer_runtime

--- a/src/xagent/core/tools/adapters/vibe/browser_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_tools.py
@@ -11,10 +11,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _has_local_browser_runtime(contribution: Any) -> bool:
+    from ....computer.native_browser import LOCAL_BROWSER_TASK_EXTENSION
+    from ....task_runtime import (
+        TaskRuntimeContribution,
+        full_task_runtime_contribution,
+    )
+
+    if not isinstance(contribution, TaskRuntimeContribution):
+        return False
+    full_contribution = full_task_runtime_contribution(contribution)
+    return any(
+        provider_name == LOCAL_BROWSER_TASK_EXTENSION
+        and any(
+            getattr(tool, "name", None) == "computer"
+            for tool in provider_contribution.tools
+        )
+        for provider_name, provider_contribution in (
+            full_contribution.provider_contributions
+        )
+    )
+
+
 @register_tool(categories={"browser"})
 async def create_browser_tools(config: "BaseToolConfig") -> List[Any]:
     """Create browser automation tools."""
     if not config.get_browser_tools_enabled():
+        return []
+
+    # A bound Local browser task contributes its own ``computer`` instance.
+    # Suppress the Playwright browser family as one unit so the runtime tool
+    # does not collide with the core tool or accidentally expose a second,
+    # unrelated browser to the model.
+    contribution = config.get_task_runtime_contribution()
+    if _has_local_browser_runtime(contribution):
         return []
 
     task_id = config.get_task_id()

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from ....computer.browser import BrowserComputerEnvironment
 from ....computer.environment import (
@@ -16,6 +16,8 @@ from ....computer.schema import (
     ComputerActionBatch,
     ComputerActionType,
     ComputerObservation,
+    ComputerTarget,
+    NormalizedPoint,
 )
 from ....context_ref import (
     CONTEXT_REFS_KEY,
@@ -31,11 +33,17 @@ ComputerEnvironmentFactory = Callable[..., ComputerEnvironment]
 _STEP_SESSION_ARG = "_xagent_step_id"
 
 
-def _initial_screenshot_actions() -> list[ComputerAction]:
-    return [ComputerAction(type=ComputerActionType.SCREENSHOT)]
-
-
 class ComputerToolArgs(BaseModel):
+    """One flat computer action.
+
+    The public schema intentionally avoids a one-element ``actions`` array.
+    Several otherwise capable tool-calling models serialize that nested shape
+    as a string. The pre-validator still accepts the preview shape so existing
+    traces and clients remain replayable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     expected_frame_id: str | None = Field(
         default=None,
         description=(
@@ -43,46 +51,73 @@ class ComputerToolArgs(BaseModel):
             "state-changing call; omit only when requesting a fresh screenshot."
         ),
     )
-    actions: list[ComputerAction] = Field(
-        default_factory=_initial_screenshot_actions,
-        min_length=1,
-        max_length=1,
-        description=(
-            "One browser action. Coordinates are normalized from 0 to 1. Every "
-            "call returns a fresh observation before another action is planned."
-        ),
+    action: ComputerActionType = Field(
+        default=ComputerActionType.SCREENSHOT,
+        description="One action to perform. Omit for a fresh screenshot.",
     )
+    target: ComputerTarget | None = None
+    url: str | None = None
+    text: str | None = Field(default=None, max_length=65_536)
+    keys: list[str] = Field(default_factory=list, max_length=16)
+    delta_x: float = Field(default=0, ge=-1, le=1)
+    delta_y: float = Field(default=0, ge=-1, le=1)
+    start: NormalizedPoint | None = None
+    end: NormalizedPoint | None = None
+    duration_ms: int = Field(default=0, ge=0, le=30_000)
+    metadata: dict[str, Any] = Field(default_factory=dict, max_length=128)
 
     @model_validator(mode="before")
     @classmethod
-    def _lift_action_scoped_frame_id(cls, value: Any) -> Any:
-        """Normalize a common tool-call shape without weakening frame checks."""
+    def _normalize_preview_shapes(cls, value: Any) -> Any:
+        """Lift legacy nested shapes without exposing them in the JSON schema."""
 
         if not isinstance(value, Mapping):
             return value
-        raw_actions = value.get("actions")
-        if (
-            not isinstance(raw_actions, list)
-            or len(raw_actions) != 1
-            or not isinstance(raw_actions[0], Mapping)
-            or "expected_frame_id" not in raw_actions[0]
-        ):
-            return value
-
-        action = dict(raw_actions[0])
-        nested_frame_id = action.pop("expected_frame_id")
         normalized = dict(value)
-        normalized["actions"] = [action]
-        if nested_frame_id is None:
-            return normalized
-        top_level_frame_id = normalized.get("expected_frame_id")
-        if top_level_frame_id is None:
-            normalized["expected_frame_id"] = nested_frame_id
-        elif top_level_frame_id != nested_frame_id:
-            raise ValueError(
-                "action expected_frame_id conflicts with the top-level value"
-            )
+        raw_actions = normalized.pop("actions", None)
+        if raw_actions is not None:
+            if (
+                not isinstance(raw_actions, list)
+                or len(raw_actions) != 1
+                or not isinstance(raw_actions[0], Mapping)
+            ):
+                raise ValueError("actions must contain exactly one action object")
+            nested = dict(raw_actions[0])
+            nested_frame_id = nested.pop("expected_frame_id", None)
+            if nested_frame_id is not None:
+                top_level_frame_id = normalized.get("expected_frame_id")
+                if top_level_frame_id is None:
+                    normalized["expected_frame_id"] = nested_frame_id
+                elif top_level_frame_id != nested_frame_id:
+                    raise ValueError(
+                        "action expected_frame_id conflicts with the top-level value"
+                    )
+            for key, item in nested.items():
+                normalized.setdefault("action" if key == "type" else key, item)
+        raw_action = normalized.get("action")
+        if isinstance(raw_action, Mapping):
+            nested = dict(raw_action)
+            normalized.pop("action")
+            for key, item in nested.items():
+                normalized.setdefault("action" if key == "type" else key, item)
+        if "type" in normalized:
+            normalized.setdefault("action", normalized.pop("type"))
         return normalized
+
+    def to_action(self) -> ComputerAction:
+        return ComputerAction(
+            type=self.action,
+            target=self.target,
+            url=self.url,
+            text=self.text,
+            keys=self.keys,
+            delta_x=self.delta_x,
+            delta_y=self.delta_y,
+            start=self.start,
+            end=self.end,
+            duration_ms=self.duration_ms,
+            metadata=self.metadata,
+        )
 
 
 class ComputerToolResult(BaseModel):
@@ -107,12 +142,14 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         workspace: TaskWorkspace | None = None,
         environment_factory: ComputerEnvironmentFactory = BrowserComputerEnvironment,
         environment_instructions: str | None = None,
+        environment_label: str = "browser",
         headless: bool = True,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
         self._environment_factory = environment_factory
+        self._environment_label = environment_label.strip() or "computer"
         self._environment_instructions = (
             environment_instructions.strip()
             if isinstance(environment_instructions, str)
@@ -131,7 +168,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
 
     @property
     def description(self) -> str:
-        return f"""Inspect and control a browser through screenshots.
+        return f"""Inspect and control {self._environment_label} through screenshots.
 
         First request a screenshot without expected_frame_id. Inspect the returned
         image, then send exactly one action with that frame_id as expected_frame_id.
@@ -148,7 +185,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
 
     @property
     def tags(self) -> list[str]:
-        return ["browser", "computer-use", "vision", "automation"]
+        return ["computer-use", "vision", "automation"]
 
     def args_type(self) -> type[BaseModel]:
         return ComputerToolArgs
@@ -169,7 +206,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         if not session_id:
             return self._error_result(
                 session_id="",
-                error="Computer tool requires a task-scoped browser session.",
+                error="Computer tool requires a task-scoped session.",
             )
         if self._workspace is None:
             return self._error_result(
@@ -178,6 +215,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             )
         try:
             parsed = ComputerToolArgs.model_validate(raw_args)
+            action = parsed.to_action()
         except ValidationError as exc:
             environment = self._environments.get(session_id)
             current = environment.current_observation if environment else None
@@ -196,7 +234,6 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             )
             self._environments[session_id] = environment
 
-        action = parsed.actions[0]
         screenshot_only = action.type is ComputerActionType.SCREENSHOT
         try:
             current = environment.current_observation
@@ -226,7 +263,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
                     ComputerActionBatch(
                         session_id=session_id,
                         expected_frame_id=parsed.expected_frame_id,
-                        actions=parsed.actions,
+                        actions=[action],
                     )
                 )
         except (
@@ -246,7 +283,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             return self._error_result(
                 session_id=session_id,
                 frame_id=current.frame_id if current else None,
-                error=f"Browser computer action failed: {exc}",
+                error=f"Computer action failed: {exc}",
             )
 
         result = ComputerToolResult(
@@ -255,7 +292,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             frame_id=observation.frame_id,
             observation=observation,
             message=(
-                f"Browser observation captured for frame {observation.frame_id}. "
+                f"Computer observation captured for frame {observation.frame_id}. "
                 "Use this exact frame_id for the next state-changing action."
             ),
         ).model_dump(mode="json", exclude_none=True)

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -106,12 +106,22 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         task_id: str | None = None,
         workspace: TaskWorkspace | None = None,
         environment_factory: ComputerEnvironmentFactory = BrowserComputerEnvironment,
+        environment_instructions: str | None = None,
         headless: bool = True,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
         self._environment_factory = environment_factory
+        self._environment_instructions = (
+            environment_instructions.strip()
+            if isinstance(environment_instructions, str)
+            and environment_instructions.strip()
+            else (
+                "This is a new ephemeral browser. It does not inherit the user's "
+                "existing browser profile or signed-in sessions."
+            )
+        )
         self._headless = headless
         self._environments: dict[str, ComputerEnvironment] = {}
 
@@ -121,7 +131,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
 
     @property
     def description(self) -> str:
-        return """Inspect and control an isolated temporary browser through screenshots.
+        return f"""Inspect and control a browser through screenshots.
 
         First request a screenshot without expected_frame_id. Inspect the returned
         image, then send exactly one action with that frame_id as expected_frame_id.
@@ -133,8 +143,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         Use `type` to insert at the current caret and `replace_text` with a target
         to replace a field. Keyboard chords use keys such as ["CTRL", "A"].
 
-        This is a new ephemeral browser. It does not inherit the user's existing
-        browser profile or signed-in sessions.
+        {self._environment_instructions}
         """
 
     @property

--- a/src/xagent/web/api/computer.py
+++ b/src/xagent/web/api/computer.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
 
-from ...config import get_native_browser_app_name, get_native_browser_enabled
+from ...config import get_local_computer_enabled
 from ...core.computer.native_browser_readiness import (
-    NativeBrowserReadiness,
-    NativeBrowserReadinessIssue,
-    get_native_browser_readiness,
+    LocalComputerReadiness,
+    LocalComputerReadinessIssue,
+    get_local_computer_readiness,
 )
 from ..models.user import User
 from .auth import get_current_user
@@ -15,44 +15,50 @@ computer_router = APIRouter(prefix="/api/computer", tags=["computer"])
 
 
 @computer_router.get(
-    "/local-browser/readiness",
-    response_model=NativeBrowserReadiness,
+    "/local-computer/readiness",
+    response_model=LocalComputerReadiness,
 )
-async def get_local_browser_readiness(
+@computer_router.get(
+    "/local-browser/readiness",
+    response_model=LocalComputerReadiness,
+    include_in_schema=False,
+)
+async def get_local_computer_readiness_endpoint(
     response: Response,
     user: User = Depends(get_current_user),
-) -> NativeBrowserReadiness:
-    """Return whether this administrator can use the host's local browser."""
+) -> LocalComputerReadiness:
+    """Return whether this administrator can control a local host window."""
 
     response.headers["Cache-Control"] = "no-store"
-    application = get_native_browser_app_name()
-    if not get_native_browser_enabled():
-        issue = NativeBrowserReadinessIssue(
+    if not get_local_computer_enabled():
+        issue = LocalComputerReadinessIssue(
             code="disabled",
-            message="Local browser is disabled on this Xagent host.",
+            message="Local computer is disabled on this Xagent host.",
         )
-        return NativeBrowserReadiness(
+        return LocalComputerReadiness(
             ready=False,
             connected=False,
             attached=False,
-            application=application,
             issues=[issue],
             message=issue.message,
         )
     if not bool(user.is_admin):
-        issue = NativeBrowserReadinessIssue(
+        issue = LocalComputerReadinessIssue(
             code="not_authorized",
             message=(
-                "Local browser is restricted to Xagent administrators because "
-                "it controls a browser on the backend host."
+                "Local computer is restricted to Xagent administrators because "
+                "it controls applications on the backend host."
             ),
         )
-        return NativeBrowserReadiness(
+        return LocalComputerReadiness(
             ready=False,
             connected=False,
             attached=False,
-            application=application,
             issues=[issue],
             message=issue.message,
         )
-    return await get_native_browser_readiness()
+    return await get_local_computer_readiness()
+
+
+# Compatibility for tests and integrations using the preview function name.
+get_local_browser_readiness = get_local_computer_readiness_endpoint

--- a/src/xagent/web/api/computer.py
+++ b/src/xagent/web/api/computer.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response
+
+from ...config import get_native_browser_app_name, get_native_browser_enabled
+from ...core.computer.native_browser_readiness import (
+    NativeBrowserReadiness,
+    NativeBrowserReadinessIssue,
+    get_native_browser_readiness,
+)
+from ..models.user import User
+from .auth import get_current_user
+
+computer_router = APIRouter(prefix="/api/computer", tags=["computer"])
+
+
+@computer_router.get(
+    "/local-browser/readiness",
+    response_model=NativeBrowserReadiness,
+)
+async def get_local_browser_readiness(
+    response: Response,
+    user: User = Depends(get_current_user),
+) -> NativeBrowserReadiness:
+    """Return whether this administrator can use the host's local browser."""
+
+    response.headers["Cache-Control"] = "no-store"
+    application = get_native_browser_app_name()
+    if not get_native_browser_enabled():
+        issue = NativeBrowserReadinessIssue(
+            code="disabled",
+            message="Local browser is disabled on this Xagent host.",
+        )
+        return NativeBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=application,
+            issues=[issue],
+            message=issue.message,
+        )
+    if not bool(user.is_admin):
+        issue = NativeBrowserReadinessIssue(
+            code="not_authorized",
+            message=(
+                "Local browser is restricted to Xagent administrators because "
+                "it controls a browser on the backend host."
+            ),
+        )
+        return NativeBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=application,
+            issues=[issue],
+            message=issue.message,
+        )
+    return await get_native_browser_readiness()

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -71,8 +71,8 @@ from .logging_config import setup_logging
 from .models.database import init_db
 from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
 from .services.local_browser_runtime import (
-    register_local_browser_runtime,
-    unregister_local_browser_runtime,
+    register_local_computer_runtime,
+    unregister_local_computer_runtime,
 )
 from .services.orphan_upload_gc import run_orphan_upload_gc_loop
 from .services.skill_runtime import (
@@ -891,7 +891,7 @@ async def startup_event() -> None:
     # Keep built-in task-runtime providers scoped to the application lifespan.
     # Register even when disabled so task creation receives a precise 403
     # instead of an ambiguous "unknown extension" error.
-    register_local_browser_runtime()
+    register_local_computer_runtime()
 
     # Reopen process-local task admission before any trigger, command, or
     # channel ingress can create background execution work for this lifespan.
@@ -1475,7 +1475,7 @@ async def shutdown_event() -> None:
     from .services.task_runtime import shutdown_task_runtime_hook_executor
 
     shutdown_task_runtime_hook_executor()
-    unregister_local_browser_runtime()
+    unregister_local_computer_runtime()
 
     # Shutdown all sandboxes
     from .sandbox_manager import get_sandbox_manager

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -41,6 +41,7 @@ from .api.auth import auth_router
 from .api.channel import router as channel_router
 from .api.chat import chat_router
 from .api.cloud_storage import cloud_router
+from .api.computer import computer_router
 from .api.conversation_logs import router as conversation_logs_router
 from .api.custom_api import custom_api_router
 from .api.files import file_router
@@ -69,6 +70,10 @@ from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
 from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
+from .services.local_browser_runtime import (
+    register_local_browser_runtime,
+    unregister_local_browser_runtime,
+)
 from .services.orphan_upload_gc import run_orphan_upload_gc_loop
 from .services.skill_runtime import (
     SkillRuntimeSessionBoundaryError,
@@ -83,7 +88,6 @@ from .services.uploaded_file_recovery import (
 setup_logging()  # Uses XAGENT_LOG_LEVEL env var or defaults to INFO
 
 logger = logging.getLogger(__name__)
-
 
 __all__ = ["app"]
 
@@ -841,6 +845,7 @@ memory_router = MemoryManagementRouter(get_memory_store).get_router()
 app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(cloud_router)
+app.include_router(computer_router)
 app.include_router(conversation_logs_router)
 app.include_router(file_router)
 app.include_router(jobs_router)
@@ -882,6 +887,11 @@ async def startup_event() -> None:
     logger.info("Initializing database...")
     init_db()
     logger.info("Database initialized successfully")
+
+    # Keep built-in task-runtime providers scoped to the application lifespan.
+    # Register even when disabled so task creation receives a precise 403
+    # instead of an ambiguous "unknown extension" error.
+    register_local_browser_runtime()
 
     # Reopen process-local task admission before any trigger, command, or
     # channel ingress can create background execution work for this lifespan.
@@ -1465,6 +1475,7 @@ async def shutdown_event() -> None:
     from .services.task_runtime import shutdown_task_runtime_hook_executor
 
     shutdown_task_runtime_hook_executor()
+    unregister_local_browser_runtime()
 
     # Shutdown all sandboxes
     from .sandbox_manager import get_sandbox_manager

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import partial
 from typing import Any
 
-from ...config import (
-    get_native_browser_app_name,
-    get_native_browser_enabled,
-)
+from ...config import get_local_computer_enabled
 from ...core.computer.native_browser import (
-    LOCAL_BROWSER_TASK_EXTENSION,
-    NativeBrowserEnvironment,
+    LEGACY_LOCAL_BROWSER_TASK_EXTENSION,
+    LOCAL_COMPUTER_TASK_EXTENSION,
+    NativeComputerEnvironment,
 )
 from ...core.task_runtime import (
     TaskRuntimeClientError,
@@ -26,62 +25,73 @@ from .task_runtime import (
     unregister_task_extension,
 )
 
+_TARGET_AGENT_CONFIG_KEY = "local_computer_target"
 
-class LocalBrowserTaskRuntimeProvider:
-    """Bind one task to a browser window on the Xagent backend host."""
+
+class LocalComputerTaskRuntimeProvider:
+    """Bind one task to an application window on the Xagent backend host."""
+
+    def __init__(self, extension_name: str = LOCAL_COMPUTER_TASK_EXTENSION) -> None:
+        self.extension_name = extension_name
 
     def on_task_created(
         self,
         context: TaskRuntimeContext,
         configuration: Mapping[str, Any],
     ) -> None:
-        if configuration:
+        target = _validate_target_configuration(configuration)
+        if not get_local_computer_enabled():
             raise TaskRuntimeClientError(
-                "Local browser does not accept per-task configuration."
-            )
-        if not get_native_browser_enabled():
-            raise TaskRuntimeClientError(
-                "Local browser is disabled on this Xagent host.",
+                "Local computer is disabled on this Xagent host.",
                 status_code=403,
             )
         if not _task_owner_is_admin(context):
             raise TaskRuntimeClientError(
-                "Local browser is restricted to Xagent administrators because "
-                "it controls a browser on the backend host.",
+                "Local computer is restricted to Xagent administrators because "
+                "it controls applications on the backend host.",
                 status_code=403,
             )
+        if target is not None:
+            _store_task_target(context, target)
 
     def build_runtime(
         self,
         context: TaskRuntimeContext,
     ) -> TaskRuntimeContribution | None:
-        if not _task_is_bound(context):
+        if not _task_is_bound(context, self.extension_name):
             return None
         if context.workspace is None:
-            raise RuntimeError("Local browser requires a task workspace")
+            raise RuntimeError("Local computer requires a task workspace")
 
-        application = get_native_browser_app_name()
+        target = _task_target(context)
+        environment_factory = partial(
+            NativeComputerEnvironment,
+            target_pid=target.get("pid") if target else None,
+            target_window_id=target.get("window_id") if target else None,
+        )
         tool = ComputerTool(
             task_id=str(context.task_id),
             workspace=context.workspace,
-            environment_factory=NativeBrowserEnvironment,
+            environment_factory=environment_factory,
+            environment_label="the selected local application window",
             headless=False,
             environment_instructions=(
-                f"This task controls one visible {application} window on the "
-                "same host as Xagent through cua-driver. It uses that browser's "
-                "existing profile and signed-in sessions. The first screenshot "
-                "locks the task to one concrete window; never switch to another "
-                "window if it closes. Actions use background delivery unless the "
-                "current observation explicitly recommends foreground delivery. "
-                "Never ask the user to reveal credentials."
+                "This task controls one application window on the same host as "
+                "Xagent through cua-driver. The selected window may be a browser "
+                "or any other supported desktop application and may contain the "
+                "user's existing signed-in state. The first screenshot locks the "
+                "task to that exact window; never switch windows silently. "
+                "Browser-only navigation belongs to the Browser runtime. Actions "
+                "use background delivery unless the observation explicitly "
+                "recommends foreground delivery. Never ask for credentials."
             ),
         )
         return TaskRuntimeContribution(
             tools=(tool,),
             environment=(
-                f"Local browser is enabled for this task. Operate the visible "
-                f"{application} window with the computer tool. This is the "
-                "backend host browser, not a Chrome extension or remote relay."
+                "Local computer is enabled for this task. Operate the selected "
+                "application window with the computer tool. This is the Xagent "
+                "backend host, not a browser extension or remote relay."
             ),
             preferred_input_modalities=("image",),
         )
@@ -90,13 +100,16 @@ class LocalBrowserTaskRuntimeProvider:
         self,
         context: TaskRuntimeContext,
     ) -> Mapping[str, Any] | None:
-        if not _task_is_bound(context):
+        if not _task_is_bound(context, self.extension_name):
             return None
-        return {
-            "kind": "local_browser",
-            "application": get_native_browser_app_name(),
-            "enabled": get_native_browser_enabled(),
+        target = _task_target(context)
+        metadata: dict[str, Any] = {
+            "kind": "local_computer",
+            "enabled": get_local_computer_enabled(),
         }
+        if target:
+            metadata["target"] = target
+        return metadata
 
     def on_task_deleted(self, context: TaskRuntimeContext) -> None:
         # The task-scoped ComputerTool owns cua-driver and closes it through
@@ -104,31 +117,36 @@ class LocalBrowserTaskRuntimeProvider:
         del context
 
 
-def register_local_browser_runtime() -> None:
+def register_local_computer_runtime() -> None:
     """Register the built-in provider once for this web process."""
 
-    if LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions():
+    if LOCAL_COMPUTER_TASK_EXTENSION not in registered_task_extensions():
         register_task_extension(
-            LOCAL_BROWSER_TASK_EXTENSION,
-            LocalBrowserTaskRuntimeProvider(),
+            LOCAL_COMPUTER_TASK_EXTENSION,
+            LocalComputerTaskRuntimeProvider(),
+        )
+    if LEGACY_LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions():
+        register_task_extension(
+            LEGACY_LOCAL_BROWSER_TASK_EXTENSION,
+            LocalComputerTaskRuntimeProvider(LEGACY_LOCAL_BROWSER_TASK_EXTENSION),
         )
 
 
-def unregister_local_browser_runtime() -> None:
+def unregister_local_computer_runtime() -> None:
     """Remove the built-in provider at the end of the web-app lifespan."""
 
-    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+    unregister_task_extension(LOCAL_COMPUTER_TASK_EXTENSION)
+    unregister_task_extension(LEGACY_LOCAL_BROWSER_TASK_EXTENSION)
 
 
-def _task_is_bound(context: TaskRuntimeContext) -> bool:
+def _task_is_bound(context: TaskRuntimeContext, extension_name: str) -> bool:
     session = context.session_factory()
     try:
         task = session.query(Task).filter(Task.id == context.task_id).first()
         if task is None or int(task.user_id) != context.user_id:
             return False
-        return (
-            LOCAL_BROWSER_TASK_EXTENSION
-            in task_extension_bindings_from_agent_config(task.agent_config)
+        return extension_name in task_extension_bindings_from_agent_config(
+            task.agent_config
         )
     finally:
         session.close()
@@ -141,3 +159,69 @@ def _task_owner_is_admin(context: TaskRuntimeContext) -> bool:
         return bool(user is not None and user.is_admin)
     finally:
         session.close()
+
+
+def _validate_target_configuration(
+    configuration: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    if not configuration:
+        return None
+    allowed = {"pid", "window_id", "application", "title"}
+    unexpected = set(configuration) - allowed
+    if unexpected:
+        raise TaskRuntimeClientError(
+            "Local computer configuration contains unsupported fields: "
+            + ", ".join(sorted(unexpected))
+        )
+    try:
+        pid = int(configuration["pid"])
+        window_id = int(configuration["window_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TaskRuntimeClientError(
+            "Local computer requires integer pid and window_id values."
+        ) from exc
+    if pid <= 0 or window_id <= 0:
+        raise TaskRuntimeClientError(
+            "Local computer pid and window_id must be positive."
+        )
+    target: dict[str, Any] = {"pid": pid, "window_id": window_id}
+    for key in ("application", "title"):
+        value = str(configuration.get(key) or "").strip()
+        if value:
+            target[key] = value[:512]
+    return target
+
+
+def _store_task_target(
+    context: TaskRuntimeContext,
+    target: Mapping[str, Any],
+) -> None:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            raise TaskRuntimeClientError("Local computer task was not found.")
+        agent_config = dict(task.agent_config or {})
+        agent_config[_TARGET_AGENT_CONFIG_KEY] = dict(target)
+        task.agent_config = agent_config
+        session.commit()
+    finally:
+        session.close()
+
+
+def _task_target(context: TaskRuntimeContext) -> dict[str, Any] | None:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            return None
+        raw = (task.agent_config or {}).get(_TARGET_AGENT_CONFIG_KEY)
+        return dict(raw) if isinstance(raw, Mapping) else None
+    finally:
+        session.close()
+
+
+# Preview-name compatibility for imports and app lifespan wiring.
+LocalBrowserTaskRuntimeProvider = LocalComputerTaskRuntimeProvider
+register_local_browser_runtime = register_local_computer_runtime
+unregister_local_browser_runtime = unregister_local_computer_runtime

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ...config import (
+    get_native_browser_app_name,
+    get_native_browser_enabled,
+)
+from ...core.computer.native_browser import (
+    LOCAL_BROWSER_TASK_EXTENSION,
+    NativeBrowserEnvironment,
+)
+from ...core.task_runtime import (
+    TaskRuntimeClientError,
+    TaskRuntimeContext,
+    TaskRuntimeContribution,
+)
+from ...core.tools.adapters.vibe.computer import ComputerTool
+from ..models.task import Task
+from ..models.user import User
+from .task_runtime import (
+    register_task_extension,
+    registered_task_extensions,
+    task_extension_bindings_from_agent_config,
+    unregister_task_extension,
+)
+
+
+class LocalBrowserTaskRuntimeProvider:
+    """Bind one task to a browser window on the Xagent backend host."""
+
+    def on_task_created(
+        self,
+        context: TaskRuntimeContext,
+        configuration: Mapping[str, Any],
+    ) -> None:
+        if configuration:
+            raise TaskRuntimeClientError(
+                "Local browser does not accept per-task configuration."
+            )
+        if not get_native_browser_enabled():
+            raise TaskRuntimeClientError(
+                "Local browser is disabled on this Xagent host.",
+                status_code=403,
+            )
+        if not _task_owner_is_admin(context):
+            raise TaskRuntimeClientError(
+                "Local browser is restricted to Xagent administrators because "
+                "it controls a browser on the backend host.",
+                status_code=403,
+            )
+
+    def build_runtime(
+        self,
+        context: TaskRuntimeContext,
+    ) -> TaskRuntimeContribution | None:
+        if not _task_is_bound(context):
+            return None
+        if context.workspace is None:
+            raise RuntimeError("Local browser requires a task workspace")
+
+        application = get_native_browser_app_name()
+        tool = ComputerTool(
+            task_id=str(context.task_id),
+            workspace=context.workspace,
+            environment_factory=NativeBrowserEnvironment,
+            headless=False,
+            environment_instructions=(
+                f"This task controls one visible {application} window on the "
+                "same host as Xagent through cua-driver. It uses that browser's "
+                "existing profile and signed-in sessions. The first screenshot "
+                "locks the task to one concrete window; never switch to another "
+                "window if it closes. Actions use background delivery unless the "
+                "current observation explicitly recommends foreground delivery. "
+                "Never ask the user to reveal credentials."
+            ),
+        )
+        return TaskRuntimeContribution(
+            tools=(tool,),
+            environment=(
+                f"Local browser is enabled for this task. Operate the visible "
+                f"{application} window with the computer tool. This is the "
+                "backend host browser, not a Chrome extension or remote relay."
+            ),
+            preferred_input_modalities=("image",),
+        )
+
+    def public_metadata(
+        self,
+        context: TaskRuntimeContext,
+    ) -> Mapping[str, Any] | None:
+        if not _task_is_bound(context):
+            return None
+        return {
+            "kind": "local_browser",
+            "application": get_native_browser_app_name(),
+            "enabled": get_native_browser_enabled(),
+        }
+
+    def on_task_deleted(self, context: TaskRuntimeContext) -> None:
+        # The task-scoped ComputerTool owns cua-driver and closes it through
+        # normal AgentService teardown. The binding itself has no durable state.
+        del context
+
+
+def register_local_browser_runtime() -> None:
+    """Register the built-in provider once for this web process."""
+
+    if LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions():
+        register_task_extension(
+            LOCAL_BROWSER_TASK_EXTENSION,
+            LocalBrowserTaskRuntimeProvider(),
+        )
+
+
+def unregister_local_browser_runtime() -> None:
+    """Remove the built-in provider at the end of the web-app lifespan."""
+
+    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def _task_is_bound(context: TaskRuntimeContext) -> bool:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            return False
+        return (
+            LOCAL_BROWSER_TASK_EXTENSION
+            in task_extension_bindings_from_agent_config(task.agent_config)
+        )
+    finally:
+        session.close()
+
+
+def _task_owner_is_admin(context: TaskRuntimeContext) -> bool:
+    session = context.session_factory()
+    try:
+        user = session.query(User).filter(User.id == context.user_id).first()
+        return bool(user is not None and user.is_admin)
+    finally:
+        session.close()

--- a/tests/core/computer/test_computer_tool.py
+++ b/tests/core/computer/test_computer_tool.py
@@ -90,12 +90,8 @@ async def test_computer_tool_requires_initial_screenshot_then_expected_frame() -
 
     missing_frame = await tool.run_json_async(
         {
-            "actions": [
-                {
-                    "type": "click",
-                    "target": {"point": {"x": 0.5, "y": 0.5}},
-                }
-            ]
+            "action": "click",
+            "target": {"point": {"x": 0.5, "y": 0.5}},
         }
     )
     assert missing_frame["success"] is False
@@ -104,12 +100,8 @@ async def test_computer_tool_requires_initial_screenshot_then_expected_frame() -
     acted = await tool.run_json_async(
         {
             "expected_frame_id": "frame-1",
-            "actions": [
-                {
-                    "type": "click",
-                    "target": {"point": {"x": 0.5, "y": 0.5}},
-                }
-            ],
+            "action": "click",
+            "target": {"point": {"x": 0.5, "y": 0.5}},
         }
     )
 
@@ -204,7 +196,7 @@ async def test_computer_tool_returns_validation_error_with_current_frame() -> No
 
 
 def test_computer_tool_accepts_only_one_action_per_observation() -> None:
-    with pytest.raises(ValueError, match="at most 1"):
+    with pytest.raises(ValueError, match="exactly one action object"):
         ComputerTool(
             task_id="task-1",
             workspace=object(),  # type: ignore[arg-type]
@@ -212,6 +204,31 @@ def test_computer_tool_accepts_only_one_action_per_observation() -> None:
         ).args_type().model_validate(
             {"actions": [{"type": "screenshot"}, {"type": "screenshot"}]}
         )
+
+
+def test_computer_tool_exposes_flat_action_schema_and_accepts_legacy_shape() -> None:
+    args_type = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=EnvironmentFactory(),
+    ).args_type()
+
+    schema = args_type.model_json_schema()
+    assert "action" in schema["properties"]
+    assert "actions" not in schema["properties"]
+    parsed = args_type.model_validate(
+        {
+            "expected_frame_id": "frame-1",
+            "actions": [
+                {
+                    "type": "click",
+                    "target": {"point": {"x": 0.5, "y": 0.5}},
+                }
+            ],
+        }
+    )
+    assert parsed.action.value == "click"
+    assert parsed.to_action().target is not None
 
 
 @pytest.mark.asyncio

--- a/tests/core/computer/test_cua_driver_client.py
+++ b/tests/core/computer/test_cua_driver_client.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from xagent.core.computer import cua_driver
+from xagent.core.computer.cua_driver import CuaDriverError, CuaDriverMCPClient
+
+
+class FakeSession:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.initialized = False
+        self.closed = False
+
+    async def __aenter__(self) -> "FakeSession":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        self.closed = True
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if name == "failure":
+            return CallToolResult(
+                isError=True,
+                content=[TextContent(type="text", text="permission denied")],
+            )
+        return CallToolResult(
+            content=[
+                TextContent(type="text", text=f"{name} done"),
+                ImageContent(
+                    type="image",
+                    data=base64.b64encode(b"png").decode(),
+                    mimeType="image/png",
+                ),
+            ],
+            structuredContent={"name": name},
+        )
+
+
+class BlockingSession(FakeSession):
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        super().__init__(*_args, **_kwargs)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if name == "blocking":
+            self.started.set()
+            await self.release.wait()
+        return CallToolResult(
+            content=[TextContent(type="text", text=f"{name} done")],
+            structuredContent={"name": name},
+        )
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_serializes_calls_on_owned_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions: list[FakeSession] = []
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    def fake_session(*args: Any, **kwargs: Any) -> FakeSession:
+        session = FakeSession(*args, **kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", fake_session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    first, second = await asyncio.gather(
+        client.call_tool("one", {"value": 1}),
+        client.call_tool("two", {"value": 2}),
+    )
+    await client.close()
+
+    assert first.structured == {"name": "one"}
+    assert first.image_bytes == b"png"
+    assert second.text == "two done"
+    assert len(sessions) == 1
+    assert sessions[0].initialized is True
+    assert sessions[0].calls == [
+        ("one", {"value": 1}),
+        ("two", {"value": 2}),
+    ]
+    assert sessions[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_surfaces_mcp_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", FakeSession)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    with pytest.raises(CuaDriverError, match="permission denied"):
+        await client.call_tool("failure")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_skips_cancelled_queued_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = BlockingSession()
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", lambda *_args, **_kwargs: session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    blocking = asyncio.create_task(client.call_tool("blocking"))
+    await session.started.wait()
+    stale = asyncio.create_task(client.call_tool("stale"))
+    while client._queue is None or client._queue.qsize() < 1:
+        await asyncio.sleep(0)
+
+    stale.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stale
+    session.release.set()
+
+    assert (await blocking).structured == {"name": "blocking"}
+    await client.close()
+    assert session.calls == [("blocking", {})]

--- a/tests/core/computer/test_cua_driver_client.py
+++ b/tests/core/computer/test_cua_driver_client.py
@@ -79,7 +79,8 @@ async def test_cua_driver_client_serializes_calls_on_owned_worker(
     sessions: list[FakeSession] = []
 
     @asynccontextmanager
-    async def fake_stdio(*_args: Any, **_kwargs: Any):
+    async def fake_stdio(*_args: Any, **kwargs: Any):
+        assert kwargs["errlog"].fileno() >= 0
         yield object(), object()
 
     def fake_session(*args: Any, **kwargs: Any) -> FakeSession:

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.cua_driver import CuaDriverResult
+from xagent.core.computer.native_browser import NativeBrowserEnvironment
+from xagent.core.computer.schema import (
+    COMPUTER_FRAME_ID_METADATA_KEY,
+    COMPUTER_SESSION_ID_METADATA_KEY,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerTarget,
+)
+from xagent.core.context_ref import ContextReference
+
+
+class FakeObservationStore:
+    async def save_screenshot(self, **kwargs: Any) -> ContextReference:
+        return ContextReference(
+            file_ref={
+                "file_id": "native-shot",
+                "filename": "native.png",
+                "mime_type": kwargs["mime_type"],
+            },
+            metadata={
+                COMPUTER_SESSION_ID_METADATA_KEY: kwargs["session_id"],
+                COMPUTER_FRAME_ID_METADATA_KEY: kwargs["frame_id"],
+            },
+        )
+
+
+class FakeCuaDriver:
+    def __init__(
+        self,
+        *,
+        windows: list[dict[str, Any]] | None = None,
+        escalation: dict[str, Any] | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+        self.windows = windows if windows is not None else self._default_windows()
+        self.escalation = escalation
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> CuaDriverResult:
+        payload = dict(arguments or {})
+        self.calls.append((name, payload))
+        if name == "list_windows":
+            return CuaDriverResult(structured={"windows": self.windows})
+        if name == "get_window_state":
+            structured: dict[str, Any] = {
+                "window_id": payload["window_id"],
+                "pid": payload["pid"],
+                "url": "https://example.com/inbox",
+                "element_count": 2,
+                "screenshot_width": 1200,
+                "screenshot_height": 800,
+                "elements": [
+                    {
+                        "element_index": 4,
+                        "element_token": "snapshot-1:4",
+                        "role": "AXButton",
+                        "label": "Continue",
+                        "frame": {"x": 200, "y": 300, "w": 200, "h": 80},
+                    },
+                    {
+                        "element_index": 5,
+                        "element_token": "snapshot-1:5",
+                        "role": "AXSecureTextField",
+                        "label": "Password",
+                        "value": "do-not-leak",
+                        "frame": {"x": 300, "y": 450, "w": 300, "h": 50},
+                    },
+                ],
+            }
+            if self.escalation is not None:
+                structured["escalation"] = self.escalation
+            return CuaDriverResult(
+                structured=structured,
+                image_bytes=b"native-png",
+                image_mime_type="image/png",
+            )
+        if name == "health_report":
+            return CuaDriverResult(structured={"schema_version": "1", "overall": "ok"})
+        return CuaDriverResult(
+            structured={"effect": "confirmed", "verified": True},
+            text=f"{name} completed",
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+    @staticmethod
+    def _default_windows() -> list[dict[str, Any]]:
+        return [
+            {
+                "window_id": 10,
+                "pid": 100,
+                "app_name": "Google Chrome",
+                "title": "Background",
+                "bounds": {"x": 10, "y": 10, "width": 900, "height": 700},
+                "z_index": 1,
+                "is_on_screen": True,
+                "on_current_space": False,
+            },
+            {
+                "window_id": 20,
+                "pid": 200,
+                "app_name": "Google Chrome",
+                "title": "Inbox",
+                "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
+                "z_index": 9,
+                "is_on_screen": True,
+                "on_current_space": True,
+            },
+        ]
+
+
+def make_environment(driver: FakeCuaDriver) -> NativeBrowserEnvironment:
+    return NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+    )
+
+
+def batch(frame_id: str, action: ComputerAction) -> ComputerActionBatch:
+    return ComputerActionBatch(
+        session_id="task-1",
+        expected_frame_id=frame_id,
+        actions=[action],
+    )
+
+
+def test_native_browser_requires_explicit_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+
+    with pytest.raises(RuntimeError, match="Native browser access is disabled"):
+        NativeBrowserEnvironment(session_id="task-1", workspace=object())
+
+
+@pytest.mark.asyncio
+async def test_native_browser_binds_frontmost_window_and_redacts_password() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+
+    observation = await environment.observe()
+
+    assert observation.title == "Inbox"
+    assert observation.active_url == "https://example.com/inbox"
+    assert observation.viewport.width == 1200
+    assert observation.metadata["pid"] == 200
+    assert observation.metadata["window_id"] == 20
+    assert "move" not in observation.metadata["supported_actions"]
+    assert observation.elements[0].element_id == "snapshot-1:4"
+    assert observation.elements[1].label == "Sensitive input"
+    assert observation.elements[1].text is None
+    assert "do-not-leak" not in observation.model_dump_json()
+    assert [name for name, _payload in driver.calls[:3]] == [
+        "start_session",
+        "list_windows",
+        "get_window_state",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_browser_click_uses_bound_window_and_element_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    second = await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+            ),
+        )
+    )
+
+    name, payload = driver.calls[3]
+    assert name == "click"
+    assert payload["pid"] == 200
+    assert payload["window_id"] == 20
+    assert payload["element_token"] == "snapshot-1:4"
+    assert payload["delivery_mode"] == "background"
+    assert second.metadata["last_action_result"]["effect"] == "confirmed"
+    assert [name for name, _payload in driver.calls].count("list_windows") == 1
+
+
+@pytest.mark.asyncio
+async def test_native_browser_requires_driver_proof_for_foreground_delivery() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    with pytest.raises(ValueError, match="escalation recommendation"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="snapshot-1:4"),
+                    metadata={"delivery_mode": "foreground"},
+                ),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_browser_allows_driver_recommended_foreground_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+    driver = FakeCuaDriver(
+        escalation={"recommended": "foreground", "reason": "background did not land"}
+    )
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+                metadata={"delivery_mode": "foreground"},
+            ),
+        )
+    )
+
+    assert driver.calls[3][1]["delivery_mode"] == "foreground"
+
+
+@pytest.mark.asyncio
+async def test_native_browser_defensively_rejects_incomplete_drag() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+    invalid_drag = ComputerAction.model_construct(
+        type=ComputerActionType.DRAG,
+        target=None,
+        url=None,
+        text=None,
+        keys=[],
+        delta_x=0,
+        delta_y=0,
+        start=None,
+        end=None,
+        duration_ms=0,
+        metadata={},
+    )
+
+    with pytest.raises(ValueError, match="drag requires start and end points"):
+        await environment.execute(batch(first.frame_id, invalid_drag))
+
+
+@pytest.mark.asyncio
+async def test_native_browser_navigation_and_teardown_use_driver() -> None:
+    driver = FakeCuaDriver()
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        navigation_allowlist=["example.com"],
+    )
+    first = await environment.observe()
+
+    await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.NAVIGATE,
+                url="https://example.com/account",
+            ),
+        )
+    )
+    await environment.close()
+
+    action_calls = driver.calls[3:6]
+    assert [name for name, _payload in action_calls] == [
+        "hotkey",
+        "type_text",
+        "press_key",
+    ]
+    assert all(payload["delivery_mode"] == "foreground" for _, payload in action_calls)
+    assert ("end_session", {"session": "task-1"}) in driver.calls
+    assert driver.closed is True
+    assert environment.closed is True
+
+
+@pytest.mark.asyncio
+async def test_native_browser_refuses_missing_or_hidden_browser() -> None:
+    driver = FakeCuaDriver(windows=[])
+    with pytest.raises(RuntimeError, match="No local 'Google Chrome' window"):
+        await make_environment(driver).observe()
+
+    hidden = FakeCuaDriver(
+        windows=[
+            {
+                "window_id": 10,
+                "pid": 100,
+                "app_name": "Google Chrome",
+                "title": "Hidden",
+                "bounds": {"x": 10, "y": 10, "width": 900, "height": 700},
+                "z_index": 1,
+                "is_on_screen": False,
+                "on_current_space": False,
+            }
+        ]
+    )
+    with pytest.raises(RuntimeError, match="No visible 'Google Chrome' window"):
+        await make_environment(hidden).observe()

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from xagent.core.computer.cua_driver import CuaDriverResult
-from xagent.core.computer.native_browser import NativeBrowserEnvironment
+from xagent.core.computer.native_browser import NativeComputerEnvironment
 from xagent.core.computer.schema import (
     COMPUTER_FRAME_ID_METADATA_KEY,
     COMPUTER_SESSION_ID_METADATA_KEY,
@@ -122,8 +122,8 @@ class FakeCuaDriver:
         ]
 
 
-def make_environment(driver: FakeCuaDriver) -> NativeBrowserEnvironment:
-    return NativeBrowserEnvironment(
+def make_environment(driver: FakeCuaDriver) -> NativeComputerEnvironment:
+    return NativeComputerEnvironment(
         session_id="task-1",
         workspace=object(),
         driver=driver,
@@ -139,17 +139,18 @@ def batch(frame_id: str, action: ComputerAction) -> ComputerActionBatch:
     )
 
 
-def test_native_browser_requires_explicit_enablement(
+def test_local_computer_requires_explicit_enablement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+    monkeypatch.delenv("XAGENT_LOCAL_COMPUTER_ENABLED", raising=False)
 
-    with pytest.raises(RuntimeError, match="Native browser access is disabled"):
-        NativeBrowserEnvironment(session_id="task-1", workspace=object())
+    with pytest.raises(RuntimeError, match="Local computer access is disabled"):
+        NativeComputerEnvironment(session_id="task-1", workspace=object())
 
 
 @pytest.mark.asyncio
-async def test_native_browser_binds_frontmost_window_and_redacts_password() -> None:
+async def test_local_computer_binds_frontmost_window_and_redacts_password() -> None:
     driver = FakeCuaDriver()
     environment = make_environment(driver)
 
@@ -160,7 +161,13 @@ async def test_native_browser_binds_frontmost_window_and_redacts_password() -> N
     assert observation.viewport.width == 1200
     assert observation.metadata["pid"] == 200
     assert observation.metadata["window_id"] == 20
+    assert observation.environment.value == "desktop"
+    assert observation.metadata["computer_runtime_kind"] == "local_computer"
+    assert (
+        observation.metadata["available_windows"][0]["application"] == "Google Chrome"
+    )
     assert "move" not in observation.metadata["supported_actions"]
+    assert "navigate" not in observation.metadata["supported_actions"]
     assert observation.elements[0].element_id == "snapshot-1:4"
     assert observation.elements[1].label == "Sensitive input"
     assert observation.elements[1].text is None
@@ -275,44 +282,37 @@ async def test_native_browser_defensively_rejects_incomplete_drag() -> None:
 
 
 @pytest.mark.asyncio
-async def test_native_browser_navigation_and_teardown_use_driver() -> None:
+async def test_local_computer_rejects_browser_navigation_and_tears_down() -> None:
     driver = FakeCuaDriver()
-    environment = NativeBrowserEnvironment(
+    environment = NativeComputerEnvironment(
         session_id="task-1",
         workspace=object(),
         driver=driver,
         observation_store=FakeObservationStore(),  # type: ignore[arg-type]
-        navigation_allowlist=["example.com"],
     )
     first = await environment.observe()
 
-    await environment.execute(
-        batch(
-            first.frame_id,
-            ComputerAction(
-                type=ComputerActionType.NAVIGATE,
-                url="https://example.com/account",
-            ),
+    with pytest.raises(ValueError, match="not supported"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.NAVIGATE,
+                    url="https://example.com/account",
+                ),
+            )
         )
-    )
     await environment.close()
 
-    action_calls = driver.calls[3:6]
-    assert [name for name, _payload in action_calls] == [
-        "hotkey",
-        "type_text",
-        "press_key",
-    ]
-    assert all(payload["delivery_mode"] == "foreground" for _, payload in action_calls)
     assert ("end_session", {"session": "task-1"}) in driver.calls
     assert driver.closed is True
     assert environment.closed is True
 
 
 @pytest.mark.asyncio
-async def test_native_browser_refuses_missing_or_hidden_browser() -> None:
+async def test_local_computer_refuses_missing_or_hidden_window() -> None:
     driver = FakeCuaDriver(windows=[])
-    with pytest.raises(RuntimeError, match="No local 'Google Chrome' window"):
+    with pytest.raises(RuntimeError, match="No visible application window"):
         await make_environment(driver).observe()
 
     hidden = FakeCuaDriver(
@@ -329,5 +329,36 @@ async def test_native_browser_refuses_missing_or_hidden_browser() -> None:
             }
         ]
     )
-    with pytest.raises(RuntimeError, match="No visible 'Google Chrome' window"):
+    with pytest.raises(RuntimeError, match="No visible application window"):
         await make_environment(hidden).observe()
+
+
+@pytest.mark.asyncio
+async def test_local_computer_honors_exact_user_selected_window() -> None:
+    driver = FakeCuaDriver()
+    environment = NativeComputerEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=100,
+        target_window_id=10,
+    )
+
+    # Window 10 is on another Space and is therefore not a valid selected target.
+    with pytest.raises(RuntimeError, match="no longer visible"):
+        await environment.observe()
+
+    visible_driver = FakeCuaDriver()
+    visible_driver.windows[0]["on_current_space"] = True
+    selected = NativeComputerEnvironment(
+        session_id="task-2",
+        workspace=object(),
+        driver=visible_driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=100,
+        target_window_id=10,
+    )
+    observation = await selected.observe()
+    assert observation.metadata["pid"] == 100
+    assert observation.metadata["window_id"] == 10

--- a/tests/core/computer/test_native_browser_readiness.py
+++ b/tests/core/computer/test_native_browser_readiness.py
@@ -12,12 +12,14 @@ class FakeClient:
     def __init__(self, responses: dict[str, CuaDriverResult | Exception]) -> None:
         self.responses = responses
         self.closed = False
+        self.calls: list[tuple[str, dict[str, Any]]] = []
 
     async def call_tool(
         self,
         name: str,
-        _arguments: dict[str, Any],
+        arguments: dict[str, Any],
     ) -> CuaDriverResult:
+        self.calls.append((name, arguments))
         response = self.responses[name]
         if isinstance(response, Exception):
             raise response
@@ -51,9 +53,13 @@ async def test_native_browser_readiness_combines_health_and_window(
                 structured={
                     "windows": [
                         {
+                            "pid": 100,
+                            "window_id": 10,
                             "app_name": "Google Chrome",
                             "title": "Inbox",
-                            "on_current_space": True,
+                            # cua-driver 0.16 may omit Space metadata after
+                            # honoring on_screen_only at the transport layer.
+                            "on_current_space": None,
                             "is_on_screen": True,
                             "z_index": 4,
                         }
@@ -70,10 +76,12 @@ async def test_native_browser_readiness_combines_health_and_window(
     assert result.connected is True
     assert result.attached is True
     assert result.title == "Inbox"
+    assert result.windows[0].pid == 100
     assert result.permissions == {
         "accessibility": True,
         "screen_recording": True,
     }
+    assert ("list_windows", {"on_screen_only": True}) in client.calls
     assert client.closed is True
 
 
@@ -98,7 +106,7 @@ async def test_native_browser_readiness_reports_driver_failure(
 
 
 @pytest.mark.asyncio
-async def test_native_browser_readiness_reports_permissions_and_missing_browser(
+async def test_local_computer_readiness_reports_permissions_and_missing_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = FakeClient(
@@ -124,5 +132,5 @@ async def test_native_browser_readiness_reports_permissions_and_missing_browser(
     assert [issue.code for issue in result.issues] == [
         "screen_recording_permission_missing",
         "accessibility_permission_missing",
-        "browser_not_found",
+        "window_not_found",
     ]

--- a/tests/core/computer/test_native_browser_readiness.py
+++ b/tests/core/computer/test_native_browser_readiness.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.computer import native_browser_readiness as readiness
+from xagent.core.computer.cua_driver import CuaDriverError, CuaDriverResult
+
+
+class FakeClient:
+    def __init__(self, responses: dict[str, CuaDriverResult | Exception]) -> None:
+        self.responses = responses
+        self.closed = False
+
+    async def call_tool(
+        self,
+        name: str,
+        _arguments: dict[str, Any],
+    ) -> CuaDriverResult:
+        response = self.responses[name]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> None:
+    readiness.reset_native_browser_readiness_cache()
+
+
+@pytest.mark.asyncio
+async def test_native_browser_readiness_combines_health_and_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverResult(
+                structured={
+                    "overall": "ok",
+                    "checks": [
+                        {"name": "tcc_accessibility", "status": "pass"},
+                        {"name": "tcc_screen_recording", "status": "pass"},
+                    ],
+                }
+            ),
+            "list_windows": CuaDriverResult(
+                structured={
+                    "windows": [
+                        {
+                            "app_name": "Google Chrome",
+                            "title": "Inbox",
+                            "on_current_space": True,
+                            "is_on_screen": True,
+                            "z_index": 4,
+                        }
+                    ]
+                }
+            ),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_native_browser_readiness()
+
+    assert result.ready is True
+    assert result.connected is True
+    assert result.attached is True
+    assert result.title == "Inbox"
+    assert result.permissions == {
+        "accessibility": True,
+        "screen_recording": True,
+    }
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_native_browser_readiness_reports_driver_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverError("not installed"),
+            "list_windows": CuaDriverResult(structured={"windows": []}),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_native_browser_readiness()
+
+    assert result.ready is False
+    assert result.connected is False
+    assert [issue.code for issue in result.issues] == ["driver_unavailable"]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_native_browser_readiness_reports_permissions_and_missing_browser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverResult(
+                structured={
+                    "overall": "degraded",
+                    "checks": [
+                        {"name": "tcc_accessibility", "status": "fail"},
+                        {"name": "tcc_screen_recording", "status": "fail"},
+                    ],
+                }
+            ),
+            "list_windows": CuaDriverResult(structured={"windows": []}),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_native_browser_readiness()
+
+    assert result.connected is True
+    assert result.attached is False
+    assert [issue.code for issue in result.issues] == [
+        "screen_recording_permission_missing",
+        "accessibility_permission_missing",
+        "browser_not_found",
+    ]

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -21,6 +21,10 @@ _OPENROUTER_TOOL_CHOICE_ERROR = (
 _THINKING_TOOL_CHOICE_ERROR = (
     "OpenAI bad request (400): Thinking mode does not support this tool_choice"
 )
+_MANDATORY_REASONING_ERROR = (
+    "OpenAI bad request (400): Reasoning is mandatory for this endpoint "
+    "and cannot be disabled."
+)
 
 
 def _tool_schema() -> dict[str, Any]:
@@ -127,6 +131,26 @@ class _ScriptedChatLLM(BaseLLM):
         if self.errors:
             raise RuntimeError(self.errors.pop(0))
         return "ok"
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        del messages, temperature, max_tokens, tools, response_format
+        del output_config, kwargs
+        self.tool_choices.append(tool_choice)
+        self.thinking_values.append(thinking)
+        if self.errors:
+            raise RuntimeError(self.errors.pop(0))
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
 
 
 async def _select_glm(_prompt: str) -> str:
@@ -587,6 +611,73 @@ async def test_router_chat_propagates_non_matching_errors_without_retry(monkeypa
         )
 
     assert llm.tool_choices == ["required"]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_enables_thinking_when_selected_model_requires_it(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    result = await router.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=[_tool_schema()],
+        tool_choice="required",
+        thinking={"type": "disabled", "enable": False},
+    )
+
+    assert result == "ok"
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_stream_enables_thinking_when_selected_model_requires_it(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    chunks = [
+        chunk
+        async for chunk in router.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR, _MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -14,6 +14,10 @@ from xagent.config import (
     BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS,
     BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS,
     BOXLITE_HOME_DIR,
+    BROWSER_CUA_DRIVER_COMMAND,
+    BROWSER_CUA_DRIVER_MAX_ELEMENTS,
+    BROWSER_CUA_DRIVER_SOCKET,
+    BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
     CELERY_BROKER_URL,
     CELERY_ENABLED,
     CELERY_RESULT_BACKEND,
@@ -47,6 +51,8 @@ from xagent.config import (
     MCP_OAUTH_ALLOW_PRIVATE_HOSTS,
     MCP_OAUTH_PROXY_URL,
     MCP_TOOL_INIT_TIMEOUT_SECONDS,
+    NATIVE_BROWSER_APP_NAME,
+    NATIVE_BROWSER_ENABLED,
     OPENROUTER_OFFICIAL_PROVIDERS_ONLY,
     PASSWORD_RESET_EXPIRE_MINUTES,
     PREVIEW_TMP_DIR,
@@ -102,6 +108,10 @@ from xagent.config import (
     get_background_job_sweep_interval_seconds,
     get_background_job_visibility_timeout_seconds,
     get_boxlite_home_dir,
+    get_browser_cua_driver_command,
+    get_browser_cua_driver_max_elements,
+    get_browser_cua_driver_socket,
+    get_browser_cua_driver_timeout_seconds,
     get_celery_broker_url,
     get_celery_enabled,
     get_celery_result_backend,
@@ -137,6 +147,8 @@ from xagent.config import (
     get_mcp_oauth_allow_private_hosts,
     get_mcp_oauth_proxy_url,
     get_mcp_tool_init_timeout_seconds,
+    get_native_browser_app_name,
+    get_native_browser_enabled,
     get_openrouter_official_providers_only,
     get_password_reset_expire_minutes,
     get_preview_tmp_dir,
@@ -208,6 +220,19 @@ class TestEnvironmentVariableConstants:
 
     def test_storage_root_constant(self):
         assert STORAGE_ROOT == "XAGENT_STORAGE_ROOT"
+
+    def test_local_browser_constants(self):
+        assert NATIVE_BROWSER_ENABLED == "XAGENT_NATIVE_BROWSER_ENABLED"
+        assert NATIVE_BROWSER_APP_NAME == "XAGENT_NATIVE_BROWSER_APP_NAME"
+        assert BROWSER_CUA_DRIVER_COMMAND == "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
+        assert BROWSER_CUA_DRIVER_SOCKET == "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
+        assert (
+            BROWSER_CUA_DRIVER_TIMEOUT_SECONDS
+            == "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
+        )
+        assert (
+            BROWSER_CUA_DRIVER_MAX_ELEMENTS == "XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS"
+        )
 
     def test_sandbox_image_constant(self):
         assert SANDBOX_IMAGE == "SANDBOX_IMAGE"
@@ -1586,6 +1611,48 @@ class TestTaskRuntimeHookConfig:
 
         assert get_task_runtime_hook_max_workers() == 8
         assert get_task_runtime_hook_queue_timeout_seconds() == 30
+
+
+class TestLocalBrowserConfig:
+    def test_defaults(self, monkeypatch):
+        for name in (
+            NATIVE_BROWSER_ENABLED,
+            NATIVE_BROWSER_APP_NAME,
+            BROWSER_CUA_DRIVER_COMMAND,
+            BROWSER_CUA_DRIVER_SOCKET,
+            BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
+            BROWSER_CUA_DRIVER_MAX_ELEMENTS,
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        assert get_native_browser_enabled() is False
+        assert get_native_browser_app_name() == "Google Chrome"
+        assert get_browser_cua_driver_command() == "cua-driver"
+        assert get_browser_cua_driver_socket() is None
+        assert get_browser_cua_driver_timeout_seconds() == 30
+        assert get_browser_cua_driver_max_elements() == 100
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv(NATIVE_BROWSER_ENABLED, "true")
+        monkeypatch.setenv(NATIVE_BROWSER_APP_NAME, "Chromium")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_COMMAND, "/opt/bin/cua-driver")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_SOCKET, "/tmp/cua.sock")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "12.5")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_MAX_ELEMENTS, "250")
+
+        assert get_native_browser_enabled() is True
+        assert get_native_browser_app_name() == "Chromium"
+        assert get_browser_cua_driver_command() == "/opt/bin/cua-driver"
+        assert get_browser_cua_driver_socket() == "/tmp/cua.sock"
+        assert get_browser_cua_driver_timeout_seconds() == 12.5
+        assert get_browser_cua_driver_max_elements() == 250
+
+    def test_invalid_values_fall_back(self, monkeypatch):
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "0")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_MAX_ELEMENTS, "invalid")
+
+        assert get_browser_cua_driver_timeout_seconds() == 30
+        assert get_browser_cua_driver_max_elements() == 100
 
 
 class TestCheckpointStorageConfig:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -21,6 +21,10 @@ from xagent.config import (
     CELERY_BROKER_URL,
     CELERY_ENABLED,
     CELERY_RESULT_BACKEND,
+    CUA_DRIVER_COMMAND,
+    CUA_DRIVER_MAX_ELEMENTS,
+    CUA_DRIVER_SOCKET,
+    CUA_DRIVER_TIMEOUT_SECONDS,
     DATABASE_URL,
     DB_MAX_OVERFLOW,
     DB_POOL_SIZE,
@@ -46,6 +50,7 @@ from xagent.config import (
     HOT_PATH_TASK_CACHE_TTL_SECONDS,
     KB_COLLECTIONS_TIMEOUT_SECONDS,
     LANCEDB_PATH,
+    LOCAL_COMPUTER_ENABLED,
     MAX_TRACE_PAYLOAD_BYTES,
     MAX_UPLOAD_SIZE,
     MCP_OAUTH_ALLOW_PRIVATE_HOSTS,
@@ -115,6 +120,10 @@ from xagent.config import (
     get_celery_broker_url,
     get_celery_enabled,
     get_celery_result_backend,
+    get_cua_driver_command,
+    get_cua_driver_max_elements,
+    get_cua_driver_socket,
+    get_cua_driver_timeout_seconds,
     get_database_url,
     get_db_max_overflow,
     get_db_pool_size,
@@ -142,6 +151,7 @@ from xagent.config import (
     get_hot_path_task_cache_ttl_seconds,
     get_kb_collections_timeout_seconds,
     get_lancedb_path,
+    get_local_computer_enabled,
     get_max_trace_payload_bytes,
     get_max_upload_size_bytes,
     get_mcp_oauth_allow_private_hosts,
@@ -222,6 +232,11 @@ class TestEnvironmentVariableConstants:
         assert STORAGE_ROOT == "XAGENT_STORAGE_ROOT"
 
     def test_local_browser_constants(self):
+        assert LOCAL_COMPUTER_ENABLED == "XAGENT_LOCAL_COMPUTER_ENABLED"
+        assert CUA_DRIVER_COMMAND == "XAGENT_CUA_DRIVER_COMMAND"
+        assert CUA_DRIVER_SOCKET == "XAGENT_CUA_DRIVER_SOCKET"
+        assert CUA_DRIVER_TIMEOUT_SECONDS == "XAGENT_CUA_DRIVER_TIMEOUT_SECONDS"
+        assert CUA_DRIVER_MAX_ELEMENTS == "XAGENT_CUA_DRIVER_MAX_ELEMENTS"
         assert NATIVE_BROWSER_ENABLED == "XAGENT_NATIVE_BROWSER_ENABLED"
         assert NATIVE_BROWSER_APP_NAME == "XAGENT_NATIVE_BROWSER_APP_NAME"
         assert BROWSER_CUA_DRIVER_COMMAND == "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
@@ -1613,9 +1628,14 @@ class TestTaskRuntimeHookConfig:
         assert get_task_runtime_hook_queue_timeout_seconds() == 30
 
 
-class TestLocalBrowserConfig:
+class TestLocalComputerConfig:
     def test_defaults(self, monkeypatch):
         for name in (
+            LOCAL_COMPUTER_ENABLED,
+            CUA_DRIVER_COMMAND,
+            CUA_DRIVER_SOCKET,
+            CUA_DRIVER_TIMEOUT_SECONDS,
+            CUA_DRIVER_MAX_ELEMENTS,
             NATIVE_BROWSER_ENABLED,
             NATIVE_BROWSER_APP_NAME,
             BROWSER_CUA_DRIVER_COMMAND,
@@ -1625,12 +1645,16 @@ class TestLocalBrowserConfig:
         ):
             monkeypatch.delenv(name, raising=False)
 
-        assert get_native_browser_enabled() is False
+        assert get_local_computer_enabled() is False
         assert get_native_browser_app_name() == "Google Chrome"
         assert get_browser_cua_driver_command() == "cua-driver"
         assert get_browser_cua_driver_socket() is None
         assert get_browser_cua_driver_timeout_seconds() == 30
         assert get_browser_cua_driver_max_elements() == 100
+        assert get_cua_driver_command() == "cua-driver"
+        assert get_cua_driver_socket() is None
+        assert get_cua_driver_timeout_seconds() == 30
+        assert get_cua_driver_max_elements() == 100
 
     def test_env_overrides(self, monkeypatch):
         monkeypatch.setenv(NATIVE_BROWSER_ENABLED, "true")
@@ -1646,6 +1670,22 @@ class TestLocalBrowserConfig:
         assert get_browser_cua_driver_socket() == "/tmp/cua.sock"
         assert get_browser_cua_driver_timeout_seconds() == 12.5
         assert get_browser_cua_driver_max_elements() == 250
+
+    def test_canonical_env_overrides_legacy(self, monkeypatch):
+        monkeypatch.setenv(NATIVE_BROWSER_ENABLED, "false")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_COMMAND, "/legacy/cua-driver")
+        monkeypatch.setenv(LOCAL_COMPUTER_ENABLED, "true")
+        monkeypatch.setenv(CUA_DRIVER_COMMAND, "/current/cua-driver")
+        monkeypatch.setenv(CUA_DRIVER_SOCKET, "/tmp/current.sock")
+        monkeypatch.setenv(CUA_DRIVER_TIMEOUT_SECONDS, "9")
+        monkeypatch.setenv(CUA_DRIVER_MAX_ELEMENTS, "75")
+
+        assert get_local_computer_enabled() is True
+        assert get_native_browser_enabled() is True
+        assert get_cua_driver_command() == "/current/cua-driver"
+        assert get_cua_driver_socket() == "/tmp/current.sock"
+        assert get_cua_driver_timeout_seconds() == 9
+        assert get_cua_driver_max_elements() == 75
 
     def test_invalid_values_fall_back(self, monkeypatch):
         monkeypatch.setenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "0")

--- a/tests/web/api/test_computer_readiness.py
+++ b/tests/web/api/test_computer_readiness.py
@@ -5,18 +5,19 @@ from types import SimpleNamespace
 import pytest
 from starlette.responses import Response
 
-from xagent.core.computer.native_browser_readiness import NativeBrowserReadiness
+from xagent.core.computer.native_browser_readiness import LocalComputerReadiness
 from xagent.web.api import computer
 
 
 @pytest.mark.asyncio
-async def test_local_browser_readiness_is_disabled_by_default(
+async def test_local_computer_readiness_is_disabled_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+    monkeypatch.delenv("XAGENT_LOCAL_COMPUTER_ENABLED", raising=False)
     response = Response()
 
-    result = await computer.get_local_browser_readiness(
+    result = await computer.get_local_computer_readiness_endpoint(
         response,
         user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
     )
@@ -27,17 +28,17 @@ async def test_local_browser_readiness_is_disabled_by_default(
 
 
 @pytest.mark.asyncio
-async def test_local_browser_readiness_does_not_probe_for_non_admin(
+async def test_local_computer_readiness_does_not_probe_for_non_admin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
 
-    async def unexpected_probe() -> NativeBrowserReadiness:
+    async def unexpected_probe() -> LocalComputerReadiness:
         raise AssertionError("driver probe must not run")
 
-    monkeypatch.setattr(computer, "get_native_browser_readiness", unexpected_probe)
+    monkeypatch.setattr(computer, "get_local_computer_readiness", unexpected_probe)
 
-    result = await computer.get_local_browser_readiness(
+    result = await computer.get_local_computer_readiness_endpoint(
         Response(),
         user=SimpleNamespace(is_admin=False),  # type: ignore[arg-type]
     )
@@ -47,11 +48,11 @@ async def test_local_browser_readiness_does_not_probe_for_non_admin(
 
 
 @pytest.mark.asyncio
-async def test_local_browser_readiness_probes_for_enabled_admin(
+async def test_local_computer_readiness_probes_for_enabled_admin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
-    expected = NativeBrowserReadiness(
+    expected = LocalComputerReadiness(
         ready=True,
         connected=True,
         attached=True,
@@ -59,12 +60,12 @@ async def test_local_browser_readiness_probes_for_enabled_admin(
         title="Inbox",
     )
 
-    async def probe() -> NativeBrowserReadiness:
+    async def probe() -> LocalComputerReadiness:
         return expected
 
-    monkeypatch.setattr(computer, "get_native_browser_readiness", probe)
+    monkeypatch.setattr(computer, "get_local_computer_readiness", probe)
 
-    result = await computer.get_local_browser_readiness(
+    result = await computer.get_local_computer_readiness_endpoint(
         Response(),
         user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
     )

--- a/tests/web/api/test_computer_readiness.py
+++ b/tests/web/api/test_computer_readiness.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.responses import Response
+
+from xagent.core.computer.native_browser_readiness import NativeBrowserReadiness
+from xagent.web.api import computer
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_is_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+    response = Response()
+
+    result = await computer.get_local_browser_readiness(
+        response,
+        user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
+    )
+
+    assert result.ready is False
+    assert [issue.code for issue in result.issues] == ["disabled"]
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_does_not_probe_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+
+    async def unexpected_probe() -> NativeBrowserReadiness:
+        raise AssertionError("driver probe must not run")
+
+    monkeypatch.setattr(computer, "get_native_browser_readiness", unexpected_probe)
+
+    result = await computer.get_local_browser_readiness(
+        Response(),
+        user=SimpleNamespace(is_admin=False),  # type: ignore[arg-type]
+    )
+
+    assert result.ready is False
+    assert [issue.code for issue in result.issues] == ["not_authorized"]
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_probes_for_enabled_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    expected = NativeBrowserReadiness(
+        ready=True,
+        connected=True,
+        attached=True,
+        application="Google Chrome",
+        title="Inbox",
+    )
+
+    async def probe() -> NativeBrowserReadiness:
+        return expected
+
+    monkeypatch.setattr(computer, "get_native_browser_readiness", probe)
+
+    result = await computer.get_local_browser_readiness(
+        Response(),
+        user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
+    )
+
+    assert result == expected

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -5,7 +5,10 @@ from typing import Any
 
 import pytest
 
-from xagent.core.computer.native_browser import LOCAL_BROWSER_TASK_EXTENSION
+from xagent.core.computer.native_browser import (
+    LEGACY_LOCAL_BROWSER_TASK_EXTENSION,
+    LOCAL_COMPUTER_TASK_EXTENSION,
+)
 from xagent.core.task_runtime import (
     TaskRuntimeClientError,
     TaskRuntimeContext,
@@ -13,15 +16,15 @@ from xagent.core.task_runtime import (
     merge_task_runtime_contributions,
 )
 from xagent.core.tools.adapters.vibe.browser_tools import (
-    _has_local_browser_runtime,
+    _has_local_computer_runtime,
     create_browser_tools,
 )
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.services.local_browser_runtime import (
-    LocalBrowserTaskRuntimeProvider,
-    register_local_browser_runtime,
-    unregister_local_browser_runtime,
+    LocalComputerTaskRuntimeProvider,
+    register_local_computer_runtime,
+    unregister_local_computer_runtime,
 )
 from xagent.web.services.task_runtime import (
     agent_config_with_task_extension_bindings,
@@ -36,6 +39,7 @@ class FakeSession:
         self.user = user
         self.model: Any = None
         self.closed = False
+        self.committed = False
 
     def query(self, model: Any) -> "FakeSession":
         self.model = model
@@ -54,20 +58,26 @@ class FakeSession:
     def close(self) -> None:
         self.closed = True
 
+    def commit(self) -> None:
+        self.committed = True
 
-def make_context(*, bound: bool, admin: bool, workspace: Any = object()):
+
+def make_context(
+    *,
+    bound: bool,
+    admin: bool,
+    workspace: Any = object(),
+    extension: str = LOCAL_COMPUTER_TASK_EXTENSION,
+):
     agent_config = (
-        agent_config_with_task_extension_bindings({}, [LOCAL_BROWSER_TASK_EXTENSION])
-        if bound
-        else {}
+        agent_config_with_task_extension_bindings({}, [extension]) if bound else {}
     )
     sessions: list[FakeSession] = []
+    task = SimpleNamespace(id=7, user_id=3, agent_config=agent_config)
+    user = SimpleNamespace(id=3, is_admin=admin)
 
     def session_factory() -> FakeSession:
-        session = FakeSession(
-            task=SimpleNamespace(id=7, user_id=3, agent_config=agent_config),
-            user=SimpleNamespace(id=3, is_admin=admin),
-        )
+        session = FakeSession(task=task, user=user)
         sessions.append(session)
         return session
 
@@ -83,25 +93,32 @@ def make_context(*, bound: bool, admin: bool, workspace: Any = object()):
     )
 
 
-def test_local_browser_registration_is_explicit_and_lifespan_scoped() -> None:
-    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+def test_local_computer_registration_is_explicit_and_lifespan_scoped() -> None:
+    unregister_task_extension(LOCAL_COMPUTER_TASK_EXTENSION)
+    unregister_task_extension(LEGACY_LOCAL_BROWSER_TASK_EXTENSION)
     try:
-        register_local_browser_runtime()
-        register_local_browser_runtime()
-        assert registered_task_extensions().count(LOCAL_BROWSER_TASK_EXTENSION) == 1
+        register_local_computer_runtime()
+        register_local_computer_runtime()
+        assert registered_task_extensions().count(LOCAL_COMPUTER_TASK_EXTENSION) == 1
+        assert (
+            registered_task_extensions().count(LEGACY_LOCAL_BROWSER_TASK_EXTENSION) == 1
+        )
 
-        unregister_local_browser_runtime()
-        assert LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions()
+        unregister_local_computer_runtime()
+        assert LOCAL_COMPUTER_TASK_EXTENSION not in registered_task_extensions()
+        assert LEGACY_LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions()
     finally:
-        unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+        unregister_task_extension(LOCAL_COMPUTER_TASK_EXTENSION)
+        unregister_task_extension(LEGACY_LOCAL_BROWSER_TASK_EXTENSION)
 
 
-def test_local_browser_create_requires_enablement_and_admin(
+def test_local_computer_create_requires_enablement_admin_and_valid_target(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    provider = LocalBrowserTaskRuntimeProvider()
+    provider = LocalComputerTaskRuntimeProvider()
     context, sessions = make_context(bound=True, admin=True)
     monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+    monkeypatch.delenv("XAGENT_LOCAL_COMPUTER_ENABLED", raising=False)
 
     with pytest.raises(TaskRuntimeClientError, match="disabled") as disabled:
         provider.on_task_created(context, {})
@@ -115,12 +132,23 @@ def test_local_browser_create_requires_enablement_and_admin(
     provider.on_task_created(context, {})
     assert sessions[-1].closed is True
 
+    provider.on_task_created(
+        context,
+        {
+            "pid": 100,
+            "window_id": 20,
+            "application": "Music",
+            "title": "Songs",
+        },
+    )
+    assert sessions[-1].committed is True
 
-def test_local_browser_contributes_standard_computer_tool_only_when_bound(
+
+def test_local_computer_contributes_standard_computer_tool_only_when_bound(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
-    provider = LocalBrowserTaskRuntimeProvider()
+    provider = LocalComputerTaskRuntimeProvider()
     unbound, _ = make_context(bound=False, admin=True)
     assert provider.build_runtime(unbound) is None
 
@@ -130,15 +158,15 @@ def test_local_browser_contributes_standard_computer_tool_only_when_bound(
     assert isinstance(contribution, TaskRuntimeContribution)
     assert [tool.name for tool in contribution.tools] == ["computer"]
     assert contribution.preferred_input_modalities == ("image",)
-    assert "not a Chrome extension or remote relay" in (contribution.environment or "")
+    assert "not a browser extension or remote relay" in (contribution.environment or "")
     assert sessions[-1].closed is True
 
 
 @pytest.mark.asyncio
-async def test_local_browser_binding_suppresses_playwright_browser_family() -> None:
+async def test_local_computer_binding_suppresses_colliding_playwright_family() -> None:
     contribution = merge_task_runtime_contributions(
         {
-            LOCAL_BROWSER_TASK_EXTENSION: TaskRuntimeContribution(
+            LOCAL_COMPUTER_TASK_EXTENSION: TaskRuntimeContribution(
                 tools=(SimpleNamespace(name="computer"),)
             )
         }
@@ -151,25 +179,37 @@ async def test_local_browser_binding_suppresses_playwright_browser_family() -> N
     assert await create_browser_tools(config) == []
 
 
-def test_unbound_local_browser_provider_does_not_suppress_playwright() -> None:
+def test_unbound_local_computer_provider_does_not_suppress_playwright() -> None:
     contribution = merge_task_runtime_contributions(
-        {LOCAL_BROWSER_TASK_EXTENSION: None}
+        {LOCAL_COMPUTER_TASK_EXTENSION: None}
     )
 
-    assert _has_local_browser_runtime(contribution) is False
+    assert _has_local_computer_runtime(contribution) is False
 
 
-def test_local_browser_public_metadata_is_bound_task_only(
+def test_local_computer_public_metadata_is_bound_task_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
-    provider = LocalBrowserTaskRuntimeProvider()
+    provider = LocalComputerTaskRuntimeProvider()
     unbound, _ = make_context(bound=False, admin=True)
     bound, _ = make_context(bound=True, admin=True)
 
     assert provider.public_metadata(unbound) is None
     assert provider.public_metadata(bound) == {
-        "kind": "local_browser",
-        "application": "Google Chrome",
+        "kind": "local_computer",
         "enabled": True,
     }
+
+
+def test_legacy_local_browser_binding_still_builds_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_LOCAL_COMPUTER_ENABLED", "true")
+    provider = LocalComputerTaskRuntimeProvider(LEGACY_LOCAL_BROWSER_TASK_EXTENSION)
+    context, _ = make_context(
+        bound=True,
+        admin=True,
+        extension=LEGACY_LOCAL_BROWSER_TASK_EXTENSION,
+    )
+    assert provider.build_runtime(context) is not None

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.native_browser import LOCAL_BROWSER_TASK_EXTENSION
+from xagent.core.task_runtime import (
+    TaskRuntimeClientError,
+    TaskRuntimeContext,
+    TaskRuntimeContribution,
+    merge_task_runtime_contributions,
+)
+from xagent.core.tools.adapters.vibe.browser_tools import (
+    _has_local_browser_runtime,
+    create_browser_tools,
+)
+from xagent.web.models.task import Task
+from xagent.web.models.user import User
+from xagent.web.services.local_browser_runtime import (
+    LocalBrowserTaskRuntimeProvider,
+    register_local_browser_runtime,
+    unregister_local_browser_runtime,
+)
+from xagent.web.services.task_runtime import (
+    agent_config_with_task_extension_bindings,
+    registered_task_extensions,
+    unregister_task_extension,
+)
+
+
+class FakeSession:
+    def __init__(self, *, task: Any, user: Any) -> None:
+        self.task = task
+        self.user = user
+        self.model: Any = None
+        self.closed = False
+
+    def query(self, model: Any) -> "FakeSession":
+        self.model = model
+        return self
+
+    def filter(self, *_args: Any) -> "FakeSession":
+        return self
+
+    def first(self) -> Any:
+        if self.model is Task:
+            return self.task
+        if self.model is User:
+            return self.user
+        raise AssertionError(f"unexpected query model: {self.model}")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def make_context(*, bound: bool, admin: bool, workspace: Any = object()):
+    agent_config = (
+        agent_config_with_task_extension_bindings({}, [LOCAL_BROWSER_TASK_EXTENSION])
+        if bound
+        else {}
+    )
+    sessions: list[FakeSession] = []
+
+    def session_factory() -> FakeSession:
+        session = FakeSession(
+            task=SimpleNamespace(id=7, user_id=3, agent_config=agent_config),
+            user=SimpleNamespace(id=3, is_admin=admin),
+        )
+        sessions.append(session)
+        return session
+
+    return (
+        TaskRuntimeContext(
+            task_id=7,
+            user_id=3,
+            source="internal",
+            session_factory=session_factory,
+            workspace=workspace,
+        ),
+        sessions,
+    )
+
+
+def test_local_browser_registration_is_explicit_and_lifespan_scoped() -> None:
+    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+    try:
+        register_local_browser_runtime()
+        register_local_browser_runtime()
+        assert registered_task_extensions().count(LOCAL_BROWSER_TASK_EXTENSION) == 1
+
+        unregister_local_browser_runtime()
+        assert LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions()
+    finally:
+        unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def test_local_browser_create_requires_enablement_and_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LocalBrowserTaskRuntimeProvider()
+    context, sessions = make_context(bound=True, admin=True)
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+
+    with pytest.raises(TaskRuntimeClientError, match="disabled") as disabled:
+        provider.on_task_created(context, {})
+    assert disabled.value.status_code == 403
+
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    non_admin, _ = make_context(bound=True, admin=False)
+    with pytest.raises(TaskRuntimeClientError, match="administrators"):
+        provider.on_task_created(non_admin, {})
+
+    provider.on_task_created(context, {})
+    assert sessions[-1].closed is True
+
+
+def test_local_browser_contributes_standard_computer_tool_only_when_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    unbound, _ = make_context(bound=False, admin=True)
+    assert provider.build_runtime(unbound) is None
+
+    bound, sessions = make_context(bound=True, admin=True)
+    contribution = provider.build_runtime(bound)
+
+    assert isinstance(contribution, TaskRuntimeContribution)
+    assert [tool.name for tool in contribution.tools] == ["computer"]
+    assert contribution.preferred_input_modalities == ("image",)
+    assert "not a Chrome extension or remote relay" in (contribution.environment or "")
+    assert sessions[-1].closed is True
+
+
+@pytest.mark.asyncio
+async def test_local_browser_binding_suppresses_playwright_browser_family() -> None:
+    contribution = merge_task_runtime_contributions(
+        {
+            LOCAL_BROWSER_TASK_EXTENSION: TaskRuntimeContribution(
+                tools=(SimpleNamespace(name="computer"),)
+            )
+        }
+    )
+    config = SimpleNamespace(
+        get_browser_tools_enabled=lambda: True,
+        get_task_runtime_contribution=lambda: contribution,
+    )
+
+    assert await create_browser_tools(config) == []
+
+
+def test_unbound_local_browser_provider_does_not_suppress_playwright() -> None:
+    contribution = merge_task_runtime_contributions(
+        {LOCAL_BROWSER_TASK_EXTENSION: None}
+    )
+
+    assert _has_local_browser_runtime(contribution) is False
+
+
+def test_local_browser_public_metadata_is_bound_task_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    unbound, _ = make_context(bound=False, admin=True)
+    bound, _ = make_context(bound=True, admin=True)
+
+    assert provider.public_metadata(unbound) is None
+    assert provider.public_metadata(bound) == {
+        "kind": "local_browser",
+        "application": "Google Chrome",
+        "enabled": True,
+    }


### PR DESCRIPTION
## Review boundary

This PR adds one narrowly scoped capability: **Local computer**, meaning an Xagent backend directly controls one explicitly selected application window on the **same host** through `cua-driver mcp`. It builds on the generic Computer Use foundation in #1098 and browser loop in #1104.

Please evaluate this PR as a same-host, window-scoped computer runtime. Browser automation remains a separate runtime. Remote user-device takeover and whole-desktop control are separate transports/scopes and intentionally excluded.

## In scope: what this PR does

- adds a task-scoped `cua-driver` MCP client and a provider-neutral local computer environment
- enumerates visible host application windows in the composer and requires the user to select one exact `(pid, window_id)` before task creation
- persists that exact target with the task and never silently switches applications or windows
- controls browser windows or other desktop application windows through the shared Computer Use action/observation contract
- reports desktop observations, FileRef-backed screenshots, and accessibility elements through the shared schema
- exposes a flat single-action tool contract to avoid nested one-element action-array serialization failures while accepting the preview shape for compatibility
- contributes Local computer through the generic Task Runtime Extension hook, with `image` as a routing preference rather than a hard model requirement
- suppresses the colliding Playwright `computer` family only for tasks that bind Local computer, so the model sees one unambiguous `computer` tool
- adds authenticated readiness/window discovery and a compact composer `+` menu entry
- keeps the feature disabled by default and restricts task creation/readiness probing to administrators
- uses canonical `XAGENT_LOCAL_COMPUTER_*` / `XAGENT_CUA_DRIVER_*` configuration while reading the preview Local browser names for compatibility
- handles the specific provider response where reasoning is mandatory by retrying the same selected model once with thinking enabled

## Browser separation

- High-level web navigation remains part of the Browser runtime.
- Local computer does not expose a browser-specific `navigate` action; it operates the selected application GUI.
- A selected local browser window may still use its existing signed-in state through normal GUI actions, but it is not treated as a tab-scoped browser session.

## Out of scope: what this PR does not do

- no Chrome extension for taking over a tab on a user's laptop
- no WebSocket/Redis browser relay, pairing flow, or other remote-user-device transport
- no macOS Desktop Relay or companion application
- no whole-display capture/control mode in the Xagent product surface
- no native provider-specific Computer Use model API integration
- no automatic `cua-driver` installation, packaging, permission granting, or host lifecycle management
- no attempt to make a cloud Xagent directly control an end user's computer

These excluded transports can integrate later through the generic runtime-extension boundary without being added to this implementation.

## Deployment behavior

- **Local/self-hosted Xagent:** can operate an explicitly selected application window on that same machine, including an existing signed-in browser window.
- **Cloud/server Xagent:** can only operate a window on the cloud/server host. It cannot see or control an end user's laptop through this PR.

## Validation

- focused backend suites for Computer Use, Task Runtime Extension, readiness, routing, and config: all passed
- frontend TypeScript type-check passed
- frontend ChatInput and AppProvider tests: 99 passed
- pre-commit over every changed file passed, including ruff, mypy, frontend lint, and frontend type-check
- real local `cua-driver 0.16.0` readiness probe passed with permissions healthy and 17 visible windows enumerated
