### PR TITLE
enh(widget): report connect-time revocation as 4003 with the real reason (#1057)

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1261,28 +1261,43 @@ async def public_chat_websocket_endpoint(
     """Serve widget websocket chat with per-message revalidation."""
     # Handshake budget (#1056): mirror of the share connect gate — a widget
     # key is embedded in a public page, so connection attempts are anonymous
-    # and need a per-IP ceiling. This endpoint closes pre-accept on auth
-    # failure below (uvicorn collapses that into a plain HTTP 403), so the
-    # pre-accept refusal here is consistent with its existing behaviour and
-    # is the cheapest rejection: no upgrade is performed at all. The IP is
-    # captured once — it cannot change for the lifetime of the socket — and
-    # reused by the per-turn gate in the loop below.
+    # and need a per-IP ceiling. Checked *pre-accept* on purpose: an over-limit
+    # probe is refused as a plain HTTP 403 with no upgrade performed at all,
+    # which is the cheapest rejection — and unlike the auth denials below, a
+    # rate-limited connect carries no reason the frontend recovery flow needs
+    # to read. The IP is captured once — it cannot change for the lifetime of
+    # the socket — and reused by the per-turn gate in the loop below.
     remote_ip = remote_ip_from_request(websocket)
     if not get_share_rate_limiter().allow_widget_ws_connect(remote_ip):
         await websocket.close(code=4008, reason="Too many connection attempts")
         return
 
+    # Accept the handshake *before* the auth/access checks (#1057), matching the
+    # share path. uvicorn only preserves a close code + reason on the wire for a
+    # *post-accept* close: a pre-accept ``websocket.close()`` collapses into a
+    # bare HTTP 403 with an empty body, so the browser sees a rejected Upgrade
+    # (onclose code=1006, reason="") and the real code/reason never arrive.
+    # Accepting first makes the 4003 below a real close whose reason reaches the
+    # widget client — the same post-accept behavior the per-message revalidation
+    # loop already relies on — so a returning guest whose widget was revoked can
+    # tell an access denial apart from a transport failure and recover, instead
+    # of the generic 4001 the pre-accept close used to flatten it into.
+    await websocket.accept()
     try:
         principal = await _authorize_public_chat_websocket(
             token=token,
             task_id=task_id,
             expected_auth_mode=expected_auth_mode,
         )
+    except HTTPException as exc:
+        await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
+        return
     except Exception:
         await websocket.close(code=4001, reason="Authentication required")
         return
 
-    await manager.connect(websocket, task_id)
+    # Already accepted above; register the live socket without re-accepting.
+    manager.register_connection(websocket, task_id)
 
     try:
         await handle_status_request(websocket, task_id, principal)

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1273,15 +1273,12 @@ async def public_chat_websocket_endpoint(
         return
 
     # Accept the handshake *before* the auth/access checks (#1057), matching the
-    # share path. uvicorn only preserves a close code + reason on the wire for a
-    # *post-accept* close: a pre-accept ``websocket.close()`` collapses into a
-    # bare HTTP 403 with an empty body, so the browser sees a rejected Upgrade
-    # (onclose code=1006, reason="") and the real code/reason never arrive.
-    # Accepting first makes the 4003 below a real close whose reason reaches the
-    # widget client — the same post-accept behavior the per-message revalidation
-    # loop already relies on — so a returning guest whose widget was revoked can
-    # tell an access denial apart from a transport failure and recover, instead
-    # of the generic 4001 the pre-accept close used to flatten it into.
+    # share path. uvicorn only preserves a close code + reason for a *post-accept*
+    # close; a pre-accept ``websocket.close()`` collapses into a bare HTTP 403
+    # (browser sees onclose code=1006, reason=""), discarding the denial. Accepting
+    # first makes the 4003 below a real close whose reason reaches the widget
+    # client, so a returning guest whose widget was revoked can tell an access
+    # denial apart from a transport failure and recover.
     await websocket.accept()
     try:
         principal = await _authorize_public_chat_websocket(

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -281,16 +281,23 @@ async def test_public_access_websocket_preserves_auth_close_codes(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("endpoint_kind", ["public", "share"])
-async def test_public_access_websocket_initial_auth_failure_stays_4001(
+async def test_public_access_websocket_initial_http_auth_failure_maps_to_4003(
     monkeypatch: pytest.MonkeyPatch,
     endpoint_kind: str,
 ) -> None:
+    # Both endpoints now accept the handshake before auth and map an auth-time
+    # HTTPException to a 4003 close carrying the real reason, so the frontend
+    # recovery flow can act on it (#973 for share, #1057 for widget). This is
+    # the connect-time analogue of the per-message revalidation 4003 — the far
+    # more common sequence for a revoked widget guest, who reloads the page and
+    # reconnects rather than staying on a live socket.
     websocket = _SingleMessageWebSocket({"type": "chat", "message": "hello"})
     authorize = AsyncMock(
-        side_effect=HTTPException(status_code=401, detail="Invalid token")
+        side_effect=HTTPException(status_code=403, detail="Widget is unavailable")
     )
     connection_manager = MagicMock()
     connection_manager.connect = AsyncMock()
+    connection_manager.register_connection = MagicMock()
     connection_manager.disconnect = MagicMock()
     monkeypatch.setattr(public_chat_access, "manager", connection_manager)
 
@@ -320,18 +327,67 @@ async def test_public_access_websocket_initial_auth_failure_stays_4001(
             token="share-token",
         )
 
+    # Accept-first is what lets the 4003 reason survive the handshake instead of
+    # collapsing into a bare HTTP 403 (browser sees 1006/"").
+    websocket.accept.assert_awaited_once()
+    websocket.close.assert_awaited_once_with(
+        code=4003,
+        reason="Widget is unavailable",
+    )
+    # Rejected before registration: neither the async accept-and-register helper
+    # nor the register-only path runs, so the socket never joins task broadcasts.
+    connection_manager.connect.assert_not_awaited()
+    connection_manager.register_connection.assert_not_called()
+    connection_manager.disconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint_kind", ["public", "share"])
+async def test_public_access_websocket_initial_non_http_failure_stays_4001(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint_kind: str,
+) -> None:
+    # A non-HTTP failure at connect-time auth (an infra error, not an access
+    # denial) carries no reason the recovery flow keys on, so both endpoints
+    # keep the generic 4001 rather than dressing it up as a 4003 access denial.
+    websocket = _SingleMessageWebSocket({"type": "chat", "message": "hello"})
+    authorize = AsyncMock(side_effect=RuntimeError("database is down"))
+    connection_manager = MagicMock()
+    connection_manager.connect = AsyncMock()
+    connection_manager.register_connection = MagicMock()
+    connection_manager.disconnect = MagicMock()
+    monkeypatch.setattr(public_chat_access, "manager", connection_manager)
+
     if endpoint_kind == "public":
-        websocket.close.assert_awaited_once_with(
-            code=4001,
-            reason="Authentication required",
+        monkeypatch.setattr(
+            public_chat_access,
+            "_authorize_public_chat_websocket",
+            authorize,
+            raising=False,
+        )
+        await public_chat_access.public_chat_websocket_endpoint(
+            websocket=websocket,
+            task_id=42,
+            token="widget-token",
+            expected_auth_mode="widget",
         )
     else:
-        # The share endpoint accepts before auth and maps an auth-time
-        # HTTPException to a 4003 close carrying the real reason, so the frontend
-        # recovery flow can act on it (#973). Only non-HTTP failures stay 4001.
-        websocket.close.assert_awaited_once_with(
-            code=4003,
-            reason="Invalid token",
+        monkeypatch.setattr(
+            public_chat_access,
+            "_authorize_share_chat_websocket",
+            authorize,
+            raising=False,
         )
+        await public_chat_access.share_chat_websocket_endpoint(
+            websocket=websocket,
+            task_id=42,
+            token="share-token",
+        )
+
+    websocket.close.assert_awaited_once_with(
+        code=4001,
+        reason="Authentication required",
+    )
     connection_manager.connect.assert_not_awaited()
+    connection_manager.register_connection.assert_not_called()
     connection_manager.disconnect.assert_not_called()

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -285,12 +285,10 @@ async def test_public_access_websocket_initial_http_auth_failure_maps_to_4003(
     monkeypatch: pytest.MonkeyPatch,
     endpoint_kind: str,
 ) -> None:
-    # Both endpoints now accept the handshake before auth and map an auth-time
-    # HTTPException to a 4003 close carrying the real reason, so the frontend
-    # recovery flow can act on it (#973 for share, #1057 for widget). This is
-    # the connect-time analogue of the per-message revalidation 4003 — the far
-    # more common sequence for a revoked widget guest, who reloads the page and
-    # reconnects rather than staying on a live socket.
+    # Both endpoints map an auth-time HTTPException to a 4003 (#973 for share,
+    # #1057 for widget): the connect-time analogue of the per-message
+    # revalidation 4003, and the common sequence for a revoked widget guest who
+    # reloads the page and reconnects rather than staying on a live socket.
     websocket = _SingleMessageWebSocket({"type": "chat", "message": "hello"})
     authorize = AsyncMock(
         side_effect=HTTPException(status_code=403, detail="Widget is unavailable")
@@ -327,8 +325,6 @@ async def test_public_access_websocket_initial_http_auth_failure_maps_to_4003(
             token="share-token",
         )
 
-    # Accept-first is what lets the 4003 reason survive the handshake instead of
-    # collapsing into a bare HTTP 403 (browser sees 1006/"").
     websocket.accept.assert_awaited_once()
     websocket.close.assert_awaited_once_with(
         code=4003,
@@ -384,6 +380,10 @@ async def test_public_access_websocket_initial_non_http_failure_stays_4001(
             token="share-token",
         )
 
+    # accept() runs unconditionally before the try/except that yields both the
+    # 4003 and 4001 outcomes, so pin it here too: a regression moving accept into
+    # only the HTTPException branch would slip past a 4001-only assertion.
+    websocket.accept.assert_awaited_once()
     websocket.close.assert_awaited_once_with(
         code=4001,
         reason="Authentication required",

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -438,29 +438,25 @@ async def test_widget_ws_turn_gate_does_not_gate_interventions(
 def test_widget_ws_connect_over_limit_is_refused_pre_accept(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Over-limit widget WS connection attempts are refused pre-accept with
-    4008 (#1056), mirroring the share gate. The widget endpoint already closes
-    pre-accept on auth failure, so a garbage token lets this test tell the two
-    refusals apart by close code: 4001 while the budget admits, 4008 once it
-    trips. That distinction is TestClient-only — both closes are pre-accept,
-    and in production uvicorn collapses either into a bare HTTP 403 (the
-    browser sees code=1006, reason=""), unlike the share test where the
-    admitted attempt's denial is post-accept and genuinely reaches the client.
-    The codes here pin server-side gate ordering, not client-observable
-    behaviour."""
+    """Over-limit widget WS connection attempts are refused before the
+    handshake is accepted (#1056), mirroring the share gate. Since #1057 the
+    widget endpoint also accepts before auth, so a garbage token's denial is a
+    post-accept 4003 (it surfaces at receive) while the connect-gate rejection
+    stays pre-accept (it surfaces at context-manager entry) — that asymmetry is
+    what pins the gate ordering, exactly as on the share path."""
     from starlette.websockets import WebSocketDisconnect
 
     monkeypatch.setenv("XAGENT_WIDGET_WS_CONNECT_IP_RATE_LIMIT", "1/minute")
     reset_share_rate_limiter()
 
     url = "/api/widget/chat/ws/1?token=garbage"
-    # First attempt is admitted by the connect gate, then auth rejects it.
-    with pytest.raises(WebSocketDisconnect) as first:
-        with client.websocket_connect(url):
-            pass
-    assert first.value.code == 4001
+    # First attempt is admitted: it upgrades, then auth rejects it post-accept.
+    with client.websocket_connect(url) as ws:
+        with pytest.raises(WebSocketDisconnect) as first:
+            ws.receive_text()
+    assert first.value.code == 4003
 
-    # Second attempt from the same caller trips the budget.
+    # Second attempt from the same caller trips the budget pre-accept.
     with pytest.raises(WebSocketDisconnect) as denied:
         with client.websocket_connect(url):
             pass

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -358,19 +358,11 @@ def test_widget_ws_reconnect_after_revocation_reports_4003(
     channel: str,
     revocation: str,
 ) -> None:
-    """A guest reconnecting after revocation is rejected at connect with 4003.
-
-    This is the connect-time counterpart of the mid-session test above and the
-    far more common sequence: a revoked guest reloads the page, so the socket is
-    re-established from scratch and the denial happens during connect-time auth,
-    not on a live socket's next inbound message. Since #1057 the widget endpoint
-    accepts the handshake before auth, so the ``ensure_widget_*_available``
-    denial surfaces as a post-accept ``4003`` carrying the real reason — the
-    same recovery signal the mid-session and share paths already emit. Before
-    #1057 this close was pre-accept, so uvicorn collapsed it into a bare HTTP
-    403 (browser: ``1006``/``""``) and the guest could not tell a revoked widget
-    from a dropped network. All three revocation levers are covered, mirroring
-    the mid-session case.
+    """Connect-time counterpart of the mid-session test above: a revoked guest
+    reloads the page and reconnects, so the ``ensure_widget_*_available`` denial
+    happens at connect-time auth and surfaces as a post-accept ``4003`` (see the
+    module docstring for the accept-first rationale). All three revocation levers
+    are covered, mirroring the mid-session case.
     """
     guest = _build_guest(channel, monkeypatch)
     revoke: Callable[[], None] = getattr(guest, revocation)

--- a/tests/web/api/test_widget_ws_revalidation.py
+++ b/tests/web/api/test_widget_ws_revalidation.py
@@ -21,10 +21,14 @@ what the assertions actually depend on.
 Boundary of that guarantee, so it is explicit for the next reader: revalidation
 fires only on *inbound* messages. A revoked guest that simply stops sending
 keeps receiving outbound and broadcast frames on its open socket — "dropped on
-the next message" is the whole contract, not "dropped when revoked". Nor does
-this cover connect-time revocation, which the endpoint reports as a generic
-``4001`` (pre-accept, so uvicorn discards the real code and reason) and which an
-existing test in ``test_public_chat_websocket_db_boundary.py`` pins.
+the next message" is the whole contract, not "dropped when revoked".
+
+Connect-time revocation — the guest reloads the page after being revoked and
+reconnects, the far more common sequence — is covered by
+``test_widget_ws_reconnect_after_revocation_reports_4003`` below. Since #1057 the
+widget endpoint accepts the handshake before auth (like the share path), so that
+denial is a post-accept ``4003`` carrying the real reason rather than the generic
+pre-accept ``4001`` uvicorn used to collapse into a bare HTTP 403.
 """
 
 from __future__ import annotations
@@ -340,6 +344,43 @@ def test_widget_ws_closes_4003_when_widget_is_revoked_mid_session(
         revoke()
 
         ws.send_text(json.dumps({"type": "chat", "message": "still there?"}))
+        denied = _drain_until_disconnect(ws)
+
+    assert denied.code == 4003
+    assert denied.reason == "Widget is unavailable"
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("channel", ["agent", "workforce"])
+@pytest.mark.parametrize("revocation", ["disable", "rotate", "unpublish"])
+def test_widget_ws_reconnect_after_revocation_reports_4003(
+    monkeypatch: pytest.MonkeyPatch,
+    channel: str,
+    revocation: str,
+) -> None:
+    """A guest reconnecting after revocation is rejected at connect with 4003.
+
+    This is the connect-time counterpart of the mid-session test above and the
+    far more common sequence: a revoked guest reloads the page, so the socket is
+    re-established from scratch and the denial happens during connect-time auth,
+    not on a live socket's next inbound message. Since #1057 the widget endpoint
+    accepts the handshake before auth, so the ``ensure_widget_*_available``
+    denial surfaces as a post-accept ``4003`` carrying the real reason — the
+    same recovery signal the mid-session and share paths already emit. Before
+    #1057 this close was pre-accept, so uvicorn collapsed it into a bare HTTP
+    403 (browser: ``1006``/``""``) and the guest could not tell a revoked widget
+    from a dropped network. All three revocation levers are covered, mirroring
+    the mid-session case.
+    """
+    guest = _build_guest(channel, monkeypatch)
+    revoke: Callable[[], None] = getattr(guest, revocation)
+    revoke()
+
+    url = f"/api/widget/chat/ws/{guest.task_id}?token={guest.token}"
+    # Accept-first (#1057): the connection upgrades, then connect-time auth
+    # rejects it, so the denial surfaces at receive rather than at
+    # context-manager entry (a pre-accept close would raise on the ``with``).
+    with client.websocket_connect(url) as ws:
         denied = _drain_until_disconnect(ws)
 
     assert denied.code == 4003


### PR DESCRIPTION
## Summary

Closes #1057.

Aligns the widget WebSocket endpoint `public_chat_websocket_endpoint` with the sibling `share_chat_websocket_endpoint` on how a **connect-time** auth failure is reported.

Previously the widget path authorized *before* accepting the handshake and closed pre-accept on any exception:

```python
except Exception:
    await websocket.close(code=4001, reason="Authentication required")
```

Two problems fell out of that:

1. uvicorn only preserves a close code + reason for a **post-accept** close; a pre-accept close collapses into a bare HTTP 403, so the browser sees `code=1006, reason=""`. The real denial (`4003` / "Widget is unavailable") was discarded — the widget client could not tell "your widget was revoked" from "the network dropped".
2. The bare `except Exception` flattened an `HTTPException` from the revocation checks into the same generic `4001` as a malformed token.

This produced an asymmetry *within the widget path itself*: mid-session revocation gives a clean `4003` + reason (covered by #992/#1049), but a guest who reconnects after revocation — the far more common sequence, since a revoked guest reloads the page — got nothing actionable.

## Changes

- **Accept-first, then map exceptions** (matching the share path): the pre-accept per-IP connect budget from #1056 is preserved, then `websocket.accept()` runs before auth. An auth-time `HTTPException` maps to `4003` + the real reason; only non-HTTP failures keep `4001`.
- Switch `manager.connect` → `manager.register_connection`, since `accept()` now happens explicitly and `connect()` would double-accept.
- Update the two stale comments that justified the old pre-accept-4001 behaviour.

## Ordering / #1056

Accept-first means every widget connect attempt completes a 101 upgrade before rejection, which is why the share path needed a per-IP connect budget. That budget landed for the widget path in #1056 (merged), so this change builds on it and keeps the connect gate pre-accept.

## Tests

- Rename/split the pinned `test_public_access_websocket_initial_auth_failure_stays_4001` into an HTTP→`4003` case (`..._initial_http_auth_failure_maps_to_4003`) and a non-HTTP→`4001` case (`..._initial_non_http_failure_stays_4001`).
- Add end-to-end `test_widget_ws_reconnect_after_revocation_reports_4003`, parametrized over all three revocation levers (disable / rotate / unpublish) × agent/workforce — the reconnect-after-revocation case the issue flagged as untested.
- Re-pin `test_widget_ws_connect_over_limit_is_refused_pre_accept` on the pre-accept-`4008` vs post-accept-`4003` ordering, mirroring the share gate test.

## No frontend change needed

`use-websocket.ts` already treats a `4003` as a permanent failure carrying `event.reason`, and the widget page's "clear stale taskId + recover" path is scoped to `authMode === "share"`. A revoked widget guest now surfaces a terminal error with the real reason ("Widget is unavailable") instead of a generic transport failure.

## Verification

- Affected test files: 52 passed; broader public_chat/share/widget/websocket sweep green.
- Full pre-commit hook set passes (ruff, mypy, isort, codespell).