### PR TITLE
fix: retry Auto model when reasoning is mandatory

### DIFF
--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ROUTER_ABILITIES = ["chat", "tool_calling"]
 _UNROUTED_ROUTER_ABILITIES = {"vision", "thinking_mode"}
 _DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
+_ENABLE_DOWNSTREAM_THINKING = {"type": "enabled", "enable": True}
 _CONTENT_PART_MODALITIES = {
     "audio": "audio",
     "audio_url": "audio",
@@ -69,6 +70,23 @@ _MODALITY_ABILITIES = {
 
 class RouterModalityRoutingError(RuntimeError):
     """The installed router cannot enforce required input modalities."""
+
+
+def _should_retry_with_thinking(
+    exc: Exception,
+    *,
+    thinking: dict[str, Any] | None,
+) -> bool:
+    if thinking is None or not (
+        thinking.get("type") == "disabled" or thinking.get("enable") is False
+    ):
+        return False
+
+    # OpenRouter currently exposes this provider constraint only through an
+    # untyped 400 response. Retry the same selected model once with reasoning
+    # enabled instead of repeating the rejected payload or rerouting.
+    exc_msg = str(exc).lower()
+    return "reasoning is mandatory" in exc_msg and "cannot be disabled" in exc_msg
 
 
 def _should_retry_without_thinking(
@@ -114,6 +132,14 @@ def _next_retry_state(
     thinking: dict[str, Any] | None,
     tool_choice: str | dict[str, Any] | None,
 ) -> tuple[str | dict[str, Any] | None, dict[str, Any] | None, str, str] | None:
+    if _should_retry_with_thinking(exc, thinking=thinking):
+        return (
+            tool_choice,
+            _ENABLE_DOWNSTREAM_THINKING,
+            "selected model requires reasoning; retrying with thinking enabled",
+            "enable_thinking",
+        )
+
     if _should_retry_without_thinking(exc, thinking=thinking, tool_choice=tool_choice):
         return (
             tool_choice,

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -77,6 +77,8 @@ def _should_retry_with_thinking(
     *,
     thinking: dict[str, Any] | None,
 ) -> bool:
+    # This is the primary stop condition after a retry swaps in enabled thinking;
+    # retry-action tracking remains defense in depth for the shared retry loop.
     if isinstance(thinking, dict) and (
         thinking.get("type") == "enabled" or thinking.get("enable") is True
     ):
@@ -85,6 +87,7 @@ def _should_retry_with_thinking(
     # OpenRouter currently exposes this provider constraint only through an
     # untyped 400 response. Retry the same selected model once with reasoning
     # enabled instead of repeating the rejected payload or rerouting.
+    # Replace string matching with typed provider errors when available.
     exc_msg = str(exc).lower()
     return "reasoning is mandatory" in exc_msg and "cannot be disabled" in exc_msg
 

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ROUTER_ABILITIES = ["chat", "tool_calling"]
 _UNROUTED_ROUTER_ABILITIES = {"vision", "thinking_mode"}
+# Normalized intents translated into OpenRouter's reasoning/thinking request body.
 _DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
 _ENABLE_DOWNSTREAM_THINKING = {"type": "enabled", "enable": True}
 _CONTENT_PART_MODALITIES = {

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -77,8 +77,8 @@ def _should_retry_with_thinking(
     *,
     thinking: dict[str, Any] | None,
 ) -> bool:
-    if thinking is None or not (
-        thinking.get("type") == "disabled" or thinking.get("enable") is False
+    if isinstance(thinking, dict) and (
+        thinking.get("type") == "enabled" or thinking.get("enable") is True
     ):
         return False
 

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -21,6 +21,10 @@ _OPENROUTER_TOOL_CHOICE_ERROR = (
 _THINKING_TOOL_CHOICE_ERROR = (
     "OpenAI bad request (400): Thinking mode does not support this tool_choice"
 )
+_MANDATORY_REASONING_ERROR = (
+    "OpenAI bad request (400): Reasoning is mandatory for this endpoint "
+    "and cannot be disabled."
+)
 
 
 def _tool_schema() -> dict[str, Any]:
@@ -127,6 +131,26 @@ class _ScriptedChatLLM(BaseLLM):
         if self.errors:
             raise RuntimeError(self.errors.pop(0))
         return "ok"
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        del messages, temperature, max_tokens, tools, response_format
+        del output_config, kwargs
+        self.tool_choices.append(tool_choice)
+        self.thinking_values.append(thinking)
+        if self.errors:
+            raise RuntimeError(self.errors.pop(0))
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
 
 
 async def _select_glm(_prompt: str) -> str:
@@ -587,6 +611,73 @@ async def test_router_chat_propagates_non_matching_errors_without_retry(monkeypa
         )
 
     assert llm.tool_choices == ["required"]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_enables_thinking_when_selected_model_requires_it(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    result = await router.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=[_tool_schema()],
+        tool_choice="required",
+        thinking={"type": "disabled", "enable": False},
+    )
+
+    assert result == "ok"
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_stream_enables_thinking_when_selected_model_requires_it(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    chunks = [
+        chunk
+        async for chunk in router.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR, _MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "enabled", "enable": True},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -668,7 +668,13 @@ async def test_router_stream_enables_thinking_when_selected_model_requires_it(
 
 @pytest.mark.asyncio
 async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
-    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR, _MANDATORY_REASONING_ERROR])
+    llm = _ScriptedChatLLM(
+        [
+            _MANDATORY_REASONING_ERROR,
+            _THINKING_TOOL_CHOICE_ERROR,
+            _MANDATORY_REASONING_ERROR,
+        ]
+    )
     router = RouterLLM(downstream_resolver=lambda _model_id: llm)
     monkeypatch.setattr(router, "_select_model", _select_glm)
 
@@ -683,7 +689,9 @@ async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
     assert llm.thinking_values == [
         {"type": "disabled", "enable": False},
         {"type": "enabled", "enable": True},
+        {"type": "disabled", "enable": False},
     ]
+    assert llm.tool_choices == ["required", "required", "required"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -613,9 +613,14 @@ async def test_router_chat_propagates_non_matching_errors_without_retry(monkeypa
     assert llm.tool_choices == ["required"]
 
 
+@pytest.mark.parametrize(
+    "thinking",
+    [None, {"type": "disabled", "enable": False}],
+    ids=["unspecified", "disabled"],
+)
 @pytest.mark.asyncio
 async def test_router_chat_enables_thinking_when_selected_model_requires_it(
-    monkeypatch,
+    monkeypatch, thinking
 ):
     llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
     router = RouterLLM(downstream_resolver=lambda _model_id: llm)
@@ -625,35 +630,15 @@ async def test_router_chat_enables_thinking_when_selected_model_requires_it(
         [{"role": "user", "content": "score?"}],
         tools=[_tool_schema()],
         tool_choice="required",
-        thinking={"type": "disabled", "enable": False},
+        thinking=thinking,
     )
 
     assert result == "ok"
     assert llm.thinking_values == [
-        {"type": "disabled", "enable": False},
+        thinking,
         {"type": "enabled", "enable": True},
     ]
-
-
-@pytest.mark.asyncio
-async def test_router_chat_enables_thinking_when_request_omits_preference(
-    monkeypatch,
-):
-    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    result = await router.chat(
-        [{"role": "user", "content": "score?"}],
-        tools=[_tool_schema()],
-        tool_choice="required",
-    )
-
-    assert result == "ok"
-    assert llm.thinking_values == [
-        None,
-        {"type": "enabled", "enable": True},
-    ]
+    assert llm.tool_choices == ["required", "required"]
 
 
 @pytest.mark.asyncio
@@ -699,6 +684,26 @@ async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
         {"type": "disabled", "enable": False},
         {"type": "enabled", "enable": True},
     ]
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_retry_mandatory_reasoning_when_already_enabled(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "enabled", "enable": True},
+        )
+
+    assert llm.thinking_values == [{"type": "enabled", "enable": True}]
+    assert llm.tool_choices == ["required"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -636,6 +636,27 @@ async def test_router_chat_enables_thinking_when_selected_model_requires_it(
 
 
 @pytest.mark.asyncio
+async def test_router_chat_enables_thinking_when_request_omits_preference(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    result = await router.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=[_tool_schema()],
+        tool_choice="required",
+    )
+
+    assert result == "ok"
+    assert llm.thinking_values == [
+        None,
+        {"type": "enabled", "enable": True},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_router_stream_enables_thinking_when_selected_model_requires_it(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- detect the untyped OpenRouter 400 returned when an Auto-selected endpoint requires reasoning
- retry the same selected model once with thinking enabled instead of rerouting or failing the task
- cover both streaming and non-streaming calls, including protection against repeating the same retry action

## Root cause

Auto routing uses a strict tool-call request with thinking explicitly disabled. Some downstream endpoints require reasoning and reject that request with `Reasoning is mandatory for this endpoint and cannot be disabled.` Because the provider exposes this only as an untyped 400, the existing compatibility retry layer did not recognize it and the task failed immediately.

## Impact

Auto model requests can continue when the selected downstream endpoint mandates reasoning. Other provider errors and retry behavior remain unchanged.

## Validation

- `PYTHONPATH=src pytest -q tests/core/model/chat/basic/test_router.py` — 22 passed
- `ruff format --check src/xagent/core/model/chat/basic/router.py tests/core/model/chat/basic/test_router.py`
- `ruff check src/xagent/core/model/chat/basic/router.py tests/core/model/chat/basic/test_router.py`
- commit hooks passed: Ruff, formatting, mypy, isort, codespell, whitespace checks