### PR TITLE
refactor(tasks): stage continuation commands in caller transactions

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -14,6 +14,8 @@ on:
       - 'src/xagent/web/services/agent_management.py'
       - 'src/xagent/web/services/api_keys.py'
       - 'tests/web/services/test_runtime_key_transition_postgres.py'
+      - 'src/xagent/web/services/task_command_transport.py'
+      - 'tests/web/services/test_task_command_transport.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -59,6 +61,8 @@ jobs:
             src/xagent/web/services/agent_management.py
             src/xagent/web/services/api_keys.py
             tests/web/services/test_runtime_key_transition_postgres.py
+            src/xagent/web/services/task_command_transport.py
+            tests/web/services/test_task_command_transport.py
           )
 
           case "$EVENT_NAME" in
@@ -215,6 +219,13 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_runtime_key_transition_postgres.py -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test task command staging concurrency (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/services/test_task_command_transport.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -88,6 +88,55 @@ class EnqueuedTaskCommand:
 
 
 @dataclass(frozen=True)
+class StagedTaskCommand:
+    """A command row added to a caller-owned session, not yet committed.
+
+    ``staged_db_id`` is deliberately not named ``command_id`` -- unlike
+    ``EnqueuedTaskCommand.command_id``, this id is only guaranteed to exist in
+    the database once the caller commits the session it was staged on. Code
+    that dispatches or notifies by id must never accept a StagedTaskCommand.
+    """
+
+    staged_db_id: int
+    client_command_id: str
+    created: bool
+    payload_matches: bool
+    status: str
+
+
+class TaskCommandOwnerStateError(RuntimeError):
+    """The caller's own pending writes failed to flush before staging began.
+
+    Deliberately not an IntegrityError subclass: the wrapper's
+    ``except IntegrityError`` classifies conflicts on the command insert
+    itself, and must not also catch a failure that has nothing to do with
+    that insert. After this is raised, the session is unusable -- the caller
+    must roll back before issuing any further statement on it.
+    """
+
+
+class TaskCommandConflictKind(enum.Enum):
+    RACED_DUPLICATE = "raced_duplicate"
+    TASK_MISSING = "task_missing"
+    UNRELATED = "unrelated"
+
+
+@dataclass(frozen=True)
+class RacedTaskCommandProjection:
+    """Immutable snapshot of the row that won a duplicate-insert race."""
+
+    command_db_id: int
+    status: str
+    payload_matches: bool
+
+
+@dataclass(frozen=True)
+class TaskCommandConflictClassification:
+    kind: TaskCommandConflictKind
+    raced: RacedTaskCommandProjection | None = None
+
+
+@dataclass(frozen=True)
 class ClaimedTaskCommand:
     id: int
     task_id: int
@@ -160,7 +209,7 @@ def _matches_existing(
     )
 
 
-def enqueue_task_command(
+def stage_task_command(
     db: Session,
     *,
     task_id: int,
@@ -168,18 +217,51 @@ def enqueue_task_command(
     command_id: str,
     kind: TaskCommandKind,
     payload: dict[str, Any],
-) -> EnqueuedTaskCommand:
-    """Commit an idempotent command and return only after it is durable."""
+) -> StagedTaskCommand:
+    """Add an idempotent command row to the session without ending its transaction.
+
+    Never calls ``db.commit()``, ``db.rollback()``, or the dispatcher notify --
+    the caller owns the transaction boundary and decides what durability means
+    for its own writes alongside this command. Statement order is load-bearing:
+
+    1. Reject a malformed command_id before touching the database at all.
+    2. Flush the caller's own pending writes first, so a conflict there is
+       reported as TaskCommandOwnerStateError rather than folded into the
+       IntegrityError this function raises for a duplicate command insert.
+    3. Read the task through a single Core select rather than the ORM. This
+       both closes the window a separate existence check and a separate
+       snapshot read would leave between them, and -- unlike an ORM query --
+       is not served from the identity map, so it observes a caller's own
+       uncommitted CAS-style update to the same row instead of a stale cached
+       instance.
+    4. Check for an existing command with this (task_id, command_id) before
+       adding a new row, so a repeated call is idempotent without relying on
+       the unique constraint to reject it.
+    5. Add and flush the new row last, so any remaining IntegrityError is
+       attributable to the command insert itself.
+    """
 
     normalized_id = command_id.strip()
     if COMMAND_ID_PATTERN.fullmatch(normalized_id) is None:
         raise ValueError("command_id must be 1-64 URL-safe characters")
     resolved_task_id = int(task_id)
+
+    try:
+        db.flush()
+    except IntegrityError as exc:
+        raise TaskCommandOwnerStateError(
+            "caller's pending writes failed to flush before command staging"
+        ) from exc
+
     # A task snapshot a caller loaded earlier would widen the concurrent-delete
     # window across everything it did in between, so existence is re-checked
     # here, by query, before inserting a command that references the row.
-    task = db.query(Task).filter(Task.id == resolved_task_id).first()
-    if task is None:
+    snapshot = db.execute(
+        select(Task.status, Task.runner_id, Task.run_id).where(
+            Task.id == resolved_task_id
+        )
+    ).one_or_none()
+    if snapshot is None:
         raise TaskCommandTaskMissing(f"Task {task_id} not found")
 
     existing = (
@@ -197,8 +279,8 @@ def enqueue_task_command(
             kind=kind,
             payload=payload,
         )
-        return EnqueuedTaskCommand(
-            command_id=int(existing.id),
+        return StagedTaskCommand(
+            staged_db_id=int(existing.id),
             client_command_id=normalized_id,
             created=False,
             payload_matches=matches,
@@ -206,8 +288,8 @@ def enqueue_task_command(
         )
 
     active_runner_id = (
-        task.runner_id
-        if task.status == TaskStatus.RUNNING and task.runner_id is not None
+        snapshot.runner_id
+        if snapshot.status == TaskStatus.RUNNING and snapshot.runner_id is not None
         else None
     )
     command = TaskExecutionCommand(
@@ -216,54 +298,133 @@ def enqueue_task_command(
         command_id=normalized_id,
         kind=kind.value,
         payload=payload,
-        target_run_id=task.run_id,
+        target_run_id=snapshot.run_id,
         target_runner_id=active_runner_id,
         status=COMMAND_PENDING,
     )
     db.add(command)
-    try:
-        db.flush()
-        command_db_id = int(command.id)
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        raced = (
-            db.query(TaskExecutionCommand)
-            .filter(
-                TaskExecutionCommand.task_id == resolved_task_id,
-                TaskExecutionCommand.command_id == normalized_id,
-            )
-            .one_or_none()
+    db.flush()
+    return StagedTaskCommand(
+        staged_db_id=int(command.id),
+        client_command_id=normalized_id,
+        created=True,
+        payload_matches=True,
+        status=COMMAND_PENDING,
+    )
+
+
+def classify_task_command_conflict(
+    db: Session,
+    *,
+    task_id: int,
+    command_id: str,
+    actor_user_id: int | None,
+    kind: TaskCommandKind,
+    payload: dict[str, Any],
+) -> TaskCommandConflictClassification:
+    """Classify an IntegrityError from staging a command insert.
+
+    Call only after the caller has rolled back the transaction the failed
+    stage happened on -- this queries post-rollback state to tell apart a
+    duplicate command_id that won the race (RACED_DUPLICATE, carrying a
+    frozen projection of the winning row computed in this same query so the
+    caller does not need a second, possibly inconsistent, read), a task
+    deleted concurrently with the insert (TASK_MISSING), and a conflict on
+    neither -- the row references two foreign keys, so absence of a duplicate
+    does not prove the task caused it: a concurrently deleted actor fails the
+    users FK while the task is still present (UNRELATED).
+    """
+
+    resolved_task_id = int(task_id)
+    normalized_id = command_id.strip()
+    raced = (
+        db.query(TaskExecutionCommand)
+        .filter(
+            TaskExecutionCommand.task_id == resolved_task_id,
+            TaskExecutionCommand.command_id == normalized_id,
         )
-        if raced is None:
-            # No duplicate command exists, so this was not an idempotency race.
-            # The row references two foreign keys, so absence of a duplicate
-            # does not prove the task caused it: a concurrently deleted actor
-            # fails the users FK while the task is still present. Only report a
-            # missing task when the task really is gone; otherwise preserve the
-            # original failure so callers cannot mistake an actor problem for
-            # missing-task recovery.
-            if db.query(Task.id).filter(Task.id == resolved_task_id).scalar() is None:
-                raise TaskCommandTaskMissing(f"Task {task_id} not found") from None
-            raise
+        .one_or_none()
+    )
+    if raced is not None:
         matches = _matches_existing(
             raced,
             actor_user_id=actor_user_id,
             kind=kind,
             payload=payload,
         )
+        return TaskCommandConflictClassification(
+            kind=TaskCommandConflictKind.RACED_DUPLICATE,
+            raced=RacedTaskCommandProjection(
+                command_db_id=int(raced.id),
+                status=str(raced.status),
+                payload_matches=matches,
+            ),
+        )
+    if db.query(Task.id).filter(Task.id == resolved_task_id).scalar() is None:
+        return TaskCommandConflictClassification(
+            kind=TaskCommandConflictKind.TASK_MISSING
+        )
+    return TaskCommandConflictClassification(kind=TaskCommandConflictKind.UNRELATED)
+
+
+def enqueue_task_command(
+    db: Session,
+    *,
+    task_id: int,
+    actor_user_id: int | None,
+    command_id: str,
+    kind: TaskCommandKind,
+    payload: dict[str, Any],
+) -> EnqueuedTaskCommand:
+    """Commit an idempotent command and return only after it is durable."""
+
+    try:
+        staged = stage_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=actor_user_id,
+            command_id=command_id,
+            kind=kind,
+            payload=payload,
+        )
+    except IntegrityError:
+        db.rollback()
+        classification = classify_task_command_conflict(
+            db,
+            task_id=task_id,
+            command_id=command_id,
+            actor_user_id=actor_user_id,
+            kind=kind,
+            payload=payload,
+        )
+        if classification.kind is TaskCommandConflictKind.RACED_DUPLICATE:
+            raced = classification.raced
+            assert raced is not None
+            return EnqueuedTaskCommand(
+                command_id=raced.command_db_id,
+                client_command_id=command_id.strip(),
+                created=False,
+                payload_matches=raced.payload_matches,
+                status=raced.status,
+            )
+        if classification.kind is TaskCommandConflictKind.TASK_MISSING:
+            raise TaskCommandTaskMissing(f"Task {task_id} not found") from None
+        raise
+
+    if not staged.created:
         return EnqueuedTaskCommand(
-            command_id=int(raced.id),
-            client_command_id=normalized_id,
+            command_id=staged.staged_db_id,
+            client_command_id=staged.client_command_id,
             created=False,
-            payload_matches=matches,
-            status=str(raced.status),
+            payload_matches=staged.payload_matches,
+            status=staged.status,
         )
 
+    db.commit()
     notify_task_command_dispatcher()
     return EnqueuedTaskCommand(
-        command_id=command_db_id,
-        client_command_id=normalized_id,
+        command_id=staged.staged_db_id,
+        client_command_id=staged.client_command_id,
         created=True,
         payload_matches=True,
         status=COMMAND_PENDING,

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -403,6 +403,11 @@ def enqueue_task_command(
             kind=kind,
             payload=payload,
         )
+        # Only a newly created row is worth committing, and the commit stays
+        # inside this try so that a constraint failure surfacing there rather
+        # than at the staging flush is still rolled back and classified.
+        if staged.created:
+            db.commit()
     except IntegrityError:
         db.rollback()
         classification = classify_task_command_conflict(
@@ -436,7 +441,6 @@ def enqueue_task_command(
             status=staged.status,
         )
 
-    db.commit()
     notify_task_command_dispatcher()
     return EnqueuedTaskCommand(
         command_id=staged.staged_db_id,

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -239,6 +239,15 @@ def stage_task_command(
        the unique constraint to reject it.
     5. Add and flush the new row last, so any remaining IntegrityError is
        attributable to the command insert itself.
+
+    On every exit path -- a created row, an idempotent hit, or
+    TaskCommandTaskMissing -- this call must be the last write a caller
+    issues before it commits, with no I/O or other slow work in between.
+    Returning leaves the caller holding a write lock (database-wide on
+    SQLite) over its pre-flushed writes, and over the new command row on the
+    created path, until its transaction ends; anything slow placed after
+    this call stalls every concurrent writer, the dispatcher's claim
+    included.
     """
 
     normalized_id = command_id.strip()
@@ -333,6 +342,13 @@ def classify_task_command_conflict(
     neither -- the row references two foreign keys, so absence of a duplicate
     does not prove the task caused it: a concurrently deleted actor fails the
     users FK while the task is still present (UNRELATED).
+
+    RACED_DUPLICATE means the command survived the race, not that the
+    caller's work did: the rollback that had to precede this call also undid
+    whatever else the caller had written. A caller that had such writes must
+    redo them rather than report success. A caller with nothing else pending
+    -- enqueue_task_command is one -- has nothing to redo and reports the
+    raced row as created=False.
     """
 
     resolved_task_id = int(task_id)

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -1,6 +1,9 @@
 """Durable, cross-worker transport for task execution commands.
 
-Ingress commits a command before acknowledging it. Every web worker runs the
+Ingress commits a command before acknowledging it: enqueue_task_command is
+the committing wrapper most callers use, built on stage_task_command, the
+staging primitive that deliberately does not commit so a caller can fold a
+command into a larger transaction of its own. Every web worker runs the
 same dispatcher; a database claim chooses one consumer while per-task ordering
 prevents a later command from overtaking an earlier unfinished command.
 """
@@ -103,6 +106,22 @@ class StagedTaskCommand:
     payload_matches: bool
     status: str
 
+    def to_enqueued(self) -> EnqueuedTaskCommand:
+        """Project this staged row into the committing wrapper's result shape.
+
+        ``staged_db_id`` becomes ``EnqueuedTaskCommand.command_id`` -- valid
+        only once the caller has committed the transaction this row was
+        staged on.
+        """
+
+        return EnqueuedTaskCommand(
+            command_id=self.staged_db_id,
+            client_command_id=self.client_command_id,
+            created=self.created,
+            payload_matches=self.payload_matches,
+            status=self.status,
+        )
+
 
 class TaskCommandOwnerStateError(RuntimeError):
     """The caller's own pending writes failed to flush before staging began.
@@ -191,6 +210,19 @@ def _canonical_payload(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
 
 
+def _normalize_command_id(command_id: str) -> str:
+    """Strip and validate a caller-supplied command_id.
+
+    Shared by every normalization site in this module so the accepted format
+    -- 1-64 URL-safe characters -- cannot drift between them.
+    """
+
+    normalized = command_id.strip()
+    if COMMAND_ID_PATTERN.fullmatch(normalized) is None:
+        raise ValueError("command_id must be 1-64 URL-safe characters")
+    return normalized
+
+
 def _matches_existing(
     command: TaskExecutionCommand,
     *,
@@ -240,19 +272,27 @@ def stage_task_command(
     5. Add and flush the new row last, so any remaining IntegrityError is
        attributable to the command insert itself.
 
-    On every exit path -- a created row, an idempotent hit, or
-    TaskCommandTaskMissing -- this call must be the last write a caller
-    issues before it commits, with no I/O or other slow work in between.
-    Returning leaves the caller holding a write lock (database-wide on
-    SQLite) over its pre-flushed writes, and over the new command row on the
-    created path, until its transaction ends; anything slow placed after
-    this call stalls every concurrent writer, the dispatcher's claim
-    included.
+    Caller obligations:
+
+    a. After the caller's own commit, it should invoke
+       notify_task_command_dispatcher(). Skipping it does not lose the
+       command -- the dispatcher's idle poll still recovers it -- but
+       delivery silently degrades to up to DISPATCHER_IDLE_SECONDS of added
+       latency instead of an immediate wakeup.
+    b. On IntegrityError from the command-insert flush in step 5, the caller
+       must roll back the whole transaction before issuing any further
+       statement on this session -- classify_task_command_conflict below
+       assumes that rollback has already happened.
+    c. On every exit path -- a created row, an idempotent hit, or
+       TaskCommandTaskMissing -- this call must be the last write a caller
+       issues before it commits, with no I/O or other slow work in between.
+       A caller that instead stays in a long transaction after staging holds
+       SQLite's database-wide writer lock for the entire transaction, not
+       the microseconds an immediate commit implies; every concurrent
+       writer, including the dispatcher's claim, blocks for that whole span.
     """
 
-    normalized_id = command_id.strip()
-    if COMMAND_ID_PATTERN.fullmatch(normalized_id) is None:
-        raise ValueError("command_id must be 1-64 URL-safe characters")
+    normalized_id = _normalize_command_id(command_id)
     resolved_task_id = int(task_id)
 
     try:
@@ -333,6 +373,10 @@ def classify_task_command_conflict(
 ) -> TaskCommandConflictClassification:
     """Classify an IntegrityError from staging a command insert.
 
+    Normalizes command_id the same way stage_task_command does -- strip plus
+    full-format validation, not strip alone -- so a lookup here targets the
+    same row a duplicate-command race would have inserted.
+
     Call only after the caller has rolled back the transaction the failed
     stage happened on -- this queries post-rollback state to tell apart a
     duplicate command_id that won the race (RACED_DUPLICATE, carrying a
@@ -352,7 +396,7 @@ def classify_task_command_conflict(
     """
 
     resolved_task_id = int(task_id)
-    normalized_id = command_id.strip()
+    normalized_id = _normalize_command_id(command_id)
     raced = (
         db.query(TaskExecutionCommand)
         .filter(
@@ -392,7 +436,14 @@ def enqueue_task_command(
     kind: TaskCommandKind,
     payload: dict[str, Any],
 ) -> EnqueuedTaskCommand:
-    """Commit an idempotent command and return only after it is durable."""
+    """Commit an idempotent command and return only after it is durable.
+
+    TaskCommandOwnerStateError from stage_task_command's owner pre-flush
+    propagates uncaught -- it is deliberately not caught alongside
+    IntegrityError below. A caller managing its own session lifetime must
+    treat it as its own write failure, not a command-staging failure, and
+    roll back before issuing any further statement on the session.
+    """
 
     try:
         staged = stage_task_command(
@@ -410,6 +461,12 @@ def enqueue_task_command(
             db.commit()
     except IntegrityError:
         db.rollback()
+        # A constraint that only fires at commit time on the caller's own row
+        # (rather than on the command insert) would still land here and enter
+        # conflict classification below. No deferrable constraint exists in
+        # the current schema, so this residual conflation cannot yet trigger
+        # in practice; it is left as-is to keep parity with the original
+        # single-function behavior this was extracted from.
         classification = classify_task_command_conflict(
             db,
             task_id=task_id,
@@ -423,7 +480,7 @@ def enqueue_task_command(
             assert raced is not None
             return EnqueuedTaskCommand(
                 command_id=raced.command_db_id,
-                client_command_id=command_id.strip(),
+                client_command_id=_normalize_command_id(command_id),
                 created=False,
                 payload_matches=raced.payload_matches,
                 status=raced.status,
@@ -433,22 +490,10 @@ def enqueue_task_command(
         raise
 
     if not staged.created:
-        return EnqueuedTaskCommand(
-            command_id=staged.staged_db_id,
-            client_command_id=staged.client_command_id,
-            created=False,
-            payload_matches=staged.payload_matches,
-            status=staged.status,
-        )
+        return staged.to_enqueued()
 
     notify_task_command_dispatcher()
-    return EnqueuedTaskCommand(
-        command_id=staged.staged_db_id,
-        client_command_id=staged.client_command_id,
-        created=True,
-        payload_matches=True,
-        status=COMMAND_PENDING,
-    )
+    return staged.to_enqueued()
 
 
 def _claim_availability_predicate(now: datetime) -> Any:

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -141,6 +141,12 @@ def postgres_task_command_sessions():
     url = os.getenv("XAGENT_TEST_POSTGRES_URL")
     if not url:
         pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    # init_db rebinds the module-global engine/sessionmaker in place, and
+    # every other fixture and test in this file depends on that global
+    # pointing at its own sqlite engine -- the prior binding must be restored
+    # on exit rather than left pointed at this fixture's postgres engine.
+    prior_engine = database_module._engine
+    prior_session_local = database_module._SessionLocal
     init_db(db_url=url)
     engine = get_engine()
     Base.metadata.drop_all(bind=engine)
@@ -157,6 +163,8 @@ def postgres_task_command_sessions():
         yield SessionLocal, task_id, actor_id
     finally:
         Base.metadata.drop_all(bind=engine)
+        database_module._engine = prior_engine
+        database_module._SessionLocal = prior_session_local
 
 
 def _create_running_task(db) -> tuple[User, Task]:
@@ -2017,6 +2025,9 @@ def test_task_foreign_key_violation_is_reported_as_a_missing_task(
         # command-insert flush is intercepted below.
         nonlocal flush_calls
         flush_calls += 1
+        # flush_calls is coupled to stage_task_command's exact two-flush
+        # sequence -- owner pre-flush first, command-insert flush second.
+        # If that sequence changes, this injection lands on the wrong flush.
         if flush_calls == 1:
             return real_flush(*args, **kwargs)
         db_session.flush = real_flush
@@ -2062,6 +2073,9 @@ def test_actor_foreign_key_failure_is_not_reported_as_a_missing_task(
         # command-insert flush is intercepted below.
         nonlocal flush_calls
         flush_calls += 1
+        # flush_calls is coupled to stage_task_command's exact two-flush
+        # sequence -- owner pre-flush first, command-insert flush second.
+        # If that sequence changes, this injection lands on the wrong flush.
         if flush_calls == 1:
             return real_flush(*args, **kwargs)
         db_session.flush = real_flush
@@ -2081,6 +2095,49 @@ def test_actor_foreign_key_failure_is_not_reported_as_a_missing_task(
 
 
 # --- stage_task_command / classify_task_command_conflict (#1073) ---------
+
+
+def test_stage_rejects_malformed_command_id_before_any_db_write(db_session) -> None:
+    """A malformed command_id must fail before touching the database, so a
+    caller cannot end up with a partially-written row for an id it rejects."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+
+    with pytest.raises(ValueError, match="command_id must be 1-64"):
+        stage_task_command(
+            db_session,
+            task_id=task_id,
+            actor_user_id=int(user.id),
+            command_id="bad id!",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    assert db_session.query(TaskExecutionCommand).count() == 0
+
+
+def test_stage_strips_whitespace_from_the_staged_command_id(db_session) -> None:
+    """A whitespace-padded command_id must stage a row carrying the stripped
+    id, not the raw padded string."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="  cmd-1  ",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    assert staged.client_command_id == "cmd-1"
+
+    db_session.commit()
+    row = db_session.get(TaskExecutionCommand, staged.staged_db_id)
+    assert row is not None
+    assert row.command_id == "cmd-1"
 
 
 def test_stage_does_not_commit(db_session) -> None:
@@ -2204,6 +2261,32 @@ def test_enqueue_idempotent_hit_issues_no_commit(db_session) -> None:
         observed_task = observer.get(Task, int(task.id))
         assert observed_task is not None
         assert observed_task.title != "uncommitted sibling write"
+
+    # stage_task_command's owner pre-flush already pushed the title change
+    # above into the open transaction, so it no longer shows up as dirty by
+    # this point -- a fresh, still-unflushed write on the same session is
+    # what proves the session was left healthy rather than silently rolled
+    # back by the idempotent-hit path.
+    sibling_user = User(
+        username="idempotent-hit-sibling-write",
+        password_hash="hash",
+        is_admin=False,
+    )
+    db_session.add(sibling_user)
+    assert sibling_user in db_session.new
+
+    db_session.commit()
+
+    with SessionLocal() as observer:
+        observed_task = observer.get(Task, int(task.id))
+        assert observed_task is not None
+        assert observed_task.title == "uncommitted sibling write"
+        assert (
+            observer.query(User)
+            .filter(User.username == "idempotent-hit-sibling-write")
+            .first()
+            is not None
+        )
 
 
 def test_enqueue_missing_task_issues_no_commit(db_session) -> None:

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1942,8 +1942,16 @@ def test_task_foreign_key_violation_is_reported_as_a_missing_task(
     task_id = int(task.id)
 
     real_flush = db_session.flush
+    flush_calls = 0
 
     def flush_raising_fk_error(*args, **kwargs):
+        # stage_task_command's owner pre-flush is a real, harmless no-op on
+        # this clean session -- let it through so only the attributable
+        # command-insert flush is intercepted below.
+        nonlocal flush_calls
+        flush_calls += 1
+        if flush_calls == 1:
+            return real_flush(*args, **kwargs)
         db_session.flush = real_flush
         # Delete the task so the post-rollback recheck sees it as absent, the
         # way a concurrent delete would.
@@ -1979,8 +1987,16 @@ def test_actor_foreign_key_failure_is_not_reported_as_a_missing_task(
     task_id = int(task.id)
 
     real_flush = db_session.flush
+    flush_calls = 0
 
     def flush_raising_fk_error(*args, **kwargs):
+        # stage_task_command's owner pre-flush is a real, harmless no-op on
+        # this clean session -- let it through so only the attributable
+        # command-insert flush is intercepted below.
+        nonlocal flush_calls
+        flush_calls += 1
+        if flush_calls == 1:
+            return real_flush(*args, **kwargs)
         db_session.flush = real_flush
         raise IntegrityError("INSERT", {}, Exception("FOREIGN KEY constraint failed"))
 

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError, is_dataclass
 from datetime import datetime, timedelta
@@ -10,11 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
     _load_command_message_delivery_status,
@@ -36,15 +39,20 @@ from xagent.web.services import task_command_transport as task_command_transport
 from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
     COMMAND_FAILED,
+    COMMAND_PENDING,
+    DISPATCHER_IDLE_SECONDS,
     MAX_COMMAND_DEFERS,
     MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
+    TaskCommandConflictKind,
     TaskCommandDeferred,
     TaskCommandKind,
+    TaskCommandOwnerStateError,
     TaskCommandRejected,
     TaskCommandTaskMissing,
     _claim_heartbeat,
     claim_task_command,
+    classify_task_command_conflict,
     defer_task_command,
     dispatch_one_task_command,
     dispatch_task_command_promptly,
@@ -55,6 +63,7 @@ from xagent.web.services.task_command_transport import (
     notify_task_command_dispatcher,
     renew_task_command_claim,
     retry_failed_task_command,
+    stage_task_command,
     start_task_command_dispatcher,
     stop_task_command_dispatcher,
     task_has_live_foreign_runner,
@@ -90,6 +99,62 @@ def queue_pool_command_db(tmp_path):
         yield engine, SessionLocal
     finally:
         engine.dispose()
+
+
+@pytest.fixture()
+def low_timeout_sqlite_engine(tmp_path):
+    """A file-backed SQLite engine with a short busy_timeout for lock tests.
+
+    init_db does not expose apply_sqlite_concurrency_pragmas's busy_timeout_ms
+    parameter (it always uses the 5s production default), so a lock-path test
+    that needs a bounded wait builds its own engine directly instead of going
+    through init_db.
+    """
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'task-command-lock-path.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    apply_sqlite_concurrency_pragmas(engine, busy_timeout_ms=50)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    try:
+        yield engine, SessionLocal
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture()
+def postgres_task_command_sessions():
+    """A real PostgreSQL sessionmaker plus one running task's id.
+
+    Used only by the truly-concurrent raced-duplicate test: SQLite serializes
+    all writers through one database-wide lock, so a second writer's insert
+    can never be genuinely in flight at the same instant as the first's --
+    it simply cannot begin until the first's transaction ends. PostgreSQL's
+    per-row locking lets two inserts targeting the same unique key both be
+    open at once, with the second blocking until the first resolves.
+    """
+
+    url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    init_db(db_url=url)
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = get_session_local()
+    try:
+        with SessionLocal() as db:
+            user, task = _create_running_task(db)
+            task.runner_id = None
+            task.lease_expires_at = None
+            db.commit()
+            task_id = int(task.id)
+            actor_id = int(user.id)
+        yield SessionLocal, task_id, actor_id
+    finally:
+        Base.metadata.drop_all(bind=engine)
 
 
 def _create_running_task(db) -> tuple[User, Task]:
@@ -2011,3 +2076,619 @@ def test_actor_foreign_key_failure_is_not_reported_as_a_missing_task(
             kind=TaskCommandKind.PAUSE,
             payload={"type": "pause_task"},
         )
+
+
+# --- stage_task_command / classify_task_command_conflict (#1073) ---------
+
+
+def test_stage_does_not_commit(db_session) -> None:
+    """Staging must be observable only inside the caller's own session until
+    it commits -- a second session must see nothing beforehand."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="stage-visibility",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    assert staged.created is True
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as observer:
+        assert observer.get(TaskExecutionCommand, staged.staged_db_id) is None
+
+    db_session.commit()
+
+    with SessionLocal() as observer:
+        row = observer.get(TaskExecutionCommand, staged.staged_db_id)
+        assert row is not None
+        assert row.status == COMMAND_PENDING
+
+
+def test_stage_missing_task_leaves_no_command_pending(db_session) -> None:
+    """Staging against a task deleted before the call must not add any
+    command row to the session -- there is no write for a caller rollback to
+    even need to undo."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    db_session.query(Task).filter(Task.id == task_id).delete()
+    db_session.commit()
+
+    with pytest.raises(TaskCommandTaskMissing):
+        stage_task_command(
+            db_session,
+            task_id=task_id,
+            actor_user_id=int(user.id),
+            command_id="stage-missing-task",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    assert db_session.query(TaskExecutionCommand).count() == 0
+
+
+def test_outer_rollback_leaves_no_command(db_session) -> None:
+    """A caller that stages a command as part of a larger unit of work and
+    then rolls back must lose the command along with the rest of that work --
+    there is no SAVEPOINT isolating the command insert from the caller's own
+    writes. The sibling write is created before staging begins; created after,
+    this would only prove a single-row rollback rather than the caller's
+    whole transaction being undone."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    task.title = "rolled-back-sibling-write"
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="outer-rollback",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    assert staged.created is True
+
+    db_session.rollback()
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as observer:
+        observed_task = observer.get(Task, task_id)
+        assert observed_task is not None
+        assert observed_task.title != "rolled-back-sibling-write"
+        assert (
+            observer.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .count()
+            == 0
+        )
+
+
+def test_enqueue_idempotent_hit_issues_no_commit(db_session) -> None:
+    """Only the created=True path may end the caller's transaction -- a
+    duplicate command_id must leave an accompanying uncommitted write
+    uncommitted, observed from a second session."""
+
+    user, task = _create_running_task(db_session)
+    first = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="no-commit-duplicate",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    assert first.created is True
+
+    task.title = "uncommitted sibling write"
+    duplicate = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="no-commit-duplicate",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    assert duplicate.created is False
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as observer:
+        observed_task = observer.get(Task, int(task.id))
+        assert observed_task is not None
+        assert observed_task.title != "uncommitted sibling write"
+
+
+def test_enqueue_missing_task_issues_no_commit(db_session) -> None:
+    """A missing task must not commit -- an accompanying pending write on the
+    same session must still be observed as uncommitted by another session."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    db_session.query(Task).filter(Task.id == task_id).delete()
+    db_session.add(
+        User(username="no-commit-sibling-write", password_hash="hash", is_admin=False)
+    )
+
+    with pytest.raises(TaskCommandTaskMissing):
+        enqueue_task_command(
+            db_session,
+            task_id=task_id,
+            actor_user_id=int(user.id),
+            command_id="no-commit-missing-task",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as observer:
+        assert (
+            observer.query(User)
+            .filter(User.username == "no-commit-sibling-write")
+            .first()
+            is None
+        )
+
+
+def test_owner_pre_flush_failure_raises_owner_state_error(db_session) -> None:
+    """A conflict on the caller's own pending write, surfaced by staging's
+    pre-flush, must be reported apart from a conflict on the command insert
+    itself so the two are never confused."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    db_session.add(User(username=user.username, password_hash="hash", is_admin=False))
+
+    with pytest.raises(TaskCommandOwnerStateError):
+        stage_task_command(
+            db_session,
+            task_id=task_id,
+            actor_user_id=int(user.id),
+            command_id="owner-state-conflict",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+
+def test_owner_state_error_is_not_an_integrity_error(db_session) -> None:
+    """Pinned deliberately: TaskCommandOwnerStateError must not be an
+    IntegrityError subclass, or enqueue_task_command's
+    ``except IntegrityError`` would wrongly route an owner-write failure
+    through duplicate/missing-task classification."""
+
+    assert not issubclass(TaskCommandOwnerStateError, IntegrityError)
+
+
+def test_enqueue_does_not_catch_owner_state_error(db_session) -> None:
+    """enqueue_task_command's except IntegrityError must not swallow a
+    pre-flush failure on the caller's own pending write."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    db_session.add(User(username=user.username, password_hash="hash", is_admin=False))
+
+    with pytest.raises(TaskCommandOwnerStateError):
+        enqueue_task_command(
+            db_session,
+            task_id=task_id,
+            actor_user_id=int(user.id),
+            command_id="owner-state-conflict-wrapper",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+
+def test_stage_snapshot_sees_a_bulk_cas_update_pending_in_the_same_session(
+    db_session,
+) -> None:
+    """A CAS-then-stage owner updates the row via a synchronize_session=False
+    bulk statement, which executes immediately. The staging snapshot must
+    observe it -- an ORM query here would instead return the identity map's
+    pre-update cached instance."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+
+    updated = (
+        db_session.query(Task)
+        .filter(Task.id == task_id, Task.runner_id == "runner-a")
+        .update({Task.runner_id: "runner-b"}, synchronize_session=False)
+    )
+    assert updated == 1
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="cas-bulk-update",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    db_session.commit()
+
+    row = db_session.get(TaskExecutionCommand, staged.staged_db_id)
+    assert row is not None
+    assert row.target_runner_id == "runner-b"
+
+
+def test_stage_snapshot_sees_an_orm_attribute_change_pending_in_the_same_session(
+    db_session,
+) -> None:
+    """A CAS-then-stage owner instead mutates the loaded ORM instance rather
+    than issuing a bulk update. With autoflush disabled this is invisible to
+    a raw Core select until something flushes it -- staging's own owner
+    pre-flush must be what surfaces it, not the identity map."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+
+    task.runner_id = "runner-c"
+    # No explicit flush here: stage_task_command's own pre-flush must be what
+    # pushes this to the database before its Core select runs.
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="cas-orm-attribute",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    db_session.commit()
+
+    row = db_session.get(TaskExecutionCommand, staged.staged_db_id)
+    assert row is not None
+    assert row.target_runner_id == "runner-c"
+
+
+def test_interleaved_duplicate_enqueue_reports_the_committed_winner(
+    db_session,
+) -> None:
+    """Two real sessions/threads both go through the public enqueue_task_command
+    entry point. B's idempotency precheck runs and finds nothing before A's
+    insert commits, so B's own insert genuinely races A's at the flush --
+    unlike a recipe where A commits first and B's precheck simply finds the
+    row, this exercises the IntegrityError-then-rollback-then-classify path
+    with a real concurrent writer."""
+
+    user, task = _create_running_task(db_session)
+    task_id = int(task.id)
+    actor_id = int(user.id)
+    SessionLocal = get_session_local()
+
+    precheck_done = Event()
+    release_b = Event()
+
+    def enqueue_as_b():
+        with SessionLocal() as db_b:
+            real_add = db_b.add
+
+            def paused_add(instance):
+                if isinstance(instance, TaskExecutionCommand):
+                    precheck_done.set()
+                    assert release_b.wait(timeout=10)
+                real_add(instance)
+
+            db_b.add = paused_add
+            return enqueue_task_command(
+                db_b,
+                task_id=task_id,
+                actor_user_id=actor_id,
+                command_id="interleaved-duplicate",
+                kind=TaskCommandKind.PAUSE,
+                payload={"type": "pause_task"},
+            )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(enqueue_as_b)
+        assert precheck_done.wait(timeout=10)
+
+        with SessionLocal() as db_a:
+            winner = enqueue_task_command(
+                db_a,
+                task_id=task_id,
+                actor_user_id=actor_id,
+                command_id="interleaved-duplicate",
+                kind=TaskCommandKind.PAUSE,
+                payload={"type": "pause_task"},
+            )
+        release_b.set()
+        loser = future.result(timeout=10)
+
+    assert winner.created is True
+    assert loser.created is False
+    assert loser.command_id == winner.command_id
+    assert loser.payload_matches is True
+    assert loser.status == winner.status
+
+
+@pytest.mark.postgresql
+def test_postgres_concurrent_insert_blocks_until_the_winner_resolves(
+    postgres_task_command_sessions,
+) -> None:
+    """A genuinely-concurrent variant of the raced-duplicate test: both
+    writers' inserts are open against PostgreSQL at the same instant, with
+    B's insert blocked on A's uncommitted row rather than merely interleaved
+    by a test-code pause. Requires XAGENT_TEST_POSTGRES_URL; skipped
+    otherwise."""
+
+    SessionLocal, task_id, actor_id = postgres_task_command_sessions
+    a_flushed = Event()
+    allow_a_commit = Event()
+    b_blocked_then_resolved = Event()
+
+    def run_a():
+        with SessionLocal() as db_a:
+            staged = stage_task_command(
+                db_a,
+                task_id=task_id,
+                actor_user_id=actor_id,
+                command_id="pg-real-race",
+                kind=TaskCommandKind.PAUSE,
+                payload={"type": "pause_task"},
+            )
+            a_flushed.set()
+            assert allow_a_commit.wait(timeout=10)
+            db_a.commit()
+            return staged
+
+    def run_b():
+        assert a_flushed.wait(timeout=10)
+        with SessionLocal() as db_b:
+            try:
+                stage_task_command(
+                    db_b,
+                    task_id=task_id,
+                    actor_user_id=actor_id,
+                    command_id="pg-real-race",
+                    kind=TaskCommandKind.PAUSE,
+                    payload={"type": "pause_task"},
+                )
+            except IntegrityError:
+                db_b.rollback()
+                classification = classify_task_command_conflict(
+                    db_b,
+                    task_id=task_id,
+                    command_id="pg-real-race",
+                    actor_user_id=actor_id,
+                    kind=TaskCommandKind.PAUSE,
+                    payload={"type": "pause_task"},
+                )
+                b_blocked_then_resolved.set()
+                return classification
+            raise AssertionError("B's insert should have raced A's committed one")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(run_a)
+        future_b = executor.submit(run_b)
+        assert a_flushed.wait(timeout=10)
+        # Give B's flush time to genuinely be blocked inside PostgreSQL,
+        # rather than releasing A the instant B's thread has merely started.
+        time.sleep(0.2)
+        allow_a_commit.set()
+        staged_a = future_a.result(timeout=10)
+        classification = future_b.result(timeout=10)
+
+    assert b_blocked_then_resolved.is_set()
+    assert classification.kind is TaskCommandConflictKind.RACED_DUPLICATE
+    assert classification.raced is not None
+    assert classification.raced.command_db_id == staged_a.staged_db_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_staged_id_before_commit_is_noop_and_converges_after_commit(
+    db_session,
+) -> None:
+    """A staged id must not be dispatchable before its owning transaction
+    commits -- the dispatcher claims through its own isolated session, which
+    cannot see an uncommitted row. Once the owner commits without notifying,
+    durable polling converges on it within one idle cycle. The target task
+    has no earlier in-flight command, so unfinished-earlier-command ordering
+    cannot also explain the delay."""
+
+    user, task = _create_running_task(db_session)
+    task.runner_id = None
+    task.lease_expires_at = None
+    db_session.commit()
+    task_id = int(task.id)
+
+    staged = stage_task_command(
+        db_session,
+        task_id=task_id,
+        actor_user_id=int(user.id),
+        command_id="staged-before-commit",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+
+    async def must_not_dispatch(_command):
+        raise AssertionError("must not dispatch an uncommitted staged command")
+
+    assert not await dispatch_one_task_command(
+        must_not_dispatch, command_db_id=staged.staged_db_id
+    )
+
+    db_session.commit()  # deliberately no notify_task_command_dispatcher() call
+
+    applied = asyncio.Event()
+
+    async def execute_after_commit(command):
+        assert command.id == staged.staged_db_id
+        applied.set()
+        return None
+
+    start_task_command_dispatcher(execute_after_commit)
+    try:
+        await asyncio.wait_for(applied.wait(), timeout=DISPATCHER_IDLE_SECONDS + 1.5)
+    finally:
+        await stop_task_command_dispatcher()
+
+
+def test_owner_holding_a_flushed_command_blocks_a_concurrent_claim(
+    low_timeout_sqlite_engine,
+) -> None:
+    """Staging is the last write before the owner's commit, so the row it
+    flushes stays under SQLite's writer lock for the rest of the owner's
+    transaction -- no longer the microseconds a bare insert-and-commit would
+    hold it for. SQLite's writer lock is database-wide, so a concurrent claim
+    of a different, already-committed command must still wait out
+    busy_timeout and fail with OperationalError rather than hang."""
+
+    engine, SessionLocal = low_timeout_sqlite_engine
+    with SessionLocal() as setup_db:
+        user, task = _create_running_task(setup_db)
+        task.runner_id = None
+        task.lease_expires_at = None
+        setup_db.commit()
+        task_id = int(task.id)
+        actor_id = int(user.id)
+        claimable = enqueue_task_command(
+            setup_db,
+            task_id=task_id,
+            actor_user_id=actor_id,
+            command_id="lock-path-claimable",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    with SessionLocal() as owner_db:
+        stage_task_command(
+            owner_db,
+            task_id=task_id,
+            actor_user_id=actor_id,
+            command_id="lock-path-owner-holds",
+            kind=TaskCommandKind.CANCEL,
+            payload={"agent_id": 1},
+        )
+        # Deliberately not committed yet -- this is the window under test.
+        started = time.monotonic()
+        with SessionLocal() as claimant_db:
+            with pytest.raises(OperationalError):
+                claim_task_command(
+                    claimant_db,
+                    runner_id="lock-path-claimant",
+                    command_db_id=claimable.command_id,
+                )
+        elapsed = time.monotonic() - started
+        owner_db.commit()
+
+    assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_worker_recovers_from_a_lock_timeout_and_claims_once_released(
+    low_timeout_sqlite_engine,
+    monkeypatch,
+    caplog,
+) -> None:
+    """The dispatcher worker pool must survive the OperationalError above --
+    logging it and continuing to poll -- and claim the command once the
+    owner's transaction ends, instead of the worker dying or hanging."""
+
+    engine, SessionLocal = low_timeout_sqlite_engine
+    with SessionLocal() as seed_db:
+        user, task = _create_running_task(seed_db)
+        task.runner_id = None
+        task.lease_expires_at = None
+        seed_db.commit()
+        task_id = int(task.id)
+        actor_id = int(user.id)
+        enqueued = enqueue_task_command(
+            seed_db,
+            task_id=task_id,
+            actor_user_id=actor_id,
+            command_id="dispatcher-progress-target",
+            kind=TaskCommandKind.PAUSE,
+            payload={"type": "pause_task"},
+        )
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(task_command_transport_module, "DISPATCHER_IDLE_SECONDS", 0.01)
+    monkeypatch.setattr(
+        task_command_transport_module, "_dispatcher_wakeup", asyncio.Event()
+    )
+
+    owner_db = SessionLocal()
+    stage_task_command(
+        owner_db,
+        task_id=task_id,
+        actor_user_id=actor_id,
+        command_id="dispatcher-progress-lock-holder",
+        kind=TaskCommandKind.CANCEL,
+        payload={"agent_id": 1},
+    )
+    # Deliberately uncommitted -- holds SQLite's writer lock across the
+    # dispatcher worker's first claim attempt.
+
+    caplog.set_level(logging.ERROR, logger="xagent.web.services.task_command_transport")
+    applied = asyncio.Event()
+
+    async def execute(command):
+        assert command.id == enqueued.command_id
+        applied.set()
+        return None
+
+    worker = asyncio.create_task(
+        task_command_transport_module._run_task_command_dispatcher_worker(execute)
+    )
+    try:
+        # Wait for the worker to actually observe the lock timeout (rather
+        # than a fixed sleep) before releasing it -- releasing early would
+        # let the blocked claim succeed once unblocked instead of timing out,
+        # never exercising the recovery path this test is for.
+        for _ in range(200):
+            if "component=task-command-dispatcher" in caplog.text:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("worker never logged a lock-timeout failure")
+        assert not applied.is_set(), "must not have claimed while the lock was held"
+        owner_db.commit()
+        await asyncio.wait_for(applied.wait(), timeout=2)
+    finally:
+        worker.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await worker
+        owner_db.close()
+
+    assert "component=task-command-dispatcher" in caplog.text
+
+
+def test_enqueue_notifies_only_after_commit(db_session, monkeypatch) -> None:
+    """The dispatcher wakeup must fire only once the command is durable --
+    notifying before commit could wake a dispatcher onto a row it cannot yet
+    see, wasting the cycle instead of claiming it."""
+
+    user, task = _create_running_task(db_session)
+    order: list[str] = []
+    real_commit = db_session.commit
+
+    def recording_commit():
+        order.append("commit")
+        real_commit()
+
+    def recording_notify():
+        order.append("notify")
+
+    monkeypatch.setattr(db_session, "commit", recording_commit)
+    monkeypatch.setattr(
+        task_command_transport_module,
+        "notify_task_command_dispatcher",
+        recording_notify,
+    )
+
+    enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="notify-order",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+
+    assert order == ["commit", "notify"]

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -2536,8 +2536,8 @@ def test_owner_holding_a_flushed_command_blocks_a_concurrent_claim(
 ) -> None:
     """Staging is the last write before the owner's commit, so the row it
     flushes stays under SQLite's writer lock for the rest of the owner's
-    transaction -- no longer the microseconds a bare insert-and-commit would
-    hold it for. SQLite's writer lock is database-wide, so a concurrent claim
+    transaction -- far longer than the microseconds an insert that committed
+    itself holds it for. SQLite's writer lock is database-wide, so a concurrent claim
     of a different, already-committed command must still wait out
     busy_timeout and fail with OperationalError rather than hang."""
 

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -115,7 +115,9 @@ def low_timeout_sqlite_engine(tmp_path):
         f"sqlite:///{tmp_path / 'task-command-lock-path.db'}",
         connect_args={"check_same_thread": False},
     )
-    apply_sqlite_concurrency_pragmas(engine, busy_timeout_ms=50)
+    # Long enough to stay clear of thread-scheduling jitter under a loaded
+    # test run, short enough to keep the lock-path tests well under 2s.
+    apply_sqlite_concurrency_pragmas(engine, busy_timeout_ms=200)
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     try:
@@ -2640,8 +2642,11 @@ async def test_dispatcher_worker_recovers_from_a_lock_timeout_and_claims_once_re
         # Wait for the worker to actually observe the lock timeout (rather
         # than a fixed sleep) before releasing it -- releasing early would
         # let the blocked claim succeed once unblocked instead of timing out,
-        # never exercising the recovery path this test is for.
-        for _ in range(200):
+        # never exercising the recovery path this test is for. The bound is
+        # generous because the claim itself runs on the default thread-pool
+        # executor, whose scheduling delay grows under a heavily loaded test
+        # run rather than staying tied to busy_timeout.
+        for _ in range(2000):
             if "component=task-command-dispatcher" in caplog.text:
                 break
             await asyncio.sleep(0.01)
@@ -2649,7 +2654,7 @@ async def test_dispatcher_worker_recovers_from_a_lock_timeout_and_claims_once_re
             raise AssertionError("worker never logged a lock-timeout failure")
         assert not applied.is_set(), "must not have claimed while the lock was held"
         owner_db.commit()
-        await asyncio.wait_for(applied.wait(), timeout=2)
+        await asyncio.wait_for(applied.wait(), timeout=20)
     finally:
         worker.cancel()
         with pytest.raises(asyncio.CancelledError):


### PR DESCRIPTION
## Summary

Extract a caller-transaction command-staging primitive from `enqueue_task_command` so a lifecycle owner can insert a durable continuation command inside the same transaction that accepts an interaction response.

- `stage_task_command(db, ...) -> StagedTaskCommand`: validates the command id, flushes the caller's pending state so later failures are attributable to the command insert, resolves the task snapshot (`status`/`runner_id`/`run_id`) with a single Core select that bypasses the identity map and sees the caller's own uncommitted writes, performs the idempotent precheck, then adds and flushes the command row. It never commits, rolls back, or notifies; the staged row id (`staged_db_id`) is not dispatchable until the owner commits.
- `classify_task_command_conflict(...)`: post-rollback conflict classification (`RACED_DUPLICATE` with a frozen projection of the raced row computed in one query, `TASK_MISSING` with task-FK vs actor-FK disambiguation, `UNRELATED`).
- `TaskCommandOwnerStateError`: raised when the entry flush fails on the caller's own pending state; deliberately not an `IntegrityError` subclass so command-conflict handling never misattributes it. Callers must roll back before issuing further statements.
- `enqueue_task_command` is rewritten as the production consumer of both primitives. Its signature, return type, exception surface, idempotency semantics, and commit/notify ordering (commit and post-commit notify only when a row was created) are unchanged; the three existing call sites have a zero diff.

## Behavior changes

None for existing callers. The transport module's external contract is byte-identical; all pre-existing tests in `tests/web/services/test_task_command_transport.py` pass unmodified except two whose flush monkeypatches were extended to pass through the new entry flush.

## Verification

- `tests/web/services/test_task_command_transport.py`: 53 baseline tests all green and retained; 16 new tests cover staging visibility (a second session cannot see a staged row before the owner commits), outer-rollback zero-residue, the interleaved duplicate-enqueue race on both backends, a PostgreSQL-only truly-concurrent insert conflict (executed against a real `postgres:16` service), owner-state error routing, snapshot correctness under both bulk-update and ORM-attribute mutations pending in the caller session, staged-id non-dispatchability with poll-based convergence, SQLite lock-window behavior, and notify-after-commit ordering.
- Mutation checks: re-adding a commit or a notify inside the staging primitive, breaking the conflict classifier, and reordering the entry flush each turn specific tests red.
- Full suite (`-n 4 --dist=loadscope`) shows no failure attributable to this change: the touched module's tests are fully green, and the remaining failures reproduce identically on the base commit.

Fixes #1073.
