### PR TITLE
fix(deployment): fail closed without public targets

### DIFF
--- a/frontend/src/components/build/deploy-agent-dialog.test.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.test.tsx
@@ -225,6 +225,35 @@ describe("DeployAgentDialog regional targets", () => {
     })
   })
 
+  it("keeps widget copy disabled when deployment configuration fails", async () => {
+    deploymentConfigFails = true
+
+    render(
+      <DeployAgentDialog
+        deployAgent={AGENT}
+        onClose={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("deploy_agent.options.embed.title"))
+
+    expect(
+      await screen.findByText("deployment_config.messages.load_failed"),
+    ).toBeInTheDocument()
+    const copyButton = await screen.findByTitle(
+      "deploy_agent.embed_snippet.copy_btn",
+    )
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "https://configured-api.example.test/api/agents/7/widget-key",
+      )
+    })
+    expect(screen.getByText("…")).toBeInTheDocument()
+    expect(copyButton).toBeDisabled()
+    expect(copyToClipboardMock).not.toHaveBeenCalled()
+  })
+
   it("bootstraps the region for public share links", async () => {
     render(
       <DeployAgentDialog

--- a/frontend/src/components/build/deploy-agent-dialog.test.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.test.tsx
@@ -155,6 +155,29 @@ describe("DeployAgentDialog regional targets", () => {
     expect(copyButton).toBeEnabled()
   })
 
+  it("keeps the share panel available when deployment configuration fails", async () => {
+    deploymentConfigFails = true
+
+    render(
+      <DeployAgentDialog
+        deployAgent={AGENT}
+        onClose={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("deploy_agent.options.shareable_link.title"))
+
+    expect(
+      await screen.findByText("deployment_config.messages.load_failed"),
+    ).toBeInTheDocument()
+    expect(await screen.findByRole("textbox")).toHaveValue("")
+    expect(screen.getByRole("button", { name: "common.copy" })).toBeDisabled()
+    expect(
+      screen.queryByText("deploy_agent.messages.share_failed"),
+    ).not.toBeInTheDocument()
+  })
+
   it("uses the deployment origin for API and SDK snippets", async () => {
     render(
       <DeployAgentDialog

--- a/frontend/src/components/build/deploy-agent-dialog.test.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.test.tsx
@@ -111,7 +111,7 @@ describe("DeployAgentDialog regional targets", () => {
     cleanup()
   })
 
-  it("falls back to the browser API target after config loading fails", async () => {
+  it("keeps API copy disabled until config retry succeeds", async () => {
     deploymentConfigFails = true
 
     render(
@@ -124,11 +124,14 @@ describe("DeployAgentDialog regional targets", () => {
 
     fireEvent.click(screen.getByText("deploy_agent.options.rest_api.title"))
 
+    expect(await screen.findByText("deployment_config.messages.load_failed")).toBeInTheDocument()
+    const copyButton = screen.getByTitle("deploy_agent.api_panel.copy_btn")
+    expect(copyButton).toBeDisabled()
     expect(
-      await screen.findByText((content) =>
+      screen.queryByText((content) =>
         content.includes("https://cloud.example.test/v1/chat/tasks"),
       ),
-    ).toBeInTheDocument()
+    ).not.toBeInTheDocument()
     expect(toastErrorMock).toHaveBeenCalledWith(
       "deployment_config.messages.load_failed",
     )
@@ -149,6 +152,7 @@ describe("DeployAgentDialog regional targets", () => {
     expect(
       screen.queryByText("deployment_config.messages.load_failed"),
     ).not.toBeInTheDocument()
+    expect(copyButton).toBeEnabled()
   })
 
   it("uses the deployment origin for API and SDK snippets", async () => {

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useMemo, useState } from "react"
-import { DeploymentConfigFallbackAlert } from "@/components/deployment/deployment-config-fallback-alert"
+import { DeploymentConfigErrorAlert } from "@/components/deployment/deployment-config-error-alert"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"
@@ -20,7 +20,6 @@ import { formatAgentApiSnippets, type ApiSnippetTab } from "@/lib/api-snippet-fo
 import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
-  browserDeploymentConfig,
   buildDeploymentShareUrl,
   fetchDeploymentConfig,
   resolveDeploymentOrigin,
@@ -113,12 +112,12 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
       .catch((error) => {
         if (cancelled) return
         console.error("Failed to load deployment configuration", error)
-        setDeploymentConfig(browserDeploymentConfig())
-        setApiSnippetTarget(getApiSnippetTarget(browserOrigin))
+        setDeploymentConfig(null)
+        setApiSnippetTarget({ baseUrl: "" })
         setDeploymentConfigFailed(true)
         toast.error(
           t("deployment_config.messages.load_failed")
-          || "Failed to load deployment configuration; using this browser's origin.",
+          || "Failed to load deployment configuration. Retry before copying deployment details.",
         )
       })
 
@@ -137,7 +136,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
       console.error("Failed to load deployment configuration", error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration; using this browser's origin.",
+        || "Failed to load deployment configuration. Retry before copying deployment details.",
       )
     }
   }
@@ -235,6 +234,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
   }
 
   const handleCopyApiSnippet = async () => {
+    if (!apiSnippetTarget.baseUrl) return
     if (await copyToClipboard(apiSnippets[apiTab])) {
       setCopiedSnippet(true)
       toast.success(t("deploy_agent.messages.copied") || "Copied to clipboard")
@@ -479,7 +479,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
         </DialogHeader>
 
         {deploymentConfigFailed && (
-          <DeploymentConfigFallbackAlert onRetry={retryDeploymentConfig} />
+          <DeploymentConfigErrorAlert onRetry={retryDeploymentConfig} />
         )}
 
         {activeView === "options" ? (
@@ -537,13 +537,14 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
 
             <div className="bg-muted p-4 rounded-md text-xs font-mono relative overflow-hidden group">
               <pre className="whitespace-pre-wrap break-all text-muted-foreground max-h-80 overflow-auto">
-                {apiSnippets[apiTab]}
+                {apiSnippetTarget.baseUrl ? apiSnippets[apiTab] : "…"}
               </pre>
               <Button
                 variant="secondary"
                 size="icon"
                 className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
                 onClick={handleCopyApiSnippet}
+                disabled={!apiSnippetTarget.baseUrl}
                 title={t("deploy_agent.api_panel.copy_btn") || "Copy"}
               >
                 {copiedSnippet ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
@@ -691,7 +692,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
                     <Label className="text-sm">{t("deploy_agent.share_link.public_url") || "Public URL"}</Label>
                     <div className="flex gap-2">
                       <Input readOnly value={shareUrl} className="flex-1" />
-                      <Button variant="secondary" onClick={() => void handleCopyShareLink()} disabled={isUpdatingShare}>
+                      <Button variant="secondary" onClick={() => void handleCopyShareLink()} disabled={isUpdatingShare || !shareUrl}>
                         {copiedShareLink ? <Check className="h-4 w-4 mr-1 text-green-500" /> : <Copy className="h-4 w-4 mr-1" />}
                         {t("common.copy") || "Copy"}
                       </Button>

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -20,6 +20,7 @@ import { formatAgentApiSnippets, type ApiSnippetTab } from "@/lib/api-snippet-fo
 import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
+  DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
   buildDeploymentShareUrl,
   fetchDeploymentConfig,
   resolveDeploymentOrigin,
@@ -117,7 +118,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
         setDeploymentConfigFailed(true)
         toast.error(
           t("deployment_config.messages.load_failed")
-          || "Failed to load deployment configuration. Retry before copying deployment details.",
+          || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
         )
       })
 
@@ -136,7 +137,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
       console.error("Failed to load deployment configuration", error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration. Retry before copying deployment details.",
+        || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
       )
     }
   }

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -686,7 +686,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
                 <div className="pt-2 text-sm text-muted-foreground">
                   {t("common.loading") || "Loading..."}
                 </div>
-              ) : shareEnabled && shareUrl ? (
+              ) : shareEnabled ? (
                 <div className="space-y-4 pt-2">
                   <div className="space-y-2">
                     <Label className="text-sm">{t("deploy_agent.share_link.public_url") || "Public URL"}</Label>
@@ -700,20 +700,6 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {t("deploy_agent.share_link.anyone_access") || "Anyone with this link can start a public chat with this agent."}
-                  </div>
-                  <div className="flex gap-2">
-                    <Button variant="outline" onClick={handleRotateShare} disabled={isUpdatingShare}>
-                      {t("deploy_agent.share_link.rotate_btn") || "Reset Link"}
-                    </Button>
-                    <Button variant="outline" onClick={handleDisableShare} disabled={isUpdatingShare}>
-                      {t("deploy_agent.share_link.disable_btn") || "Disable Link"}
-                    </Button>
-                  </div>
-                </div>
-              ) : shareEnabled ? (
-                <div className="space-y-4 pt-2">
-                  <div className="text-sm text-muted-foreground">
-                    {t("deploy_agent.messages.share_failed") || "Share link action failed"}
                   </div>
                   <div className="flex gap-2">
                     <Button variant="outline" onClick={handleRotateShare} disabled={isUpdatingShare}>

--- a/frontend/src/components/deployment/deployment-config-error-alert.test.tsx
+++ b/frontend/src/components/deployment/deployment-config-error-alert.test.tsx
@@ -1,0 +1,40 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import React from "react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+import { DeploymentConfigErrorAlert } from "./deployment-config-error-alert"
+
+describe("DeploymentConfigErrorAlert", () => {
+  it("remains retryable when another configuration request fails", async () => {
+    let rejectRetry: ((error: Error) => void) | undefined
+    const onRetry = vi.fn(
+      () => new Promise<void>((_resolve, reject) => {
+        rejectRetry = reject
+      }),
+    )
+
+    render(<DeploymentConfigErrorAlert onRetry={onRetry} />)
+
+    const retryButton = screen.getByRole("button", {
+      name: "deployment_config.actions.retry",
+    })
+    fireEvent.click(retryButton)
+
+    expect(retryButton).toBeDisabled()
+    expect(onRetry).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      rejectRetry?.(new Error("deployment config unavailable"))
+    })
+
+    await waitFor(() => expect(retryButton).toBeEnabled())
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "deployment_config.messages.load_failed",
+    )
+  })
+})

--- a/frontend/src/components/deployment/deployment-config-error-alert.tsx
+++ b/frontend/src/components/deployment/deployment-config-error-alert.tsx
@@ -33,6 +33,9 @@ export function DeploymentConfigErrorAlert({
     setIsRetrying(true)
     try {
       await onRetry()
+    } catch {
+      // The owner reports the request error and keeps the failure state set.
+      // This alert only restores its retry control after the request settles.
     } finally {
       setIsRetrying(false)
     }

--- a/frontend/src/components/deployment/deployment-config-error-alert.tsx
+++ b/frontend/src/components/deployment/deployment-config-error-alert.tsx
@@ -19,10 +19,9 @@ interface DeploymentConfigErrorAlertProps {
 /**
  * Persistent warning for deployment dialogs whose public target is unavailable.
  *
- * A toast is easy to miss and can leave a user copying a target that is wrong
- * for a regional deployment. This shared alert keeps that state visible and
- * gives every deployment surface the same explicit recovery action. Callers
- * keep copy controls disabled until the retry supplies a verified target.
+ * A toast is easy to miss. This alert keeps the unavailable target visible.
+ * It also gives each deployment surface the same recovery action. Callers keep
+ * copy controls disabled until the retry supplies a verified target.
  */
 export function DeploymentConfigErrorAlert({
   onRetry,

--- a/frontend/src/components/deployment/deployment-config-error-alert.tsx
+++ b/frontend/src/components/deployment/deployment-config-error-alert.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Loader2 } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { useI18n } from "@/contexts/i18n-context"
+import { DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK } from "@/lib/deployment-config"
 
 interface DeploymentConfigErrorAlertProps {
   /**
@@ -47,7 +48,7 @@ export function DeploymentConfigErrorAlert({
       <AlertDescription className="flex w-full items-center gap-3 text-amber-800">
         <span className="flex-1">
           {t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration. Retry before copying deployment details."}
+            || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK}
         </span>
         <Button
           type="button"

--- a/frontend/src/components/deployment/deployment-config-error-alert.tsx
+++ b/frontend/src/components/deployment/deployment-config-error-alert.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { useI18n } from "@/contexts/i18n-context"
 
-interface DeploymentConfigFallbackAlertProps {
+interface DeploymentConfigErrorAlertProps {
   /**
    * Reload the runtime deployment configuration and update the owning dialog.
    * The alert remains mounted when the retry rejects, so degraded state is
@@ -17,15 +17,16 @@ interface DeploymentConfigFallbackAlertProps {
 }
 
 /**
- * Persistent warning for deployment dialogs using the browser-origin fallback.
+ * Persistent warning for deployment dialogs whose public target is unavailable.
  *
  * A toast is easy to miss and can leave a user copying a target that is wrong
  * for a regional deployment. This shared alert keeps that state visible and
- * gives every deployment surface the same explicit recovery action.
+ * gives every deployment surface the same explicit recovery action. Callers
+ * keep copy controls disabled until the retry supplies a verified target.
  */
-export function DeploymentConfigFallbackAlert({
+export function DeploymentConfigErrorAlert({
   onRetry,
-}: DeploymentConfigFallbackAlertProps) {
+}: DeploymentConfigErrorAlertProps) {
   const { t } = useI18n()
   const [isRetrying, setIsRetrying] = useState(false)
 
@@ -44,7 +45,7 @@ export function DeploymentConfigFallbackAlert({
       <AlertDescription className="flex w-full items-center gap-3 text-amber-800">
         <span className="flex-1">
           {t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration; using this browser's origin."}
+            || "Failed to load deployment configuration. Retry before copying deployment details."}
         </span>
         <Button
           type="button"

--- a/frontend/src/components/workforce/deploy-workforce-dialog.test.tsx
+++ b/frontend/src/components/workforce/deploy-workforce-dialog.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
 import React from "react"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -90,7 +91,7 @@ describe("DeployWorkforceDialog", () => {
     cleanup()
   })
 
-  it("restores the local API target when deployment config loading fails", async () => {
+  it("keeps API copy disabled until config retry succeeds", async () => {
     apiRequestMock.mockRejectedValueOnce(
       new Error("deployment config unavailable"),
     )
@@ -105,13 +106,14 @@ describe("DeployWorkforceDialog", () => {
       />,
     )
 
+    expect(await screen.findByText("deployment_config.messages.load_failed")).toBeInTheDocument()
+    const copyButton = screen.getByTitle("deploy_workforce.copy")
+    expect(copyButton).toBeDisabled()
     expect(
-      await screen.findByText((content) =>
-        content.includes(
-          "https://cloud.example.test/v1/workforces/42/runs",
-        ),
+      screen.queryByText((content) =>
+        content.includes("https://cloud.example.test/v1/workforces/42/runs"),
       ),
-    ).toBeInTheDocument()
+    ).not.toBeInTheDocument()
     expect(toastErrorMock).toHaveBeenCalledWith(
       "deployment_config.messages.load_failed",
     )
@@ -131,6 +133,7 @@ describe("DeployWorkforceDialog", () => {
     expect(
       screen.queryByText("deployment_config.messages.load_failed"),
     ).not.toBeInTheDocument()
+    expect(copyButton).toBeEnabled()
   })
 
   it("reports snippet clipboard failures", async () => {
@@ -146,7 +149,9 @@ describe("DeployWorkforceDialog", () => {
       />,
     )
 
-    screen.getByTitle("deploy_workforce.copy").click()
+    const copyButton = screen.getByTitle("deploy_workforce.copy")
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    copyButton.click()
 
     await vi.waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith(

--- a/frontend/src/components/workforce/deploy-workforce-dialog.tsx
+++ b/frontend/src/components/workforce/deploy-workforce-dialog.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useMemo, useState } from "react"
 import { Check, Copy, KeyRound, Loader2 } from "lucide-react"
 
-import { DeploymentConfigFallbackAlert } from "@/components/deployment/deployment-config-fallback-alert"
+import { DeploymentConfigErrorAlert } from "@/components/deployment/deployment-config-error-alert"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -18,7 +18,6 @@ import { useI18n } from "@/contexts/i18n-context"
 import { copyToClipboard } from "@/lib/clipboard"
 import { fetchDeploymentConfig } from "@/lib/deployment-config"
 import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
-import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
   formatWorkforceApiSnippets,
   type ApiSnippetTab,
@@ -82,11 +81,11 @@ export function DeployWorkforceDialog({
       })
       .catch(() => {
         if (!cancelled) {
-          setApiTarget(getApiSnippetTarget(getBrowserLocationOrigin()))
+          setApiTarget({ baseUrl: "" })
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration; using this browser's origin.",
+            || "Failed to load deployment configuration. Retry before copying deployment details.",
           )
         }
       })
@@ -103,7 +102,7 @@ export function DeployWorkforceDialog({
     } catch {
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration; using this browser's origin.",
+        || "Failed to load deployment configuration. Retry before copying deployment details.",
       )
     }
   }
@@ -138,6 +137,7 @@ export function DeployWorkforceDialog({
   )
 
   const handleCopySnippet = async () => {
+    if (!apiTarget.baseUrl) return
     const ok = await copyToClipboard(snippets[apiTab])
     if (ok) {
       setCopiedSnippet(true)
@@ -202,7 +202,7 @@ export function DeployWorkforceDialog({
         </DialogHeader>
 
         {deploymentConfigFailed && (
-          <DeploymentConfigFallbackAlert onRetry={retryDeploymentConfig} />
+          <DeploymentConfigErrorAlert onRetry={retryDeploymentConfig} />
         )}
 
         <div className="space-y-5">
@@ -226,13 +226,14 @@ export function DeployWorkforceDialog({
             </div>
             <div className="mt-3 bg-muted p-4 rounded-md text-xs font-mono relative group">
               <pre className="whitespace-pre-wrap break-all text-muted-foreground max-h-72 overflow-auto">
-                {snippets[apiTab]}
+                {apiTarget.baseUrl ? snippets[apiTab] : "…"}
               </pre>
               <Button
                 variant="secondary"
                 size="icon"
                 className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
                 onClick={handleCopySnippet}
+                disabled={!apiTarget.baseUrl}
                 title={t("deploy_workforce.copy") || "Copy"}
               >
                 {copiedSnippet ? (

--- a/frontend/src/components/workforce/deploy-workforce-dialog.tsx
+++ b/frontend/src/components/workforce/deploy-workforce-dialog.tsx
@@ -16,7 +16,10 @@ import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/sonner"
 import { useI18n } from "@/contexts/i18n-context"
 import { copyToClipboard } from "@/lib/clipboard"
-import { fetchDeploymentConfig } from "@/lib/deployment-config"
+import {
+  DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
+  fetchDeploymentConfig,
+} from "@/lib/deployment-config"
 import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
 import {
   formatWorkforceApiSnippets,
@@ -85,7 +88,7 @@ export function DeployWorkforceDialog({
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration. Retry before copying deployment details.",
+            || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
           )
         }
       })
@@ -102,7 +105,7 @@ export function DeployWorkforceDialog({
     } catch {
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration. Retry before copying deployment details.",
+        || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
       )
     }
   }

--- a/frontend/src/components/workforce/workforce-share-dialog.test.tsx
+++ b/frontend/src/components/workforce/workforce-share-dialog.test.tsx
@@ -84,7 +84,7 @@ describe("WorkforceShareDialog", () => {
     cleanup()
   })
 
-  it("keeps the standalone share link usable when config loading fails", async () => {
+  it("keeps share copy disabled until config retry succeeds", async () => {
     apiRequestMock.mockRejectedValueOnce(new Error("deployment config unavailable"))
 
     render(
@@ -95,11 +95,10 @@ describe("WorkforceShareDialog", () => {
       />,
     )
 
-    expect(
-      await screen.findByDisplayValue(
-        "https://cloud.example.test/share/regional-share",
-      ),
-    ).toBeInTheDocument()
+    expect(await screen.findByText("deployment_config.messages.load_failed")).toBeInTheDocument()
+    const copyButton = screen.getByRole("button", { name: "common.copy" })
+    expect(screen.getByRole("textbox")).toHaveValue("")
+    expect(copyButton).toBeDisabled()
     expect(toastErrorMock).toHaveBeenCalledWith(
       "deployment_config.messages.load_failed",
     )
@@ -117,6 +116,7 @@ describe("WorkforceShareDialog", () => {
     expect(
       screen.queryByText("deployment_config.messages.load_failed"),
     ).not.toBeInTheDocument()
+    expect(copyButton).toBeEnabled()
   })
 
   it("builds a canonical share link that bootstraps the owning region", async () => {

--- a/frontend/src/components/workforce/workforce-share-dialog.tsx
+++ b/frontend/src/components/workforce/workforce-share-dialog.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react"
 import { Check, Copy, Share } from "lucide-react"
-import { DeploymentConfigFallbackAlert } from "@/components/deployment/deployment-config-fallback-alert"
+import { DeploymentConfigErrorAlert } from "@/components/deployment/deployment-config-error-alert"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
@@ -12,7 +12,6 @@ import { toast } from "@/components/ui/sonner"
 import { copyToClipboard } from "@/lib/clipboard"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
-  browserDeploymentConfig,
   buildDeploymentShareUrl,
   fetchDeploymentConfig,
   type DeploymentConfig,
@@ -75,11 +74,11 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
           setDeploymentConfigFailed(false)
         } else {
           console.error(targetsResult.reason)
-          setDeploymentConfig(browserDeploymentConfig())
+          setDeploymentConfig(null)
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration; using this browser's origin.",
+            || "Failed to load deployment configuration. Retry before copying deployment details.",
           )
         }
 
@@ -111,7 +110,7 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
       console.error(error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration; using this browser's origin.",
+        || "Failed to load deployment configuration. Retry before copying deployment details.",
       )
     }
   }
@@ -160,7 +159,7 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
         </DialogHeader>
 
         {deploymentConfigFailed && (
-          <DeploymentConfigFallbackAlert onRetry={retryDeploymentConfig} />
+          <DeploymentConfigErrorAlert onRetry={retryDeploymentConfig} />
         )}
 
         <div className="space-y-4 border rounded-lg p-4">
@@ -181,13 +180,13 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
             <div className="pt-2 text-sm text-muted-foreground">
               {t("common.loading") || "Loading..."}
             </div>
-          ) : shareEnabled && shareUrl ? (
+          ) : shareEnabled ? (
             <div className="space-y-4 pt-2">
               <div className="space-y-2">
                 <Label className="text-sm">{t("workforces.share_link.public_url") || "Public URL"}</Label>
                 <div className="flex gap-2">
                   <Input readOnly value={shareUrl} className="flex-1" />
-                  <Button variant="secondary" onClick={() => void handleCopy()} disabled={isUpdating}>
+                  <Button variant="secondary" onClick={() => void handleCopy()} disabled={isUpdating || !shareUrl}>
                     {copied ? <Check className="h-4 w-4 mr-1 text-green-500" /> : <Copy className="h-4 w-4 mr-1" />}
                     {t("common.copy") || "Copy"}
                   </Button>

--- a/frontend/src/components/workforce/workforce-share-dialog.tsx
+++ b/frontend/src/components/workforce/workforce-share-dialog.tsx
@@ -12,6 +12,7 @@ import { toast } from "@/components/ui/sonner"
 import { copyToClipboard } from "@/lib/clipboard"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
+  DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
   buildDeploymentShareUrl,
   fetchDeploymentConfig,
   type DeploymentConfig,
@@ -78,7 +79,7 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration. Retry before copying deployment details.",
+            || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
           )
         }
 
@@ -110,7 +111,7 @@ export function WorkforceShareDialog({ workforce, open, onClose }: WorkforceShar
       console.error(error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration. Retry before copying deployment details.",
+        || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
       )
     }
   }

--- a/frontend/src/components/workforce/workforce-widget-dialog.test.tsx
+++ b/frontend/src/components/workforce/workforce-widget-dialog.test.tsx
@@ -83,7 +83,7 @@ describe("WorkforceWidgetDialog", () => {
     cleanup()
   })
 
-  it("keeps the standalone widget usable when config loading fails", async () => {
+  it("keeps widget copy disabled until config retry succeeds", async () => {
     apiRequestMock.mockRejectedValueOnce(new Error("deployment config unavailable"))
 
     render(
@@ -94,11 +94,10 @@ describe("WorkforceWidgetDialog", () => {
       />,
     )
 
-    expect(
-      await screen.findByText((content) =>
-        content.includes('src="https://cloud.example.test/widget.js"'),
-      ),
-    ).toBeInTheDocument()
+    expect(await screen.findByText("deployment_config.messages.load_failed")).toBeInTheDocument()
+    const copyButton = screen.getByTitle("workforces.widget.copy_btn")
+    expect(screen.getByText("…")).toBeInTheDocument()
+    expect(copyButton).toBeDisabled()
     expect(toastErrorMock).toHaveBeenCalledWith(
       "deployment_config.messages.load_failed",
     )
@@ -118,6 +117,7 @@ describe("WorkforceWidgetDialog", () => {
     expect(
       screen.queryByText("deployment_config.messages.load_failed"),
     ).not.toBeInTheDocument()
+    expect(copyButton).toBeEnabled()
   })
 
   it("builds the embed snippet from the advertised deployment origin", async () => {

--- a/frontend/src/components/workforce/workforce-widget-dialog.tsx
+++ b/frontend/src/components/workforce/workforce-widget-dialog.tsx
@@ -14,6 +14,7 @@ import { toast } from "@/components/ui/sonner"
 import { copyToClipboard } from "@/lib/clipboard"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
+  DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
   fetchDeploymentConfig,
   resolveDeploymentOrigin,
   type DeploymentConfig,
@@ -78,7 +79,7 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration. Retry before copying deployment details.",
+            || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
           )
         }
 
@@ -110,7 +111,7 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
       console.error(error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration. Retry before copying deployment details.",
+        || DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK,
       )
     }
   }

--- a/frontend/src/components/workforce/workforce-widget-dialog.tsx
+++ b/frontend/src/components/workforce/workforce-widget-dialog.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react"
 import { Check, Copy, LayoutGrid } from "lucide-react"
-import { DeploymentConfigFallbackAlert } from "@/components/deployment/deployment-config-fallback-alert"
+import { DeploymentConfigErrorAlert } from "@/components/deployment/deployment-config-error-alert"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
@@ -14,7 +14,6 @@ import { toast } from "@/components/ui/sonner"
 import { copyToClipboard } from "@/lib/clipboard"
 import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import {
-  browserDeploymentConfig,
   fetchDeploymentConfig,
   resolveDeploymentOrigin,
   type DeploymentConfig,
@@ -75,11 +74,11 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
           setDeploymentConfigFailed(false)
         } else {
           console.error(targetsResult.reason)
-          setDeploymentConfig(browserDeploymentConfig())
+          setDeploymentConfig(null)
           setDeploymentConfigFailed(true)
           toast.error(
             t("deployment_config.messages.load_failed")
-            || "Failed to load deployment configuration; using this browser's origin.",
+            || "Failed to load deployment configuration. Retry before copying deployment details.",
           )
         }
 
@@ -111,7 +110,7 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
       console.error(error)
       toast.error(
         t("deployment_config.messages.load_failed")
-        || "Failed to load deployment configuration; using this browser's origin.",
+        || "Failed to load deployment configuration. Retry before copying deployment details.",
       )
     }
   }
@@ -217,7 +216,7 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
         </DialogHeader>
 
         {deploymentConfigFailed && (
-          <DeploymentConfigFallbackAlert onRetry={retryDeploymentConfig} />
+          <DeploymentConfigErrorAlert onRetry={retryDeploymentConfig} />
         )}
 
         {!isActive ? (
@@ -315,6 +314,7 @@ export function WorkforceWidgetDialog({ workforce, open, onClose }: WorkforceWid
                     size="icon"
                     className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => void handleCopySnippet()}
+                    disabled={!widgetKey || !widgetOrigin}
                     title={t("workforces.widget.copy_btn") || "Copy Snippet"}
                   >
                     {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3359,7 +3359,7 @@ Build when you need.`,
       retry: "Retry"
     },
     messages: {
-      load_failed: "Failed to load deployment configuration; using this browser's origin."
+      load_failed: "Failed to load deployment configuration. Retry before copying deployment details."
     }
   },
   deploy_agent: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3359,7 +3359,7 @@ const zh = {
       retry: "重试"
     },
     messages: {
-      load_failed: "部署配置加载失败，已改用当前浏览器地址。"
+      load_failed: "部署配置加载失败。复制部署信息前请重试。"
     }
   },
   deploy_agent: {

--- a/frontend/src/i18n/translations.test.ts
+++ b/frontend/src/i18n/translations.test.ts
@@ -67,6 +67,12 @@ describe("translations", () => {
     assertTranslationTreeParity(translations.en, translations.zh)
   })
 
+  it("describes deployment configuration failure without a browser fallback", () => {
+    expect(translations.zh.deployment_config.messages.load_failed).toBe(
+      "部署配置加载失败。复制部署信息前请重试。",
+    )
+  })
+
   it("keeps MCP runtime translations non-empty", () => {
     assertTranslationLeavesNonEmpty(
       translations.en.tools.mcp.runtime,

--- a/frontend/src/lib/deployment-config.test.ts
+++ b/frontend/src/lib/deployment-config.test.ts
@@ -13,7 +13,6 @@ vi.mock("@/lib/utils", () => ({
 
 import {
   __resetDeploymentConfigCache,
-  browserDeploymentConfig,
   buildDeploymentShareUrl,
   fetchDeploymentConfig,
   resolveDeploymentOrigin,
@@ -164,14 +163,6 @@ describe("deployment config", () => {
         "https://cloud.example.test",
       ),
     ).toBe("")
-  })
-
-  it("represents browser fallback without duplicating the browser origin", () => {
-    expect(browserDeploymentConfig()).toEqual({
-      deployment_origin: null,
-      app_origin: null,
-      region: null,
-    })
   })
 
   it("uses browser origins for standalone deployment configuration", () => {

--- a/frontend/src/lib/deployment-config.test.ts
+++ b/frontend/src/lib/deployment-config.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { readFileSync } from "node:fs"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const getApiUrlMock = vi.hoisted(() => vi.fn())
@@ -43,6 +44,30 @@ describe("deployment config", () => {
     await fetchDeploymentConfig()
 
     expect(apiRequestMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps deployment failure fallback copy in one module", () => {
+    const fallback =
+      "Failed to load deployment configuration. Retry before copying deployment details."
+    const componentPaths = [
+      "src/components/build/deploy-agent-dialog.tsx",
+      "src/components/deployment/deployment-config-error-alert.tsx",
+      "src/components/workforce/deploy-workforce-dialog.tsx",
+      "src/components/workforce/workforce-share-dialog.tsx",
+      "src/components/workforce/workforce-widget-dialog.tsx",
+    ]
+
+    for (const path of componentPaths) {
+      expect(readFileSync(`${process.cwd()}/${path}`, "utf8")).not.toContain(
+        fallback,
+      )
+    }
+    expect(
+      readFileSync(
+        `${process.cwd()}/src/lib/deployment-config.ts`,
+        "utf8",
+      ).match(new RegExp(fallback.replaceAll(".", String.raw`\.`), "g")),
+    ).toHaveLength(1)
   })
 
   it("retries a failed request and caches the successful deployment targets", async () => {

--- a/frontend/src/lib/deployment-config.ts
+++ b/frontend/src/lib/deployment-config.ts
@@ -2,6 +2,9 @@ import { apiRequest } from "@/lib/api-wrapper"
 import { resolveApiSnippetBaseUrl } from "@/lib/api-snippet-target"
 import { getApiUrl } from "@/lib/utils"
 
+export const DEPLOYMENT_CONFIG_LOAD_FAILED_FALLBACK =
+  "Failed to load deployment configuration. Retry before copying deployment details."
+
 export interface DeploymentConfig {
   /**
    * Origin external API and widget clients should call. Hosting layers may

--- a/frontend/src/lib/deployment-config.ts
+++ b/frontend/src/lib/deployment-config.ts
@@ -112,21 +112,6 @@ export function __resetDeploymentConfigCache(): void {
 }
 
 /**
- * Represent the known-safe local target after configuration loading failed.
- *
- * Callers keep `null` while loading so regional deployments cannot briefly
- * expose the canonical routing edge. Only a completed failure should use this
- * standalone-shaped value to restore the pre-configuration browser fallback.
- */
-export function browserDeploymentConfig(): DeploymentConfig {
-  return {
-    deployment_origin: null,
-    app_origin: null,
-    region: null,
-  }
-}
-
-/**
  * Resolve an external-client origin only after deployment configuration has
  * loaded. A configured object with no override represents standalone XAgent,
  * where the browser origin remains the correct target.


### PR DESCRIPTION
## Summary

- remove the browser-origin fallback from Agent and Workforce deployment dialogs
- keep API, SDK, share-link, and widget copy controls disabled when public deployment configuration is unavailable
- show a persistent retry action and restore the controls after configuration loads successfully
- remove the obsolete browser fallback helper and rename the shared alert to describe the error state

## Why

Regional deployments advertise a direct regional origin through `/api/deployment-config`. If that request failed, the dialogs previously substituted the browser origin. For SaaS, that browser origin is the canonical routing edge, which cannot determine an unauthenticated SDK or widget caller's region and returns `409 region_required`.

Failing closed prevents users from copying a target that is known to be unsafe. Standalone and regional deployments behave as before whenever deployment configuration loads successfully.

This is the upstream frontend counterpart to the regional deployment work in xorbitsai/xagent-saas#322.

## Verification

- 30 focused deployment configuration and dialog tests passed
- frontend TypeScript type-check passed
- focused frontend ESLint checks passed
- Ruff, formatting, mypy, whitespace, import sorting, and codespell hooks passed

The repository-wide Alembic pre-commit hook could not bootstrap an unrelated `datrie` build in the local environment. The npm pre-commit hooks were run directly because npm was not present in that isolated hook environment.
