### PR TITLE
fix: preserve Home and Build behavior without route overrides

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages",
-    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx",
+    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/src/app/build/page-extension.test.tsx
+++ b/frontend/src/app/build/page-extension.test.tsx
@@ -49,6 +49,7 @@ vi.mock("next/link", () => ({
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     t: (key: string) => key,
+    locale: "en",
   }),
 }))
 

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -12,6 +12,9 @@ const resolveTaskLlmSelectionMock = vi.hoisted(() => vi.fn())
 const dispatchMock = vi.hoisted(() => vi.fn())
 const setTaskIdMock = vi.hoisted(() => vi.fn())
 const setPendingMessageMock = vi.hoisted(() => vi.fn())
+const resolveAgentLogoUrlMock = vi.hoisted(() => vi.fn())
+const formatDisplayDateMock = vi.hoisted(() => vi.fn())
+const localeMock = vi.hoisted(() => ({ value: "en" as "en" | "zh" }))
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -22,8 +25,24 @@ vi.mock("@/lib/api-wrapper", async () => {
 
 vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
-  return { ...actual, getApiUrl: () => "http://api.local" }
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    resolveAgentLogoUrl: (...args: Parameters<typeof actual.resolveAgentLogoUrl>) => {
+      resolveAgentLogoUrlMock(...args)
+      return actual.resolveAgentLogoUrl(...args)
+    },
+  }
 })
+
+vi.mock("@/lib/time-utils", () => ({
+  formatDisplayDate: (...args: [unknown, "en" | "zh", Intl.DateTimeFormatOptions]) => {
+    formatDisplayDateMock(...args)
+    return typeof args[0] === "string" && args[0].startsWith("valid-")
+      ? `formatted:${args[0]}`
+      : ""
+  },
+}))
 
 vi.mock("@/lib/models", () => ({
   resolveTaskLlmSelection: resolveTaskLlmSelectionMock,
@@ -44,6 +63,7 @@ vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     t: (key: string, vars?: Record<string, string | number>) =>
       vars?.name ? `${key}:${vars.name}` : key,
+    locale: localeMock.value,
   }),
 }))
 
@@ -119,6 +139,21 @@ const conflictPayload = {
   },
 }
 
+function cardDateRows(card: Element | null): Element[] {
+  const metadata = Array.from(card?.querySelectorAll("div") ?? []).find((element) =>
+    element.classList.contains("space-y-1.5"),
+  )
+  return metadata ? Array.from(metadata.children) : []
+}
+
+function cardAvatar(card: Element | null): Element | null {
+  return card?.querySelector('div[class*="h-10"][class*="w-10"]') ?? null
+}
+
+function cardTextOccurrences(card: Element | null, text: string): number {
+  return (card?.textContent ?? "").split(text).length - 1
+}
+
 function jsonResponse(data: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(data), {
     status: 200,
@@ -146,6 +181,9 @@ function resetMocks() {
   dispatchMock.mockReset()
   setTaskIdMock.mockReset()
   setPendingMessageMock.mockReset()
+  resolveAgentLogoUrlMock.mockReset()
+  formatDisplayDateMock.mockReset()
+  localeMock.value = "en"
   voiceInputState.hasAsrModel = false
 }
 
@@ -218,6 +256,107 @@ describe("BuildsPage rendering", () => {
     ]) {
       expect(screen.queryByRole("button", { name })).not.toBeInTheDocument()
     }
+  })
+
+  it("uses the shared logo and date owners once per Build card with independent date rows", async () => {
+    localeMock.value = "zh"
+    apiRequestMock.mockResolvedValue(jsonResponse([
+      {
+        ...agent,
+        id: 91,
+        name: "Absolute Agent",
+        logo_url: "HTTPS://assets.example/agent.png",
+        created_at: "valid-created",
+        updated_at: "",
+      },
+      {
+        ...agent,
+        id: 92,
+        name: "Relative Agent",
+        logo_url: "/logos/relative.png",
+        created_at: "not-a-date",
+        updated_at: "valid-updated",
+      },
+      {
+        ...agent,
+        id: 93,
+        name: "Invalid Agent",
+        logo_url: "javascript:alert(1)",
+        created_at: "not-a-date",
+        updated_at: " ",
+      },
+    ]))
+
+    const view = render(<BuildsPage />)
+
+    const absoluteName = await screen.findByText("Absolute Agent")
+    const absoluteCard = absoluteName.closest("[class*='cursor-pointer']")
+    const relativeCard = screen.getByText("Relative Agent").closest("[class*='cursor-pointer']")
+    const invalidCard = screen.getByText("Invalid Agent").closest("[class*='cursor-pointer']")
+    expect(absoluteCard).not.toBeNull()
+    expect(relativeCard).not.toBeNull()
+    expect(invalidCard).not.toBeNull()
+    expect(absoluteCard?.querySelector("img")).toHaveAttribute(
+      "src",
+      "HTTPS://assets.example/agent.png",
+    )
+    expect(relativeCard?.querySelector("img")).toHaveAttribute(
+      "src",
+      "http://api.local/logos/relative.png",
+    )
+    const invalidAvatar = cardAvatar(invalidCard)
+    expect(invalidAvatar).not.toBeNull()
+    expect(invalidAvatar?.querySelectorAll("img")).toHaveLength(0)
+    expect(invalidAvatar?.querySelectorAll("svg")).toHaveLength(1)
+    const invalidBot = invalidAvatar?.querySelector("svg")
+    expect(invalidBot).not.toHaveClass("lucide-chevron-right")
+    expect(invalidBot?.querySelector('rect[width="18"][height="10"]')).toBeInTheDocument()
+
+    expect(absoluteCard).toHaveTextContent("builds.card.createdAt: formatted:valid-created")
+    expect(cardTextOccurrences(absoluteCard, "builds.card.createdAt")).toBe(1)
+    expect(cardTextOccurrences(absoluteCard, "builds.card.updatedAt")).toBe(0)
+    expect(relativeCard).toHaveTextContent("builds.card.updatedAt: formatted:valid-updated")
+    expect(cardTextOccurrences(relativeCard, "builds.card.createdAt")).toBe(0)
+    expect(cardTextOccurrences(relativeCard, "builds.card.updatedAt")).toBe(1)
+    expect(cardTextOccurrences(invalidCard, "builds.card.createdAt")).toBe(0)
+    expect(cardTextOccurrences(invalidCard, "builds.card.updatedAt")).toBe(0)
+    const absoluteRows = cardDateRows(absoluteCard)
+    const relativeRows = cardDateRows(relativeCard)
+    const invalidRows = cardDateRows(invalidCard)
+    expect(absoluteRows).toHaveLength(1)
+    expect(absoluteRows[0].querySelectorAll("svg")).toHaveLength(1)
+    expect(relativeRows).toHaveLength(1)
+    expect(relativeRows[0].querySelectorAll("svg")).toHaveLength(1)
+    expect(invalidRows).toHaveLength(0)
+
+    resolveAgentLogoUrlMock.mockClear()
+    formatDisplayDateMock.mockClear()
+    view.rerender(<BuildsPage />)
+    expect(resolveAgentLogoUrlMock).toHaveBeenCalledTimes(3)
+    expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(1, "HTTPS://assets.example/agent.png", "http://api.local")
+    expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(2, "/logos/relative.png", "http://api.local")
+    expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(3, "javascript:alert(1)", "http://api.local")
+    expect(formatDisplayDateMock).toHaveBeenCalledTimes(6)
+    expect(formatDisplayDateMock).toHaveBeenCalledWith("valid-created", "zh", {
+      year: "numeric", month: "numeric", day: "numeric",
+    })
+    expect(formatDisplayDateMock).toHaveBeenCalledWith("valid-updated", "zh", {
+      year: "numeric", month: "numeric", day: "numeric",
+    })
+  })
+
+  it("keeps Build card display shaping in the shared owners", () => {
+    const source = readFileSync(`${process.cwd()}/src/app/build/page.tsx`, "utf8")
+    const cardRender = source.slice(source.indexOf("{filteredAgents.map((agent) => {"))
+    expect(cardRender).toContain("const resolvedLogoUrl = resolveAgentLogoUrl(agent.logo_url, getApiUrl())")
+    expect(cardRender.match(/resolveAgentLogoUrl\(/g)).toHaveLength(1)
+    expect(cardRender).toContain("const createdDate = formatDisplayDate(agent.created_at, locale, {")
+    expect(cardRender).toContain("const updatedDate = formatDisplayDate(agent.updated_at, locale, {")
+    expect(cardRender.match(/formatDisplayDate\(agent\.created_at/g)).toHaveLength(1)
+    expect(cardRender.match(/formatDisplayDate\(agent\.updated_at/g)).toHaveLength(1)
+    expect(cardRender.match(/\{createdDate && \(/g)).toHaveLength(1)
+    expect(cardRender.match(/\{updatedDate && \(/g)).toHaveLength(1)
+    expect(cardRender).not.toMatch(/const formatDate|\$\{getApiUrl\(\)\}\$\{agent\.logo_url\}|agent\.updated_at\s*\|\|\s*agent\.created_at/)
   })
 })
 

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -931,9 +931,17 @@ describe("BuildsPage publication lifecycle", () => {
     const mutation = source.slice(mutationStart, wrapperStart)
     const wrapper = source.slice(wrapperStart, nextOwnerStart)
     expect(mutation).not.toContain("fetchAgents")
-    expect(wrapper).not.toContain("catch")
-    expect(wrapper).toContain("void fetchAgents()")
-    expect(wrapper).not.toContain("await fetchAgents()")
+    // A bare `not.toContain("catch")` also passes if the wrapper is rewritten as
+    // `.then(onFulfilled, onRejected)`, which reintroduces error handling in the
+    // wrapper without the literal word "catch". Pin the exact refresh statement
+    // and additionally rule out any `.then(` usage so that rewrite is caught too.
+    expect(wrapper).toContain(
+      "const outcome = await performPublicationMutation(agentId, kind)\n"
+      + "    if (outcome === \"success\" && isMountedRef.current) {\n"
+      + "      void fetchAgents()\n"
+      + "    }",
+    )
+    expect(wrapper.match(/\.then\(/g) ?? []).toHaveLength(0)
   })
 })
 
@@ -961,6 +969,26 @@ function typeCreatePrompt(value: string) {
 
 function startBuildWithEnter() {
   fireEvent.keyDown(createPromptInput(), { key: "Enter" })
+}
+
+// Reproduces only voice-input-controller.tsx's native-setter write + bubbled
+// input/change event dispatch (setNativeValue + dispatchInputEvents): the native
+// HTMLTextAreaElement.prototype value setter (bypassing React's tracked instance
+// setter) followed by the same bubbled input/change events production dispatches
+// after a transcription lands, rather than testing-library's fireEvent convenience
+// helpers. This does NOT cover insertTranscribedText's focus/caret-splice/
+// setSelectionRange/fragment-data behavior — caret handling is untested here.
+function simulateVoiceTranscription(target: HTMLTextAreaElement, text: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")
+  act(() => {
+    descriptor?.set?.call(target, text)
+    try {
+      target.dispatchEvent(new InputEvent("input", { bubbles: true, data: text, inputType: "insertText" }))
+    } catch {
+      target.dispatchEvent(new Event("input", { bubbles: true }))
+    }
+    target.dispatchEvent(new Event("change", { bubbles: true }))
+  })
 }
 
 function openCreateModal() {
@@ -1287,6 +1315,27 @@ describe("BuildsPage task creation lifecycle", () => {
     await act(async () => aba.resolve(jsonResponse(taskCore())))
     openCreateModal()
     expect(createPromptInput()).toHaveValue("A")
+  })
+
+  it("treats a native voice transcription write as an edit that blocks a stale successful clear (A3)", async () => {
+    const result = deferred<Response>()
+    configureCreateApi(() => result.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("A")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    simulateVoiceTranscription(createPromptInput(), "A transcribed by voice")
+    expect(createPromptInput()).toHaveValue("A transcribed by voice")
+
+    await act(async () => result.resolve(jsonResponse(taskCore())))
+
+    expect(setPendingMessageMock).toHaveBeenCalledTimes(1)
+    expect(setTaskIdMock).toHaveBeenCalledWith(7)
+    openCreateModal()
+    expect(createPromptInput()).toHaveValue("A transcribed by voice")
   })
 
   it("keeps B pending when stale A settles first, and does not operationalize commit exceptions", async () => {

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -7,6 +7,10 @@ const routerPushMock = vi.hoisted(() => vi.fn())
 const routerReplaceMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const voiceInputState = vi.hoisted(() => ({ hasAsrModel: false }))
+const resolveTaskLlmSelectionMock = vi.hoisted(() => vi.fn())
+const dispatchMock = vi.hoisted(() => vi.fn())
+const setTaskIdMock = vi.hoisted(() => vi.fn())
+const setPendingMessageMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -19,6 +23,10 @@ vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
   return { ...actual, getApiUrl: () => "http://api.local" }
 })
+
+vi.mock("@/lib/models", () => ({
+  resolveTaskLlmSelection: resolveTaskLlmSelectionMock,
+}))
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock, replace: routerReplaceMock }),
@@ -40,9 +48,9 @@ vi.mock("@/contexts/i18n-context", () => ({
 
 vi.mock("@/contexts/app-context-chat", () => ({
   useApp: () => ({
-    dispatch: vi.fn(),
-    setTaskId: vi.fn(),
-    setPendingMessage: vi.fn(),
+    dispatch: dispatchMock,
+    setTaskId: setTaskIdMock,
+    setPendingMessage: setPendingMessageMock,
   }),
 }))
 
@@ -133,6 +141,10 @@ function resetMocks() {
   routerPushMock.mockReset()
   routerReplaceMock.mockReset()
   toastErrorMock.mockReset()
+  resolveTaskLlmSelectionMock.mockReset()
+  dispatchMock.mockReset()
+  setTaskIdMock.mockReset()
+  setPendingMessageMock.mockReset()
   voiceInputState.hasAsrModel = false
 }
 
@@ -488,4 +500,494 @@ describe("BuildsPage Agent deletion", () => {
     }))
     await waitFor(() => expect(discardRequests).toBe(2))
   })
+})
+
+const successfulSelection = {
+  kind: "success" as const,
+  llmIds: ["general", null, null, null] as [string, null, null, null],
+}
+
+function taskCore(taskId = 7) {
+  return {
+    task_id: taskId,
+    title: "created task",
+    status: "running",
+    created_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+function createPromptInput(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText("builds.list.createModal.placeholder")
+}
+
+function typeCreatePrompt(value: string) {
+  fireEvent.change(createPromptInput(), { target: { value } })
+}
+
+function startBuildWithEnter() {
+  fireEvent.keyDown(createPromptInput(), { key: "Enter" })
+}
+
+function openCreateModal() {
+  fireEvent.click(screen.getByRole("button", { name: "builds.list.header.create" }))
+  return createPromptInput()
+}
+
+function configureCreateApi(create: () => Promise<Response> | Response) {
+  apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+    if (url === "http://api.local/api/agents" && !options?.method) {
+      return Promise.resolve(jsonResponse([]))
+    }
+    if (url === "http://api.local/api/chat/task/create") return create()
+    throw new Error(`Unexpected apiRequest: ${url}`)
+  })
+}
+
+describe("BuildsPage task creation lifecycle", () => {
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetMocks()
+    resolveTaskLlmSelectionMock.mockResolvedValue(successfulSelection)
+    consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+    cleanup()
+  })
+
+  it("uses the shared resolver, real task body parser, and the exact success commit order", async () => {
+    const events: string[] = []
+    dispatchMock.mockImplementation((action) => events.push(action.type))
+    setPendingMessageMock.mockImplementation(() => events.push("pending"))
+    setTaskIdMock.mockImplementation(() => {
+      events.push("taskId")
+      expect(createPromptInput()).toHaveValue("  hello\n  world  ")
+    })
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/task/create") {
+        expect(options?.method).toBe("POST")
+        expect(JSON.parse(String(options?.body))).toEqual({
+          title: "hello world",
+          description: "hello\n  world",
+          llm_ids: ["general", null, null, null],
+        })
+        return Promise.resolve(jsonResponse(taskCore(9)))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("  hello\n  world  ")
+    startBuildWithEnter()
+
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(9))
+    expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(1)
+    expect(events).toEqual(["RESET_STATE", "pending", "TRIGGER_TASK_UPDATE", "taskId"])
+    expect(setPendingMessageMock).toHaveBeenCalledWith({
+      message: "hello\n  world",
+      files: [],
+      targetTaskId: 9,
+    })
+    expect(screen.queryByPlaceholderText("builds.list.createModal.placeholder")).not.toBeInTheDocument()
+
+    openCreateModal()
+    expect(createPromptInput()).toHaveValue("")
+  })
+
+  it.each([
+    ["no_model", { kind: "no_model" as const }, "chatPage.input.noModelAlert"],
+    [
+      "operational_error",
+      { kind: "operational_error" as const, error: new Error("resolver failure") },
+      "builds.list.createModal.startTaskFailed",
+    ],
+  ])("keeps the prompt and modal open for resolver %s", async (_kind, selection, expectedToast) => {
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore())))
+    resolveTaskLlmSelectionMock.mockResolvedValueOnce(selection)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("  preserve this exact\n  draft  ")
+    startBuildWithEnter()
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(expectedToast))
+    expect(createPromptInput()).toHaveValue("  preserve this exact\n  draft  ")
+    expect(screen.getByPlaceholderText("builds.list.createModal.placeholder")).toBeInTheDocument()
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    if (_kind === "operational_error") expect(consoleErrorMock).toHaveBeenCalled()
+    else expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("uses a synchronous ref latch for same-act Enter and click", async () => {
+    const selection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(selection.promise)
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore())))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+
+    await act(async () => {
+      startBuildWithEnter()
+      fireEvent.click(screen.getByRole("button", { name: "builds.list.createModal.buildBtn" }))
+    })
+
+    expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(1)
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+  })
+
+  it("does not POST after unmount or close while model resolution is pending", async () => {
+    const selection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(selection.promise)
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore())))
+    const view = render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    view.unmount()
+    await act(async () => selection.resolve(successfulSelection))
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+
+    const closedSelection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(closedSelection.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    await act(async () => closedSelection.resolve(successfulSelection))
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("does not parse after close before transport completion, or publish after parsing starts", async () => {
+    const response = deferred<Response>()
+    const taskResponse = new Response(JSON.stringify(taskCore()))
+    const text = vi.fn(taskResponse.text.bind(taskResponse))
+    Object.defineProperty(taskResponse, "text", { value: text })
+    configureCreateApi(() => response.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    await act(async () => response.resolve(taskResponse))
+    expect(text).not.toHaveBeenCalled()
+    expect(dispatchMock).not.toHaveBeenCalled()
+
+    cleanup()
+    const body = deferred<string>()
+    const parsingResponse = new Response("")
+    const parsingText = vi.fn(() => body.promise)
+    Object.defineProperty(parsingResponse, "text", { value: parsingText })
+    configureCreateApi(() => Promise.resolve(parsingResponse))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(parsingText).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    await act(async () => body.resolve(JSON.stringify(taskCore())))
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("does not parse or publish after unmount at either task-body boundary", async () => {
+    const response = deferred<Response>()
+    const taskResponse = new Response(JSON.stringify(taskCore()))
+    const text = vi.fn(taskResponse.text.bind(taskResponse))
+    Object.defineProperty(taskResponse, "text", { value: text })
+    configureCreateApi(() => response.promise)
+    const firstView = render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    firstView.unmount()
+    await act(async () => response.resolve(taskResponse))
+    expect(text).not.toHaveBeenCalled()
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+
+    const body = deferred<string>()
+    const parsingResponse = new Response("")
+    const parsingText = vi.fn(() => body.promise)
+    Object.defineProperty(parsingResponse, "text", { value: parsingText })
+    configureCreateApi(() => Promise.resolve(parsingResponse))
+    const secondView = render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(parsingText).toHaveBeenCalledTimes(1))
+    secondView.unmount()
+    await act(async () => body.resolve(JSON.stringify(taskCore())))
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves the controlled prompt when a user closes and reopens the modal", async () => {
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore())))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("  preserve this draft  ")
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    openCreateModal()
+    expect(createPromptInput()).toHaveValue("  preserve this draft  ")
+  })
+
+  it("cancels before Manual navigation and keeps late completion silent", async () => {
+    const response = deferred<Response>()
+    configureCreateApi(() => response.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    fireEvent.click(screen.getByRole("button", { name: "builds.list.createModal.manualBtn" }))
+    expect(routerPushMock).toHaveBeenCalledWith("/build/new")
+    await act(async () => response.resolve(jsonResponse(taskCore())))
+
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["non-OK", jsonResponse(taskCore(), { status: 500 })],
+    ["empty", new Response("")],
+    ["malformed", new Response("{")],
+    ["invalid core", jsonResponse({ id: 7 })],
+  ])("keeps task state at zero for current %s task-body failures", async (_name, response) => {
+    configureCreateApi(() => Promise.resolve(response))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("builds.list.createModal.startTaskFailed"))
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+  })
+
+  it("treats an unreadable task body as a current operational failure", async () => {
+    const response = new Response("unreadable")
+    Object.defineProperty(response, "text", {
+      value: vi.fn().mockRejectedValue(new Error("body unavailable")),
+    })
+    configureCreateApi(() => Promise.resolve(response))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("builds.list.createModal.startTaskFailed"))
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves B after A succeeds or fails, and preserves A after ABA", async () => {
+    const success = deferred<Response>()
+    configureCreateApi(() => success.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("A")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typeCreatePrompt("B")
+    await act(async () => success.resolve(jsonResponse(taskCore())))
+    expect(screen.queryByPlaceholderText("builds.list.createModal.placeholder")).not.toBeInTheDocument()
+    openCreateModal()
+    expect(createPromptInput()).toHaveValue("B")
+
+    cleanup()
+    const failed = deferred<Response>()
+    configureCreateApi(() => failed.promise)
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("A")
+    startBuildWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typeCreatePrompt("B")
+    await act(async () => failed.resolve(jsonResponse(taskCore(), { status: 500 })))
+    expect(createPromptInput()).toHaveValue("B")
+    typeCreatePrompt("A")
+    const aba = deferred<Response>()
+    configureCreateApi(() => aba.promise)
+    fireEvent.click(screen.getByRole("button", { name: "builds.list.createModal.buildBtn" }))
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typeCreatePrompt("B")
+    typeCreatePrompt("A")
+    await act(async () => aba.resolve(jsonResponse(taskCore())))
+    openCreateModal()
+    expect(createPromptInput()).toHaveValue("A")
+  })
+
+  it("keeps B pending when stale A settles first, and does not operationalize commit exceptions", async () => {
+    const firstSelection = deferred<typeof successfulSelection>()
+    const secondSelection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock
+      .mockReturnValueOnce(firstSelection.promise)
+      .mockReturnValueOnce(secondSelection.promise)
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore(8))))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("A")
+    startBuildWithEnter()
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    openCreateModal()
+    typeCreatePrompt("B")
+    startBuildWithEnter()
+    await act(async () => firstSelection.resolve(successfulSelection))
+    expect(screen.getByRole("button", { name: "common.loading" })).toBeDisabled()
+    await act(async () => secondSelection.resolve(successfulSelection))
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(8))
+
+    cleanup()
+    dispatchMock.mockReset()
+    setPendingMessageMock.mockReset()
+    setTaskIdMock.mockReset()
+    toastErrorMock.mockReset()
+    dispatchMock.mockImplementation((action) => {
+      if (action.type === "TRIGGER_TASK_UPDATE") throw new Error("commit failed")
+    })
+    configureCreateApi(() => Promise.resolve(jsonResponse(taskCore())))
+    render(<BuildsPage />)
+    await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+    openCreateModal()
+    typeCreatePrompt("prompt")
+    startBuildWithEnter()
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith({ type: "TRIGGER_TASK_UPDATE" }))
+    expect(dispatchMock).toHaveBeenCalledWith({ type: "RESET_STATE" })
+    expect(setPendingMessageMock).toHaveBeenCalledTimes(1)
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).toHaveBeenCalled()
+
+    const resolverCallsBeforeRetry = resolveTaskLlmSelectionMock.mock.calls.length
+    dispatchMock.mockReset()
+    setTaskIdMock.mockReset()
+    await waitFor(() => expect(screen.getByRole("button", { name: "builds.list.createModal.buildBtn" })).toBeEnabled())
+    fireEvent.click(screen.getByRole("button", { name: "builds.list.createModal.buildBtn" }))
+    await waitFor(() => expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(resolverCallsBeforeRetry + 1))
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(7))
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    "resolver rejects",
+    "transport rejects",
+    "Response.text() rejects and parseApiResponse falls back to empty parsed data",
+  ] as const)(
+    "keeps B pending and silent when stale A's %s",
+    async (phase) => {
+      const firstSelection = deferred<typeof successfulSelection>()
+      const secondSelection = deferred<typeof successfulSelection>()
+      const firstTransport = deferred<Response>()
+      const firstBody = deferred<string>()
+      const firstResponse = new Response("")
+      Object.defineProperty(firstResponse, "text", {
+        value: vi.fn(() => firstBody.promise),
+      })
+
+      if (phase === "resolver rejects") {
+        resolveTaskLlmSelectionMock
+          .mockReturnValueOnce(firstSelection.promise)
+          .mockReturnValueOnce(secondSelection.promise)
+      } else {
+        resolveTaskLlmSelectionMock
+          .mockResolvedValueOnce(successfulSelection)
+          .mockReturnValueOnce(secondSelection.promise)
+      }
+      let taskRequestCount = 0
+      configureCreateApi(() => {
+        taskRequestCount += 1
+        return phase !== "resolver rejects" && taskRequestCount === 1
+          ? firstTransport.promise
+          : Promise.resolve(jsonResponse(taskCore()))
+      })
+
+      render(<BuildsPage />)
+      await waitFor(() => expect(screen.queryByText("common.loading")).not.toBeInTheDocument())
+      openCreateModal()
+      typeCreatePrompt("A")
+      startBuildWithEnter()
+
+      if (phase === "transport rejects") {
+        await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith(
+          "http://api.local/api/chat/task/create",
+          expect.anything(),
+        ))
+      }
+      if (phase === "Response.text() rejects and parseApiResponse falls back to empty parsed data") {
+        await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith(
+          "http://api.local/api/chat/task/create",
+          expect.anything(),
+        ))
+        await act(async () => firstTransport.resolve(firstResponse))
+        await waitFor(() => expect(firstResponse.text).toHaveBeenCalledTimes(1))
+      }
+
+      fireEvent.click(screen.getByRole("button", { name: "Close" }))
+      openCreateModal()
+      typeCreatePrompt("B")
+      startBuildWithEnter()
+      expect(screen.getByRole("button", { name: "common.loading" })).toBeDisabled()
+
+      dispatchMock.mockClear()
+      setPendingMessageMock.mockClear()
+      setTaskIdMock.mockClear()
+      toastErrorMock.mockClear()
+      consoleErrorMock.mockClear()
+      const staleFailure = new Error(`stale ${phase}`)
+      if (phase === "resolver rejects") await act(async () => firstSelection.reject(staleFailure))
+      if (phase === "transport rejects") await act(async () => firstTransport.reject(staleFailure))
+      if (phase === "Response.text() rejects and parseApiResponse falls back to empty parsed data") {
+        await act(async () => firstBody.reject(staleFailure))
+      }
+
+      expect(screen.getByPlaceholderText("builds.list.createModal.placeholder")).toHaveValue("B")
+      expect(screen.getByRole("button", { name: "common.loading" })).toBeDisabled()
+      expect(dispatchMock).not.toHaveBeenCalled()
+      expect(setPendingMessageMock).not.toHaveBeenCalled()
+      expect(setTaskIdMock).not.toHaveBeenCalled()
+      expect(toastErrorMock).not.toHaveBeenCalled()
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+
+      await act(async () => secondSelection.resolve(successfulSelection))
+      await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(7))
+    },
+  )
 })

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { readFileSync } from "node:fs"
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -499,6 +500,301 @@ describe("BuildsPage Agent deletion", () => {
       name: "builds.list.deleteDialog.confirmDiscardDraft:Draft Workforce",
     }))
     await waitFor(() => expect(discardRequests).toBe(2))
+  })
+})
+
+function publicationAgent(status: "draft" | "published", id = 42) {
+  return { ...agent, id, status }
+}
+
+function publicationActionName(kind: "publish" | "unpublish") {
+  return `builds.list.actions.${kind}`
+}
+
+describe("BuildsPage publication lifecycle", () => {
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetMocks()
+    consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+    cleanup()
+  })
+
+  it.each([
+    ["publish", "http://api.local/api/agents/42/publish", "builds.publication.publishFailed", "Failed to publish agent:"],
+    ["unpublish", "http://api.local/api/agents/42/unpublish", "builds.publication.unpublishFailed", "Failed to unpublish agent:"],
+  ] as const)("reports mounted non-OK %s failures with the operation-owned key and diagnostic", async (kind, endpoint, key, diagnostic) => {
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        return Promise.resolve(jsonResponse([publicationAgent(kind === "publish" ? "draft" : "published")]))
+      }
+      if (url === endpoint && options?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 503 }))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName(kind) }))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(endpoint, { method: "POST" })
+      expect(toastErrorMock).toHaveBeenCalledWith(key)
+      expect(consoleErrorMock).toHaveBeenCalledWith(diagnostic, expect.any(Response))
+    })
+  })
+
+  it.each([
+    ["publish", "http://api.local/api/agents/42/publish", "builds.publication.publishFailed", "Failed to publish agent:"],
+    ["unpublish", "http://api.local/api/agents/42/unpublish", "builds.publication.unpublishFailed", "Failed to unpublish agent:"],
+  ] as const)("reports mounted rejected %s requests with the operation-owned key and diagnostic", async (kind, endpoint, key, diagnostic) => {
+    const rejection = new Error(`${kind} transport rejected`)
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        return Promise.resolve(jsonResponse([publicationAgent(kind === "publish" ? "draft" : "published")]))
+      }
+      if (url === endpoint && options?.method === "POST") return Promise.reject(rejection)
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName(kind) }))
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(key)
+      expect(consoleErrorMock).toHaveBeenCalledWith(diagnostic, rejection)
+    })
+  })
+
+  it("starts one list refresh after a successful publication", async () => {
+    const refresh = deferred<Response>()
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        return listRequests === 1 ? Promise.resolve(jsonResponse([publicationAgent("draft")])) : refresh.promise
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName("publish") }))
+
+    await waitFor(() => expect(listRequests).toBe(2))
+    expect(toastErrorMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      refresh.resolve(jsonResponse([]))
+      await refresh.promise
+    })
+  })
+
+  it("keeps refresh rejection in the list owner without a publication toast", async () => {
+    const refreshFailure = new Error("refresh rejected")
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        return listRequests === 1
+          ? Promise.resolve(jsonResponse([publicationAgent("draft")]))
+          : Promise.reject(refreshFailure)
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName("publish") }))
+
+    await waitFor(() => {
+      expect(listRequests).toBe(2)
+      expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch agents:", refreshFailure)
+    })
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps a refresh 503 out of publication feedback", async () => {
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        return Promise.resolve(
+          listRequests === 1
+            ? jsonResponse([publicationAgent("draft")])
+            : new Response(null, { status: 503 }),
+        )
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") {
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName("publish") }))
+
+    await waitFor(() => expect(listRequests).toBe(2))
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["204", () => new Response(null, { status: 204 })],
+    ["503", () => new Response(null, { status: 503 })],
+    ["rejection", () => Promise.reject(new Error("late publication rejection"))],
+  ] as const)("is silent and does not refresh when an unmounted publication settles as %s", async (_outcome, settle) => {
+    const mutation = deferred<Response>()
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        return Promise.resolve(jsonResponse([publicationAgent("draft")]))
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") return mutation.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    const { unmount } = render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    fireEvent.click(screen.getByRole("button", { name: publicationActionName("publish") }))
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/agents/42/publish",
+      { method: "POST" },
+    ))
+
+    unmount()
+    await act(async () => {
+      const result = settle()
+      if (result instanceof Promise) {
+        mutation.reject(await result.catch((error) => error))
+      } else {
+        mutation.resolve(result)
+      }
+      await mutation.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+
+    expect(listRequests).toBe(1)
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("does not silence an older publication failure after a newer success", async () => {
+    const older = deferred<Response>()
+    const newer = deferred<Response>()
+    const refresh = deferred<Response>()
+    let publicationRequests = 0
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        return listRequests === 1 ? Promise.resolve(jsonResponse([publicationAgent("draft")])) : refresh.promise
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") {
+        publicationRequests += 1
+        return publicationRequests === 1 ? older.promise : newer.promise
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Research Agent")
+    const publish = screen.getByRole("button", { name: publicationActionName("publish") })
+    fireEvent.click(publish)
+    fireEvent.click(publish)
+
+    await act(async () => {
+      newer.resolve(new Response(null, { status: 204 }))
+      await newer.promise
+    })
+    await waitFor(() => expect(listRequests).toBe(2))
+
+    await act(async () => {
+      older.resolve(new Response(null, { status: 503 }))
+      await older.promise
+    })
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("builds.publication.publishFailed"))
+
+    await act(async () => {
+      refresh.resolve(jsonResponse([]))
+      await refresh.promise
+    })
+  })
+
+  it("starts a refresh for each reverse-order successful publish and unpublish", async () => {
+    const publish = deferred<Response>()
+    const unpublish = deferred<Response>()
+    const firstRefresh = deferred<Response>()
+    const secondRefresh = deferred<Response>()
+    let listRequests = 0
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/agents" && !options?.method) {
+        listRequests += 1
+        if (listRequests === 1) return Promise.resolve(jsonResponse([
+          publicationAgent("draft", 42),
+          publicationAgent("published", 43),
+        ]))
+        return listRequests === 2 ? firstRefresh.promise : secondRefresh.promise
+      }
+      if (url === "http://api.local/api/agents/42/publish" && options?.method === "POST") return publish.promise
+      if (url === "http://api.local/api/agents/43/unpublish" && options?.method === "POST") return unpublish.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<BuildsPage />)
+    await screen.findAllByText("Research Agent")
+    const [publishButton] = screen.getAllByRole("button", { name: publicationActionName("publish") })
+    const [unpublishButton] = screen.getAllByRole("button", { name: publicationActionName("unpublish") })
+    fireEvent.click(publishButton)
+    fireEvent.click(unpublishButton)
+
+    await act(async () => {
+      unpublish.resolve(new Response(null, { status: 204 }))
+      await unpublish.promise
+    })
+    await act(async () => {
+      publish.resolve(new Response(null, { status: 204 }))
+      await publish.promise
+    })
+    await waitFor(() => expect(listRequests).toBe(3))
+
+    await act(async () => {
+      firstRefresh.resolve(jsonResponse([]))
+      secondRefresh.resolve(jsonResponse([]))
+      await Promise.all([firstRefresh.promise, secondRefresh.promise])
+    })
+  })
+
+  it("keeps the mutation and refresh phases structurally separate", () => {
+    const source = readFileSync(`${process.cwd()}/src/app/build/page.tsx`, "utf8")
+    const mutationStart = source.indexOf("const performPublicationMutation")
+    const wrapperStart = source.indexOf("const handlePublication")
+    const nextOwnerStart = source.indexOf("const [agentDeleteSession", wrapperStart)
+
+    expect(mutationStart).toBeGreaterThan(-1)
+    expect(wrapperStart).toBeGreaterThan(mutationStart)
+    expect(nextOwnerStart).toBeGreaterThan(wrapperStart)
+
+    const mutation = source.slice(mutationStart, wrapperStart)
+    const wrapper = source.slice(wrapperStart, nextOwnerStart)
+    expect(mutation).not.toContain("fetchAgents")
+    expect(wrapper).not.toContain("catch")
+    expect(wrapper).toContain("void fetchAgents()")
+    expect(wrapper).not.toContain("await fetchAgents()")
   })
 })
 

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -136,29 +136,50 @@ function BuildsPageContent() {
     }
   }, [])
 
-  const handlePublish = async (agentId: number) => {
+  const publicationOperations = {
+    publish: {
+      suffix: "publish",
+      errorKey: "builds.publication.publishFailed",
+      diagnostic: "Failed to publish agent:",
+    },
+    unpublish: {
+      suffix: "unpublish",
+      errorKey: "builds.publication.unpublishFailed",
+      diagnostic: "Failed to unpublish agent:",
+    },
+  } as const
+
+  const performPublicationMutation = async (
+    agentId: number,
+    kind: keyof typeof publicationOperations,
+  ): Promise<"success" | "failed" | "stale"> => {
+    const operation = publicationOperations[kind]
     try {
-      const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/publish`, {
+      const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/${operation.suffix}`, {
         method: "POST",
       })
-      if (response.ok) {
-        fetchAgents() // Refresh list
+      if (!isMountedRef.current) return "stale"
+      if (!response.ok) {
+        console.error(operation.diagnostic, response)
+        toast.error(t(operation.errorKey))
+        return "failed"
       }
+      return "success"
     } catch (error) {
-      console.error("Failed to publish agent:", error)
+      if (!isMountedRef.current) return "stale"
+      console.error(operation.diagnostic, error)
+      toast.error(t(operation.errorKey))
+      return "failed"
     }
   }
 
-  const handleUnpublish = async (agentId: number) => {
-    try {
-      const response = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/unpublish`, {
-        method: "POST",
-      })
-      if (response.ok) {
-        fetchAgents() // Refresh list
-      }
-    } catch (error) {
-      console.error("Failed to unpublish agent:", error)
+  const handlePublication = async (
+    agentId: number,
+    kind: keyof typeof publicationOperations,
+  ) => {
+    const outcome = await performPublicationMutation(agentId, kind)
+    if (outcome === "success" && isMountedRef.current) {
+      void fetchAgents()
     }
   }
 
@@ -574,9 +595,9 @@ function BuildsPageContent() {
                                       onClick={(e) => {
                                         e.stopPropagation()
                                         if (agent.status === 'published') {
-                                          handleUnpublish(agent.id)
+                                          void handlePublication(agent.id, "unpublish")
                                         } else {
-                                          handlePublish(agent.id)
+                                          void handlePublication(agent.id, "publish")
                                         }
                                       }}
                                     >

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -19,7 +19,8 @@ import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
 import { useRouter, useSearchParams } from "next/navigation"
 import { apiRequest, parseApiResponse } from "@/lib/api-wrapper"
-import { getApiUrl } from "@/lib/utils"
+import { getApiUrl, resolveAgentLogoUrl } from "@/lib/utils"
+import { formatDisplayDate } from "@/lib/time-utils"
 import { resolveTaskLlmSelection } from "@/lib/models"
 import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create"
 import {
@@ -47,7 +48,7 @@ import {
 } from "@/lib/build-page-extension"
 
 function BuildsPageContent() {
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
   const { dispatch, setTaskId, setPendingMessage } = useApp()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -449,11 +450,6 @@ function BuildsPageContent() {
     }
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString()
-  }
-
   return (
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
@@ -519,7 +515,15 @@ function BuildsPageContent() {
             {/* List */}
             {filteredAgents.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                {filteredAgents.map((agent) => (
+                {filteredAgents.map((agent) => {
+                  const resolvedLogoUrl = resolveAgentLogoUrl(agent.logo_url, getApiUrl())
+                  const createdDate = formatDisplayDate(agent.created_at, locale, {
+                    year: "numeric", month: "numeric", day: "numeric",
+                  })
+                  const updatedDate = formatDisplayDate(agent.updated_at, locale, {
+                    year: "numeric", month: "numeric", day: "numeric",
+                  })
+                  return (
                   <div
                     key={agent.id}
                     className="group relative flex flex-col justify-between space-y-4 rounded-xl border bg-card p-6 shadow-sm transition-all cursor-pointer hover:shadow-md hover:border-primary/50"
@@ -529,8 +533,8 @@ function BuildsPageContent() {
                       <div className="space-y-4">
                         <div className="flex items-start gap-4">
                           <div className="h-10 w-10 shrink-0 rounded-lg bg-primary/10 flex items-center justify-center text-primary overflow-hidden">
-                            {agent.logo_url ? (
-                              <img src={`${getApiUrl()}${agent.logo_url}`} alt={agent.name} className="h-full w-full object-cover" />
+                            {resolvedLogoUrl ? (
+                              <img src={resolvedLogoUrl} alt={agent.name} className="h-full w-full object-cover" />
                             ) : (
                               <Bot className="h-6 w-6" />
                             )}
@@ -635,14 +639,18 @@ function BuildsPageContent() {
 
                     <div className="space-y-4 pt-2">
                       <div className="space-y-1.5">
-                        <div className="flex items-center text-xs text-muted-foreground">
-                          <Calendar className="h-3.5 w-3.5 mr-1.5" />
-                          {t('builds.card.createdAt')}: {formatDate(agent.created_at)}
-                        </div>
-                        <div className="flex items-center text-xs text-muted-foreground">
-                          <Clock className="h-3.5 w-3.5 mr-1.5" />
-                          {t('builds.card.updatedAt')}: {formatDate(agent.updated_at || agent.created_at)}
-                        </div>
+                        {createdDate && (
+                          <div className="flex items-center text-xs text-muted-foreground">
+                            <Calendar className="h-3.5 w-3.5 mr-1.5" />
+                            {t('builds.card.createdAt')}: {createdDate}
+                          </div>
+                        )}
+                        {updatedDate && (
+                          <div className="flex items-center text-xs text-muted-foreground">
+                            <Clock className="h-3.5 w-3.5 mr-1.5" />
+                            {t('builds.card.updatedAt')}: {updatedDate}
+                          </div>
+                        )}
                       </div>
                       <div className="space-y-4" onClick={(e) => e.stopPropagation()}>
                         <BuildAgentCardExtension agentId={agent.id} />
@@ -714,7 +722,8 @@ function BuildsPageContent() {
                       </div>
                     </div>
                   </div>
-                ))}
+                  )
+                })}
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center h-[400px] text-center space-y-4 border rounded-lg bg-muted/10 border-dashed">

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -18,8 +18,10 @@ import { FeatureEmptyState } from "@/components/ui/feature-empty-state"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
 import { useRouter, useSearchParams } from "next/navigation"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
+import { resolveTaskLlmSelection } from "@/lib/models"
+import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create"
 import {
   canDeleteAgent,
   canEditAgent,
@@ -44,43 +46,6 @@ import {
   BuildPageExtensionProvider,
 } from "@/lib/build-page-extension"
 
-interface LlmModel {
-  model_id: string
-  is_default?: boolean
-}
-
-interface DefaultModelRecord {
-  config_type?: "general" | "small_fast" | "visual" | "compact"
-  model?: {
-    model_id?: string
-  } | null
-}
-
-interface TaskCreateResponse {
-  task_id: number
-}
-
-const isLlmModel = (value: unknown): value is LlmModel => {
-  if (!value || typeof value !== "object") {
-    return false
-  }
-
-  const candidate = value as Record<string, unknown>
-  return (
-    typeof candidate.model_id === "string" &&
-    (candidate.is_default === undefined || typeof candidate.is_default === "boolean")
-  )
-}
-
-const isTaskCreateResponse = (value: unknown): value is TaskCreateResponse => {
-  if (!value || typeof value !== "object") {
-    return false
-  }
-
-  const candidate = value as Record<string, unknown>
-  return typeof candidate.task_id === "number"
-}
-
 function BuildsPageContent() {
   const { t } = useI18n()
   const { dispatch, setTaskId, setPendingMessage } = useApp()
@@ -91,6 +56,9 @@ function BuildsPageContent() {
   const isMountedRef = useRef(false)
   const agentListRequestGenerationRef = useRef(0)
   const agentDeleteActionGenerationRef = useRef(0)
+  const activeTaskCreateAttemptRef = useRef<number | null>(null)
+  const taskCreateCounterRef = useRef(0)
+  const draftRevisionRef = useRef(0)
   const [searchTerm, setSearchTerm] = useState("")
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
@@ -162,6 +130,7 @@ function BuildsPageContent() {
     void fetchAgents()
     return () => {
       isMountedRef.current = false
+      activeTaskCreateAttemptRef.current = null
       agentListRequestGenerationRef.current += 1
       agentDeleteActionGenerationRef.current += 1
     }
@@ -339,106 +308,105 @@ function BuildsPageContent() {
     setIsCreateModalOpen(true)
   }
 
-  const resolveTaskLlmIds = async (): Promise<[string, string | null, string | null, string | null] | null> => {
-    const apiUrl = getApiUrl()
-    const [modelsResponse, defaultResponse] = await Promise.all([
-      apiRequest(`${apiUrl}/api/models/?category=llm`, { headers: {} }),
-      apiRequest(`${apiUrl}/api/models/user-default`, { headers: {} }),
-    ])
-
-    let allModels: LlmModel[] = []
-    if (modelsResponse.ok) {
-      const modelsData = await modelsResponse.json()
-      if (Array.isArray(modelsData)) {
-        allModels = modelsData.filter(isLlmModel)
-      }
-    }
-
-    const defaultModels: Record<string, string | undefined> = {}
-    if (defaultResponse.ok) {
-      const defaultsData = await defaultResponse.json()
-      if (Array.isArray(defaultsData)) {
-        defaultsData.forEach((defaultConfig: DefaultModelRecord) => {
-          if (defaultConfig?.config_type && defaultConfig.model?.model_id) {
-            defaultModels[defaultConfig.config_type] = defaultConfig.model.model_id
-          }
-        })
-      }
-    }
-
-    const generalModelId =
-      defaultModels.general ||
-      allModels.find((model) => model.is_default)?.model_id ||
-      allModels[0]?.model_id
-
-    if (!generalModelId) {
-      return null
-    }
-
-    return [
-      generalModelId,
-      defaultModels.small_fast ?? null,
-      defaultModels.visual ?? null,
-      defaultModels.compact ?? null,
-    ]
-  }
-
   const handleBuildWithPrompt = async () => {
-    const prompt = createPrompt.trim()
-    if (!prompt || isStartingTask) return
+    const rawPrompt = createPrompt
+    const prompt = rawPrompt.trim()
+    if (!prompt || activeTaskCreateAttemptRef.current !== null) return
+
+    const attempt = ++taskCreateCounterRef.current
+    activeTaskCreateAttemptRef.current = attempt
+    const revision = draftRevisionRef.current
+    const isCurrent = () => isMountedRef.current && activeTaskCreateAttemptRef.current === attempt
 
     setIsStartingTask(true)
     try {
-      dispatch({ type: "RESET_STATE" })
-      const llmIds = await resolveTaskLlmIds()
-      if (!llmIds) {
-        toast.error(t("chatPage.input.noModelAlert"))
+      let task = null
+
+      try {
+        const selection = await resolveTaskLlmSelection()
+        if (!isCurrent()) return
+
+        if (selection.kind === "no_model") {
+          toast.error(t("chatPage.input.noModelAlert"))
+          return
+        }
+        if (selection.kind === "operational_error") throw selection.error
+
+        const taskResponse = await apiRequest(`${getApiUrl()}/api/chat/task/create`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: normalizeTaskPromptTitle(rawPrompt),
+            description: prompt,
+            llm_ids: selection.llmIds,
+          }),
+        })
+
+        if (!isCurrent()) return
+        const parsed = await parseApiResponse(taskResponse)
+        if (!isCurrent()) return
+
+        task = taskResponse.ok ? parseTaskCreateCore(parsed.data) : null
+        if (!task) throw new Error("Task create response is invalid")
+      } catch (error) {
+        if (isCurrent()) {
+          console.error("Failed to start task from build modal:", error)
+          toast.error(t("builds.list.createModal.startTaskFailed"))
+        }
         return
       }
 
-      const taskResponse = await apiRequest(`${getApiUrl()}/api/chat/task/create`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          title: prompt,
-          description: prompt,
-          llm_ids: llmIds,
-        }),
-      })
+      if (!isCurrent() || !task) return
 
-      if (!taskResponse.ok) {
-        throw new Error("Failed to create task")
+      try {
+        if (!isCurrent()) return
+        dispatch({ type: "RESET_STATE" })
+
+        if (!isCurrent()) return
+        setPendingMessage({
+          message: prompt,
+          files: [],
+          targetTaskId: task.taskId,
+        })
+
+        if (!isCurrent()) return
+        dispatch({ type: "TRIGGER_TASK_UPDATE" })
+
+        if (!isCurrent()) return
+        setTaskId(task.taskId)
+
+        if (!isCurrent()) return
+        setIsCreateModalOpen(false)
+
+        if (!isCurrent()) return
+        if (draftRevisionRef.current === revision) {
+          draftRevisionRef.current += 1
+          setCreatePrompt("")
+        }
+      } catch (error) {
+        if (isCurrent()) console.error("Failed to commit task creation:", error)
       }
-
-      const taskData = await taskResponse.json()
-      if (!isTaskCreateResponse(taskData)) {
-        throw new Error("Task create response is missing task_id")
-      }
-
-      setPendingMessage({
-        message: prompt,
-        files: [],
-        targetTaskId: taskData.task_id,
-      })
-      dispatch({ type: "TRIGGER_TASK_UPDATE" })
-      setTaskId(taskData.task_id)
-      setIsCreateModalOpen(false)
-      setCreatePrompt("")
-    } catch (error) {
-      console.error("Failed to start task from build modal:", error)
-      toast.error(t("builds.list.createModal.startTaskFailed"))
-      setIsCreateModalOpen(true)
-      setCreatePrompt(prompt)
     } finally {
-      setIsStartingTask(false)
+      if (isCurrent()) {
+        activeTaskCreateAttemptRef.current = null
+        setIsStartingTask(false)
+      }
     }
   }
 
+  const handleCreateModalOpenChange = (open: boolean) => {
+    if (!open) {
+      activeTaskCreateAttemptRef.current = null
+      setIsStartingTask(false)
+    }
+    setIsCreateModalOpen(open)
+  }
+
   const handleManualCreate = () => {
+    handleCreateModalOpenChange(false)
     router.push("/build/new")
-    setIsCreateModalOpen(false)
   }
 
   const createPromptVoiceInputLabel =
@@ -778,7 +746,7 @@ function BuildsPageContent() {
         onOpenChange={(open) => { if (!open) setTriggersAgent(null) }}
       />
 
-      <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+      <Dialog open={isCreateModalOpen} onOpenChange={handleCreateModalOpenChange}>
         <DialogContent className="sm:max-w-[550px] gap-0 p-0 overflow-hidden bg-background shadow-lg rounded-xl">
           <DialogHeader className="px-6 py-5 border-b pr-10">
             <DialogTitle className="flex items-start sm:items-center gap-2 text-xl font-semibold">
@@ -809,7 +777,7 @@ function BuildsPageContent() {
                   ref={createPromptRef}
                   data-voice-input="false"
                   value={createPrompt}
-                  onChange={(e) => setCreatePrompt(e.target.value)}
+                  onChange={(e) => { draftRevisionRef.current += 1; setCreatePrompt(e.target.value) }}
                   placeholder={t("builds.list.createModal.placeholder")}
                   className="min-h-[100px] flex-1 resize-none border-0 shadow-none focus-visible:ring-0"
                   onKeyDown={(e) => {

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,9 +1,14 @@
 import React from "react"
-import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
+const resolveTaskLlmSelectionMock = vi.hoisted(() => vi.fn())
 const homeExtensionRenderMock = vi.hoisted(() => vi.fn())
+const setPendingMessageMock = vi.hoisted(() => vi.fn())
+const setTaskIdMock = vi.hoisted(() => vi.fn())
+const routerPushMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
 
 async function createHomeExtensionMock() {
   const ReactModule = await vi.importActual<typeof import("react")>("react")
@@ -22,13 +27,21 @@ vi.mock("@/lib/api-wrapper", async () => {
   return { ...actual, apiRequest: apiRequestMock }
 })
 
+vi.mock("@/lib/models", () => ({
+  resolveTaskLlmSelection: resolveTaskLlmSelectionMock,
+}))
+
 vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
   return { ...actual, getApiUrl: () => "http://api.local" }
 })
 
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { error: toastErrorMock },
+}))
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: routerPushMock }),
 }))
 
 vi.mock("next/link", () => ({
@@ -50,8 +63,8 @@ vi.mock("@/contexts/i18n-context", () => ({
 
 vi.mock("@/contexts/app-context-chat", () => ({
   useApp: () => ({
-    setTaskId: vi.fn(),
-    setPendingMessage: vi.fn(),
+    setTaskId: setTaskIdMock,
+    setPendingMessage: setPendingMessageMock,
   }),
 }))
 
@@ -79,17 +92,77 @@ vi.mock("@/lib/home-page-extension", createHomeExtensionMock)
 
 import Home from "./page"
 
-function jsonResponse(data: unknown) {
+const successfulSelection = {
+  kind: "success" as const,
+  llmIds: ["general", null, null, null] as [string, null, null, null],
+}
+
+function jsonResponse(data: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(data), {
     status: 200,
     headers: { "Content-Type": "application/json" },
+    ...init,
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function input(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText("home.hero.searchPlaceholder")
+}
+
+function submitButton(): HTMLButtonElement {
+  const button = input().parentElement?.querySelector("button:not([aria-label])")
+  if (!(button instanceof HTMLButtonElement)) throw new Error("Home submit button not found")
+  return button
+}
+
+function typePrompt(value: string) {
+  fireEvent.input(input(), { target: { value } })
+}
+
+function submitWithEnter() {
+  fireEvent.keyDown(input(), { key: "Enter" })
+}
+
+function taskCore(taskId = 7) {
+  return {
+    task_id: taskId,
+    title: "created task",
+    status: "running",
+    created_at: "2026-01-01T00:00:00Z",
+  }
+}
+
 describe("Home", () => {
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>
+
+  function expectNoTaskCreatePublication() {
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(routerPushMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  }
+
   beforeEach(() => {
     apiRequestMock.mockReset()
+    resolveTaskLlmSelectionMock.mockReset()
     homeExtensionRenderMock.mockClear()
+    setPendingMessageMock.mockReset()
+    setTaskIdMock.mockReset()
+    routerPushMock.mockReset()
+    toastErrorMock.mockReset()
+    consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    resolveTaskLlmSelectionMock.mockResolvedValue(successfulSelection)
     apiRequestMock.mockImplementation((url: string) => {
       if (url.startsWith("http://api.local/api/templates/")) {
         return Promise.resolve(jsonResponse([]))
@@ -101,7 +174,10 @@ describe("Home", () => {
     })
   })
 
-  afterEach(() => cleanup())
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+    cleanup()
+  })
 
   it("renders a hook-bearing configured extension as one component", async () => {
     render(<Home />)
@@ -109,10 +185,7 @@ describe("Home", () => {
     expect(screen.getByRole("button", { name: "voiceInput.start" })).toBeInTheDocument()
     const extension = await screen.findByTestId("home-extension")
     expect(extension).toBeInTheDocument()
-    expect(extension.parentElement).toHaveAttribute(
-      "data-slot",
-      "home-page-extension",
-    )
+    expect(extension.parentElement).toHaveAttribute("data-slot", "home-page-extension")
     expect(extension.parentElement).toHaveClass("shrink-0")
     expect(screen.getAllByTestId("home-extension")).toHaveLength(1)
     expect(homeExtensionRenderMock).toHaveBeenCalled()
@@ -124,7 +197,6 @@ describe("Home", () => {
     vi.resetModules()
     try {
       const { default: DefaultHome } = await import("./page")
-
       const { container } = render(<DefaultHome />)
       const slot = container.querySelector('[data-slot="home-page-extension"]')
 
@@ -136,5 +208,351 @@ describe("Home", () => {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
       vi.resetModules()
     }
+  })
+
+  it("uses the shared resolver, real task body parser, and ordered successful commit", async () => {
+    const events: string[] = []
+    setPendingMessageMock.mockImplementation(() => events.push("pending"))
+    setTaskIdMock.mockImplementation(() => {
+      events.push("taskId")
+      expect(input()).toHaveValue("  hello\n  world  ")
+      expect(input().style.height).toBe("56px")
+    })
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") {
+        expect(options?.method).toBe("POST")
+        expect(JSON.parse(String(options?.body))).toEqual({
+          title: "hello world",
+          description: "hello\n  world",
+          llm_ids: ["general", null, null, null],
+        })
+        return Promise.resolve(jsonResponse(taskCore(9)))
+      }
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+
+    render(<Home />)
+    typePrompt("  hello\n  world  ")
+    input().style.height = "56px"
+    submitWithEnter()
+
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(9))
+    expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(1)
+    expect(events).toEqual(["pending", "taskId"])
+    expect(setPendingMessageMock).toHaveBeenCalledWith({
+      message: "hello\n  world",
+      files: [],
+      targetTaskId: 9,
+    })
+    expect(input().value).toBe("")
+    expect(input().style.height).toBe("auto")
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps no_model distinct from an operational resolver failure", async () => {
+    resolveTaskLlmSelectionMock.mockResolvedValueOnce({ kind: "no_model" })
+    render(<Home />)
+    const noModelPrompt = "  no model draft  "
+    typePrompt(noModelPrompt)
+    input().style.height = "72px"
+    const noModelStyle = input().getAttribute("style")
+    submitWithEnter()
+    expect(await screen.findByText("chatPage.input.noModelAlert")).toBeInTheDocument()
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(input().value).toBe(noModelPrompt)
+    expect(input()).toHaveAttribute("style", noModelStyle)
+
+    cleanup()
+    resolveTaskLlmSelectionMock.mockResolvedValueOnce({
+      kind: "operational_error",
+      error: new Error("resolver failure"),
+    })
+    render(<Home />)
+    const operationalErrorPrompt = "  operational error draft  "
+    typePrompt(operationalErrorPrompt)
+    input().style.height = "64px"
+    const operationalErrorStyle = input().getAttribute("style")
+    submitWithEnter()
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).toHaveBeenCalled()
+    expect(input().value).toBe(operationalErrorPrompt)
+    expect(input()).toHaveAttribute("style", operationalErrorStyle)
+  })
+
+  it("uses the ref token as a same-act Enter/click latch", async () => {
+    const selection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(selection.promise)
+    render(<Home />)
+    typePrompt("prompt")
+
+    await act(async () => {
+      submitWithEnter()
+      fireEvent.click(submitButton())
+    })
+
+    expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(1)
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+  })
+
+  it("does not POST or publish effects after unmount during model resolution", async () => {
+    const selection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(selection.promise)
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+
+    view.unmount()
+    await act(async () => selection.resolve(successfulSelection))
+
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("silences a rejected resolver after Home unmount", async () => {
+    const selection = deferred<typeof successfulSelection>()
+    resolveTaskLlmSelectionMock.mockReturnValueOnce(selection.promise)
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+    expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(1)
+
+    view.unmount()
+    await act(async () => selection.reject(new Error("resolver unavailable")))
+
+    expect(apiRequestMock).not.toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything())
+    expectNoTaskCreatePublication()
+  })
+
+  it("silences a rejected create transport after Home unmount", async () => {
+    const response = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return response.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    view.unmount()
+    await act(async () => response.reject(new Error("transport unavailable")))
+
+    expectNoTaskCreatePublication()
+  })
+
+  it("silences parseApiResponse's empty-data fallback after Response.text() rejects post-unmount", async () => {
+    const body = deferred<string>()
+    const taskResponse = new Response("unreadable")
+    const text = vi.fn(() => body.promise)
+    Object.defineProperty(taskResponse, "text", { value: text })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return Promise.resolve(taskResponse)
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+    await waitFor(() => expect(text).toHaveBeenCalledTimes(1))
+
+    view.unmount()
+    await act(async () => {
+      body.reject(new Error("body unavailable"))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+
+    expectNoTaskCreatePublication()
+  })
+
+  it("does not parse a response that arrives after unmount", async () => {
+    const response = deferred<Response>()
+    const taskResponse = new Response(JSON.stringify(taskCore()))
+    const text = vi.fn(taskResponse.text.bind(taskResponse))
+    Object.defineProperty(taskResponse, "text", { value: text })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return response.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    view.unmount()
+    await act(async () => response.resolve(taskResponse))
+
+    expect(text).not.toHaveBeenCalled()
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("allows parsing to finish after unmount but publishes no effects", async () => {
+    const body = deferred<string>()
+    const taskResponse = new Response("")
+    const text = vi.fn(() => body.promise)
+    Object.defineProperty(taskResponse, "text", { value: text })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return Promise.resolve(taskResponse)
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    const view = render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+    await waitFor(() => expect(text).toHaveBeenCalledTimes(1))
+
+    view.unmount()
+    await act(async () => body.resolve(JSON.stringify(taskCore())))
+
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["non-OK", jsonResponse(taskCore(), { status: 500 })],
+    ["empty", new Response("")],
+    ["malformed", new Response("{")],
+    ["invalid core", jsonResponse({ id: 7 })],
+  ])("keeps task actions at zero and reports current %s create failure", async (_name, taskResponse) => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return Promise.resolve(taskResponse)
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).toHaveBeenCalled()
+  })
+
+  it("reports a current unreadable task body as one operational failure", async () => {
+    const taskResponse = new Response("unreadable")
+    Object.defineProperty(taskResponse, "text", {
+      value: vi.fn().mockRejectedValue(new Error("body unavailable")),
+    })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return Promise.resolve(taskResponse)
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+  })
+
+  it("never overwrites a newer B draft or its height after A succeeds or fails", async () => {
+    const result = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return result.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("A")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typePrompt("B")
+    input().style.height = "72px"
+
+    await act(async () => result.resolve(jsonResponse(taskCore())))
+    expect(input().value).toBe("B")
+    expect(input().style.height).toBe("72px")
+
+    cleanup()
+    const failed = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return failed.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("A")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typePrompt("B")
+    input().style.height = "72px"
+    await act(async () => failed.resolve(jsonResponse(taskCore(), { status: 500 })))
+
+    expect(input().value).toBe("B")
+    expect(input().style.height).toBe("72px")
+  })
+
+  it("preserves A after an ABA edit even when the old attempt succeeds", async () => {
+    const result = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return result.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("A")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+    typePrompt("B")
+    typePrompt("A")
+    input().style.height = "64px"
+
+    await act(async () => result.resolve(jsonResponse(taskCore())))
+
+    expect(input().value).toBe("A")
+    expect(input().style.height).toBe("64px")
+  })
+
+  it("does not classify a synchronous commit collaborator throw as an operational create failure", async () => {
+    setTaskIdMock.mockImplementation(() => { throw new Error("commit failed") })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return Promise.resolve(jsonResponse(taskCore()))
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("prompt")
+    submitWithEnter()
+
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(7))
+    expect(setPendingMessageMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).toHaveBeenCalled()
+    expect(input().value).toBe("prompt")
+
+    const resolverCallsBeforeRetry = resolveTaskLlmSelectionMock.mock.calls.length
+    setTaskIdMock.mockReset()
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    fireEvent.click(submitButton())
+    await waitFor(() => expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(resolverCallsBeforeRetry + 1))
+    await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(7))
+    expect(toastErrorMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,4 +1,5 @@
-import React from "react"
+import React, { StrictMode } from "react"
+import { readFileSync } from "node:fs"
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -9,6 +10,7 @@ const setPendingMessageMock = vi.hoisted(() => vi.fn())
 const setTaskIdMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const localeMock = vi.hoisted(() => ({ value: "en" as "en" | "zh" }))
 
 async function createHomeExtensionMock() {
   const ReactModule = await vi.importActual<typeof import("react")>("react")
@@ -57,7 +59,7 @@ vi.mock("next/link", () => ({
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     t: (key: string) => key,
-    locale: "en",
+    locale: localeMock.value,
   }),
 }))
 
@@ -105,6 +107,14 @@ function jsonResponse(data: unknown, init?: ResponseInit) {
   })
 }
 
+function unreadableResponse() {
+  const response = new Response("unreadable")
+  Object.defineProperty(response, "text", {
+    value: vi.fn().mockRejectedValue(new Error("body unavailable")),
+  })
+  return response
+}
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -141,6 +151,51 @@ function taskCore(taskId = 7) {
     created_at: "2026-01-01T00:00:00Z",
   }
 }
+
+function templateCard(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `Template ${id}`,
+    category: "Automation",
+    description: `Description ${id}`,
+    features: [`Feature ${id}`],
+    connections: [{ name: `Connection ${id}`, logo: null }],
+    setup_time: "5 min",
+    likes: 2,
+    used_count: 3,
+    ...overrides,
+  }
+}
+
+function recentTask(taskId: number, overrides: Record<string, unknown> = {}) {
+  return {
+    task_id: taskId,
+    title: `Task ${taskId}`,
+    created_at: "2026-01-01T00:00:00Z",
+    agent_name: "Agent",
+    agent_logo_url: null,
+    ...overrides,
+  }
+}
+
+function omitField(value: Record<string, unknown>, field: string) {
+  const copy = { ...value }
+  delete copy[field]
+  return copy
+}
+
+function sourceSlice(source: string, start: string, end: string) {
+  const startIndex = source.indexOf(start)
+  const endIndex = source.indexOf(end, startIndex + start.length)
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing source slice: ${start} -> ${end}`)
+  return source.slice(startIndex, endIndex)
+}
+
+function templateUrl(locale = localeMock.value) {
+  return `http://api.local/api/templates/?lang=${locale}`
+}
+
+const recentTasksUrl = "http://api.local/api/chat/tasks?page=1&per_page=5"
 
 describe("Home", () => {
   let consoleErrorMock: ReturnType<typeof vi.spyOn>
@@ -554,5 +609,566 @@ describe("Home", () => {
     await waitFor(() => expect(resolveTaskLlmSelectionMock).toHaveBeenCalledTimes(resolverCallsBeforeRetry + 1))
     await waitFor(() => expect(setTaskIdMock).toHaveBeenCalledWith(7))
     expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  describe("independent Home loaders", () => {
+    beforeEach(() => {
+      localeMock.value = "en"
+    })
+
+    it("keeps recent tasks when the template transport fails and reports the template owner", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.reject(new Error("templates down"))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(1)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Task 1")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+      expect(screen.queryByText("Template 1")).not.toBeInTheDocument()
+    })
+
+    it("keeps templates when the recent-task transport fails and reports the recent owner", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("one")]))
+        if (url === recentTasksUrl) return Promise.reject(new Error("tasks down"))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Template one")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+      expect(screen.queryByText("Task 1")).not.toBeInTheDocument()
+    })
+
+    it.each([
+      ["empty", new Response("")],
+      ["malformed", new Response("{")],
+      ["body-reader rejection with parser empty fallback", unreadableResponse()],
+      ["JSON primitive", jsonResponse("not a template collection")],
+      ["wrong shape", jsonResponse({ templates: [] })],
+    ])("treats current template %s data as its own failure", async (_name, response) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(response)
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(2)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Task 2")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+    })
+
+    it.each([
+      ["empty", new Response("")],
+      ["malformed", new Response("{")],
+      ["body-reader rejection with parser empty fallback", unreadableResponse()],
+      ["JSON primitive", jsonResponse(7)],
+      ["unsupported array", jsonResponse([recentTask(3)])],
+      ["wrong object", jsonResponse({ pagination: {} })],
+    ])("treats current recent %s data as its own failure", async (_name, response) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("kept")]))
+        if (url === recentTasksUrl) return Promise.resolve(response)
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Template kept")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+    })
+
+    it("rejects non-OK loader responses before body parsing and clears only old templates", async () => {
+      const oldTemplate = deferred<Response>()
+      const currentBody = vi.fn(() => Promise.resolve(JSON.stringify([templateCard("bad")])) )
+      let templateRequest = 0
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.startsWith("http://api.local/api/templates/")) {
+          templateRequest += 1
+          if (templateRequest === 1) return oldTemplate.promise
+          const response = new Response("valid but unavailable", { status: 503 })
+          Object.defineProperty(response, "text", { value: currentBody })
+          return Promise.resolve(response)
+        }
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(4)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      await act(async () => oldTemplate.resolve(jsonResponse([templateCard("old")])))
+      expect(await screen.findByText("Template old")).toBeInTheDocument()
+
+      localeMock.value = "zh"
+      view.rerender(<Home />)
+
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+      expect(screen.queryByText("Template old")).not.toBeInTheDocument()
+      expect(screen.getByText("Task 4")).toBeInTheDocument()
+      expect(currentBody).not.toHaveBeenCalled()
+    })
+
+    it("rejects a current non-OK recent response before parsing without affecting templates", async () => {
+      const recentBody = vi.fn(() => Promise.resolve(JSON.stringify({ tasks: [recentTask(40)] })))
+      const recentResponse = new Response("valid but unavailable", { status: 503 })
+      Object.defineProperty(recentResponse, "text", { value: recentBody })
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("kept")]))
+        if (url === recentTasksUrl) return Promise.resolve(recentResponse)
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Template kept")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+      expect(recentBody).not.toHaveBeenCalled()
+      expect(screen.queryByText("Task 40")).not.toBeInTheDocument()
+    })
+
+    it("validates every template before retaining the ordered first three and navigation IDs", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([
+          templateCard("one"), templateCard("two"), templateCard("three"), templateCard("four"),
+        ]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [] }))
+        if (url === "http://api.local/api/templates/two/use") return Promise.resolve(jsonResponse({}))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Template one")).toBeInTheDocument()
+      expect(screen.getByText("Template two")).toBeInTheDocument()
+      expect(screen.getByText("Template three")).toBeInTheDocument()
+      expect(screen.queryByText("Template four")).not.toBeInTheDocument()
+      fireEvent.click(screen.getAllByRole("button", { name: "home.templates.useTemplate" })[1])
+      await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith("/build/new?template=two"))
+    })
+
+    it("renders every copied template and recent-task value from distinctive wire fields", async () => {
+      const createdAt = "2024-05-06T07:08:09Z"
+      const formattedDate = new Date(createdAt).toLocaleDateString("en-US", {
+        month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+      })
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([
+          templateCard("distinct-template-id", {
+            name: "Distinct Template Name",
+            category: "Distinct Template Category",
+            description: "Distinct Template Description",
+            features: [],
+            connections: [{ name: "Distinct Connection Name", logo: "https://assets.local/distinct-connection.png" }],
+            setup_time: "37 distinctive minutes",
+            likes: 7654321,
+            used_count: 7654322,
+          }),
+          templateCard("feature-template-id", {
+            name: "Feature Template Name",
+            features: ["Distinct Template Feature"],
+          }),
+        ]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(8765432, {
+          title: "Distinct Recent Title",
+          created_at: createdAt,
+          agent_name: "Distinct Recent Agent",
+          agent_logo_url: "https://assets.local/distinct-agent.png",
+        })] }))
+        if (url === "http://api.local/api/templates/distinct-template-id/use") return Promise.resolve(jsonResponse({}))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Distinct Template Name")).toBeInTheDocument()
+      expect(screen.getByText("Distinct Template Category")).toBeInTheDocument()
+      expect(screen.getByText("Distinct Template Description")).toBeInTheDocument()
+      expect(screen.getByText("Distinct Template Feature")).toBeInTheDocument()
+      expect(screen.getByText("37 distinctive minutes")).toBeInTheDocument()
+      expect(screen.getByText("7654321")).toBeInTheDocument()
+      expect(screen.getByText("7654322")).toBeInTheDocument()
+      expect(screen.getByRole("img", { name: "Distinct Connection Name" })).toHaveAttribute(
+        "src", "https://assets.local/distinct-connection.png",
+      )
+      fireEvent.click(screen.getAllByRole("button", { name: "home.templates.useTemplate" })[0])
+      await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith("/build/new?template=distinct-template-id"))
+
+      const recentLink = screen.getByRole("link", { name: /Distinct Recent Title/ })
+      expect(recentLink).toHaveAttribute("href", "/task/8765432")
+      expect(recentLink).toHaveTextContent("Distinct Recent Agent")
+      expect(recentLink).toHaveTextContent(formattedDate)
+      expect(screen.getByRole("img", { name: "Agent" })).toHaveAttribute(
+        "src", "https://assets.local/distinct-agent.png",
+      )
+    })
+
+    it("rejects a malformed fourth template instead of slicing before complete validation", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([
+          templateCard("one"), templateCard("two"), templateCard("three"), templateCard("bad", { likes: 1.5 }),
+        ]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(5)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+
+      expect(await screen.findByText("Task 5")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+      expect(screen.queryByText("Template one")).not.toBeInTheDocument()
+    })
+
+    it.each([
+      ["id", { id: 1 }], ["name", { name: 1 }], ["category", { category: 1 }],
+      ["description", { description: 1 }], ["setup_time", { setup_time: 1 }],
+      ["features array", { features: "feature" }], ["feature member", { features: [1] }],
+      ["connections array", { connections: {} }], ["connection record", { connections: [null] }],
+      ["connection name", { connections: [{ name: 1, logo: null }] }],
+      ["connection logo", { connections: [{ name: "ok", logo: 1 }] }],
+      ["likes non-number", { likes: "1" }], ["likes fraction", { likes: 1.5 }],
+      ["likes unsafe", { likes: Number.MAX_SAFE_INTEGER + 1 }],
+      ["used count non-number", { used_count: "1" }], ["used count fraction", { used_count: 1.5 }],
+      ["used count unsafe", { used_count: Number.MAX_SAFE_INTEGER + 1 }],
+    ])("rejects malformed consumed template %s", async (_name, patch) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("bad", patch)]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+    })
+
+    it.each([
+      ["missing id", omitField(templateCard("bad"), "id")], ["null id", templateCard("bad", { id: null })],
+      ["missing name", omitField(templateCard("bad"), "name")], ["null name", templateCard("bad", { name: null })],
+      ["missing category", omitField(templateCard("bad"), "category")], ["null category", templateCard("bad", { category: null })],
+      ["missing description", omitField(templateCard("bad"), "description")], ["null description", templateCard("bad", { description: null })],
+      ["missing features", omitField(templateCard("bad"), "features")], ["null features", templateCard("bad", { features: null })],
+      ["missing connections", omitField(templateCard("bad"), "connections")], ["null connections", templateCard("bad", { connections: null })],
+      ["missing setup_time", omitField(templateCard("bad"), "setup_time")], ["null setup_time", templateCard("bad", { setup_time: null })],
+      ["missing likes", omitField(templateCard("bad"), "likes")], ["null likes", templateCard("bad", { likes: null })],
+      ["missing used_count", omitField(templateCard("bad"), "used_count")], ["null used_count", templateCard("bad", { used_count: null })],
+      ["missing connection name", templateCard("bad", { connections: [omitField({ name: "connection", logo: null }, "name")] })],
+      ["null connection name", templateCard("bad", { connections: [{ name: null, logo: null }] })],
+      ["missing connection logo", templateCard("bad", { connections: [omitField({ name: "connection", logo: null }, "logo")] })],
+    ])("rejects producer-required template field when %s", async (_name, record) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([record]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(51)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findByText("Task 51")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch templates:", expect.any(Error)))
+    })
+
+    it("accepts blank values for every consumed template string, null and blank logos, negative safe counters, and ignores broader fields", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("", {
+          name: "", category: "", description: "", setup_time: "", features: [""],
+          connections: [{ name: "", logo: "" }], likes: -2, used_count: -3,
+          featured: "wrong", sample_prompts: "wrong", tags: "wrong", author: 1, version: null, views: "wrong", is_liked: "wrong",
+        }), templateCard("null-logo", { connections: [{ name: "", logo: null }] })]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findAllByRole("button", { name: "home.templates.useTemplate" })).toHaveLength(2)
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ["numeric string ID", { task_id: "7" }], ["zero ID", { task_id: 0 }], ["negative ID", { task_id: -1 }],
+      ["fraction ID", { task_id: 1.5 }], ["unsafe ID", { task_id: Number.MAX_SAFE_INTEGER + 1 }],
+      ["non-string title", { title: 1 }], ["invalid date", { created_at: 1 }],
+      ["invalid name", { agent_name: null }], ["invalid logo", { agent_logo_url: 1 }],
+    ])("rejects malformed consumed recent-task %s", async (_name, patch) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("kept")]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(6, patch)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findByText("Template kept")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+    })
+
+    it.each([
+      ["missing task_id", omitField(recentTask(52), "task_id")],
+      ["null task_id", recentTask(52, { task_id: null })],
+      ["missing title", omitField(recentTask(52), "title")],
+      ["null title", recentTask(52, { title: null })],
+    ])("rejects producer-required recent-task field when %s", async (_name, record) => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("kept-required")]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [record] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findByText("Template kept-required")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+    })
+
+    it("rejects a null tasks property while templates remain visible", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([templateCard("kept-null-tasks")]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: null }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findByText("Template kept-null-tasks")).toBeInTheDocument()
+      await waitFor(() => expect(consoleErrorMock).toHaveBeenCalledWith("Failed to fetch recent tasks:", expect.any(Error)))
+    })
+
+    it("accepts producer-omitted Agent fields and renders each existing fallback", async () => {
+      const withoutAgentName = omitField(
+        recentTask(11, { agent_logo_url: "/assets/agent-11.png" }),
+        "agent_name",
+      )
+      const withoutAgentLogo = omitField(
+        recentTask(12, { agent_name: "Named Agent" }),
+        "agent_logo_url",
+      )
+      const withoutAgent = omitField(
+        omitField(recentTask(13), "agent_name"),
+        "agent_logo_url",
+      )
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([]))
+        if (url === recentTasksUrl) {
+          return Promise.resolve(jsonResponse({
+            tasks: [withoutAgentName, withoutAgentLogo, withoutAgent],
+          }))
+        }
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+
+      render(<Home />)
+
+      const withoutNameLink = await screen.findByRole("link", { name: /Task 11/ })
+      expect(withoutNameLink).toHaveTextContent("home.recent.defaultAgent")
+      expect(withoutNameLink.querySelector("img")).toHaveAttribute(
+        "src",
+        "http://api.local/assets/agent-11.png",
+      )
+
+      const withoutLogoLink = screen.getByRole("link", { name: /Task 12/ })
+      expect(withoutLogoLink).toHaveTextContent("Named Agent")
+      expect(withoutLogoLink.querySelector("img")).not.toBeInTheDocument()
+      expect(withoutLogoLink.firstElementChild?.firstElementChild?.querySelector("svg")).toBeInTheDocument()
+
+      const withoutAgentLink = screen.getByRole("link", { name: /Task 13/ })
+      expect(withoutAgentLink).toHaveTextContent("home.recent.defaultAgent")
+      expect(withoutAgentLink.querySelector("img")).not.toBeInTheDocument()
+      expect(withoutAgentLink.firstElementChild?.firstElementChild?.querySelector("svg")).toBeInTheDocument()
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("accepts recent blank/null/missing display fields and ignores unconsumed task and pagination data", async () => {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({
+          tasks: [
+            recentTask(7, { title: "", created_at: "not a date", agent_name: "", agent_logo_url: "", status: 1, model_id: {}, total_tokens: "wrong" }),
+            recentTask(8, { created_at: null }),
+            recentTask(9, { created_at: "" }),
+            { task_id: 10, title: "Task 10", agent_name: "Agent", agent_logo_url: null },
+          ],
+          pagination: "wrong",
+        }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<Home />)
+      expect(await screen.findByRole("link", { name: /home\.recent\.untitledTask/ })).toHaveAttribute("href", "/task/7")
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("does not refetch recents on locale change and suppresses an old locale completion", async () => {
+      const en = deferred<Response>()
+      const zh = deferred<Response>()
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl("en")) return en.promise
+        if (url === templateUrl("zh")) return zh.promise
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [recentTask(8)] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith(recentTasksUrl))
+      const recentCalls = apiRequestMock.mock.calls.filter(([url]) => url === recentTasksUrl).length
+      localeMock.value = "zh"
+      view.rerender(<Home />)
+      await act(async () => en.resolve(jsonResponse([templateCard("old")])))
+      expect(screen.queryByText("Template old")).not.toBeInTheDocument()
+      await act(async () => zh.resolve(jsonResponse([templateCard("new")])))
+      expect(await screen.findByText("Template new")).toBeInTheDocument()
+      expect(apiRequestMock.mock.calls.filter(([url]) => url === recentTasksUrl)).toHaveLength(recentCalls)
+    })
+
+    it("keeps current-locale templates when an old valid body finishes parsing last", async () => {
+      const oldBody = deferred<string>()
+      const oldResponse = new Response("old")
+      const oldText = vi.fn(() => oldBody.promise)
+      Object.defineProperty(oldResponse, "text", { value: oldText })
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl("en")) return Promise.resolve(oldResponse)
+        if (url === templateUrl("zh")) return Promise.resolve(jsonResponse([templateCard("current-zh")]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({ tasks: [] }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      await waitFor(() => expect(oldText).toHaveBeenCalledTimes(1))
+
+      localeMock.value = "zh"
+      view.rerender(<Home />)
+      expect(await screen.findByText("Template current-zh")).toBeInTheDocument()
+
+      await act(async () => oldBody.resolve(JSON.stringify([templateCard("obsolete-en")])))
+      expect(screen.getByText("Template current-zh")).toBeInTheDocument()
+      expect(screen.queryByText("Template obsolete-en")).not.toBeInTheDocument()
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("does not parse or diagnose either source after unmount, including parser fallback", async () => {
+      const templates = deferred<Response>()
+      const tasks = deferred<Response>()
+      const templateResponse = new Response("template")
+      const recentResponse = new Response("recent")
+      const templateText = vi.fn(templateResponse.text.bind(templateResponse))
+      const recentText = vi.fn(() => Promise.reject(new Error("body unavailable")))
+      Object.defineProperty(templateResponse, "text", { value: templateText })
+      Object.defineProperty(recentResponse, "text", { value: recentText })
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return templates.promise
+        if (url === recentTasksUrl) return tasks.promise
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      view.unmount()
+      await act(async () => {
+        templates.resolve(templateResponse)
+        tasks.resolve(recentResponse)
+      })
+      expect(templateText).not.toHaveBeenCalled()
+      expect(recentText).not.toHaveBeenCalled()
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("silences both loader transport rejections after unmount", async () => {
+      const templates = deferred<Response>()
+      const tasks = deferred<Response>()
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return templates.promise
+        if (url === recentTasksUrl) return tasks.promise
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      view.unmount()
+      await act(async () => {
+        templates.reject(new Error("templates unavailable"))
+        tasks.reject(new Error("tasks unavailable"))
+      })
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("allows parser fallback to settle after cleanup without publishing either loader", async () => {
+      const templateBody = deferred<string>()
+      const recentBody = deferred<string>()
+      const templateResponse = new Response("template")
+      const recentResponse = new Response("recent")
+      const templateText = vi.fn(() => templateBody.promise)
+      const recentText = vi.fn(() => recentBody.promise)
+      Object.defineProperty(templateResponse, "text", { value: templateText })
+      Object.defineProperty(recentResponse, "text", { value: recentText })
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(templateResponse)
+        if (url === recentTasksUrl) return Promise.resolve(recentResponse)
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      const view = render(<Home />)
+      await waitFor(() => {
+        expect(templateText).toHaveBeenCalledTimes(1)
+        expect(recentText).toHaveBeenCalledTimes(1)
+      })
+      view.unmount()
+      await act(async () => {
+        templateBody.resolve("{")
+        recentBody.reject(new Error("reader unavailable"))
+      })
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("is StrictMode-safe for obsolete completion and rejection", async () => {
+      const firstTemplates = deferred<Response>()
+      const secondTemplates = deferred<Response>()
+      const firstRecent = deferred<Response>()
+      const secondRecent = deferred<Response>()
+      let templateCall = 0
+      let recentCall = 0
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return (++templateCall === 1 ? firstTemplates : secondTemplates).promise
+        if (url === recentTasksUrl) return (++recentCall === 1 ? firstRecent : secondRecent).promise
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+      render(<StrictMode><Home /></StrictMode>)
+      await act(async () => {
+        firstTemplates.resolve(jsonResponse([templateCard("obsolete")]))
+        firstRecent.reject(new Error("obsolete recent"))
+        secondTemplates.resolve(jsonResponse([templateCard("active")]))
+        secondRecent.resolve(jsonResponse({ tasks: [recentTask(9)] }))
+      })
+      expect(await screen.findByText("Template active")).toBeInTheDocument()
+      expect(screen.queryByText("Template obsolete")).not.toBeInTheDocument()
+      expect(screen.getByText("Task 9")).toBeInTheDocument()
+      expect(consoleErrorMock).not.toHaveBeenCalled()
+    })
+
+    it("keeps exact copied Home projections and ordered loader ownership fences in page source", () => {
+      const source = readFileSync("src/app/page.tsx", "utf8")
+      const templateDecoder = sourceSlice(
+        source,
+        "function decodeHomeTemplateCard(value: unknown)",
+        "function decodeHomeTemplates(value: unknown)",
+      )
+      const recentDecoder = sourceSlice(
+        source,
+        "function decodeRecentTask(value: unknown)",
+        "function decodeRecentTasks(value: unknown)",
+      )
+      const templateLoader = sourceSlice(
+        source,
+        "const generation = ++templateGenerationRef.current;",
+        "    void fetchTemplates();",
+      )
+      const recentLoader = sourceSlice(
+        source,
+        "const fetchRecentTasks = async () => {",
+        "    void fetchRecentTasks();",
+      )
+
+      expect(source).toMatch(/interface HomeTemplateCard[\s\S]*id: string[\s\S]*used_count: number/)
+      expect(source).toMatch(/interface RecentTask[\s\S]*task_id: number[\s\S]*agent_logo_url\?: string \| null/)
+      expect(source).toMatch(/const templateGenerationRef = useRef\(0\)/)
+      expect(templateLoader).toContain(
+        "const isCurrent = () => active && generation === templateGenerationRef.current;",
+      )
+      expect(templateLoader).toMatch(
+        /const response = await apiRequest\(`\$\{getApiUrl\(\)\}\/api\/templates\/\?lang=\$\{locale\}`\);\s*if \(!isCurrent\(\)\) return;\s*if \(!response\.ok\)[\s\S]*?const parsed = await parseApiResponse\(response\);\s*if \(!isCurrent\(\)\) return;\s*const decoded = decodeHomeTemplates\(parsed\.data\);/,
+      )
+      expect(recentLoader).toMatch(
+        /const response = await apiRequest\(`\$\{getApiUrl\(\)\}\/api\/chat\/tasks\?page=1&per_page=5`\);\s*if \(!active\) return;\s*if \(!response\.ok\)[\s\S]*?const parsed = await parseApiResponse\(response\);\s*if \(!active\) return;\s*const decoded = decodeRecentTasks\(parsed\.data\);/,
+      )
+
+      expect(templateDecoder.match(/return \{/g)).toHaveLength(1)
+      expect(templateDecoder).toMatch(
+        /connections\.push\(\{ name: connection\.name, logo: connection\.logo \}\);[\s\S]*?return \{\s*id: value\.id,\s*name: value\.name,\s*category: value\.category,\s*description: value\.description,\s*features: \[\.\.\.value\.features\],\s*connections,\s*setup_time: value\.setup_time,\s*likes: value\.likes,\s*used_count: value\.used_count,\s*\};/,
+      )
+      expect(recentDecoder.match(/return \{/g)).toHaveLength(1)
+      expect(recentDecoder).toMatch(
+        /return \{\s*task_id: value\.task_id,\s*title: value\.title,\s*created_at: value\.created_at,\s*agent_name: value\.agent_name,\s*agent_logo_url: value\.agent_logo_url,\s*\};/,
+      )
+      expect(templateDecoder).not.toMatch(/\.\.\.value\s*[,}]|\.\.\.connection\s*[,}]|Object\.assign/)
+      expect(recentDecoder).not.toMatch(/\.\.\.value\s*[,}]|Object\.assign/)
+      expect(`${templateDecoder}\n${recentDecoder}`).not.toMatch(
+        /as HomeTemplateCard|as RecentTask|return value;/,
+      )
+      expect(source).toMatch(/task\.created_at === null \? 0 : task\.created_at === undefined \? Number\.NaN : task\.created_at/)
+      expect(source).not.toMatch(/Promise\.all\(\[\s*apiRequest\(`\$\{getApiUrl\(\)\}\/api\/templates/)
+    })
   })
 })

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -11,6 +11,8 @@ const setTaskIdMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const localeMock = vi.hoisted(() => ({ value: "en" as "en" | "zh" }))
+const resolveAgentLogoUrlMock = vi.hoisted(() => vi.fn())
+const formatDisplayDateMock = vi.hoisted(() => vi.fn())
 
 async function createHomeExtensionMock() {
   const ReactModule = await vi.importActual<typeof import("react")>("react")
@@ -35,8 +37,24 @@ vi.mock("@/lib/models", () => ({
 
 vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
-  return { ...actual, getApiUrl: () => "http://api.local" }
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    resolveAgentLogoUrl: (...args: Parameters<typeof actual.resolveAgentLogoUrl>) => {
+      resolveAgentLogoUrlMock(...args)
+      return actual.resolveAgentLogoUrl(...args)
+    },
+  }
 })
+
+vi.mock("@/lib/time-utils", () => ({
+  formatDisplayDate: (...args: [unknown, "en" | "zh", Intl.DateTimeFormatOptions]) => {
+    formatDisplayDateMock(...args)
+    return typeof args[0] === "string" && args[0].startsWith("2024-")
+      ? `formatted:${args[0]}`
+      : ""
+  },
+}))
 
 vi.mock("@/components/ui/sonner", () => ({
   toast: { error: toastErrorMock },
@@ -216,6 +234,8 @@ describe("Home", () => {
     setTaskIdMock.mockReset()
     routerPushMock.mockReset()
     toastErrorMock.mockReset()
+    resolveAgentLogoUrlMock.mockReset()
+    formatDisplayDateMock.mockReset()
     consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined)
     resolveTaskLlmSelectionMock.mockResolvedValue(successfulSelection)
     apiRequestMock.mockImplementation((url: string) => {
@@ -745,9 +765,7 @@ describe("Home", () => {
 
     it("renders every copied template and recent-task value from distinctive wire fields", async () => {
       const createdAt = "2024-05-06T07:08:09Z"
-      const formattedDate = new Date(createdAt).toLocaleDateString("en-US", {
-        month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
-      })
+      const formattedDate = `formatted:${createdAt}`
       apiRequestMock.mockImplementation((url: string) => {
         if (url === templateUrl()) return Promise.resolve(jsonResponse([
           templateCard("distinct-template-id", {
@@ -979,6 +997,67 @@ describe("Home", () => {
       expect(consoleErrorMock).not.toHaveBeenCalled()
     })
 
+    it("resolves each Recent Task Agent logo once and keeps date metadata structurally complete", async () => {
+      const validCreatedAt = "2024-05-06T07:08:09Z"
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === templateUrl()) return Promise.resolve(jsonResponse([]))
+        if (url === recentTasksUrl) return Promise.resolve(jsonResponse({
+          tasks: [
+            recentTask(71, {
+              created_at: validCreatedAt,
+              agent_name: "Resolved Agent",
+              agent_logo_url: "/logos/resolved.png",
+            }),
+            recentTask(72, {
+              created_at: "not-a-date",
+              agent_name: "Fallback Agent",
+              agent_logo_url: "javascript:alert(1)",
+            }),
+          ],
+        }))
+        throw new Error(`Unexpected apiRequest: ${url}`)
+      })
+
+      render(<Home />)
+
+      const validLink = await screen.findByRole("link", { name: /Task 71/ })
+      const invalidLink = screen.getByRole("link", { name: /Task 72/ })
+      expect(validLink.querySelector("img")).toHaveAttribute(
+        "src",
+        "http://api.local/logos/resolved.png",
+      )
+      const invalidAvatar = invalidLink.querySelector('div[class*="w-12"][class*="h-12"]')
+      expect(invalidAvatar).not.toBeNull()
+      expect(invalidAvatar?.querySelectorAll("img")).toHaveLength(0)
+      expect(invalidAvatar?.querySelectorAll("svg")).toHaveLength(1)
+      const invalidBot = invalidAvatar?.querySelector("svg")
+      expect(invalidBot).not.toHaveClass("lucide-chevron-right")
+      expect(invalidBot?.querySelector('rect[width="18"][height="10"]')).toBeInTheDocument()
+      const validMetadata = validLink.querySelector("p.text-muted-foreground.font-medium")
+      const invalidMetadata = invalidLink.querySelector("p.text-muted-foreground.font-medium")
+      expect(validMetadata?.textContent).toBe(`Resolved Agent • formatted:${validCreatedAt}`)
+      expect(invalidMetadata?.textContent).toBe("Fallback Agent")
+      expect(invalidLink).not.toHaveTextContent("Invalid Date")
+      expect(resolveAgentLogoUrlMock).toHaveBeenCalledTimes(2)
+      expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(
+        1,
+        "/logos/resolved.png",
+        "http://api.local",
+      )
+      expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(
+        2,
+        "javascript:alert(1)",
+        "http://api.local",
+      )
+      expect(formatDisplayDateMock).toHaveBeenCalledTimes(2)
+      expect(formatDisplayDateMock).toHaveBeenNthCalledWith(1, validCreatedAt, "en", {
+        month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+      })
+      expect(formatDisplayDateMock).toHaveBeenNthCalledWith(2, "not-a-date", "en", {
+        month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+      })
+    })
+
     it("does not refetch recents on locale change and suppresses an old locale completion", async () => {
       const en = deferred<Response>()
       const zh = deferred<Response>()
@@ -1167,7 +1246,17 @@ describe("Home", () => {
       expect(`${templateDecoder}\n${recentDecoder}`).not.toMatch(
         /as HomeTemplateCard|as RecentTask|return value;/,
       )
-      expect(source).toMatch(/task\.created_at === null \? 0 : task\.created_at === undefined \? Number\.NaN : task\.created_at/)
+      const recentRender = sourceSlice(
+        source,
+        "{recentTasks.map((task) => {",
+        "              </div>\n            </>",
+      )
+      expect(recentRender).toContain("const resolvedLogoUrl = resolveAgentLogoUrl(task.agent_logo_url, getApiUrl());")
+      expect(recentRender.match(/resolveAgentLogoUrl\(/g)).toHaveLength(1)
+      expect(recentRender).toContain("const displayDate = formatDisplayDate(task.created_at, locale, {")
+      expect(recentRender).toContain("{resolvedLogoUrl ? (")
+      expect(recentRender.match(/\{displayDate \? ` • \$\{displayDate\}` : ""\}/g)).toHaveLength(1)
+      expect(recentRender).not.toMatch(/startsWith\(["']http|new Date\(|toLocaleDateString|\$\{getApiUrl\(\)\}\$\{task\.agent_logo_url\}/)
       expect(source).not.toMatch(/Promise\.all\(\[\s*apiRequest\(`\$\{getApiUrl\(\)\}\/api\/templates/)
     })
   })

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -165,6 +165,26 @@ function submitWithEnter() {
   fireEvent.keyDown(input(), { key: "Enter" })
 }
 
+// Reproduces only voice-input-controller.tsx's native-setter write + bubbled
+// input/change event dispatch (setNativeValue + dispatchInputEvents): the native
+// HTMLTextAreaElement.prototype value setter (bypassing React's tracked instance
+// setter) followed by the same bubbled input/change events production dispatches
+// after a transcription lands, rather than testing-library's fireEvent convenience
+// helpers. This does NOT cover insertTranscribedText's focus/caret-splice/
+// setSelectionRange/fragment-data behavior — caret handling is untested here.
+function simulateVoiceTranscription(target: HTMLTextAreaElement, text: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")
+  act(() => {
+    descriptor?.set?.call(target, text)
+    try {
+      target.dispatchEvent(new InputEvent("input", { bubbles: true, data: text, inputType: "insertText" }))
+    } catch {
+      target.dispatchEvent(new Event("input", { bubbles: true }))
+    }
+    target.dispatchEvent(new Event("change", { bubbles: true }))
+  })
+}
+
 function taskCore(taskId = 7) {
   return {
     task_id: taskId,
@@ -401,17 +421,63 @@ describe("Home", () => {
       expect(slot).toHaveClass("shrink-0", { exact: true })
       expect(slot).not.toHaveAttribute("style")
       expect(slot).toBeEmptyDOMElement()
-      expect(defaultExtension.homeGetStartedDestinationOverrides).toEqual({})
+      expect(
+        (defaultExtension as { homeGetStartedDestinationOverrides?: unknown })
+          .homeGetStartedDestinationOverrides,
+      ).toEqual({})
     } finally {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
       vi.resetModules()
     }
     const restoredMock = await import("@/lib/home-page-extension")
-    expect(restoredMock.homeGetStartedDestinationOverrides).toBe(homeGetStartedDestinationOverridesMock)
+    expect(
+      (restoredMock as { homeGetStartedDestinationOverrides?: unknown })
+        .homeGetStartedDestinationOverrides,
+    ).toBe(homeGetStartedDestinationOverridesMock)
     const { default: RestoredHome } = await import("./page")
     render(<RestoredHome />)
     expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
     expect(homeExtensionRenderMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders every canonical Get Started destination when a replacement extension omits homeGetStartedDestinationOverrides entirely (A1 old-surface compatibility)", async () => {
+    vi.doUnmock("@/lib/home-page-extension")
+    vi.resetModules()
+    try {
+      vi.doMock("@/lib/home-page-extension", async () => {
+        const ReactModule = await vi.importActual<typeof import("react")>("react")
+        return {
+          HomePageExtension: ReactModule.memo(() => (
+            ReactModule.createElement("div", { "data-testid": "old-surface-extension" })
+          )),
+          // The old replacement surface genuinely has no such export; vitest's
+          // mock proxy throws on access of a key absent from the factory's
+          // return value (a stricter guard than real module namespace access),
+          // so this is declared with an undefined value to reproduce the real
+          // "export absent" shape without tripping that guard.
+          homeGetStartedDestinationOverrides: undefined,
+        }
+      })
+      vi.resetModules()
+      const { default: OldSurfaceHome } = await import("./page")
+      render(<OldSurfaceHome />)
+
+      expect(await screen.findByTestId("old-surface-extension")).toBeInTheDocument()
+      expectLinkedGetStartedCard("home.getStarted.docs.title", "https://docs.xagent.co/api-reference/introduction")
+      expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+      expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+    } finally {
+      vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
+      vi.resetModules()
+    }
+    const restoredMock = await import("@/lib/home-page-extension")
+    expect(
+      (restoredMock as { homeGetStartedDestinationOverrides?: unknown })
+        .homeGetStartedDestinationOverrides,
+    ).toBe(homeGetStartedDestinationOverridesMock)
+    const { default: RestoredHome } = await import("./page")
+    render(<RestoredHome />)
+    expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
   })
 
   it("resolves canonical and distinct configured Get Started destinations per key", () => {
@@ -706,7 +772,10 @@ describe("Home", () => {
     expect(contractInterface.match(/^\s+\w+\??:/gm)).toHaveLength(3)
     expect(contractInterface).not.toContain("tutorial")
     expect(extensionSource).toMatch(/export const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides = \{\}/)
-    expect(pageSource).toMatch(/const configuredHomeGetStartedDestinationOverrides:\s*HomeGetStartedDestinationOverrides = homeGetStartedDestinationOverrides/)
+    expect(pageSource).toMatch(/import \* as homePageExtensionModule from "@\/lib\/home-page-extension";/)
+    expect(pageSource).toMatch(
+      /const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =\s*\(homePageExtensionModule as \{ homeGetStartedDestinationOverrides\?: HomeGetStartedDestinationOverrides \}\)\s*\.homeGetStartedDestinationOverrides \?\? \{\}/,
+    )
     expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = \{/)
     expect(resolver).toContain("configured === undefined")
     expect(resolver).toContain("typeof configured !== \"string\"")
@@ -718,7 +787,7 @@ describe("Home", () => {
     expect(cardRender).toContain("focus-visible:ring-2")
     expect(cardRender).not.toMatch(/\bon[A-Z][A-Za-z]*|\btabIndex\b|\brole\b|\bcontrols\b|\bstyle\b|\bcursor\s*=|\bcontentEditable\b|\bsuppressContentEditableWarning\b|\bdraggable\b|\{\s*\.\.\./)
     const destinationCalls = Array.from(cardRender.matchAll(
-      /resolveHomeGetStartedDestination\(configuredHomeGetStartedDestinationOverrides\.(docs|guides|whatsNew), defaultHomeGetStartedDestinations\.\1\)/g,
+      /resolveHomeGetStartedDestination\(homeGetStartedDestinationOverrides\.(docs|guides|whatsNew), defaultHomeGetStartedDestinations\.\1\)/g,
     )).map((match) => match[1])
     expect(destinationCalls).toEqual(["docs", "guides", "whatsNew"])
     expect(cardRender.match(/resolveHomeGetStartedDestination\(/g)).toHaveLength(3)
@@ -943,6 +1012,33 @@ describe("Home", () => {
     expect(consoleErrorMock).not.toHaveBeenCalled()
   })
 
+  it("reports a mounted create transport rejection and preserves the draft and height", async () => {
+    const response = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return response.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    const rejectedPrompt = "prompt"
+    typePrompt(rejectedPrompt)
+    input().style.height = "80px"
+    const rejectedStyle = input().getAttribute("style")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    await act(async () => response.reject(new Error("transport unavailable")))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
+    expect(setPendingMessageMock).not.toHaveBeenCalled()
+    expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(routerPushMock).not.toHaveBeenCalled()
+    expect(consoleErrorMock).toHaveBeenCalled()
+    expect(input().value).toBe(rejectedPrompt)
+    expect(input()).toHaveAttribute("style", rejectedStyle)
+  })
+
   it.each([
     ["non-OK", jsonResponse(taskCore(), { status: 500 })],
     ["empty", new Response("")],
@@ -956,13 +1052,18 @@ describe("Home", () => {
       throw new Error(`Unexpected apiRequest: ${url}`)
     })
     render(<Home />)
-    typePrompt("prompt")
+    const failurePrompt = "prompt"
+    typePrompt(failurePrompt)
+    input().style.height = "88px"
+    const failureStyle = input().getAttribute("style")
     submitWithEnter()
 
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
     expect(setPendingMessageMock).not.toHaveBeenCalled()
     expect(setTaskIdMock).not.toHaveBeenCalled()
     expect(consoleErrorMock).toHaveBeenCalled()
+    expect(input().value).toBe(failurePrompt)
+    expect(input()).toHaveAttribute("style", failureStyle)
   })
 
   it("reports a current unreadable task body as one operational failure", async () => {
@@ -977,12 +1078,17 @@ describe("Home", () => {
       throw new Error(`Unexpected apiRequest: ${url}`)
     })
     render(<Home />)
-    typePrompt("prompt")
+    const unreadablePrompt = "prompt"
+    typePrompt(unreadablePrompt)
+    input().style.height = "92px"
+    const unreadableStyle = input().getAttribute("style")
     submitWithEnter()
 
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("common.errors.taskFailed"))
     expect(setPendingMessageMock).not.toHaveBeenCalled()
     expect(setTaskIdMock).not.toHaveBeenCalled()
+    expect(input().value).toBe(unreadablePrompt)
+    expect(input()).toHaveAttribute("style", unreadableStyle)
   })
 
   it("never overwrites a newer B draft or its height after A succeeds or fails", async () => {
@@ -1044,6 +1150,29 @@ describe("Home", () => {
 
     expect(input().value).toBe("A")
     expect(input().style.height).toBe("64px")
+  })
+
+  it("treats a native voice transcription write as an edit that blocks a stale successful clear (A3)", async () => {
+    const result = deferred<Response>()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/templates/")) return Promise.resolve(jsonResponse([]))
+      if (url === "http://api.local/api/chat/tasks?page=1&per_page=5") return Promise.resolve(jsonResponse({ tasks: [] }))
+      if (url === "http://api.local/api/chat/task/create") return result.promise
+      throw new Error(`Unexpected apiRequest: ${url}`)
+    })
+    render(<Home />)
+    typePrompt("A")
+    submitWithEnter()
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/chat/task/create", expect.anything()))
+
+    simulateVoiceTranscription(input(), "A transcribed by voice")
+    expect(input().value).toBe("A transcribed by voice")
+
+    await act(async () => result.resolve(jsonResponse(taskCore())))
+
+    expect(setPendingMessageMock).toHaveBeenCalledTimes(1)
+    expect(setTaskIdMock).toHaveBeenCalledWith(7)
+    expect(input().value).toBe("A transcribed by voice")
   })
 
   it("does not classify a synchronous commit collaborator throw as an operational create failure", async () => {
@@ -1653,7 +1782,7 @@ describe("Home", () => {
       )
       const templateLoader = sourceSlice(
         source,
-        "const generation = ++templateGenerationRef.current;",
+        "let active = true;",
         "    void fetchTemplates();",
       )
       const recentLoader = sourceSlice(
@@ -1664,9 +1793,9 @@ describe("Home", () => {
 
       expect(source).toMatch(/interface HomeTemplateCard[\s\S]*id: string[\s\S]*used_count: number/)
       expect(source).toMatch(/interface RecentTask[\s\S]*task_id: number[\s\S]*agent_logo_url\?: string \| null/)
-      expect(source).toMatch(/const templateGenerationRef = useRef\(0\)/)
+      expect(source).not.toMatch(/templateGenerationRef/)
       expect(templateLoader).toContain(
-        "const isCurrent = () => active && generation === templateGenerationRef.current;",
+        "const isCurrent = () => active;",
       )
       expect(templateLoader).toMatch(
         /const response = await apiRequest\(`\$\{getApiUrl\(\)\}\/api\/templates\/\?lang=\$\{locale\}`\);\s*if \(!isCurrent\(\)\) return;\s*if \(!response\.ok\)[\s\S]*?const parsed = await parseApiResponse\(response\);\s*if \(!isCurrent\(\)\) return;\s*const decoded = decodeHomeTemplates\(parsed\.data\);/,

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -2,6 +2,7 @@ import React, { StrictMode } from "react"
 import { readFileSync } from "node:fs"
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { HomeGetStartedDestinationOverrides } from "@/lib/page-extension-contracts"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const resolveTaskLlmSelectionMock = vi.hoisted(() => vi.fn())
@@ -13,6 +14,9 @@ const toastErrorMock = vi.hoisted(() => vi.fn())
 const localeMock = vi.hoisted(() => ({ value: "en" as "en" | "zh" }))
 const resolveAgentLogoUrlMock = vi.hoisted(() => vi.fn())
 const formatDisplayDateMock = vi.hoisted(() => vi.fn())
+const homeGetStartedDestinationOverridesMock = vi.hoisted(() => (
+  {} as HomeGetStartedDestinationOverrides
+))
 
 async function createHomeExtensionMock() {
   const ReactModule = await vi.importActual<typeof import("react")>("react")
@@ -21,7 +25,7 @@ async function createHomeExtensionMock() {
     homeExtensionRenderMock()
     return ReactModule.createElement("div", { "data-testid": "home-extension" })
   })
-  return { HomePageExtension }
+  return { HomePageExtension, homeGetStartedDestinationOverrides: homeGetStartedDestinationOverridesMock }
 }
 
 vi.mock("@/lib/api-wrapper", async () => {
@@ -209,6 +213,120 @@ function sourceSlice(source: string, start: string, end: string) {
   return source.slice(startIndex, endIndex)
 }
 
+function getStartedCard(title: string) {
+  const heading = screen.getByRole("heading", { name: title })
+  const card = heading.closest('[data-slot="card"]')
+  if (!(card instanceof HTMLDivElement)) throw new Error(`Get Started card not found: ${title}`)
+  const wrapper = card.parentElement
+  if (!(wrapper instanceof HTMLDivElement || wrapper instanceof HTMLAnchorElement)) {
+    throw new Error(`Get Started wrapper not found: ${title}`)
+  }
+  return { card, wrapper }
+}
+
+function expectInertGetStartedCard(title: string) {
+  const { card, wrapper } = getStartedCard(title)
+  const wrapperAndDescendants = [wrapper, ...Array.from(wrapper.querySelectorAll<HTMLElement | SVGElement>("*"))]
+  const inertInteractionSelector = [
+    "a",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "[tabindex]:not([tabindex='-1'])",
+    "[role='button']",
+    "[role='checkbox']",
+    "[role='combobox']",
+    "[role='link']",
+    "[role='menuitem']",
+    "[role='menuitemcheckbox']",
+    "[role='menuitemradio']",
+    "[role='option']",
+    "[role='radio']",
+    "[role='searchbox']",
+    "[role='slider']",
+    "[role='spinbutton']",
+    "[role='switch']",
+    "[role='tab']",
+    "[role='treeitem']",
+    "[contenteditable]",
+    "summary",
+    "details",
+    "iframe",
+    "object",
+    "embed",
+    "video[controls]",
+    "audio[controls]",
+    "[draggable='true']",
+  ].join(", ")
+  expect(wrapper.tagName).toBe("DIV")
+  expect(wrapper).not.toHaveAttribute("role")
+  expect(wrapper).not.toHaveAttribute("tabindex")
+  expect(wrapper.tabIndex).toBe(-1)
+  for (const className of [
+    "rounded-xl",
+    "outline-none",
+    "group",
+    "cursor-pointer",
+    "hover:shadow-md",
+    "focus-visible:outline-none",
+    "focus-visible:ring-2",
+    "focus-visible:ring-ring",
+    "focus-visible:ring-offset-2",
+    "focus-visible:ring-offset-background",
+  ]) {
+    expect(wrapper).not.toHaveClass(className)
+  }
+  for (const className of ["group", "cursor-pointer", "hover:shadow-md"]) {
+    expect(card).not.toHaveClass(className)
+  }
+  expect(wrapperAndDescendants.filter((element) => element.matches(inertInteractionSelector))).toHaveLength(0)
+  const wrapperAndDescendantClassTokens = wrapperAndDescendants
+    .flatMap((element) => (element.getAttribute("class") ?? "").split(/\s+/).filter(Boolean))
+  expect(wrapperAndDescendantClassTokens.some((className) => (
+    className.includes("hover")
+    || className.includes("focus-visible")
+    || className.includes("group")
+    || className.includes("cursor-")
+    || /(?:^|:)!?\[cursor:[^\]]+\]$/.test(className)
+  ))).toBe(false)
+  expect(wrapperAndDescendants.some((element) => (element.getAttribute("style") ?? "").trim() !== "")).toBe(false)
+  expect(wrapperAndDescendants.some((element) => (element.getAttribute("cursor") ?? "").trim() !== "")).toBe(false)
+}
+
+function expectLinkedGetStartedCard(title: string, href: string) {
+  const { card, wrapper } = getStartedCard(title)
+  expect(wrapper).toBeInstanceOf(HTMLAnchorElement)
+  expect(wrapper).toHaveAttribute("href", href)
+  expect(wrapper).toHaveAttribute("target", "_blank")
+  expect(wrapper).toHaveAttribute("rel", "noopener noreferrer")
+  expect(wrapper).not.toHaveAttribute("tabindex")
+  expect(wrapper.tabIndex).toBe(0)
+  wrapper.focus()
+  expect(wrapper).toHaveFocus()
+  expect(wrapper).toHaveClass(
+    "focus-visible:outline-none",
+    "focus-visible:ring-2",
+    "focus-visible:ring-ring",
+    "focus-visible:ring-offset-2",
+    "focus-visible:ring-offset-background",
+    "rounded-xl",
+  )
+  expect(card).toHaveClass("group", "cursor-pointer", "hover:shadow-md")
+  expect(card.querySelector("h3")).toHaveClass("group-hover:text-primary")
+  if (title === "home.getStarted.guides.title") {
+    expect(card.querySelector("svg")?.parentElement).toHaveClass("group-hover:scale-110")
+  }
+}
+
+function restoreIntersectionObserver(descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, "IntersectionObserver", descriptor)
+  } else {
+    delete (globalThis as { IntersectionObserver?: typeof IntersectionObserver }).IntersectionObserver
+  }
+}
+
 function templateUrl(locale = localeMock.value) {
   return `http://api.local/api/templates/?lang=${locale}`
 }
@@ -227,6 +345,9 @@ describe("Home", () => {
   }
 
   beforeEach(() => {
+    delete homeGetStartedDestinationOverridesMock.docs
+    delete homeGetStartedDestinationOverridesMock.guides
+    delete homeGetStartedDestinationOverridesMock.whatsNew
     apiRequestMock.mockReset()
     resolveTaskLlmSelectionMock.mockReset()
     homeExtensionRenderMock.mockClear()
@@ -272,6 +393,7 @@ describe("Home", () => {
     vi.resetModules()
     try {
       const { default: DefaultHome } = await import("./page")
+      const defaultExtension = await import("@/lib/home-page-extension")
       const { container } = render(<DefaultHome />)
       const slot = container.querySelector('[data-slot="home-page-extension"]')
 
@@ -279,10 +401,330 @@ describe("Home", () => {
       expect(slot).toHaveClass("shrink-0", { exact: true })
       expect(slot).not.toHaveAttribute("style")
       expect(slot).toBeEmptyDOMElement()
+      expect(defaultExtension.homeGetStartedDestinationOverrides).toEqual({})
     } finally {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
       vi.resetModules()
     }
+    const restoredMock = await import("@/lib/home-page-extension")
+    expect(restoredMock.homeGetStartedDestinationOverrides).toBe(homeGetStartedDestinationOverridesMock)
+    const { default: RestoredHome } = await import("./page")
+    render(<RestoredHome />)
+    expect(await screen.findByTestId("home-extension")).toBeInTheDocument()
+    expect(homeExtensionRenderMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("resolves canonical and distinct configured Get Started destinations per key", () => {
+    render(<Home />)
+
+    expectLinkedGetStartedCard("home.getStarted.docs.title", "https://docs.xagent.co/api-reference/introduction")
+    expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+    expectInertGetStartedCard("home.getStarted.video.title")
+
+    cleanup()
+    homeGetStartedDestinationOverridesMock.docs = "/docs with internal space"
+    homeGetStartedDestinationOverridesMock.guides = "custom-guide:destination"
+    homeGetStartedDestinationOverridesMock.whatsNew = "  /whats-new  "
+    render(<Home />)
+
+    expectLinkedGetStartedCard("home.getStarted.docs.title", "/docs with internal space")
+    expectLinkedGetStartedCard("home.getStarted.guides.title", "custom-guide:destination")
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "  /whats-new  ")
+    expect(getStartedCard("home.getStarted.video.title").wrapper.querySelector("a")).toBeNull()
+  })
+
+  it("rejects pointer, hover, focus, native, inline-style, SVG, and media-control affordances injected into an inert card", () => {
+    render(<Home />)
+    const { card, wrapper } = getStartedCard("home.getStarted.video.title")
+    const video = card.querySelector("video")
+    if (!(video instanceof HTMLVideoElement)) throw new Error("Tutorial video was not eagerly loaded")
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    card.append(svg)
+    expectInertGetStartedCard("home.getStarted.video.title")
+    try {
+      card.classList.add("cursor-pointer")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("cursor-pointer")
+
+      card.classList.add("cursor-[pointer]")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("cursor-[pointer]")
+
+      card.classList.add("[cursor:pointer]")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("[cursor:pointer]")
+
+      card.classList.add("dark:![cursor:pointer]")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("dark:![cursor:pointer]")
+
+      card.classList.add("hover:shadow-lg")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("hover:shadow-lg")
+
+      card.classList.add("dark:hover:shadow-lg")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("dark:hover:shadow-lg")
+
+      card.classList.add("[&:hover]:shadow-lg")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("[&:hover]:shadow-lg")
+
+      card.classList.add("group-hover/get-started:shadow-lg")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      card.classList.remove("group-hover/get-started:shadow-lg")
+
+      wrapper.classList.add("focus-visible:ring-2")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      wrapper.classList.remove("focus-visible:ring-2")
+
+      wrapper.setAttribute("style", "cursor: url(/pointer.cur), pointer")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      wrapper.removeAttribute("style")
+
+      wrapper.setAttribute("contenteditable", "true")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      wrapper.removeAttribute("contenteditable")
+
+      wrapper.setAttribute("draggable", "true")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      wrapper.removeAttribute("draggable")
+
+      svg.setAttribute("class", "hover:shadow-lg")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      svg.removeAttribute("class")
+
+      svg.setAttribute("cursor", "pointer")
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+      svg.removeAttribute("cursor")
+
+      video.controls = true
+      expect(() => expectInertGetStartedCard("home.getStarted.video.title")).toThrow()
+    } finally {
+      card.classList.remove("cursor-pointer")
+      card.classList.remove("cursor-[pointer]")
+      card.classList.remove("[cursor:pointer]")
+      card.classList.remove("dark:![cursor:pointer]")
+      card.classList.remove("hover:shadow-lg")
+      card.classList.remove("dark:hover:shadow-lg")
+      card.classList.remove("[&:hover]:shadow-lg")
+      card.classList.remove("group-hover/get-started:shadow-lg")
+      wrapper.classList.remove("focus-visible:ring-2")
+      wrapper.removeAttribute("style")
+      wrapper.removeAttribute("contenteditable")
+      wrapper.removeAttribute("draggable")
+      svg.remove()
+      video.controls = false
+    }
+  })
+
+  it("keeps null, blank, and runtime-invalid configured destinations inert without affecting siblings", () => {
+    const invalidValues: unknown[] = [
+      1,
+      true,
+      {},
+      [],
+      new String("boxed"),
+      (globalThis as { BigInt: (value: number) => bigint }).BigInt(1),
+      Symbol("destination"),
+      () => "/not-used",
+    ]
+
+    homeGetStartedDestinationOverridesMock.docs = null
+    homeGetStartedDestinationOverridesMock.guides = null
+    homeGetStartedDestinationOverridesMock.whatsNew = null
+    const nullView = render(<Home />)
+    expectInertGetStartedCard("home.getStarted.docs.title")
+    expectInertGetStartedCard("home.getStarted.guides.title")
+    expectInertGetStartedCard("home.getStarted.whatsNew.title")
+    expectInertGetStartedCard("home.getStarted.video.title")
+    nullView.unmount()
+
+    for (const invalid of [null, "", " \t\n", "\u00a0", ...invalidValues]) {
+      for (const key of ["docs", "guides", "whatsNew"] as const) {
+        delete homeGetStartedDestinationOverridesMock.docs
+        delete homeGetStartedDestinationOverridesMock.guides
+        delete homeGetStartedDestinationOverridesMock.whatsNew
+        if (key === "docs") homeGetStartedDestinationOverridesMock.guides = "/valid-guides"
+        if (key === "guides") homeGetStartedDestinationOverridesMock.docs = "/valid-docs"
+        if (key === "whatsNew") homeGetStartedDestinationOverridesMock.docs = "/valid-docs"
+        ;(homeGetStartedDestinationOverridesMock as Record<string, unknown>)[key] = invalid
+        const { unmount } = render(<Home />)
+
+        if (key === "docs") {
+          expectInertGetStartedCard("home.getStarted.docs.title")
+          expectLinkedGetStartedCard("home.getStarted.guides.title", "/valid-guides")
+          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+        } else if (key === "guides") {
+          expectLinkedGetStartedCard("home.getStarted.docs.title", "/valid-docs")
+          expectInertGetStartedCard("home.getStarted.guides.title")
+          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+        } else {
+          expectLinkedGetStartedCard("home.getStarted.docs.title", "/valid-docs")
+          expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+          expectInertGetStartedCard("home.getStarted.whatsNew.title")
+        }
+        expectInertGetStartedCard("home.getStarted.video.title")
+        unmount()
+      }
+    }
+  })
+
+  it("resolves a mixed custom, null, and undefined destination row independently", () => {
+    homeGetStartedDestinationOverridesMock.docs = "custom:docs"
+    homeGetStartedDestinationOverridesMock.guides = null
+    delete homeGetStartedDestinationOverridesMock.whatsNew
+    render(<Home />)
+
+    expectLinkedGetStartedCard("home.getStarted.docs.title", "custom:docs")
+    expectInertGetStartedCard("home.getStarted.guides.title")
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+    expect([
+      "home.getStarted.video.title",
+      "home.getStarted.docs.title",
+      "home.getStarted.guides.title",
+      "home.getStarted.whatsNew.title",
+    ].filter((title) => getStartedCard(title).wrapper instanceof HTMLAnchorElement)).toHaveLength(2)
+  })
+
+  it("observes both video cards with exact options and loads each only after its own intersection", async () => {
+    const originalIntersectionObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "IntersectionObserver")
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    let callback: IntersectionObserverCallback | undefined
+    let options: IntersectionObserverInit | undefined
+    let view: ReturnType<typeof render> | undefined
+    class FakeIntersectionObserver {
+      root = null
+      rootMargin = ""
+      thresholds: readonly number[] = []
+      constructor(nextCallback: IntersectionObserverCallback, nextOptions?: IntersectionObserverInit) {
+        callback = nextCallback
+        options = nextOptions
+      }
+      observe = observe
+      unobserve = vi.fn()
+      disconnect = disconnect
+      takeRecords = () => [] as IntersectionObserverEntry[]
+    }
+
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: FakeIntersectionObserver,
+    })
+    homeGetStartedDestinationOverridesMock.docs = null
+    try {
+      view = render(<Home />)
+      const videoTargets = Array.from(document.querySelectorAll<HTMLElement>("[data-get-started-video='true']"))
+      expectInertGetStartedCard("home.getStarted.docs.title")
+      expect(options).toEqual({ rootMargin: "200px 0px", threshold: 0.1 })
+      expect(observe).toHaveBeenCalledTimes(2)
+      expect(observe.mock.calls[0][0]).toBe(videoTargets[0])
+      expect(observe.mock.calls[1][0]).toBe(videoTargets[1])
+      expect(videoTargets.map((target) => target.dataset.videoIndex)).toEqual(["0", "1"])
+      expect(videoTargets[0].querySelector("video")).toBeNull()
+      expect(videoTargets[1].querySelector("video")).toBeNull()
+      expect(videoTargets[0].querySelector("svg")).toBeInTheDocument()
+      expect(videoTargets[1].querySelector("svg")).toBeInTheDocument()
+      expect(document.querySelectorAll("video")).toHaveLength(0)
+      if (!callback) throw new Error("IntersectionObserver callback was not registered")
+
+      await act(async () => callback?.([
+        { isIntersecting: false, target: videoTargets[0] },
+        { isIntersecting: false, target: videoTargets[1] },
+      ] as unknown as IntersectionObserverEntry[], {} as IntersectionObserver))
+      expect(document.querySelectorAll("video")).toHaveLength(0)
+      expect(videoTargets[0].querySelector("video")).toBeNull()
+      expect(videoTargets[1].querySelector("video")).toBeNull()
+      expect(videoTargets[0].querySelector("svg")).toBeInTheDocument()
+      expect(videoTargets[1].querySelector("svg")).toBeInTheDocument()
+
+      await act(async () => callback?.([
+        { isIntersecting: true, target: videoTargets[1] },
+      ] as unknown as IntersectionObserverEntry[], {} as IntersectionObserver))
+      expect(document.querySelector('video[src="/videos/Documentation.mp4"]')).toBeInTheDocument()
+      expect(document.querySelector('video[src="/videos/Tutorial.mp4"]')).toBeNull()
+
+      await act(async () => callback?.([
+        { isIntersecting: true, target: videoTargets[0] },
+      ] as unknown as IntersectionObserverEntry[], {} as IntersectionObserver))
+      expect(document.querySelector('video[src="/videos/Tutorial.mp4"]')).toBeInTheDocument()
+      expect(document.querySelector('video[src="/videos/Documentation.mp4"]')).toBeInTheDocument()
+      view.unmount()
+      view = undefined
+      expect(disconnect).toHaveBeenCalledTimes(1)
+    } finally {
+      view?.unmount()
+      restoreIntersectionObserver(originalIntersectionObserverDescriptor)
+      expect(Object.getOwnPropertyDescriptor(globalThis, "IntersectionObserver")).toEqual(originalIntersectionObserverDescriptor)
+    }
+  })
+
+  it("continues observing disabled destinations and eagerly loads both videos without IntersectionObserver", () => {
+    const originalIntersectionObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "IntersectionObserver")
+    homeGetStartedDestinationOverridesMock.docs = null
+    let view: ReturnType<typeof render> | undefined
+    try {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      })
+      view = render(<Home />)
+      expectInertGetStartedCard("home.getStarted.docs.title")
+      expect(document.querySelector('video[src="/videos/Tutorial.mp4"]')).toBeInTheDocument()
+      expect(document.querySelector('video[src="/videos/Documentation.mp4"]')).toBeInTheDocument()
+      view.unmount()
+      view = undefined
+    } finally {
+      view?.unmount()
+      restoreIntersectionObserver(originalIntersectionObserverDescriptor)
+      expect(Object.getOwnPropertyDescriptor(globalThis, "IntersectionObserver")).toEqual(originalIntersectionObserverDescriptor)
+    }
+  })
+
+  it("keeps the Home replacement contract, resolver, interaction owner, and cumulative manifest non-vacuously source-locked", () => {
+    const contractsSource = readFileSync("src/lib/page-extension-contracts.ts", "utf8")
+    const extensionSource = readFileSync("src/lib/home-page-extension.tsx", "utf8")
+    const pageSource = readFileSync("src/app/page.tsx", "utf8")
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { scripts: Record<string, string> }
+    const expectedManifest = "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+    const contractInterface = sourceSlice(
+      contractsSource,
+      "export interface HomeGetStartedDestinationOverrides",
+      "// The page guarantees a stable Provider lifetime and agentId join key.",
+    )
+    const resolver = sourceSlice(pageSource, "function resolveHomeGetStartedDestination(", "export default function Home()")
+    const cardRender = sourceSlice(pageSource, "{[", "          {/* Build agents with templates */}")
+
+    expect(contractInterface).toMatch(/docs\?: string \| null/)
+    expect(contractInterface).toMatch(/guides\?: string \| null/)
+    expect(contractInterface).toMatch(/whatsNew\?: string \| null/)
+    expect(contractInterface.match(/\?: string \| null/g)).toHaveLength(3)
+    expect(contractInterface.match(/^\s+\w+\??:/gm)).toHaveLength(3)
+    expect(contractInterface).not.toContain("tutorial")
+    expect(extensionSource).toMatch(/export const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides = \{\}/)
+    expect(pageSource).toMatch(/const configuredHomeGetStartedDestinationOverrides:\s*HomeGetStartedDestinationOverrides = homeGetStartedDestinationOverrides/)
+    expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = \{/)
+    expect(resolver).toContain("configured === undefined")
+    expect(resolver).toContain("typeof configured !== \"string\"")
+    expect(resolver).toContain("configured.trim().length === 0")
+    expect(resolver).toContain("return configured")
+    expect(resolver).not.toMatch(/\?\?|return configured\.trim\(\)/)
+    expect(cardRender).toContain("const isLinked = typeof card.link === \"string\"")
+    expect(cardRender).toContain("isLinked &&")
+    expect(cardRender).toContain("focus-visible:ring-2")
+    expect(cardRender).not.toMatch(/\bon[A-Z][A-Za-z]*|\btabIndex\b|\brole\b|\bcontrols\b|\bstyle\b|\bcursor\s*=|\bcontentEditable\b|\bsuppressContentEditableWarning\b|\bdraggable\b|\{\s*\.\.\./)
+    const destinationCalls = Array.from(cardRender.matchAll(
+      /resolveHomeGetStartedDestination\(configuredHomeGetStartedDestinationOverrides\.(docs|guides|whatsNew), defaultHomeGetStartedDestinations\.\1\)/g,
+    )).map((match) => match[1])
+    expect(destinationCalls).toEqual(["docs", "guides", "whatsNew"])
+    expect(cardRender.match(/resolveHomeGetStartedDestination\(/g)).toHaveLength(3)
+    expect(cardRender.match(/defaultHomeGetStartedDestinations\./g)).toHaveLength(3)
+    expect(cardRender).not.toMatch(/https:\/\/docs\.xagent\.co\//)
+    expect(packageJson.scripts["test:home-build-pages"]).toBe(expectedManifest)
   })
 
   it("uses the shared resolver, real task body parser, and ordered successful commit", async () => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,7 +21,7 @@ import {
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { apiRequest, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
-import { getApiUrl, resolveAgentLogoUrl } from "@/lib/utils";
+import { cn, getApiUrl, resolveAgentLogoUrl } from "@/lib/utils";
 import { formatDisplayDate } from "@/lib/time-utils";
 import { resolveTaskLlmSelection } from "@/lib/models";
 import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create";
@@ -30,7 +30,11 @@ import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
-import { HomePageExtension } from "@/lib/home-page-extension";
+import {
+  HomePageExtension,
+  homeGetStartedDestinationOverrides,
+} from "@/lib/home-page-extension";
+import type { HomeGetStartedDestinationOverrides } from "@/lib/page-extension-contracts";
 import { toast } from "@/components/ui/sonner";
 
 interface HomeTemplateConnection {
@@ -140,6 +144,24 @@ function decodeRecentTasks(value: unknown): RecentTask[] | null {
     tasks.push(decoded);
   }
   return tasks;
+}
+
+const configuredHomeGetStartedDestinationOverrides:
+  HomeGetStartedDestinationOverrides = homeGetStartedDestinationOverrides
+
+const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
+  docs: "https://docs.xagent.co/api-reference/introduction",
+  guides: "https://docs.xagent.co/models/overview",
+  whatsNew: "https://docs.xagent.co/release-notes",
+}
+
+function resolveHomeGetStartedDestination(
+  configured: unknown,
+  defaultDestination: string,
+): string | null {
+  if (configured === undefined) return defaultDestination
+  if (typeof configured !== "string" || configured.trim().length === 0) return null
+  return configured
 }
 
 export default function Home() {
@@ -491,14 +513,18 @@ export default function Home() {
           <h2 className="text-[16px] font-bold mb-4 text-foreground">{t("home.getStarted.title")}</h2>
           <div ref={getStartedSectionRef} className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mb-10">
             {[
-              { title: t("home.getStarted.video.title"), desc: t("home.getStarted.video.description", { appName: branding.appName }), video: "/videos/Tutorial.mp4" },
-              { title: t("home.getStarted.docs.title"), desc: t("home.getStarted.docs.description"), video: "/videos/Documentation.mp4", link: "https://docs.xagent.co/api-reference/introduction" },
-              { title: t("home.getStarted.guides.title"), desc: t("home.getStarted.guides.description"), icon: <ListChecks className="w-8 h-8 text-green-500" />, bg: "bg-green-50 dark:bg-green-950/30", link: "https://docs.xagent.co/models/overview" },
-              { title: t("home.getStarted.whatsNew.title"), desc: t("home.getStarted.whatsNew.description"), icon: <Sparkles className="w-8 h-8 text-orange-500" />, bg: "bg-orange-50 dark:bg-orange-950/30", link: "https://docs.xagent.co/release-notes" }
+              { title: t("home.getStarted.video.title"), desc: t("home.getStarted.video.description", { appName: branding.appName }), video: "/videos/Tutorial.mp4", link: null },
+              { title: t("home.getStarted.docs.title"), desc: t("home.getStarted.docs.description"), video: "/videos/Documentation.mp4", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.docs, defaultHomeGetStartedDestinations.docs) },
+              { title: t("home.getStarted.guides.title"), desc: t("home.getStarted.guides.description"), icon: <ListChecks className="w-8 h-8 text-green-500" />, bg: "bg-green-50 dark:bg-green-950/30", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.guides, defaultHomeGetStartedDestinations.guides) },
+              { title: t("home.getStarted.whatsNew.title"), desc: t("home.getStarted.whatsNew.description"), icon: <Sparkles className="w-8 h-8 text-orange-500" />, bg: "bg-orange-50 dark:bg-orange-950/30", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.whatsNew, defaultHomeGetStartedDestinations.whatsNew) }
             ].map((card, i) => {
               const shouldLoadVideo = card.video ? visibleGetStartedVideos.has(i) : false;
+              const isLinked = typeof card.link === "string";
               const cardContent = (
-                <Card className="py-0 gap-0 overflow-hidden border-border/60 hover:shadow-md transition-all duration-300 group cursor-pointer bg-card rounded-xl flex flex-col h-full">
+                <Card className={cn(
+                  "py-0 gap-0 overflow-hidden border-border/60 transition-all duration-300 bg-card rounded-xl flex flex-col h-full",
+                  isLinked && "hover:shadow-md group cursor-pointer",
+                )}>
                   <div
                     className={`h-[180px] relative flex items-center justify-center overflow-hidden ${card.video ? 'bg-muted' : card.bg}`}
                     data-get-started-video={card.video ? "true" : undefined}
@@ -524,24 +550,30 @@ export default function Home() {
                         </div>
                       )
                     ) : (
-                      <div className="group-hover:scale-110 transition-transform duration-300">
+                      <div className={cn(
+                        "transition-transform duration-300",
+                        isLinked && "group-hover:scale-110",
+                      )}>
                         {card.icon}
                       </div>
                     )}
                   </div>
                   <CardContent className="p-4 flex-1">
-                    <h3 className="font-semibold text-[13px] mb-1 group-hover:text-primary transition-colors">{card.title}</h3>
+                    <h3 className={cn(
+                      "font-semibold text-[13px] mb-1 transition-colors",
+                      isLinked && "group-hover:text-primary",
+                    )}>{card.title}</h3>
                     <p className="text-[12px] text-muted-foreground leading-relaxed">{card.desc}</p>
                   </CardContent>
                 </Card>
               );
 
-              return card.link ? (
-                <a key={i} href={card.link} target="_blank" rel="noopener noreferrer" className="block outline-none">
+              return isLinked ? (
+                <a key={i} href={card.link!} target="_blank" rel="noopener noreferrer" className="block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
                   {cardContent}
                 </a>
               ) : (
-                <div key={i} className="block outline-none">
+                <div key={i} className="block">
                   {cardContent}
                 </div>
               );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,11 +20,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
-import { apiRequest, parseApiResponse } from "@/lib/api-wrapper";
+import { apiRequest, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
 import { resolveTaskLlmSelection } from "@/lib/models";
 import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create";
-import type { ConnectionInfo, Template } from "@/types/template";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
@@ -33,12 +32,113 @@ import { useVoiceInputControls } from "@/components/voice-input-controller";
 import { HomePageExtension } from "@/lib/home-page-extension";
 import { toast } from "@/components/ui/sonner";
 
+interface HomeTemplateConnection {
+  name: string;
+  logo: string | null;
+}
+
+interface HomeTemplateCard {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  features: string[];
+  connections: HomeTemplateConnection[];
+  setup_time: string;
+  likes: number;
+  used_count: number;
+}
+
 interface RecentTask {
-  task_id: number | string;
-  title?: string | null;
-  agent_name?: string | null;
+  task_id: number;
+  title: string;
+  created_at?: string | null;
+  agent_name?: string;
   agent_logo_url?: string | null;
-  created_at: string;
+}
+
+function isSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+function decodeHomeTemplateCard(value: unknown): HomeTemplateCard | null {
+  if (
+    !isJsonRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.category !== "string" ||
+    typeof value.description !== "string" ||
+    !Array.isArray(value.features) ||
+    !value.features.every((feature) => typeof feature === "string") ||
+    !Array.isArray(value.connections) ||
+    typeof value.setup_time !== "string" ||
+    !isSafeInteger(value.likes) ||
+    !isSafeInteger(value.used_count)
+  ) return null;
+
+  const connections: HomeTemplateConnection[] = [];
+  for (const connection of value.connections) {
+    if (
+      !isJsonRecord(connection) ||
+      typeof connection.name !== "string" ||
+      (typeof connection.logo !== "string" && connection.logo !== null)
+    ) return null;
+    connections.push({ name: connection.name, logo: connection.logo });
+  }
+
+  return {
+    id: value.id,
+    name: value.name,
+    category: value.category,
+    description: value.description,
+    features: [...value.features],
+    connections,
+    setup_time: value.setup_time,
+    likes: value.likes,
+    used_count: value.used_count,
+  };
+}
+
+function decodeHomeTemplates(value: unknown): HomeTemplateCard[] | null {
+  if (!Array.isArray(value)) return null;
+  const templates: HomeTemplateCard[] = [];
+  for (const template of value) {
+    const decoded = decodeHomeTemplateCard(template);
+    if (!decoded) return null;
+    templates.push(decoded);
+  }
+  return templates;
+}
+
+function decodeRecentTask(value: unknown): RecentTask | null {
+  if (
+    !isJsonRecord(value) ||
+    !isSafeInteger(value.task_id) ||
+    value.task_id <= 0 ||
+    typeof value.title !== "string" ||
+    (value.created_at !== undefined && value.created_at !== null && typeof value.created_at !== "string") ||
+    (value.agent_name !== undefined && typeof value.agent_name !== "string") ||
+    (value.agent_logo_url !== undefined && value.agent_logo_url !== null && typeof value.agent_logo_url !== "string")
+  ) return null;
+
+  return {
+    task_id: value.task_id,
+    title: value.title,
+    created_at: value.created_at,
+    agent_name: value.agent_name,
+    agent_logo_url: value.agent_logo_url,
+  };
+}
+
+function decodeRecentTasks(value: unknown): RecentTask[] | null {
+  if (!isJsonRecord(value) || !Array.isArray(value.tasks)) return null;
+  const tasks: RecentTask[] = [];
+  for (const task of value.tasks) {
+    const decoded = decodeRecentTask(task);
+    if (!decoded) return null;
+    tasks.push(decoded);
+  }
+  return tasks;
 }
 
 export default function Home() {
@@ -46,7 +146,7 @@ export default function Home() {
   const { t, locale } = useI18n();
   const { setPendingMessage, setTaskId } = useApp();
   const branding = getBrandingFromEnv();
-  const [templates, setTemplates] = useState<Template[]>([]);
+  const [templates, setTemplates] = useState<HomeTemplateCard[]>([]);
   const [recentTasks, setRecentTasks] = useState<RecentTask[]>([]);
   const [isCreating, setIsCreating] = useState(false);
   const [showNoModelAlert, setShowNoModelAlert] = useState(false);
@@ -57,6 +157,7 @@ export default function Home() {
   const activeTaskCreateAttemptRef = useRef<number | null>(null);
   const taskCreateCounterRef = useRef(0);
   const draftRevisionRef = useRef(0);
+  const templateGenerationRef = useRef(0);
   const homeVoiceInput = useVoiceInputControls();
 
   useEffect(() => {
@@ -65,28 +166,57 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const generation = ++templateGenerationRef.current;
+    let active = true;
+    const isCurrent = () => active && generation === templateGenerationRef.current;
+
+    const fetchTemplates = async () => {
       try {
-        const [templatesRes, tasksRes] = await Promise.all([
-          apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`),
-          apiRequest(`${getApiUrl()}/api/chat/tasks?page=1&per_page=5`)
-        ]);
+        const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`);
+        if (!isCurrent()) return;
+        if (!response.ok) throw new Error(`Template request failed: ${response.status}`);
 
-        if (templatesRes.ok) {
-          const data = await templatesRes.json();
-          setTemplates(Array.isArray(data) ? data.slice(0, 3) : []);
-        }
+        const parsed = await parseApiResponse(response);
+        if (!isCurrent()) return;
+        const decoded = decodeHomeTemplates(parsed.data);
+        if (!decoded) throw new Error("Invalid template response");
 
-        if (tasksRes.ok) {
-          const data = await tasksRes.json();
-          setRecentTasks((data.tasks || (Array.isArray(data) ? data : [])) as RecentTask[]);
-        }
+        setTemplates(decoded.slice(0, 3));
       } catch (error) {
-        console.error("Failed to fetch data", error);
+        if (isCurrent()) {
+          setTemplates([]);
+          console.error("Failed to fetch templates:", error);
+        }
       }
     };
-    fetchData();
+
+    void fetchTemplates();
+    return () => { active = false; };
   }, [locale]);
+
+  useEffect(() => {
+    let active = true;
+
+    const fetchRecentTasks = async () => {
+      try {
+        const response = await apiRequest(`${getApiUrl()}/api/chat/tasks?page=1&per_page=5`);
+        if (!active) return;
+        if (!response.ok) throw new Error(`Recent task request failed: ${response.status}`);
+
+        const parsed = await parseApiResponse(response);
+        if (!active) return;
+        const decoded = decodeRecentTasks(parsed.data);
+        if (!decoded) throw new Error("Invalid recent task response");
+
+        setRecentTasks(decoded);
+      } catch (error) {
+        if (active) console.error("Failed to fetch recent tasks:", error);
+      }
+    };
+
+    void fetchRecentTasks();
+    return () => { active = false; };
+  }, []);
 
   useEffect(() => {
     const section = getStartedSectionRef.current;
@@ -463,7 +593,7 @@ export default function Home() {
                         <div className="flex items-center">
                           {template.connections && template.connections.length > 0 ? (
                             <div className="flex gap-1.5">
-                              {template.connections.slice(0, 4).map((conn: ConnectionInfo, idx: number) => (
+                              {template.connections.slice(0, 4).map((conn, idx: number) => (
                                 <div key={idx} className="w-8 h-8 rounded-lg bg-background border border-border flex items-center justify-center overflow-hidden shadow-sm">
                                   {conn.logo ? <img src={conn.logo} alt={conn.name} className="w-5 h-5 object-contain" /> : <span className="text-[10px] font-bold text-primary/70">{(conn.name || "").substring(0, 2).toUpperCase()}</span>}
                                 </div>
@@ -513,7 +643,7 @@ export default function Home() {
                       <div>
                         <h4 className="font-semibold text-[16px] group-hover:text-primary transition-colors">{task.title || t("home.recent.untitledTask")}</h4>
                         <p className="text-[13px] text-muted-foreground mt-0.5 font-medium">
-                          {task.agent_name || t("home.recent.defaultAgent")} • {new Date(task.created_at).toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                          {task.agent_name || t("home.recent.defaultAgent")} • {new Date(task.created_at === null ? 0 : task.created_at === undefined ? Number.NaN : task.created_at).toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                         </p>
                       </div>
                     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,7 +21,8 @@ import {
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { apiRequest, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
-import { getApiUrl } from "@/lib/utils";
+import { getApiUrl, resolveAgentLogoUrl } from "@/lib/utils";
+import { formatDisplayDate } from "@/lib/time-utils";
 import { resolveTaskLlmSelection } from "@/lib/models";
 import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create";
 import { useI18n } from "@/contexts/i18n-context";
@@ -630,12 +631,17 @@ export default function Home() {
             <>
               <h2 className="text-[16px] font-bold mb-4 text-foreground">{t("home.recent.title")}</h2>
               <div className="space-y-3">
-                {recentTasks.map(task => (
+                {recentTasks.map((task) => {
+                  const resolvedLogoUrl = resolveAgentLogoUrl(task.agent_logo_url, getApiUrl());
+                  const displayDate = formatDisplayDate(task.created_at, locale, {
+                    month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+                  });
+                  return (
                   <Link key={task.task_id} href={`/task/${task.task_id}`} className="flex items-center justify-between p-4 rounded-2xl border border-border/60 bg-card hover:border-primary/30 hover:shadow-md transition-all duration-300 group">
                     <div className="flex items-center gap-5">
                       <div className="w-12 h-12 rounded-xl bg-primary/5 flex items-center justify-center shrink-0 border border-primary/10">
-                        {task.agent_logo_url ? (
-                          <img src={task.agent_logo_url.startsWith("http") ? task.agent_logo_url : `${getApiUrl()}${task.agent_logo_url}`} alt="Agent" className="w-7 h-7 rounded object-cover" />
+                        {resolvedLogoUrl ? (
+                          <img src={resolvedLogoUrl} alt="Agent" className="w-7 h-7 rounded object-cover" />
                         ) : (
                           <Bot className="w-6 h-6 text-primary/80" />
                         )}
@@ -643,7 +649,7 @@ export default function Home() {
                       <div>
                         <h4 className="font-semibold text-[16px] group-hover:text-primary transition-colors">{task.title || t("home.recent.untitledTask")}</h4>
                         <p className="text-[13px] text-muted-foreground mt-0.5 font-medium">
-                          {task.agent_name || t("home.recent.defaultAgent")} • {new Date(task.created_at === null ? 0 : task.created_at === undefined ? Number.NaN : task.created_at).toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                          {task.agent_name || t("home.recent.defaultAgent")}{displayDate ? ` • ${displayDate}` : ""}
                         </p>
                       </div>
                     </div>
@@ -651,7 +657,8 @@ export default function Home() {
                       <ChevronRight className="w-4 h-4" />
                     </div>
                   </Link>
-                ))}
+                  );
+                })}
               </div>
             </>
           )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,8 +20,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
-import { apiRequest } from "@/lib/api-wrapper";
+import { apiRequest, parseApiResponse } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
+import { resolveTaskLlmSelection } from "@/lib/models";
+import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create";
 import type { ConnectionInfo, Template } from "@/types/template";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
@@ -29,6 +31,7 @@ import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
 import { HomePageExtension } from "@/lib/home-page-extension";
+import { toast } from "@/components/ui/sonner";
 
 interface RecentTask {
   task_id: number | string;
@@ -36,18 +39,6 @@ interface RecentTask {
   agent_name?: string | null;
   agent_logo_url?: string | null;
   created_at: string;
-}
-
-interface LlmModel {
-  model_id: string;
-  is_default?: boolean;
-}
-
-interface DefaultModelRecord {
-  config_type?: "general" | "small_fast" | "visual" | "compact";
-  model?: {
-    model_id?: string;
-  } | null;
 }
 
 export default function Home() {
@@ -62,7 +53,16 @@ export default function Home() {
   const [visibleGetStartedVideos, setVisibleGetStartedVideos] = useState<Set<number>>(new Set());
   const getStartedSectionRef = useRef<HTMLDivElement | null>(null);
   const homeChatInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const mountedRef = useRef(false);
+  const activeTaskCreateAttemptRef = useRef<number | null>(null);
+  const taskCreateCounterRef = useRef(0);
+  const draftRevisionRef = useRef(0);
   const homeVoiceInput = useVoiceInputControls();
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; activeTaskCreateAttemptRef.current = null; };
+  }, []);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -134,103 +134,92 @@ export default function Home() {
     router.push(`/build/new?template=${templateId}`);
   };
 
-  const resolveTaskLlmIds = async (): Promise<[string, string | null, string | null, string | null] | null> => {
-    const apiUrl = getApiUrl();
-    const [modelsResponse, defaultResponse] = await Promise.all([
-      apiRequest(`${apiUrl}/api/models/?category=llm`, { headers: {} }),
-      apiRequest(`${apiUrl}/api/models/user-default`, { headers: {} }),
-    ]);
-
-    let allModels: LlmModel[] = [];
-    if (modelsResponse.ok) {
-      const modelsData = await modelsResponse.json();
-      if (Array.isArray(modelsData)) {
-        allModels = modelsData as LlmModel[];
-      }
-    }
-
-    const defaultModels: Record<string, string | undefined> = {};
-    if (defaultResponse.ok) {
-      const defaultsData = await defaultResponse.json();
-      if (Array.isArray(defaultsData)) {
-        defaultsData.forEach((defaultConfig: DefaultModelRecord) => {
-          if (defaultConfig?.config_type && defaultConfig.model?.model_id) {
-            defaultModels[defaultConfig.config_type] = defaultConfig.model.model_id;
-          }
-        });
-      }
-    }
-
-    const generalModelId =
-      defaultModels.general ||
-      allModels.find((model) => model.is_default)?.model_id ||
-      allModels[0]?.model_id;
-
-    if (!generalModelId) {
-      return null;
-    }
-
-    return [
-      generalModelId,
-      defaultModels.small_fast ?? null,
-      defaultModels.visual ?? null,
-      defaultModels.compact ?? null,
-    ];
-  };
-
   const handleCreateTask = async (content: string) => {
-    if (isCreating) return;
+    const rawPrompt = content;
+    const submittedPrompt = rawPrompt.trim();
+    if (!submittedPrompt) return;
+    if (activeTaskCreateAttemptRef.current !== null) return;
+
+    const attempt = ++taskCreateCounterRef.current;
+    activeTaskCreateAttemptRef.current = attempt;
+    const revision = draftRevisionRef.current;
+    const isCurrent = () => mountedRef.current && activeTaskCreateAttemptRef.current === attempt;
+
     setIsCreating(true);
+
     try {
-      const llmIds = await resolveTaskLlmIds();
-      if (!llmIds) {
-        setShowNoModelAlert(true);
+      let task = null;
+
+      try {
+        const selection = await resolveTaskLlmSelection();
+        if (!isCurrent()) return;
+
+        if (selection.kind === "no_model") {
+          setShowNoModelAlert(true);
+          return;
+        }
+        if (selection.kind === "operational_error") throw selection.error;
+
+        const taskResponse = await apiRequest(`${getApiUrl()}/api/chat/task/create`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: normalizeTaskPromptTitle(submittedPrompt),
+            description: submittedPrompt,
+            llm_ids: selection.llmIds,
+          }),
+        });
+
+        if (!isCurrent()) return;
+        const parsed = await parseApiResponse(taskResponse);
+        if (!isCurrent()) return;
+
+        task = taskResponse.ok ? parseTaskCreateCore(parsed.data) : null;
+        if (!task) throw new Error("Failed to create task");
+      } catch (error) {
+        if (isCurrent()) {
+          console.error("Failed to create task:", error);
+          toast.error(t("common.errors.taskFailed"));
+        }
         return;
       }
 
-      const requestBody = {
-        title: content,
-        description: content,
-        llm_ids: llmIds,
-      };
+      if (!isCurrent() || !task) return;
 
-      const taskResponse = await apiRequest(`${getApiUrl()}/api/chat/task/create`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-      });
+      try {
+        if (!isCurrent()) return;
+        setPendingMessage({
+          message: submittedPrompt,
+          files: [],
+          targetTaskId: task.taskId,
+        });
 
-      if (taskResponse.ok) {
-        const taskData = await taskResponse.json();
-        const taskId = taskData.id || taskData.task_id;
+        if (!isCurrent()) return;
+        setTaskId(task.taskId);
 
-        if (taskId) {
-          const parsedTaskId = typeof taskId === 'string' ? parseInt(taskId) : taskId;
-
-          setPendingMessage({
-            message: content,
-            files: [],
-            targetTaskId: parsedTaskId
-          });
-
-          setTaskId(parsedTaskId);
+        if (!isCurrent()) return;
+        if (draftRevisionRef.current === revision && homeChatInputRef.current) {
+          homeChatInputRef.current.value = "";
+          homeChatInputRef.current.style.height = "auto";
+          draftRevisionRef.current += 1;
         }
-      } else {
-        console.error("Failed to create task");
+      } catch (error) {
+        if (isCurrent()) console.error("Failed to commit task creation:", error);
       }
-    } catch (err) {
-      console.error("Failed to send message:", err);
     } finally {
-      setIsCreating(false);
+      if (isCurrent()) {
+        activeTaskCreateAttemptRef.current = null;
+        setIsCreating(false);
+      }
     }
   };
 
   const handleChatButtonClick = () => {
     const val = homeChatInputRef.current?.value;
     if (val && val.trim()) {
-      handleCreateTask(val.trim());
+      handleCreateTask(val);
     }
   };
 
@@ -296,6 +285,7 @@ export default function Home() {
               className="border-0 bg-transparent text-white text-[16px] leading-relaxed placeholder:text-[hsl(240_5%_60%)] focus-visible:ring-0 focus-visible:outline-none flex-1 resize-none overflow-hidden min-h-[28px] max-h-[120px] py-1 px-2"
               rows={1}
               onInput={(e) => {
+                draftRevisionRef.current += 1;
                 const target = e.target as HTMLTextAreaElement;
                 target.style.height = "auto";
                 target.style.height = Math.min(target.scrollHeight, 120) + "px";
@@ -304,7 +294,7 @@ export default function Home() {
                 if (e.key === 'Enter' && !e.shiftKey) {
                   e.preventDefault();
                   if (e.currentTarget.value.trim() && !isCreating) {
-                    handleCreateTask(e.currentTarget.value.trim());
+                    handleCreateTask(e.currentTarget.value);
                   }
                 }
               }}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -30,10 +30,8 @@ import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
-import {
-  HomePageExtension,
-  homeGetStartedDestinationOverrides,
-} from "@/lib/home-page-extension";
+import * as homePageExtensionModule from "@/lib/home-page-extension";
+import { HomePageExtension } from "@/lib/home-page-extension";
 import type { HomeGetStartedDestinationOverrides } from "@/lib/page-extension-contracts";
 import { toast } from "@/components/ui/sonner";
 
@@ -146,8 +144,13 @@ function decodeRecentTasks(value: unknown): RecentTask[] | null {
   return tasks;
 }
 
-const configuredHomeGetStartedDestinationOverrides:
-  HomeGetStartedDestinationOverrides = homeGetStartedDestinationOverrides
+// `homeGetStartedDestinationOverrides` is an OPTIONAL export of the replaceable
+// home-page-extension module: a replacement that only implements the required
+// `HomePageExtension` export must still build, so this is read through the
+// module namespace with a fallback rather than a static named import.
+const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =
+  (homePageExtensionModule as { homeGetStartedDestinationOverrides?: HomeGetStartedDestinationOverrides })
+    .homeGetStartedDestinationOverrides ?? {}
 
 const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
   docs: "https://docs.xagent.co/api-reference/introduction",
@@ -180,7 +183,6 @@ export default function Home() {
   const activeTaskCreateAttemptRef = useRef<number | null>(null);
   const taskCreateCounterRef = useRef(0);
   const draftRevisionRef = useRef(0);
-  const templateGenerationRef = useRef(0);
   const homeVoiceInput = useVoiceInputControls();
 
   useEffect(() => {
@@ -189,9 +191,8 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    const generation = ++templateGenerationRef.current;
     let active = true;
-    const isCurrent = () => active && generation === templateGenerationRef.current;
+    const isCurrent = () => active;
 
     const fetchTemplates = async () => {
       try {
@@ -288,8 +289,7 @@ export default function Home() {
   };
 
   const handleCreateTask = async (content: string) => {
-    const rawPrompt = content;
-    const submittedPrompt = rawPrompt.trim();
+    const submittedPrompt = content.trim();
     if (!submittedPrompt) return;
     if (activeTaskCreateAttemptRef.current !== null) return;
 
@@ -514,9 +514,9 @@ export default function Home() {
           <div ref={getStartedSectionRef} className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mb-10">
             {[
               { title: t("home.getStarted.video.title"), desc: t("home.getStarted.video.description", { appName: branding.appName }), video: "/videos/Tutorial.mp4", link: null },
-              { title: t("home.getStarted.docs.title"), desc: t("home.getStarted.docs.description"), video: "/videos/Documentation.mp4", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.docs, defaultHomeGetStartedDestinations.docs) },
-              { title: t("home.getStarted.guides.title"), desc: t("home.getStarted.guides.description"), icon: <ListChecks className="w-8 h-8 text-green-500" />, bg: "bg-green-50 dark:bg-green-950/30", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.guides, defaultHomeGetStartedDestinations.guides) },
-              { title: t("home.getStarted.whatsNew.title"), desc: t("home.getStarted.whatsNew.description"), icon: <Sparkles className="w-8 h-8 text-orange-500" />, bg: "bg-orange-50 dark:bg-orange-950/30", link: resolveHomeGetStartedDestination(configuredHomeGetStartedDestinationOverrides.whatsNew, defaultHomeGetStartedDestinations.whatsNew) }
+              { title: t("home.getStarted.docs.title"), desc: t("home.getStarted.docs.description"), video: "/videos/Documentation.mp4", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.docs, defaultHomeGetStartedDestinations.docs) },
+              { title: t("home.getStarted.guides.title"), desc: t("home.getStarted.guides.description"), icon: <ListChecks className="w-8 h-8 text-green-500" />, bg: "bg-green-50 dark:bg-green-950/30", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.guides, defaultHomeGetStartedDestinations.guides) },
+              { title: t("home.getStarted.whatsNew.title"), desc: t("home.getStarted.whatsNew.description"), icon: <Sparkles className="w-8 h-8 text-orange-500" />, bg: "bg-orange-50 dark:bg-orange-950/30", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.whatsNew, defaultHomeGetStartedDestinations.whatsNew) }
             ].map((card, i) => {
               const shouldLoadVideo = card.video ? visibleGetStartedVideos.has(i) : false;
               const isLinked = typeof card.link === "string";

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -1603,7 +1603,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         toast.success(t("builds.editor.success.published"))
       } else {
         const error = await response.json()
-        toast.error(error.detail || t("builds.editor.error.publishFailed"))
+        toast.error(error.detail || t("builds.publication.publishFailed"))
       }
     } catch (error) {
       console.error("Failed to publish agent:", error)
@@ -1631,7 +1631,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         toast.success(t("builds.editor.success.unpublished"))
       } else {
         const error = await response.json()
-        toast.error(error.detail || t("builds.editor.error.unpublishFailed"))
+        toast.error(error.detail || t("builds.publication.unpublishFailed"))
       }
     } catch (error) {
       console.error("Failed to unpublish agent:", error)
@@ -1660,7 +1660,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         }
       } else {
         const error = await response.json()
-        toast.error(error.detail || t("builds.editor.error.publishFailed"))
+        toast.error(error.detail || t("builds.publication.publishFailed"))
       }
     } catch (error) {
       console.error("Failed to publish agent:", error)

--- a/frontend/src/components/settings/default-models.tsx
+++ b/frontend/src/components/settings/default-models.tsx
@@ -27,9 +27,9 @@ import {
   getUserDefaultModels,
   setUserDefaultModel,
   removeUserDefaultModel,
-  DefaultModelConfig,
   DefaultModelType,
-  Model,
+  ModelWithAccess,
+  UserDefaultModelMap,
 } from "@/lib/models"
 import { useAuth } from "@/contexts/auth-context"
 import { useI18n } from "@/contexts/i18n-context"
@@ -89,27 +89,26 @@ const modelTypeConfig = {
   },
 }
 
-const defaultModelTypes = Object.keys(modelTypeConfig) as DefaultModelType[]
+type SettingsDefaultModelType = Exclude<DefaultModelType, 'rerank'>
+const defaultModelTypes = Object.keys(modelTypeConfig) as SettingsDefaultModelType[]
 
-const getModelCategory = (model: Model): string => {
-  return model.category || ''
+const getModelCategory = (model: ModelWithAccess): string => {
+  return model.category
 }
 
-const getModelAbilities = (model: Model): string[] => {
+const getModelAbilities = (model: ModelWithAccess): string[] => {
   return model.abilities || []
 }
 
-const getModelDisplayName = (model: Model): string => {
-  if (model.model_name) return model.model_name
-  return model.name
+const getModelDisplayName = (model: ModelWithAccess): string => {
+  return model.model_name
 }
 
-const getModelProviderLabel = (model: Model): string => {
-  if (model.model_provider) return model.model_provider
-  return model.provider
+const getModelProviderLabel = (model: ModelWithAccess): string => {
+  return model.model_provider
 }
 
-const getCompatibleModels = (models: Model[], configType: DefaultModelType): Model[] => {
+const getCompatibleModels = (models: ModelWithAccess[], configType: SettingsDefaultModelType): ModelWithAccess[] => {
   if (configType === 'embedding') {
     return models.filter((model) => getModelCategory(model) === 'embedding')
   }
@@ -145,8 +144,8 @@ const getCompatibleModels = (models: Model[], configType: DefaultModelType): Mod
 
 export function DefaultModelsSettings() {
   const { token } = useAuth()
-  const [models, setModels] = useState<Model[]>([])
-  const [defaultModels, setDefaultModels] = useState<DefaultModelConfig>({})
+  const [models, setModels] = useState<ModelWithAccess[]>([])
+  const [defaultModels, setDefaultModels] = useState<UserDefaultModelMap>({})
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState<string | null>(null)
   const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
@@ -162,19 +161,19 @@ export function DefaultModelsSettings() {
     try {
       setLoading(true)
       const [modelsData, defaultsData] = await Promise.all([
-        getUserModels(token),
-        getUserDefaultModels(token),
+        getUserModels(),
+        getUserDefaultModels(),
       ])
       setModels(modelsData)
       setDefaultModels(defaultsData)
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: t('settings.defaultModels.messages.loadFailed') })
     } finally {
       setLoading(false)
     }
   }
 
-  const handleSetDefault = async (configType: DefaultModelType, modelId: number) => {
+  const handleSetDefault = async (configType: SettingsDefaultModelType, modelId: number) => {
     if (!token) return
 
     try {
@@ -184,19 +183,19 @@ export function DefaultModelsSettings() {
       await setUserDefaultModel(token, configType, modelId)
 
       // Reload defaults
-      const defaultsData = await getUserDefaultModels(token)
+      const defaultsData = await getUserDefaultModels()
       setDefaultModels(defaultsData)
 
       const typeTitle = t(`settings.defaultModels.types.${configType}.title`)
       setMessage({ type: 'success', text: t('settings.defaultModels.messages.updated', { type: typeTitle }) })
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: t('settings.defaultModels.messages.setFailed') })
     } finally {
       setSaving(null)
     }
   }
 
-  const handleRemoveDefault = async (configType: DefaultModelType) => {
+  const handleRemoveDefault = async (configType: SettingsDefaultModelType) => {
     if (!token) return
 
     try {
@@ -206,12 +205,12 @@ export function DefaultModelsSettings() {
       await removeUserDefaultModel(token, configType)
 
       // Reload defaults
-      const defaultsData = await getUserDefaultModels(token)
+      const defaultsData = await getUserDefaultModels()
       setDefaultModels(defaultsData)
 
       const typeTitle = t(`settings.defaultModels.types.${configType}.title`)
       setMessage({ type: 'success', text: t('settings.defaultModels.messages.removed', { type: typeTitle }) })
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: t('settings.defaultModels.messages.removeFailed') })
     } finally {
       setSaving(null)

--- a/frontend/src/components/settings/default-models.tsx
+++ b/frontend/src/components/settings/default-models.tsx
@@ -92,54 +92,38 @@ const modelTypeConfig = {
 type SettingsDefaultModelType = Exclude<DefaultModelType, 'rerank'>
 const defaultModelTypes = Object.keys(modelTypeConfig) as SettingsDefaultModelType[]
 
-const getModelCategory = (model: ModelWithAccess): string => {
-  return model.category
-}
-
-const getModelAbilities = (model: ModelWithAccess): string[] => {
-  return model.abilities || []
-}
-
-const getModelDisplayName = (model: ModelWithAccess): string => {
-  return model.model_name
-}
-
-const getModelProviderLabel = (model: ModelWithAccess): string => {
-  return model.model_provider
-}
-
 const getCompatibleModels = (models: ModelWithAccess[], configType: SettingsDefaultModelType): ModelWithAccess[] => {
   if (configType === 'embedding') {
-    return models.filter((model) => getModelCategory(model) === 'embedding')
+    return models.filter((model) => model.category === 'embedding')
   }
   if (configType === 'image') {
-    return models.filter((model) => getModelCategory(model) === 'image')
+    return models.filter((model) => model.category === 'image')
   }
   if (configType === 'image_edit') {
-    return models.filter((model) => getModelCategory(model) === 'image' && getModelAbilities(model).includes('edit'))
+    return models.filter((model) => model.category === 'image' && (model.abilities || []).includes('edit'))
   }
   if (configType === 'video') {
-    return models.filter((model) => getModelCategory(model) === 'video' && getModelAbilities(model).includes('generate'))
+    return models.filter((model) => model.category === 'video' && (model.abilities || []).includes('generate'))
   }
   if (configType === 'asr') {
-    return models.filter((model) => getModelCategory(model) === 'speech' && getModelAbilities(model).includes('asr'))
+    return models.filter((model) => model.category === 'speech' && (model.abilities || []).includes('asr'))
   }
   if (configType === 'tts') {
-    return models.filter((model) => getModelCategory(model) === 'speech' && getModelAbilities(model).includes('tts'))
+    return models.filter((model) => model.category === 'speech' && (model.abilities || []).includes('tts'))
   }
   if (configType === 'speech') {
     return models.filter((model) => {
-      const abilities = getModelAbilities(model)
-      return getModelCategory(model) === 'speech' && abilities.includes('asr') && abilities.includes('tts')
+      const abilities = model.abilities || []
+      return model.category === 'speech' && abilities.includes('asr') && abilities.includes('tts')
     })
   }
   if (configType === 'sound_effect') {
-    return models.filter((model) => getModelCategory(model) === 'sound_effect')
+    return models.filter((model) => model.category === 'sound_effect')
   }
   if (configType === 'music') {
-    return models.filter((model) => getModelCategory(model) === 'music')
+    return models.filter((model) => model.category === 'music')
   }
-  return models.filter((model) => getModelCategory(model) === 'llm')
+  return models.filter((model) => model.category === 'llm')
 }
 
 export function DefaultModelsSettings() {
@@ -285,16 +269,16 @@ export function DefaultModelsSettings() {
                       <div className="flex items-center justify-between">
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium truncate">
-                            {getModelDisplayName(currentDefault.model)}
+                            {currentDefault.model.model_name}
                           </p>
                           <div className="flex items-center gap-1 mt-1">
                             <Badge variant="secondary" className="text-xs">
-                              {getModelProviderLabel(currentDefault.model)}
+                              {currentDefault.model.model_provider}
                             </Badge>
                             <Badge variant="outline" className="text-xs">
                               {tDynamic(
-                                `models.tabs.${getModelCategory(currentDefault.model)}`,
-                                getModelCategory(currentDefault.model),
+                                `models.tabs.${currentDefault.model.category}`,
+                                currentDefault.model.category,
                               )}
                             </Badge>
                           </div>
@@ -323,7 +307,7 @@ export function DefaultModelsSettings() {
                         }
                         options={compatibleModels.map((model) => ({
                           value: model.id.toString(),
-                          label: `${getModelDisplayName(model)} (${getModelProviderLabel(model)})`,
+                          label: `${model.model_name} (${model.model_provider})`,
                         }))}
                         placeholder={t('settings.defaultModels.labels.selectModel')}
                       />

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2360,6 +2360,10 @@ Build when you need.`,
         sendFailed: "Failed to send message. Please try again.",
       }
     },
+    publication: {
+      publishFailed: "Failed to publish agent",
+      unpublishFailed: "Failed to unpublish agent",
+    },
     editor: {
       aiAssistant: "{appName} Assistant",
       stepGuide: {
@@ -2444,8 +2448,6 @@ Build when you need.`,
       },
       error: {
         failed: "Failed to create agent",
-        publishFailed: "Failed to publish agent",
-        unpublishFailed: "Failed to unpublish agent",
         kbToolsNotEnabled: "Knowledge bases are selected but the Knowledge tool category is not enabled. Please enable the Knowledge tools before saving.",
         unknown: "An unknown error occurred",
         notFound: "Agent not found",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2360,6 +2360,10 @@ const zh = {
         sendFailed: "发送消息失败，请重试。",
       }
     },
+    publication: {
+      publishFailed: "发布 Agent 失败",
+      unpublishFailed: "取消发布 Agent 失败",
+    },
     editor: {
       aiAssistant: "{appName} 助手",
       stepGuide: {
@@ -2444,8 +2448,6 @@ const zh = {
       },
       error: {
         failed: "创建 Agent 失败",
-        publishFailed: "发布 Agent 失败",
-        unpublishFailed: "取消发布 Agent 失败",
         kbToolsNotEnabled: "选择了知识库但未启用知识库工具，请在工具类别中勾选「知识库」工具后再保存。",
         unknown: "发生未知错误",
         notFound: "Agent 不存在",

--- a/frontend/src/i18n/translations.test.ts
+++ b/frontend/src/i18n/translations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { readFileSync } from "node:fs"
 
 import {
   resolveDynamicTranslation,
@@ -103,6 +104,44 @@ describe("translations", () => {
       discardNotAllowed: expect.any(String),
       discardHasRuns: expect.any(String),
     }))
+  })
+
+  it("keeps publication failure copy neutral, exact, and fully migrated", () => {
+    expect(translations.en.builds.publication).toEqual({
+      publishFailed: "Failed to publish agent",
+      unpublishFailed: "Failed to unpublish agent",
+    })
+    expect(translations.zh.builds.publication).toEqual({
+      publishFailed: "发布 Agent 失败",
+      unpublishFailed: "取消发布 Agent 失败",
+    })
+    for (const editorError of [
+      translations.en.builds.editor.error,
+      translations.zh.builds.editor.error,
+    ]) {
+      expect(editorError as Record<string, unknown>).not.toHaveProperty("publishFailed")
+      expect(editorError as Record<string, unknown>).not.toHaveProperty("unpublishFailed")
+    }
+
+    const buildPage = readFileSync(`${process.cwd()}/src/app/build/page.tsx`, "utf8")
+    const agentBuilder = readFileSync(
+      `${process.cwd()}/src/components/build/agent-builder.tsx`,
+      "utf8",
+    )
+    const localeSources = [
+      readFileSync(`${process.cwd()}/src/i18n/locales/en.ts`, "utf8"),
+      readFileSync(`${process.cwd()}/src/i18n/locales/zh.ts`, "utf8"),
+    ]
+
+    expect(buildPage.match(/builds\.publication\.publishFailed/g)).toHaveLength(1)
+    expect(buildPage.match(/builds\.publication\.unpublishFailed/g)).toHaveLength(1)
+    expect(agentBuilder.match(/builds\.publication\.publishFailed/g)).toHaveLength(2)
+    expect(agentBuilder.match(/builds\.publication\.unpublishFailed/g)).toHaveLength(1)
+
+    for (const source of [buildPage, agentBuilder, ...localeSources]) {
+      expect(source).not.toContain("builds.editor.error.publishFailed")
+      expect(source).not.toContain("builds.editor.error.unpublishFailed")
+    }
   })
 
   it("provides localized Widget Session lifecycle copy", () => {

--- a/frontend/src/lib/home-page-extension.tsx
+++ b/frontend/src/lib/home-page-extension.tsx
@@ -1,3 +1,8 @@
-import type { HomePageExtensionComponent } from "@/lib/page-extension-contracts"
+import type {
+  HomeGetStartedDestinationOverrides,
+  HomePageExtensionComponent,
+} from "@/lib/page-extension-contracts"
 
 export const HomePageExtension: HomePageExtensionComponent = () => null
+
+export const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides = {}

--- a/frontend/src/lib/home-page-extension.tsx
+++ b/frontend/src/lib/home-page-extension.tsx
@@ -5,4 +5,8 @@ import type {
 
 export const HomePageExtension: HomePageExtensionComponent = () => null
 
+// Optional export: a replacement module may omit `homeGetStartedDestinationOverrides`
+// entirely and still satisfy this module's contract (only `HomePageExtension` is
+// required). The canonical default here is the empty object, i.e. all destinations
+// resolve to their OSS defaults.
 export const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides = {}

--- a/frontend/src/lib/models.test.ts
+++ b/frontend/src/lib/models.test.ts
@@ -1,5 +1,100 @@
-import { describe, expect, it } from "vitest"
-import { hostnameFromUrl } from "./models"
+import { readFileSync } from "node:fs"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./api-wrapper", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./api-wrapper")>()),
+  apiRequest: vi.fn(),
+}))
+
+import { apiRequest } from "./api-wrapper"
+import {
+  getUserDefaultModels,
+  getUserModels,
+  hostnameFromUrl,
+  parseModelList,
+  parseUserDefaultModels,
+  resolveTaskLlmSelection,
+} from "./models"
+
+const mockedRequest = vi.mocked(apiRequest)
+
+const currentBackendDefaultTypes = [
+  "general",
+  "small_fast",
+  "visual",
+  "compact",
+  "embedding",
+  "image",
+  "image_edit",
+  "video",
+  "asr",
+  "tts",
+  "speech",
+  "sound_effect",
+  "music",
+  "rerank",
+] as const
+
+const model = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  model_id: "gpt",
+  category: "llm",
+  model_provider: "openai",
+  model_name: "GPT",
+  base_url: null,
+  temperature: null,
+  context_window: null,
+  dimension: null,
+  abilities: null,
+  description: null,
+  created_at: null,
+  updated_at: null,
+  is_active: true,
+  is_owner: true,
+  can_edit: true,
+  can_delete: true,
+  is_shared: false,
+  ...overrides,
+})
+
+const defaultEntry = (
+  configType: string,
+  modelOverrides: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {},
+) => ({
+  id: 2,
+  user_id: 3,
+  model_id: 1,
+  config_type: configType,
+  created_at: null,
+  updated_at: null,
+  model: model(modelOverrides),
+  ...overrides,
+})
+
+const jsonResponse = (value: unknown, init?: ResponseInit) => new Response(JSON.stringify(value), init)
+
+const unreadableResponse = () => {
+  const response = new Response("unreadable")
+  Object.defineProperty(response, "text", {
+    value: vi.fn().mockRejectedValue(new Error("body unavailable")),
+  })
+  return response
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  mockedRequest.mockReset()
+})
 
 describe("hostnameFromUrl", () => {
   it("returns empty string for missing url", () => {
@@ -20,5 +115,450 @@ describe("hostnameFromUrl", () => {
   it("returns empty string for non-absolute urls instead of a garbled fallback", () => {
     expect(hostnameFromUrl("/v1")).toBe("")
     expect(hostnameFromUrl("not a url")).toBe("")
+  })
+})
+
+describe("model producer decoders", () => {
+  it("copies complete producer records and ignores unconsumed extras", () => {
+    const raw = model({
+      abilities: ["chat"],
+      temperature: 0.7,
+      context_window: 128000,
+      dimension: 1536,
+      is_default: true,
+    })
+
+    const parsed = parseModelList([raw])
+
+    expect(parsed).toEqual([expect.objectContaining({ model_id: "gpt", abilities: ["chat"] })])
+    expect(parsed?.[0]).not.toBe(raw)
+    expect(parsed?.[0]).not.toHaveProperty("is_default")
+    expect(Object.keys(parsed?.[0] ?? {}).sort()).toEqual([
+      "abilities",
+      "base_url",
+      "can_delete",
+      "can_edit",
+      "category",
+      "context_window",
+      "created_at",
+      "description",
+      "dimension",
+      "id",
+      "is_active",
+      "is_owner",
+      "is_shared",
+      "model_id",
+      "model_name",
+      "model_provider",
+      "temperature",
+      "updated_at",
+    ])
+    ;(raw.abilities as unknown as string[]).push("mutated")
+    expect(parsed?.[0].abilities).toEqual(["chat"])
+  })
+
+  it.each([
+    [null],
+    [{}],
+    ["model"],
+    [42],
+    [true],
+    [[model({ id: 0 })]],
+    [[model({ id: 1.5 })]],
+    [[model({ id: Number.MAX_SAFE_INTEGER + 1 })]],
+    [[model({ model_id: 1 })]],
+    [[model({ temperature: Infinity })]],
+    [[model({ context_window: 1.5 })]],
+    [[model({ abilities: ["chat", 1] })]],
+    [[model({ is_shared: "false" })]],
+  ])("rejects malformed model-list body %#", (value) => {
+    expect(parseModelList(value)).toBeNull()
+  })
+
+  it("rejects every missing or wrong consumed ModelWithAccessInfo field", () => {
+    const requiredStrings = ["model_id", "category", "model_provider", "model_name"]
+    const nullableStrings = ["base_url", "description", "created_at", "updated_at"]
+    const nullableFiniteNumbers = ["temperature"]
+    const nullableIntegers = ["context_window", "dimension"]
+    const booleans = ["is_active", "is_owner", "can_edit", "can_delete", "is_shared"]
+
+    for (const value of ["1", 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity]) {
+      expect(parseModelList([model({ id: value })])).toBeNull()
+    }
+    const missingId = model() as Record<string, unknown>
+    delete missingId.id
+    expect(parseModelList([missingId])).toBeNull()
+
+    for (const field of requiredStrings) {
+      expect(parseModelList([model({ [field]: 1 })])).toBeNull()
+      const missing = model() as Record<string, unknown>
+      delete missing[field]
+      expect(parseModelList([missing])).toBeNull()
+    }
+
+    for (const field of nullableStrings) {
+      expect(parseModelList([model({ [field]: 1 })])).toBeNull()
+      expect(parseModelList([model({ [field]: undefined })])).toBeNull()
+    }
+
+    for (const field of nullableFiniteNumbers) {
+      expect(parseModelList([model({ [field]: "0.7" })])).toBeNull()
+      for (const value of [NaN, Infinity, -Infinity]) {
+        expect(parseModelList([model({ [field]: value })])).toBeNull()
+      }
+      expect(parseModelList([model({ [field]: undefined })])).toBeNull()
+    }
+
+    for (const field of nullableIntegers) {
+      expect(parseModelList([model({ [field]: "1" })])).toBeNull()
+      expect(parseModelList([model({ [field]: 1.5 })])).toBeNull()
+      expect(parseModelList([model({ [field]: NaN })])).toBeNull()
+      expect(parseModelList([model({ [field]: Infinity })])).toBeNull()
+      expect(parseModelList([model({ [field]: undefined })])).toBeNull()
+    }
+
+    for (const value of ["chat", ["chat", 1], 1, undefined]) {
+      expect(parseModelList([model({ abilities: value })])).toBeNull()
+    }
+
+    for (const field of booleans) {
+      expect(parseModelList([model({ [field]: "true" })])).toBeNull()
+      expect(parseModelList([model({ [field]: undefined })])).toBeNull()
+    }
+  })
+
+  it("indexes the raw default array by config type, copies nested models, and recognizes rerank", () => {
+    const raw = defaultEntry("rerank", { model_name: "Reranker", abilities: ["rank"] })
+    const parsed = parseUserDefaultModels([raw])
+
+    expect(parsed).toEqual({
+      rerank: expect.objectContaining({
+        config_type: "rerank",
+        model: expect.objectContaining({ model_name: "Reranker", abilities: ["rank"] }),
+      }),
+    })
+    expect(parsed?.rerank).not.toBe(raw)
+    expect(parsed?.rerank?.model).not.toBe(raw.model)
+    expect(Object.keys(parsed?.rerank ?? {}).sort()).toEqual([
+      "config_type",
+      "created_at",
+      "id",
+      "model",
+      "model_id",
+      "updated_at",
+      "user_id",
+    ])
+    ;(raw.model.abilities as unknown as string[]).push("mutated")
+    expect(parsed?.rerank?.model.abilities).toEqual(["rank"])
+  })
+
+  it.each(currentBackendDefaultTypes)("indexes current backend-known default type %s", (configType) => {
+    const parsed = parseUserDefaultModels([
+      defaultEntry(configType, { model_id: `${configType}-model` }),
+    ])
+
+    expect(parsed).toEqual({
+      [configType]: expect.objectContaining({
+        config_type: configType,
+        model: expect.objectContaining({ model_id: `${configType}-model` }),
+      }),
+    })
+  })
+
+  it.each(["id", "user_id", "model_id"] as const)("rejects every invalid %s", (field) => {
+    for (const value of ["1", 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(parseUserDefaultModels([defaultEntry("general", {}, { [field]: value })])).toBeNull()
+    }
+  })
+
+  it("rejects every missing or wrong top-level user-default field", () => {
+    const positiveIds = ["id", "user_id", "model_id"]
+    for (const field of positiveIds) {
+      expect(parseUserDefaultModels([defaultEntry("general", {}, { [field]: "1" })])).toBeNull()
+      const missing = defaultEntry("general") as Record<string, unknown>
+      delete missing[field]
+      expect(parseUserDefaultModels([missing])).toBeNull()
+    }
+
+    expect(parseUserDefaultModels([defaultEntry("general", {}, { config_type: 1 })])).toBeNull()
+    const missingConfigType = defaultEntry("general") as Record<string, unknown>
+    delete missingConfigType.config_type
+    expect(parseUserDefaultModels([missingConfigType])).toBeNull()
+
+    for (const field of ["created_at", "updated_at"]) {
+      expect(parseUserDefaultModels([defaultEntry("general", {}, { [field]: false })])).toBeNull()
+      const missing = defaultEntry("general") as Record<string, unknown>
+      delete missing[field]
+      expect(parseUserDefaultModels([missing])).toBeNull()
+    }
+
+    expect(parseUserDefaultModels([defaultEntry("general", {}, { model: [] })])).toBeNull()
+    const missingModel = defaultEntry("general") as Record<string, unknown>
+    delete missingModel.model
+    expect(parseUserDefaultModels([missingModel])).toBeNull()
+  })
+
+  it.each([
+    [null],
+    [{}],
+    ["defaults"],
+    [1],
+    [true],
+    [[defaultEntry("general", { category: 1 })]],
+    [[defaultEntry("general", {}, { config_type: 1 })]],
+    [[defaultEntry("general", {}, { created_at: 1 })]],
+  ])("rejects malformed user-default body %#", (value) => {
+    expect(parseUserDefaultModels(value)).toBeNull()
+  })
+
+  it("ignores valid unknown config types only after validating their full record", () => {
+    expect(parseUserDefaultModels([defaultEntry("future_default")])).toEqual({})
+    expect(parseUserDefaultModels([defaultEntry("future_default", { model_id: 1 })])).toBeNull()
+  })
+
+  it("rejects mixed arrays and duplicate recognized defaults", () => {
+    expect(parseModelList([model(), model({ category: 1 })])).toBeNull()
+    expect(parseUserDefaultModels([defaultEntry("general"), defaultEntry("visual", { category: 1 })])).toBeNull()
+    expect(parseUserDefaultModels([defaultEntry("general"), defaultEntry("general", { model_id: "next" })])).toBeNull()
+  })
+})
+
+describe("model readers", () => {
+  it("uses exact filtered and unfiltered list URLs and enforces a requested category", async () => {
+    mockedRequest.mockResolvedValueOnce(jsonResponse([model()]))
+    await expect(getUserModels({ category: "llm" })).resolves.toEqual([expect.objectContaining({ category: "llm" })])
+    expect(mockedRequest).toHaveBeenLastCalledWith("/api/models/?category=llm")
+
+    mockedRequest.mockResolvedValueOnce(jsonResponse([model()]))
+    await expect(getUserModels()).resolves.toEqual([expect.objectContaining({ model_id: "gpt" })])
+    expect(mockedRequest).toHaveBeenLastCalledWith("/api/models/")
+
+    mockedRequest.mockResolvedValueOnce(jsonResponse([model({ category: "embedding" })]))
+    await expect(getUserModels({ category: "llm" })).rejects.toThrow("Invalid models response")
+  })
+
+  it("accepts a valid HTTP-200 JSON empty model collection", async () => {
+    mockedRequest.mockResolvedValueOnce(jsonResponse([]))
+    await expect(getUserModels({ category: "llm" })).resolves.toEqual([])
+  })
+
+  it("accepts a valid HTTP-200 JSON empty default collection", async () => {
+    mockedRequest.mockResolvedValueOnce(jsonResponse([]))
+    await expect(getUserDefaultModels()).resolves.toEqual({})
+  })
+
+  it.each([
+    ["primitive", new Response("true")],
+    ["object", jsonResponse({ model: model() })],
+    ["empty", new Response("")],
+    ["malformed JSON", new Response("{")],
+    ["unreadable", unreadableResponse()],
+    ["non-OK", jsonResponse([model()], { status: 500 })],
+    ["schema-invalid", jsonResponse([model({ category: 1 })])],
+  ])("rejects %s model responses through the real body parser", async (_name, response) => {
+    mockedRequest.mockResolvedValueOnce(response)
+    await expect(getUserModels()).rejects.toThrow()
+  })
+
+  it.each([
+    ["primitive", new Response("true")],
+    ["object", jsonResponse({ general: defaultEntry("general") })],
+    ["empty", new Response("")],
+    ["malformed JSON", new Response("{")],
+    ["unreadable", unreadableResponse()],
+    ["non-OK", jsonResponse([defaultEntry("general")], { status: 500 })],
+    ["nested model malformed", jsonResponse([defaultEntry("general", { is_active: "yes" })])],
+  ])("rejects %s default responses through the real body parser", async (_name, response) => {
+    mockedRequest.mockResolvedValueOnce(response)
+    await expect(getUserDefaultModels()).rejects.toThrow()
+  })
+})
+
+describe("task LLM selection", () => {
+  it("starts both reads before either settles and waits for higher-priority defaults", async () => {
+    const models = deferred<Response>()
+    const defaults = deferred<Response>()
+    mockedRequest.mockReturnValueOnce(models.promise).mockReturnValueOnce(defaults.promise)
+
+    const selection = resolveTaskLlmSelection()
+    expect(mockedRequest).toHaveBeenCalledTimes(2)
+    expect(mockedRequest).toHaveBeenNthCalledWith(1, "/api/models/?category=llm")
+    expect(mockedRequest).toHaveBeenNthCalledWith(2, "/api/models/user-default")
+
+    models.resolve(jsonResponse([model({ model_id: "models-first" })]))
+    await Promise.resolve()
+    let settled = false
+    void selection.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    defaults.resolve(jsonResponse([defaultEntry("general", { model_id: "defaults-win" })]))
+    await expect(selection).resolves.toEqual({
+      kind: "success",
+      llmIds: ["defaults-win", null, null, null],
+    })
+    expect(mockedRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses defaults general even when the model reader fails", async () => {
+    mockedRequest
+      .mockRejectedValueOnce(new Error("models down"))
+      .mockResolvedValueOnce(jsonResponse([defaultEntry("general", { model_id: "default" })]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["default", null, null, null],
+    })
+  })
+
+  it.each([
+    ["non-OK", jsonResponse([model()], { status: 500 })],
+    ["malformed", new Response("{")],
+  ])("uses defaults general when Models returns %s", async (_name, modelsResponse) => {
+    mockedRequest
+      .mockResolvedValueOnce(modelsResponse)
+      .mockResolvedValueOnce(jsonResponse([defaultEntry("general", { model_id: "default" })]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["default", null, null, null],
+    })
+  })
+
+  it("uses the first non-empty response-order model when defaults fail", async () => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([
+        model({ model_id: "" }),
+        model({ model_id: "first" }),
+        model({ model_id: "later", is_default: true }),
+      ]))
+      .mockRejectedValueOnce(new Error("defaults down"))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["first", null, null, null],
+    })
+  })
+
+  it("uses a fulfilled Models fallback while retaining fulfilled specialized defaults", async () => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([model({ model_id: "  fallback\t" })]))
+      .mockResolvedValueOnce(jsonResponse([
+        defaultEntry("small_fast", { model_id: "\tsmall fast  " }),
+        defaultEntry("visual", { model_id: "  visual\t" }),
+        defaultEntry("compact", { model_id: " compact " }),
+      ]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["  fallback\t", "\tsmall fast  ", "  visual\t", " compact "],
+    })
+  })
+
+  it("preserves a whitespace-bearing Defaults general ID byte-for-byte", async () => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([model({ model_id: "fallback" })]))
+      .mockResolvedValueOnce(jsonResponse([
+        defaultEntry("general", { model_id: "  default general\t" }),
+      ]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["  default general\t", null, null, null],
+    })
+  })
+
+  it.each([
+    ["non-OK", jsonResponse([defaultEntry("general")], { status: 500 })],
+    ["malformed", new Response("{")],
+  ])("uses the model fallback when Defaults returns %s", async (_name, defaultsResponse) => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([model({ model_id: "fallback" })]))
+      .mockResolvedValueOnce(defaultsResponse)
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["fallback", null, null, null],
+    })
+  })
+
+  it("projects specialized defaults only from a fulfilled source and maps empty IDs to null", async () => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([model({ model_id: "fallback" })]))
+      .mockResolvedValueOnce(jsonResponse([
+        defaultEntry("general", { model_id: "general" }),
+        defaultEntry("small_fast", { model_id: "" }),
+        defaultEntry("visual", { model_id: "vision" }),
+        defaultEntry("compact", { model_id: "" }),
+      ]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds: ["general", null, "vision", null],
+    })
+  })
+
+  it.each([
+    ["defaults", async () => jsonResponse([]), async () => { throw new Error("defaults down") }],
+    ["models", async () => { throw new Error("models down") }, async () => jsonResponse([])],
+    ["both", async () => { throw new Error("models down") }, async () => { throw new Error("defaults down") }],
+  ])("returns an operational error when %s fails and no candidate remains", async (_name, first, second) => {
+    mockedRequest.mockImplementationOnce(first)
+    mockedRequest.mockImplementationOnce(second)
+    await expect(resolveTaskLlmSelection()).resolves.toMatchObject({ kind: "operational_error" })
+  })
+
+  it("returns no_model only when both valid readers prove there is no candidate", async () => {
+    mockedRequest.mockResolvedValueOnce(jsonResponse([model({ model_id: "" })]))
+    mockedRequest.mockResolvedValueOnce(jsonResponse([defaultEntry("general", { model_id: "" })]))
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({ kind: "no_model" })
+  })
+
+  it("returns no_model when both valid readers return empty JSON collections", async () => {
+    mockedRequest
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]))
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({ kind: "no_model" })
+  })
+
+  it.each([
+    [
+      "Models",
+      jsonResponse([]),
+      jsonResponse([defaultEntry("general", { model_id: "default candidate" })]),
+      ["default candidate", null, null, null],
+    ],
+    [
+      "Defaults",
+      jsonResponse([model({ model_id: "model candidate" })]),
+      jsonResponse([]),
+      ["model candidate", null, null, null],
+    ],
+  ])("allows an empty valid %s source when its sibling has a candidate", async (_emptySource, modelsResponse, defaultsResponse, llmIds) => {
+    mockedRequest
+      .mockResolvedValueOnce(modelsResponse)
+      .mockResolvedValueOnce(defaultsResponse)
+
+    await expect(resolveTaskLlmSelection()).resolves.toEqual({
+      kind: "success",
+      llmIds,
+    })
+  })
+})
+
+describe("Home and Build model-reader architecture", () => {
+  it("keeps endpoint decoding out of pages and imports only the shared resolver", () => {
+    const home = readFileSync(`${process.cwd()}/src/app/page.tsx`, "utf8")
+    const build = readFileSync(`${process.cwd()}/src/app/build/page.tsx`, "utf8")
+
+    for (const source of [home, build]) {
+      expect(source).not.toContain("/api/models")
+      expect(source).not.toMatch(/\b(?:LlmModel|DefaultModelRecord|resolveTaskLlmIds|parseModelList|parseUserDefaultModels)\b/)
+      expect(source).not.toMatch(/\b(?:getUserModels|getUserDefaultModels)\b/)
+      expect(source).toMatch(/import\s*\{\s*resolveTaskLlmSelection\s*\}\s*from\s*["']@\/lib\/models["']/)
+      expect(source).not.toMatch(/import\s*\{[^}]*\b(?:getUserModels|getUserDefaultModels|parseModelList|parseUserDefaultModels)\b[^}]*\}\s*from\s*["']@\/lib\/models["']/)
+      expect(source).toContain("parseApiResponse")
+    }
   })
 })

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -3,22 +3,26 @@
  */
 
 import { getApiUrl } from './utils';
-import { apiRequest } from './api-wrapper';
+import { apiRequest, isJsonRecord, parseApiResponse } from './api-wrapper';
 
-export type DefaultModelType =
-  | 'general'
-  | 'small_fast'
-  | 'visual'
-  | 'compact'
-  | 'embedding'
-  | 'image'
-  | 'image_edit'
-  | 'video'
-  | 'asr'
-  | 'tts'
-  | 'speech'
-  | 'sound_effect'
-  | 'music';
+const currentBackendDefaultModelTypes = [
+  'general',
+  'small_fast',
+  'visual',
+  'compact',
+  'embedding',
+  'image',
+  'image_edit',
+  'video',
+  'asr',
+  'tts',
+  'speech',
+  'sound_effect',
+  'music',
+  'rerank',
+] as const;
+
+export type DefaultModelType = (typeof currentBackendDefaultModelTypes)[number];
 
 export interface Model {
   id: number;
@@ -91,32 +95,254 @@ export interface DefaultModelConfig {
   music?: ModelConfig;
 }
 
+export interface ModelWithAccess {
+  id: number;
+  model_id: string;
+  category: string;
+  model_provider: string;
+  model_name: string;
+  base_url: string | null;
+  temperature: number | null;
+  context_window: number | null;
+  dimension: number | null;
+  abilities: string[] | null;
+  description: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  is_active: boolean;
+  is_owner: boolean;
+  can_edit: boolean;
+  can_delete: boolean;
+  is_shared: boolean;
+}
+
+export interface UserDefaultModelEntry {
+  id: number;
+  user_id: number;
+  model_id: number;
+  config_type: DefaultModelType;
+  created_at: string | null;
+  updated_at: string | null;
+  model: ModelWithAccess;
+}
+
+export type UserDefaultModelMap = Partial<Record<DefaultModelType, UserDefaultModelEntry>>;
+
+const defaultTypes: ReadonlySet<string> = new Set(currentBackendDefaultModelTypes);
+
+const positiveSafeInt = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+
+const nullableString = (value: unknown): value is string | null =>
+  value === null || typeof value === 'string';
+
+const nullableFinite = (value: unknown): value is number | null =>
+  value === null || (typeof value === 'number' && Number.isFinite(value));
+
+const nullableInt = (value: unknown): value is number | null =>
+  value === null || (typeof value === 'number' && Number.isInteger(value));
+
+function isKnownDefaultModelType(value: string): value is DefaultModelType {
+  return defaultTypes.has(value);
+}
+
+export function parseModelList(value: unknown): ModelWithAccess[] | null {
+  if (!Array.isArray(value)) return null;
+
+  const result: ModelWithAccess[] = [];
+  for (const item of value) {
+    if (!isJsonRecord(item)) return null;
+
+    const {
+      id,
+      model_id,
+      category,
+      model_provider,
+      model_name,
+      base_url,
+      temperature,
+      context_window,
+      dimension,
+      abilities,
+      description,
+      created_at,
+      updated_at,
+      is_active,
+      is_owner,
+      can_edit,
+      can_delete,
+      is_shared,
+    } = item;
+    const validAbilities = abilities === null
+      || (Array.isArray(abilities) && abilities.every((ability) => typeof ability === 'string'));
+
+    if (
+      !positiveSafeInt(id)
+      || typeof model_id !== 'string'
+      || typeof category !== 'string'
+      || typeof model_provider !== 'string'
+      || typeof model_name !== 'string'
+      || !nullableString(base_url)
+      || !nullableFinite(temperature)
+      || !nullableInt(context_window)
+      || !nullableInt(dimension)
+      || !validAbilities
+      || !nullableString(description)
+      || !nullableString(created_at)
+      || !nullableString(updated_at)
+      || typeof is_active !== 'boolean'
+      || typeof is_owner !== 'boolean'
+      || typeof can_edit !== 'boolean'
+      || typeof can_delete !== 'boolean'
+      || typeof is_shared !== 'boolean'
+    ) {
+      return null;
+    }
+
+    result.push({
+      id,
+      model_id,
+      category,
+      model_provider,
+      model_name,
+      base_url,
+      temperature,
+      context_window,
+      dimension,
+      abilities: abilities === null ? null : [...abilities],
+      description,
+      created_at,
+      updated_at,
+      is_active,
+      is_owner,
+      can_edit,
+      can_delete,
+      is_shared,
+    });
+  }
+
+  return result;
+}
+
+export function parseUserDefaultModels(value: unknown): UserDefaultModelMap | null {
+  if (!Array.isArray(value)) return null;
+
+  const result: UserDefaultModelMap = {};
+  for (const item of value) {
+    if (
+      !isJsonRecord(item)
+      || !positiveSafeInt(item.id)
+      || !positiveSafeInt(item.user_id)
+      || !positiveSafeInt(item.model_id)
+      || typeof item.config_type !== 'string'
+      || !nullableString(item.created_at)
+      || !nullableString(item.updated_at)
+    ) {
+      return null;
+    }
+
+    const models = parseModelList([item.model]);
+    if (!models) return null;
+
+    if (isKnownDefaultModelType(item.config_type)) {
+      if (result[item.config_type]) return null;
+
+      result[item.config_type] = {
+        id: item.id,
+        user_id: item.user_id,
+        model_id: item.model_id,
+        config_type: item.config_type,
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        model: models[0],
+      };
+    }
+  }
+
+  return result;
+}
+
 /**
  * Get all models for current user
  */
-export async function getUserModels(_token: string): Promise<Model[]> {
-  const apiUrl = getApiUrl()
-  const response = await apiRequest(`${apiUrl}/api/models/`);
+export async function getUserModels(options: { category?: string } = {}): Promise<ModelWithAccess[]> {
+  const apiUrl = getApiUrl();
+  const query = options.category ? `?category=${encodeURIComponent(options.category)}` : '';
+  const response = await apiRequest(`${apiUrl}/api/models/${query}`);
 
   if (!response.ok) {
     throw new Error('Failed to fetch models');
   }
+  const parsed = await parseApiResponse(response);
+  const models = parseModelList(parsed.data);
+  if (!models || (options.category && models.some((model) => model.category !== options.category))) {
+    throw new Error('Invalid models response');
+  }
 
-  return response.json();
+  return models;
 }
 
 /**
  * Get user's default model configuration
  */
-export async function getUserDefaultModels(_token: string): Promise<DefaultModelConfig> {
-  const apiUrl = getApiUrl()
+export async function getUserDefaultModels(): Promise<UserDefaultModelMap> {
+  const apiUrl = getApiUrl();
   const response = await apiRequest(`${apiUrl}/api/models/user-default`);
 
   if (!response.ok) {
     throw new Error('Failed to fetch default models');
   }
 
-  return response.json();
+  const parsed = await parseApiResponse(response);
+  const defaults = parseUserDefaultModels(parsed.data);
+  if (!defaults) throw new Error('Invalid default models response');
+
+  return defaults;
+}
+
+export type TaskLlmSelection =
+  | { kind: 'success'; llmIds: [string, string | null, string | null, string | null] }
+  | { kind: 'no_model' }
+  | { kind: 'operational_error'; error: Error }
+
+export async function resolveTaskLlmSelection(): Promise<TaskLlmSelection> {
+  const [models, defaults] = await Promise.allSettled([
+    getUserModels({ category: 'llm' }),
+    getUserDefaultModels(),
+  ]);
+  const defaultMap = defaults.status === 'fulfilled' ? defaults.value : null;
+  const fallback = models.status === 'fulfilled'
+    ? models.value.find((model) => model.model_id)?.model_id
+    : undefined;
+  const general = defaultMap?.general?.model.model_id || fallback;
+
+  if (general) {
+    return {
+      kind: 'success',
+      llmIds: [
+        general,
+        defaultMap?.small_fast?.model.model_id || null,
+        defaultMap?.visual?.model.model_id || null,
+        defaultMap?.compact?.model.model_id || null,
+      ],
+    };
+  }
+
+  if (models.status === 'rejected') {
+    return {
+      kind: 'operational_error',
+      error: models.reason instanceof Error ? models.reason : new Error('Failed to fetch models'),
+    };
+  }
+
+  if (defaults.status === 'rejected') {
+    return {
+      kind: 'operational_error',
+      error: defaults.reason instanceof Error ? defaults.reason : new Error('Failed to fetch default models'),
+    };
+  }
+
+  return { kind: 'no_model' };
 }
 
 /**

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -3,6 +3,12 @@ import type { ComponentType, ReactNode } from "react"
 // Embedding distributions may replace default implementation modules during frontend composition.
 export type HomePageExtensionComponent = ComponentType
 
+export interface HomeGetStartedDestinationOverrides {
+  docs?: string | null
+  guides?: string | null
+  whatsNew?: string | null
+}
+
 // The page guarantees a stable Provider lifetime and agentId join key.
 // The paired replacement implementation owns data loading, sharing, and invalidation.
 export interface BuildAgentCardExtensionProps {

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -1,8 +1,28 @@
 import type { ComponentType, ReactNode } from "react"
 
 // Embedding distributions may replace default implementation modules during frontend composition.
+// For the Home extension module (`home-page-extension.tsx`), `HomePageExtension` is the
+// required export; `homeGetStartedDestinationOverrides` is OPTIONAL — a replacement module
+// that omits it still builds and falls back to all canonical defaults (see page.tsx, which
+// reads it through the module namespace rather than a static named import). A replacement
+// module that omits the optional export will produce a benign webpack "Attempted import
+// error" WARNING at compile time (not an error), so distributions with warnings-as-errors
+// gates should expect it.
 export type HomePageExtensionComponent = ComponentType
 
+/**
+ * Per-key override for the "Get started" card destinations on the home page.
+ * Each key is resolved independently with three-state semantics:
+ * - `undefined` (key omitted, or the whole `homeGetStartedDestinationOverrides`
+ *   export is missing from a replacement module): the canonical OSS default
+ *   destination is used.
+ * - `null` (or a non-string / blank value): the card renders as a
+ *   non-interactive card — no anchor, no tab stop, no pointer cursor, and no
+ *   link-only hover styling.
+ * - a string that is non-empty after trimming: used as the destination
+ *   verbatim, including any surrounding whitespace, which is deliberately
+ *   not trimmed from the emitted href.
+ */
 export interface HomeGetStartedDestinationOverrides {
   docs?: string | null
   guides?: string | null

--- a/frontend/src/lib/task-create.test.ts
+++ b/frontend/src/lib/task-create.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { normalizeTaskPromptTitle, parseTaskCreateCore } from "./task-create"
+
+const validCore = (overrides: Record<string, unknown> = {}) => ({
+  task_id: 7,
+  title: "task",
+  status: "running",
+  created_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+})
+
+describe("task create core contract", () => {
+  it("returns only a copied camelCase core projection", () => {
+    const raw = validCore({ extra: true, nested: { retained: false } })
+    const parsed = parseTaskCreateCore(raw)
+
+    expect(parsed).toEqual({
+      taskId: 7,
+      title: "task",
+      status: "running",
+      createdAt: "2026-01-01T00:00:00Z",
+    })
+    expect(parsed).not.toBe(raw)
+    expect(parsed).not.toHaveProperty("extra")
+    expect(parsed).not.toHaveProperty("nested")
+    raw.title = "mutated"
+    expect(parsed?.title).toBe("task")
+  })
+
+  it.each(["task_id", "title", "status", "created_at"])("rejects missing core field %s", (field) => {
+    const payload = validCore()
+    delete payload[field as keyof typeof payload]
+    expect(parseTaskCreateCore(payload)).toBeNull()
+  })
+
+  it.each([
+    ["id alias", validCore({ task_id: undefined, id: 7 })],
+    ["numeric string", validCore({ task_id: "7" })],
+    ["zero", validCore({ task_id: 0 })],
+    ["negative", validCore({ task_id: -1 })],
+    ["fraction", validCore({ task_id: 1.5 })],
+    ["unsafe integer", validCore({ task_id: Number.MAX_SAFE_INTEGER + 1 })],
+    ["null id", validCore({ task_id: null })],
+    ["array id", validCore({ task_id: [] })],
+    ["object id", validCore({ task_id: {} })],
+    ["boolean id", validCore({ task_id: true })],
+    ["undefined id", validCore({ task_id: undefined })],
+  ])("rejects %s", (_name, value) => {
+    expect(parseTaskCreateCore(value)).toBeNull()
+  })
+
+  it.each(["title", "status", "created_at"] as const)("rejects every non-string %s", (field) => {
+    for (const value of [null, [], {}, true, false, 1, undefined]) {
+      expect(parseTaskCreateCore(validCore({ [field]: value }))).toBeNull()
+    }
+  })
+
+  it("accepts empty strings because the backend contract requires types, not minimum lengths", () => {
+    expect(parseTaskCreateCore(validCore({ title: "", status: "", created_at: "" }))).toEqual({
+      taskId: 7,
+      title: "",
+      status: "",
+      createdAt: "",
+    })
+  })
+
+  it.each([null, [], {}, true, false, "task", 1, undefined])("rejects non-record JSON value %#", (value) => {
+    expect(parseTaskCreateCore(value)).toBeNull()
+  })
+
+  it("normalizes Unicode and internal whitespace without truncation", () => {
+    const long = "x".repeat(10_000)
+    expect(normalizeTaskPromptTitle("\u00a0\t hello\n\u2003world \r\n ")).toBe("hello world")
+    expect(normalizeTaskPromptTitle(`  ${long}  `)).toBe(long)
+  })
+})

--- a/frontend/src/lib/task-create.ts
+++ b/frontend/src/lib/task-create.ts
@@ -1,0 +1,20 @@
+import { isJsonRecord } from "./api-wrapper"
+
+export interface TaskCreateCore {
+  taskId: number
+  title: string
+  status: string
+  createdAt: string
+}
+
+export function normalizeTaskPromptTitle(prompt: string): string {
+  return prompt.trim().replace(/\s+/gu, " ")
+}
+
+export function parseTaskCreateCore(value: unknown): TaskCreateCore | null {
+  if (!isJsonRecord(value)) return null
+  const { task_id, title, status, created_at } = value
+  if (typeof task_id !== "number" || !Number.isSafeInteger(task_id) || task_id <= 0) return null
+  if (typeof title !== "string" || typeof status !== "string" || typeof created_at !== "string") return null
+  return { taskId: task_id, title, status, createdAt: created_at }
+}

--- a/frontend/src/lib/time-utils.test.ts
+++ b/frontend/src/lib/time-utils.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { formatDisplayDate } from "./time-utils"
+
+const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
+
+const dateOptions = Object.freeze({
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+} as const)
+
+const homeDateOptions = Object.freeze({
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+} as const)
+
+describe("formatDisplayDate", () => {
+  let priorTimeZone: string | undefined
+
+  beforeEach(() => {
+    priorTimeZone = process.env.TZ
+    process.env.TZ = "UTC"
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (priorTimeZone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = priorTimeZone
+    }
+  })
+
+  it.each([
+    undefined,
+    null,
+    1,
+    new Date(),
+    {},
+    [],
+    true,
+    new String("2024-05-06T07:08:09Z"),
+    bigintValue,
+    Symbol("date"),
+    () => "2024-05-06T07:08:09Z",
+    "",
+    "   ",
+    "not a date",
+  ])("returns empty for unsupported input %#", (value) => {
+    expect(() => formatDisplayDate(value, "en", dateOptions)).not.toThrow()
+    expect(formatDisplayDate(value, "en", dateOptions)).toBe("")
+  })
+
+  it.each([
+    ["en", "en-US"],
+    ["zh", "zh-CN"],
+  ] as const)("uses %s locale with each caller option contract", (locale, expectedLocale) => {
+    const formatSpy = vi.spyOn(Intl, "DateTimeFormat")
+    const buildDate = formatDisplayDate("2024-05-06T07:08:09Z", locale, dateOptions)
+    const homeDate = formatDisplayDate("2024-05-06T07:08:09Z", locale, homeDateOptions)
+
+    expect(buildDate).not.toBe("")
+    expect(homeDate).not.toBe("")
+    expect(formatSpy).toHaveBeenNthCalledWith(1, expectedLocale, dateOptions)
+    expect(formatSpy).toHaveBeenNthCalledWith(2, expectedLocale, homeDateOptions)
+  })
+
+  it("formats a cross-day timestamp in the fixed UTC test environment", () => {
+    const timestamp = "2024-05-06T23:30:00Z"
+    const expected = new Intl.DateTimeFormat("en-US", {
+      ...dateOptions,
+      timeZone: "UTC",
+    }).format(new Date(timestamp))
+
+    expect(formatDisplayDate(timestamp, "en", dateOptions)).toBe(expected)
+
+    const homeExpected = new Intl.DateTimeFormat("en-US", {
+      ...homeDateOptions,
+      timeZone: "UTC",
+    }).format(new Date(timestamp))
+    expect(formatDisplayDate(timestamp, "en", homeDateOptions)).toBe(homeExpected)
+
+    const offsetTimestamp = "2024-05-07T01:30:00+02:00"
+    const offsetExpected = new Intl.DateTimeFormat("en-US", {
+      ...homeDateOptions,
+      timeZone: "UTC",
+    }).format(new Date(offsetTimestamp))
+    expect(formatDisplayDate(offsetTimestamp, "en", homeDateOptions)).toBe(offsetExpected)
+  })
+
+  it("does not reuse permissive legacy formatting owners", () => {
+    const source = readFileSync("src/lib/time-utils.ts", "utf8")
+    const start = source.indexOf("export function formatDisplayDate")
+    const end = source.indexOf("/**\n * Normalizes", start)
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    const helper = source.slice(start, end)
+    expect(helper).toContain("const date = new Date(value)")
+    expect(helper).not.toMatch(/normalizeTimestampMs|formatTime|toLocaleDateString|utils\.formatDate/)
+  })
+})

--- a/frontend/src/lib/time-utils.test.ts
+++ b/frontend/src/lib/time-utils.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { Locale } from "@/i18n/translations"
 import { formatDisplayDate } from "./time-utils"
 
 const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
@@ -66,6 +67,19 @@ describe("formatDisplayDate", () => {
     expect(homeDate).not.toBe("")
     expect(formatSpy).toHaveBeenNthCalledWith(1, expectedLocale, dateOptions)
     expect(formatSpy).toHaveBeenNthCalledWith(2, expectedLocale, homeDateOptions)
+  })
+
+  it("falls back to the locale tag itself for locales without an explicit mapping", () => {
+    const formatSpy = vi.spyOn(Intl, "DateTimeFormat")
+    const widenedLocale = "vi" as unknown as Locale
+
+    const formatted = formatDisplayDate("2024-05-06T07:08:09Z", widenedLocale, dateOptions)
+
+    expect(formatted).not.toBe("")
+    expect(formatSpy).toHaveBeenCalledWith("vi", dateOptions)
+
+    const source = readFileSync("src/lib/time-utils.ts", "utf8")
+    expect(source).toContain("const displayDateLocales: Partial<Record<Locale, string>> = {")
   })
 
   it("formats a cross-day timestamp in the fixed UTC test environment", () => {

--- a/frontend/src/lib/time-utils.ts
+++ b/frontend/src/lib/time-utils.ts
@@ -2,6 +2,26 @@
  * Time formatting utility functions
  * Unified handling of timestamp and ISO format time display
  */
+import type { Locale } from "@/i18n/translations"
+
+const displayDateLocales: Record<Locale, string> = {
+  en: "en-US",
+  zh: "zh-CN",
+}
+
+/** Formats a non-blank, parseable display-date string, returning empty text for invalid input. */
+export function formatDisplayDate(
+  value: unknown,
+  locale: Locale,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  if (typeof value !== "string" || value.trim() === "") return ""
+
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return ""
+
+  return new Intl.DateTimeFormat(displayDateLocales[locale], options).format(date)
+}
 
 /**
  * Normalizes various timestamp formats (seconds, milliseconds, numeric strings, ISO strings)

--- a/frontend/src/lib/time-utils.ts
+++ b/frontend/src/lib/time-utils.ts
@@ -4,7 +4,9 @@
  */
 import type { Locale } from "@/i18n/translations"
 
-const displayDateLocales: Record<Locale, string> = {
+// Partial with a lookup fallback: distributions may replace @/i18n/translations
+// with a widened Locale union, and any unmapped locale is itself a BCP 47 tag.
+const displayDateLocales: Partial<Record<Locale, string>> = {
   en: "en-US",
   zh: "zh-CN",
 }
@@ -20,7 +22,7 @@ export function formatDisplayDate(
   const date = new Date(value)
   if (!Number.isFinite(date.getTime())) return ""
 
-  return new Intl.DateTimeFormat(displayDateLocales[locale], options).format(date)
+  return new Intl.DateTimeFormat(displayDateLocales[locale] ?? locale, options).format(date)
 }
 
 /**

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+import { resolveAgentLogoUrl } from "./utils"
+
+const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
+
+const logoPathCases = [
+  ["no leading slash", "logos/agent.png"],
+  ["one leading slash", "/logos/agent.png"],
+] as const
+
+const logoBaseCases = [
+  ["same-origin empty", ""],
+  ["same-origin one slash", "/"],
+  ["same-origin multiple slashes", "///"],
+  ["root prefix no trailing slash", "/api"],
+  ["root prefix one trailing slash", "/api/"],
+  ["root prefix multiple trailing slashes", "/api///"],
+  ["absolute prefix no trailing slash", "https://api.example/v1"],
+  ["absolute prefix one trailing slash", "https://api.example/v1/"],
+  ["absolute prefix multiple trailing slashes", "https://api.example/v1///"],
+] as const
+
+const joinedLogoCases = logoBaseCases.flatMap(([baseLabel, base]) =>
+  logoPathCases.map(([pathLabel, path]) => {
+    const normalizedBase = /^\/+$/u.test(base) ? "" : base.replace(/\/+$/u, "")
+    return [baseLabel, base, pathLabel, path, `${normalizedBase}/${path.replace(/^\//u, "")}`] as const
+  }),
+)
+
+const internalSpaceCases = [
+  ["relative logo path", "logos/agent image.png", "/api", "/api/logos/agent image.png"],
+  ["root-relative API base", "logos/agent.png", "/api internal", "/api internal/logos/agent.png"],
+  ["absolute HTTP logo path", "https://assets.example/agent image.png", "/ignored", "https://assets.example/agent image.png"],
+  ["absolute API base path prefix", "logos/agent.png", "https://api.example/v1 internal", "https://api.example/v1 internal/logos/agent.png"],
+] as const
+
+describe("resolveAgentLogoUrl", () => {
+  it.each([
+    ["HTTPS://assets.example/logo.png", "not consulted", "HTTPS://assets.example/logo.png"],
+    ["http://assets.example:8443/logo.png?size=1#top", "\\u0000bad", "http://assets.example:8443/logo.png?size=1#top"],
+  ])("accepts %s with base %s", (value, base, expected) => {
+    expect(resolveAgentLogoUrl(value, base)).toBe(expected)
+  })
+
+  it.each(joinedLogoCases)(
+    "joins %s base %s with a %s logo path %s using one boundary slash",
+    (_baseLabel, base, _pathLabel, path, expected) => {
+      expect(resolveAgentLogoUrl(path, base)).toBe(expected)
+    },
+  )
+
+  it.each(internalSpaceCases)(
+    "preserves ordinary internal spaces in a %s byte-for-byte",
+    (_label, value, base, expected) => {
+      expect(resolveAgentLogoUrl(value, base)).toBe(expected)
+    },
+  )
+
+  it("accepts a colon after a slash in a relative logo path", () => {
+    expect(resolveAgentLogoUrl("icons/tenant:42/logo.png", "/api:v1")).toBe(
+      "/api:v1/icons/tenant:42/logo.png",
+    )
+    expect(resolveAgentLogoUrl("/icons/tenant:42/logo.png", "https://api.example/v1/")).toBe(
+      "https://api.example/v1/icons/tenant:42/logo.png",
+    )
+    expect(resolveAgentLogoUrl("1tenant:42/logo.png", "/api")).toBe(
+      "/api/1tenant:42/logo.png",
+    )
+    expect(resolveAgentLogoUrl("custom_name:payload", "/api")).toBe(
+      "/api/custom_name:payload",
+    )
+  })
+
+  it.each([
+    undefined,
+    null,
+    1,
+    true,
+    {},
+    [],
+    new String("logo.png"),
+    bigintValue,
+    Symbol("logo"),
+    () => "logo.png",
+    "",
+    "   ",
+    " logo.png",
+    "logo.png ",
+    " logo.png ",
+    "\u00a0logo.png",
+    "\tlogo.png",
+    "logo.png\n",
+    "logo\u0000.png",
+    "logo\u001f.png",
+    "logo\u007f.png",
+    "logo\\path.png",
+    "logo\\\\path.png",
+    "logo/mixed\\path.png",
+    "logo\\mixed/path.png",
+    "https://assets.example\\logo.png",
+    "/\t/host",
+    "/\n/host",
+    "/\r/host",
+    "/\u0000/host",
+    "/\u007f/host",
+    "//assets.example/logo.png",
+    "///assets.example/logo.png",
+    "/",
+    "////",
+    "data:image/png;base64,x",
+    "DATA:image/png;base64,x",
+    "Custom+V1.Test-Scheme:payload",
+    "javascript:alert(1)",
+    "httpx://assets.example/logo.png",
+    "http://",
+    "https://",
+    "http:/assets.example/logo.png",
+    "https:///host/path",
+    "https:////host/path",
+    "https://?query",
+    "https://#fragment",
+    "https://:443/logo.png",
+  ])("rejects unsupported logo input %#", (value) => {
+    expect(() => resolveAgentLogoUrl(value, "/api")).not.toThrow()
+    expect(resolveAgentLogoUrl(value, "/api")).toBeNull()
+  })
+
+  it.each([
+    "relative-base",
+    "//api.example",
+    "///api.example",
+    "ftp://api.example",
+    "httpx://api.example",
+    "http://",
+    "https://",
+    "http:/api.example",
+    "https:///api",
+    "https:////host/path",
+    "https://?query",
+    "https://#fragment",
+    "/api?query=1",
+    "/api#fragment",
+    "/api\\path",
+    " /api",
+    "/api ",
+    "/api\u2003",
+    "/api\tsegment",
+    "/api\nsegment",
+    "/api\rsegment",
+    "/api\u0000segment",
+    "/api\u001fsegment",
+    "/api\u007fsegment",
+    "https://api\t.example",
+    "https://api\n.example",
+    "https://api\r.example",
+    "https://api\u0000.example",
+    "https://api\u001f.example",
+    "https://api\u007f.example",
+    "https://api.example\\v1",
+    "https://:443/api",
+  ])("rejects invalid relative-path API base %s", (base) => {
+    expect(resolveAgentLogoUrl("logos/agent.png", base)).toBeNull()
+  })
+
+  it.each(["\t", "\n", "\r", "\u0000", "\u001f", "\u007f"])(
+    "rejects controls in an absolute HTTP(S) logo authority: %j",
+    (control) => {
+      expect(resolveAgentLogoUrl(`https://assets${control}.example/logo.png`, "/api")).toBeNull()
+    },
+  )
+
+  it("does not consult an invalid base for an already-valid absolute logo", () => {
+    expect(resolveAgentLogoUrl("https://assets.example/logo.png", "\u0000invalid")).toBe(
+      "https://assets.example/logo.png",
+    )
+  })
+})

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,6 +16,79 @@ export function getApiUrl(): string {
   return apiUrl
 }
 
+const ASCII_CONTROL_OR_DEL = /[\u0000-\u001F\u007F]/
+const EXPLICIT_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/
+const HTTP_AUTHORITY = /^https?:\/\/[^/?#\\]/i
+
+function hasUnsafeUrlText(value: string): boolean {
+  return (
+    value.length === 0
+    || value.trim() !== value
+    || ASCII_CONTROL_OR_DEL.test(value)
+    || value.includes("\\")
+  )
+}
+
+function isHttpUrlWithAuthority(value: string): boolean {
+  if (!HTTP_AUTHORITY.test(value)) return false
+  try {
+    const parsed = new URL(value)
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:")
+      && parsed.hostname.length > 0
+    )
+  } catch {
+    return false
+  }
+}
+
+function normalizeRelativeLogoBase(apiBase: string): string | null {
+  if (
+    apiBase.trim() !== apiBase
+    || ASCII_CONTROL_OR_DEL.test(apiBase)
+    || apiBase.includes("\\")
+    || apiBase.includes("?")
+    || apiBase.includes("#")
+  ) return null
+
+  if (apiBase === "" || /^\/+$/u.test(apiBase)) return ""
+
+  if (HTTP_AUTHORITY.test(apiBase)) {
+    return isHttpUrlWithAuthority(apiBase)
+      ? apiBase.replace(/\/+$/u, "")
+      : null
+  }
+
+  if (
+    EXPLICIT_SCHEME.test(apiBase)
+    || apiBase.startsWith("//")
+    || !/^\/[^/]/u.test(apiBase)
+  ) return null
+
+  return apiBase.replace(/\/+$/u, "")
+}
+
+/**
+ * Resolves an Agent logo API value to an image URL without accepting
+ * protocol-relative, scheme-like, or malformed URL forms.
+ */
+export function resolveAgentLogoUrl(value: unknown, apiBase: string): string | null {
+  if (typeof value !== "string" || hasUnsafeUrlText(value)) return null
+
+  if (/^https?:/i.test(value)) {
+    return isHttpUrlWithAuthority(value) ? value : null
+  }
+
+  if (EXPLICIT_SCHEME.test(value) || value.startsWith("//")) return null
+
+  const relativePath = value.startsWith("/") ? value.slice(1) : value
+  if (relativePath.length === 0 || /^\/+$/u.test(relativePath)) return null
+
+  const normalizedBase = normalizeRelativeLogoBase(apiBase)
+  if (normalizedBase === null) return null
+  return `${normalizedBase}/${relativePath}`
+}
+
 export function getFilePublicPreviewUrl(fileId: string, apiUrl = getApiUrl()): string {
   return `${apiUrl}/api/files/public/preview/${encodeURIComponent(fileId)}`
 }


### PR DESCRIPTION
## Summary

- make Home and Build use the same model-selection, task-response validation, and prompt-title normalization owners while preserving the two batched model collection requests
- separate Home template/recent-task lifecycles and Build publication/refresh lifecycles so stale or late work cannot publish page-owned state
- centralize Agent logo and locale-aware display-date shaping across the canonical pages
- expose typed Home Get Started destination overrides so embedding distributions can configure or disable links without replacing the route

## Root cause

The canonical Home and Build routes owned parallel task-creation and presentation paths, while several lifecycle and destination behaviors had no reusable contract. That made equivalent behavior drift between the pages and forced embedding distributions to replace a complete route for small configuration differences.

## Impact

Home and Build now retain one canonical page implementation with shared behavioral owners. Task state is published only after validated responses, stale lifecycle completions stay silent, display shaping is consistent, and Get Started links can be overridden or rendered inert through the existing Home extension seam.

## Validation

- `npm run test:home-build-pages -- --reporter=verbose` — 9 files, 406 tests
- `npm run type-check`
- scoped ESLint — 0 errors; 3 existing `no-img-element` warnings
- `npm run build`
- `NEXT_OUTPUT=standalone npm run build`
- repository pre-commit hooks on the exact changed files

Both Next builds completed successfully. They continue to print the repository-level Next/ESLint invalid-options diagnostic that is independently covered by the passing scoped ESLint and type-check commands.

Closes #1105
