### PR TITLE
fix(checkpoint): distinguish transient load failures from missing checkpoints

### DIFF
--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -58,9 +58,10 @@ class CheckpointReadError(RuntimeError):
 class CheckpointUnavailableError(CheckpointReadError):
     """Raised when a checkpoint read could not be completed.
 
-    Covers query failures (session checkout, transient DB errors) and
-    decode failures that cannot be proven to be permanent corruption
-    because the candidate row window was exhausted before ruling it out.
+    Covers infrastructure failures only: session checkout, query
+    execution, and generic per-row decode errors such as a failed blob
+    prefetch. Rows that decode as permanently unreadable are classified
+    by the corrupt error once the matching set is exhausted.
     """
 
 

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -232,6 +232,20 @@ class TraceCheckpointStore:
             "snapshot": dict(payload),
         }
 
+    def _validate_snapshot(self, container: dict[str, Any]) -> dict[str, Any]:
+        """Return the readable checkpoint's snapshot, or raise if absent.
+
+        A container whose ``checkpoint_type`` is readable but that carries no
+        ``snapshot`` dict claims to be a checkpoint while holding no payload
+        -- corrupt, not absent.
+        """
+        snapshot = container.get("snapshot")
+        if isinstance(snapshot, dict):
+            return dict(snapshot)
+        raise CheckpointCorruptError(
+            "Checkpoint payload has a readable checkpoint_type but no snapshot."
+        )
+
     def _unwrap_checkpoint_payload(self, payload: Any) -> dict[str, Any] | None:
         # ``None`` is the reader's authoritative "no checkpoint" -- pass it
         # through unchanged. Anything else that isn't a recognized shape is
@@ -244,23 +258,13 @@ class TraceCheckpointStore:
                 "Checkpoint reader returned a non-dict, non-None payload."
             )
         if payload.get("checkpoint_type") in READABLE_CHECKPOINT_TYPES:
-            snapshot = payload.get("snapshot")
-            if isinstance(snapshot, dict):
-                return dict(snapshot)
-            raise CheckpointCorruptError(
-                "Checkpoint payload has a readable checkpoint_type but no snapshot."
-            )
+            return self._validate_snapshot(payload)
         data = payload.get("data")
         if (
             isinstance(data, dict)
             and data.get("checkpoint_type") in READABLE_CHECKPOINT_TYPES
         ):
-            snapshot = data.get("snapshot")
-            if isinstance(snapshot, dict):
-                return dict(snapshot)
-            raise CheckpointCorruptError(
-                "Checkpoint payload has a readable checkpoint_type but no snapshot."
-            )
+            return self._validate_snapshot(data)
         if payload.get("type") == "checkpoint" or "context" in payload:
             return dict(payload)
         raise CheckpointCorruptError(

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -44,6 +44,46 @@ class CheckpointPersistenceError(RuntimeError):
     """Raised when a checkpoint cannot be durably persisted."""
 
 
+class CheckpointReadError(RuntimeError):
+    """Base for checkpoint read failures that must not collapse to absence.
+
+    ``None`` from a checkpoint reader means "queried successfully, nothing
+    found" — an authoritative fact callers may act on (e.g. build a fresh
+    context). Anything that prevented that determination raises one of the
+    subclasses below instead, so a transient or refused read can never be
+    mistaken for a checkpoint that genuinely does not exist.
+    """
+
+
+class CheckpointUnavailableError(CheckpointReadError):
+    """Raised when a checkpoint read could not be completed.
+
+    Covers query failures (session checkout, transient DB errors) and
+    decode failures that cannot be proven to be permanent corruption
+    because the candidate row window was exhausted before ruling it out.
+    """
+
+
+class CheckpointCorruptError(CheckpointReadError):
+    """Raised when matching checkpoint rows exist but none are usable.
+
+    Distinct from ``CheckpointUnavailableError``: the read completed and
+    the candidate set was proven exhausted, but every row is permanently
+    undecodable or shaped without a payload. This is a terminal state, not
+    a retryable one.
+    """
+
+
+class CheckpointAccessRefusedError(CheckpointReadError):
+    """Raised when a reader is not authoritative for the requested partition.
+
+    The checkpoint may exist, but this reader's partition (run binding,
+    build scope) is not the one allowed to observe it right now. Distinct
+    from absence: callers must not treat a refusal as "no checkpoint" and
+    fall back to building fresh state.
+    """
+
+
 async def read_latest_checkpoint_payload(
     reader: Any,
     execution_id: str,

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -81,7 +81,20 @@ class CheckpointAccessRefusedError(CheckpointReadError):
     build scope) is not the one allowed to observe it right now. Distinct
     from absence: callers must not treat a refusal as "no checkpoint" and
     fall back to building fresh state.
+
+    ``reason`` discriminates *why* the read was refused, so consumers can
+    report an accurate message instead of one generic sentence for every
+    case: ``"lease_mismatch"`` (an active lease exists but is not bound to
+    this reader), ``"active_run"`` (a different run is in progress under
+    its own lease), or ``"superseded_legacy"`` (a tagged run has already
+    superseded the untagged/legacy partition this reader is confined to).
+    Defaults to ``"active_run"``, the most common case, so existing call
+    sites that do not pass ``reason`` keep working unchanged.
     """
+
+    def __init__(self, message: str, *, reason: str = "active_run") -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 async def read_latest_checkpoint_payload(

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -220,21 +220,39 @@ class TraceCheckpointStore:
         }
 
     def _unwrap_checkpoint_payload(self, payload: Any) -> dict[str, Any] | None:
-        if not isinstance(payload, dict):
+        # ``None`` is the reader's authoritative "no checkpoint" -- pass it
+        # through unchanged. Anything else that isn't a recognized shape is
+        # corrupt, not absent: a caller must not treat a malformed payload
+        # as "build fresh state".
+        if payload is None:
             return None
+        if not isinstance(payload, dict):
+            raise CheckpointCorruptError(
+                "Checkpoint reader returned a non-dict, non-None payload."
+            )
         if payload.get("checkpoint_type") in READABLE_CHECKPOINT_TYPES:
             snapshot = payload.get("snapshot")
-            return dict(snapshot) if isinstance(snapshot, dict) else None
+            if isinstance(snapshot, dict):
+                return dict(snapshot)
+            raise CheckpointCorruptError(
+                "Checkpoint payload has a readable checkpoint_type but no snapshot."
+            )
         data = payload.get("data")
         if (
             isinstance(data, dict)
             and data.get("checkpoint_type") in READABLE_CHECKPOINT_TYPES
         ):
             snapshot = data.get("snapshot")
-            return dict(snapshot) if isinstance(snapshot, dict) else None
+            if isinstance(snapshot, dict):
+                return dict(snapshot)
+            raise CheckpointCorruptError(
+                "Checkpoint payload has a readable checkpoint_type but no snapshot."
+            )
         if payload.get("type") == "checkpoint" or "context" in payload:
             return dict(payload)
-        return None
+        raise CheckpointCorruptError(
+            "Checkpoint payload shape is not recognized by any reader."
+        )
 
     def _execution_id(self, payload: dict[str, Any]) -> str:
         execution_id = payload.get("execution_id")

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -16,7 +16,7 @@ from ..task_runtime import (
     normalize_input_modalities,
 )
 from ..workspace import WorkspaceManager
-from .checkpoint import read_latest_checkpoint_payload
+from .checkpoint import CheckpointCorruptError, read_latest_checkpoint_payload
 from .context import ContextManager, ExecutionContext
 from .result import extract_assistant_message
 from .runtime import ExecutionInterrupted, PatternRuntime, load_pattern_checkpoint
@@ -82,6 +82,14 @@ class AgentRunner:
         checkpoint = checkpoint or (
             await self._load_latest_checkpoint(execution_id) if resume else None
         )
+        if (
+            resume
+            and checkpoint is not None
+            and not isinstance(checkpoint.get("context"), dict)
+        ):
+            raise CheckpointCorruptError(
+                "Resume checkpoint exists but carries no execution context."
+            )
         if task is None:
             task = self._resolve_task(
                 task=task,
@@ -363,11 +371,12 @@ class AgentRunner:
         cold_start_checkpoint: dict[str, Any] | None = None
         if context is None:
             checkpoint = await self._load_latest_checkpoint(execution_id)
-            if not (
-                isinstance(checkpoint, dict)
-                and isinstance(checkpoint.get("context"), dict)
-            ):
+            if checkpoint is None:
                 return None
+            if not isinstance(checkpoint.get("context"), dict):
+                raise CheckpointCorruptError(
+                    "Stored checkpoint carries no execution context to restore."
+                )
             cold_start_checkpoint = checkpoint
             context = ExecutionContext.from_dict(checkpoint["context"])
             self.context_manager.set_context(context)

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -360,6 +360,7 @@ class AgentRunner:
         reason: str | None = None,
     ) -> ExecutionContext | None:
         context = self.context_manager.get_context(execution_id)
+        cold_start_checkpoint: dict[str, Any] | None = None
         if context is None:
             checkpoint = await self._load_latest_checkpoint(execution_id)
             if not (
@@ -367,6 +368,7 @@ class AgentRunner:
                 and isinstance(checkpoint.get("context"), dict)
             ):
                 return None
+            cold_start_checkpoint = checkpoint
             context = ExecutionContext.from_dict(checkpoint["context"])
             self.context_manager.set_context(context)
 
@@ -407,6 +409,23 @@ class AgentRunner:
                     self.pause(execution_id, reason=reason or "new user message")
                 return context
 
+        # Resolve the checkpoint-merge baseline before any context mutation
+        # below (add_user_message, pending marker) so a failed read leaves
+        # zero residue instead of an in-memory message that was never
+        # durably confirmed -- a retry after the failure must actually
+        # persist, not find a ghost confirmation from the rejected attempt.
+        # A live runtime's cached checkpoint wins over a fresh read; the
+        # cold-start read above (if this call triggered one) is reused
+        # instead of reading the same window twice.
+        control = self._active_controls.get(execution_id)
+        checkpoint_baseline: dict[str, Any] | None
+        if control is not None and control.runtime.last_checkpoint is not None:
+            checkpoint_baseline = control.runtime.last_checkpoint
+        elif cold_start_checkpoint is not None:
+            checkpoint_baseline = cold_start_checkpoint
+        else:
+            checkpoint_baseline = await self._load_latest_checkpoint(execution_id)
+
         # Attach files + display text to the new Message so they survive
         # checkpoint round-trips: Message.metadata is serialized by
         # ExecutionContext. The on_user_message_posted callback reads
@@ -436,6 +455,7 @@ class AgentRunner:
             execution_id=execution_id,
             context=context,
             label="user_message_injected",
+            baseline=checkpoint_baseline,
         )
         # Snapshot the watermark BEFORE the callback so we can detect a
         # change (see comment below) and persist it.
@@ -477,10 +497,16 @@ class AgentRunner:
                     execution_id=execution_id,
                     context=context,
                     label="user_message_trace_watermark",
+                    baseline=checkpoint_baseline,
                 )
             except Exception:
-                # Preserve the pending marker for resume catch-up when the
-                # trace watermark cannot be persisted after acceptance.
+                # Declared swallow point: the message was already durably
+                # accepted by the injection checkpoint above, so a failure
+                # here (including a checkpoint read/write error) only
+                # costs the watermark re-persist and must not turn an
+                # accepted message into a rejected delivery. Preserve the
+                # pending marker for resume catch-up when the trace
+                # watermark cannot be persisted after acceptance.
                 logger.warning(
                     "user-message watermark checkpoint failed after injection for %s",
                     execution_id,
@@ -967,16 +993,11 @@ class AgentRunner:
         execution_id: str,
         context: ExecutionContext,
         label: str,
+        baseline: dict[str, Any] | None,
     ) -> None:
         if self.tracer is None:
             return
 
-        control = self._active_controls.get(execution_id)
-        baseline = (
-            control.runtime.last_checkpoint
-            if control is not None and control.runtime.last_checkpoint is not None
-            else await self._load_latest_checkpoint(execution_id)
-        )
         payload = dict(baseline or {})
         payload.update(
             {

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 from uuid import uuid4
 
 from ..utils.security import redact_sensitive_text
@@ -1028,7 +1028,14 @@ class Tracer:
         self,
         execution_id: str,
     ) -> Optional[Dict[str, Any]]:
-        """Load the latest checkpoint from the first handler that supports it."""
+        """Load the latest checkpoint from the first handler that supports it.
+
+        The first capable handler's result is authoritative -- including
+        ``None`` for "no checkpoint" -- and is returned verbatim without
+        probing a second handler. Every production stack today runs a
+        single reader, so treating a raise as "try the next handler" would
+        silently hide a failure instead of surfacing it to the caller.
+        """
         for handler in list(self.handlers):
             method = getattr(handler, "load_latest_checkpoint", None)
             if not callable(method):
@@ -1036,8 +1043,7 @@ class Tracer:
             payload = method(execution_id)
             if inspect.isawaitable(payload):
                 payload = await payload
-            if isinstance(payload, dict):
-                return payload
+            return cast(Optional[Dict[str, Any]], payload)
         return None
 
     async def get_latest_checkpoint(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -157,6 +157,7 @@ async def _schedule_waiting_a2a_resume(
     task_lease: TaskLease,
     heartbeat_stop: asyncio.Event,
     heartbeat_task: asyncio.Task[TaskLeaseHeartbeatOutcome],
+    resumable_status: TaskStatus,
 ) -> None:
     from .websocket import background_task_manager, execute_resume_background
 
@@ -177,6 +178,10 @@ async def _schedule_waiting_a2a_resume(
                 preacquired_lease=task_lease,
                 preacquired_heartbeat_stop=heartbeat_stop,
                 preacquired_heartbeat_task=heartbeat_task,
+                # The prelease claimed this task out of an input-required
+                # status; hand that over so a checkpoint the resume cannot
+                # read restores it instead of failing it terminally.
+                preacquired_prior_status=resumable_status,
             )
         )
         background_task_manager.register_reserved_resume(task_id, bg_task)
@@ -444,6 +449,7 @@ async def _resume_input_required_a2a_task(
             task_lease=task_lease,
             heartbeat_stop=heartbeat_stop,
             heartbeat_task=heartbeat_task,
+            resumable_status=resumable_status,
         )
         ownership_transferred = True
     except (

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -456,12 +456,15 @@ async def _resume_input_required_a2a_task(
         # Ownership was never transferred, so restore the exact prelease
         # to the prior input-required status exactly like the absent-
         # checkpoint fallback above, then translate the failure instead of
-        # letting it escape as a raw exception.
-        cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-        if not await drain_async_task_cancellation_safe(cleanup_task):
-            raise TaskLeaseLostError(
-                f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
-            ) from exc
+        # letting it escape as a raw exception. Same ownership_transferred/
+        # prelease_cleanup_done guard as the sibling except BaseException
+        # handler below, for symmetry.
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
+                ) from exc
         if isinstance(exc, CheckpointCorruptError):
             raise a2a_error(
                 "unsupported_operation",
@@ -470,18 +473,19 @@ async def _resume_input_required_a2a_task(
                 details={"taskId": task_id},
             ) from exc
         if isinstance(exc, CheckpointAccessRefusedError):
-            if exc.reason == "lease_mismatch":
-                message = (
+            message = {
+                "lease_mismatch": (
                     "This task is currently owned by a different execution "
                     "and cannot accept a new message."
-                )
-            elif exc.reason == "superseded_legacy":
-                message = (
+                ),
+                "superseded_legacy": (
                     "This task's checkpoint history has been superseded by "
                     "a newer run and cannot accept a new message."
-                )
-            else:
-                message = "Task is currently running and cannot accept a new message."
+                ),
+            }.get(
+                exc.reason,
+                "Task is currently running and cannot accept a new message.",
+            )
             raise a2a_error(
                 "unsupported_operation",
                 message,

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -12,6 +12,11 @@ from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import String, and_, cast, func, or_, update
 
+from ...core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from ..models.agent import Agent
 from ..models.database import get_session_local
 from ..models.task import Task, TaskStatus
@@ -441,6 +446,40 @@ async def _resume_input_required_a2a_task(
             heartbeat_task=heartbeat_task,
         )
         ownership_transferred = True
+    except (
+        CheckpointUnavailableError,
+        CheckpointCorruptError,
+        CheckpointAccessRefusedError,
+    ) as exc:
+        # Ownership was never transferred, so restore the exact prelease
+        # to the prior input-required status exactly like the absent-
+        # checkpoint fallback above, then translate the failure instead of
+        # letting it escape as a raw exception.
+        cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+        if not await drain_async_task_cancellation_safe(cleanup_task):
+            raise TaskLeaseLostError(
+                f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
+            ) from exc
+        if isinstance(exc, CheckpointUnavailableError):
+            raise a2a_error(
+                "temporarily_unavailable",
+                "The task's saved progress could not be read. Please retry.",
+                status_code=503,
+                details={"taskId": task_id},
+            ) from exc
+        if isinstance(exc, CheckpointCorruptError):
+            raise a2a_error(
+                "unsupported_operation",
+                "The task's saved progress is unreadable.",
+                status_code=400,
+                details={"taskId": task_id},
+            ) from exc
+        raise a2a_error(
+            "unsupported_operation",
+            "Task is currently running and cannot accept a new message.",
+            status_code=400,
+            details={"taskId": task_id},
+        ) from exc
     except BaseException:
         if not ownership_transferred and not prelease_cleanup_done:
             cleanup_task = asyncio.create_task(stop_and_restore_prelease())

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -15,7 +15,7 @@ from sqlalchemy import String, and_, cast, func, or_, update
 from ...core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
-    CheckpointUnavailableError,
+    CheckpointReadError,
 )
 from ..models.agent import Agent
 from ..models.database import get_session_local
@@ -452,11 +452,7 @@ async def _resume_input_required_a2a_task(
             resumable_status=resumable_status,
         )
         ownership_transferred = True
-    except (
-        CheckpointUnavailableError,
-        CheckpointCorruptError,
-        CheckpointAccessRefusedError,
-    ) as exc:
+    except CheckpointReadError as exc:
         # Ownership was never transferred, so restore the exact prelease
         # to the prior input-required status exactly like the absent-
         # checkpoint fallback above, then translate the failure instead of
@@ -466,13 +462,6 @@ async def _resume_input_required_a2a_task(
             raise TaskLeaseLostError(
                 f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
             ) from exc
-        if isinstance(exc, CheckpointUnavailableError):
-            raise a2a_error(
-                "temporarily_unavailable",
-                "The task's saved progress could not be read. Please retry.",
-                status_code=503,
-                details={"taskId": task_id},
-            ) from exc
         if isinstance(exc, CheckpointCorruptError):
             raise a2a_error(
                 "unsupported_operation",
@@ -480,10 +469,34 @@ async def _resume_input_required_a2a_task(
                 status_code=400,
                 details={"taskId": task_id},
             ) from exc
+        if isinstance(exc, CheckpointAccessRefusedError):
+            if exc.reason == "lease_mismatch":
+                message = (
+                    "This task is currently owned by a different execution "
+                    "and cannot accept a new message."
+                )
+            elif exc.reason == "superseded_legacy":
+                message = (
+                    "This task's checkpoint history has been superseded by "
+                    "a newer run and cannot accept a new message."
+                )
+            else:
+                message = "Task is currently running and cannot accept a new message."
+            raise a2a_error(
+                "unsupported_operation",
+                message,
+                status_code=400,
+                details={"taskId": task_id},
+            ) from exc
+        # CheckpointUnavailableError, or any future CheckpointReadError
+        # subclass this dispatch does not yet know about: treat it
+        # conservatively as retryable rather than assuming a terminal or
+        # policy failure, so an unrecognized failure mode never silently
+        # collapses into a data-losing branch.
         raise a2a_error(
-            "unsupported_operation",
-            "Task is currently running and cannot accept a new message.",
-            status_code=400,
+            "temporarily_unavailable",
+            "The task's saved progress could not be read. Please retry.",
+            status_code=503,
             details={"taskId": task_id},
         ) from exc
     except BaseException:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -57,6 +57,31 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_ROW_SCAN_LIMIT = 100
 
 
+def _checkpoint_execution_id_predicate(execution_id: str) -> Any:
+    """SQL mirror of ``checkpoint_execution_id()``: root wins, then the flat
+    field, then the snapshot's own id -- so legacy rows that only set one of
+    them are not skipped. The read query and history pruning must agree on
+    which rows belong to one execution, or pruning could drop a row the read
+    path still considers current (or vice versa); both consume this one
+    predicate rather than keeping independently maintained copies in sync by
+    hand.
+    """
+    return (
+        func.coalesce(
+            func.nullif(
+                DatabaseTraceEvent.data["root_execution_id"].as_string(),
+                "",
+            ),
+            func.nullif(
+                DatabaseTraceEvent.data["execution_id"].as_string(),
+                "",
+            ),
+            DatabaseTraceEvent.data["snapshot"]["execution_id"].as_string(),
+        )
+        == execution_id
+    )
+
+
 def _convert_float_to_datetime(timestamp: Any) -> datetime:
     """Convert float timestamp to datetime for database storage."""
     if isinstance(timestamp, (int, float)):
@@ -155,22 +180,11 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 DatabaseTraceEvent.data["checkpoint_type"]
                 .as_string()
                 .in_(sorted(READABLE_CHECKPOINT_TYPES)),
-                # SQL mirror of checkpoint_execution_id(): root wins, then
-                # the flat field, then the snapshot's own id. The LIMIT
-                # below bounds this predicate's matching set, not an
-                # unfiltered row scan, so a zero-row result is authoritative.
-                func.coalesce(
-                    func.nullif(
-                        DatabaseTraceEvent.data["root_execution_id"].as_string(),
-                        "",
-                    ),
-                    func.nullif(
-                        DatabaseTraceEvent.data["execution_id"].as_string(),
-                        "",
-                    ),
-                    DatabaseTraceEvent.data["snapshot"]["execution_id"].as_string(),
-                )
-                == str(execution_id),
+                # The page size below bounds this predicate's matching set,
+                # not an unfiltered row scan, so a page shorter than it
+                # proves the matching set exhausted (see the scan loop
+                # below), and a zero-row first page is authoritative.
+                _checkpoint_execution_id_predicate(str(execution_id)),
             )
             if self.build_id is None:
                 try:
@@ -586,21 +600,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     DatabaseTraceEvent.data["checkpoint_type"]
                     .as_string()
                     .in_(sorted(READABLE_CHECKPOINT_TYPES)),
-                    # SQL mirror of checkpoint_execution_id(): root wins,
-                    # then the flat field, then the snapshot's own id, so
-                    # legacy rows that only set one of them are not skipped.
-                    func.coalesce(
-                        func.nullif(
-                            DatabaseTraceEvent.data["root_execution_id"].as_string(),
-                            "",
-                        ),
-                        func.nullif(
-                            DatabaseTraceEvent.data["execution_id"].as_string(),
-                            "",
-                        ),
-                        DatabaseTraceEvent.data["snapshot"]["execution_id"].as_string(),
-                    )
-                    == execution_id,
+                    _checkpoint_execution_id_predicate(execution_id),
                 )
                 .order_by(
                     DatabaseTraceEvent.timestamp.desc(),

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -305,6 +305,10 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     # A short page proves the matching set is exhausted --
                     # no further rows exist beyond this one.
                     break
+                # OFFSET paging over (timestamp DESC, id DESC): a row inserted
+                # mid-scan shifts later pages by one. Root reads are fenced to a
+                # single run partition, which excludes concurrent writers there;
+                # build-scoped histories are append-only per build.
                 offset += CHECKPOINT_ROW_SCAN_LIMIT
 
             if not saw_any_row:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -13,6 +13,9 @@ from ...config import get_checkpoint_history_limit
 from ...core.agent.checkpoint import (
     CHECKPOINT_TYPE,
     READABLE_CHECKPOINT_TYPES,
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
     checkpoint_execution_id,
 )
 from ...core.agent.trace import BaseTraceHandler
@@ -26,6 +29,7 @@ from ...web.models.task import TraceEvent as DatabaseTraceEvent
 from ...web.models.tool_config import ToolUsage
 from ...web.services.ops_signals import (
     CHECKPOINT_DECODE_FALLBACK,
+    CHECKPOINT_LOAD_UNAVAILABLE,
     clear_degradation,
     register_degradation,
 )
@@ -42,6 +46,12 @@ from ...web.services.trace_message_storage import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Candidate rows scanned per checkpoint read. A window this size lets a few
+# unreadable rows fall back to an older readable one without a second query;
+# whether it was large enough to prove the whole matching set was scanned
+# governs the unavailable-vs-corrupt classification below.
+CHECKPOINT_ROW_SCAN_LIMIT = 100
 
 
 def _convert_float_to_datetime(timestamp: Any) -> datetime:
@@ -105,35 +115,62 @@ class DatabaseTraceHandler(BaseTraceHandler):
     async def load_latest_checkpoint(
         self, execution_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Load the latest agent checkpoint persisted as a trace event."""
-        try:
-            return await asyncio.to_thread(
-                self._sync_load_latest_checkpoint,
-                execution_id,
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to load latest checkpoint for task %s execution %s: %s",
-                self.task_id,
-                execution_id,
-                e,
-            )
-            return None
+        """Load the latest agent checkpoint persisted as a trace event.
+
+        ``None`` means the query completed and found nothing -- an
+        authoritative fact. Anything that prevented that determination
+        (query failure, refused partition, undecodable rows) is translated
+        to a ``CheckpointReadError`` subclass inside the sync worker below
+        and propagates through here unchanged; it must never collapse back
+        to ``None``, or a transient failure would be indistinguishable from
+        "no checkpoint" to every caller up the stack.
+        """
+        return await asyncio.to_thread(
+            self._sync_load_latest_checkpoint,
+            execution_id,
+        )
 
     def _sync_load_latest_checkpoint(
         self,
         execution_id: str,
     ) -> Optional[Dict[str, Any]]:
-        db = next(get_db())
+        try:
+            db = next(get_db())
+        except Exception as exc:
+            register_degradation(
+                CHECKPOINT_LOAD_UNAVAILABLE,
+                f"task {self.task_id}: checkpoint session checkout failed",
+            )
+            raise CheckpointUnavailableError(
+                f"task {self.task_id}: could not open a database session "
+                "to read the checkpoint"
+            ) from exc
         try:
             query = db.query(DatabaseTraceEvent).filter(
                 DatabaseTraceEvent.task_id == self.task_id,
                 DatabaseTraceEvent.event_type == "system_update_general",
+                DatabaseTraceEvent.data["checkpoint_type"]
+                .as_string()
+                .in_(sorted(READABLE_CHECKPOINT_TYPES)),
+                # SQL mirror of checkpoint_execution_id(): root wins, then
+                # the flat field, then the snapshot's own id. The LIMIT
+                # below bounds this predicate's matching set, not an
+                # unfiltered row scan, so a zero-row result is authoritative.
+                func.coalesce(
+                    func.nullif(
+                        DatabaseTraceEvent.data["root_execution_id"].as_string(),
+                        "",
+                    ),
+                    func.nullif(
+                        DatabaseTraceEvent.data["execution_id"].as_string(),
+                        "",
+                    ),
+                    DatabaseTraceEvent.data["snapshot"]["execution_id"].as_string(),
+                )
+                == str(execution_id),
             )
             if self.build_id is None:
-                allowed, run_id = self._root_checkpoint_read_partition(db)
-                if not allowed:
-                    return None
+                run_id = self._root_checkpoint_read_partition(db)
                 query = query.filter(
                     DatabaseTraceEvent.build_id.is_(None),
                     self._checkpoint_run_partition_filter(run_id),
@@ -141,20 +178,34 @@ class DatabaseTraceHandler(BaseTraceHandler):
             else:
                 query = query.filter(DatabaseTraceEvent.build_id == self.build_id)
 
-            rows = (
-                query.order_by(
-                    DatabaseTraceEvent.timestamp.desc(),
-                    DatabaseTraceEvent.id.desc(),
+            try:
+                rows = (
+                    query.order_by(
+                        DatabaseTraceEvent.timestamp.desc(),
+                        DatabaseTraceEvent.id.desc(),
+                    )
+                    .limit(CHECKPOINT_ROW_SCAN_LIMIT)
+                    .all()
                 )
-                .limit(100)
-                .all()
-            )
+            except Exception as exc:
+                register_degradation(
+                    CHECKPOINT_LOAD_UNAVAILABLE,
+                    f"task {self.task_id}: checkpoint query failed",
+                )
+                raise CheckpointUnavailableError(
+                    f"task {self.task_id}: checkpoint query failed"
+                ) from exc
+            # The query itself succeeded -- whatever the decode loop below
+            # concludes about the rows it found, the read infrastructure is
+            # healthy again.
+            clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+            if not rows:
+                return None
+
+            saw_generic_failure = False
+            saw_undecodable_row = False
             for row in rows:
                 data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
-                if data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES:
-                    continue
-                if checkpoint_execution_id(data) != str(execution_id):
-                    continue
                 try:
                     data = decode_trace_event_data(
                         db,
@@ -163,6 +214,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         strict=True,
                     )
                 except CheckpointMessageDecodeError as exc:
+                    saw_undecodable_row = True
                     logger.warning(
                         "Skipping unreadable checkpoint trace event %s for task %s: %s",
                         row.event_id,
@@ -177,6 +229,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     # degradation on /health so a systemic decode failure is
                     # observable instead of only a per-row warning log; the
                     # signal self-clears on the next successful decode.
+                    saw_generic_failure = True
                     register_degradation(
                         CHECKPOINT_DECODE_FALLBACK,
                         f"task {self.task_id}: checkpoint decode failed, "
@@ -192,7 +245,29 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     continue
                 clear_degradation(CHECKPOINT_DECODE_FALLBACK)
                 snapshot = data.get("snapshot")
-                return dict(snapshot) if isinstance(snapshot, dict) else None
+                if not isinstance(snapshot, dict):
+                    # The row claims to be a checkpoint but carries no
+                    # payload -- corrupt, not absent.
+                    raise CheckpointCorruptError(
+                        f"task {self.task_id}: checkpoint row {row.event_id} "
+                        "has a readable checkpoint_type but no snapshot"
+                    )
+                return dict(snapshot)
+
+            # Every candidate row failed. A generic (transient) failure on
+            # any row, or a full scan window that cannot prove the matching
+            # set was exhausted, is conservatively unavailable -- retryable.
+            # Only a confirmed-exhausted set of exclusively permanent decode
+            # failures is corrupt.
+            if saw_generic_failure or len(rows) >= CHECKPOINT_ROW_SCAN_LIMIT:
+                raise CheckpointUnavailableError(
+                    f"task {self.task_id}: checkpoint read could not be "
+                    "completed for all candidate rows"
+                )
+            if saw_undecodable_row:
+                raise CheckpointCorruptError(
+                    f"task {self.task_id}: all matching checkpoint rows are undecodable"
+                )
             return None
         finally:
             db.close()
@@ -200,24 +275,38 @@ class DatabaseTraceHandler(BaseTraceHandler):
     def _root_checkpoint_read_partition(
         self,
         db: Session,
-    ) -> tuple[bool, str | None]:
-        """Resolve the only root-task run partition safe for this reader.
+    ) -> str | None:
+        """Resolve the run partition this reader may read, or refuse.
 
         Exact executions read only checkpoints tagged with their bound run.
-        Legacy callers can read only untagged rows, and only while the task has
-        no active run. Build-scoped checkpoints retain their historical
-        build-only partitioning and do not call this helper.
+        Legacy callers can read only untagged rows, and only while the task
+        has no active run and no run has ever been tagged. Build-scoped
+        checkpoints retain their historical build-only partitioning and do
+        not call this helper. A refusal means the checkpoint may exist but
+        this reader is not authoritative for it right now -- distinct from
+        a query that completed and found nothing.
         """
 
         lease = current_task_lease()
         if lease is not None:
             if lease.task_id != self.task_id or lease.run_id is None:
-                return False, None
-            return True, lease.run_id
+                raise CheckpointAccessRefusedError(
+                    f"task {self.task_id}: active lease is not bound to this reader"
+                )
+            return lease.run_id
 
         task_run = db.query(Task.run_id).filter(Task.id == self.task_id).one_or_none()
-        if task_run is None or task_run[0] is not None:
-            return False, None
+        if task_run is None:
+            # The task row itself is gone -- an exceptional condition, not
+            # a partition policy decision.
+            raise CheckpointUnavailableError(
+                f"task {self.task_id}: task row is missing"
+            )
+        if task_run[0] is not None:
+            raise CheckpointAccessRefusedError(
+                f"task {self.task_id}: an active run is in progress under "
+                "a different lease"
+            )
         tagged_checkpoint_exists = (
             db.query(DatabaseTraceEvent.id)
             .filter(
@@ -235,8 +324,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
             is not None
         )
         if tagged_checkpoint_exists:
-            return False, None
-        return True, None
+            # Positive proof a checkpoint exists in a partition this legacy
+            # reader is not allowed to read -- a refusal, not an absence.
+            raise CheckpointAccessRefusedError(
+                f"task {self.task_id}: a tagged run has already superseded "
+                "legacy checkpoints"
+            )
+        return None
 
     @staticmethod
     def _checkpoint_run_partition_filter(run_id: str | None) -> Any:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -15,6 +15,7 @@ from ...core.agent.checkpoint import (
     READABLE_CHECKPOINT_TYPES,
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
+    CheckpointReadError,
     CheckpointUnavailableError,
     checkpoint_execution_id,
 )
@@ -170,7 +171,26 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 == str(execution_id),
             )
             if self.build_id is None:
-                run_id = self._root_checkpoint_read_partition(db)
+                try:
+                    run_id = self._root_checkpoint_read_partition(db)
+                except CheckpointReadError:
+                    # Already a partition verdict (refused, or the task row
+                    # is missing); it carries its own classification.
+                    raise
+                except Exception as exc:
+                    # Resolving the partition is part of the read. A DB
+                    # failure here leaves the partition unknown, so the read
+                    # could not be completed -- same translation the main
+                    # query below gets, or the failure would escape the
+                    # contract as a raw driver exception no consumer catches.
+                    register_degradation(
+                        CHECKPOINT_LOAD_UNAVAILABLE,
+                        f"task {self.task_id}: checkpoint partition resolution failed",
+                    )
+                    raise CheckpointUnavailableError(
+                        f"task {self.task_id}: could not resolve the "
+                        "checkpoint read partition"
+                    ) from exc
                 query = query.filter(
                     DatabaseTraceEvent.build_id.is_(None),
                     self._checkpoint_run_partition_filter(run_id),

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -318,12 +318,19 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     snapshot = data.get("snapshot")
                     if not isinstance(snapshot, dict):
                         # The row claims to be a checkpoint but carries no
-                        # payload -- corrupt, not absent.
-                        raise CheckpointCorruptError(
-                            f"task {self.task_id}: checkpoint row "
-                            f"{row.event_id} has a readable checkpoint_type "
-                            "but no snapshot"
+                        # payload: a permanent failure for this row, the same
+                        # class as an undecodable one. Per-row failures never
+                        # abort the scan -- an older row may still carry a
+                        # usable checkpoint -- and the verdict for the whole
+                        # matching set is decided once, after exhaustion.
+                        saw_undecodable_row = True
+                        logger.warning(
+                            "Skipping checkpoint trace event %s for task %s: "
+                            "readable checkpoint_type but no snapshot",
+                            row.event_id,
+                            self.task_id,
                         )
+                        continue
                     return dict(snapshot)
 
                 if len(rows) < CHECKPOINT_ROW_SCAN_LIMIT:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -396,6 +396,10 @@ class DatabaseTraceHandler(BaseTraceHandler):
         if task_run is None:
             # The task row itself is gone -- an exceptional condition, not
             # a partition policy decision.
+            # No register_degradation: the signal is process-wide and is only
+            # cleared once a page query succeeds later in the read, which this
+            # branch never reaches -- one absent task would latch it for the
+            # whole process.
             raise CheckpointUnavailableError(
                 f"task {self.task_id}: task row is missing"
             )

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -311,7 +311,8 @@ class DatabaseTraceHandler(BaseTraceHandler):
         if lease is not None:
             if lease.task_id != self.task_id or lease.run_id is None:
                 raise CheckpointAccessRefusedError(
-                    f"task {self.task_id}: active lease is not bound to this reader"
+                    f"task {self.task_id}: active lease is not bound to this reader",
+                    reason="lease_mismatch",
                 )
             return lease.run_id
 
@@ -325,7 +326,8 @@ class DatabaseTraceHandler(BaseTraceHandler):
         if task_run[0] is not None:
             raise CheckpointAccessRefusedError(
                 f"task {self.task_id}: an active run is in progress under "
-                "a different lease"
+                "a different lease",
+                reason="active_run",
             )
         tagged_checkpoint_exists = (
             db.query(DatabaseTraceEvent.id)
@@ -348,7 +350,8 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # reader is not allowed to read -- a refusal, not an absence.
             raise CheckpointAccessRefusedError(
                 f"task {self.task_id}: a tagged run has already superseded "
-                "legacy checkpoints"
+                "legacy checkpoints",
+                reason="superseded_legacy",
             )
         return None
 

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -56,6 +56,14 @@ logger = logging.getLogger(__name__)
 # examine before ruling on unavailable vs. corrupt.
 CHECKPOINT_ROW_SCAN_LIMIT = 100
 
+# Operational bound on the scan loop. With history pruning disabled
+# (XAGENT_CHECKPOINT_HISTORY_LIMIT=0) and a large backlog of matching rows,
+# the loop would otherwise issue one query per CHECKPOINT_ROW_SCAN_LIMIT
+# rows before proving the matching set exhausted. This caps that cost: a
+# scan that reaches the cap without a resolution is treated as unavailable
+# rather than continuing indefinitely.
+CHECKPOINT_SCAN_MAX_PAGES = 50
+
 
 def _checkpoint_execution_id_predicate(execution_id: str) -> Any:
     """SQL mirror of ``checkpoint_execution_id()``: root wins, then the flat
@@ -223,7 +231,24 @@ class DatabaseTraceHandler(BaseTraceHandler):
             saw_undecodable_row = False
             saw_any_row = False
             offset = 0
+            page_count = 0
             while True:
+                page_count += 1
+                if page_count > CHECKPOINT_SCAN_MAX_PAGES:
+                    # The matching set is not proven exhausted, but scanning
+                    # further is not bounded work anymore -- treat it the
+                    # same as any other read that could not be completed.
+                    register_degradation(
+                        CHECKPOINT_LOAD_UNAVAILABLE,
+                        f"task {self.task_id}: checkpoint scan reached the "
+                        f"{CHECKPOINT_SCAN_MAX_PAGES}-page cap without "
+                        "resolving",
+                    )
+                    raise CheckpointUnavailableError(
+                        f"task {self.task_id}: checkpoint scan exceeded "
+                        f"{CHECKPOINT_SCAN_MAX_PAGES} pages without "
+                        "resolving"
+                    )
                 try:
                     rows = (
                         ordered_query.offset(offset)
@@ -318,6 +343,12 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # conservatively unavailable -- retryable. Only a fully scanned
             # set that is exclusively permanent decode failures is corrupt.
             if saw_generic_failure:
+                register_degradation(
+                    CHECKPOINT_LOAD_UNAVAILABLE,
+                    f"task {self.task_id}: checkpoint scan exhausted the "
+                    "matching set with a generic decode failure among the "
+                    "candidate rows",
+                )
                 raise CheckpointUnavailableError(
                     f"task {self.task_id}: checkpoint read could not be "
                     "completed for all candidate rows"

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -48,10 +48,12 @@ from ...web.services.trace_message_storage import (
 
 logger = logging.getLogger(__name__)
 
-# Candidate rows scanned per checkpoint read. A window this size lets a few
-# unreadable rows fall back to an older readable one without a second query;
-# whether it was large enough to prove the whole matching set was scanned
-# governs the unavailable-vs-corrupt classification below.
+# Page size for one batch of the checkpoint read scan. A read does not stop
+# at the first page: it keeps paging through the matching set (see
+# _sync_load_latest_checkpoint below) until a readable row is found or the
+# set is proven exhausted (a page shorter than this). The constant only
+# bounds the cost of one query, not how many candidate rows a read may
+# examine before ruling on unavailable vs. corrupt.
 CHECKPOINT_ROW_SCAN_LIMIT = 100
 
 
@@ -198,88 +200,106 @@ class DatabaseTraceHandler(BaseTraceHandler):
             else:
                 query = query.filter(DatabaseTraceEvent.build_id == self.build_id)
 
-            try:
-                rows = (
-                    query.order_by(
-                        DatabaseTraceEvent.timestamp.desc(),
-                        DatabaseTraceEvent.id.desc(),
-                    )
-                    .limit(CHECKPOINT_ROW_SCAN_LIMIT)
-                    .all()
-                )
-            except Exception as exc:
-                register_degradation(
-                    CHECKPOINT_LOAD_UNAVAILABLE,
-                    f"task {self.task_id}: checkpoint query failed",
-                )
-                raise CheckpointUnavailableError(
-                    f"task {self.task_id}: checkpoint query failed"
-                ) from exc
-            # The query itself succeeded -- whatever the decode loop below
-            # concludes about the rows it found, the read infrastructure is
-            # healthy again.
-            clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
-            if not rows:
-                return None
+            ordered_query = query.order_by(
+                DatabaseTraceEvent.timestamp.desc(),
+                DatabaseTraceEvent.id.desc(),
+            )
 
             saw_generic_failure = False
             saw_undecodable_row = False
-            for row in rows:
-                data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
+            saw_any_row = False
+            offset = 0
+            while True:
                 try:
-                    data = decode_trace_event_data(
-                        db,
-                        task_id=self.task_id,
-                        data=data,
-                        strict=True,
+                    rows = (
+                        ordered_query.offset(offset)
+                        .limit(CHECKPOINT_ROW_SCAN_LIMIT)
+                        .all()
                     )
-                except CheckpointMessageDecodeError as exc:
-                    saw_undecodable_row = True
-                    logger.warning(
-                        "Skipping unreadable checkpoint trace event %s for task %s: %s",
-                        row.event_id,
-                        self.task_id,
-                        exc,
-                    )
-                    continue
-                except Exception:
-                    # E.g. a transient DB error from the blob prefetch. Fall
-                    # back to an older readable checkpoint instead of letting
-                    # the error abort loading for the whole task. Surface the
-                    # degradation on /health so a systemic decode failure is
-                    # observable instead of only a per-row warning log; the
-                    # signal self-clears on the next successful decode.
-                    saw_generic_failure = True
+                except Exception as exc:
                     register_degradation(
-                        CHECKPOINT_DECODE_FALLBACK,
-                        f"task {self.task_id}: checkpoint decode failed, "
-                        f"fell back past event {row.event_id}",
+                        CHECKPOINT_LOAD_UNAVAILABLE,
+                        f"task {self.task_id}: checkpoint query failed",
                     )
-                    logger.warning(
-                        "Skipping checkpoint trace event %s for task %s after "
-                        "decode failure",
-                        row.event_id,
-                        self.task_id,
-                        exc_info=True,
-                    )
-                    continue
-                clear_degradation(CHECKPOINT_DECODE_FALLBACK)
-                snapshot = data.get("snapshot")
-                if not isinstance(snapshot, dict):
-                    # The row claims to be a checkpoint but carries no
-                    # payload -- corrupt, not absent.
-                    raise CheckpointCorruptError(
-                        f"task {self.task_id}: checkpoint row {row.event_id} "
-                        "has a readable checkpoint_type but no snapshot"
-                    )
-                return dict(snapshot)
+                    raise CheckpointUnavailableError(
+                        f"task {self.task_id}: checkpoint query failed"
+                    ) from exc
+                # This page succeeded -- whatever the decode loop below
+                # concludes about the rows it found, the read infrastructure
+                # is healthy again.
+                clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+                if not rows:
+                    break
+                saw_any_row = True
 
-            # Every candidate row failed. A generic (transient) failure on
-            # any row, or a full scan window that cannot prove the matching
-            # set was exhausted, is conservatively unavailable -- retryable.
-            # Only a confirmed-exhausted set of exclusively permanent decode
-            # failures is corrupt.
-            if saw_generic_failure or len(rows) >= CHECKPOINT_ROW_SCAN_LIMIT:
+                for row in rows:
+                    data: Dict[str, Any] = (
+                        row.data if isinstance(row.data, dict) else {}
+                    )
+                    try:
+                        data = decode_trace_event_data(
+                            db,
+                            task_id=self.task_id,
+                            data=data,
+                            strict=True,
+                        )
+                    except CheckpointMessageDecodeError as exc:
+                        saw_undecodable_row = True
+                        logger.warning(
+                            "Skipping unreadable checkpoint trace event %s "
+                            "for task %s: %s",
+                            row.event_id,
+                            self.task_id,
+                            exc,
+                        )
+                        continue
+                    except Exception:
+                        # E.g. a transient DB error from the blob prefetch.
+                        # Fall back to an older readable checkpoint instead
+                        # of letting the error abort loading for the whole
+                        # task. Surface the degradation on /health so a
+                        # systemic decode failure is observable instead of
+                        # only a per-row warning log; the signal self-clears
+                        # on the next successful decode.
+                        saw_generic_failure = True
+                        register_degradation(
+                            CHECKPOINT_DECODE_FALLBACK,
+                            f"task {self.task_id}: checkpoint decode failed, "
+                            f"fell back past event {row.event_id}",
+                        )
+                        logger.warning(
+                            "Skipping checkpoint trace event %s for task %s "
+                            "after decode failure",
+                            row.event_id,
+                            self.task_id,
+                            exc_info=True,
+                        )
+                        continue
+                    clear_degradation(CHECKPOINT_DECODE_FALLBACK)
+                    snapshot = data.get("snapshot")
+                    if not isinstance(snapshot, dict):
+                        # The row claims to be a checkpoint but carries no
+                        # payload -- corrupt, not absent.
+                        raise CheckpointCorruptError(
+                            f"task {self.task_id}: checkpoint row "
+                            f"{row.event_id} has a readable checkpoint_type "
+                            "but no snapshot"
+                        )
+                    return dict(snapshot)
+
+                if len(rows) < CHECKPOINT_ROW_SCAN_LIMIT:
+                    # A short page proves the matching set is exhausted --
+                    # no further rows exist beyond this one.
+                    break
+                offset += CHECKPOINT_ROW_SCAN_LIMIT
+
+            if not saw_any_row:
+                return None
+            # The matching set is exhausted and every candidate row failed.
+            # A generic (transient) failure anywhere in the scan is
+            # conservatively unavailable -- retryable. Only a fully scanned
+            # set that is exclusively permanent decode failures is corrupt.
+            if saw_generic_failure:
                 raise CheckpointUnavailableError(
                     f"task {self.task_id}: checkpoint read could not be "
                     "completed for all candidate rows"

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -45,7 +45,12 @@ from ...config import (
     get_external_upload_dirs,
     get_uploads_dir,
 )
-from ...core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
+from ...core.agent.checkpoint import (
+    CHECKPOINT_EVENT_TYPE,
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from ...core.agent.trace import TraceEvent, TraceHandler
 from ...core.execution_scope import (
     EXECUTION_SCOPE_NOT_PROVIDED,
@@ -2736,8 +2741,19 @@ def _acquire_resume_task_lease(
     task_id: int,
     task_owner_user_id: int | None,
     expected_run_id: str | None,
+    *,
+    prior_status_out: list[TaskStatus] | None = None,
 ) -> TaskLease | None:
-    """Validate and claim a resume lease in one worker transaction."""
+    """Validate and claim a resume lease in one worker transaction.
+
+    ``prior_status_out``, when given, receives the task's status as read
+    here -- before the lease-acquiring update below flips it to RUNNING.
+    A checkpoint read failure later in the resume attempt needs this to
+    restore the task instead of falling through to a terminal FAILED. It
+    is an out parameter rather than part of the return value because this
+    function is called through ``acquire_task_lease_cancellation_safe``,
+    whose acquire/cleanup pair is typed for a bare ``TaskLease``.
+    """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         task = db.query(Task).filter(Task.id == task_id).first()
@@ -2752,6 +2768,8 @@ def _acquire_resume_task_lease(
                 f"owner {int(task.user_id)}; refusing to resume as the "
                 "wrong user"
             )
+        if task is not None and prior_status_out is not None:
+            prior_status_out.append(TaskStatus(task.status))
         lease = acquire_task_lease_no_commit(
             db,
             task_id,
@@ -2766,6 +2784,27 @@ def _acquire_resume_task_lease(
             sync_workforce_run_status(db, task, TaskStatus.RUNNING)
         db.commit()
         return lease
+
+
+def _restore_resumed_task_lease_to_prior_status(
+    lease: TaskLease,
+    *,
+    status: TaskStatus,
+) -> bool:
+    """Release the exact resume lease back to its pre-acquisition status.
+
+    Mirrors the A2A input-required prelease restore: a checkpoint read
+    failure during resume must not silently downgrade a paused/waiting
+    task to a terminal FAILED. Uses the same exact-lease WHERE fence
+    (task id + runner id + run id) as the TTL reaper, so the two can never
+    both release the same row -- whichever loses the race affects zero
+    rows instead of double-releasing.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        restored = release_task_lease_no_commit(db, lease, status=status)
+        db.commit()
+        return restored
 
 
 def _finalize_resumed_task(
@@ -2961,6 +3000,12 @@ async def execute_resume_background(
     settlement_error: str | None = None
     broadcast_error_message: str | None = None
     defer_db_cleanup_to_ttl_recovery = False
+    # Captured just before lease acquisition flips the task to RUNNING; the
+    # checkpoint-unavailable/refused recovery path below restores to this
+    # instead of a terminal FAILED. Stays None when this call adopted a
+    # preacquired lease (no acquisition happened here to capture it from).
+    resume_prior_status: TaskStatus | None = None
+    restore_lease_to_prior_status: TaskStatus | None = None
     result: Dict[str, Any] | None = None
     prepared_outputs: _PreparedTaskFileOutputs | None = None
     # Token tracking + mid-run quota gate for the resumed segment (resume had
@@ -3081,17 +3126,21 @@ async def execute_resume_background(
             )
 
         if lease is None:
+            prior_status_box: list[TaskStatus] = []
             lease = await acquire_task_lease_cancellation_safe(
                 lambda: _acquire_resume_task_lease(
                     task_id,
                     task_owner_user_id,
                     expected_run_id,
+                    prior_status_out=prior_status_box,
                 ),
                 lambda acquired: _settle_resumed_task_lease(
                     acquired,
                     error_message="resume cancelled during lease acquisition",
                 ),
             )
+            if prior_status_box:
+                resume_prior_status = prior_status_box[0]
             if lease is None:
                 logger.info(
                     "Task %s resume skipped; another runner owns the lease", task_id
@@ -3449,6 +3498,36 @@ async def execute_resume_background(
             # otherwise left reclaimable when no lease was acquired). Do not
             # emit the generic FAILED/task_error payload below.
             return
+        elif (
+            isinstance(e, (CheckpointUnavailableError, CheckpointAccessRefusedError))
+            and lease is not None
+            and not lease_released
+            and resume_prior_status is not None
+        ):
+            # Not pool exhaustion (handled above) but still a read that
+            # could not be completed, or a partition this reader was not
+            # authoritative for -- retryable, not a policy decision this
+            # task made. Restore it to whatever it was before this resume
+            # attempt claimed the lease instead of a terminal FAILED; the
+            # finally block below performs the actual write once the
+            # heartbeat has stopped.
+            restore_lease_to_prior_status = resume_prior_status
+            logger.error(
+                "task_id=%s component=resume checkpoint could not be read; "
+                "restoring prior status %s: %s",
+                task_id,
+                resume_prior_status.value,
+                e,
+                exc_info=True,
+            )
+            if delivery_turn_id is not None and not delivery_was_dispatched:
+                if await mark_deferred_delivery_failed():
+                    await notify_deferred_delivery(
+                        False,
+                        "The task's saved progress could not be read. Please retry.",
+                        retry_with_new_id=True,
+                        rejection_outcome="not_accepted",
+                    )
         else:
             logger.error(
                 "V2 resume background task %s failed: %s",
@@ -3567,6 +3646,28 @@ async def execute_resume_background(
                         )
                     )
                 if (
+                    lease is not None
+                    and not lease_released
+                    and not defer_db_cleanup_to_ttl_recovery
+                    and restore_lease_to_prior_status is not None
+                ):
+                    try:
+                        restored = await run_db_io_cancellation_safe(
+                            lambda: _restore_resumed_task_lease_to_prior_status(
+                                lease,
+                                status=restore_lease_to_prior_status,
+                            )
+                        )
+                        if restored:
+                            lease_released = True
+                    except Exception:
+                        logger.error(
+                            "resume lease restore-to-prior-status failed for "
+                            "task %s; retaining lease for TTL recovery",
+                            task_id,
+                            exc_info=True,
+                        )
+                elif (
                     lease is not None
                     and not lease_released
                     and not defer_db_cleanup_to_ttl_recovery
@@ -5746,15 +5847,38 @@ async def _handle_chat_message_unserialized(
                     posted = False
                     if live_task_lease is not None:
                         with bind_task_lease_context(live_task_lease):
-                            posted = await agent_service.post_user_message(
-                                str(task_id),
-                                execution_message=user_message_for_llm,
-                                display_message=display_user_message,
-                                files=display_file_refs,
-                                turn_id=turn_id,
-                                request_interrupt=True,
-                                reason="new websocket user message",
-                            )
+                            try:
+                                posted = await agent_service.post_user_message(
+                                    str(task_id),
+                                    execution_message=user_message_for_llm,
+                                    display_message=display_user_message,
+                                    files=display_file_refs,
+                                    turn_id=turn_id,
+                                    request_interrupt=True,
+                                    reason="new websocket user message",
+                                )
+                            except CheckpointUnavailableError:
+                                # Fold into the existing posted=False path
+                                # below: the durable message is deferred to
+                                # the resume owner instead of injected live,
+                                # exactly as when there was no exact lease
+                                # or checkpoint to inject into. Distinct
+                                # from corrupt/refused, which are not
+                                # retryable by simply deferring.
+                                posted = False
+                            except (
+                                CheckpointCorruptError,
+                                CheckpointAccessRefusedError,
+                            ):
+                                background_task_manager.release_resume_reservation(
+                                    task_id
+                                )
+                                await finish_delivery(
+                                    False,
+                                    "The task's saved progress could not be read.",
+                                    rejection_outcome="not_accepted",
+                                )
+                                return
                     delivery_injected = posted
                     if not posted:
                         logger.warning(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3730,6 +3730,18 @@ async def execute_resume_background(
                                     task_id,
                                     exc_info=True,
                                 )
+                        else:
+                            logger.warning(
+                                "task_id=%s component=resume restore to prior "
+                                "status %s affected no rows; the task row no "
+                                "longer matches this lease fence (runner_id=%s "
+                                "run_id=%s), so another releaser now owns its "
+                                "status",
+                                task_id,
+                                restore_lease_to_prior_status.value,
+                                lease.runner_id,
+                                lease.run_id,
+                            )
                 elif (
                     lease is not None
                     and not lease_released

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2793,12 +2793,14 @@ def _restore_resumed_task_lease_to_prior_status(
 ) -> bool:
     """Release the exact resume lease back to its pre-acquisition status.
 
-    Mirrors the A2A input-required prelease restore: a checkpoint read
-    failure during resume must not silently downgrade a paused/waiting
-    task to a terminal FAILED. Uses the same exact-lease WHERE fence
-    (task id + runner id + run id) as the TTL reaper, so the two can never
-    both release the same row -- whichever loses the race affects zero
-    rows instead of double-releasing.
+    A checkpoint read failure during resume must not silently downgrade a
+    paused/waiting task to a terminal FAILED. Uses the same exact-lease
+    WHERE fence (task id + runner id + run id) as the TTL reaper, so the
+    two can never both release the same row -- whichever loses the race
+    affects zero rows instead of double-releasing. The commit below is
+    unconditional, unlike the A2A prelease restore: when the fence excludes
+    every row, the UPDATE affects zero rows and this commits that no-op
+    rather than rolling back.
     """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
@@ -3510,7 +3512,7 @@ async def execute_resume_background(
             isinstance(e, (CheckpointUnavailableError, CheckpointAccessRefusedError))
             and lease is not None
             and not lease_released
-            and resume_prior_status is not None
+            and resume_prior_status in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}
         ):
             # Not pool exhaustion (handled above) but still a read that
             # could not be completed, or a partition this reader was not
@@ -3518,7 +3520,11 @@ async def execute_resume_background(
             # task made. Restore it to whatever it was before this resume
             # attempt claimed the lease instead of a terminal FAILED; the
             # finally block below performs the actual write once the
-            # heartbeat has stopped.
+            # heartbeat has stopped. RUNNING is never a restore target:
+            # ``release_task_lease_no_commit`` refuses to release a lease
+            # back to RUNNING, so a prior status of RUNNING (an abandoned
+            # lease this attempt stole via TTL expiry) falls through to the
+            # settle/FAILED branch below instead of dead-ending here.
             restore_lease_to_prior_status = resume_prior_status
             logger.error(
                 "task_id=%s component=resume checkpoint could not be read; "
@@ -3675,6 +3681,53 @@ async def execute_resume_background(
                             task_id,
                             exc_info=True,
                         )
+                    else:
+                        if restored:
+                            # Correct the optimistic RUNNING state a client
+                            # may still be showing after the lease claim
+                            # above flipped it, before this failure restored
+                            # the prior status. Best-effort: a missed
+                            # broadcast does not change the restore result
+                            # that already committed.
+                            try:
+                                restored_snapshot = (
+                                    await task_execution_controller.snapshot(task_id)
+                                )
+                                event_type = (
+                                    "task_waiting_for_user"
+                                    if restore_lease_to_prior_status
+                                    == TaskStatus.WAITING_FOR_USER
+                                    else "task_paused"
+                                )
+                                message = (
+                                    "Task waiting for user response"
+                                    if restore_lease_to_prior_status
+                                    == TaskStatus.WAITING_FOR_USER
+                                    else "Task paused"
+                                )
+                                await manager.broadcast_to_task(
+                                    {
+                                        "type": event_type,
+                                        "task_id": task_id,
+                                        "message": message,
+                                        "timestamp": datetime.now(
+                                            timezone.utc
+                                        ).timestamp(),
+                                        **(
+                                            restored_snapshot.as_dict()
+                                            if restored_snapshot is not None
+                                            else {}
+                                        ),
+                                    },
+                                    task_id,
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "resume lease restore-to-prior-status "
+                                    "broadcast failed for task %s",
+                                    task_id,
+                                    exc_info=True,
+                                )
                 elif (
                     lease is not None
                     and not lease_released

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -48,7 +48,7 @@ from ...config import (
 from ...core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
     CheckpointAccessRefusedError,
-    CheckpointCorruptError,
+    CheckpointReadError,
     CheckpointUnavailableError,
 )
 from ...core.agent.trace import TraceEvent, TraceHandler
@@ -5866,10 +5866,13 @@ async def _handle_chat_message_unserialized(
                                 # from corrupt/refused, which are not
                                 # retryable by simply deferring.
                                 posted = False
-                            except (
-                                CheckpointCorruptError,
-                                CheckpointAccessRefusedError,
-                            ):
+                            except CheckpointReadError:
+                                # Corrupt and refused reach here today. The
+                                # base class is deliberate: a read failure
+                                # that is not the retryable-by-deferring
+                                # unavailable case must reject the claimed
+                                # delivery rather than escape this handler
+                                # and orphan it.
                                 background_task_manager.release_resume_reservation(
                                     task_id
                                 )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5933,14 +5933,17 @@ async def _handle_chat_message_unserialized(
                                 # that is not the retryable-by-deferring
                                 # unavailable case must reject the claimed
                                 # delivery rather than escape this handler
-                                # and orphan it.
+                                # and orphan it. Use finish_delivery_failure,
+                                # not finish_delivery, so the row is actually
+                                # persisted DELIVERY_FAILED -- otherwise it
+                                # stays DELIVERY_PENDING forever and a retry
+                                # with the same client_message_id loops on
+                                # "still being applied".
                                 background_task_manager.release_resume_reservation(
                                     task_id
                                 )
-                                await finish_delivery(
-                                    False,
-                                    "The task's saved progress could not be read.",
-                                    rejection_outcome="not_accepted",
+                                await finish_delivery_failure(
+                                    "The task's saved progress could not be read."
                                 )
                                 return
                     delivery_injected = posted

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -220,6 +220,17 @@ def _task_status_uses_live_control(
     return status in {TaskStatus.WAITING_FOR_USER, TaskStatus.RUNNING}
 
 
+def _waiting_or_paused_event_fields(status: TaskStatus) -> tuple[str, str]:
+    """Event type and default message for a task settled at WAITING_FOR_USER
+    or PAUSED. Shared by the live-lease restore broadcast and the
+    historical-replay status reassertion so both present identical labels
+    for the same status."""
+
+    if status == TaskStatus.WAITING_FOR_USER:
+        return "task_waiting_for_user", "Task waiting for user response"
+    return "task_paused", "Task paused"
+
+
 # User-facing messages for turn rejections that are NOT transient. The
 # default "busy" message tells the user to retry, which is actively
 # misleading for workforce rejections where retrying can never succeed.
@@ -3693,17 +3704,8 @@ async def execute_resume_background(
                                 restored_snapshot = (
                                     await task_execution_controller.snapshot(task_id)
                                 )
-                                event_type = (
-                                    "task_waiting_for_user"
-                                    if restore_lease_to_prior_status
-                                    == TaskStatus.WAITING_FOR_USER
-                                    else "task_paused"
-                                )
-                                message = (
-                                    "Task waiting for user response"
-                                    if restore_lease_to_prior_status
-                                    == TaskStatus.WAITING_FOR_USER
-                                    else "Task paused"
+                                event_type, message = _waiting_or_paused_event_fields(
+                                    restore_lease_to_prior_status
                                 )
                                 await manager.broadcast_to_task(
                                     {
@@ -7068,10 +7070,8 @@ def _load_historical_stream_snapshot_sync(
             # state after replay so stale running trace events do not keep the UI in
             # a running state.
             if task.status in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
-                event_type = (
-                    "task_waiting_for_user"
-                    if task.status == TaskStatus.WAITING_FOR_USER
-                    else "task_paused"
+                event_type, default_message = _waiting_or_paused_event_fields(
+                    task.status
                 )
                 question_message = None
                 question_interactions = None
@@ -7080,11 +7080,7 @@ def _load_historical_stream_snapshot_sync(
                         get_latest_waiting_question(db, task_id)
                     )
 
-                message = (
-                    question_message or "Task waiting for user response"
-                    if task.status == TaskStatus.WAITING_FOR_USER
-                    else "Task paused"
-                )
+                message = question_message or default_message
                 status_event = {
                     "type": event_type,
                     "task_id": task_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2983,6 +2983,7 @@ async def execute_resume_background(
     preacquired_lease: TaskLease | None = None,
     preacquired_heartbeat_stop: asyncio.Event | None = None,
     preacquired_heartbeat_task: (asyncio.Task[TaskLeaseHeartbeatOutcome] | None) = None,
+    preacquired_prior_status: TaskStatus | None = None,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
@@ -3000,10 +3001,13 @@ async def execute_resume_background(
     settlement_error: str | None = None
     broadcast_error_message: str | None = None
     defer_db_cleanup_to_ttl_recovery = False
-    # Captured just before lease acquisition flips the task to RUNNING; the
-    # checkpoint-unavailable/refused recovery path below restores to this
-    # instead of a terminal FAILED. Stays None when this call adopted a
-    # preacquired lease (no acquisition happened here to capture it from).
+    # The status this task held before a lease claim flipped it to RUNNING;
+    # the checkpoint-unavailable/refused recovery path below restores to
+    # this instead of a terminal FAILED. Captured at acquisition when this
+    # call claims the lease, and handed over by the claimant when the lease
+    # was preacquired -- a caller that claims the lease elsewhere owns the
+    # same obligation, or its resume would answer a transient read failure
+    # by downgrading a still-resumable task.
     resume_prior_status: TaskStatus | None = None
     restore_lease_to_prior_status: TaskStatus | None = None
     result: Dict[str, Any] | None = None
@@ -3105,6 +3109,10 @@ async def execute_resume_background(
                 raise ValueError(
                     "The preacquired resume lease does not match expected_run_id"
                 )
+            # Adopt the claimant's pre-acquisition status so the recovery
+            # path below is wired on this entry too, not only when this
+            # call claimed the lease itself.
+            resume_prior_status = preacquired_prior_status
         if previous_task is not None and not previous_task.done():
             try:
                 await previous_task

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -20,6 +20,7 @@ import threading
 
 GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED = "gmail_oidc_service_account_unverified"
 CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
+CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -683,6 +683,11 @@ def validate_preacquired_task_lease_isolated(
     return states.get(_task_lease_key(lease), TaskLeaseRefreshState.LOST)
 
 
+_NON_TERMINAL_RELEASE_STATUSES = frozenset(
+    {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}
+)
+
+
 def release_task_lease(
     db: Session,
     lease: TaskLease | None,
@@ -703,27 +708,38 @@ def release_task_lease_no_commit(
     *,
     status: TaskStatus,
 ) -> bool:
-    """Stage release of one exact lease; the caller owns commit/rollback."""
+    """Stage release of one exact lease; the caller owns commit/rollback.
+
+    Releasing to a non-terminal resting state also clears ``error_message``:
+    the row is healthy again, and a message left by an earlier failed attempt
+    would otherwise keep surfacing to clients. ``output`` is left alone --
+    only terminal transitions own it (see
+    ``fail_and_release_task_lease_no_commit`` and the FAILED branch of
+    ``recover_expired_task_lease_no_commit``).
+    """
     if status == TaskStatus.RUNNING:
         raise ValueError("Cannot release a task lease with RUNNING status")
     if lease is None:
         return False
     control_state = control_state_for_status(status).value
     current_version = func.coalesce(Task.state_version, 0)
+    values: dict[str, Any] = {
+        "status": task_status_predicate.value(status),
+        "runner_id": None,
+        "lease_expires_at": None,
+        "last_heartbeat_at": utc_now(),
+        "control_state": control_state,
+        "state_version": lease_state_version_case(
+            status, control_state, current_version
+        ),
+    }
+    if status in _NON_TERMINAL_RELEASE_STATUSES:
+        values["error_message"] = None
     stmt = (
         update(Task)
         .where(Task.id == lease.task_id)
         .where(Task.runner_id == lease.runner_id)
-        .values(
-            status=task_status_predicate.value(status),
-            runner_id=None,
-            lease_expires_at=None,
-            last_heartbeat_at=utc_now(),
-            control_state=control_state,
-            state_version=lease_state_version_case(
-                status, control_state, current_version
-            ),
-        )
+        .values(**values)
     )
     if lease.run_id is not None:
         stmt = stmt.where(Task.run_id == lease.run_id)

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -1288,7 +1288,9 @@ def finish_turn(
       - ``status == RUNNING`` + we own lease or it's expired: flip to
         FAILED, set placeholder ``error_message``, clear stale
         ``output``
-      - other statuses (PAUSED / WAITING_FOR_USER): leave alone
+      - other statuses (PAUSED / WAITING_FOR_USER): control status and
+        ``output`` are preserved; the lease release clears any stale
+        ``error_message`` left by an earlier failed attempt
     """
     from ..models.chat_message import TaskChatMessage
     from .workforce_runtime import sync_workforce_run_status

--- a/tests/core/agent/test_checkpoint.py
+++ b/tests/core/agent/test_checkpoint.py
@@ -9,8 +9,11 @@ from xagent.core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
     CHECKPOINT_TYPE,
     LEGACY_CHECKPOINT_TYPES,
+    CheckpointCorruptError,
     CheckpointPersistenceError,
+    CheckpointUnavailableError,
     TraceCheckpointStore,
+    read_latest_checkpoint_payload,
 )
 from xagent.core.agent.trace import TraceEvent, TraceHandler, Tracer
 
@@ -253,3 +256,128 @@ async def test_runner_can_use_trace_checkpoint_store_for_resume() -> None:
     assert loaded is not None
     assert loaded["label"] == "final"
     assert loaded["context"]["messages"][-1]["content"] == "done"
+
+
+class RaisingCheckpointReader:
+    """Sole checkpoint-capable handler; a second handler must never run."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any]:
+        del execution_id
+        raise self.error
+
+
+class UnreachableCheckpointReader:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        del execution_id
+        self.calls += 1
+        raise AssertionError("a prior capable reader already answered")
+
+
+@pytest.mark.asyncio
+async def test_tracer_returns_first_reader_result_verbatim_including_none() -> None:
+    """The first capable handler's result is authoritative -- Tracer must not
+    probe a second handler after a valid ``None`` (absent) result."""
+    tracer = Tracer()
+
+    class NoneReturningHandler:
+        async def load_latest_checkpoint(
+            self, execution_id: str
+        ) -> dict[str, Any] | None:
+            del execution_id
+            return None
+
+    unreachable = UnreachableCheckpointReader()
+    tracer.add_handler(NoneReturningHandler())
+    tracer.add_handler(unreachable)
+
+    result = await tracer.load_latest_checkpoint("exec-first-reader-wins")
+
+    assert result is None
+    assert unreachable.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_tracer_propagates_first_reader_exception() -> None:
+    """A raising first reader must abort the lookup, not fall through to a
+    second handler -- today's production stacks all run a single reader, so
+    treating a raise as "try the next one" would hide the failure."""
+    tracer = Tracer()
+    unreachable = UnreachableCheckpointReader()
+    tracer.add_handler(RaisingCheckpointReader(CheckpointUnavailableError("down")))
+    tracer.add_handler(unreachable)
+
+    with pytest.raises(CheckpointUnavailableError):
+        await tracer.load_latest_checkpoint("exec-raising-reader")
+
+    assert unreachable.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_read_latest_checkpoint_payload_propagates_reader_exception() -> None:
+    reader = RaisingCheckpointReader(CheckpointUnavailableError("down"))
+
+    with pytest.raises(CheckpointUnavailableError):
+        await read_latest_checkpoint_payload(reader, "exec-raising-probe")
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_propagates_reader_exception() -> None:
+    store = TraceCheckpointStore(
+        RaisingCheckpointReader(CheckpointUnavailableError("down"))
+    )
+
+    with pytest.raises(CheckpointUnavailableError):
+        await store.load_latest_checkpoint("exec-raising-store")
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_returns_none_without_raising() -> None:
+    """A wrapped reader's authoritative ``None`` must pass through as
+    absence, not be misread as an unrecognized (corrupt) shape."""
+
+    class NoneReturningReader:
+        async def load_latest_checkpoint(
+            self, execution_id: str
+        ) -> dict[str, Any] | None:
+            del execution_id
+            return None
+
+    store = TraceCheckpointStore(NoneReturningReader())
+
+    assert await store.load_latest_checkpoint("exec-none-passthrough") is None
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_unrecognized_shape_raises_corrupt() -> None:
+    class UnrecognizedShapeReader:
+        async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any]:
+            del execution_id
+            return {"unexpected": "shape"}
+
+    store = TraceCheckpointStore(UnrecognizedShapeReader())
+
+    with pytest.raises(CheckpointCorruptError):
+        await store.load_latest_checkpoint("exec-unrecognized-shape")
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_readable_type_without_snapshot_raises_corrupt() -> (
+    None
+):
+    class NoSnapshotReader:
+        async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any]:
+            return {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "root_execution_id": execution_id,
+            }
+
+    store = TraceCheckpointStore(NoSnapshotReader())
+
+    with pytest.raises(CheckpointCorruptError):
+        await store.load_latest_checkpoint("exec-no-snapshot")

--- a/tests/core/agent/test_checkpoint.py
+++ b/tests/core/agent/test_checkpoint.py
@@ -9,6 +9,7 @@ from xagent.core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
     CHECKPOINT_TYPE,
     LEGACY_CHECKPOINT_TYPES,
+    CheckpointAccessRefusedError,
     CheckpointCorruptError,
     CheckpointPersistenceError,
     CheckpointUnavailableError,
@@ -381,3 +382,15 @@ async def test_trace_checkpoint_store_readable_type_without_snapshot_raises_corr
 
     with pytest.raises(CheckpointCorruptError):
         await store.load_latest_checkpoint("exec-no-snapshot")
+
+
+def test_checkpoint_access_refused_error_reason_defaults_to_active_run() -> None:
+    """Existing call sites that construct this error without ``reason`` keep
+    working, and get the most common refusal classification for free."""
+    error = CheckpointAccessRefusedError("refused")
+    assert error.reason == "active_run"
+
+
+def test_checkpoint_access_refused_error_carries_an_explicit_reason() -> None:
+    error = CheckpointAccessRefusedError("refused", reason="lease_mismatch")
+    assert error.reason == "lease_mismatch"

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -14,6 +14,7 @@ from xagent.core.agent import (
     PatternRuntime,
     TraceEventCallback,
 )
+from xagent.core.agent.checkpoint import CheckpointUnavailableError
 from xagent.core.agent.runner import AgentRunner
 from xagent.core.agent.runtime import LLMCallInterrupted
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
@@ -305,6 +306,118 @@ async def test_runner_treats_canonical_empty_checkpoint_as_authoritative() -> No
 
     assert context is None
     assert checkpoint_store.legacy_reads == 0
+
+
+class UnavailableCheckpointStore:
+    """Every read fails -- distinct from ``EmptyCanonicalCheckpointStore``,
+    whose ``None`` is an authoritative "no checkpoint" the runner may act
+    on by building fresh state."""
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any]:
+        del execution_id
+        raise CheckpointUnavailableError("checkpoint store unavailable")
+
+
+class FlakyOnceCheckpointStore:
+    """Fails the first read, then behaves like a normal checkpoint store.
+
+    Models a transient failure during ``inject_user_message``'s baseline
+    read: the retry after the failure must actually persist the message,
+    not find a "ghost" confirmation left behind by the rejected attempt.
+    """
+
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+        self.load_calls = 0
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        self.load_calls += 1
+        if self.load_calls == 1:
+            raise CheckpointUnavailableError("transient")
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_does_not_build_fresh_context_on_unavailable() -> None:
+    runner = AgentRunner(
+        agent=Agent(name="checkpoint-reader", patterns=[], llm=None),
+        tracer=UnavailableCheckpointStore(),
+    )
+    build_context_calls: list[Any] = []
+    original_build_context = runner._build_context
+
+    async def spy_build_context(*args: Any, **kwargs: Any) -> Any:
+        build_context_calls.append((args, kwargs))
+        return await original_build_context(*args, **kwargs)
+
+    runner._build_context = spy_build_context  # type: ignore[method-assign]
+
+    with pytest.raises(CheckpointUnavailableError):
+        await runner.run(
+            task=None,
+            execution_id="exec-resume-unavailable",
+            resume=True,
+        )
+
+    assert build_context_calls == []
+    assert runner.context_manager.get_context("exec-resume-unavailable") is None
+
+
+@pytest.mark.asyncio
+async def test_inject_user_message_propagates_unavailable() -> None:
+    """Distinct from the canonical-empty-checkpoint case above: a read
+    failure must not be swallowed into the same ``None`` "no checkpoint"
+    result -- the caller cannot tell a real failure from genuine absence."""
+    runner = AgentRunner(
+        agent=Agent(name="checkpoint-reader", patterns=[], llm=None),
+        tracer=UnavailableCheckpointStore(),
+    )
+
+    with pytest.raises(CheckpointUnavailableError):
+        await runner.inject_user_message(
+            "missing-execution-unavailable",
+            "Continue",
+            request_interrupt=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_inject_rejection_leaves_no_dedupe_residue() -> None:
+    tracer = FlakyOnceCheckpointStore()
+    runner = AgentRunner(
+        agent=Agent(name="checkpoint-reader", patterns=[], llm=None),
+        tracer=tracer,
+    )
+    context = ExecutionContext(execution_id="exec-residue")
+    runner.context_manager.set_context(context)
+
+    with pytest.raises(CheckpointUnavailableError):
+        await runner.inject_user_message(
+            "exec-residue",
+            "Continue",
+            turn_id="turn-1",
+            request_interrupt=False,
+        )
+
+    # The rejected attempt must not have mutated the in-memory context.
+    assert context.messages == []
+
+    # A retry must actually persist the message -- it must not find a
+    # ghost confirmation left behind by the failed attempt above.
+    result = await runner.inject_user_message(
+        "exec-residue",
+        "Continue",
+        turn_id="turn-1",
+        request_interrupt=False,
+    )
+
+    assert result is context
+    assert len(context.messages) == 1
+    assert tracer.by_execution_id["exec-residue"]["context"]["messages"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -14,7 +14,10 @@ from xagent.core.agent import (
     PatternRuntime,
     TraceEventCallback,
 )
-from xagent.core.agent.checkpoint import CheckpointUnavailableError
+from xagent.core.agent.checkpoint import (
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from xagent.core.agent.runner import AgentRunner
 from xagent.core.agent.runtime import LLMCallInterrupted
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
@@ -306,6 +309,17 @@ async def test_runner_treats_canonical_empty_checkpoint_as_authoritative() -> No
 
     assert context is None
     assert checkpoint_store.legacy_reads == 0
+
+
+class ContextlessCheckpointStore:
+    """Returns a recognized checkpoint payload that carries no context.
+
+    Every production checkpoint writer persists a ``context`` dict; a
+    stored payload without one is malformed. The runner must classify it
+    as corrupt rather than silently building fresh state on resume."""
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any]:
+        return {"type": "checkpoint", "execution_id": execution_id}
 
 
 class UnavailableCheckpointStore:
@@ -1353,3 +1367,46 @@ def test_resolve_compact_threshold_default_env_override(monkeypatch) -> None:
 def test_resolve_compact_threshold_missing_llm() -> None:
     agent = Agent(name="t", patterns=[FakePattern({})], llm=None)
     assert AgentRunner(agent=agent)._resolve_compact_threshold() == 32000
+
+
+@pytest.mark.asyncio
+async def test_run_resume_raises_corrupt_on_contextless_checkpoint() -> None:
+    runner = AgentRunner(
+        agent=Agent(name="checkpoint-reader", patterns=[], llm=None),
+        tracer=ContextlessCheckpointStore(),
+    )
+    build_context_calls: list[Any] = []
+    original_build_context = runner._build_context
+
+    async def spy_build_context(*args: Any, **kwargs: Any) -> Any:
+        build_context_calls.append((args, kwargs))
+        return await original_build_context(*args, **kwargs)
+
+    runner._build_context = spy_build_context  # type: ignore[method-assign]
+
+    with pytest.raises(CheckpointCorruptError):
+        await runner.run(
+            task=None,
+            execution_id="exec-resume-contextless",
+            resume=True,
+        )
+
+    assert build_context_calls == []
+    assert runner.context_manager.get_context("exec-resume-contextless") is None
+
+
+@pytest.mark.asyncio
+async def test_inject_user_message_raises_corrupt_on_contextless_checkpoint() -> None:
+    """A found checkpoint without a context dict is malformed, not absent:
+    returning ``None`` here would be indistinguishable from "no checkpoint"
+    and the caller would defer forever against a row that can never resume."""
+    runner = AgentRunner(
+        agent=Agent(name="checkpoint-reader", patterns=[], llm=None),
+        tracer=ContextlessCheckpointStore(),
+    )
+
+    with pytest.raises(CheckpointCorruptError):
+        await runner.inject_user_message(
+            "exec-inject-contextless",
+            message="hello",
+        )

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -10,6 +10,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from xagent.core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from xagent.web.api import a2a as a2a_api
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
@@ -1067,6 +1072,115 @@ def test_checkpoint_resume_exception_restores_input_required_status() -> None:
         assert recovered.status == TaskStatus.WAITING_FOR_USER
     finally:
         db.close()
+
+
+def _resume_error_task(agent_id: int, *, context_id: str) -> int:
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="waiting",
+            status=TaskStatus.WAITING_FOR_USER,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": context_id},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return int(task.id)
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_status"),
+    [
+        (CheckpointUnavailableError("checkpoint query failed"), 503),
+        (CheckpointCorruptError("all matching rows undecodable"), 400),
+        (
+            CheckpointAccessRefusedError("active lease is not bound to this reader"),
+            400,
+        ),
+    ],
+)
+def test_checkpoint_read_error_maps_to_distinct_status_and_restores_waiting(
+    error: Exception,
+    expected_status: int,
+) -> None:
+    """Unlike a generic exception (500, above), a checkpoint read failure
+    gets a status distinguishing retryable (unavailable) from terminal
+    (corrupt, refused) -- and, like the generic case, restores the prior
+    input-required status since ownership was never transferred."""
+    agent_id, full_key = _create_published_agent_with_key()
+    task_id = _resume_error_task(agent_id, context_id=f"ctx-{type(error).__name__}")
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(side_effect=error)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": f"msg-{type(error).__name__}",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == expected_status, response.text
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
+
+
+def test_checkpoint_access_refused_reuses_existing_running_task_message() -> None:
+    """Refused reuses the same 400 message as the pre-existing 'another run
+    is already active' rejection -- it is the same fact from the reader's
+    point of view, discovered later in the resume attempt."""
+    agent_id, full_key = _create_published_agent_with_key()
+    task_id = _resume_error_task(agent_id, context_id="ctx-refused-message")
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(
+        side_effect=CheckpointAccessRefusedError("active lease is not bound")
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-refused-message",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    assert "currently running" in response.json()["error"]["message"]
 
 
 def test_list_tasks_uses_database_filters_and_pagination() -> None:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -752,6 +752,80 @@ def test_checkpoint_resume_schedule_failure_exactly_restores_waiting_task() -> N
         db.close()
 
 
+@pytest.mark.asyncio
+async def test_a2a_handover_restores_input_required_on_unreadable_checkpoint() -> None:
+    """The A2A handover carries the pre-claim status into the resume.
+
+    The prelease claims the task out of WAITING_FOR_USER and commits RUNNING
+    before handing the lease to ``execute_resume_background``, which therefore
+    never runs the acquisition that captures a prior status. The status travels
+    only as the ``preacquired_prior_status`` kwarg, so drive the real path
+    across the handover: a checkpoint the resume cannot read must land the row
+    back on WAITING_FOR_USER under its original run, not on a terminal FAILED.
+    """
+    from xagent.web.api import websocket as websocket_api
+
+    agent_id, _full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="waiting on handover",
+            status=TaskStatus.WAITING_FOR_USER,
+            control_state=TaskControlState.WAITING_FOR_USER.value,
+            run_id="run-handover",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-handover"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        snapshot = A2ATaskSnapshot.from_task(task)
+    finally:
+        db.close()
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=CheckpointUnavailableError("checkpoint store unavailable")
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        assert await a2a_api._resume_input_required_a2a_task(
+            agent_id=agent_id,
+            task_owner_user_id=owner_id,
+            task=snapshot,
+            text="follow up after handover",
+            message_id="msg-handover",
+        )
+        # Ownership transferred synchronously: the scheduled resume has not run
+        # yet, so its registration is still the one this handover created.
+        resume_task = websocket_api.background_task_manager.resume_tasks[task_id]
+        await asyncio.wait_for(resume_task, timeout=30)
+
+    agent_service.resume_execution_by_id.assert_awaited_once()
+    db = _direct_db_session()
+    try:
+        restored = db.query(Task).filter(Task.id == task_id).one()
+        assert restored.status == TaskStatus.WAITING_FOR_USER
+        assert restored.control_state == TaskControlState.WAITING_FOR_USER.value
+        assert restored.run_id == "run-handover"
+        assert restored.runner_id is None
+        assert restored.lease_expires_at is None
+        assert restored.error_message is None
+    finally:
+        db.close()
+
+
 def test_recovered_paused_checkpoint_resumes_without_transcript_fallback() -> None:
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -13,6 +13,7 @@ from sqlalchemy.pool import QueuePool
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
+    CheckpointReadError,
     CheckpointUnavailableError,
 )
 from xagent.web.api import a2a as a2a_api
@@ -1181,6 +1182,105 @@ def test_checkpoint_access_refused_reuses_existing_running_task_message() -> Non
 
     assert response.status_code == 400, response.text
     assert "currently running" in response.json()["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    ("reason", "unexpected_phrase"),
+    [
+        ("lease_mismatch", "currently running"),
+        ("superseded_legacy", "currently running"),
+    ],
+)
+def test_checkpoint_access_refused_reason_gets_a_distinct_message(
+    reason: str,
+    unexpected_phrase: str,
+) -> None:
+    """Only the ``active_run`` reason reuses the pre-existing 'currently
+    running' message; the other two refusal reasons are distinct facts
+    (a stray lease, a superseded legacy partition) and must not be reported
+    with a message that claims a run is in progress."""
+    agent_id, full_key = _create_published_agent_with_key()
+    task_id = _resume_error_task(agent_id, context_id=f"ctx-refused-{reason}")
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(
+        side_effect=CheckpointAccessRefusedError(f"refused for {reason}", reason=reason)
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": f"msg-refused-{reason}",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    message = response.json()["error"]["message"]
+    assert unexpected_phrase not in message
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
+
+
+def test_checkpoint_read_error_unknown_subclass_is_treated_as_retryable() -> None:
+    """A ``CheckpointReadError`` subclass this dispatch does not recognize
+    must default to the retryable (unavailable) branch, not silently fall
+    into the terminal refused/corrupt handling -- conservative in the face
+    of an unrecognized failure mode, matching the unavailable status code
+    and the waiting-status restoration."""
+
+    class _UnknownCheckpointReadError(CheckpointReadError):
+        pass
+
+    agent_id, full_key = _create_published_agent_with_key()
+    task_id = _resume_error_task(agent_id, context_id="ctx-unknown-checkpoint-error")
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(
+        side_effect=_UnknownCheckpointReadError("unrecognized checkpoint failure")
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-unknown-checkpoint-error",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 503, response.text
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
 
 
 def test_list_tasks_uses_database_filters_and_pagination() -> None:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -779,6 +779,7 @@ async def test_a2a_handover_restores_input_required_on_unreadable_checkpoint() -
             source="a2a",
             is_visible=False,
             agent_config={"a2a_context_id": "ctx-handover"},
+            error_message="stale a2a failure",
         )
         db.add(task)
         db.commit()

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -27,6 +27,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from tests.shared.execution_scope import register_scope_resolver
 from xagent.core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
     CheckpointCorruptError,
     CheckpointUnavailableError,
 )
@@ -1279,12 +1280,20 @@ def _fake_acquire_with_prior_status(lease: TaskLease, prior_status: TaskStatus):
 
 
 @pytest.mark.asyncio
-async def test_resume_background_restores_prior_status_on_checkpoint_unavailable() -> (
-    None
-):
-    """A checkpoint read failure during resume (not a pool timeout) must
-    restore the task to whatever it was before this attempt claimed the
-    lease, not fall through to the generic terminal FAILED path."""
+@pytest.mark.parametrize(
+    "read_error",
+    [
+        CheckpointUnavailableError("checkpoint store unavailable"),
+        CheckpointAccessRefusedError("partition refused"),
+    ],
+)
+async def test_resume_background_restores_prior_status_on_checkpoint_read_failure(
+    read_error: Exception,
+) -> None:
+    """A retryable checkpoint read failure during resume (not a pool
+    timeout) must restore the task to whatever it was before this attempt
+    claimed the lease, not fall through to the generic terminal FAILED
+    path. Unavailable and refused reads share the restore branch."""
     lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
     settle = MagicMock()
     restore = MagicMock(return_value=True)
@@ -1304,9 +1313,7 @@ async def test_resume_background_restores_prior_status_on_checkpoint_unavailable
             return None
 
     agent_service = MagicMock()
-    agent_service.resume_execution_by_id = AsyncMock(
-        side_effect=CheckpointUnavailableError("checkpoint query failed")
-    )
+    agent_service.resume_execution_by_id = AsyncMock(side_effect=read_error)
     ws_manager = MagicMock(broadcast_to_task=AsyncMock())
 
     with _Patches(

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -1187,6 +1187,80 @@ def test_acquire_resume_lease_reports_prior_status_when_claim_is_lost() -> None:
     assert prior_status_box == [TaskStatus.PAUSED]
 
 
+@pytest.mark.asyncio
+async def test_resume_background_restores_prior_status_for_preacquired_lease() -> None:
+    """A resume that adopts someone else's lease owes the same restore.
+
+    The A2A input-required flow claims the lease itself and hands it over,
+    so this entry never runs the acquisition that captures the status. If
+    the handover does not carry it, a checkpoint the resume cannot read
+    downgrades a still-resumable task to a terminal FAILED on that path
+    while the self-acquiring path recovers it.
+    """
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    heartbeat_stop = asyncio.Event()
+    heartbeat_task: asyncio.Task[Any] = asyncio.create_task(asyncio.sleep(0))
+    settle = MagicMock()
+    restore = MagicMock(return_value=True)
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=CheckpointUnavailableError("checkpoint query failed")
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with _Patches(
+        [
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket._restore_resumed_task_lease_to_prior_status",
+                restore,
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+            preacquired_lease=lease,
+            preacquired_heartbeat_stop=heartbeat_stop,
+            preacquired_heartbeat_task=heartbeat_task,
+            preacquired_prior_status=TaskStatus.WAITING_FOR_USER,
+        )
+
+    settle.assert_not_called()
+    restore.assert_called_once()
+    assert restore.call_args.kwargs["status"] == TaskStatus.WAITING_FOR_USER
+    assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
 def _fake_acquire_with_prior_status(lease: TaskLease, prior_status: TaskStatus):
     """Mirror ``_acquire_resume_task_lease``'s prior-status side channel."""
 

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -1105,6 +1105,88 @@ async def test_resume_pool_timeout_does_not_start_secondary_db_cleanup(caplog) -
     )
 
 
+def test_acquire_resume_lease_reports_prior_status_before_claiming() -> None:
+    """The real acquire must fill the prior-status box on the claim path.
+
+    Every restore-to-prior test below patches this function with a fake
+    that mirrors the out parameter, so nothing else would notice if the
+    production function stopped populating it -- the resume path would
+    just silently fall back to the terminal FAILED branch. Pin the real
+    function against its own contract, and pin that the status recorded
+    is the pre-acquisition one rather than the RUNNING the claim writes.
+    """
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    task = SimpleNamespace(id=42, user_id=1, status=TaskStatus.WAITING_FOR_USER)
+    query = MagicMock()
+    query.filter.return_value = query
+    query.first.return_value = task
+    db = MagicMock()
+    db.query.return_value = query
+    session_context = MagicMock()
+    session_context.__enter__.return_value = db
+    session_context.__exit__.return_value = False
+    session_factory = MagicMock(return_value=session_context)
+
+    prior_status_box: list[TaskStatus] = []
+    with (
+        patch(
+            "xagent.web.api.websocket.get_session_local",
+            return_value=session_factory,
+        ),
+        patch(
+            "xagent.web.api.websocket.acquire_task_lease_no_commit",
+            return_value=lease,
+        ),
+        patch("xagent.web.api.websocket.sync_workforce_run_status"),
+    ):
+        acquired = _acquire_resume_task_lease(
+            42,
+            1,
+            "run-a",
+            prior_status_out=prior_status_box,
+        )
+
+    assert acquired is lease
+    assert prior_status_box == [TaskStatus.WAITING_FOR_USER]
+
+
+def test_acquire_resume_lease_reports_prior_status_when_claim_is_lost() -> None:
+    """A lost claim must not leave the box holding a fabricated status."""
+    task = SimpleNamespace(id=42, user_id=1, status=TaskStatus.PAUSED)
+    query = MagicMock()
+    query.filter.return_value = query
+    query.first.return_value = task
+    db = MagicMock()
+    db.query.return_value = query
+    session_context = MagicMock()
+    session_context.__enter__.return_value = db
+    session_context.__exit__.return_value = False
+    session_factory = MagicMock(return_value=session_context)
+
+    prior_status_box: list[TaskStatus] = []
+    with (
+        patch(
+            "xagent.web.api.websocket.get_session_local",
+            return_value=session_factory,
+        ),
+        patch(
+            "xagent.web.api.websocket.acquire_task_lease_no_commit",
+            return_value=None,
+        ),
+    ):
+        acquired = _acquire_resume_task_lease(
+            42,
+            1,
+            "run-a",
+            prior_status_out=prior_status_box,
+        )
+
+    assert acquired is None
+    # Recorded, but the caller only consults it when a lease was claimed,
+    # so a lost claim can never restore a status it does not own.
+    assert prior_status_box == [TaskStatus.PAUSED]
+
+
 def _fake_acquire_with_prior_status(lease: TaskLease, prior_status: TaskStatus):
     """Mirror ``_acquire_resume_task_lease``'s prior-status side channel."""
 

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -26,6 +26,10 @@ import pytest
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from tests.shared.execution_scope import register_scope_resolver
+from xagent.core.agent.checkpoint import (
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from xagent.core.execution_scope import (
     EXECUTION_SCOPE_NOT_PROVIDED,
     ExecutionScope,
@@ -1096,6 +1100,261 @@ async def test_resume_pool_timeout_does_not_start_secondary_db_cleanup(caplog) -
     assert "component=resume" in caplog.text
     assert "retaining lease for TTL recovery" in caplog.text
     assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
+def _fake_acquire_with_prior_status(lease: TaskLease, prior_status: TaskStatus):
+    """Mirror ``_acquire_resume_task_lease``'s prior-status side channel."""
+
+    def _acquire(
+        task_id_arg: int,
+        task_owner_user_id_arg: int | None,
+        expected_run_id_arg: str | None,
+        *,
+        prior_status_out: list[Any] | None = None,
+    ) -> TaskLease:
+        if prior_status_out is not None:
+            prior_status_out.append(prior_status)
+        return lease
+
+    return _acquire
+
+
+@pytest.mark.asyncio
+async def test_resume_background_restores_prior_status_on_checkpoint_unavailable() -> (
+    None
+):
+    """A checkpoint read failure during resume (not a pool timeout) must
+    restore the task to whatever it was before this attempt claimed the
+    lease, not fall through to the generic terminal FAILED path."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    settle = MagicMock()
+    restore = MagicMock(return_value=True)
+    mark_delivery = MagicMock()
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=CheckpointUnavailableError("checkpoint query failed")
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                side_effect=_fake_acquire_with_prior_status(
+                    lease, TaskStatus.WAITING_FOR_USER
+                ),
+            ),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket._restore_resumed_task_lease_to_prior_status",
+                restore,
+            ),
+            patch(
+                "xagent.web.api.websocket.mark_user_message_delivery_sync",
+                mark_delivery,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            delivery_turn_id="resume-turn",
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    settle.assert_not_called()
+    restore.assert_called_once()
+    _, restore_kwargs = restore.call_args
+    assert restore.call_args.args[0] == lease
+    assert restore_kwargs["status"] == TaskStatus.WAITING_FOR_USER
+    # Retryable, not a rejected/failed delivery: the client should retry
+    # with a fresh id once the task is back to waiting.
+    mark_delivery.assert_called_once()
+    assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_background_checkpoint_unavailable_from_pool_timeout_keeps_lease() -> (
+    None
+):
+    """When the unavailable read is itself pool exhaustion, the existing
+    pool-timeout recovery (retain the lease for TTL reaping) wins over the
+    new restore-to-prior path -- ``is_database_pool_timeout`` must see
+    through the ``CheckpointUnavailableError`` wrapper via its cause chain."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    settle = MagicMock()
+    restore = MagicMock(return_value=True)
+
+    def _raise_wrapped_pool_timeout(*args: Any, **kwargs: Any) -> Any:
+        try:
+            raise SQLAlchemyTimeoutError("pool exhausted")
+        except SQLAlchemyTimeoutError as exc:
+            raise CheckpointUnavailableError("checkpoint query failed") from exc
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=_raise_wrapped_pool_timeout
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                side_effect=_fake_acquire_with_prior_status(
+                    lease, TaskStatus.WAITING_FOR_USER
+                ),
+            ),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket._restore_resumed_task_lease_to_prior_status",
+                restore,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    settle.assert_not_called()
+    restore.assert_not_called()
+    assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_background_marks_failed_on_checkpoint_corrupt() -> None:
+    """Corrupt is a terminal state, not a retryable one -- it must fall
+    through to the ordinary FAILED settlement, not the restore path."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    settle = MagicMock(return_value=True)
+    restore = MagicMock()
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=CheckpointCorruptError("all matching rows undecodable")
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                side_effect=_fake_acquire_with_prior_status(
+                    lease, TaskStatus.WAITING_FOR_USER
+                ),
+            ),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket._restore_resumed_task_lease_to_prior_status",
+                restore,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    restore.assert_not_called()
+    settle.assert_called_once()
+    assert any(
         call.args[0].get("type") == "task_error"
         for call in ws_manager.broadcast_to_task.call_args_list
     )

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -1365,6 +1365,87 @@ async def test_resume_background_restores_prior_status_on_checkpoint_unavailable
 
 
 @pytest.mark.asyncio
+async def test_resume_background_restore_broadcast_failure_does_not_affect_restore() -> (
+    None
+):
+    """The corrective post-restore broadcast is best-effort: a failure there
+    must not undo the already-committed restore or escape the call."""
+    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    settle = MagicMock()
+    restore = MagicMock(return_value=True)
+    mark_delivery = MagicMock()
+
+    class FakeTracker:
+        quota_interrupt_reason = None
+
+        def __init__(self, *, task_id: int, **kwargs: Any) -> None:
+            self.complete_tracking = AsyncMock()
+            self.stop_periodic_updates = AsyncMock()
+
+        async def start_tracking(self) -> None:
+            return None
+
+        async def interrupt_reason_for_quota(self) -> None:
+            return None
+
+    agent_service = MagicMock()
+    agent_service.resume_execution_by_id = AsyncMock(
+        side_effect=CheckpointUnavailableError("checkpoint query failed")
+    )
+
+    async def _broadcast(payload: dict, *_args: Any, **_kwargs: Any) -> None:
+        if payload.get("type") in {"task_waiting_for_user", "task_paused"}:
+            raise RuntimeError("broadcast down")
+
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock(side_effect=_broadcast))
+
+    with _Patches(
+        [
+            patch(
+                "xagent.web.api.websocket._acquire_resume_task_lease",
+                side_effect=_fake_acquire_with_prior_status(
+                    lease, TaskStatus.WAITING_FOR_USER
+                ),
+            ),
+            patch("xagent.web.api.websocket._settle_resumed_task_lease", settle),
+            patch(
+                "xagent.web.api.websocket._restore_resumed_task_lease_to_prior_status",
+                restore,
+            ),
+            patch(
+                "xagent.web.api.websocket.mark_user_message_delivery_sync",
+                mark_delivery,
+            ),
+            patch(
+                "xagent.web.api.websocket.run_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch(
+                "xagent.web.api.websocket.stop_task_lease_heartbeat",
+                new=AsyncMock(),
+            ),
+            patch("xagent.web.api.websocket.manager", ws_manager),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
+            patch("xagent.web.tracking.task_tracker.TaskTracker", FakeTracker),
+        ]
+    ):
+        # Must not raise even though the corrective broadcast fails.
+        await execute_resume_background(
+            task_id=42,
+            agent_service=agent_service,
+            task_owner_user_id=1,
+            delivery_turn_id="resume-turn",
+            expected_run_id="run-a",
+            resolved_execution_scope=None,
+        )
+
+    settle.assert_not_called()
+    restore.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_resume_background_checkpoint_unavailable_from_pool_timeout_keeps_lease() -> (
     None
 ):

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -24,6 +24,11 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.execution_scope import register_scope_resolver
+from xagent.core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointUnavailableError,
+)
 from xagent.core.execution_scope import (
     ExecutionScope,
 )
@@ -1388,6 +1393,148 @@ async def test_deferred_chat_message_is_acked_after_durable_command_commit(
     assert kwargs["delivery_already_dispatched"] is False
     assert kwargs["delivery_websocket"] is None
     assert kwargs["delivery_client_message_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_live_lease_injection_degrades_to_deferred_on_checkpoint_unavailable(
+    db_session,
+) -> None:
+    """A checkpoint read failure during live injection must fold into the
+    same posted=False deferred-delivery path as no exact lease at all --
+    not a raw exception and not a rejection."""
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "unavailable-runner"
+    task.run_id = "unavailable-run"
+    db_session.commit()
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(
+        side_effect=CheckpointUnavailableError("checkpoint query failed")
+    )
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    resume_bg = AsyncMock()
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+    websocket = MagicMock()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_chat_message(
+            websocket,
+            int(task.id),
+            {
+                "message": "Wait for the checkpoint",
+                "client_message_id": "unavailable-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+        for _ in range(100):
+            db_session.expire_all()
+            stored_command = (
+                db_session.query(TaskExecutionCommand)
+                .filter_by(task_id=int(task.id), command_id="unavailable-turn-1")
+                .one()
+            )
+            if (
+                stored_command.status == "pending"
+                and int(stored_command.attempt_count or 0) >= 1
+                and resume_bg.await_count == 1
+            ):
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("deferred command claim was not released in time")
+
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0]["client_message_id"] == "unavailable-turn-1"
+    assert stored_command.status == "pending"
+    assert not any(
+        call.args[0].get("type") == "message_rejected"
+        for call in ws_manager.send_personal_message.call_args_list
+    )
+    kwargs = resume_bg.call_args.kwargs
+    assert kwargs["delivery_already_dispatched"] is False
+    assert kwargs["delivery_websocket"] is None
+    assert kwargs["delivery_client_message_id"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        CheckpointCorruptError("all matching rows undecodable"),
+        CheckpointAccessRefusedError("active lease is not bound to this reader"),
+    ],
+)
+async def test_live_lease_injection_rejects_delivery_on_corrupt_or_refused(
+    db_session,
+    error: Exception,
+) -> None:
+    """Corrupt/refused are not retryable by deferring -- reject the claimed
+    delivery outright instead of scheduling a resume attempt."""
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "rejected-runner"
+    task.run_id = "rejected-run"
+    db_session.commit()
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(side_effect=error)
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    resume_bg = AsyncMock()
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Wait for the checkpoint",
+                "client_message_id": "rejected-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    resume_bg.assert_not_awaited()
+    bg_mgr.release_resume_reservation.assert_called_once_with(int(task.id))
+    rejected = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_rejected"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["client_message_id"] == "rejected-turn-1"
+    assert rejected[0]["rejection_outcome"] == "not_accepted"
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -39,6 +39,7 @@ from xagent.web.api.websocket import (
     _handle_chat_message_unserialized,
     _handle_pause_task_unserialized,
     _handle_resume_task_unserialized,
+    _waiting_or_paused_event_fields,
     background_task_manager,
     execute_resume_background,
     get_authenticated_user,
@@ -2869,6 +2870,21 @@ async def test_resume_background_settles_running_prior_status_on_checkpoint_unav
     assert len(failures) == 1
 
 
+def test_waiting_or_paused_event_fields_shared_by_both_call_sites() -> None:
+    """The live-lease restore broadcast and the historical-replay status
+    reassertion both compute their event type/message off this one helper;
+    pin its output so a change to either site's vocabulary is caught here
+    rather than only in one of the two integration tests."""
+    assert _waiting_or_paused_event_fields(TaskStatus.WAITING_FOR_USER) == (
+        "task_waiting_for_user",
+        "Task waiting for user response",
+    )
+    assert _waiting_or_paused_event_fields(TaskStatus.PAUSED) == (
+        "task_paused",
+        "Task paused",
+    )
+
+
 @pytest.mark.parametrize(
     ("prior_status", "expected_event_type"),
     [
@@ -2912,7 +2928,9 @@ async def test_resume_background_broadcasts_corrective_event_after_restore(
         if call.args[0].get("type") == expected_event_type
     ]
     assert len(corrective) == 1
+    assert corrective[0]["type"] == expected_event_type
     assert corrective[0]["status"] == prior_status.value
+    assert "state_version" in corrective[0]
     assert not any(
         call.args[0].get("type") == "task_error"
         for call in ws_manager.broadcast_to_task.call_args_list

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2818,6 +2818,100 @@ async def test_execute_resume_background_persists_missing_checkpoint_failure(
     assert failures[0]["task"]["status"] == TaskStatus.FAILED.value
 
 
+@pytest.mark.asyncio
+async def test_resume_background_settles_running_prior_status_on_checkpoint_unavailable(
+    db_session,
+) -> None:
+    """A RUNNING prior status is never a valid restore target.
+
+    ``release_task_lease_no_commit`` refuses to release a lease back to
+    RUNNING. A resume that steals an abandoned lease from a task whose row
+    was still RUNNING (no active runner, expired TTL) must therefore fall
+    through to the ordinary settle/FAILED path on a checkpoint read failure,
+    not attempt a "restore to prior status" that can only dead-end with the
+    lease stuck unreleased until TTL recovery.
+    """
+    owner = _user(db_session, "running-prior-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
+    agent = MagicMock(
+        resume_execution_by_id=AsyncMock(
+            side_effect=CheckpointUnavailableError("checkpoint query failed")
+        ),
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with patch("xagent.web.api.websocket.manager", ws_manager):
+        _register_current_resume(int(task.id))
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+        )
+
+    db_session.expire_all()
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
+    assert task.runner_id is None
+    failures = [
+        call.args[0]
+        for call in ws_manager.broadcast_to_task.call_args_list
+        if call.args[0].get("type") == "task_error"
+    ]
+    assert len(failures) == 1
+
+
+@pytest.mark.parametrize(
+    ("prior_status", "expected_event_type"),
+    [
+        (TaskStatus.PAUSED, "task_paused"),
+        (TaskStatus.WAITING_FOR_USER, "task_waiting_for_user"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_resume_background_broadcasts_corrective_event_after_restore(
+    db_session,
+    prior_status: TaskStatus,
+    expected_event_type: str,
+) -> None:
+    """After a checkpoint-unavailable restore, clients that saw the optimistic
+    RUNNING transition need the prior status re-asserted -- reusing the same
+    event vocabulary the historical-replay path uses for PAUSED/WAITING_FOR_USER."""
+    owner = _user(db_session, "restore-broadcast-owner")
+    task = _task(db_session, owner.id, status=prior_status)
+    agent = MagicMock(
+        resume_execution_by_id=AsyncMock(
+            side_effect=CheckpointUnavailableError("checkpoint query failed")
+        ),
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with patch("xagent.web.api.websocket.manager", ws_manager):
+        _register_current_resume(int(task.id))
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+        )
+
+    db_session.expire_all()
+    db_session.refresh(task)
+    assert task.status == prior_status
+
+    corrective = [
+        call.args[0]
+        for call in ws_manager.broadcast_to_task.call_args_list
+        if call.args[0].get("type") == expected_event_type
+    ]
+    assert len(corrective) == 1
+    assert corrective[0]["status"] == prior_status.value
+    assert not any(
+        call.args[0].get("type") == "task_error"
+        for call in ws_manager.broadcast_to_task.call_args_list
+    )
+
+
 @pytest.mark.parametrize(
     ("settled", "expected_error_broadcasts"),
     [(True, 1), (False, 0)],

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1535,6 +1535,13 @@ async def test_live_lease_injection_rejects_delivery_on_corrupt_or_refused(
     assert len(rejected) == 1
     assert rejected[0]["client_message_id"] == "rejected-turn-1"
     assert rejected[0]["rejection_outcome"] == "not_accepted"
+    db_session.expire_all()
+    stored = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == "rejected-turn-1")
+        .one()
+    )
+    assert stored.delivery_status == DELIVERY_FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2903,6 +2903,9 @@ async def test_resume_background_broadcasts_corrective_event_after_restore(
     event vocabulary the historical-replay path uses for PAUSED/WAITING_FOR_USER."""
     owner = _user(db_session, "restore-broadcast-owner")
     task = _task(db_session, owner.id, status=prior_status)
+    task.error_message = "earlier attempt failed"
+    task.output = "prior turn answer"
+    db_session.commit()
     agent = MagicMock(
         resume_execution_by_id=AsyncMock(
             side_effect=CheckpointUnavailableError("checkpoint query failed")
@@ -2921,6 +2924,8 @@ async def test_resume_background_broadcasts_corrective_event_after_restore(
     db_session.expire_all()
     db_session.refresh(task)
     assert task.status == prior_status
+    assert task.error_message is None  # named: restore clears stale error
+    assert task.output == "prior turn answer"  # named: restore preserves output
 
     corrective = [
         call.args[0]

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -1153,10 +1153,11 @@ def test_database_trace_handler_unbound_legacy_load_fails_closed_after_tagged_ru
         # this unbound legacy reader is not authoritative for. That is a
         # refusal, not the "queried successfully, found nothing" fact that
         # ``None`` reserves.
-        with pytest.raises(CheckpointAccessRefusedError):
+        with pytest.raises(CheckpointAccessRefusedError) as excinfo:
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             )
+        assert excinfo.value.reason == "superseded_legacy"
     finally:
         db.close()
 
@@ -1226,10 +1227,43 @@ def test_database_trace_handler_unbound_root_load_fails_closed_for_active_run(
     try:
         # An active run is in progress under a different lease; this unbound
         # legacy reader is refused, not told the checkpoint is absent.
-        with pytest.raises(CheckpointAccessRefusedError):
+        with pytest.raises(CheckpointAccessRefusedError) as excinfo:
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             )
+        assert excinfo.value.reason == "active_run"
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_refuses_lease_bound_to_another_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bound lease for a different task id is not this reader's partition
+    -- distinct from ``active_run``/``superseded_legacy``: the read itself
+    is contaminated by a stray context, not a policy decision about this
+    task's own rows."""
+    SessionLocal, db, task = _create_trace_handler_test_task("lease-mismatch-load")
+    task_id = int(task.id)
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with (
+            bind_task_lease_context(TaskLease(task_id + 1, "runner-a", "run-a")),
+            pytest.raises(CheckpointAccessRefusedError) as excinfo,
+        ):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            )
+        assert excinfo.value.reason == "lease_mismatch"
     finally:
         db.close()
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -12,7 +12,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool, StaticPool
 
-from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
+from xagent.core.agent.checkpoint import (
+    CHECKPOINT_EVENT_TYPE,
+    CHECKPOINT_TYPE,
+    CheckpointAccessRefusedError,
+)
 from xagent.core.agent.trace import (
     TraceAction,
     TraceCategory,
@@ -1145,12 +1149,14 @@ def test_database_trace_handler_unbound_legacy_load_fails_closed_after_tagged_ru
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        assert (
+        # A tagged run has positive proof a checkpoint exists in a partition
+        # this unbound legacy reader is not authoritative for. That is a
+        # refusal, not the "queried successfully, found nothing" fact that
+        # ``None`` reserves.
+        with pytest.raises(CheckpointAccessRefusedError):
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             )
-            is None
-        )
     finally:
         db.close()
 
@@ -1218,12 +1224,62 @@ def test_database_trace_handler_unbound_root_load_fails_closed_for_active_run(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        assert (
+        # An active run is in progress under a different lease; this unbound
+        # legacy reader is refused, not told the checkpoint is absent.
+        with pytest.raises(CheckpointAccessRefusedError):
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             )
-            is None
+    finally:
+        db.close()
+
+
+def test_partition_refusal_is_distinct_from_absence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused partition read must never be reported the same way as a
+    query that succeeded and genuinely found nothing."""
+    SessionLocal, db, task = _create_trace_handler_test_task("refusal-vs-absence")
+    task_id = int(task.id)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="tagged-checkpoint",
+            execution_id="shared-execution",
+            label="tagged",
+            timestamp=datetime.now(timezone.utc),
+            run_id="run-a",
         )
+    )
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        # No lease bound, and a tagged run has positive proof a checkpoint
+        # exists: this legacy reader is not authoritative for that
+        # partition and must be refused, not told "absent".
+        with pytest.raises(CheckpointAccessRefusedError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            )
+        # A reader that IS bound to the tagged run reads its own partition
+        # and, for an execution id with no matching row there, gets the
+        # authoritative "queried successfully, found nothing" result.
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert (
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "other-execution"
+                )
+                is None
+            )
     finally:
         db.close()
 

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -415,6 +415,62 @@ def test_release_task_lease_refuses_ownerless_running_state(db_session) -> None:
     assert task.lease_expires_at is not None
 
 
+@pytest.mark.parametrize(
+    "status",
+    [TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER],
+)
+def test_release_to_non_terminal_status_clears_stale_error_message(
+    db_session, status
+) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    task.error_message = "earlier failure"
+    task.output = "prior answer"
+    db_session.commit()
+
+    changed = task_lease_service.release_task_lease_no_commit(
+        db_session,
+        lease,
+        status=status,
+    )
+    db_session.commit()
+
+    assert changed is True
+    db_session.refresh(task)
+    assert task.status == status
+    assert task.error_message is None
+    assert task.output == "prior answer"
+
+
+@pytest.mark.parametrize(
+    "status",
+    [TaskStatus.COMPLETED, TaskStatus.FAILED],
+)
+def test_release_to_terminal_status_leaves_content_fields_alone(
+    db_session, status
+) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    task.error_message = "earlier failure"
+    task.output = "prior answer"
+    db_session.commit()
+
+    changed = task_lease_service.release_task_lease_no_commit(
+        db_session,
+        lease,
+        status=status,
+    )
+    db_session.commit()
+
+    assert changed is True
+    db_session.refresh(task)
+    assert task.status == status
+    assert task.error_message == "earlier failure"
+    assert task.output == "prior answer"
+
+
 @pytest.mark.asyncio
 async def test_lease_heartbeat_keeps_loop_responsive_during_pool_checkout(
     queue_pool_runtime_db,

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1412,6 +1412,85 @@ def test_prune_matches_legacy_execution_id_shapes(
         db.close()
 
 
+def test_checkpoint_execution_id_predicate_matches_the_python_helper() -> None:
+    """The read query and history pruning share one SQL predicate; it must
+    agree with ``checkpoint_execution_id()`` (the Python SSOT the storage
+    encoder also follows) on every shape a stored row can take, not just the
+    common one. A row with no execution-id information anywhere never
+    matches a real, non-empty id -- absence and the empty string are the
+    same SQL fact."""
+    from xagent.core.agent.checkpoint import checkpoint_execution_id
+    from xagent.web.api.trace_handlers import _checkpoint_execution_id_predicate
+
+    real_execution_id = "exec-parity-real"
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        rows = {
+            "absent-fields": {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {"context": {"messages": []}},
+            },
+            "present-but-empty": {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "root_execution_id": "",
+                "execution_id": "",
+                "snapshot": {"context": {"messages": []}},
+            },
+            "snapshot-only": {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {
+                    "execution_id": real_execution_id,
+                    "context": {"messages": []},
+                },
+            },
+            "tagged-only": {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "root_execution_id": real_execution_id,
+                "snapshot": {"context": {"messages": []}},
+            },
+        }
+        for event_id, data in rows.items():
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=event_id,
+                    event_type="system_update_general",
+                    timestamp=datetime.now(timezone.utc),
+                    data=data,
+                )
+            )
+        db.commit()
+
+        # The Python SSOT: only the two id-bearing shapes resolve to the
+        # real execution id, regardless of whether it came from the root
+        # tag or the nested snapshot.
+        expected_matches = {"snapshot-only", "tagged-only"}
+        for event_id, data in rows.items():
+            resolved = checkpoint_execution_id(data)
+            if event_id in expected_matches:
+                assert resolved == real_execution_id, event_id
+            else:
+                assert resolved == "", event_id
+
+        # The SQL predicate must select exactly the same matching set.
+        matched_ids = {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent)
+            .filter(
+                DatabaseTraceEvent.task_id == task_id,
+                _checkpoint_execution_id_predicate(real_execution_id),
+            )
+            .all()
+        }
+        assert matched_ids == expected_matches
+    finally:
+        db.close()
+
+
 def test_database_trace_handler_prune_disabled_keeps_all_checkpoints(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1989,3 +1989,40 @@ def test_checkpoint_partition_read_failure_is_translated_and_chained(
     finally:
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         db.close()
+
+
+def test_checkpoint_read_for_missing_task_row_is_unavailable_not_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vanished task row is an exceptional condition, not a policy one.
+
+    Refusal means "a checkpoint may exist but this reader is not the one
+    allowed to observe it", which callers answer by leaving the task
+    alone. A task row that is simply gone tells the reader nothing about
+    the partition, so it belongs with the read failures instead -- the two
+    verdicts are decided on adjacent branches and must not collapse.
+    """
+    from xagent.core.agent.checkpoint import (
+        CheckpointAccessRefusedError,
+        CheckpointUnavailableError,
+    )
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        clear_degradation,
+    )
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        handler = DatabaseTraceHandler(999999)
+        with pytest.raises(CheckpointUnavailableError) as missing_row:
+            handler._sync_load_latest_checkpoint("exec-missing-task")
+        assert not isinstance(missing_row.value, CheckpointAccessRefusedError)
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1859,3 +1859,133 @@ def test_load_checkpoint_readable_type_without_snapshot_raises_corrupt(
             )
     finally:
         db.close()
+
+
+def test_checkpoint_read_failure_preserves_pool_timeout_cause_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Translating a read failure must chain the original exception.
+
+    Resume consumers discriminate pool exhaustion before they act on an
+    unavailable checkpoint, and ``is_database_pool_timeout`` finds that
+    fact by walking ``__cause__``/``__context__``. A translation that drops
+    the chain would make an exhausted-pool read look like an ordinary
+    unavailable one, and the recovery path would answer it by issuing more
+    database writes against the same exhausted pool.
+    """
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.db_runtime import is_database_pool_timeout
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        clear_degradation,
+    )
+
+    def timing_out_get_db() -> Iterator[Session]:
+        raise SQLAlchemyTimeoutError("QueuePool limit reached")
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", timing_out_get_db)
+    clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    try:
+        handler = DatabaseTraceHandler(999999)
+        with pytest.raises(CheckpointUnavailableError) as checkout_failure:
+            handler._sync_load_latest_checkpoint("exec-checkout-timeout")
+        assert is_database_pool_timeout(checkout_failure.value)
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+
+
+def test_checkpoint_query_failure_preserves_pool_timeout_cause_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The row-scan translation carries the same obligation as checkout."""
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+    from sqlalchemy.orm import Query
+
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.db_runtime import is_database_pool_timeout
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        clear_degradation,
+    )
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+
+        def failing_all(self: Query) -> Any:
+            del self
+            raise SQLAlchemyTimeoutError("QueuePool limit reached")
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        # Only the row scan uses ``.all()``; partition resolution reads
+        # through ``one_or_none``/``first`` and still completes, so this
+        # lands on the row-scan translation rather than the partition one.
+        monkeypatch.setattr(Query, "all", failing_all)
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        handler = DatabaseTraceHandler(task_id)
+        with pytest.raises(CheckpointUnavailableError) as query_failure:
+            handler._sync_load_latest_checkpoint("exec-query-timeout")
+        assert "checkpoint query failed" in str(query_failure.value)
+        assert is_database_pool_timeout(query_failure.value)
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()
+
+
+def test_checkpoint_partition_read_failure_is_translated_and_chained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partition resolution is part of the read, not a step outside it.
+
+    A database failure while resolving which run partition this reader may
+    observe leaves the partition unknown, so the read could not be
+    completed. It must surface as ``CheckpointUnavailableError`` like any
+    other query failure -- a raw driver exception here would bypass every
+    consumer that catches the checkpoint read contract.
+    """
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.db_runtime import is_database_pool_timeout
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+
+        def failing_partition(self: DatabaseTraceHandler, _db: Session) -> Any:
+            del self
+            raise SQLAlchemyTimeoutError("QueuePool limit reached")
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        monkeypatch.setattr(
+            DatabaseTraceHandler,
+            "_root_checkpoint_read_partition",
+            failing_partition,
+        )
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        handler = DatabaseTraceHandler(task_id)
+        with pytest.raises(CheckpointUnavailableError) as partition_failure:
+            handler._sync_load_latest_checkpoint("exec-partition-failure")
+        assert is_database_pool_timeout(partition_failure.value)
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -2410,6 +2410,7 @@ def test_checkpoint_read_for_missing_task_row_is_unavailable_not_refused(
     )
     from xagent.web.services.ops_signals import (
         CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
         clear_degradation,
     )
 
@@ -2425,6 +2426,7 @@ def test_checkpoint_read_for_missing_task_row_is_unavailable_not_refused(
         with pytest.raises(CheckpointUnavailableError) as missing_row:
             handler._sync_load_latest_checkpoint("exec-missing-task")
         assert not isinstance(missing_row.value, CheckpointAccessRefusedError)
+        assert CHECKPOINT_LOAD_UNAVAILABLE not in active_degradations()
     finally:
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         db.close()

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1778,11 +1778,14 @@ def test_load_checkpoint_generic_decode_failure_raises_unavailable(
         db.close()
 
 
-def test_load_checkpoint_undecodable_window_full_raises_unavailable_not_corrupt(
+def test_load_checkpoint_undecodable_full_batch_is_exhausted_raises_corrupt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A full scan window can't prove the candidate set is exhausted."""
-    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    """A first batch exactly at the page size is not ambiguous: the scan
+    pages past it, finds nothing more, and that proves the matching set was
+    exhausted -- exclusively permanent decode failures is corrupt, not a
+    conservative unavailable."""
+    from xagent.core.agent.checkpoint import CheckpointCorruptError
     from xagent.web.api.trace_handlers import CHECKPOINT_ROW_SCAN_LIMIT
 
     SessionLocal = _session_factory()
@@ -1795,11 +1798,11 @@ def test_load_checkpoint_undecodable_window_full_raises_unavailable_not_corrupt(
             db.add(
                 DatabaseTraceEvent(
                     task_id=task_id,
-                    event_id=f"window-full-{i}",
+                    event_id=f"full-batch-{i}",
                     event_type="system_update_general",
                     timestamp=now + timedelta(seconds=i),
                     data=_checkpoint_data(
-                        "exec-window-full",
+                        "exec-full-batch",
                         {
                             "__encoding": MESSAGE_REFS_ENCODING,
                             "count": 1,
@@ -1815,10 +1818,205 @@ def test_load_checkpoint_undecodable_window_full_raises_unavailable_not_corrupt(
             "xagent.web.api.trace_handlers.get_db",
             lambda: _get_db_factory(SessionLocal),
         )
-        with pytest.raises(CheckpointUnavailableError):
+        with pytest.raises(CheckpointCorruptError):
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
-                "exec-window-full"
+                "exec-full-batch"
             )
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_scan_continues_past_a_batch_of_undecodable_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A readable row in a later batch is still found -- the scan does not
+    give up after the first page, it pages until the set is exhausted or a
+    readable row turns up."""
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        # Newest four rows (scanned first, in two pages of two) are
+        # undecodable; the oldest row (third page) is readable.
+        for i in range(4):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=f"multi-batch-bad-{i}",
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=10 - i),
+                    data=_checkpoint_data(
+                        "exec-multi-batch",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{i}"]),
+                            "refs": [f"sha256:missing-{i}"],
+                        },
+                    ),
+                )
+            )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="multi-batch-readable",
+                event_type="system_update_general",
+                timestamp=now,
+                data=_checkpoint_data(
+                    "exec-multi-batch", [{"role": "user", "content": "hello"}]
+                ),
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.CHECKPOINT_ROW_SCAN_LIMIT", 2
+        )
+        loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+            "exec-multi-batch"
+        )
+        assert loaded is not None
+        assert loaded["context"]["messages"] == [{"role": "user", "content": "hello"}]
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_scan_exhausts_multiple_batches_raises_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every row across every batch is permanently undecodable, and the
+    scan proves the set exhausted (a page shorter than the batch size) --
+    corrupt, not unavailable."""
+    from xagent.core.agent.checkpoint import CheckpointCorruptError
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        for i in range(4):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=f"multi-batch-corrupt-{i}",
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=i),
+                    data=_checkpoint_data(
+                        "exec-multi-batch-corrupt",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{i}"]),
+                            "refs": [f"sha256:missing-{i}"],
+                        },
+                    ),
+                )
+            )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.CHECKPOINT_ROW_SCAN_LIMIT", 2
+        )
+        with pytest.raises(CheckpointCorruptError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-multi-batch-corrupt"
+            )
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_generic_failure_mid_scan_raises_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic (transient) failure on one row anywhere in a multi-batch
+    scan is conservatively unavailable, even if every other row in the scan
+    is a confirmed permanent decode failure."""
+    from unittest.mock import patch
+
+    import xagent.web.services.trace_message_storage as tms
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        # Newest row is marked to fail the blob prefetch generically; it is
+        # otherwise perfectly readable (encoded so decode actually needs the
+        # blob lookup this test makes fail).
+        flaky_data = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data(
+                "exec-mid-scan-failure",
+                [{"role": "user", "content": "needs prefetch"}],
+            ),
+        )
+        flaky_data["__test_trigger_generic_failure"] = True
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="mid-scan-flaky",
+                event_type="system_update_general",
+                timestamp=now + timedelta(seconds=10),
+                data=flaky_data,
+            )
+        )
+        # Older rows are permanently undecodable, spanning a second batch.
+        for i in range(3):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=f"mid-scan-corrupt-{i}",
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=i),
+                    data=_checkpoint_data(
+                        "exec-mid-scan-failure",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{i}"]),
+                            "refs": [f"sha256:missing-{i}"],
+                        },
+                    ),
+                )
+            )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.CHECKPOINT_ROW_SCAN_LIMIT", 2
+        )
+        original_lookup = tms._load_trace_blob_lookup
+
+        def _flaky_lookup(db: Session, *, task_id: int, data_items: list[Any]) -> Any:
+            if any(
+                isinstance(item, dict) and item.get("__test_trigger_generic_failure")
+                for item in data_items
+            ):
+                raise RuntimeError("transient db error")
+            return original_lookup(db, task_id=task_id, data_items=data_items)
+
+        with patch.object(tms, "_load_trace_blob_lookup", side_effect=_flaky_lookup):
+            with pytest.raises(CheckpointUnavailableError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "exec-mid-scan-failure"
+                )
     finally:
         db.close()
 

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1600,3 +1600,262 @@ def test_convert_trace_checkpoint_messages_continues_after_row_error(
         )
     finally:
         db.close()
+
+
+def test_load_checkpoint_query_failure_raises_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
+
+    def broken_get_db() -> Iterator[Session]:
+        raise RuntimeError("pool checkout failed")
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", broken_get_db)
+    clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    try:
+        handler = DatabaseTraceHandler(999999)
+        with pytest.raises(CheckpointUnavailableError):
+            handler._sync_load_latest_checkpoint("exec-query-failure")
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+
+
+@pytest.mark.asyncio
+async def test_load_checkpoint_async_wrapper_propagates_query_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The async wrapper must not collapse a read failure back to ``None``."""
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        clear_degradation,
+    )
+
+    def broken_get_db() -> Iterator[Session]:
+        raise RuntimeError("pool checkout failed")
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", broken_get_db)
+    clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    try:
+        handler = DatabaseTraceHandler(999999)
+        with pytest.raises(CheckpointUnavailableError):
+            await handler.load_latest_checkpoint("exec-query-failure-async")
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+
+
+def test_load_checkpoint_zero_rows_returns_none_and_clears_stale_degradation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        # A prior transient failure left the signal active; a query that
+        # completes successfully -- even with zero matching rows -- must
+        # clear it, not just a query that finds a checkpoint.
+        register_degradation(CHECKPOINT_LOAD_UNAVAILABLE, "stale from a prior failure")
+        try:
+            loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-empty"
+            )
+            assert loaded is None
+            assert CHECKPOINT_LOAD_UNAVAILABLE not in active_degradations()
+        finally:
+            clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_all_rows_undecodable_raises_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every matching row permanently undecodable, set exhausted -> corrupt."""
+    from xagent.core.agent.checkpoint import CheckpointCorruptError
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        for offset, event_id in enumerate(["corrupt-old", "corrupt-new"]):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=event_id,
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=offset),
+                    data=_checkpoint_data(
+                        "exec-corrupt",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{event_id}"]),
+                            "refs": [f"sha256:missing-{event_id}"],
+                        },
+                    ),
+                )
+            )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        with pytest.raises(CheckpointCorruptError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint("exec-corrupt")
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_generic_decode_failure_raises_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient failure on every row must not be reported as corrupt."""
+    from unittest.mock import patch
+
+    import xagent.web.services.trace_message_storage as tms
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        encoded = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data(
+                "exec-transient", [{"role": "user", "content": "needs prefetch"}]
+            ),
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="needs-prefetch",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=encoded,
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        with patch.object(
+            tms,
+            "_load_trace_blob_lookup",
+            side_effect=RuntimeError("transient db error"),
+        ):
+            with pytest.raises(CheckpointUnavailableError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "exec-transient"
+                )
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_undecodable_window_full_raises_unavailable_not_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full scan window can't prove the candidate set is exhausted."""
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.api.trace_handlers import CHECKPOINT_ROW_SCAN_LIMIT
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        for i in range(CHECKPOINT_ROW_SCAN_LIMIT):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=f"window-full-{i}",
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=i),
+                    data=_checkpoint_data(
+                        "exec-window-full",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{i}"]),
+                            "refs": [f"sha256:missing-{i}"],
+                        },
+                    ),
+                )
+            )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        with pytest.raises(CheckpointUnavailableError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-window-full"
+            )
+    finally:
+        db.close()
+
+
+def test_load_checkpoint_readable_type_without_snapshot_raises_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row that claims to be a checkpoint but carries no payload is corrupt,
+    not absent -- it must not be silently treated as "no checkpoint"."""
+    from xagent.core.agent.checkpoint import CheckpointCorruptError
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="no-snapshot",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data={
+                    "checkpoint_type": CHECKPOINT_TYPE,
+                    "execution_id": "exec-no-snapshot",
+                },
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        with pytest.raises(CheckpointCorruptError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-no-snapshot"
+            )
+    finally:
+        db.close()

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -2015,16 +2015,88 @@ def test_load_checkpoint_scan_exhausts_multiple_batches_raises_corrupt(
         db.close()
 
 
+def test_load_checkpoint_scan_stops_at_max_page_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With history pruning disabled, a backlog large enough to keep paging
+    past the cap must stop and fail unavailable instead of scanning the
+    matching set to exhaustion query by query."""
+    from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        # 4 undecodable rows with a page size of 2 and a page cap of 2 means
+        # both pages come back full (no short page to prove exhaustion), so
+        # the loop must hit the cap on the 3rd iteration instead of issuing
+        # a 3rd query.
+        for i in range(4):
+            db.add(
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id=f"max-page-cap-{i}",
+                    event_type="system_update_general",
+                    timestamp=now + timedelta(seconds=i),
+                    data=_checkpoint_data(
+                        "exec-max-page-cap",
+                        {
+                            "__encoding": MESSAGE_REFS_ENCODING,
+                            "count": 1,
+                            "hash": canonical_json_hash([f"sha256:missing-{i}"]),
+                            "refs": [f"sha256:missing-{i}"],
+                        },
+                    ),
+                )
+            )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.CHECKPOINT_ROW_SCAN_LIMIT", 2
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.CHECKPOINT_SCAN_MAX_PAGES", 2
+        )
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        with pytest.raises(CheckpointUnavailableError):
+            DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "exec-max-page-cap"
+            )
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()
+
+
 def test_load_checkpoint_generic_failure_mid_scan_raises_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A generic (transient) failure on one row anywhere in a multi-batch
     scan is conservatively unavailable, even if every other row in the scan
-    is a confirmed permanent decode failure."""
+    is a confirmed permanent decode failure. The final raise must also
+    register the degradation signal -- the intervening successful page
+    fetches clear it, so nothing else re-raises it before this raise site
+    does."""
     from unittest.mock import patch
 
     import xagent.web.services.trace_message_storage as tms
     from xagent.core.agent.checkpoint import CheckpointUnavailableError
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
 
     SessionLocal = _session_factory()
     db = SessionLocal()
@@ -2091,12 +2163,15 @@ def test_load_checkpoint_generic_failure_mid_scan_raises_unavailable(
                 raise RuntimeError("transient db error")
             return original_lookup(db, task_id=task_id, data_items=data_items)
 
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         with patch.object(tms, "_load_trace_blob_lookup", side_effect=_flaky_lookup):
             with pytest.raises(CheckpointUnavailableError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "exec-mid-scan-failure"
                 )
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active_degradations()
     finally:
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         db.close()
 
 

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -2213,6 +2213,56 @@ def test_load_checkpoint_readable_type_without_snapshot_raises_corrupt(
         db.close()
 
 
+def test_load_checkpoint_snapshotless_newest_row_does_not_shadow_older_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A newest row with a readable checkpoint_type but no snapshot is a
+    per-row permanent failure, not a verdict on the matching set: the scan
+    falls through to the older valid row and returns its snapshot."""
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="shadowing-no-snapshot",
+                event_type="system_update_general",
+                timestamp=now + timedelta(seconds=10),
+                data={
+                    "checkpoint_type": CHECKPOINT_TYPE,
+                    "execution_id": "exec-shadowed",
+                },
+            )
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="shadowing-valid-older",
+                event_type="system_update_general",
+                timestamp=now,
+                data=_checkpoint_data(
+                    "exec-shadowed", [{"role": "user", "content": "hello"}]
+                ),
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+            "exec-shadowed"
+        )
+        assert loaded is not None
+        assert loaded["context"]["messages"] == [{"role": "user", "content": "hello"}]
+    finally:
+        db.close()
+
+
 def test_checkpoint_read_failure_preserves_pool_timeout_cause_chain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

A transient database error while loading the latest checkpoint is currently indistinguishable from "no checkpoint exists": the loader collapses every failure to `None`, and resume paths interpret that as authoritative absence — silently rebuilding an empty context (discarding execution position, DAG state, and the completed-tool ledger, with the risk of re-executing side effects) or reporting a permanent condition for a retryable one.

This change makes checkpoint reads a typed contract and threads it through every consumer:

- `CheckpointReadError(RuntimeError)` with `CheckpointUnavailableError` (transient: session checkout, query, or partition-resolution failure; registers a self-clearing degradation signal), `CheckpointCorruptError` (matching rows exist but none decodes; malformed or snapshot-less payloads), and `CheckpointAccessRefusedError` (the run-partition policy refuses the read — including when a run-tagged checkpoint provably exists — which is not absence). `None` now means exactly one thing: the query succeeded and the reader's own partition has no matching row. The matching predicate is pushed into SQL so the row window bounds matching rows, and a window full of undecodable rows classifies as unavailable rather than corrupt.
- Pass-through layers (`Tracer`, `TraceCheckpointStore`, `read_latest_checkpoint_payload`, the agent-tool delegate) propagate the contract verbatim; the tracer returns the first capable reader's result instead of probing later handlers. Reader-less tracer stacks keep their existing absent semantics.
- `AgentRunner` never builds a fresh context on a failed read, and the message-injection baseline read happens before any context mutation, so a rejected injection leaves no dedupe-matching residue.
- Web resume: the lease acquisition path captures the pre-acquisition status, and a transient read failure restores the task to that status (instead of settling it as FAILED) through the exact-lease fence, including when A2A hands over a pre-acquired lease. Database-pool exhaustion keeps its existing no-write TTL-recovery path, in which case the task recovers as PAUSED. The live-lease injection point degrades unavailable reads to the existing deferred-delivery path and rejects corrupt/refused ones without orphaning the delivery claim.
- A2A input-required: unavailable maps to a retryable 503 while the task stays `waiting_for_user`; corrupt and refused map to distinct terminal 400s; all three restore the exact prelease first.

## Behavior changes

- Resume paths no longer continue on an empty context after a transient read failure; they surface a retryable error and preserve the waiting state (or PAUSED via TTL recovery under pool exhaustion).
- A2A distinguishes retryable unavailability (503) from absence and corruption (400s) instead of one uniform message.
- `/health` gains a `CHECKPOINT_LOAD_UNAVAILABLE` degradation signal that self-clears on the next successful read.
- Authoritative-absence behavior is unchanged: legitimate absent checkpoints keep today's semantics everywhere.

## Verification

- 134 tests across the checkpoint/runner/websocket/A2A surfaces (18 net-new plus updated fakes), including: four-state translation at the loader (query failure, zero rows, all-rows-undecodable, partition refusal vs absence), pass-through pins at each intermediate layer, no-fresh-context and zero-residue runner pins, restore-to-prior-status for both self-acquired and handed-over leases, pool-timeout ordering with exception-chain preservation, deferred-delivery degradation and claim non-orphaning, and per-state A2A error codes.
- Mutation checks: restoring the original catch-all, conflating refusal with absence, swapping the window-full classification, reordering the baseline read, and disabling the restore branch each turn specific tests red.
- `tests/web` fully green; full-suite failures are a strict subset of the base commit's pre-existing set (verified against a clean checkout at the same base).

Fixes #978.
