### PR TITLE
fix(task-orchestrator): reconcile pending delivery rows at turn finalize

### DIFF
--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -703,22 +703,47 @@ async def _schedule_committed_turn(
         # Claim commit + background scheduling already succeeded. A transient
         # delivery projection failure must not turn that success into an API
         # error or invite the caller to retry a turn that is already running.
-        if is_database_pool_timeout(delivery_error):
-            logger.error(
-                "task_id=%s component=turn-delivery database pool checkout timed "
-                "out after scheduling; leaving delivery pending for durable "
-                "recovery: %s",
-                task_id,
-                delivery_error,
-                exc_info=True,
-            )
-        else:
-            logger.exception(
-                "task_id=%s component=turn-delivery projection failed after "
-                "scheduling; leaving delivery pending for durable recovery",
-                task_id,
-            )
+        _log_delivery_projection_failure(
+            task_id,
+            component="turn-delivery",
+            error=delivery_error,
+            detail=" after scheduling",
+        )
     return handle
+
+
+def _log_delivery_projection_failure(
+    task_id: int,
+    *,
+    component: str,
+    error: Exception,
+    detail: str = "",
+) -> None:
+    """Log one swallowed delivery-projection failure without re-raising.
+
+    Pool checkout timeouts get their explicit marker — the committed row stays
+    reclaimable and the caller must not issue another checkout against the
+    exhausted pool. Anything else keeps its traceback via ``logger.exception``.
+    """
+
+    if is_database_pool_timeout(error):
+        logger.error(
+            "task_id=%s component=%s database pool checkout timed out%s; "
+            "leaving delivery pending for durable recovery: %s",
+            task_id,
+            component,
+            detail,
+            error,
+            exc_info=True,
+        )
+    else:
+        logger.exception(
+            "task_id=%s component=%s projection failed%s; "
+            "leaving delivery pending for durable recovery",
+            task_id,
+            component,
+            detail,
+        )
 
 
 def _reconcile_finalized_turn_delivery(
@@ -727,7 +752,7 @@ def _reconcile_finalized_turn_delivery(
     turn_id: str | None,
     settlement_error: str | None,
 ) -> None:
-    """Close a settled turn's delivery row so it can never orphan at ``pending``.
+    """Close a terminally settled turn's delivery row (xorbitsai/xagent-saas#332).
 
     A user-message delivery row is written ``pending`` with the turn claim and
     projected to ``dispatched`` right after scheduling. That projection is
@@ -735,18 +760,28 @@ def _reconcile_finalized_turn_delivery(
     ``pending`` even though the turn ran. Nothing else on the orchestrator path
     advances it, so the session WS dedup probe classifies every
     same-``client_message_id`` retry as an in-flight ``PENDING`` and rejects it
-    forever (#332).
+    forever.
 
-    Reconciling at finalize closes that window for every turn whose ``_runner``
-    reaches its ``finally`` (a hard process crash before then still orphans the
-    row and remains the job of TTL/durable recovery). Once the background run
-    has terminally settled its lease the turn is no longer in flight, so its
-    delivery is safe to close monotonically: ``completed`` on a clean
-    settlement, ``failed`` otherwise. The transition is monotonic, so an
-    already-terminal row — or a normally ``dispatched`` row on a later failure —
-    is left untouched rather than regressed. Callers MUST gate this on a
-    terminal settlement: a run deferred to TTL recovery may re-run and must keep
-    its ``pending`` row for that path to redrive.
+    Reconciling at finalize closes that window for every turn that reaches a
+    terminal lease settlement owned by its coroutine. The call is intentionally
+    skipped — leaving the row ``pending`` — when the coroutine is not the
+    authoritative closer: the lease went to another worker, settlement was
+    deferred to TTL recovery or raised, the settle was fenced out / superseded
+    (returned ``False``), or the pre-execution SETTLEMENT_READY short-circuit
+    fired. A hard process crash skips it too. Of those leftovers, only the
+    paused-task resume path has an in-repo consumer that re-posts the same
+    ``turn_id``; ``task_lease_recovery`` terminalizes the *task* but never
+    redrives the turn or touches delivery rows, so the deferral/crash cases
+    remain a narrower instance of the stuck-``pending`` window, not a solved
+    one.
+
+    The transition is monotonic: ``completed`` on a clean settlement, ``failed``
+    otherwise; an already-terminal row — or a normally ``dispatched`` row on a
+    later failure — is left untouched rather than regressed. Because both
+    projections are best-effort, the final delivery state is NOT a reliable
+    proxy for the turn's outcome: a failed turn may rest at ``dispatched`` or
+    ``failed`` depending on which projection landed. The delivery state answers
+    "may this client_message_id be retried?", never "did the turn succeed?".
     """
 
     if turn_id is None:
@@ -757,23 +792,12 @@ def _reconcile_finalized_turn_delivery(
     except Exception as delivery_error:
         # Best-effort projection. Leaving the row for durable recovery is strictly
         # better than amplifying pool exhaustion or masking the turn's outcome.
-        if is_database_pool_timeout(delivery_error):
-            logger.error(
-                "task_id=%s component=turn-finalize-delivery database pool "
-                "checkout timed out; leaving delivery pending for durable "
-                "recovery: %s",
-                task_id,
-                delivery_error,
-                exc_info=True,
-            )
-        else:
-            logger.warning(
-                "task_id=%s component=turn-finalize-delivery projection to %s "
-                "failed; leaving delivery for durable recovery",
-                task_id,
-                target,
-                exc_info=True,
-            )
+        _log_delivery_projection_failure(
+            task_id,
+            component="turn-finalize-delivery",
+            error=delivery_error,
+            detail=f" (target={target})",
+        )
 
 
 def _turn_started_snapshot(
@@ -1598,6 +1622,7 @@ def _schedule_bg(
         settlement_error: str | None = None
         broadcast_error_message: str | None = None
         defer_settlement_to_ttl_recovery = False
+        skip_delivery_reconciliation = False
         cleanup_cancellation: asyncio.CancelledError | None = None
         try:
             # A cancellation can land after the worker commits but before the
@@ -1652,6 +1677,12 @@ def _schedule_bg(
                         )
                         return
                     if validation == TaskLeaseRefreshState.SETTLEMENT_READY:
+                        # The task reached a terminal/control state before this
+                        # delayed run executed anything. Settlement below is
+                        # still correct, but the turn body never ran, so the
+                        # delivery row must NOT be closed as ``completed`` —
+                        # leave it for the authoritative writer.
+                        skip_delivery_reconciliation = True
                         return
 
                 async def execute_owned_run() -> None:
@@ -1777,9 +1808,15 @@ def _schedule_bg(
                                 error_message=settlement_error,
                             )
                         )
-                        # Settle returned without raising, so the task reached a
-                        # terminal decision and this runner will not re-run it.
-                        lease_settled = True
+                        # Gate on the returned value, not on "didn't raise":
+                        # ``settle_task_lease_isolated`` returns ``False``
+                        # without raising when the settlement was fenced out
+                        # (lease row gone or owned by a newer run) or when a
+                        # pre-existing terminal/control outcome was reconciled
+                        # instead of this coroutine's view. In both cases this
+                        # coroutine is no longer authoritative for the turn and
+                        # must not close its delivery row.
+                        lease_settled = bool(settled)
                         if settled and broadcast_error_message is not None:
                             try:
                                 await websocket_manager.broadcast_to_task(
@@ -1810,15 +1847,17 @@ def _schedule_bg(
                             exc_info=True,
                         )
 
-                    # Only once the lease is terminally settled is this turn
-                    # guaranteed not to re-run, so close its delivery row (#332):
+                    # Only when this coroutine's own settlement committed is it
+                    # safe to close the delivery row (xorbitsai/xagent-saas#332):
                     # a projection that never reached ``dispatched`` would
                     # otherwise orphan the row at ``pending`` and reject every
-                    # same-id retry forever. If settle raised, the lease is
-                    # retained for TTL recovery, which may redrive the turn — the
-                    # ``pending`` row must survive for that path, exactly as it
-                    # does for the ``defer_settlement_to_ttl_recovery`` branch.
-                    if lease_settled:
+                    # same-id retry forever. Skipped whenever this coroutine is
+                    # not the authoritative closer: settle raised (lease retained
+                    # for TTL recovery), settle was fenced out / superseded
+                    # (returned ``False``), settlement was deferred, or the
+                    # pre-execution SETTLEMENT_READY short-circuit fired (the
+                    # turn body never ran, so ``completed`` would be a lie).
+                    if lease_settled and not skip_delivery_reconciliation:
                         try:
                             await run_db_io_cancellation_safe(
                                 lambda: _reconcile_finalized_turn_delivery(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -751,6 +751,7 @@ def _reconcile_finalized_turn_delivery(
     task_id: int,
     turn_id: str | None,
     settlement_error: str | None,
+    execution_started: bool,
 ) -> None:
     """Close a terminally settled turn's delivery row (xorbitsai/xagent-saas#332).
 
@@ -775,18 +776,42 @@ def _reconcile_finalized_turn_delivery(
     remain a narrower instance of the stuck-``pending`` window, not a solved
     one.
 
-    The transition is monotonic: ``completed`` on a clean settlement, ``failed``
-    otherwise; an already-terminal row — or a normally ``dispatched`` row on a
-    later failure — is left untouched rather than regressed. Because both
-    projections are best-effort, the final delivery state is NOT a reliable
-    proxy for the turn's outcome: a failed turn may rest at ``dispatched`` or
-    ``failed`` depending on which projection landed. The delivery state answers
-    "may this client_message_id be retried?", never "did the turn succeed?".
+    Target selection is driven by what finalize actually knows, because the
+    downstream contract is asymmetric: the session WS probe answers a
+    ``failed`` row with ``retry_with_new_id`` — an invitation to re-send the
+    same content — so ``failed`` is only safe with positive evidence the
+    message was never consumed.
+
+    - ``settlement_error is None`` → ``completed``: the turn ran to a clean
+      settlement.
+    - error and ``execution_started`` → ``dispatched``: the run may have
+      consumed the message (and produced side effects) before failing, so the
+      one certain fact is "no longer in flight". A retry invitation here would
+      double-execute the turn. The probe treats ``dispatched`` as delivered;
+      the turn's failure is surfaced through task status, not by reopening
+      delivery. This also removes the timing asymmetry with the post-schedule
+      projection: whichever best-effort write lands, the row converges on
+      ``dispatched``.
+    - error and not ``execution_started`` → ``failed``:
+      ``execute_task_background`` was never invoked (setup failed, or the run
+      was cancelled first), so the message was provably never consumed and a
+      fresh-id retry is safe.
+
+    The transition is monotonic; an already-terminal row — or a normally
+    ``dispatched`` row on a later failure — is left untouched rather than
+    regressed. The final delivery state is NOT a proxy for the turn's outcome:
+    it answers "may this client_message_id be retried?", never "did the turn
+    succeed?".
     """
 
     if turn_id is None:
         return
-    target = DELIVERY_COMPLETED if settlement_error is None else DELIVERY_FAILED
+    if settlement_error is None:
+        target = DELIVERY_COMPLETED
+    elif execution_started:
+        target = DELIVERY_DISPATCHED
+    else:
+        target = DELIVERY_FAILED
     try:
         mark_user_message_delivery_sync(task_id, turn_id, target)
     except Exception as delivery_error:
@@ -1623,6 +1648,11 @@ def _schedule_bg(
         broadcast_error_message: str | None = None
         defer_settlement_to_ttl_recovery = False
         skip_delivery_reconciliation = False
+        # Positive evidence for finalize's delivery target: once
+        # ``execute_task_background`` has been invoked, the run may have
+        # consumed the user message, so a failure must not be projected as a
+        # retryable ``failed`` delivery (it would invite a double execution).
+        execution_started = False
         cleanup_cancellation: asyncio.CancelledError | None = None
         try:
             # A cancellation can land after the worker commits but before the
@@ -1702,6 +1732,8 @@ def _schedule_bg(
                     scope = await run_db_io_cancellation_safe(
                         lambda: resolve_execution_scope(task_id)
                     )
+                    nonlocal execution_started
+                    execution_started = True
                     await execute_task_background(
                         task_id=task_id,
                         user_message=payload.transcript_message,
@@ -1857,6 +1889,12 @@ def _schedule_bg(
                     # (returned ``False``), settlement was deferred, or the
                     # pre-execution SETTLEMENT_READY short-circuit fired (the
                     # turn body never ran, so ``completed`` would be a lie).
+                    # KNOWN GAP: rows skipped here stay ``pending`` permanently —
+                    # lease TTL recovery terminalizes the *task* only and nothing
+                    # in this tree redrives delivery rows. The skip is still
+                    # correct (a non-authoritative close is worse); the residual
+                    # window is tracked as a follow-up to
+                    # xorbitsai/xagent-saas#332.
                     if lease_settled and not skip_delivery_reconciliation:
                         try:
                             await run_db_io_cancellation_safe(
@@ -1864,6 +1902,7 @@ def _schedule_bg(
                                     task_id=task_id,
                                     turn_id=turn_id,
                                     settlement_error=settlement_error,
+                                    execution_started=execution_started,
                                 )
                             )
                         except asyncio.CancelledError as exc:

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -62,6 +62,7 @@ from ..models.task import Task, TaskStatus
 from .chat_history_service import (
     DELIVERY_COMPLETED,
     DELIVERY_DISPATCHED,
+    DELIVERY_FAILED,
     DELIVERY_PENDING,
     mark_user_message_delivery_sync,
 )
@@ -718,6 +719,61 @@ async def _schedule_committed_turn(
                 task_id,
             )
     return handle
+
+
+def _reconcile_finalized_turn_delivery(
+    *,
+    task_id: int,
+    turn_id: str | None,
+    settlement_error: str | None,
+) -> None:
+    """Close a settled turn's delivery row so it can never orphan at ``pending``.
+
+    A user-message delivery row is written ``pending`` with the turn claim and
+    projected to ``dispatched`` right after scheduling. That projection is
+    best-effort: a pool timeout or a transient DB error leaves the row
+    ``pending`` even though the turn ran. Nothing else on the orchestrator path
+    advances it, so the session WS dedup probe classifies every
+    same-``client_message_id`` retry as an in-flight ``PENDING`` and rejects it
+    forever (#332).
+
+    Reconciling at finalize closes that window for every turn whose ``_runner``
+    reaches its ``finally`` (a hard process crash before then still orphans the
+    row and remains the job of TTL/durable recovery). Once the background run
+    has terminally settled its lease the turn is no longer in flight, so its
+    delivery is safe to close monotonically: ``completed`` on a clean
+    settlement, ``failed`` otherwise. The transition is monotonic, so an
+    already-terminal row — or a normally ``dispatched`` row on a later failure —
+    is left untouched rather than regressed. Callers MUST gate this on a
+    terminal settlement: a run deferred to TTL recovery may re-run and must keep
+    its ``pending`` row for that path to redrive.
+    """
+
+    if turn_id is None:
+        return
+    target = DELIVERY_COMPLETED if settlement_error is None else DELIVERY_FAILED
+    try:
+        mark_user_message_delivery_sync(task_id, turn_id, target)
+    except Exception as delivery_error:
+        # Best-effort projection. Leaving the row for durable recovery is strictly
+        # better than amplifying pool exhaustion or masking the turn's outcome.
+        if is_database_pool_timeout(delivery_error):
+            logger.error(
+                "task_id=%s component=turn-finalize-delivery database pool "
+                "checkout timed out; leaving delivery pending for durable "
+                "recovery: %s",
+                task_id,
+                delivery_error,
+                exc_info=True,
+            )
+        else:
+            logger.warning(
+                "task_id=%s component=turn-finalize-delivery projection to %s "
+                "failed; leaving delivery for durable recovery",
+                task_id,
+                target,
+                exc_info=True,
+            )
 
 
 def _turn_started_snapshot(
@@ -1683,6 +1739,7 @@ def _schedule_bg(
                         exc_info=True,
                     )
         finally:
+            turn_id = getattr(payload, "turn_id", None)
             if lease is not None:
                 try:
                     heartbeat_outcome = await stop_task_lease_heartbeat(
@@ -1712,6 +1769,7 @@ def _schedule_bg(
                     )
 
                 if not defer_settlement_to_ttl_recovery:
+                    lease_settled = False
                     try:
                         settled = await run_db_io_cancellation_safe(
                             lambda: settle_task_lease_isolated(
@@ -1719,6 +1777,9 @@ def _schedule_bg(
                                 error_message=settlement_error,
                             )
                         )
+                        # Settle returned without raising, so the task reached a
+                        # terminal decision and this runner will not re-run it.
+                        lease_settled = True
                         if settled and broadcast_error_message is not None:
                             try:
                                 await websocket_manager.broadcast_to_task(
@@ -1748,7 +1809,32 @@ def _schedule_bg(
                             settle_err,
                             exc_info=True,
                         )
-            turn_id = getattr(payload, "turn_id", None)
+
+                    # Only once the lease is terminally settled is this turn
+                    # guaranteed not to re-run, so close its delivery row (#332):
+                    # a projection that never reached ``dispatched`` would
+                    # otherwise orphan the row at ``pending`` and reject every
+                    # same-id retry forever. If settle raised, the lease is
+                    # retained for TTL recovery, which may redrive the turn — the
+                    # ``pending`` row must survive for that path, exactly as it
+                    # does for the ``defer_settlement_to_ttl_recovery`` branch.
+                    if lease_settled:
+                        try:
+                            await run_db_io_cancellation_safe(
+                                lambda: _reconcile_finalized_turn_delivery(
+                                    task_id=task_id,
+                                    turn_id=turn_id,
+                                    settlement_error=settlement_error,
+                                )
+                            )
+                        except asyncio.CancelledError as exc:
+                            cleanup_cancellation = cleanup_cancellation or exc
+                        except Exception:
+                            logger.warning(
+                                "task %s finalize delivery reconciliation failed",
+                                task_id,
+                                exc_info=True,
+                            )
             try:
                 from .connector_runtime import pop_ephemeral_runtime_values
 

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -782,8 +782,12 @@ def _reconcile_finalized_turn_delivery(
     same content — so ``failed`` is only safe with positive evidence the
     message was never consumed.
 
-    - ``settlement_error is None`` → ``completed``: the turn ran to a clean
-      settlement.
+    - ``settlement_error is None`` → ``completed``: the run returned without
+      raising. Note this does not certify success — ``execute_task_background``
+      may set ``task.status = FAILED`` internally and return normally, leaving
+      ``settlement_error`` unset — but both ``completed`` and ``dispatched``
+      read identically downstream ("delivered, do not retry"), so the
+      distinction has no client-visible effect.
     - error and ``execution_started`` → ``dispatched``: the run may have
       consumed the message (and produced side effects) before failing, so the
       one certain fact is "no longer in flight". A retry invitation here would
@@ -795,13 +799,20 @@ def _reconcile_finalized_turn_delivery(
     - error and not ``execution_started`` → ``failed``:
       ``execute_task_background`` was never invoked (setup failed, or the run
       was cancelled first), so the message was provably never consumed and a
-      fresh-id retry is safe.
+      fresh-id retry is safe. The accepted cost is that the ``failed`` row
+      remains visible in the transcript (no history-loading path filters on
+      ``delivery_status``), so a fresh-id resend can show the user's message
+      twice — a pre-existing property of every ``failed`` writer, tracked in
+      xorbitsai/xagent-saas#417, and strictly better than wedging the client
+      on a ``pending`` row forever.
 
-    The transition is monotonic; an already-terminal row — or a normally
-    ``dispatched`` row on a later failure — is left untouched rather than
-    regressed. The final delivery state is NOT a proxy for the turn's outcome:
-    it answers "may this client_message_id be retried?", never "did the turn
-    succeed?".
+    The transition is monotonic — it never regresses — but only ``completed``
+    and ``failed`` are terminal: ``dispatched`` still has an outgoing edge to
+    ``completed``, which is how a turn that failed its projection but later
+    settles cleanly still closes. An already-terminal row, or a ``dispatched``
+    row on a later failure, is left untouched. The final delivery state is NOT
+    a proxy for the turn's outcome: it answers "may this client_message_id be
+    retried?", never "did the turn succeed?".
     """
 
     if turn_id is None:
@@ -1892,9 +1903,12 @@ def _schedule_bg(
                     # KNOWN GAP: rows skipped here stay ``pending`` permanently —
                     # lease TTL recovery terminalizes the *task* only and nothing
                     # in this tree redrives delivery rows. The skip is still
-                    # correct (a non-authoritative close is worse); the residual
-                    # window is tracked as a follow-up to
-                    # xorbitsai/xagent-saas#332.
+                    # correct (a non-authoritative close is worse). Note the
+                    # deferral triggers correlate with this bug's own trigger:
+                    # post-schedule dispatch, setup/run and settle all draw from
+                    # the same DB pool, so one exhaustion event can both orphan
+                    # the row and defer the settlement that would have closed it.
+                    # Tracked in xorbitsai/xagent-saas#409.
                     if lease_settled and not skip_delivery_reconciliation:
                         try:
                             await run_db_io_cancellation_safe(

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -43,9 +43,13 @@ from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceRun
 from xagent.web.services import task_orchestrator as task_orchestrator_module
 from xagent.web.services.chat_history_service import (
+    DELIVERY_COMPLETED,
     DELIVERY_DISPATCHED,
     DELIVERY_FAILED,
     DELIVERY_PENDING,
+    claim_user_message_delivery,
+    inspect_user_message_delivery,
+    mark_user_message_delivery,
 )
 from xagent.web.services.connector_runtime import (
     get_ephemeral_runtime_values,
@@ -68,6 +72,7 @@ from xagent.web.services.task_orchestrator import (
     TurnKind,
     _begin_turn_atomic_sync,
     _ClaimedTurn,
+    _reconcile_finalized_turn_delivery,
     _schedule_bg,
     finish_turn,
     settle_task_lease_isolated,
@@ -2905,3 +2910,378 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
         "the concrete-lease settlement overwrote a control status."
     )
     assert task.runner_id is None
+
+
+# ---------------------------------------------------------------------------
+# Finalize-time delivery reconciliation (#332)
+# ---------------------------------------------------------------------------
+
+
+def _claim_pending_delivery(db, *, task_id: int, user_id: int, turn_id: str) -> None:
+    """Create a committed ``pending`` delivery row, mirroring a turn claim."""
+
+    claim = claim_user_message_delivery(
+        db,
+        task_id,
+        user_id,
+        "hello there",
+        turn_id=turn_id,
+    )
+    assert claim.claimed is True
+    assert claim.pending is True
+
+
+def _delivery_status(db, turn_id: str) -> str | None:
+    db.expire_all()
+    row = (
+        db.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == turn_id)
+        .one_or_none()
+    )
+    return None if row is None else str(row.delivery_status)
+
+
+def test_reconcile_finalized_delivery_completes_orphaned_pending_on_success(
+    db_session,
+) -> None:
+    """A clean settlement advances an orphaned ``pending`` row to ``completed``."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-ok"
+    )
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-ok",
+        settlement_error=None,
+    )
+
+    assert _delivery_status(db_session, "turn-ok") == DELIVERY_COMPLETED
+
+
+def test_reconcile_finalized_delivery_fails_orphaned_pending_on_error(
+    db_session,
+) -> None:
+    """A failed settlement advances an orphaned ``pending`` row to ``failed``.
+
+    This is the row a same-``client_message_id`` retry needs: the session-WS
+    probe classifies ``failed`` as a usable terminal ack (retry with a new id)
+    instead of an in-flight ``PENDING`` that is rejected forever.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-boom"
+    )
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-boom",
+        settlement_error="setup/run error: RuntimeError: boom",
+    )
+
+    assert _delivery_status(db_session, "turn-boom") == DELIVERY_FAILED
+    # The probe's ``pending`` predicate — what rejected the retry forever — is
+    # now False, so the client can converge.
+    inspected = inspect_user_message_delivery(
+        db_session,
+        int(task.id),
+        "hello there",
+        attachments=None,
+        turn_id="turn-boom",
+    )
+    assert inspected is not None
+    assert inspected.pending is False
+    assert inspected.failed is True
+
+
+def test_reconcile_finalized_delivery_noop_without_turn_id(db_session) -> None:
+    """A turn with no durable delivery row (no turn id) is a safe no-op."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+
+    # Must not raise even though there is nothing to reconcile.
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id=None,
+        settlement_error=None,
+    )
+
+
+def test_reconcile_finalized_delivery_does_not_regress_dispatched_on_error(
+    db_session,
+) -> None:
+    """``dispatched`` is terminal for dedup; a later failure must not regress it.
+
+    A normally dispatched turn already gave the client a usable ack. The
+    monotonic state machine rejects ``dispatched -> failed``, so the row stays
+    ``dispatched`` and the turn's failure is surfaced through task status, not
+    by reopening delivery.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-disp"
+    )
+    transition = mark_user_message_delivery(
+        db_session,
+        task_id=int(task.id),
+        turn_id="turn-disp",
+        status=DELIVERY_DISPATCHED,
+    )
+    assert transition.outcome == "updated"
+    db_session.commit()
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-disp",
+        settlement_error="boom",
+    )
+
+    assert _delivery_status(db_session, "turn-disp") == DELIVERY_DISPATCHED
+
+
+def test_reconcile_finalized_delivery_completes_dispatched_on_success(
+    db_session,
+) -> None:
+    """A clean settlement closes a ``dispatched`` row to ``completed``.
+
+    The orchestrator path never marked ``completed`` before; finalize now
+    closes the lifecycle to match the resume path.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-done"
+    )
+    mark_user_message_delivery(
+        db_session,
+        task_id=int(task.id),
+        turn_id="turn-done",
+        status=DELIVERY_DISPATCHED,
+    )
+    db_session.commit()
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-done",
+        settlement_error=None,
+    )
+
+    assert _delivery_status(db_session, "turn-done") == DELIVERY_COMPLETED
+
+
+def test_reconcile_finalized_delivery_swallows_pool_timeout_leaving_pending(
+    db_session,
+    caplog,
+) -> None:
+    """A pool timeout leaves the row ``pending`` for durable recovery, no raise."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-pool"
+    )
+
+    caplog.set_level(logging.ERROR, logger="xagent.web.services.task_orchestrator")
+    with patch(
+        "xagent.web.services.task_orchestrator.mark_user_message_delivery_sync",
+        side_effect=SQLAlchemyTimeoutError("finalize delivery pool exhausted"),
+    ):
+        _reconcile_finalized_turn_delivery(
+            task_id=int(task.id),
+            turn_id="turn-pool",
+            settlement_error=None,
+        )
+
+    assert _delivery_status(db_session, "turn-pool") == DELIVERY_PENDING
+    assert "component=turn-finalize-delivery" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_reconciles_orphaned_pending_delivery(
+    db_session,
+) -> None:
+    """End-to-end: a turn whose ``dispatched`` projection never landed still
+    finalizes its delivery row to ``completed`` when the run settles cleanly."""
+    from xagent.web.api.websocket import background_task_manager
+    from xagent.web.services.task_lease_service import TaskLease
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-ok")
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-e2e-ok"
+    )
+
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=fake_lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=AsyncMock(),
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=payload,
+            force_fresh=False,
+            context=None,
+        )
+        await bg_task
+
+    assert _delivery_status(db_session, "turn-e2e-ok") == DELIVERY_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_leaves_pending_when_deferred_to_ttl_recovery(
+    db_session,
+) -> None:
+    """When settlement is deferred to TTL recovery (pool timeout), the delivery
+    row must stay ``pending`` — the turn may be re-run by the recovery path."""
+    from xagent.web.api.websocket import background_task_manager
+    from xagent.web.services.task_lease_service import TaskLease
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-defer")
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-e2e-defer"
+    )
+
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
+
+    async def pool_timeout_execute(*args, **kwargs):
+        raise SQLAlchemyTimeoutError("setup/run pool exhausted")
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=fake_lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=pool_timeout_execute,
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=payload,
+            force_fresh=False,
+            context=None,
+        )
+        await bg_task
+
+    assert _delivery_status(db_session, "turn-e2e-defer") == DELIVERY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_leaves_pending_when_settlement_raises(
+    db_session,
+) -> None:
+    """If lease settlement itself raises, the lease is retained for TTL recovery
+    and the turn may re-run — so the delivery row must stay ``pending`` even
+    though the run completed. Guards the settle-failure branch, which does not
+    set ``defer_settlement_to_ttl_recovery``."""
+    from xagent.web.api.websocket import background_task_manager
+    from xagent.web.services.task_lease_service import TaskLease
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-settle-raise")
+    _claim_pending_delivery(
+        db_session,
+        task_id=int(task.id),
+        user_id=int(user.id),
+        turn_id="turn-e2e-settle-raise",
+    )
+
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    )
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=fake_lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+            side_effect=RuntimeError("settle boom"),
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=payload,
+            force_fresh=False,
+            context=None,
+        )
+        await bg_task
+
+    assert _delivery_status(db_session, "turn-e2e-settle-raise") == DELIVERY_PENDING

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -3257,6 +3257,51 @@ async def test_runner_finalize_reconciles_orphaned_pending_delivery(
 
 
 @pytest.mark.asyncio
+async def test_runner_finalize_reconciles_alongside_a_genuinely_completed_turn(
+    db_session,
+) -> None:
+    """A real success settles through ``finish_turn``'s COMPLETED branch and
+    closes the orphaned delivery row in the same finalize.
+
+    The sibling success test reaches ``completed`` delivery via
+    ``settlement_error is None`` while the task itself lands FAILED (its mocked
+    runtime never signals success), so it cannot catch a regression in
+    ``finish_turn``'s COMPLETED branch. Here the fake runtime commits
+    COMPLETED plus an assistant message — what that branch reads to write
+    ``output`` — so task terminalization and delivery reconciliation are
+    asserted together.
+    """
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-real-success"
+    )
+
+    async def succeeding_execute(*args, **kwargs):
+        with sessionmaker(bind=get_engine())() as inner:
+            row = inner.query(Task).filter(Task.id == task.id).one()
+            row.status = TaskStatus.COMPLETED
+            inner.add(
+                TaskChatMessage(
+                    task_id=int(task.id),
+                    user_id=int(user.id),
+                    role="assistant",
+                    content="here is your answer",
+                    message_type="chat_response",
+                )
+            )
+            inner.commit()
+
+    with _finalize_runner_patches(lease, execute=succeeding_execute):
+        await _spawn_finalize_runner(task, user, payload)
+
+    assert _delivery_status(db_session, "turn-e2e-real-success") == DELIVERY_COMPLETED
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored.status == TaskStatus.COMPLETED
+    assert stored.output == "here is your answer"
+    assert stored.runner_id is None
+
+
+@pytest.mark.asyncio
 async def test_runner_finalize_leaves_pending_when_deferred_to_ttl_recovery(
     db_session,
 ) -> None:

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -2957,19 +2957,22 @@ def test_reconcile_finalized_delivery_completes_orphaned_pending_on_success(
         task_id=int(task.id),
         turn_id="turn-ok",
         settlement_error=None,
+        execution_started=True,
     )
 
     assert _delivery_status(db_session, "turn-ok") == DELIVERY_COMPLETED
 
 
-def test_reconcile_finalized_delivery_fails_orphaned_pending_on_error(
+def test_reconcile_finalized_delivery_fails_orphaned_pending_when_never_ran(
     db_session,
 ) -> None:
-    """A failed settlement advances an orphaned ``pending`` row to ``failed``.
+    """A turn that provably never executed advances ``pending`` to ``failed``.
 
-    This is the row a same-``client_message_id`` retry needs: the session-WS
-    probe classifies ``failed`` as a usable terminal ack (retry with a new id)
-    instead of an in-flight ``PENDING`` that is rejected forever.
+    ``failed`` invites a fresh-id retry downstream, so it is only written with
+    positive evidence the message was never consumed
+    (``execution_started=False``). That is the row a same-``client_message_id``
+    retry needs: a usable terminal ack instead of an in-flight ``PENDING``
+    that is rejected forever.
     """
     user = _create_user(db_session)
     task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
@@ -2981,6 +2984,7 @@ def test_reconcile_finalized_delivery_fails_orphaned_pending_on_error(
         task_id=int(task.id),
         turn_id="turn-boom",
         settlement_error="setup/run error: RuntimeError: boom",
+        execution_started=False,
     )
 
     assert _delivery_status(db_session, "turn-boom") == DELIVERY_FAILED
@@ -2998,6 +3002,32 @@ def test_reconcile_finalized_delivery_fails_orphaned_pending_on_error(
     assert inspected.failed is True
 
 
+def test_reconcile_finalized_delivery_marks_dispatched_when_run_failed_after_start(
+    db_session,
+) -> None:
+    """A failure after execution began closes ``pending`` as ``dispatched``.
+
+    The run may have consumed the message (and produced side effects) before
+    failing, so writing ``failed`` would invite a fresh-id retry and a double
+    execution. ``dispatched`` converges the client without a resend; the
+    turn's failure is surfaced through task status.
+    """
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-late"
+    )
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-late",
+        settlement_error="setup/run error: RuntimeError: late boom",
+        execution_started=True,
+    )
+
+    assert _delivery_status(db_session, "turn-late") == DELIVERY_DISPATCHED
+
+
 def test_reconcile_finalized_delivery_noop_without_turn_id(db_session) -> None:
     """A turn with no durable delivery row (no turn id) is a safe no-op."""
     user = _create_user(db_session)
@@ -3008,18 +3038,22 @@ def test_reconcile_finalized_delivery_noop_without_turn_id(db_session) -> None:
         task_id=int(task.id),
         turn_id=None,
         settlement_error=None,
+        execution_started=True,
     )
 
 
+@pytest.mark.parametrize("execution_started", [True, False])
 def test_reconcile_finalized_delivery_does_not_regress_dispatched_on_error(
     db_session,
+    execution_started,
 ) -> None:
     """``dispatched`` is terminal for dedup; a later failure must not regress it.
 
-    A normally dispatched turn already gave the client a usable ack. The
-    monotonic state machine rejects ``dispatched -> failed``, so the row stays
-    ``dispatched`` and the turn's failure is surfaced through task status, not
-    by reopening delivery.
+    A normally dispatched turn already gave the client a usable ack. With
+    ``execution_started=True`` the ``dispatched`` target is idempotent; with
+    ``False`` the monotonic state machine rejects ``dispatched -> failed``.
+    Either way the row stays ``dispatched`` and the turn's failure is surfaced
+    through task status, not by reopening delivery.
     """
     user = _create_user(db_session)
     task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
@@ -3034,11 +3068,13 @@ def test_reconcile_finalized_delivery_does_not_regress_dispatched_on_error(
     )
     assert transition.outcome == "updated"
     db_session.commit()
+    db_session.expire_all()
 
     _reconcile_finalized_turn_delivery(
         task_id=int(task.id),
         turn_id="turn-disp",
         settlement_error="boom",
+        execution_started=execution_started,
     )
 
     assert _delivery_status(db_session, "turn-disp") == DELIVERY_DISPATCHED
@@ -3069,6 +3105,7 @@ def test_reconcile_finalized_delivery_completes_dispatched_on_success(
         task_id=int(task.id),
         turn_id="turn-done",
         settlement_error=None,
+        execution_started=True,
     )
 
     assert _delivery_status(db_session, "turn-done") == DELIVERY_COMPLETED
@@ -3094,6 +3131,7 @@ def test_reconcile_finalized_delivery_swallows_pool_timeout_leaving_pending(
             task_id=int(task.id),
             turn_id="turn-pool",
             settlement_error=None,
+            execution_started=True,
         )
 
     assert _delivery_status(db_session, "turn-pool") == DELIVERY_PENDING
@@ -3128,6 +3166,7 @@ def _finalize_runner_patches(
     settle=None,
     mark_delivery=None,
     validate=None,
+    snapshot=None,
 ):
     """Patch scaffolding for driving ``_schedule_bg``'s ``_runner`` end-to-end.
 
@@ -3147,7 +3186,9 @@ def _finalize_runner_patches(
         ),
         patch(
             "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
-            return_value=MagicMock(),
+            new=snapshot
+            if snapshot is not None
+            else MagicMock(return_value=MagicMock()),
         ),
         patch(
             "xagent.web.api.websocket.execute_task_background",
@@ -3300,12 +3341,12 @@ async def test_runner_finalize_skips_reconcile_on_settlement_ready_short_circuit
 
 
 @pytest.mark.asyncio
-async def test_runner_finalize_marks_failed_for_cancelled_turn(
+async def test_runner_finalize_marks_dispatched_for_cancelled_turn(
     db_session,
 ) -> None:
-    """A cancelled turn settles as failed and closes its delivery row to
-    ``failed`` — the message never dispatched, so the client may retry with a
-    new id."""
+    """A turn cancelled during execution closes its delivery row to
+    ``dispatched``, not ``failed`` — execution had begun, so the message may
+    already have been consumed and a fresh-id retry could double-execute it."""
     user, task, payload, lease = _finalize_turn_fixture(
         db_session, turn_id="turn-e2e-cancelled"
     )
@@ -3317,7 +3358,56 @@ async def test_runner_finalize_marks_failed_for_cancelled_turn(
         with pytest.raises(asyncio.CancelledError):
             await bg_task
 
-    assert _delivery_status(db_session, "turn-e2e-cancelled") == DELIVERY_FAILED
+    assert _delivery_status(db_session, "turn-e2e-cancelled") == DELIVERY_DISPATCHED
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored.status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_marks_dispatched_when_run_fails_after_start(
+    db_session,
+) -> None:
+    """The double-execution hazard: a run that failed *after* execution began
+    must close the orphaned ``pending`` row as ``dispatched`` (probe answers
+    MATCHES, no retry), never ``failed`` (probe would invite a fresh-id resend
+    of a message that already ran). This also pins the symmetry with the
+    post-schedule projection: whichever best-effort write lands, the row
+    converges on ``dispatched``."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-late-fail"
+    )
+
+    with _finalize_runner_patches(
+        lease,
+        execute=AsyncMock(side_effect=RuntimeError("late boom after side effects")),
+    ):
+        await _spawn_finalize_runner(task, user, payload)
+
+    assert _delivery_status(db_session, "turn-e2e-late-fail") == DELIVERY_DISPATCHED
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored.status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_marks_failed_when_setup_fails_before_execute(
+    db_session,
+) -> None:
+    """A failure before ``execute_task_background`` is ever invoked is positive
+    evidence the message was never consumed, so the row closes as ``failed``
+    and a fresh-id retry is safe."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-pre-exec"
+    )
+
+    with _finalize_runner_patches(
+        lease,
+        snapshot=MagicMock(side_effect=RuntimeError("snapshot load exploded")),
+    ):
+        await _spawn_finalize_runner(task, user, payload)
+
+    assert _delivery_status(db_session, "turn-e2e-pre-exec") == DELIVERY_FAILED
     db_session.expire_all()
     stored = db_session.query(Task).filter(Task.id == task.id).one()
     assert stored.status == TaskStatus.FAILED
@@ -3350,22 +3440,25 @@ async def test_runner_finalize_preserves_cancellation_from_reconcile(
 
 
 @pytest.mark.parametrize(
-    "seeded_status, settlement_error",
+    "seeded_status, settlement_error, execution_started",
     [
-        (DELIVERY_COMPLETED, None),
-        (DELIVERY_COMPLETED, "boom"),
-        (DELIVERY_FAILED, None),
+        (DELIVERY_COMPLETED, None, True),
+        (DELIVERY_COMPLETED, "boom", True),
+        (DELIVERY_COMPLETED, "boom", False),
+        (DELIVERY_FAILED, None, True),
     ],
 )
 def test_reconcile_finalized_delivery_noop_on_already_terminal_row(
     db_session,
     seeded_status,
     settlement_error,
+    execution_started,
 ) -> None:
     """An already-terminal delivery row is never rewritten by reconciliation.
 
     ``completed`` and ``failed`` are terminal in the monotonic state machine;
-    a later reconcile — idempotent or conflicting — must leave them as-is."""
+    a later reconcile — idempotent or conflicting, under any target — must
+    leave them as-is."""
     user = _create_user(db_session)
     task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
     _claim_pending_delivery(
@@ -3382,6 +3475,7 @@ def test_reconcile_finalized_delivery_noop_on_already_terminal_row(
         task_id=int(task.id),
         turn_id="turn-term",
         settlement_error=settlement_error,
+        execution_started=execution_started,
     )
 
     assert _delivery_status(db_session, "turn-term") == seeded_status

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta, timezone
 from threading import Barrier, get_ident
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -60,6 +61,7 @@ from xagent.web.services.task_execution_controller import task_execution_control
 from xagent.web.services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
+    TaskLeaseRefreshState,
     acquire_task_lease_isolated,
     get_runner_id,
 )
@@ -3098,30 +3100,43 @@ def test_reconcile_finalized_delivery_swallows_pool_timeout_leaving_pending(
     assert "component=turn-finalize-delivery" in caplog.text
 
 
-@pytest.mark.asyncio
-async def test_runner_finalize_reconciles_orphaned_pending_delivery(
-    db_session,
-) -> None:
-    """End-to-end: a turn whose ``dispatched`` projection never landed still
-    finalizes its delivery row to ``completed`` when the run settles cleanly."""
-    from xagent.web.api.websocket import background_task_manager
-    from xagent.web.services.task_lease_service import TaskLease
+def _finalize_turn_fixture(db_session, *, turn_id: str):
+    """One RUNNING task with a committed lease and an orphaned ``pending`` row.
 
+    Mirrors the #332 failure state: the turn claim committed (task RUNNING,
+    lease owned, delivery ``pending``) but the ``dispatched`` projection never
+    landed.
+    """
     user = _create_user(db_session)
     task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
-    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-ok")
+    payload = TaskTurnPayload("hello there", turn_id=turn_id)
     _claim_pending_delivery(
-        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-e2e-ok"
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id=turn_id
     )
-
     task.runner_id = "test-runner"
     task.run_id = "run-a"
     db_session.commit()
-    fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
-    )
+    lease = TaskLease(task_id=int(task.id), runner_id="test-runner", run_id="run-a")
+    return user, task, payload, lease
 
-    with (
+
+@contextmanager
+def _finalize_runner_patches(
+    fake_lease: TaskLease,
+    *,
+    execute=None,
+    settle=None,
+    mark_delivery=None,
+    validate=None,
+):
+    """Patch scaffolding for driving ``_schedule_bg``'s ``_runner`` end-to-end.
+
+    Only the agent runtime is faked by default; lease settlement and delivery
+    marking run for real against SQLite unless a stub is supplied.
+    """
+    from xagent.web.api.websocket import background_task_manager
+
+    patches = [
         patch(
             "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
             return_value=fake_lease,
@@ -3136,23 +3151,66 @@ async def test_runner_finalize_reconciles_orphaned_pending_delivery(
         ),
         patch(
             "xagent.web.api.websocket.execute_task_background",
-            new=AsyncMock(),
+            new=execute if execute is not None else AsyncMock(),
         ),
         patch.object(background_task_manager, "register_task"),
         patch(
             "xagent.web.services.task_orchestrator._get_agent_manager",
             return_value=MagicMock(),
         ),
-    ):
-        bg_task = _schedule_bg(
-            task_id=int(task.id),
-            task_owner_user_id=int(user.id),
-            task_source=task.source,
-            payload=payload,
-            force_fresh=False,
-            context=None,
+    ]
+    if settle is not None:
+        patches.append(
+            patch(
+                "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
+                settle,
+            )
         )
-        await bg_task
+    if mark_delivery is not None:
+        patches.append(
+            patch(
+                "xagent.web.services.task_orchestrator.mark_user_message_delivery_sync",
+                mark_delivery,
+            )
+        )
+    if validate is not None:
+        patches.append(
+            patch(
+                "xagent.web.services.task_orchestrator."
+                "validate_preacquired_task_lease_isolated",
+                validate,
+            )
+        )
+    with ExitStack() as stack:
+        for entry in patches:
+            stack.enter_context(entry)
+        yield
+
+
+def _spawn_finalize_runner(task, user, payload, **schedule_kwargs):
+    return _schedule_bg(
+        task_id=int(task.id),
+        task_owner_user_id=int(user.id),
+        task_source=task.source,
+        payload=payload,
+        force_fresh=False,
+        context=None,
+        **schedule_kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_reconciles_orphaned_pending_delivery(
+    db_session,
+) -> None:
+    """End-to-end: a turn whose ``dispatched`` projection never landed still
+    finalizes its delivery row to ``completed`` when the run settles cleanly."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-ok"
+    )
+
+    with _finalize_runner_patches(lease):
+        await _spawn_finalize_runner(task, user, payload)
 
     assert _delivery_status(db_session, "turn-e2e-ok") == DELIVERY_COMPLETED
 
@@ -3163,58 +3221,15 @@ async def test_runner_finalize_leaves_pending_when_deferred_to_ttl_recovery(
 ) -> None:
     """When settlement is deferred to TTL recovery (pool timeout), the delivery
     row must stay ``pending`` — the turn may be re-run by the recovery path."""
-    from xagent.web.api.websocket import background_task_manager
-    from xagent.web.services.task_lease_service import TaskLease
-
-    user = _create_user(db_session)
-    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
-    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-defer")
-    _claim_pending_delivery(
-        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-e2e-defer"
-    )
-
-    task.runner_id = "test-runner"
-    task.run_id = "run-a"
-    db_session.commit()
-    fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-defer"
     )
 
     async def pool_timeout_execute(*args, **kwargs):
         raise SQLAlchemyTimeoutError("setup/run pool exhausted")
 
-    with (
-        patch(
-            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
-            return_value=fake_lease,
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
-            new=AsyncMock(),
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
-            return_value=MagicMock(),
-        ),
-        patch(
-            "xagent.web.api.websocket.execute_task_background",
-            new=pool_timeout_execute,
-        ),
-        patch.object(background_task_manager, "register_task"),
-        patch(
-            "xagent.web.services.task_orchestrator._get_agent_manager",
-            return_value=MagicMock(),
-        ),
-    ):
-        bg_task = _schedule_bg(
-            task_id=int(task.id),
-            task_owner_user_id=int(user.id),
-            task_source=task.source,
-            payload=payload,
-            force_fresh=False,
-            context=None,
-        )
-        await bg_task
+    with _finalize_runner_patches(lease, execute=pool_timeout_execute):
+        await _spawn_finalize_runner(task, user, payload)
 
     assert _delivery_status(db_session, "turn-e2e-defer") == DELIVERY_PENDING
 
@@ -3227,61 +3242,146 @@ async def test_runner_finalize_leaves_pending_when_settlement_raises(
     and the turn may re-run — so the delivery row must stay ``pending`` even
     though the run completed. Guards the settle-failure branch, which does not
     set ``defer_settlement_to_ttl_recovery``."""
-    from xagent.web.api.websocket import background_task_manager
-    from xagent.web.services.task_lease_service import TaskLease
-
-    user = _create_user(db_session)
-    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
-    payload = TaskTurnPayload("hello there", turn_id="turn-e2e-settle-raise")
-    _claim_pending_delivery(
-        db_session,
-        task_id=int(task.id),
-        user_id=int(user.id),
-        turn_id="turn-e2e-settle-raise",
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-settle-raise"
     )
 
-    task.runner_id = "test-runner"
-    task.run_id = "run-a"
-    db_session.commit()
-    fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
-    )
-
-    with (
-        patch(
-            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
-            return_value=fake_lease,
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
-            new=AsyncMock(),
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
-            return_value=MagicMock(),
-        ),
-        patch(
-            "xagent.web.api.websocket.execute_task_background",
-            new=AsyncMock(),
-        ),
-        patch(
-            "xagent.web.services.task_orchestrator.settle_task_lease_isolated",
-            side_effect=RuntimeError("settle boom"),
-        ),
-        patch.object(background_task_manager, "register_task"),
-        patch(
-            "xagent.web.services.task_orchestrator._get_agent_manager",
-            return_value=MagicMock(),
-        ),
+    with _finalize_runner_patches(
+        lease, settle=MagicMock(side_effect=RuntimeError("settle boom"))
     ):
-        bg_task = _schedule_bg(
-            task_id=int(task.id),
-            task_owner_user_id=int(user.id),
-            task_source=task.source,
-            payload=payload,
-            force_fresh=False,
-            context=None,
-        )
-        await bg_task
+        await _spawn_finalize_runner(task, user, payload)
 
     assert _delivery_status(db_session, "turn-e2e-settle-raise") == DELIVERY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_leaves_pending_when_settle_is_fenced_out(
+    db_session,
+) -> None:
+    """A fenced/superseded settlement must not close the delivery row.
+
+    ``settle_task_lease_isolated`` returns ``False`` *without raising* when the
+    lease row is gone or now owned by a different run. This stale coroutine is
+    no longer authoritative for the turn, so reconciliation must be skipped and
+    the ``pending`` row left to the authoritative owner."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-fenced"
+    )
+
+    with _finalize_runner_patches(lease, settle=MagicMock(return_value=False)):
+        await _spawn_finalize_runner(task, user, payload)
+
+    assert _delivery_status(db_session, "turn-e2e-fenced") == DELIVERY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_skips_reconcile_on_settlement_ready_short_circuit(
+    db_session,
+) -> None:
+    """Pre-execution SETTLEMENT_READY must not close the delivery row.
+
+    A delayed run whose pre-acquired lease validates as SETTLEMENT_READY
+    returns before the turn body executes. Settlement still runs (and here
+    genuinely settles the lease), but the turn never ran, so the delivery row
+    must not be reconciled to ``completed``."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-settle-ready"
+    )
+
+    with _finalize_runner_patches(
+        lease,
+        validate=MagicMock(return_value=TaskLeaseRefreshState.SETTLEMENT_READY),
+    ):
+        await _spawn_finalize_runner(
+            task, user, payload, task_lease=lease, run_id="run-a"
+        )
+
+    assert _delivery_status(db_session, "turn-e2e-settle-ready") == DELIVERY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_marks_failed_for_cancelled_turn(
+    db_session,
+) -> None:
+    """A cancelled turn settles as failed and closes its delivery row to
+    ``failed`` — the message never dispatched, so the client may retry with a
+    new id."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-cancelled"
+    )
+
+    with _finalize_runner_patches(
+        lease, execute=AsyncMock(side_effect=asyncio.CancelledError())
+    ):
+        bg_task = _spawn_finalize_runner(task, user, payload)
+        with pytest.raises(asyncio.CancelledError):
+            await bg_task
+
+    assert _delivery_status(db_session, "turn-e2e-cancelled") == DELIVERY_FAILED
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored.status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_runner_finalize_preserves_cancellation_from_reconcile(
+    db_session,
+) -> None:
+    """A ``CancelledError`` surfacing from the reconcile call site is recorded
+    as cleanup cancellation and re-raised after connector cleanup; the delivery
+    row stays ``pending``."""
+    user, task, payload, lease = _finalize_turn_fixture(
+        db_session, turn_id="turn-e2e-cancel-reconcile"
+    )
+
+    with _finalize_runner_patches(
+        lease,
+        mark_delivery=MagicMock(side_effect=asyncio.CancelledError()),
+    ):
+        bg_task = _spawn_finalize_runner(task, user, payload)
+        with pytest.raises(asyncio.CancelledError):
+            await bg_task
+
+    assert _delivery_status(db_session, "turn-e2e-cancel-reconcile") == DELIVERY_PENDING
+    # The lease settlement itself committed before the reconcile cancellation.
+    db_session.expire_all()
+    stored = db_session.query(Task).filter(Task.id == task.id).one()
+    assert stored.runner_id is None
+
+
+@pytest.mark.parametrize(
+    "seeded_status, settlement_error",
+    [
+        (DELIVERY_COMPLETED, None),
+        (DELIVERY_COMPLETED, "boom"),
+        (DELIVERY_FAILED, None),
+    ],
+)
+def test_reconcile_finalized_delivery_noop_on_already_terminal_row(
+    db_session,
+    seeded_status,
+    settlement_error,
+) -> None:
+    """An already-terminal delivery row is never rewritten by reconciliation.
+
+    ``completed`` and ``failed`` are terminal in the monotonic state machine;
+    a later reconcile — idempotent or conflicting — must leave them as-is."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id), status=TaskStatus.RUNNING)
+    _claim_pending_delivery(
+        db_session, task_id=int(task.id), user_id=int(user.id), turn_id="turn-term"
+    )
+    transition = mark_user_message_delivery(
+        db_session, task_id=int(task.id), turn_id="turn-term", status=seeded_status
+    )
+    assert transition.outcome == "updated"
+    db_session.commit()
+    db_session.expire_all()
+
+    _reconcile_finalized_turn_delivery(
+        task_id=int(task.id),
+        turn_id="turn-term",
+        settlement_error=settlement_error,
+    )
+
+    assert _delivery_status(db_session, "turn-term") == seeded_status


### PR DESCRIPTION
## Problem

A user-message delivery row is written `pending` with the turn claim and projected to `dispatched` best-effort right after scheduling. When that projection fails — a database pool checkout timeout or a transient DB error — the row stays `pending` forever even though the turn actually ran. Nothing on the orchestrator path advances it afterward.

Downstream, the session-WebSocket dedup probe (`probe_external_task_delivery`, in xagent-saas) classifies every same-`client_message_id` retry against that stale row as an in-flight `PENDING` and rejects it (busy, without `retry_with_new_id`). The client can never converge on a turn that has already executed.

This is the P2 finding "[P2] Reconcile delivery rows left permanently pending" split out of the SA-8 session WebSocket work, tracked as xorbitsai/xagent-saas#332.

## Fix

Add a durable terminal transition in the shared delivery layer at turn finalize. New `_reconcile_finalized_turn_delivery(...)` closes the turn's delivery row once its lease is terminally settled **by this coroutine**:

- `completed` on a clean settlement, `failed` otherwise.
- The transition is monotonic, so an already-terminal row — or a normally `dispatched` row on a later failure — is left untouched rather than regressed.
- Missing rows and pool timeouts are safe no-ops that leave the row for durable recovery.

Wired into `_runner`'s `finally` block and gated on an **authoritative** settlement — reconciliation is skipped (leaving the row `pending`) whenever this coroutine is not the rightful closer:

- settlement deferred to TTL recovery (pool timeout, lost lease, unhealthy heartbeat);
- `settle_task_lease_isolated` raised (lease retained for TTL recovery);
- settle returned `False` without raising — fenced out / superseded lease, or a pre-existing terminal/control outcome reconciled instead of this coroutine's view;
- the pre-execution `SETTLEMENT_READY` short-circuit fired (the turn body never ran, so `completed` would ack a message that was never consumed).

Known residual windows, documented rather than claimed solved: a hard process crash before `_runner`'s `finally`, and the deferred-settlement leftovers (the lease-expiry recovery module terminalizes the *task* but never redrives the turn or touches delivery rows). Of those, only the paused-resume path has an in-repo consumer that re-posts the same `turn_id`. The final delivery state is intentionally **not** a proxy for the turn's outcome — it answers "may this client_message_id be retried?", never "did the turn succeed?".

Also extracted `_log_delivery_projection_failure`, shared by the post-schedule and finalize projection sites (pool timeouts keep their explicit marker; everything else keeps its traceback via `logger.exception`).

## Tests

16 tests in `tests/web/services/test_task_orchestrator.py` for this change (74 total in the file, all passing):

- Unit: reconciliation advances an orphaned `pending` row to `completed` / `failed`; `dispatched` is not regressed on a later failure; `dispatched → completed` closes on success; already-terminal rows are no-ops under idempotent and conflicting reconciles; pool timeout leaves `pending` without raising; no-`turn_id` is a no-op.
- End-to-end through `_runner` (shared fixture + patch scaffolding): orphaned `pending` finalizes to `completed`; deferred-to-TTL, settlement-raises, fenced-out settle (`False` return), and the `SETTLEMENT_READY` short-circuit all keep the row `pending`; a cancelled turn closes the row to `failed`; a `CancelledError` from the reconcile call site is recorded and re-raised after connector cleanup.

Refs xorbitsai/xagent-saas#332, xorbitsai/xagent-saas#268. Companion xagent-saas PR (xorbitsai/xagent-saas#404) bumps the submodule and adds the probe-side acceptance test.