### PR TITLE
fix(security): refuse a client-supplied execution scope at the task-create boundary

### DIFF
--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -199,7 +199,7 @@ def _coerce_snapshot_version(raw_version: Any) -> int:
     directly, and a row persisted before ``execution_scope`` was reserved at
     the request boundary (``CLIENT_RESERVED_AGENT_CONFIG_KEYS``,
     ``xagent.web.services.task_runtime``) still carries whatever a request
-    seeded at the time. Exactly one value means "authentic snapshot written
+    seeded at the time (issue #1135). Exactly one value means "authentic snapshot written
     before this field existed": ``0``, what an absent key decodes to.
     That marker carries real trust -- the *older* half of
     ``_validate_execution_scope_snapshot_candidate``'s asymmetric gate is
@@ -780,9 +780,12 @@ class DeferToSnapshot:
     ``session_factory`` (``TaskRuntimeContext.session_factory``,
     ``xagent.core.task_runtime``) and can write this column directly, and a
     row persisted before the request-body refusal existed still carries
-    whatever a request seeded at the time. No resolver in this repository
-    sets ``snapshot_defines_namespace=True``, and none should until the
-    snapshot is server-owned end to end.
+    whatever a request seeded at the time -- those rows are not disarmed by
+    that refusal and cannot be judged from the column itself, since a value
+    stored then could name any version or marker (issue #1135 owns clearing
+    them). No resolver in this repository sets
+    ``snapshot_defines_namespace=True``, and none should until the snapshot is
+    server-owned end to end.
     The flag exists so the abstention shape a workforce sub-task needs is
     expressible and reviewable; it is inert until something opts in.
 

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -199,9 +199,11 @@ def _coerce_snapshot_version(raw_version: Any) -> int:
     directly, and a row persisted before ``execution_scope`` was reserved at
     the request boundary (``CLIENT_RESERVED_AGENT_CONFIG_KEYS``,
     ``xagent.web.services.task_runtime``) still carries whatever a request
-    seeded at the time (issue #1135). Exactly one value means "authentic snapshot written
-    before this field existed": ``0``, what an absent key decodes to.
-    That marker carries real trust -- the *older* half of
+    seeded at the time (issue #1135). One value is the pre-versioning shape
+    sentinel: ``0``, what an absent key decodes to. It says nothing about who
+    wrote the snapshot -- omitting the field produces the same value, so it is
+    a statement about shape, not provenance. It still decides handling -- the
+    *older* half of
     ``_validate_execution_scope_snapshot_candidate``'s asymmetric gate is
     relaxed on the ``snapshot_defines_namespace=True`` branch, where such a
     snapshot's namespace fields are then used verbatim -- so a value that

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -759,15 +759,25 @@ class DeferToSnapshot:
     an already-resolved scope -- those are different trust tiers, and this
     contract cannot tell them apart at read time. It cannot be fixed here
     either: any provenance marker would live in the same client-writable
-    field as the snapshot it vouches for, so the fix belongs at the input
-    boundary, where that key stops being accepted from a request (tracked as
-    issue #1016).
+    field as the snapshot it vouches for. The actual fix is at the input
+    boundary instead: a task-create request body can no longer seed this key
+    at all -- ``execution_scope`` is one of
+    ``CLIENT_RESERVED_AGENT_CONFIG_KEYS`` (``xagent.web.services.task_runtime``),
+    stripped from every client-supplied ``agent_config`` before it reaches
+    ``Task.agent_config`` (issue #1016).
 
     That makes ``snapshot_defines_namespace=True`` unshippable for now, not
-    merely delicate: with the namespace taken verbatim, a request that can
-    write ``Task.agent_config`` chooses the namespace, and public widget and
-    share task creation copy that field wholesale. No resolver in this
-    repository sets it, and none should until the snapshot is server-owned.
+    merely delicate: with the namespace taken verbatim, any writer that can
+    put a client-seeded value into ``Task.agent_config`` chooses the
+    namespace. The request-body boundary now refuses ``execution_scope``, but
+    the column is not closed under that refusal: closed-source distributions
+    register runtime-extension providers that receive a raw
+    ``session_factory`` (``TaskRuntimeContext.session_factory``,
+    ``xagent.core.task_runtime``) and can write this column directly, and a
+    row persisted before the request-body refusal existed still carries
+    whatever a request seeded at the time. No resolver in this repository
+    sets ``snapshot_defines_namespace=True``, and none should until the
+    snapshot is server-owned end to end.
     The flag exists so the abstention shape a workforce sub-task needs is
     expressible and reviewable; it is inert until something opts in.
 
@@ -1253,13 +1263,17 @@ def _execution_scope_narrowing_violations(
 
     Used only on :func:`resolve_execution_scope`'s resolver-abstention
     branch, where the resolver has supplied a mandatory *fallback* instead
-    of an authoritative answer: a persisted snapshot is
-    client-influenceable (a client-supplied ``agent_config`` can carry an
-    ``execution_scope`` key that reaches the persisted snapshot -- see
-    :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`), so an unchecked snapshot here
-    would let a caller widen its own namespace past the resolver's own most
-    conservative answer for the task. Returns an empty dict when ``snapshot``
-    narrows (or matches) ``fallback`` on every field below.
+    of an authoritative answer: a persisted snapshot remains untrusted input
+    -- a runtime-extension provider can write ``Task.agent_config`` directly
+    through its ``session_factory`` (``TaskRuntimeContext.session_factory``,
+    ``xagent.core.task_runtime``), bypassing every request-body sanitizer,
+    and a row persisted before ``execution_scope`` was reserved at the
+    request boundary (``CLIENT_RESERVED_AGENT_CONFIG_KEYS``,
+    ``xagent.web.services.task_runtime``) still carries whatever value a
+    request seeded at the time -- so an unchecked snapshot here would let a
+    caller widen its own namespace past the resolver's own most conservative
+    answer for the task. Returns an empty dict when ``snapshot`` narrows (or
+    matches) ``fallback`` on every field below.
 
     The governing rule, per field: narrowing can only extend scoping the
     fallback *already committed to*. If ``fallback``'s value for a field is
@@ -1512,12 +1526,14 @@ def resolve_execution_scope(
       - ``False`` (the default): the shape-version gate applies in both
         directions (the snapshot is about to be compared), and the snapshot
         is used only if it is a *narrowing* of the carrier's ``fallback``
-        (see :func:`_execution_scope_narrowing_violations`) -- a snapshot is
-        client-influenceable (a client-supplied ``agent_config`` can carry
-        an ``execution_scope`` key that reaches the persisted snapshot), so
-        an unchecked snapshot here would let a caller widen its own
-        namespace past the resolver's own conservative fallback. A
-        non-narrowing snapshot raises
+        (see :func:`_execution_scope_narrowing_violations`) -- a snapshot
+        remains untrusted input regardless of the request-body refusal at
+        task-create time: a runtime-extension provider can write
+        ``Task.agent_config`` directly through its ``session_factory``, and
+        a row persisted before that refusal existed still carries whatever a
+        request seeded at the time, so an unchecked snapshot here would let
+        a caller widen its own namespace past the resolver's own
+        conservative fallback. A non-narrowing snapshot raises
         :class:`ExecutionScopeAbstentionMismatchError` (a subclass of
         :class:`ExecutionScopeAuthorityError` -- see that class for why the
         distinction matters to :func:`resolve_execution_scope_off_turn`).

--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -192,10 +192,15 @@ def _coerce_scope_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
 def _coerce_snapshot_version(raw_version: Any) -> int:
     """Read ``from_dict``'s ``version`` field, or reject it as malformed.
 
-    ``version`` reaches here from a snapshot that can originate in a client-
-    supplied ``Task.agent_config`` (see :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`),
-    so it is untrusted input, and exactly one value means "authentic snapshot
-    written before this field existed": ``0``, what an absent key decodes to.
+    ``version`` reaches here from a snapshot that remains untrusted input: a
+    runtime-extension provider holding a ``session_factory``
+    (:data:`xagent.core.task_runtime.TaskRuntimeContext.session_factory`) can
+    write ``Task.agent_config`` (see :data:`EXECUTION_SCOPE_AGENT_CONFIG_KEY`)
+    directly, and a row persisted before ``execution_scope`` was reserved at
+    the request boundary (``CLIENT_RESERVED_AGENT_CONFIG_KEYS``,
+    ``xagent.web.services.task_runtime``) still carries whatever a request
+    seeded at the time. Exactly one value means "authentic snapshot written
+    before this field existed": ``0``, what an absent key decodes to.
     That marker carries real trust -- the *older* half of
     ``_validate_execution_scope_snapshot_candidate``'s asymmetric gate is
     relaxed on the ``snapshot_defines_namespace=True`` branch, where such a

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -808,7 +808,7 @@ def _selected_file_ids_from_agent_config(
 ) -> list[str]:
     if not isinstance(agent_config, dict):
         return []
-    raw_file_ids = agent_config.get("selected_file_ids")
+    raw_file_ids = agent_config.get(SELECTED_FILE_IDS_AGENT_CONFIG_KEY)
     if not isinstance(raw_file_ids, list):
         return []
     return [

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -111,6 +111,7 @@ from ..services.task_lease_service import (
     stop_task_lease_heartbeat,
 )
 from ..services.task_runtime import (
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TaskRuntimeExtensionError,
     agent_config_with_task_extension_bindings,
     build_task_runtime,
@@ -164,9 +165,9 @@ def _build_task_agent_config(
     task_agent_config: Dict[str, Any] = sanitize_client_agent_config(
         request_agent_config
     )
-    task_agent_config.pop("selected_file_ids", None)
+    task_agent_config.pop(SELECTED_FILE_IDS_AGENT_CONFIG_KEY, None)
     if selected_file_ids:
-        task_agent_config["selected_file_ids"] = selected_file_ids
+        task_agent_config[SELECTED_FILE_IDS_AGENT_CONFIG_KEY] = selected_file_ids
     return task_agent_config or None
 
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -158,6 +158,7 @@ from ..services.task_lease_service import (
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
 )
+from ..services.task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
 from ..services.uploaded_file_store import (
     StagedUploadedFile,
     SupersededObjectCleanupClaim,
@@ -571,7 +572,7 @@ def _selected_file_ids_from_task_config(task: Any) -> list[str]:
     if not isinstance(agent_config, dict):
         return []
 
-    raw_file_ids = agent_config.get("selected_file_ids")
+    raw_file_ids = agent_config.get(SELECTED_FILE_IDS_AGENT_CONFIG_KEY)
     if not isinstance(raw_file_ids, list):
         return []
 

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -58,6 +58,11 @@ _PUBLIC_METADATA_STATUS_RESERVE_BYTES = 2 * 1024
 # extension names one task actually bound to. Reusing the existing JSON column
 # keeps the per-task binding record migration-free.
 TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
+# Reserved ``tasks.agent_config`` key holding the server-validated list of
+# uploaded file ids bound to one task. ``chat.py``'s ``_build_task_agent_config``
+# owns the value it substitutes; this constant names the key so the sanitizer
+# and that boundary refer to the same string.
+SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # Keys in ``tasks.agent_config`` that only the server may write. Task-create
 # request bodies carry a free-form ``agent_config`` dict that endpoints copy
 # wholesale, so anything the server later reads back as authoritative has to
@@ -97,10 +102,26 @@ TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
 # ``tests/web/test_execution_scope_delegation.py::
 # TestWorkforceTaskConfigSnapshot::test_scope_persisted_when_active`` asserts
 # the server-written scope lands.
+#
+# ``selected_file_ids`` qualifies for the same reason and passes both checks.
+# It was declared server-owned when it was introduced -- ``chat.py``'s
+# ``_build_task_agent_config`` drops the client value and substitutes a list
+# validated against ``UploadedFile.user_id`` and ``task_id IS NULL`` -- but
+# that enforcement was local to one boundary, so the widget and share
+# task-create paths, which never set the key themselves, persisted whatever a
+# request body carried. Both readers (``chat.py``'s turn file materialization
+# and ``websocket.py``'s file-ref echo) re-check ownership in the query, so a
+# forged id could only name a file the publisher already owns and only if the
+# caller knew its uuid4 -- narrower than ``execution_scope``, where naming a
+# namespace is enough. Reserving it moves one invariant to one owner. The
+# ``pop`` in ``_build_task_agent_config`` stays: that boundary substitutes a
+# recomputed list rather than only dropping the client's, and keeping it means
+# the substitution does not depend on this set's contents.
 CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
     {
         TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
         EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+        SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     }
 )
 logger = logging.getLogger(__name__)

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -101,9 +101,11 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # ``False`` (:data:`xagent.web.schemas.chat.TaskCreateRequest.is_preview`) and
 # the re-layer never fires here. So reserving ``is_preview`` or
 # ``preview_agent_id`` would still silently strip them from this config with
-# nothing to restore them, breaking agent-builder preview. (Both readers of
-# ``preview_agent_id`` apply an ownership clause before trusting it, so it is
-# not itself exploitable.)
+# nothing to restore them, breaking agent-builder preview. That it cannot be
+# reserved is not a statement that it is safe: three of its readers resolve it
+# through an ownership-scoped query, but the SSH tools' ``_agent_id_from_task``
+# reads it with no such check and uses it to pick which targets a task may
+# reach, so the answer for that key has to be reader-side (issue #1136).
 #
 # Before adding a key here: (1) confirm no server writer reaches this column
 # *through* the sanitizer (the preview path above is the only known case);

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -60,29 +60,43 @@ _PUBLIC_METADATA_STATUS_RESERVE_BYTES = 2 * 1024
 TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
 # Keys in ``tasks.agent_config`` that only the server may write. Task-create
 # request bodies carry a free-form ``agent_config`` dict that endpoints copy
-# wholesale, so anything the server later reads back as authoritative has to be
-# stripped from that copy first -- otherwise a client can pre-seed it.
+# wholesale, so anything the server later reads back as authoritative has to
+# be stripped from that copy first -- otherwise a client can pre-seed it.
 #
-# ``execution_scope`` is listed because the scope it carries is read back as the
-# authority over where a task's bytes land -- sandbox mount, durable storage
-# prefix, workspace directory, memory dimensions. No provenance marker can make
-# that value trustworthy once it is in the column, because the marker would sit
-# in the same client-writable field as the value it vouches for, so the only
-# place to refuse it is here. The one server-side writer
-# (``build_workforce_task_config``) is on a path that never copies a request
-# dict, so stripping the key cannot reach a server-assigned value.
+# This column's key space is not closed inside this repo: closed-source
+# distributions register providers at startup (see this module's docstring
+# above), and those providers get a ``session_factory``
+# (``xagent.core.task_runtime.TaskRuntimeContext.session_factory``) they can
+# use to write this column directly. An inventory of every reserved key here
+# would only be a claim a future reader trusts instead of re-deriving, so this
+# comment holds none -- the enumeration is #1095's job.
 #
-# Other reserved keys on this column are still pass-through by long-standing
-# behavior and are tracked separately: ``a2a_context_id``, ``auth_mode``,
-# ``guest_id``, ``share_agent_id``, ``share_workforce_id``,
-# ``widget_workforce_id``, ``widget_agent_id``, ``workforce_run_id``,
-# ``a2a_state``, ``trigger_id``, ``trigger_run_id``, ``trigger_type``,
-# ``trigger_test`` and ``is_preview``. That list is the inventory, not a
-# sample: a set holding a few of them implies a protection the rest do not
-# have. Adding any of them needs one check this key did not -- whether an
-# out-of-repo caller sends it in a request body -- because unlike
-# ``execution_scope`` their writers sit next to the sanitizer rather than off
-# its path.
+# Most server writers layer on top of an already-sanitized dict (all three
+# ``sanitize_client_agent_config`` call sites -- ``public_chat_access.py:931``,
+# ``:1079``, ``chat.py:164`` -- sanitize then layer) or build ``agent_config``
+# off this path entirely: ``build_workforce_task_config``,
+# ``_trigger_execution_context`` (``services/triggers.py``), the a2a
+# create/backfill writers, and the workforce widget/share builders. One writer
+# passes *through* the sanitizer instead: ``websocket.py``'s build-preview
+# handler builds a server-owned config carrying ``is_preview: True`` and
+# ``preview_agent_id`` (``websocket.py:8419-8425``) and hands it to
+# ``TaskCreateRequest(agent_config=...)`` passed into ``create_task``
+# (``websocket.py:8447-8466``), layered below the sanitizer rather than above
+# it -- reserving either key there would silently strip it and break
+# agent-builder preview.
+#
+# Before adding a key here: (1) confirm no server writer reaches this column
+# *through* the sanitizer (the preview path above is the only known case);
+# (2) confirm no out-of-repo caller legitimately sends it in a request body
+# (#1095 tracks this).
+#
+# ``execution_scope`` qualifies today: it is read back as the authority over
+# where a task's bytes land -- sandbox mount, durable storage prefix,
+# workspace directory, memory dimensions -- and its one server-side writer,
+# ``build_workforce_task_config``, is off the sanitizer path entirely.
+# ``tests/web/test_execution_scope_delegation.py::
+# TestWorkforceTaskConfigSnapshot::test_scope_persisted_when_active`` asserts
+# the server-written scope lands.
 CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
     {
         TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -22,6 +22,7 @@ from ...config import (
     get_task_runtime_hook_max_workers,
     get_task_runtime_hook_queue_timeout_seconds,
 )
+from ...core.execution_scope import EXECUTION_SCOPE_AGENT_CONFIG_KEY
 from ...core.task_runtime import (
     EMPTY_TASK_RUNTIME_CONTRIBUTION,
     MAX_TASK_RUNTIME_EXTENSIONS,
@@ -62,12 +63,31 @@ TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
 # wholesale, so anything the server later reads back as authoritative has to be
 # stripped from that copy first -- otherwise a client can pre-seed it.
 #
-# Only the binding record is listed today. Other reserved keys on this column
-# (``execution_scope``, ``a2a_context_id``, ``auth_mode``, ``guest_id``) are
-# pass-through by long-standing behavior and are tracked separately; add them
-# here once that change is in scope and every boundary picks it up at once.
+# ``execution_scope`` is listed because the scope it carries is read back as the
+# authority over where a task's bytes land -- sandbox mount, durable storage
+# prefix, workspace directory, memory dimensions. No provenance marker can make
+# that value trustworthy once it is in the column, because the marker would sit
+# in the same client-writable field as the value it vouches for, so the only
+# place to refuse it is here. The one server-side writer
+# (``build_workforce_task_config``) is on a path that never copies a request
+# dict, so stripping the key cannot reach a server-assigned value.
+#
+# Other reserved keys on this column are still pass-through by long-standing
+# behavior and are tracked separately: ``a2a_context_id``, ``auth_mode``,
+# ``guest_id``, ``share_agent_id``, ``share_workforce_id``,
+# ``widget_workforce_id``, ``widget_agent_id``, ``workforce_run_id``,
+# ``a2a_state``, ``trigger_id``, ``trigger_run_id``, ``trigger_type``,
+# ``trigger_test`` and ``is_preview``. That list is the inventory, not a
+# sample: a set holding a few of them implies a protection the rest do not
+# have. Adding any of them needs one check this key did not -- whether an
+# out-of-repo caller sends it in a request body -- because unlike
+# ``execution_scope`` their writers sit next to the sanitizer rather than off
+# its path.
 CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
-    {TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY}
+    {
+        TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
+        EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    }
 )
 logger = logging.getLogger(__name__)
 

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -67,6 +67,11 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # request bodies carry a free-form ``agent_config`` dict that endpoints copy
 # wholesale, so anything the server later reads back as authoritative has to
 # be stripped from that copy first -- otherwise a client can pre-seed it.
+# Refusal has to happen at that copy, not afterwards: a value already sitting
+# in this column cannot be judged trustworthy after the fact, because any
+# provenance marker vouching for it would live in the same client-writable
+# field as the value itself -- the copy point is the only place the
+# distinction between client-seeded and server-written still exists.
 #
 # This column's key space is not closed inside this repo: closed-source
 # distributions register providers at startup (see this module's docstring
@@ -84,11 +89,21 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # ``_trigger_execution_context`` (``services/triggers.py``), the a2a
 # create/backfill writers, and the workforce widget/share builders. One writer
 # passes *through* the sanitizer instead: ``websocket.py``'s
-# ``handle_build_preview_execution`` builds a server-owned config carrying
-# ``is_preview: True`` and ``preview_agent_id`` and hands it to
+# ``handle_build_preview_execution`` assembles a config from the WS message
+# (``instructions``, ``knowledge_bases``, ``skills``, ``tool_categories``, and
+# ``preview_agent_id`` all come from ``message_data.get(...)``; only
+# ``is_preview: True`` is a handler-set literal) and hands it to
 # ``TaskCreateRequest(agent_config=...)`` passed into ``create_task``, layered
-# below the sanitizer rather than above it -- reserving either key there would
-# silently strip it and break agent-builder preview.
+# below the sanitizer rather than above it. ``chat.py``'s ``create_task`` only
+# re-layers ``is_preview`` onto the sanitized dict when ``request.is_preview``
+# is ``True``; the WS handler never sets that field on ``TaskCreateRequest``
+# (``websocket.py``'s ``handle_build_preview_execution``), so it defaults to
+# ``False`` (:data:`xagent.web.schemas.chat.TaskCreateRequest.is_preview`) and
+# the re-layer never fires here. So reserving ``is_preview`` or
+# ``preview_agent_id`` would still silently strip them from this config with
+# nothing to restore them, breaking agent-builder preview. (Both readers of
+# ``preview_agent_id`` apply an ownership clause before trusting it, so it is
+# not itself exploitable.)
 #
 # Before adding a key here: (1) confirm no server writer reaches this column
 # *through* the sanitizer (the preview path above is the only known case);
@@ -100,8 +115,10 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # workspace directory, memory dimensions -- and its one server-side writer,
 # ``build_workforce_task_config``, is off the sanitizer path entirely.
 # ``tests/web/test_workforce_run_service.py::
-# test_create_workforce_run_propagates_execution_scope_to_worker`` asserts the
-# server-written scope lands in the persisted column.
+# test_create_workforce_run_propagates_execution_scope_to_worker`` demonstrates
+# that writer's scope reaching the column on that path -- a demonstration,
+# not a guard: the path is off the sanitizer by construction, so this test
+# cannot regress if this set changes.
 #
 # ``selected_file_ids`` qualifies for the same reason and passes both checks.
 # It was declared server-owned when it was introduced -- ``chat.py``'s

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -59,9 +59,11 @@ _PUBLIC_METADATA_STATUS_RESERVE_BYTES = 2 * 1024
 # keeps the per-task binding record migration-free.
 TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
 # Reserved ``tasks.agent_config`` key holding the server-validated list of
-# uploaded file ids bound to one task. ``chat.py``'s ``_build_task_agent_config``
-# owns the value it substitutes; this constant names the key so the sanitizer
-# and that boundary refer to the same string.
+# uploaded file ids bound to one task. Two writers own the value they
+# substitute here -- ``chat.py``'s ``_build_task_agent_config`` and
+# ``workforce_snapshot.py``'s ``build_workforce_task_config`` -- this
+# constant names the key so the sanitizer and both boundaries refer to the
+# same string.
 SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # Keys in ``tasks.agent_config`` that only the server may write. Task-create
 # request bodies carry a free-form ``agent_config`` dict that endpoints copy
@@ -85,10 +87,13 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # ``sanitize_client_agent_config`` call sites -- ``public_chat_access.py``'s
 # ``create_public_chat_task`` and ``create_share_chat_task``, and ``chat.py``'s
 # ``_build_task_agent_config`` -- sanitize then layer) or build ``agent_config``
-# off this path entirely: ``build_workforce_task_config``,
-# ``_trigger_execution_context`` (``services/triggers.py``), the a2a
-# create/backfill writers, and the workforce widget/share builders. One writer
-# passes *through* the sanitizer instead: ``websocket.py``'s
+# off this path entirely -- e.g. ``build_workforce_task_config``
+# (``workforce_snapshot.py``) and ``_attach_workforce_task_to_trigger_run``
+# (``services/triggers.py``, via ``_trigger_execution_context``). An
+# enumeration of every off-path writer here would go stale the same way an
+# inventory of reserved keys would (see above), so this comment names
+# examples rather than claiming completeness. Exactly one writer passes
+# *through* the sanitizer instead: ``websocket.py``'s
 # ``handle_build_preview_execution`` assembles a config from the WS message
 # (``instructions``, ``knowledge_bases``, ``skills``, ``tool_categories``, and
 # ``preview_agent_id`` all come from ``message_data.get(...)``; only
@@ -110,7 +115,15 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # Before adding a key here: (1) confirm no server writer reaches this column
 # *through* the sanitizer (the preview path above is the only known case);
 # (2) confirm no out-of-repo caller legitimately sends it in a request body
-# (#1095 tracks this).
+# (#1095 tracks this); (3) confirm no ``extra_agent_config=`` caller can win a
+# collision against this key through ``_merge_agent_config``
+# (``services/workforce_runs.py``), which returns
+# ``{**extra_agent_config, **task_config}`` with no sanitizing of its own --
+# safe today only because every ``extra_agent_config=`` caller passes a
+# server literal, and the built config wins only where it actually sets the
+# key, which for the two keys below is conditional
+# (``workforce_snapshot.py``'s ``build_workforce_task_config``). That the
+# strip is call-site opt-in rather than structural is #1134.
 #
 # ``execution_scope`` qualifies today: it is read back as the authority over
 # where a task's bytes land -- sandbox mount, durable storage prefix,

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -135,7 +135,7 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # not a guard: the path is off the sanitizer by construction, so this test
 # cannot regress if this set changes.
 #
-# ``selected_file_ids`` qualifies for the same reason and passes both checks.
+# ``selected_file_ids`` qualifies for the same reason and passes the checks above.
 # It was declared server-owned when it was introduced -- ``chat.py``'s
 # ``_build_task_agent_config`` drops the client value and substitutes a list
 # validated against ``UploadedFile.user_id`` and ``task_id IS NULL`` -- but

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -77,18 +77,18 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # comment holds none -- the enumeration is #1095's job.
 #
 # Most server writers layer on top of an already-sanitized dict (all three
-# ``sanitize_client_agent_config`` call sites -- ``public_chat_access.py:931``,
-# ``:1079``, ``chat.py:164`` -- sanitize then layer) or build ``agent_config``
+# ``sanitize_client_agent_config`` call sites -- ``public_chat_access.py``'s
+# ``create_public_chat_task`` and ``create_share_chat_task``, and ``chat.py``'s
+# ``_build_task_agent_config`` -- sanitize then layer) or build ``agent_config``
 # off this path entirely: ``build_workforce_task_config``,
 # ``_trigger_execution_context`` (``services/triggers.py``), the a2a
 # create/backfill writers, and the workforce widget/share builders. One writer
-# passes *through* the sanitizer instead: ``websocket.py``'s build-preview
-# handler builds a server-owned config carrying ``is_preview: True`` and
-# ``preview_agent_id`` (``websocket.py:8419-8425``) and hands it to
-# ``TaskCreateRequest(agent_config=...)`` passed into ``create_task``
-# (``websocket.py:8447-8466``), layered below the sanitizer rather than above
-# it -- reserving either key there would silently strip it and break
-# agent-builder preview.
+# passes *through* the sanitizer instead: ``websocket.py``'s
+# ``handle_build_preview_execution`` builds a server-owned config carrying
+# ``is_preview: True`` and ``preview_agent_id`` and hands it to
+# ``TaskCreateRequest(agent_config=...)`` passed into ``create_task``, layered
+# below the sanitizer rather than above it -- reserving either key there would
+# silently strip it and break agent-builder preview.
 #
 # Before adding a key here: (1) confirm no server writer reaches this column
 # *through* the sanitizer (the preview path above is the only known case);
@@ -99,9 +99,9 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # where a task's bytes land -- sandbox mount, durable storage prefix,
 # workspace directory, memory dimensions -- and its one server-side writer,
 # ``build_workforce_task_config``, is off the sanitizer path entirely.
-# ``tests/web/test_execution_scope_delegation.py::
-# TestWorkforceTaskConfigSnapshot::test_scope_persisted_when_active`` asserts
-# the server-written scope lands.
+# ``tests/web/test_workforce_run_service.py::
+# test_create_workforce_run_propagates_execution_scope_to_worker`` asserts the
+# server-written scope lands in the persisted column.
 #
 # ``selected_file_ids`` qualifies for the same reason and passes both checks.
 # It was declared server-owned when it was introduced -- ``chat.py``'s

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -20,6 +20,7 @@ from xagent.web.models.agent import (
 from xagent.web.models.user import User
 
 from ..models.workforce import Workforce, WorkforceAgent
+from .task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
 from .workforce_access import (
     ensure_workforce_access,
     ensure_workforce_agent_run_access,
@@ -531,7 +532,7 @@ def build_workforce_task_config(
     if workforce_run_id is not None:
         config["workforce_run_id"] = workforce_run_id
     if selected_file_ids:
-        config["selected_file_ids"] = selected_file_ids
+        config[SELECTED_FILE_IDS_AGENT_CONFIG_KEY] = selected_file_ids
     # Workforce runs create fresh Task rows whose ids the embedder's scope
     # resolver cannot map. Persist the creating context's ExecutionScope
     # snapshot into agent_config (no schema migration); resolve_execution_scope

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -1494,11 +1494,14 @@ class TestSnapshotCandidateAuthority:
         self, field_name, fallback_kwargs, snapshot_kwargs
     ):
         """A snapshot that is *wider* than the resolver's mandatory fallback
-        on any namespace field must fail the turn: the snapshot is
-        client-influenceable (an ``execution_scope`` key inside a
-        client-supplied ``agent_config``), so an unchecked snapshot here
-        would let a caller widen its own namespace past the resolver's own
-        most conservative answer."""
+        on any namespace field must fail the turn: the snapshot remains
+        untrusted input even though request bodies can no longer seed it --
+        a runtime-extension provider holding a ``session_factory`` can write
+        ``Task.agent_config`` directly, and a row persisted before
+        ``execution_scope`` was reserved at the request boundary still
+        carries whatever a request seeded at the time -- so an unchecked
+        snapshot here would let a caller widen its own namespace past the
+        resolver's own most conservative answer."""
         fallback = ExecutionScope(**fallback_kwargs)
         snapshot = ExecutionScope(**snapshot_kwargs)
         self._register(

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -19,11 +19,12 @@ This keeps the dependency edges obvious and avoids the "what's
 magically in scope?" question that pure-fixture conftests get.
 """
 
+import asyncio
 import logging
 import os
 import shutil
 import tempfile
-from typing import Iterator
+from typing import Any, Iterator
 
 import pytest
 from fastapi import FastAPI, Request
@@ -53,6 +54,7 @@ from xagent.web.api.widget import widget_router
 from xagent.web.api.workforces import router as workforces_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.a2a_protocol import (
     A2AApiError,
     a2a_api_error_handler,
@@ -340,3 +342,29 @@ def _install_one_slot_queue_pool(
         sessionmaker(autocommit=False, autoflush=False, bind=engine),
     )
     return engine
+
+
+def patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the leaf that starts a real background turn with a no-op task.
+
+    The workforce guest create path reaches
+    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
+    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
+    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
+    fails the test -- while leaving no live background task for
+    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
+    ``Base.metadata.drop_all`` below.
+
+    Lives here rather than in each suite: three api/ suites need it, and while
+    each kept its own copy they drifted -- two stubbed a call the workforce
+    create path never makes, so the stub was inert and the background turn ran
+    anyway.
+    """
+
+    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
+        async def noop() -> None:
+            return None
+
+        return asyncio.create_task(noop())
+
+    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -14,6 +14,10 @@ from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 
 from xagent.config import get_uploads_dir
+from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    execution_scope_from_agent_config,
+)
 from xagent.web.api import agents as agents_api
 from xagent.web.api.public_chat_access import create_public_chat_access_token
 from xagent.web.api.widget import (
@@ -1786,6 +1790,57 @@ def test_widget_task_create_drops_forged_runtime_extension_bindings() -> None:
         assert task_extension_bindings_from_agent_config(task.agent_config) == ()
         # Only the reserved key goes; ordinary client config and the
         # server-owned keys layered on top both survive.
+        assert task.agent_config.get("keep_me") == "client value"
+        assert task.agent_config.get("auth_mode") == "widget"
+        assert task.agent_config.get("guest_id") == "guest-1"
+    finally:
+        db.close()
+
+
+def test_widget_task_create_drops_forged_execution_scope() -> None:
+    """A widget guest cannot pre-seed the scope snapshot that governs where a
+    task's bytes land -- sandbox mount, storage prefix, workspace directory,
+    memory dimensions -- by naming it in the request body's ``agent_config``.
+    """
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Widget Scope Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["example.com"],
+    )
+    guest_headers = _authenticate_widget_guest(agent_id=agent_id)
+
+    create_task_response = client.post(
+        "/api/widget/chat/task/create",
+        json={
+            "title": "forged scope",
+            "description": "forged scope",
+            "agent_id": agent_id,
+            "agent_config": {
+                EXECUTION_SCOPE_AGENT_CONFIG_KEY: {
+                    "sandbox_key_suffix": "victim",
+                    "workspace_segments": ["victim"],
+                    "memory_dimensions": {"tenant": "victim"},
+                },
+                "keep_me": "client value",
+            },
+        },
+        headers=guest_headers,
+    )
+    assert create_task_response.status_code == 200, create_task_response.text
+
+    db = _direct_db_session()
+    try:
+        task = (
+            db.query(Task)
+            .filter(Task.id == create_task_response.json()["task_id"])
+            .one()
+        )
+        assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
+        assert execution_scope_from_agent_config(task.agent_config) is None
         assert task.agent_config.get("keep_me") == "client value"
         assert task.agent_config.get("auth_mode") == "widget"
         assert task.agent_config.get("guest_id") == "guest-1"

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -39,6 +39,7 @@ from xagent.web.services.agent_management import (
     TemplateQuickAccessRaceError,
 )
 from xagent.web.services.task_runtime import (
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
     task_extension_bindings_from_agent_config,
 )
@@ -1800,7 +1801,8 @@ def test_widget_task_create_drops_forged_runtime_extension_bindings() -> None:
 def test_widget_task_create_drops_forged_execution_scope() -> None:
     """A widget guest cannot pre-seed the scope snapshot that governs where a
     task's bytes land -- sandbox mount, storage prefix, workspace directory,
-    memory dimensions -- by naming it in the request body's ``agent_config``.
+    memory dimensions -- or the bound file list, by naming either in the
+    request body's ``agent_config``.
     """
     _admin_headers()
     owner_id = _user_id("admin")
@@ -1825,6 +1827,7 @@ def test_widget_task_create_drops_forged_execution_scope() -> None:
                     "workspace_segments": ["victim"],
                     "memory_dimensions": {"tenant": "victim"},
                 },
+                SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
                 "keep_me": "client value",
             },
         },
@@ -1841,6 +1844,7 @@ def test_widget_task_create_drops_forged_execution_scope() -> None:
         )
         assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
         assert execution_scope_from_agent_config(task.agent_config) is None
+        assert SELECTED_FILE_IDS_AGENT_CONFIG_KEY not in task.agent_config
         assert task.agent_config.get("keep_me") == "client value"
         assert task.agent_config.get("auth_mode") == "widget"
         assert task.agent_config.get("guest_id") == "guest-1"

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -462,6 +462,55 @@ def test_workforce_share_task_without_guest_id_is_denied(
     assert _upload_to_task(guest, task_id).status_code == 403
 
 
+def test_workforce_share_task_create_discards_forged_agent_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Widget-workforce mirror of ``test_widget_task_create_discards_forged_agent_config``:
+    ``_create_workforce_share_chat_task`` never reads
+    ``TaskCreateRequest.agent_config`` -- ``create_workforce_run`` only sees
+    the handler's own ``extra_agent_config`` (``auth_mode``,
+    ``share_workforce_id``, ``guest_id``). A forged reserved key in the
+    request body must not survive into the persisted config, and neither
+    should an ordinary client key."""
+    workforce_id = _create_workforce("Forged Config Share WF")
+    token = _enable_workforce_share(workforce_id)
+    guest = _authenticate_share_guest(token)
+    _stub_begin_turn(monkeypatch)
+
+    created = client.post(
+        "/api/share/chat/task/create",
+        headers=guest,
+        json={
+            "title": "forged",
+            "description": "forged",
+            "agent_config": {
+                EXECUTION_SCOPE_AGENT_CONFIG_KEY: {
+                    "sandbox_key_suffix": "victim",
+                    "workspace_segments": ["victim"],
+                    "memory_dimensions": {"tenant": "victim"},
+                },
+                SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
+                "keep_me": "client value",
+            },
+        },
+    )
+    assert created.status_code == 200, created.text
+    task_id = int(created.json()["task_id"])
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
+        assert SELECTED_FILE_IDS_AGENT_CONFIG_KEY not in task.agent_config
+        assert "keep_me" not in task.agent_config
+        assert task.agent_config.get("auth_mode") == "share"
+        assert task.agent_config.get("guest_id") == _share_guest_id(
+            guest["Authorization"]
+        )
+    finally:
+        db.close()
+
+
 # ===== fail-closed on legacy tokens without a guest_id claim =====
 
 

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -35,6 +35,7 @@ from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.services import workforce_runs as workforce_runs_service
 from xagent.web.services.task_runtime import (
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
     task_extension_bindings_from_agent_config,
 )
@@ -354,7 +355,8 @@ def test_agent_share_task_create_drops_forged_runtime_extension_bindings() -> No
 def test_agent_share_task_create_drops_forged_execution_scope() -> None:
     """A share guest cannot pre-seed the scope snapshot that governs where a
     task's bytes land -- sandbox mount, storage prefix, workspace directory,
-    memory dimensions -- by naming it in the request body's ``agent_config``.
+    memory dimensions -- or the bound file list, by naming either in the
+    request body's ``agent_config``.
     """
     assert _create_published_agent("Scope Agent", "scope-agent-tok")
     guest = _authenticate_share_guest("scope-agent-tok")
@@ -371,6 +373,7 @@ def test_agent_share_task_create_drops_forged_execution_scope() -> None:
                     "workspace_segments": ["victim"],
                     "memory_dimensions": {"tenant": "victim"},
                 },
+                SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
                 "keep_me": "client value",
             },
         },
@@ -383,6 +386,7 @@ def test_agent_share_task_create_drops_forged_execution_scope() -> None:
         task = db.query(Task).filter(Task.id == task_id).one()
         assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
         assert execution_scope_from_agent_config(task.agent_config) is None
+        assert SELECTED_FILE_IDS_AGENT_CONFIG_KEY not in task.agent_config
         assert task.agent_config.get("keep_me") == "client value"
         assert task.agent_config.get("auth_mode") == "share"
         assert task.agent_config.get("guest_id") == _share_guest_id(

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -21,6 +21,10 @@ import pytest
 from fastapi import HTTPException
 from starlette.websockets import WebSocketDisconnect
 
+from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    execution_scope_from_agent_config,
+)
 from xagent.web.api.public_chat_access import (
     PublicChatAccessContext,
     create_public_chat_access_token,
@@ -338,6 +342,47 @@ def test_agent_share_task_create_drops_forged_runtime_extension_bindings() -> No
         assert task_extension_bindings_from_agent_config(task.agent_config) == ()
         # Only the reserved key goes; ordinary client config and the
         # server-owned keys layered on top both survive.
+        assert task.agent_config.get("keep_me") == "client value"
+        assert task.agent_config.get("auth_mode") == "share"
+        assert task.agent_config.get("guest_id") == _share_guest_id(
+            guest["Authorization"]
+        )
+    finally:
+        db.close()
+
+
+def test_agent_share_task_create_drops_forged_execution_scope() -> None:
+    """A share guest cannot pre-seed the scope snapshot that governs where a
+    task's bytes land -- sandbox mount, storage prefix, workspace directory,
+    memory dimensions -- by naming it in the request body's ``agent_config``.
+    """
+    assert _create_published_agent("Scope Agent", "scope-agent-tok")
+    guest = _authenticate_share_guest("scope-agent-tok")
+
+    created = client.post(
+        "/api/share/chat/task/create",
+        headers=guest,
+        json={
+            "title": "forged scope",
+            "description": "forged scope",
+            "agent_config": {
+                EXECUTION_SCOPE_AGENT_CONFIG_KEY: {
+                    "sandbox_key_suffix": "victim",
+                    "workspace_segments": ["victim"],
+                    "memory_dimensions": {"tenant": "victim"},
+                },
+                "keep_me": "client value",
+            },
+        },
+    )
+    assert created.status_code == 200, created.text
+    task_id = int(created.json()["task_id"])
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
+        assert execution_scope_from_agent_config(task.agent_config) is None
         assert task.agent_config.get("keep_me") == "client value"
         assert task.agent_config.get("auth_mode") == "share"
         assert task.agent_config.get("guest_id") == _share_guest_id(

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -130,8 +130,13 @@ def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _stub(**_kwargs: Any) -> SimpleNamespace:
         return SimpleNamespace(background_task=None)
 
+    # ``schedule_claimed_create_turn`` is what the workforce create path
+    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
+    # still starts, and its background task then races test-DB teardown.
     monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator, "begin_turn", _stub
+        workforce_runs_service.TaskTurnOrchestrator,
+        "schedule_claimed_create_turn",
+        _stub,
     )
 
 

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -13,7 +13,6 @@ rejection of legacy tokens that predate the ``guest_id`` claim.
 
 from __future__ import annotations
 
-import asyncio
 import io
 from types import SimpleNamespace
 from typing import Any
@@ -34,7 +33,6 @@ from xagent.web.api.public_chat_access import (
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
-from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.task_runtime import (
     SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
@@ -48,6 +46,7 @@ from .conftest import (
     _setup_admin,
     _share_guest_id,
     client,
+    patch_schedule_bg,
 )
 
 pytestmark = pytest.mark.usefixtures("_test_db")
@@ -125,27 +124,6 @@ def _authenticate_share_guest(share_token: str) -> dict[str, str]:
     response = client.post("/api/share/auth", json={"share_token": share_token})
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
-
-
-def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace the leaf that starts a real background turn with a no-op task.
-
-    The workforce guest create path reaches
-    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
-    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
-    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
-    fails the test -- while leaving no live background task for
-    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
-    ``Base.metadata.drop_all`` in ``conftest.py``.
-    """
-
-    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
-        async def noop() -> None:
-            return None
-
-        return asyncio.create_task(noop())
-
-    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 def _upload_to_task(headers: dict[str, str], task_id: int) -> Any:
@@ -419,7 +397,7 @@ def test_workforce_share_guest_cannot_touch_other_guests_task(
     token = _enable_workforce_share(workforce_id)
     guest_a = _authenticate_share_guest(token)
     guest_b = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -452,7 +430,7 @@ def test_workforce_share_task_without_guest_id_is_denied(
     workforce_id = _create_workforce("PreMig WF")
     token = _enable_workforce_share(workforce_id)
     guest = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -488,7 +466,7 @@ def test_workforce_share_task_create_discards_forged_agent_config(
     workforce_id = _create_workforce("Forged Config Share WF")
     token = _enable_workforce_share(workforce_id)
     guest = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -13,6 +13,7 @@ rejection of legacy tokens that predate the ``guest_id`` claim.
 
 from __future__ import annotations
 
+import asyncio
 import io
 from types import SimpleNamespace
 from typing import Any
@@ -33,7 +34,7 @@ from xagent.web.api.public_chat_access import (
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
-from xagent.web.services import workforce_runs as workforce_runs_service
+from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.task_runtime import (
     SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
@@ -126,18 +127,25 @@ def _authenticate_share_guest(share_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
-def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _stub(**_kwargs: Any) -> SimpleNamespace:
-        return SimpleNamespace(background_task=None)
+def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the leaf that starts a real background turn with a no-op task.
 
-    # ``schedule_claimed_create_turn`` is what the workforce create path
-    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
-    # still starts, and its background task then races test-DB teardown.
-    monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator,
-        "schedule_claimed_create_turn",
-        _stub,
-    )
+    The workforce guest create path reaches
+    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
+    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
+    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
+    fails the test -- while leaving no live background task for
+    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
+    ``Base.metadata.drop_all`` in ``conftest.py``.
+    """
+
+    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
+        async def noop() -> None:
+            return None
+
+        return asyncio.create_task(noop())
+
+    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 def _upload_to_task(headers: dict[str, str], task_id: int) -> Any:
@@ -411,7 +419,7 @@ def test_workforce_share_guest_cannot_touch_other_guests_task(
     token = _enable_workforce_share(workforce_id)
     guest_a = _authenticate_share_guest(token)
     guest_b = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -444,7 +452,7 @@ def test_workforce_share_task_without_guest_id_is_denied(
     workforce_id = _create_workforce("PreMig WF")
     token = _enable_workforce_share(workforce_id)
     guest = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -480,7 +488,7 @@ def test_workforce_share_task_create_discards_forged_agent_config(
     workforce_id = _create_workforce("Forged Config Share WF")
     token = _enable_workforce_share(workforce_id)
     guest = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",

--- a/tests/web/api/test_task_runtime_delete_bindings.py
+++ b/tests/web/api/test_task_runtime_delete_bindings.py
@@ -18,6 +18,7 @@ from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.schemas.chat import TaskCreateRequest
 from xagent.web.services.task_runtime import (
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
     agent_config_with_task_extension_bindings,
     register_task_extension,
@@ -168,7 +169,11 @@ async def test_task_create_binding_record_ignores_forged_entries(
 async def test_task_create_drops_a_client_forged_execution_scope() -> None:
     """A request cannot pre-seed the scope snapshot that governs where a
     task's bytes land -- sandbox mount, storage prefix, workspace directory,
-    memory dimensions -- by naming it in the request body's ``agent_config``.
+    memory dimensions -- or name a file id for the bound file list, by
+    putting either in the request body's ``agent_config``. This boundary
+    substitutes a server-validated file list rather than only dropping the
+    client's, so a request that carries no ``files`` of its own persists no
+    ``selected_file_ids`` key at all; either way, a forged id never survives.
     """
 
     _admin_headers()
@@ -186,6 +191,7 @@ async def test_task_create_drops_a_client_forged_execution_scope() -> None:
                         "workspace_segments": ["victim"],
                         "memory_dimensions": {"tenant": "victim"},
                     },
+                    SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
                     "keep_me": "client value",
                 },
             ),
@@ -198,6 +204,9 @@ async def test_task_create_drops_a_client_forged_execution_scope() -> None:
         task = db.query(Task).filter(Task.id == task_id).one()
         assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
         assert execution_scope_from_agent_config(task.agent_config) is None
+        assert "victim-file-id" not in (
+            task.agent_config.get(SELECTED_FILE_IDS_AGENT_CONFIG_KEY) or []
+        )
         assert task.agent_config.get("keep_me") == "client value"
     finally:
         db.close()

--- a/tests/web/api/test_task_runtime_delete_bindings.py
+++ b/tests/web/api/test_task_runtime_delete_bindings.py
@@ -7,6 +7,10 @@ import logging
 import pytest
 from fastapi import HTTPException
 
+from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    execution_scope_from_agent_config,
+)
 from xagent.core.task_runtime import TaskRuntimeContribution
 from xagent.web.api.admin_users import delete_user
 from xagent.web.api.chat import create_task, delete_task
@@ -66,7 +70,7 @@ def _register(name: str, provider: _Provider, registered: list[str]) -> _Provide
     return provider
 
 
-# ===== the binding record is server-owned, never client-supplied =====
+# ===== reserved agent_config keys are server-owned, never client-supplied =====
 
 
 @pytest.mark.asyncio
@@ -156,6 +160,45 @@ async def test_task_create_binding_record_ignores_forged_entries(
             "victim_ext",
         )
         assert other.deleted_task_ids == []
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_task_create_drops_a_client_forged_execution_scope() -> None:
+    """A request cannot pre-seed the scope snapshot that governs where a
+    task's bytes land -- sandbox mount, storage prefix, workspace directory,
+    memory dimensions -- by naming it in the request body's ``agent_config``.
+    """
+
+    _admin_headers()
+    _register_second_user("scope-owner", "scopepass1")
+    db = _direct_db_session()
+    try:
+        owner = db.query(User).filter(User.username == "scope-owner").one()
+        created = await create_task(
+            TaskCreateRequest(
+                title="forged scope",
+                description="forged scope",
+                agent_config={
+                    EXECUTION_SCOPE_AGENT_CONFIG_KEY: {
+                        "sandbox_key_suffix": "victim",
+                        "workspace_segments": ["victim"],
+                        "memory_dimensions": {"tenant": "victim"},
+                    },
+                    "keep_me": "client value",
+                },
+            ),
+            db=db,
+            user=owner,
+        )
+        task_id = int(created.task_id)
+
+        db.expire_all()
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
+        assert execution_scope_from_agent_config(task.agent_config) is None
+        assert task.agent_config.get("keep_me") == "client value"
     finally:
         db.close()
 

--- a/tests/web/api/test_workforce_share_link.py
+++ b/tests/web/api/test_workforce_share_link.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import io
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -23,6 +22,7 @@ from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceRun
+from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services import workforce_runs as workforce_runs_service
 
 from .conftest import (
@@ -115,18 +115,25 @@ def _authenticate_share_guest(share_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
-def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _stub(**_kwargs: Any) -> SimpleNamespace:
-        return SimpleNamespace(background_task=None)
+def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the leaf that starts a real background turn with a no-op task.
 
-    # ``schedule_claimed_create_turn`` is what the workforce create path
-    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
-    # still starts, and its background task then races test-DB teardown.
-    monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator,
-        "schedule_claimed_create_turn",
-        _stub,
-    )
+    The workforce guest create path reaches
+    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
+    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
+    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
+    fails the test -- while leaving no live background task for
+    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
+    ``Base.metadata.drop_all`` in ``conftest.py``.
+    """
+
+    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
+        async def noop() -> None:
+            return None
+
+        return asyncio.create_task(noop())
+
+    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 # ===== Share-link management endpoints =====
@@ -433,7 +440,7 @@ def test_share_task_create_starts_workforce_run(
     workforce_id = _create_workforce("Guest Run Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/share/chat/task/create",
@@ -484,7 +491,7 @@ def test_share_task_create_rejects_foreign_agent_id(
     workforce_id = _create_workforce("Foreign Agent Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     other_agent_id = _create_published_agent(_user_id(), "Unrelated Agent")
     response = client.post(
@@ -508,7 +515,7 @@ async def test_share_guest_cannot_touch_internal_run_task(
     workforce_id = _create_workforce("Scoping Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     # An owner-initiated (internal) run of the same workforce.
     db = _direct_db_session()
@@ -537,7 +544,7 @@ def test_share_guest_can_upload_to_own_shared_task(
     workforce_id = _create_workforce("Upload Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -564,7 +571,7 @@ def test_workforce_share_first_turn_attachments_reach_run(
     workforce_id = _create_workforce("First Turn File Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     # 1) Task-less upload is allowed for workforce guests (no task exists yet).
     upload = client.post(
@@ -690,7 +697,7 @@ def test_agent_share_guest_cannot_access_workforce_task(
     workforce_id = _create_workforce("Cross Guest Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",

--- a/tests/web/api/test_workforce_share_link.py
+++ b/tests/web/api/test_workforce_share_link.py
@@ -30,6 +30,7 @@ from .conftest import (
     _direct_db_session,
     _register_second_user,
     client,
+    patch_schedule_bg,
 )
 
 pytestmark = pytest.mark.usefixtures("_test_db")
@@ -113,27 +114,6 @@ def _authenticate_share_guest(share_token: str) -> dict[str, str]:
     response = client.post("/api/share/auth", json={"share_token": share_token})
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
-
-
-def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace the leaf that starts a real background turn with a no-op task.
-
-    The workforce guest create path reaches
-    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
-    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
-    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
-    fails the test -- while leaving no live background task for
-    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
-    ``Base.metadata.drop_all`` in ``conftest.py``.
-    """
-
-    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
-        async def noop() -> None:
-            return None
-
-        return asyncio.create_task(noop())
-
-    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 # ===== Share-link management endpoints =====
@@ -440,7 +420,7 @@ def test_share_task_create_starts_workforce_run(
     workforce_id = _create_workforce("Guest Run Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/share/chat/task/create",
@@ -491,7 +471,7 @@ def test_share_task_create_rejects_foreign_agent_id(
     workforce_id = _create_workforce("Foreign Agent Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     other_agent_id = _create_published_agent(_user_id(), "Unrelated Agent")
     response = client.post(
@@ -515,7 +495,7 @@ async def test_share_guest_cannot_touch_internal_run_task(
     workforce_id = _create_workforce("Scoping Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     # An owner-initiated (internal) run of the same workforce.
     db = _direct_db_session()
@@ -544,7 +524,7 @@ def test_share_guest_can_upload_to_own_shared_task(
     workforce_id = _create_workforce("Upload Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -571,7 +551,7 @@ def test_workforce_share_first_turn_attachments_reach_run(
     workforce_id = _create_workforce("First Turn File Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     # 1) Task-less upload is allowed for workforce guests (no task exists yet).
     upload = client.post(
@@ -697,7 +677,7 @@ def test_agent_share_guest_cannot_access_workforce_task(
     workforce_id = _create_workforce("Cross Guest Workforce")
     token = _enable_share(workforce_id)
     guest_headers = _authenticate_share_guest(token)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     created = client.post(
         "/api/share/chat/task/create",
@@ -750,7 +730,6 @@ async def test_ws_append_syncs_workforce_run_back_to_running(
 
     from xagent.web.api.websocket import handle_chat_message
     from xagent.web.models.workforce import WorkforceAgent
-    from xagent.web.services import task_orchestrator as task_orchestrator_service
     from xagent.web.services.workforce_snapshot import build_workforce_snapshot
 
     workforce_id = _create_workforce("Append Sync Workforce")

--- a/tests/web/api/test_workforce_share_link.py
+++ b/tests/web/api/test_workforce_share_link.py
@@ -119,8 +119,13 @@ def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _stub(**_kwargs: Any) -> SimpleNamespace:
         return SimpleNamespace(background_task=None)
 
+    # ``schedule_claimed_create_turn`` is what the workforce create path
+    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
+    # still starts, and its background task then races test-DB teardown.
     monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator, "begin_turn", _stub
+        workforce_runs_service.TaskTurnOrchestrator,
+        "schedule_claimed_create_turn",
+        _stub,
     )
 
 

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -12,7 +12,6 @@ Builds on the share-link channel patterns (#947).
 
 from __future__ import annotations
 
-import asyncio
 import io
 from typing import Any, cast
 
@@ -24,7 +23,6 @@ from xagent.web.models.deployment import Deployment, DeploymentOwnerType
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceRun
-from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
 
 from .conftest import (
@@ -32,6 +30,7 @@ from .conftest import (
     _direct_db_session,
     _register_second_user,
     client,
+    patch_schedule_bg,
 )
 
 pytestmark = pytest.mark.usefixtures("_test_db")
@@ -149,27 +148,6 @@ def _authenticate_widget_guest_by_key(
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
-
-
-def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace the leaf that starts a real background turn with a no-op task.
-
-    The workforce guest create path reaches
-    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
-    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
-    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
-    fails the test -- while leaving no live background task for
-    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
-    ``Base.metadata.drop_all`` in ``conftest.py``.
-    """
-
-    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
-        async def noop() -> None:
-            return None
-
-        return asyncio.create_task(noop())
-
-    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 # ===== Widget management endpoints =====
@@ -583,7 +561,7 @@ def test_widget_task_create_starts_workforce_run(
     workforce_id = _create_workforce("Guest Run Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/widget/chat/task/create",
@@ -625,7 +603,7 @@ def test_widget_task_create_rejects_foreign_agent_id(
     workforce_id = _create_workforce("Foreign Agent Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     foreign_agent_id = _create_published_agent(_user_id(), "Foreign Agent")
     response = client.post(
@@ -652,7 +630,7 @@ def test_widget_task_create_discards_forged_agent_config(
     workforce_id = _create_workforce("Forged Config Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/widget/chat/task/create",
@@ -785,7 +763,7 @@ def test_widget_task_access_scoped_to_guest_and_workforce(
     guest of the same workforce, or any guest of a different workforce, is
     rejected (guest_id + widget_workforce_id scoping in
     ``_get_task_for_workforce_widget_context``)."""
-    _patch_schedule_bg(monkeypatch)
+    patch_schedule_bg(monkeypatch)
     wf_a = _create_workforce("Scope Widget A")
     key_a = _enable_widget(wf_a)
     wf_b = _create_workforce("Scope Widget B")

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -12,8 +12,8 @@ Builds on the share-link channel patterns (#947).
 
 from __future__ import annotations
 
+import asyncio
 import io
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -24,7 +24,7 @@ from xagent.web.models.deployment import Deployment, DeploymentOwnerType
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceRun
-from xagent.web.services import workforce_runs as workforce_runs_service
+from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
 
 from .conftest import (
@@ -151,18 +151,25 @@ def _authenticate_widget_guest_by_key(
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
-def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _stub(**_kwargs: Any) -> SimpleNamespace:
-        return SimpleNamespace(background_task=None)
+def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the leaf that starts a real background turn with a no-op task.
 
-    # ``schedule_claimed_create_turn`` is what the workforce create path
-    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
-    # still starts, and its background task then races test-DB teardown.
-    monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator,
-        "schedule_claimed_create_turn",
-        _stub,
-    )
+    The workforce guest create path reaches
+    ``TaskTurnOrchestrator.schedule_claimed_create_turn`` ->
+    ``schedule_claimed_turn`` -> ``_schedule_bg``. Patching only that leaf
+    keeps the claim-to-schedule handoff real -- a raise anywhere in it still
+    fails the test -- while leaving no live background task for
+    ``public_chat_access.py`` to drop un-awaited, which would otherwise race
+    ``Base.metadata.drop_all`` in ``conftest.py``.
+    """
+
+    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
+        async def noop() -> None:
+            return None
+
+        return asyncio.create_task(noop())
+
+    monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
 
 
 # ===== Widget management endpoints =====
@@ -576,7 +583,7 @@ def test_widget_task_create_starts_workforce_run(
     workforce_id = _create_workforce("Guest Run Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/widget/chat/task/create",
@@ -618,7 +625,7 @@ def test_widget_task_create_rejects_foreign_agent_id(
     workforce_id = _create_workforce("Foreign Agent Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     foreign_agent_id = _create_published_agent(_user_id(), "Foreign Agent")
     response = client.post(
@@ -645,7 +652,7 @@ def test_widget_task_create_discards_forged_agent_config(
     workforce_id = _create_workforce("Forged Config Widget Workforce")
     key = _enable_widget(workforce_id)
     guest_headers = _authenticate_widget_guest_by_key(key)
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
 
     response = client.post(
         "/api/widget/chat/task/create",
@@ -778,7 +785,7 @@ def test_widget_task_access_scoped_to_guest_and_workforce(
     guest of the same workforce, or any guest of a different workforce, is
     rejected (guest_id + widget_workforce_id scoping in
     ``_get_task_for_workforce_widget_context``)."""
-    _stub_begin_turn(monkeypatch)
+    _patch_schedule_bg(monkeypatch)
     wf_a = _create_workforce("Scope Widget A")
     key_a = _enable_widget(wf_a)
     wf_b = _create_workforce("Scope Widget B")

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -18,12 +18,14 @@ from typing import Any, cast
 
 import pytest
 
+from xagent.core.execution_scope import EXECUTION_SCOPE_AGENT_CONFIG_KEY
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.deployment import Deployment, DeploymentOwnerType
 from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceRun
 from xagent.web.services import workforce_runs as workforce_runs_service
+from xagent.web.services.task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
 
 from .conftest import (
     _admin_headers,
@@ -624,6 +626,52 @@ def test_widget_task_create_rejects_foreign_agent_id(
         },
     )
     assert response.status_code == 403, response.text
+
+
+def test_widget_task_create_discards_forged_agent_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_create_workforce_widget_chat_task`` never reads
+    ``TaskCreateRequest.agent_config`` -- ``create_workforce_run`` only sees
+    the handler's own ``extra_agent_config`` (``auth_mode``,
+    ``widget_workforce_id``, ``guest_id``). A forged reserved key in the
+    request body must not survive into the persisted config, and neither
+    should an ordinary client key."""
+    workforce_id = _create_workforce("Forged Config Widget Workforce")
+    key = _enable_widget(workforce_id)
+    guest_headers = _authenticate_widget_guest_by_key(key)
+    _stub_begin_turn(monkeypatch)
+
+    response = client.post(
+        "/api/widget/chat/task/create",
+        headers=guest_headers,
+        json={
+            "title": "forged",
+            "description": "forged",
+            "agent_config": {
+                EXECUTION_SCOPE_AGENT_CONFIG_KEY: {
+                    "sandbox_key_suffix": "victim",
+                    "workspace_segments": ["victim"],
+                    "memory_dimensions": {"tenant": "victim"},
+                },
+                SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
+                "keep_me": "client value",
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    task_id = int(response.json()["task_id"])
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert EXECUTION_SCOPE_AGENT_CONFIG_KEY not in task.agent_config
+        assert SELECTED_FILE_IDS_AGENT_CONFIG_KEY not in task.agent_config
+        assert "keep_me" not in task.agent_config
+        assert task.agent_config.get("auth_mode") == "widget"
+        assert int(task.agent_config.get("widget_workforce_id")) == workforce_id
+    finally:
+        db.close()
 
 
 # ===== Task-less opening-message upload =====

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -155,8 +155,13 @@ def _stub_begin_turn(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _stub(**_kwargs: Any) -> SimpleNamespace:
         return SimpleNamespace(background_task=None)
 
+    # ``schedule_claimed_create_turn`` is what the workforce create path
+    # reaches, not ``begin_turn``: stubbing the latter is inert, the real turn
+    # still starts, and its background task then races test-DB teardown.
     monkeypatch.setattr(
-        workforce_runs_service.TaskTurnOrchestrator, "begin_turn", _stub
+        workforce_runs_service.TaskTurnOrchestrator,
+        "schedule_claimed_create_turn",
+        _stub,
     )
 
 

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -276,12 +276,13 @@ def test_the_reserved_key_set_has_exactly_the_audited_members() -> None:
 
 
 def test_agent_builder_preview_keys_are_not_reserved() -> None:
-    """``websocket.py``'s ``handle_build_preview_execution`` builds a
-    server-owned ``agent_config`` carrying ``is_preview`` and
-    ``preview_agent_id`` and passes it through ``create_task`` -- and
-    therefore through the sanitizer, layered below it rather than above.
-    Reserving either key here would strip it from that config and break
-    agent-builder preview.
+    """``websocket.py``'s ``handle_build_preview_execution`` assembles a
+    config from the WS message (``preview_agent_id`` included) and passes it
+    through ``create_task`` -- and therefore through the sanitizer, layered
+    below it rather than above. ``chat.py``'s re-layer of ``is_preview`` only
+    fires when ``TaskCreateRequest.is_preview`` is ``True``, which this WS
+    path never sets, so reserving either key here would strip it from that
+    config with nothing to restore it, breaking agent-builder preview.
     """
     assert {"is_preview", "preview_agent_id"}.isdisjoint(
         CLIENT_RESERVED_AGENT_CONFIG_KEYS

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -10,7 +10,6 @@ import pytest
 
 from xagent.core.execution_scope import (
     EXECUTION_SCOPE_AGENT_CONFIG_KEY,
-    ExecutionScope,
     execution_scope_from_agent_config,
 )
 from xagent.core.task_runtime import TaskRuntimeContext, TaskRuntimeContribution
@@ -263,12 +262,28 @@ def test_execution_scope_is_reserved_so_a_request_cannot_choose_a_namespace() ->
     assert execution_scope_from_agent_config(sanitized) is None
 
 
-def test_a_server_written_scope_still_reaches_the_column() -> None:
-    """Stripping happens on the client copy only. The one server-side writer
-    lands its value on a path that never copies a request dict, so reserving the
-    key must not make a server-assigned scope unreadable.
+def test_the_reserved_key_set_has_exactly_the_audited_members() -> None:
+    """Pin the reserved set to literal strings, not the constants that name
+    them. ``test_sanitize_drops_reserved_keys_and_keeps_client_keys`` builds
+    its forged input by iterating ``CLIENT_RESERVED_AGENT_CONFIG_KEYS``, so it
+    cannot detect a wrongly-added member -- whatever the set holds, that
+    test's forged payload holds too. This test covers that direction instead.
+    Literals are deliberate for a second reason: comparing against them also
+    fails if either constant's *value* changes, which would silently move
+    which requests get stripped at every task-create boundary.
     """
-    scope = ExecutionScope(workspace_segments=("clients", "7"))
-    server_config = {EXECUTION_SCOPE_AGENT_CONFIG_KEY: scope.to_dict()}
+    assert CLIENT_RESERVED_AGENT_CONFIG_KEYS == frozenset(
+        {"runtime_extension_bindings", "execution_scope"}
+    )
 
-    assert execution_scope_from_agent_config(server_config) == scope
+
+def test_agent_builder_preview_keys_are_not_reserved() -> None:
+    """``src/xagent/web/api/websocket.py:8447-8466`` builds a server-owned
+    ``agent_config`` carrying ``is_preview`` and ``preview_agent_id`` and
+    passes it through ``create_task`` -- and therefore through the sanitizer,
+    layered below it rather than above. Reserving either key here would strip
+    it from that config and break agent-builder preview.
+    """
+    assert {"is_preview", "preview_agent_id"}.isdisjoint(
+        CLIENT_RESERVED_AGENT_CONFIG_KEYS
+    )

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -8,6 +8,11 @@ from typing import Any
 
 import pytest
 
+from xagent.core.execution_scope import (
+    EXECUTION_SCOPE_AGENT_CONFIG_KEY,
+    ExecutionScope,
+    execution_scope_from_agent_config,
+)
 from xagent.core.task_runtime import TaskRuntimeContext, TaskRuntimeContribution
 from xagent.web.services.task_runtime import (
     CLIENT_RESERVED_AGENT_CONFIG_KEYS,
@@ -231,3 +236,39 @@ async def test_delete_reports_bindings_whose_provider_is_no_longer_registered(
     assert unreleased == ("ghost_ext",)
     assert healthy.deleted == [42]
     assert any("ghost_ext" in record.getMessage() for record in caplog.records)
+
+
+def test_execution_scope_is_reserved_so_a_request_cannot_choose_a_namespace() -> None:
+    """The persisted scope decides where a task's bytes land -- sandbox mount,
+    durable storage prefix, workspace directory, memory dimensions -- and it is
+    read back as the authority over all four. A request body that could seed it
+    would choose them, so the key is refused at the boundary rather than judged
+    afterwards: nothing carried in the same client-writable field can establish
+    that the value came from the server.
+    """
+    assert EXECUTION_SCOPE_AGENT_CONFIG_KEY in CLIENT_RESERVED_AGENT_CONFIG_KEYS
+
+    forged = {
+        "sandbox_key_suffix": "victim",
+        "workspace_segments": ["victim"],
+        "memory_dimensions": {"tenant": "victim"},
+    }
+    sanitized = sanitize_client_agent_config(
+        {EXECUTION_SCOPE_AGENT_CONFIG_KEY: forged, "keep": 1}
+    )
+
+    assert sanitized == {"keep": 1}
+    # The column value a task is created with therefore carries no scope, so the
+    # registered loader reports "no candidate" and the resolver answers alone.
+    assert execution_scope_from_agent_config(sanitized) is None
+
+
+def test_a_server_written_scope_still_reaches_the_column() -> None:
+    """Stripping happens on the client copy only. The one server-side writer
+    lands its value on a path that never copies a request dict, so reserving the
+    key must not make a server-assigned scope unreadable.
+    """
+    scope = ExecutionScope(workspace_segments=("clients", "7"))
+    server_config = {EXECUTION_SCOPE_AGENT_CONFIG_KEY: scope.to_dict()}
+
+    assert execution_scope_from_agent_config(server_config) == scope

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -279,11 +279,12 @@ def test_the_reserved_key_set_has_exactly_the_audited_members() -> None:
 
 
 def test_agent_builder_preview_keys_are_not_reserved() -> None:
-    """``src/xagent/web/api/websocket.py:8447-8466`` builds a server-owned
-    ``agent_config`` carrying ``is_preview`` and ``preview_agent_id`` and
-    passes it through ``create_task`` -- and therefore through the sanitizer,
-    layered below it rather than above. Reserving either key here would strip
-    it from that config and break agent-builder preview.
+    """``websocket.py``'s ``handle_build_preview_execution`` builds a
+    server-owned ``agent_config`` carrying ``is_preview`` and
+    ``preview_agent_id`` and passes it through ``create_task`` -- and
+    therefore through the sanitizer, layered below it rather than above.
+    Reserving either key here would strip it from that config and break
+    agent-builder preview.
     """
     assert {"is_preview", "preview_agent_id"}.isdisjoint(
         CLIENT_RESERVED_AGENT_CONFIG_KEYS

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -239,12 +239,9 @@ async def test_delete_reports_bindings_whose_provider_is_no_longer_registered(
 
 
 def test_execution_scope_is_reserved_so_a_request_cannot_choose_a_namespace() -> None:
-    """The persisted scope decides where a task's bytes land -- sandbox mount,
-    durable storage prefix, workspace directory, memory dimensions -- and it is
-    read back as the authority over all four. A request body that could seed it
-    would choose them, so the key is refused at the boundary rather than judged
-    afterwards: nothing carried in the same client-writable field can establish
-    that the value came from the server.
+    """A forged scope in a client dict is stripped, leaving no candidate for
+    resolution to read. Why the key is refused rather than judged afterwards is
+    on CLIENT_RESERVED_AGENT_CONFIG_KEYS.
     """
     assert EXECUTION_SCOPE_AGENT_CONFIG_KEY in CLIENT_RESERVED_AGENT_CONFIG_KEYS
 

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -15,6 +15,7 @@ from xagent.core.execution_scope import (
 from xagent.core.task_runtime import TaskRuntimeContext, TaskRuntimeContribution
 from xagent.web.services.task_runtime import (
     CLIENT_RESERVED_AGENT_CONFIG_KEYS,
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
     TaskRuntimeExtensionError,
     agent_config_with_task_extension_bindings,
@@ -273,7 +274,7 @@ def test_the_reserved_key_set_has_exactly_the_audited_members() -> None:
     which requests get stripped at every task-create boundary.
     """
     assert CLIENT_RESERVED_AGENT_CONFIG_KEYS == frozenset(
-        {"runtime_extension_bindings", "execution_scope"}
+        {"runtime_extension_bindings", "execution_scope", "selected_file_ids"}
     )
 
 
@@ -287,3 +288,20 @@ def test_agent_builder_preview_keys_are_not_reserved() -> None:
     assert {"is_preview", "preview_agent_id"}.isdisjoint(
         CLIENT_RESERVED_AGENT_CONFIG_KEYS
     )
+
+
+def test_selected_file_ids_is_reserved_so_a_request_cannot_name_files() -> None:
+    """The bound file list is server-validated: the chat boundary substitutes a
+    list filtered by owner and unbound-task before persisting it, and both
+    readers re-check ownership in their own query. Reserving the key moves that
+    enforcement to the one place every boundary shares, so the widget and share
+    paths -- which never set the key themselves -- stop persisting whatever a
+    request body carried.
+    """
+    assert SELECTED_FILE_IDS_AGENT_CONFIG_KEY in CLIENT_RESERVED_AGENT_CONFIG_KEYS
+
+    sanitized = sanitize_client_agent_config(
+        {SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["forged-file-id"], "keep": 1}
+    )
+
+    assert sanitized == {"keep": 1}


### PR DESCRIPTION
Reserves `execution_scope` in `CLIENT_RESERVED_AGENT_CONFIG_KEYS`, so a task-create request body can no longer seed it.

Fixes #1016.

## Why the key has to be refused rather than judged

`tasks.agent_config` is a free-form JSON column that task-create endpoints seed from the request body and copy wholesale. The execution scope stored under that key is read back as the authority over where a task's bytes land: the sandbox bind-mount root, the durable storage key prefix, the backend workspace directory, and the memory dimensions attached to its notes. A request able to seed the key therefore chose all four, and public widget and share task creation copy the same field.

No check applied after the value is in the column can establish that it came from the server, because any provenance marker would live in the same client-writable field as the value it vouches for. The distinction between "the server wrote this" and "a request wrote this" exists only where the client dict is copied, which is where the strip belongs.

The exposure is not uniform across deployments, which is worth stating because it decides how the fix reads in the logs rather than whether it is needed. With a scope resolver registered, a planted snapshot that disagrees with the resolver already fails the turn loudly. With no resolver registered, the persisted snapshot is returned exactly as loaded, with no type check and no shape-version gate — there, a request body chooses the namespace outright.

## Why stripping is sufficient and cannot reach a server-assigned value

- Exactly three sites copy a client-supplied `agent_config` — `api/chat.py` (through `_build_task_agent_config`), and the widget and share task-create paths in `api/public_chat_access.py` — and all three already route through `sanitize_client_agent_config`. `request.agent_config` appears nowhere else.
- The sanitizer runs before server-owned values are layered on, so the strip cannot remove a server-assigned key, and server keys still win on collision.
- The only server-side writer of this key builds its config in `build_workforce_task_config`, on a workforce path that never copies a request dict at all. Stripping is therefore not merely ordered after that write — it is off its path.
- No post-creation write accepts a caller-supplied mapping. Every update site composes its dict from the stored row or a server literal, and no endpoint patches the column, so refusing the key at creation closes the surface for it.

## Behaviour change

A request body carrying `agent_config.execution_scope` no longer has that key persisted; the task resolves its scope from the registered resolver alone, or is unscoped when none is registered. No in-repo client sends the key: the only `agent_config` request bodies the frontend builds carry `instructions`, `knowledge_bases`, `skills`, `tool_categories`, `is_preview` and `preview_agent_id`.

`selected_file_ids` is reserved as well. The literal `"selected_file_ids"` string is replaced by a shared constant, `SELECTED_FILE_IDS_AGENT_CONFIG_KEY`, at its readers in `chat.py` and `websocket.py` and its writer in `workforce_snapshot.py`, so the sanitizer and every boundary that touches the key refer to the same string. The key was already declared server-owned where it was introduced — the authenticated chat boundary drops the client value and substitutes a list filtered by owner and unbound task — but that enforcement was local to that one boundary, so the widget and share creates, which never set the key themselves, persisted whatever a request carried. Those two boundaries therefore stop persisting a caller-supplied value. No in-repo client sends it. The agent-path upload endpoints require an existing task, so a guest's *first* create has no real file id to name — but a guest who uploaded against an earlier task knows real ids and can name them in a later create body; the strip is what closes that route. Both readers also re-check ownership in their own query.

## Scope of this change

The comment above the key set previously named four reserved keys as the remainder. That list was a sample, not an inventory — the column carries roughly fourteen server-written, authoritatively-read keys — so it is gone rather than corrected. This column's key space is not closed inside the repository: runtime-extension providers receive a `session_factory` and can write it directly, so an enumeration here could only be a claim a later reader trusts instead of re-deriving, which is how the wrong list survived. The comment now states the rule and the checks to apply before adding a key, and #1095 owns the enumeration.

Those checks are: no server writer reaches this column *through* the sanitizer; no caller legitimately sends the key in a request body; and no `extra_agent_config=` caller can win a collision against the key through `_merge_agent_config`, which overlays an unsanitized caller mapping and is safe today only because every such caller passes a server literal. The first check has one known case — the build-preview handler assembles its `agent_config` from the WebSocket message and passes it through `create_task`, so `is_preview` and `preview_agent_id` land below the sanitizer rather than above it and cannot be reserved without breaking preview. That is pinned by a test rather than left as prose.

Two follow-ups fall out of this. Rows persisted before this reservation took effect can still carry a client-seeded `execution_scope`, including one that predates its shape-versioning, which #1135 tracks. And because `preview_agent_id` cannot be reserved without breaking preview, the SSH tools' `_agent_id_from_task` reading it off `agent_config` with no ownership check stays reader-side rather than closed at this boundary, which #1136 tracks. That the strip is applied call-site by call-site rather than enforced at one structural choke point is #1134.

## Verification

- Route-level regression at each of the three boundaries — `test_widget_task_create_drops_forged_execution_scope`, `test_agent_share_task_create_drops_forged_execution_scope`, `test_task_create_drops_a_client_forged_execution_scope` — each asserting the key is absent from the persisted row, that decoding the row yields no candidate, and that an unreserved client key survives. Per-boundary isolated: bypassing the sanitizer at one site fails exactly that site's test.
- `tests/web/services/test_task_runtime_bindings.py` — the set is pinned against literal strings, so a wrongly-added member fails a test rather than reading as reviewed, and the two preview keys are asserted absent from it.
- The workforce widget and share creates accept an `agent_config` and discard it; that is now pinned, so threading it into the workforce config later cannot silently reopen the boundary.
- Three test helpers patched `begin_turn`, which the workforce guest create path never calls; the real turn it does reach — `schedule_claimed_create_turn` / `schedule_claimed_turn` — went unstubbed, leaving a live background task that raced `Base.metadata.drop_all` in `conftest.py`. Renamed to `_patch_schedule_bg`, they now patch the `_schedule_bg` leaf instead, so the claim-to-schedule handoff stays real under test and no background task survives; no coverage is traded.
- Scope-related suites pass: `tests/core/test_execution_scope.py`, `tests/web/api/test_execution_scope_e2e.py`, `tests/web/test_execution_scope_delegation.py`, `tests/web/services/test_file_turn.py`, plus the bindings tests — 265 tests.
- `tests/web -m "not slow and not postgresql" -n 4 --dist=loadscope` — no failures.
- `mypy` is clean on the five changed production files; the pre-commit hooks are clean across all twelve changed files (five production, seven test).

