### PR TITLE
enh(widget): add remaining share-path abuse controls (auth, task-create, run quota) (#1108)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,14 @@ services:
       - XAGENT_CELERY_ENABLED=${XAGENT_CELERY_ENABLED:-true}
       - XAGENT_CELERY_BROKER_URL=redis://redis:6379/1
       - XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS=${XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS:-3600}
+      # This backend sits behind the single nginx hop above, which sets
+      # X-Forwarded-For in append mode. Trust exactly that one hop so every
+      # per-IP rate limit (share/widget auth, task-create, run sub-quota,
+      # trigger callbacks) keys on the real client IP instead of nginx's
+      # container IP — otherwise all client traffic collapses onto one IP and
+      # per-IP caps become a single global cap. Raise only if you add more
+      # trusted proxies (CDN/LB) in front of nginx.
+      - XAGENT_TRUSTED_PROXY_HOPS=${XAGENT_TRUSTED_PROXY_HOPS:-1}
     env_file:
       - .env
     volumes:

--- a/example.env
+++ b/example.env
@@ -176,7 +176,7 @@ PORT = "80"
 # IP and a per-IP cap silently becomes one global cap for the deployment.
 # XAGENT_WIDGET_AUTH_RATE_LIMIT="1200/minute"
 # XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
-# XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="120/minute"
+# XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="240/minute"
 # XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_RUN_QUOTA="500/day"
 # XAGENT_WIDGET_RUN_IP_QUOTA="60/hour"
@@ -185,11 +185,16 @@ PORT = "80"
 # Behind a reverse proxy, set the number of trusted proxy hops so the caller
 # IP for rate limiting is read from X-Forwarded-For. 0 = use the peer address.
 # IMPORTANT: when the backend sits behind a reverse proxy / load balancer and
-# this stays at 0, every callback appears to come from the proxy's IP, so the
-# per-IP limit above silently collapses into a single global cap across ALL
-# callbacks (and can throttle legitimate traffic such as Gmail push for many
-# mailboxes). Set this to the number of proxies you control in front of the
-# backend (e.g. 1 for a single nginx/ingress hop).
+# this stays at 0, every request appears to come from the proxy's IP, so every
+# per-IP limit (share/widget auth, task-create, the widget run IP sub-quota,
+# trigger callbacks) silently collapses into a single global cap across ALL
+# callers and can hard-429 legitimate traffic. Set it to the number of proxies
+# you control in front of the backend (e.g. 1 for a single nginx/ingress hop —
+# the bundled docker-compose.yml already sets 1 for its nginx). Do NOT set it
+# HIGHER than the real count: X-Forwarded-For is append-order, so an over-count
+# reads a client-supplied entry and lets the caller spoof the derived IP —
+# which now also picks a persisted quota key (widget_client_ip). Match it to
+# your real topology exactly.
 # XAGENT_TRUSTED_PROXY_HOPS="0"
 # Gmail incoming-email triggers (per-mailbox Pub/Sub provisioning).
 #

--- a/example.env
+++ b/example.env
@@ -11,12 +11,12 @@
 # When using docker-compose.yml, DATABASE_URL is automatically set.
 # You only need to configure the PostgreSQL password below.
 # POSTGRES_PASSWORD is used by both postgres and xagent services.
-POSTGRES_PASSWORD="xagent_password"
+POSTGRES_PASSWORD = "xagent_password"
 
 # Web service port (default: 80)
 # Frontend and backend are both accessible through this single port
 # nginx will route /api/* to backend and others to frontend
-PORT="80"
+PORT = "80"
 
 # ===========================================
 # Database Configuration (optional)
@@ -158,19 +158,23 @@ PORT="80"
 # loose-per-entity pairing: the caller IP is the per-visitor/per-abuser bound
 # (the widget guest_id is client-supplied, so it is never a limiter key), and
 # the per-entity bucket is a loose aggregate backstop across one embedded
-# agent/workforce's visitors. Auth + embed-ticket minting share one bucket
-# family (the two halves of one page-load handshake); their entity key is the
-# widget key or the owner entity from the ticket's signed claims. The auth
-# entity default is deliberately loose (600/min) because both endpoints fire
-# on every page load and the entity is shared by all a widget's visitors — a
-# tight per-entity bucket would 429 ordinary visitors on a busy embed. The
+# agent/workforce's visitors. Auth + embed-ticket minting share the same
+# limit *configuration* and the same per-IP counter, but their per-entity
+# counters are disjoint (embed-ticket keys the entity bucket on the widget
+# key; auth keys it on the owner entity from the ticket's signed claims), so
+# the two env values below are shared budgets only in the per-IP dimension.
+# The auth entity default is deliberately loose (1200/min, a 4:1 entity:IP
+# ratio matching the sibling widget gates) because both endpoints fire on
+# every page load and the entity is shared by all a widget's visitors — a
+# tight per-entity bucket would 429 ordinary visitors on a busy embed, and
+# an auth denial is fail-closed client-side (the widget never loads). The
 # widget run quota caps owner-billed runs per rolling window with a
 # per-creating-IP sub-quota; NOTE it applies to already-live widget tasks as
 # soon as it deploys. Separate buckets from the share limits. CAUTION: every
 # per-IP bucket here needs XAGENT_TRUSTED_PROXY_HOPS set correctly behind a
 # reverse proxy — with the default 0, all traffic resolves to the proxy's own
 # IP and a per-IP cap silently becomes one global cap for the deployment.
-# XAGENT_WIDGET_AUTH_RATE_LIMIT="600/minute"
+# XAGENT_WIDGET_AUTH_RATE_LIMIT="1200/minute"
 # XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
 # XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="120/minute"
 # XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"
@@ -231,7 +235,7 @@ PORT="80"
 # LLM API Keys
 # ===========================================
 # OPENAI_API_KEY="your-openai-api-key"
-INFERENCE_API_KEY="your-inference-api-key"
+INFERENCE_API_KEY = "your-inference-api-key"
 # DEEPSEEK_API_KEY="your-deepseek-api-key"
 # Optional DeepSeek defaults
 # DEEPSEEK_MODEL_NAME="deepseek-v4-flash"
@@ -249,8 +253,8 @@ INFERENCE_API_KEY="your-inference-api-key"
 # ===========================================
 # Embedding API Keys (for vector memory)
 # ===========================================
-DASHSCOPE_API_KEY="your-dashscope-api-key"
-OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
+DASHSCOPE_API_KEY = "your-dashscope-api-key"
+OPENAI_EMBEDDING_API_KEY = "your-openai-api-key"
 
 # Memory Store Configuration
 # Optional: Override automatic detection
@@ -274,14 +278,14 @@ OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
 # JWT Authentication (required for production)
 # Generate a secure secret with:
 # python -c "import secrets; print(secrets.token_urlsafe(48))"
-XAGENT_JWT_SECRET="replace-with-a-long-random-secret"
-XAGENT_JWT_ALGORITHM="HS256"
+XAGENT_JWT_SECRET = "replace-with-a-long-random-secret"
+XAGENT_JWT_ALGORITHM = "HS256"
 # Access token expiry in minutes (default: 120)
-XAGENT_ACCESS_TOKEN_EXPIRE_MINUTES="120"
+XAGENT_ACCESS_TOKEN_EXPIRE_MINUTES = "120"
 # Refresh token expiry in days (default: 7)
-XAGENT_REFRESH_TOKEN_EXPIRE_DAYS="7"
+XAGENT_REFRESH_TOKEN_EXPIRE_DAYS = "7"
 # Minimum password length for setup/register/change-password (default: 6)
-XAGENT_PASSWORD_MIN_LENGTH="6"
+XAGENT_PASSWORD_MIN_LENGTH = "6"
 # Password reset link expiry in minutes (default: 30)
 # XAGENT_PASSWORD_RESET_EXPIRE_MINUTES="30"
 # Frontend base URL used in reset-password emails
@@ -354,14 +358,14 @@ XAGENT_PASSWORD_MIN_LENGTH="6"
 # XAGENT_TRUSTED_EGRESS_PROXY="false"
 
 # Image processing
-CONCURRENT=5
+CONCURRENT = 5
 
 # Langfuse Tracing
-LANGFUSE_TRACING_ENABLED="true"
+LANGFUSE_TRACING_ENABLED = "true"
 # Langfuse Python SDK v4 uses `base_url`; keep `LANGFUSE_HOST` only for legacy env fallback.
-LANGFUSE_BASE_URL="http://127.0.0.1:3000"
-LANGFUSE_PUBLIC_KEY="public key"
-LANGFUSE_SECRET_KEY="secret key"
+LANGFUSE_BASE_URL = "http://127.0.0.1:3000"
+LANGFUSE_PUBLIC_KEY = "public key"
+LANGFUSE_SECRET_KEY = "secret key"
 
 # Per-field byte cap for the LLM I/O audit trace written to trace_events
 # (data.messages / data.response / etc.). Anything larger is truncated with a
@@ -372,7 +376,7 @@ LANGFUSE_SECRET_KEY="secret key"
 # Web Search API Keys
 # Provider selection: auto, google, tavily, exa, zhipu (default: auto)
 # In auto mode, priority is Zhipu > Tavily > Exa > Google.
-XAGENT_WEB_SEARCH_PROVIDER="auto"
+XAGENT_WEB_SEARCH_PROVIDER = "auto"
 
 # Website import TLS fingerprint impersonation for WAF-protected sites.
 # Leave empty/none for plain httpx. Use auto to try the crawler fallback chain.
@@ -413,28 +417,28 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # XAGENT_CHECKPOINT_HISTORY_LIMIT="8"
 
 # Zhipu Web Search (recommended for Chinese users, get key at https://open.bigmodel.cn/)
-ZHIPU_API_KEY=""
+ZHIPU_API_KEY = ""
 
 # Tavily Search API (alternative, get key at https://tavily.com)
-TAVILY_API_KEY=""
+TAVILY_API_KEY = ""
 
 # Exa AI-powered Search (get key at https://exa.ai)
-EXA_API_KEY=""
+EXA_API_KEY = ""
 
 # Google Custom Search (fallback, requires Google Cloud setup)
-GOOGLE_API_KEY=""
-GOOGLE_CSE_ID=""
+GOOGLE_API_KEY = ""
+GOOGLE_CSE_ID = ""
 
 # ===========================================
 # Google OAuth Configuration (Optional)
 # ===========================================
 # Required for Google Login and Google Drive integration
 # Create credentials at https://console.cloud.google.com/apis/credentials
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
+GOOGLE_CLIENT_ID = ""
+GOOGLE_CLIENT_SECRET = ""
 # Redirect URI for Google OAuth callback (Required for Google Login)
 # Example: http://localhost:8000/api/auth/google/callback
-GOOGLE_REDIRECT_URI=""
+GOOGLE_REDIRECT_URI = ""
 
 # Google Ads developer token (Optional)
 # Required for the Google Ads connector in MCP. Apply for/find this token in
@@ -442,18 +446,18 @@ GOOGLE_REDIRECT_URI=""
 # https://ads.google.com/aw/apicenter
 # This is a single platform-wide token shared by all users who connect the
 # Google Ads app (not a per-user secret), analogous to GOOGLE_CLIENT_ID above.
-GOOGLE_ADS_DEVELOPER_TOKEN=""
+GOOGLE_ADS_DEVELOPER_TOKEN = ""
 
 # ===========================================
 # LinkedIn OAuth Configuration (Optional)
 # ===========================================
 # Required for LinkedIn integration in MCP
 # Create credentials at https://www.linkedin.com/developers/apps/new
-LINKEDIN_CLIENT_ID=""
-LINKEDIN_CLIENT_SECRET=""
+LINKEDIN_CLIENT_ID = ""
+LINKEDIN_CLIENT_SECRET = ""
 # Redirect URI for LinkedIn OAuth callback
 # Example: http://localhost:8000/api/auth/linkedin/callback
-LINKEDIN_REDIRECT_URI=""
+LINKEDIN_REDIRECT_URI = ""
 
 # ===========================================
 # HubSpot OAuth Configuration (Optional)
@@ -462,22 +466,22 @@ LINKEDIN_REDIRECT_URI=""
 # Create a public app at https://developers.hubspot.com/ and configure the
 # app's scopes to match the connector (crm.objects.contacts/companies read+write,
 # crm.objects.deals.read)
-HUBSPOT_CLIENT_ID=""
-HUBSPOT_CLIENT_SECRET=""
+HUBSPOT_CLIENT_ID = ""
+HUBSPOT_CLIENT_SECRET = ""
 # Redirect URI for HubSpot OAuth callback
 # Example: http://localhost:8000/api/auth/hubspot/callback
-HUBSPOT_REDIRECT_URI=""
+HUBSPOT_REDIRECT_URI = ""
 
 # ===========================================
 # Meta OAuth Configuration (Optional)
 # ===========================================
 # Required for Facebook Pages and Instagram integrations in MCP
 # Create credentials at https://developers.facebook.com/apps/
-META_CLIENT_ID=""
-META_CLIENT_SECRET=""
+META_CLIENT_ID = ""
+META_CLIENT_SECRET = ""
 # Redirect URI for Meta OAuth callback
 # Example: http://localhost:8000/api/auth/meta/callback
-META_REDIRECT_URI=""
+META_REDIRECT_URI = ""
 # Optional Facebook Login for Business configuration ID. When set, Meta OAuth
 # uses config_id instead of a raw scope list, which is required by some Meta app
 # configurations for Pages and Instagram permissions.
@@ -487,7 +491,7 @@ META_REDIRECT_URI=""
 # pages_manage_posts, pages_read_user_content, instagram_basic,
 # instagram_content_publish) must also be added to that Login Configuration, or
 # users who authorize via config_id will not grant it.
-META_CONFIG_ID=""
+META_CONFIG_ID = ""
 
 # ===========================================
 # Slack OAuth Configuration (Optional)
@@ -498,12 +502,12 @@ META_CONFIG_ID=""
 # Note: chat:write.public also lets the bot post into any public channel
 # without being invited — it bypasses Slack's invite gate.
 # Leave "Token Rotation" off — bot tokens don't expire, so no refresh is needed.
-SLACK_CLIENT_ID=""
-SLACK_CLIENT_SECRET=""
+SLACK_CLIENT_ID = ""
+SLACK_CLIENT_SECRET = ""
 # Redirect URI for Slack OAuth callback — must also be added under the app's
 # "OAuth & Permissions" > "Redirect URLs".
 # Example: http://localhost:8000/api/auth/slack/callback
-SLACK_REDIRECT_URI=""
+SLACK_REDIRECT_URI = ""
 
 # ===========================================
 # Zoom OAuth Configuration (Optional)
@@ -514,12 +518,12 @@ SLACK_REDIRECT_URI=""
 # meeting:read:meeting, meeting:read:list_meetings, meeting:read:past_meeting,
 # cloud_recording:read:list_recording_files, cloud_recording:read:meeting_transcript,
 # user:read:user
-ZOOM_CLIENT_ID=""
-ZOOM_CLIENT_SECRET=""
+ZOOM_CLIENT_ID = ""
+ZOOM_CLIENT_SECRET = ""
 # Redirect URI for Zoom OAuth callback — must exactly match a URL registered
 # in the app's OAuth Allow List.
 # Example: http://localhost:8000/api/auth/zoom/callback
-ZOOM_REDIRECT_URI=""
+ZOOM_REDIRECT_URI = ""
 
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
@@ -538,7 +542,7 @@ ZOOM_REDIRECT_URI=""
 # - Environment variables: $HOME/skills,${USERPROFILE}/skills
 #
 # Examples:
-XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
+XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS = ""
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="/path/to/custom/skills"
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="~/skills,/usr/local/skills,$HOME/custom_skills"
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="./local_skills,../shared_skills"
@@ -562,7 +566,7 @@ XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
 # Maximum per-file upload size enforced by the backend.
 # Nginx maintains a separate, larger defense-in-depth ceiling (see docker/nginx.conf).
 # Supports raw bytes or human-readable values like 100M, 1G, 512K.
-XAGENT_MAX_UPLOAD_SIZE="100M"
+XAGENT_MAX_UPLOAD_SIZE = "100M"
 
 # Durable file storage for user-visible uploads and registered workspace outputs.
 # Defaults to file://$XAGENT_STORAGE_ROOT/files for local development.
@@ -620,7 +624,7 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 
 # Database encryption key
 # Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
+ENCRYPTION_KEY = "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 # ===========================================
 # Tool Output Configuration

--- a/example.env
+++ b/example.env
@@ -154,17 +154,24 @@ PORT="80"
 # XAGENT_WIDGET_WS_TURN_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_WS_TURN_RATE_LIMIT="240/minute"
 # Widget HTTP/quota abuse controls (#1108): the remaining share-path controls
-# with no widget counterpart. Auth is keyed per presented credential (embed
-# ticket or widget key) + per caller IP; task-create per widget entity (loose)
-# + per caller IP (tight). The widget run quota caps owner-billed runs one
-# embedded agent/workforce can start per rolling window; it has no per-guest
-# sub-quota because the widget guest_id is client-supplied and the caller IP
-# is unavailable at the run chokepoint. Separate buckets from the share limits.
+# with no widget counterpart. Auth (and embed-ticket minting, which shares its
+# buckets) is keyed per stable credential (widget key, or the owner entity
+# from the ticket's signed claims) + per caller IP; task-create per widget
+# entity (loose) + per caller IP (tight). The widget run quota caps
+# owner-billed runs one embedded agent/workforce can start per rolling
+# window, with a per-creating-IP sub-quota as the per-abuser dimension (the
+# widget guest_id is client-supplied, so it is never a limiter key). NOTE:
+# the run quota applies to already-live widget tasks as soon as it deploys.
+# Separate buckets from the share limits. CAUTION: every per-IP bucket here
+# needs XAGENT_TRUSTED_PROXY_HOPS set correctly behind a reverse proxy —
+# with the default 0, all traffic resolves to the proxy's own IP and a
+# per-IP cap silently becomes one global cap for the whole deployment.
 # XAGENT_WIDGET_AUTH_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
 # XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="120/minute"
 # XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_RUN_QUOTA="500/day"
+# XAGENT_WIDGET_RUN_IP_QUOTA="60/hour"
 # XAGENT_SHARE_RUN_QUOTA="500/day"
 # XAGENT_SHARE_RUN_GUEST_QUOTA="60/hour"
 # Behind a reverse proxy, set the number of trusted proxy hops so the caller

--- a/example.env
+++ b/example.env
@@ -11,12 +11,12 @@
 # When using docker-compose.yml, DATABASE_URL is automatically set.
 # You only need to configure the PostgreSQL password below.
 # POSTGRES_PASSWORD is used by both postgres and xagent services.
-POSTGRES_PASSWORD = "xagent_password"
+POSTGRES_PASSWORD="xagent_password"
 
 # Web service port (default: 80)
 # Frontend and backend are both accessible through this single port
 # nginx will route /api/* to backend and others to frontend
-PORT = "80"
+PORT="80"
 
 # ===========================================
 # Database Configuration (optional)
@@ -240,7 +240,7 @@ PORT = "80"
 # LLM API Keys
 # ===========================================
 # OPENAI_API_KEY="your-openai-api-key"
-INFERENCE_API_KEY = "your-inference-api-key"
+INFERENCE_API_KEY="your-inference-api-key"
 # DEEPSEEK_API_KEY="your-deepseek-api-key"
 # Optional DeepSeek defaults
 # DEEPSEEK_MODEL_NAME="deepseek-v4-flash"
@@ -258,8 +258,8 @@ INFERENCE_API_KEY = "your-inference-api-key"
 # ===========================================
 # Embedding API Keys (for vector memory)
 # ===========================================
-DASHSCOPE_API_KEY = "your-dashscope-api-key"
-OPENAI_EMBEDDING_API_KEY = "your-openai-api-key"
+DASHSCOPE_API_KEY="your-dashscope-api-key"
+OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
 
 # Memory Store Configuration
 # Optional: Override automatic detection
@@ -283,14 +283,14 @@ OPENAI_EMBEDDING_API_KEY = "your-openai-api-key"
 # JWT Authentication (required for production)
 # Generate a secure secret with:
 # python -c "import secrets; print(secrets.token_urlsafe(48))"
-XAGENT_JWT_SECRET = "replace-with-a-long-random-secret"
-XAGENT_JWT_ALGORITHM = "HS256"
+XAGENT_JWT_SECRET="replace-with-a-long-random-secret"
+XAGENT_JWT_ALGORITHM="HS256"
 # Access token expiry in minutes (default: 120)
-XAGENT_ACCESS_TOKEN_EXPIRE_MINUTES = "120"
+XAGENT_ACCESS_TOKEN_EXPIRE_MINUTES="120"
 # Refresh token expiry in days (default: 7)
-XAGENT_REFRESH_TOKEN_EXPIRE_DAYS = "7"
+XAGENT_REFRESH_TOKEN_EXPIRE_DAYS="7"
 # Minimum password length for setup/register/change-password (default: 6)
-XAGENT_PASSWORD_MIN_LENGTH = "6"
+XAGENT_PASSWORD_MIN_LENGTH="6"
 # Password reset link expiry in minutes (default: 30)
 # XAGENT_PASSWORD_RESET_EXPIRE_MINUTES="30"
 # Frontend base URL used in reset-password emails
@@ -363,14 +363,14 @@ XAGENT_PASSWORD_MIN_LENGTH = "6"
 # XAGENT_TRUSTED_EGRESS_PROXY="false"
 
 # Image processing
-CONCURRENT = 5
+CONCURRENT=5
 
 # Langfuse Tracing
-LANGFUSE_TRACING_ENABLED = "true"
+LANGFUSE_TRACING_ENABLED="true"
 # Langfuse Python SDK v4 uses `base_url`; keep `LANGFUSE_HOST` only for legacy env fallback.
-LANGFUSE_BASE_URL = "http://127.0.0.1:3000"
-LANGFUSE_PUBLIC_KEY = "public key"
-LANGFUSE_SECRET_KEY = "secret key"
+LANGFUSE_BASE_URL="http://127.0.0.1:3000"
+LANGFUSE_PUBLIC_KEY="public key"
+LANGFUSE_SECRET_KEY="secret key"
 
 # Per-field byte cap for the LLM I/O audit trace written to trace_events
 # (data.messages / data.response / etc.). Anything larger is truncated with a
@@ -381,7 +381,7 @@ LANGFUSE_SECRET_KEY = "secret key"
 # Web Search API Keys
 # Provider selection: auto, google, tavily, exa, zhipu (default: auto)
 # In auto mode, priority is Zhipu > Tavily > Exa > Google.
-XAGENT_WEB_SEARCH_PROVIDER = "auto"
+XAGENT_WEB_SEARCH_PROVIDER="auto"
 
 # Website import TLS fingerprint impersonation for WAF-protected sites.
 # Leave empty/none for plain httpx. Use auto to try the crawler fallback chain.
@@ -422,28 +422,28 @@ XAGENT_WEB_SEARCH_PROVIDER = "auto"
 # XAGENT_CHECKPOINT_HISTORY_LIMIT="8"
 
 # Zhipu Web Search (recommended for Chinese users, get key at https://open.bigmodel.cn/)
-ZHIPU_API_KEY = ""
+ZHIPU_API_KEY=""
 
 # Tavily Search API (alternative, get key at https://tavily.com)
-TAVILY_API_KEY = ""
+TAVILY_API_KEY=""
 
 # Exa AI-powered Search (get key at https://exa.ai)
-EXA_API_KEY = ""
+EXA_API_KEY=""
 
 # Google Custom Search (fallback, requires Google Cloud setup)
-GOOGLE_API_KEY = ""
-GOOGLE_CSE_ID = ""
+GOOGLE_API_KEY=""
+GOOGLE_CSE_ID=""
 
 # ===========================================
 # Google OAuth Configuration (Optional)
 # ===========================================
 # Required for Google Login and Google Drive integration
 # Create credentials at https://console.cloud.google.com/apis/credentials
-GOOGLE_CLIENT_ID = ""
-GOOGLE_CLIENT_SECRET = ""
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
 # Redirect URI for Google OAuth callback (Required for Google Login)
 # Example: http://localhost:8000/api/auth/google/callback
-GOOGLE_REDIRECT_URI = ""
+GOOGLE_REDIRECT_URI=""
 
 # Google Ads developer token (Optional)
 # Required for the Google Ads connector in MCP. Apply for/find this token in
@@ -451,18 +451,18 @@ GOOGLE_REDIRECT_URI = ""
 # https://ads.google.com/aw/apicenter
 # This is a single platform-wide token shared by all users who connect the
 # Google Ads app (not a per-user secret), analogous to GOOGLE_CLIENT_ID above.
-GOOGLE_ADS_DEVELOPER_TOKEN = ""
+GOOGLE_ADS_DEVELOPER_TOKEN=""
 
 # ===========================================
 # LinkedIn OAuth Configuration (Optional)
 # ===========================================
 # Required for LinkedIn integration in MCP
 # Create credentials at https://www.linkedin.com/developers/apps/new
-LINKEDIN_CLIENT_ID = ""
-LINKEDIN_CLIENT_SECRET = ""
+LINKEDIN_CLIENT_ID=""
+LINKEDIN_CLIENT_SECRET=""
 # Redirect URI for LinkedIn OAuth callback
 # Example: http://localhost:8000/api/auth/linkedin/callback
-LINKEDIN_REDIRECT_URI = ""
+LINKEDIN_REDIRECT_URI=""
 
 # ===========================================
 # HubSpot OAuth Configuration (Optional)
@@ -471,22 +471,22 @@ LINKEDIN_REDIRECT_URI = ""
 # Create a public app at https://developers.hubspot.com/ and configure the
 # app's scopes to match the connector (crm.objects.contacts/companies read+write,
 # crm.objects.deals.read)
-HUBSPOT_CLIENT_ID = ""
-HUBSPOT_CLIENT_SECRET = ""
+HUBSPOT_CLIENT_ID=""
+HUBSPOT_CLIENT_SECRET=""
 # Redirect URI for HubSpot OAuth callback
 # Example: http://localhost:8000/api/auth/hubspot/callback
-HUBSPOT_REDIRECT_URI = ""
+HUBSPOT_REDIRECT_URI=""
 
 # ===========================================
 # Meta OAuth Configuration (Optional)
 # ===========================================
 # Required for Facebook Pages and Instagram integrations in MCP
 # Create credentials at https://developers.facebook.com/apps/
-META_CLIENT_ID = ""
-META_CLIENT_SECRET = ""
+META_CLIENT_ID=""
+META_CLIENT_SECRET=""
 # Redirect URI for Meta OAuth callback
 # Example: http://localhost:8000/api/auth/meta/callback
-META_REDIRECT_URI = ""
+META_REDIRECT_URI=""
 # Optional Facebook Login for Business configuration ID. When set, Meta OAuth
 # uses config_id instead of a raw scope list, which is required by some Meta app
 # configurations for Pages and Instagram permissions.
@@ -496,7 +496,7 @@ META_REDIRECT_URI = ""
 # pages_manage_posts, pages_read_user_content, instagram_basic,
 # instagram_content_publish) must also be added to that Login Configuration, or
 # users who authorize via config_id will not grant it.
-META_CONFIG_ID = ""
+META_CONFIG_ID=""
 
 # ===========================================
 # Slack OAuth Configuration (Optional)
@@ -507,12 +507,12 @@ META_CONFIG_ID = ""
 # Note: chat:write.public also lets the bot post into any public channel
 # without being invited — it bypasses Slack's invite gate.
 # Leave "Token Rotation" off — bot tokens don't expire, so no refresh is needed.
-SLACK_CLIENT_ID = ""
-SLACK_CLIENT_SECRET = ""
+SLACK_CLIENT_ID=""
+SLACK_CLIENT_SECRET=""
 # Redirect URI for Slack OAuth callback — must also be added under the app's
 # "OAuth & Permissions" > "Redirect URLs".
 # Example: http://localhost:8000/api/auth/slack/callback
-SLACK_REDIRECT_URI = ""
+SLACK_REDIRECT_URI=""
 
 # ===========================================
 # Zoom OAuth Configuration (Optional)
@@ -523,12 +523,12 @@ SLACK_REDIRECT_URI = ""
 # meeting:read:meeting, meeting:read:list_meetings, meeting:read:past_meeting,
 # cloud_recording:read:list_recording_files, cloud_recording:read:meeting_transcript,
 # user:read:user
-ZOOM_CLIENT_ID = ""
-ZOOM_CLIENT_SECRET = ""
+ZOOM_CLIENT_ID=""
+ZOOM_CLIENT_SECRET=""
 # Redirect URI for Zoom OAuth callback — must exactly match a URL registered
 # in the app's OAuth Allow List.
 # Example: http://localhost:8000/api/auth/zoom/callback
-ZOOM_REDIRECT_URI = ""
+ZOOM_REDIRECT_URI=""
 
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
@@ -547,7 +547,7 @@ ZOOM_REDIRECT_URI = ""
 # - Environment variables: $HOME/skills,${USERPROFILE}/skills
 #
 # Examples:
-XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS = ""
+XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="/path/to/custom/skills"
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="~/skills,/usr/local/skills,$HOME/custom_skills"
 # XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS="./local_skills,../shared_skills"
@@ -571,7 +571,7 @@ XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS = ""
 # Maximum per-file upload size enforced by the backend.
 # Nginx maintains a separate, larger defense-in-depth ceiling (see docker/nginx.conf).
 # Supports raw bytes or human-readable values like 100M, 1G, 512K.
-XAGENT_MAX_UPLOAD_SIZE = "100M"
+XAGENT_MAX_UPLOAD_SIZE="100M"
 
 # Durable file storage for user-visible uploads and registered workspace outputs.
 # Defaults to file://$XAGENT_STORAGE_ROOT/files for local development.
@@ -629,7 +629,7 @@ XAGENT_MAX_UPLOAD_SIZE = "100M"
 
 # Database encryption key
 # Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-ENCRYPTION_KEY = "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
+ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 # ===========================================
 # Tool Output Configuration

--- a/example.env
+++ b/example.env
@@ -154,19 +154,23 @@ PORT="80"
 # XAGENT_WIDGET_WS_TURN_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_WS_TURN_RATE_LIMIT="240/minute"
 # Widget HTTP/quota abuse controls (#1108): the remaining share-path controls
-# with no widget counterpart. Auth (and embed-ticket minting, which shares its
-# buckets) is keyed per stable credential (widget key, or the owner entity
-# from the ticket's signed claims) + per caller IP; task-create per widget
-# entity (loose) + per caller IP (tight). The widget run quota caps
-# owner-billed runs one embedded agent/workforce can start per rolling
-# window, with a per-creating-IP sub-quota as the per-abuser dimension (the
-# widget guest_id is client-supplied, so it is never a limiter key). NOTE:
-# the run quota applies to already-live widget tasks as soon as it deploys.
-# Separate buckets from the share limits. CAUTION: every per-IP bucket here
-# needs XAGENT_TRUSTED_PROXY_HOPS set correctly behind a reverse proxy —
-# with the default 0, all traffic resolves to the proxy's own IP and a
-# per-IP cap silently becomes one global cap for the whole deployment.
-# XAGENT_WIDGET_AUTH_RATE_LIMIT="60/minute"
+# with no widget counterpart. Every widget gate uses the tight-per-IP /
+# loose-per-entity pairing: the caller IP is the per-visitor/per-abuser bound
+# (the widget guest_id is client-supplied, so it is never a limiter key), and
+# the per-entity bucket is a loose aggregate backstop across one embedded
+# agent/workforce's visitors. Auth + embed-ticket minting share one bucket
+# family (the two halves of one page-load handshake); their entity key is the
+# widget key or the owner entity from the ticket's signed claims. The auth
+# entity default is deliberately loose (600/min) because both endpoints fire
+# on every page load and the entity is shared by all a widget's visitors — a
+# tight per-entity bucket would 429 ordinary visitors on a busy embed. The
+# widget run quota caps owner-billed runs per rolling window with a
+# per-creating-IP sub-quota; NOTE it applies to already-live widget tasks as
+# soon as it deploys. Separate buckets from the share limits. CAUTION: every
+# per-IP bucket here needs XAGENT_TRUSTED_PROXY_HOPS set correctly behind a
+# reverse proxy — with the default 0, all traffic resolves to the proxy's own
+# IP and a per-IP cap silently becomes one global cap for the deployment.
+# XAGENT_WIDGET_AUTH_RATE_LIMIT="600/minute"
 # XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
 # XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="120/minute"
 # XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"

--- a/example.env
+++ b/example.env
@@ -169,17 +169,24 @@ PORT="80"
 # tight per-entity bucket would 429 ordinary visitors on a busy embed, and
 # an auth denial is fail-closed client-side (the widget never loads). The
 # widget run quota caps owner-billed runs per rolling window with a
-# per-creating-IP sub-quota; NOTE it applies to already-live widget tasks as
-# soon as it deploys. Separate buckets from the share limits. CAUTION: every
-# per-IP bucket here needs XAGENT_TRUSTED_PROXY_HOPS set correctly behind a
-# reverse proxy — with the default 0, all traffic resolves to the proxy's own
-# IP and a per-IP cap silently becomes one global cap for the deployment.
+# per-creating-IP sub-quota (keyed per widget, so exhausting it on one embed
+# never blocks the same network on another); NOTE it applies to already-live
+# widget tasks as soon as it deploys, and it is charged per conversation turn,
+# not once per task. Separate buckets from the share limits.
+# NAT / shared egress: every per-IP bucket below is shared by all genuine
+# visitors behind one address — a corporate NAT or a carrier CGNAT can put
+# thousands of people on one IP — so raise the per-IP values for deployments
+# fronted by large shared egress. CAUTION: every per-IP bucket also needs
+# XAGENT_TRUSTED_PROXY_HOPS set correctly behind a reverse proxy — with 0
+# hops, all traffic resolves to the proxy's own IP and a per-IP cap silently
+# becomes one global cap for the deployment; set it too high and the client
+# controls the derived IP through X-Forwarded-For.
 # XAGENT_WIDGET_AUTH_RATE_LIMIT="1200/minute"
 # XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
 # XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="240/minute"
 # XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_RUN_QUOTA="500/day"
-# XAGENT_WIDGET_RUN_IP_QUOTA="60/hour"
+# XAGENT_WIDGET_RUN_IP_QUOTA="120/hour"
 # XAGENT_SHARE_RUN_QUOTA="500/day"
 # XAGENT_SHARE_RUN_GUEST_QUOTA="60/hour"
 # Behind a reverse proxy, set the number of trusted proxy hops so the caller

--- a/example.env
+++ b/example.env
@@ -153,6 +153,18 @@ PORT="80"
 # XAGENT_WIDGET_WS_CONNECT_IP_RATE_LIMIT="120/minute"
 # XAGENT_WIDGET_WS_TURN_IP_RATE_LIMIT="60/minute"
 # XAGENT_WIDGET_WS_TURN_RATE_LIMIT="240/minute"
+# Widget HTTP/quota abuse controls (#1108): the remaining share-path controls
+# with no widget counterpart. Auth is keyed per presented credential (embed
+# ticket or widget key) + per caller IP; task-create per widget entity (loose)
+# + per caller IP (tight). The widget run quota caps owner-billed runs one
+# embedded agent/workforce can start per rolling window; it has no per-guest
+# sub-quota because the widget guest_id is client-supplied and the caller IP
+# is unavailable at the run chokepoint. Separate buckets from the share limits.
+# XAGENT_WIDGET_AUTH_RATE_LIMIT="60/minute"
+# XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="300/minute"
+# XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="120/minute"
+# XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="60/minute"
+# XAGENT_WIDGET_RUN_QUOTA="500/day"
 # XAGENT_SHARE_RUN_QUOTA="500/day"
 # XAGENT_SHARE_RUN_GUEST_QUOTA="60/hour"
 # Behind a reverse proxy, set the number of trusted proxy hops so the caller

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -376,8 +376,14 @@
               if (!res.ok) {
                 // Fail closed: no ticket means auth would fail, and loading the
                 // iframe anyway would let a non-allowlisted embed slip through the
-                // direct-visit path. Surface an actionable error instead.
-                console.error('Xagent Widget: embed authorization failed (HTTP ' + res.status + '). Check that this page is in the agent\'s allowed domains and that the embed snippet is current.');
+                // direct-visit path. Surface an actionable error instead — 429 is
+                // rate limiting (transient, high traffic), distinct from the
+                // domain-allowlist / stale-snippet causes behind a 403.
+                if (res.status === 429) {
+                  console.error('Xagent Widget: embed authorization rate-limited (HTTP 429). This is usually transient under high traffic; the widget will load on a later retry.');
+                } else {
+                  console.error('Xagent Widget: embed authorization failed (HTTP ' + res.status + '). Check that this page is in the agent\'s allowed domains and that the embed snippet is current.');
+                }
                 return null;
               }
               return res.json();

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -380,7 +380,7 @@
                 // rate limiting (transient, high traffic), distinct from the
                 // domain-allowlist / stale-snippet causes behind a 403.
                 if (res.status === 429) {
-                  console.error('Xagent Widget: embed authorization rate-limited (HTTP 429). This is usually transient under high traffic; the widget will load on a later retry.');
+                  console.error('Xagent Widget: embed authorization rate-limited (HTTP 429), usually transient under high traffic. Reload the page to try again.');
                 } else {
                   console.error('Xagent Widget: embed authorization failed (HTTP ' + res.status + '). Check that this page is in the agent\'s allowed domains and that the embed snippet is current.');
                 }

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -993,9 +993,13 @@ def get_widget_auth_rate_limit() -> str:
     endpoints fire on every widget page load and the entity key is shared by
     all of a widget's visitors, so a tight per-entity bucket would 429
     ordinary visitors on a busy embed. The per-IP limit below is the tight
-    per-visitor / per-abuser bound. Raise this for very high-traffic embeds.
+    per-visitor / per-abuser bound. Kept at the same 4:1 entity:IP ratio as
+    the sibling widget upload / ws-turn gates — and auth is the one gate whose
+    denial is fail-closed client-side (the widget never loads), so its
+    aggregate backstop is deliberately the most tolerant, not the tightest.
+    Raise this for very high-traffic embeds.
     """
-    return _get_rate_limit(WIDGET_AUTH_RATE_LIMIT, "600/minute")
+    return _get_rate_limit(WIDGET_AUTH_RATE_LIMIT, "1200/minute")
 
 
 def get_widget_auth_ip_rate_limit() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1022,9 +1022,12 @@ def get_widget_task_create_rate_limit() -> str:
     agent/workforce across all callers (one widget serves many legitimate
     guests). The per-IP bucket below is the tighter per-abuser gate; unlike the
     share path this cannot key on the guest, whose id is client-supplied and
-    rotatable at will.
+    rotatable at will. Kept at the 4:1 entity:IP ratio shared by every widget
+    gate: the entity bucket only accumulates on admitted requests, so ``ratio``
+    cooperating under-cap IPs are needed to saturate it — 4 here, not 2, on the
+    surface where each admitted request spawns an owner-billed run.
     """
-    return _get_rate_limit(WIDGET_TASK_CREATE_RATE_LIMIT, "120/minute")
+    return _get_rate_limit(WIDGET_TASK_CREATE_RATE_LIMIT, "240/minute")
 
 
 def get_widget_task_create_ip_rate_limit() -> str:
@@ -1060,8 +1063,11 @@ def get_widget_run_ip_quota() -> str:
 
     The per-abuser sub-quota under :func:`get_widget_run_quota`, mirroring the
     share path's per-guest window: bounds the owner-billed runs attributable
-    to one caller IP so a single abuser cannot drain the whole widget quota
-    and lock out every other visitor for a rolling day. The IP is the one the
+    to one caller IP so a single-IP abuser cannot drain the whole widget quota
+    and lock out every other visitor for a rolling day. It does NOT stop a
+    multi-IP abuser: roughly ``entity_quota / ip_quota`` IPs, each staying
+    under its own window, still exhaust the shared entity quota — structurally
+    the same limit as the share path's per-guest quota. The IP is the one the
     server observed at task creation (stamped into ``agent_config``, never
     client-supplied); tasks created before this deploy carry no marker and are
     bounded by the entity quota alone. As with the other per-IP widget

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -133,6 +133,7 @@ WIDGET_AUTH_IP_RATE_LIMIT = "XAGENT_WIDGET_AUTH_IP_RATE_LIMIT"
 WIDGET_TASK_CREATE_RATE_LIMIT = "XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT"
 WIDGET_TASK_CREATE_IP_RATE_LIMIT = "XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT"
 WIDGET_RUN_QUOTA = "XAGENT_WIDGET_RUN_QUOTA"
+WIDGET_RUN_IP_QUOTA = "XAGENT_WIDGET_RUN_IP_QUOTA"
 SHARE_RUN_QUOTA = "XAGENT_SHARE_RUN_QUOTA"
 SHARE_RUN_GUEST_QUOTA = "XAGENT_SHARE_RUN_GUEST_QUOTA"
 GMAIL_PUBSUB_PROJECT_ID = "XAGENT_GMAIL_PUBSUB_PROJECT_ID"
@@ -1036,13 +1037,31 @@ def get_widget_run_quota() -> str:
 
     The widget mirror of :func:`get_share_run_quota`, in its own bucket so a
     popular/abused widget cannot drain the owner's whole team quota. Keyed on
-    the embedded agent/workforce only: unlike the share path there is no
-    per-guest sub-quota, because the widget ``guest_id`` is client-supplied
-    and rotatable at will, and the caller IP is not available at the async
-    ``execute_task`` chokepoint where this gate runs. Per-abuser bursts are
-    bounded instead by the per-IP widget task-create and websocket-turn gates.
+    the embedded agent/workforce, with a per-creating-IP sub-quota
+    (:func:`get_widget_run_ip_quota`) as the per-abuser dimension — the widget
+    ``guest_id`` is client-supplied (rotatable at will), so unlike the share
+    path there is no per-guest sub-quota. NOTE: this quota applies to
+    already-live widget tasks as soon as it deploys (their ``agent_config``
+    carries the widget markers); the only opt-out is raising the env var.
     """
     return _get_rate_limit(WIDGET_RUN_QUOTA, "500/day")
+
+
+def get_widget_run_ip_quota() -> str:
+    """Per-creating-IP rolling run quota within a widget (#1108).
+
+    The per-abuser sub-quota under :func:`get_widget_run_quota`, mirroring the
+    share path's per-guest window: bounds the owner-billed runs attributable
+    to one caller IP so a single abuser cannot drain the whole widget quota
+    and lock out every other visitor for a rolling day. The IP is the one the
+    server observed at task creation (stamped into ``agent_config``, never
+    client-supplied); tasks created before this deploy carry no marker and are
+    bounded by the entity quota alone. As with the other per-IP widget
+    buckets, N guests behind one NAT egress share this budget — raise it for
+    large shared-egress populations, and set XAGENT_TRUSTED_PROXY_HOPS behind
+    a reverse proxy.
+    """
+    return _get_rate_limit(WIDGET_RUN_IP_QUOTA, "60/hour")
 
 
 def get_share_run_quota() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -128,6 +128,11 @@ WIDGET_UPLOAD_IP_RATE_LIMIT = "XAGENT_WIDGET_UPLOAD_IP_RATE_LIMIT"
 WIDGET_WS_CONNECT_IP_RATE_LIMIT = "XAGENT_WIDGET_WS_CONNECT_IP_RATE_LIMIT"
 WIDGET_WS_TURN_IP_RATE_LIMIT = "XAGENT_WIDGET_WS_TURN_IP_RATE_LIMIT"
 WIDGET_WS_TURN_RATE_LIMIT = "XAGENT_WIDGET_WS_TURN_RATE_LIMIT"
+WIDGET_AUTH_RATE_LIMIT = "XAGENT_WIDGET_AUTH_RATE_LIMIT"
+WIDGET_AUTH_IP_RATE_LIMIT = "XAGENT_WIDGET_AUTH_IP_RATE_LIMIT"
+WIDGET_TASK_CREATE_RATE_LIMIT = "XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT"
+WIDGET_TASK_CREATE_IP_RATE_LIMIT = "XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT"
+WIDGET_RUN_QUOTA = "XAGENT_WIDGET_RUN_QUOTA"
 SHARE_RUN_QUOTA = "XAGENT_SHARE_RUN_QUOTA"
 SHARE_RUN_GUEST_QUOTA = "XAGENT_SHARE_RUN_GUEST_QUOTA"
 GMAIL_PUBSUB_PROJECT_ID = "XAGENT_GMAIL_PUBSUB_PROJECT_ID"
@@ -977,6 +982,67 @@ def get_widget_ws_turn_rate_limit() -> str:
     legitimate guests).
     """
     return _get_rate_limit(WIDGET_WS_TURN_RATE_LIMIT, "240/minute")
+
+
+def get_widget_auth_rate_limit() -> str:
+    """Per-credential limit on ``POST /api/widget/auth`` (#1108).
+
+    The widget mirror of :func:`get_share_auth_rate_limit`, in its own bucket
+    so probes against one public channel cannot consume the other's budget.
+    Keyed on the presented credential (embed ticket or widget key) rather than
+    a resolved entity, because the gate runs before any DB lookup; the per-IP
+    ceiling below bounds a single client across credentials.
+    """
+    return _get_rate_limit(WIDGET_AUTH_RATE_LIMIT, "60/minute")
+
+
+def get_widget_auth_ip_rate_limit() -> str:
+    """Per-IP ceiling on ``POST /api/widget/auth`` across all widget keys (#1108).
+
+    The widget mirror of :func:`get_share_auth_ip_rate_limit`. Bounds one
+    caller minting guest tokens (each call does DB lookups and signs a JWT)
+    regardless of how many widget keys they cycle through.
+    """
+    return _get_rate_limit(WIDGET_AUTH_IP_RATE_LIMIT, "300/minute")
+
+
+def get_widget_task_create_rate_limit() -> str:
+    """Per-widget-entity limit on public widget task creation (#1108).
+
+    The loose backstop bounding total task-create volume through one embedded
+    agent/workforce across all callers (one widget serves many legitimate
+    guests). The per-IP bucket below is the tighter per-abuser gate; unlike the
+    share path this cannot key on the guest, whose id is client-supplied and
+    rotatable at will.
+    """
+    return _get_rate_limit(WIDGET_TASK_CREATE_RATE_LIMIT, "120/minute")
+
+
+def get_widget_task_create_ip_rate_limit() -> str:
+    """Per-caller-IP limit on public widget task creation (#1108).
+
+    The tighter bucket: task creation is the costly surface (each spawns an
+    owner-billed run), and the caller IP is the only trustworthy per-abuser
+    key on the widget path. Numerically matches the widget upload/turn IP
+    default; N guests behind one NAT egress share this budget, so raise it for
+    deployments with large shared-egress populations (and set
+    XAGENT_TRUSTED_PROXY_HOPS behind a reverse proxy).
+    """
+    return _get_rate_limit(WIDGET_TASK_CREATE_IP_RATE_LIMIT, "60/minute")
+
+
+def get_widget_run_quota() -> str:
+    """Per-widget-entity rolling run quota (#1108).
+
+    The widget mirror of :func:`get_share_run_quota`, in its own bucket so a
+    popular/abused widget cannot drain the owner's whole team quota. Keyed on
+    the embedded agent/workforce only: unlike the share path there is no
+    per-guest sub-quota, because the widget ``guest_id`` is client-supplied
+    and rotatable at will, and the caller IP is not available at the async
+    ``execute_task`` chokepoint where this gate runs. Per-abuser bursts are
+    bounded instead by the per-IP widget task-create and websocket-turn gates.
+    """
+    return _get_rate_limit(WIDGET_RUN_QUOTA, "500/day")
 
 
 def get_share_run_quota() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1008,9 +1008,11 @@ def get_widget_auth_ip_rate_limit() -> str:
     The tight per-visitor / per-abuser bound (visitors have distinct IPs):
     bounds one caller minting guest tokens / embed tickets (each call does DB
     lookups and signs a JWT) regardless of how many widget keys or tickets
-    they cycle through, since the IP is not cheaply rotatable. (Every per-IP
-    widget bucket shares the NAT / XAGENT_TRUSTED_PROXY_HOPS caveat documented
-    once in example.env.)
+    they cycle through, since the IP is not cheaply rotatable. Raise this
+    where many genuine visitors share one address (corporate NAT, carrier
+    CGNAT), and set XAGENT_TRUSTED_PROXY_HOPS correctly behind a reverse proxy
+    — otherwise every caller resolves to the proxy's IP and this becomes one
+    global cap. (example.env carries the same caveat for all per-IP buckets.)
     """
     return _get_rate_limit(WIDGET_AUTH_IP_RATE_LIMIT, "300/minute")
 
@@ -1036,7 +1038,11 @@ def get_widget_task_create_ip_rate_limit() -> str:
     The tighter bucket: task creation is the costly surface (each spawns an
     owner-billed run), and the caller IP is the only trustworthy per-abuser
     key on the widget path. Numerically matches the widget upload/turn IP
-    default. (Shared NAT / proxy-hops caveat: see example.env.)
+    default. Raise this where many genuine visitors share one address
+    (corporate NAT, carrier CGNAT), and set XAGENT_TRUSTED_PROXY_HOPS correctly
+    behind a reverse proxy — otherwise every caller resolves to the proxy's IP
+    and this becomes one global cap. (example.env carries the same caveat for
+    all per-IP buckets.)
     """
     return _get_rate_limit(WIDGET_TASK_CREATE_IP_RATE_LIMIT, "60/minute")
 
@@ -1079,8 +1085,10 @@ def get_widget_run_ip_quota() -> str:
     ``agent_config``, never client-supplied); tasks created before this deploy
     carry no marker and are bounded by the entity quota alone. Raise it for
     deployments fronted by large shared egress (corporate NAT, carrier CGNAT),
-    where many genuine visitors present one address. (Shared NAT / proxy-hops
-    caveat: see example.env.)
+    where many genuine visitors present one address, and set
+    XAGENT_TRUSTED_PROXY_HOPS correctly behind a reverse proxy — otherwise
+    every caller resolves to the proxy's IP and this becomes one global cap.
+    (example.env carries the same caveat for all per-IP buckets.)
     """
     return _get_rate_limit(WIDGET_RUN_IP_QUOTA, "120/hour")
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1008,9 +1008,9 @@ def get_widget_auth_ip_rate_limit() -> str:
     The tight per-visitor / per-abuser bound (visitors have distinct IPs):
     bounds one caller minting guest tokens / embed tickets (each call does DB
     lookups and signs a JWT) regardless of how many widget keys or tickets
-    they cycle through, since the IP is not cheaply rotatable. N guests behind
-    one NAT egress share this budget — set XAGENT_TRUSTED_PROXY_HOPS behind a
-    reverse proxy so all traffic does not collapse onto the proxy's IP.
+    they cycle through, since the IP is not cheaply rotatable. (Every per-IP
+    widget bucket shares the NAT / XAGENT_TRUSTED_PROXY_HOPS caveat documented
+    once in example.env.)
     """
     return _get_rate_limit(WIDGET_AUTH_IP_RATE_LIMIT, "300/minute")
 
@@ -1036,9 +1036,7 @@ def get_widget_task_create_ip_rate_limit() -> str:
     The tighter bucket: task creation is the costly surface (each spawns an
     owner-billed run), and the caller IP is the only trustworthy per-abuser
     key on the widget path. Numerically matches the widget upload/turn IP
-    default; N guests behind one NAT egress share this budget, so raise it for
-    deployments with large shared-egress populations (and set
-    XAGENT_TRUSTED_PROXY_HOPS behind a reverse proxy).
+    default. (Shared NAT / proxy-hops caveat: see example.env.)
     """
     return _get_rate_limit(WIDGET_TASK_CREATE_IP_RATE_LIMIT, "60/minute")
 
@@ -1059,21 +1057,21 @@ def get_widget_run_quota() -> str:
 
 
 def get_widget_run_ip_quota() -> str:
-    """Per-creating-IP rolling run quota within a widget (#1108).
+    """Per-creating-IP rolling run quota (#1108).
 
     The per-abuser sub-quota under :func:`get_widget_run_quota`, mirroring the
-    share path's per-guest window: bounds the owner-billed runs attributable
-    to one caller IP so a single-IP abuser cannot drain the whole widget quota
-    and lock out every other visitor for a rolling day. It does NOT stop a
+    share path's per-guest window. Its bucket is keyed on the creating IP
+    alone, so it is platform-level — one IP's budget spans every widget on the
+    instance, not one widget — which is what bounds a single-IP abuser from
+    draining any one widget's entity quota and locking out its other visitors
+    for a rolling day. It does NOT stop a
     multi-IP abuser: roughly ``entity_quota / ip_quota`` IPs, each staying
     under its own window, still exhaust the shared entity quota — structurally
     the same limit as the share path's per-guest quota. The IP is the one the
     server observed at task creation (stamped into ``agent_config``, never
     client-supplied); tasks created before this deploy carry no marker and are
-    bounded by the entity quota alone. As with the other per-IP widget
-    buckets, N guests behind one NAT egress share this budget — raise it for
-    large shared-egress populations, and set XAGENT_TRUSTED_PROXY_HOPS behind
-    a reverse proxy.
+    bounded by the entity quota alone. (Shared NAT / proxy-hops caveat: see
+    example.env.)
     """
     return _get_rate_limit(WIDGET_RUN_IP_QUOTA, "60/hour")
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1057,23 +1057,32 @@ def get_widget_run_quota() -> str:
 
 
 def get_widget_run_ip_quota() -> str:
-    """Per-creating-IP rolling run quota (#1108).
+    """Per-creating-IP, per-widget rolling run sub-quota (#1108).
 
     The per-abuser sub-quota under :func:`get_widget_run_quota`, mirroring the
-    share path's per-guest window. Its bucket is keyed on the creating IP
-    alone, so it is platform-level — one IP's budget spans every widget on the
-    instance, not one widget — which is what bounds a single-IP abuser from
-    draining any one widget's entity quota and locking out its other visitors
-    for a rolling day. It does NOT stop a
-    multi-IP abuser: roughly ``entity_quota / ip_quota`` IPs, each staying
-    under its own window, still exhaust the shared entity quota — structurally
-    the same limit as the share path's per-guest quota. The IP is the one the
-    server observed at task creation (stamped into ``agent_config``, never
-    client-supplied); tasks created before this deploy carry no marker and are
-    bounded by the entity quota alone. (Shared NAT / proxy-hops caveat: see
-    example.env.)
+    share path's per-guest window. Its bucket is keyed ``entity|ip``, i.e.
+    scoped to one widget: a caller's budget on one embedded agent/workforce is
+    independent of every other widget on the instance. That scoping matters
+    because this quota is charged per *turn* — a bare-IP bucket would make one
+    NAT/CGNAT egress share a single turn budget across unrelated widgets.
+
+    Sizing: this is a share of a rolling owner-billed budget, not a burst
+    throttle, so it is deliberately far below the per-minute burst gates
+    (widget WS turn / task-create, both 60/minute per IP) and instead sized as
+    a fraction of :func:`get_widget_run_quota` — at the defaults one caller
+    needs several sustained hours to drain a widget's daily budget. It does
+    NOT stop a multi-IP abuser: roughly ``entity_quota / ip_quota`` IPs, each
+    staying under its own window, still exhaust the entity quota —
+    structurally the same limit as the share path's per-guest quota.
+
+    The IP is the one the server observed at task creation (stamped into
+    ``agent_config``, never client-supplied); tasks created before this deploy
+    carry no marker and are bounded by the entity quota alone. Raise it for
+    deployments fronted by large shared egress (corporate NAT, carrier CGNAT),
+    where many genuine visitors present one address. (Shared NAT / proxy-hops
+    caveat: see example.env.)
     """
-    return _get_rate_limit(WIDGET_RUN_IP_QUOTA, "60/hour")
+    return _get_rate_limit(WIDGET_RUN_IP_QUOTA, "120/hour")
 
 
 def get_share_run_quota() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -986,23 +986,27 @@ def get_widget_ws_turn_rate_limit() -> str:
 
 
 def get_widget_auth_rate_limit() -> str:
-    """Per-credential limit on ``POST /api/widget/auth`` (#1108).
+    """Per-widget-entity limit on widget auth + embed-ticket minting (#1108).
 
-    The widget mirror of :func:`get_share_auth_rate_limit`, in its own bucket
-    so probes against one public channel cannot consume the other's budget.
-    Keyed on the presented credential (embed ticket or widget key) rather than
-    a resolved entity, because the gate runs before any DB lookup; the per-IP
-    ceiling below bounds a single client across credentials.
+    The loose aggregate backstop bounding total auth/ticket volume through one
+    embedded agent/workforce across all callers. Deliberately loose: both
+    endpoints fire on every widget page load and the entity key is shared by
+    all of a widget's visitors, so a tight per-entity bucket would 429
+    ordinary visitors on a busy embed. The per-IP limit below is the tight
+    per-visitor / per-abuser bound. Raise this for very high-traffic embeds.
     """
-    return _get_rate_limit(WIDGET_AUTH_RATE_LIMIT, "60/minute")
+    return _get_rate_limit(WIDGET_AUTH_RATE_LIMIT, "600/minute")
 
 
 def get_widget_auth_ip_rate_limit() -> str:
-    """Per-IP ceiling on ``POST /api/widget/auth`` across all widget keys (#1108).
+    """Per-caller-IP limit on widget auth + embed-ticket minting (#1108).
 
-    The widget mirror of :func:`get_share_auth_ip_rate_limit`. Bounds one
-    caller minting guest tokens (each call does DB lookups and signs a JWT)
-    regardless of how many widget keys they cycle through.
+    The tight per-visitor / per-abuser bound (visitors have distinct IPs):
+    bounds one caller minting guest tokens / embed tickets (each call does DB
+    lookups and signs a JWT) regardless of how many widget keys or tickets
+    they cycle through, since the IP is not cheaply rotatable. N guests behind
+    one NAT egress share this budget — set XAGENT_TRUSTED_PROXY_HOPS behind a
+    reverse proxy so all traffic does not collapse onto the proxy's IP.
     """
     return _get_rate_limit(WIDGET_AUTH_IP_RATE_LIMIT, "300/minute")
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -990,28 +990,76 @@ def _load_task_run_gate_user_id_isolated(task_id: int) -> int | None:
         return int(user_id) if user_id is not None else None
 
 
-def _load_task_share_quota_config_isolated(task_id: int) -> dict[str, Any] | None:
-    """Load the share-quota markers (#973) in a worker-owned short Session.
+def _load_task_public_run_quota_config_isolated(
+    task_id: int,
+) -> dict[str, Any] | None:
+    """Load the public-run-quota markers in a worker-owned short Session.
 
-    Returns the task's ``agent_config`` only when it marks a share task
-    (``auth_mode == "share"``); ``None`` skips the share quota gate. Kept
-    separate from :func:`_load_task_run_gate_user_id_isolated` so the owner
-    gate's return contract (an ``int | None`` that tests monkeypatch) stays
-    untouched.
+    Returns the task's ``agent_config`` only when it marks a public run that
+    bills the owner — a share task (``auth_mode == "share"``, #973) or a widget
+    task (``auth_mode == "widget"``, #1108); ``None`` skips the quota gate for
+    everything else. Kept separate from
+    :func:`_load_task_run_gate_user_id_isolated` so the owner gate's return
+    contract (an ``int | None`` that tests monkeypatch) stays untouched.
     """
     from ..models.database import get_session_local
 
     SessionLocal = get_session_local()
-    with SessionLocal() as share_db:
+    with SessionLocal() as quota_db:
         agent_config = (
-            share_db.query(Task.agent_config).filter(Task.id == task_id).scalar()
+            quota_db.query(Task.agent_config).filter(Task.id == task_id).scalar()
         )
-        if (
-            isinstance(agent_config, Mapping)
-            and agent_config.get("auth_mode") == "share"
+        if isinstance(agent_config, Mapping) and agent_config.get("auth_mode") in (
+            "share",
+            "widget",
         ):
             return dict(agent_config)
         return None
+
+
+def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
+    """Apply the per-entity run quota for a public (share/widget) task.
+
+    Returns ``True`` when the run is admitted (or cannot be keyed, matching the
+    original share behaviour of falling through rather than blocking a run it
+    cannot attribute), ``False`` when the rolling quota is exhausted.
+
+    Share tasks carry a server-minted ``guest_id`` and are gated per link +
+    per guest (#973). Widget tasks are gated per entity only (#1108): their
+    ``guest_id`` is client-supplied (rotatable at will) and the caller IP is
+    unavailable at this async chokepoint, so a per-guest sub-quota would be a
+    no-op against a deliberate abuser — the per-IP widget task-create / turn
+    gates carry that dimension instead.
+    """
+    from ..services.share_rate_limit import (
+        entity_rate_limit_key,
+        get_share_rate_limiter,
+    )
+
+    auth_mode = quota_config.get("auth_mode")
+    limiter = get_share_rate_limiter()
+
+    if auth_mode == "widget":
+        widget_agent_id = quota_config.get("widget_agent_id")
+        widget_workforce_id = quota_config.get("widget_workforce_id")
+        entity_key = entity_rate_limit_key(
+            int(widget_agent_id) if widget_agent_id is not None else None,
+            int(widget_workforce_id) if widget_workforce_id is not None else None,
+        )
+        if entity_key is None:
+            return True
+        return limiter.allow_widget_run(entity_key)
+
+    guest_id = quota_config.get("guest_id")
+    agent_share_id = quota_config.get("share_agent_id")
+    workforce_id = quota_config.get("share_workforce_id")
+    share_key = entity_rate_limit_key(
+        int(agent_share_id) if agent_share_id is not None else None,
+        int(workforce_id) if workforce_id is not None else None,
+    )
+    if not share_key or not isinstance(guest_id, str) or not guest_id:
+        return True
+    return limiter.allow_run(share_key, guest_id)
 
 
 def _check_task_run_gate_on_event_loop(
@@ -2893,45 +2941,33 @@ class AgentServiceManager:
                     raise
                 logger.warning("Quota gate check failed open", exc_info=True)
 
-        # Per-share run quota (#973): the run gate above bounds the OWNER's
-        # team quota, but every anonymous share run bills the owner, so one
-        # public link could still drain the whole team quota. This adds a
-        # per-link + per-guest rolling ceiling on top, keyed off the share
-        # markers PR1 stamped into agent_config. Only share tasks are gated;
-        # fails open (availability) like the run gate above, with the same
-        # pool-timeout escalation so a stalled pool doesn't cascade.
+        # Per-link run quota (#973 share, #1108 widget): the run gate above
+        # bounds the OWNER's team quota, but every anonymous public run bills
+        # the owner, so one public link could still drain the whole team quota.
+        # This adds a rolling per-entity ceiling on top, keyed off the markers
+        # stamped into agent_config at task creation. Only public tasks are
+        # gated; fails open (availability) like the run gate above, with the
+        # same pool-timeout escalation so a stalled pool doesn't cascade.
         if tracker_task_id:
             try:
-                share_config = await run_db_io_cancellation_safe(
-                    lambda: _load_task_share_quota_config_isolated(int(tracker_task_id))
+                quota_config = await run_db_io_cancellation_safe(
+                    lambda: _load_task_public_run_quota_config_isolated(
+                        int(tracker_task_id)
+                    )
                 )
-                if share_config is not None:
-                    from ..services.share_rate_limit import (
-                        entity_rate_limit_key,
-                        get_share_rate_limiter,
+                if quota_config is not None and not _admit_public_run(quota_config):
+                    reason_message = (
+                        "This shared link has reached its usage limit. "
+                        "Please try again later."
                     )
-
-                    guest_id = share_config.get("guest_id")
-                    workforce_id = share_config.get("share_workforce_id")
-                    agent_share_id = share_config.get("share_agent_id")
-                    share_key = entity_rate_limit_key(
-                        int(agent_share_id) if agent_share_id is not None else None,
-                        int(workforce_id) if workforce_id is not None else None,
-                    )
-                    if share_key and isinstance(guest_id, str) and guest_id:
-                        if not get_share_rate_limiter().allow_run(share_key, guest_id):
-                            reason_message = (
-                                "This shared link has reached its usage limit. "
-                                "Please try again later."
-                            )
-                            return {
-                                "success": False,
-                                "status": "quota_exceeded",
-                                "output": reason_message,
-                                "error": reason_message,
-                                "error_code": "share_run_quota_exceeded",
-                                "error_details": None,
-                            }
+                    return {
+                        "success": False,
+                        "status": "quota_exceeded",
+                        "output": reason_message,
+                        "error": reason_message,
+                        "error_code": "share_run_quota_exceeded",
+                        "error_details": None,
+                    }
             except Exception as exc:
                 if is_database_pool_timeout(exc):
                     logger.error(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1043,7 +1043,11 @@ def _coerce_optional_entity_id(value: Any) -> int | None:
 
 
 def _public_run_denial_channel(quota_config: Mapping[str, Any]) -> str | None:
-    """Apply the per-entity run quota for a public (share/widget) task.
+    """Charge the run quota for a public (share/widget) task; name any refusal.
+
+    NOT a speculative query despite the name: admitting consumes a slot in
+    every bucket consulted (``allow_run`` / ``widget_run_denial_reason`` hit
+    them on the admit path), so calling this twice charges twice.
 
     Returns the quota that refused the run — ``"share"``, ``"widget"`` (the
     owner's budget for that embed), or ``"widget-ip"`` (the per-caller

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1019,20 +1019,27 @@ def _load_task_public_run_quota_config_isolated(
 
 
 def _coerce_optional_entity_id(value: Any) -> int | None:
-    """Coerce an agent_config entity marker to ``int``, or ``None`` if it can't.
+    """Coerce an agent_config entity marker to a positive ``int``, else ``None``.
 
-    A malformed marker (non-numeric, injected junk) must degrade to "unkeyable"
-    — the caller then admits that one task — rather than raising into the
-    chokepoint's broad ``except``, which would log a scary "failed open" and
-    disable the gate outright. ``bool`` is rejected explicitly: ``True`` is an
-    ``int`` subclass that would otherwise coerce to ``1``.
+    Entity markers are database primary keys — always positive integers — so
+    this accepts only a non-``bool`` ``int`` or an all-digits string, both
+    ``> 0``. Anything else (a float like ``1.9`` that would silently truncate
+    onto a real entity's bucket, ``0`` / negatives that mint impossible
+    buckets, ``inf`` whose ``int()`` raises ``OverflowError``, or injected
+    junk) degrades to "unkeyable" — the caller then admits that one task —
+    rather than keying the wrong bucket or raising into the chokepoint's broad
+    ``except``, which would log a scary "failed open" and disable the gate.
+    ``bool`` is rejected explicitly: ``True`` is an ``int`` subclass that would
+    otherwise coerce to ``1``.
     """
-    if value is None or isinstance(value, bool):
+    if isinstance(value, bool):
         return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    return None
 
 
 def _deny_public_run(quota_config: Mapping[str, Any]) -> str | None:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1022,14 +1022,16 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
 
     Returns ``True`` when the run is admitted (or cannot be keyed, matching the
     original share behaviour of falling through rather than blocking a run it
-    cannot attribute), ``False`` when the rolling quota is exhausted.
+    cannot attribute), ``False`` when a rolling quota is exhausted.
 
     Share tasks carry a server-minted ``guest_id`` and are gated per link +
-    per guest (#973). Widget tasks are gated per entity only (#1108): their
-    ``guest_id`` is client-supplied (rotatable at will) and the caller IP is
-    unavailable at this async chokepoint, so a per-guest sub-quota would be a
-    no-op against a deliberate abuser — the per-IP widget task-create / turn
-    gates carry that dimension instead.
+    per guest (#973). Widget tasks are gated per entity plus the creator IP
+    the backend stamped into ``agent_config`` at task creation (#1108) — their
+    ``guest_id`` is client-supplied (rotatable at will), so the stamped IP is
+    the per-abuser dimension; without it one caller could drain the whole
+    rolling entity quota and lock every other visitor out. Tasks created
+    before the IP marker existed carry ``None`` and are bounded by the entity
+    quota alone.
     """
     from ..services.share_rate_limit import (
         entity_rate_limit_key,
@@ -1048,18 +1050,30 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
         )
         if entity_key is None:
             return True
-        return limiter.allow_widget_run(entity_key)
+        client_ip = quota_config.get("widget_client_ip")
+        return limiter.allow_widget_run(
+            entity_key, client_ip if isinstance(client_ip, str) and client_ip else None
+        )
 
-    guest_id = quota_config.get("guest_id")
-    agent_share_id = quota_config.get("share_agent_id")
-    workforce_id = quota_config.get("share_workforce_id")
-    share_key = entity_rate_limit_key(
-        int(agent_share_id) if agent_share_id is not None else None,
-        int(workforce_id) if workforce_id is not None else None,
+    if auth_mode == "share":
+        guest_id = quota_config.get("guest_id")
+        agent_share_id = quota_config.get("share_agent_id")
+        workforce_id = quota_config.get("share_workforce_id")
+        share_key = entity_rate_limit_key(
+            int(agent_share_id) if agent_share_id is not None else None,
+            int(workforce_id) if workforce_id is not None else None,
+        )
+        if not share_key or not isinstance(guest_id, str) or not guest_id:
+            return True
+        return limiter.allow_run(share_key, guest_id)
+
+    # The loader only returns share/widget configs; admit anything else so a
+    # future auth mode fails open here (visibly unmetered) rather than
+    # silently borrowing another channel's buckets.
+    logger.warning(
+        "Public run quota gate saw unexpected auth_mode %r; admitting", auth_mode
     )
-    if not share_key or not isinstance(guest_id, str) or not guest_id:
-        return True
-    return limiter.allow_run(share_key, guest_id)
+    return True
 
 
 def _check_task_run_gate_on_event_loop(
@@ -2949,37 +2963,56 @@ class AgentServiceManager:
         # gated; fails open (availability) like the run gate above, with the
         # same pool-timeout escalation so a stalled pool doesn't cascade.
         if tracker_task_id:
+            quota_auth_mode: str | None = None
             try:
                 quota_config = await run_db_io_cancellation_safe(
                     lambda: _load_task_public_run_quota_config_isolated(
                         int(tracker_task_id)
                     )
                 )
+                if quota_config is not None:
+                    raw_mode = quota_config.get("auth_mode")
+                    quota_auth_mode = raw_mode if isinstance(raw_mode, str) else None
                 if quota_config is not None and not _admit_public_run(quota_config):
-                    reason_message = (
-                        "This shared link has reached its usage limit. "
-                        "Please try again later."
-                    )
+                    # Channel-specific copy + error_code: a widget visitor on a
+                    # third-party page has no "shared link", and analytics need
+                    # to tell which public channel was throttled.
+                    if quota_auth_mode == "widget":
+                        reason_message = (
+                            "This widget has reached its usage limit. "
+                            "Please try again later."
+                        )
+                        quota_error_code = "widget_run_quota_exceeded"
+                    else:
+                        reason_message = (
+                            "This shared link has reached its usage limit. "
+                            "Please try again later."
+                        )
+                        quota_error_code = "share_run_quota_exceeded"
                     return {
                         "success": False,
                         "status": "quota_exceeded",
                         "output": reason_message,
                         "error": reason_message,
-                        "error_code": "share_run_quota_exceeded",
+                        "error_code": quota_error_code,
                         "error_details": None,
                     }
             except Exception as exc:
                 if is_database_pool_timeout(exc):
                     logger.error(
-                        "task_id=%s component=share-quota-gate database pool "
-                        "checkout timed out; terminating before further runtime "
-                        "database work: %s",
+                        "task_id=%s component=public-run-quota-gate database "
+                        "pool checkout timed out; terminating before further "
+                        "runtime database work: %s",
                         tracker_task_id,
                         exc,
                         exc_info=True,
                     )
                     raise
-                logger.warning("Share run quota check failed open", exc_info=True)
+                logger.warning(
+                    "Public run quota check failed open (auth_mode=%s)",
+                    quota_auth_mode,
+                    exc_info=True,
+                )
 
         if manage_task_lease and tracker_task_id:
             from ..services.task_execution_controller import (

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1035,12 +1035,14 @@ def _coerce_optional_entity_id(value: Any) -> int | None:
         return None
 
 
-def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
+def _deny_public_run(quota_config: Mapping[str, Any]) -> str | None:
     """Apply the per-entity run quota for a public (share/widget) task.
 
-    Returns ``True`` when the run is admitted (or cannot be keyed, matching the
+    Returns the channel whose quota refused the run (``"widget"`` / ``"share"``)
+    so the caller can pick the matching message and error code from one value,
+    or ``None`` when the run is admitted (or cannot be keyed, matching the
     original share behaviour of falling through rather than blocking a run it
-    cannot attribute), ``False`` when a rolling quota is exhausted.
+    cannot attribute).
 
     Share tasks carry a server-minted ``guest_id`` and are gated per link +
     per guest (#973). Widget tasks are gated per entity plus the creator IP
@@ -1070,11 +1072,12 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
             _coerce_optional_entity_id(quota_config.get("widget_workforce_id")),
         )
         if entity_key is None:
-            return True
+            return None
         client_ip = quota_config.get("widget_client_ip")
-        return limiter.allow_widget_run(
+        admitted = limiter.allow_widget_run(
             entity_key, client_ip if isinstance(client_ip, str) and client_ip else None
         )
+        return None if admitted else "widget"
 
     if auth_mode == "share":
         guest_id = quota_config.get("guest_id")
@@ -1083,8 +1086,8 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
             _coerce_optional_entity_id(quota_config.get("share_workforce_id")),
         )
         if not share_key or not isinstance(guest_id, str) or not guest_id:
-            return True
-        return limiter.allow_run(share_key, guest_id)
+            return None
+        return None if limiter.allow_run(share_key, guest_id) else "share"
 
     # The loader only returns share/widget configs; admit anything else so a
     # future auth mode fails open here (visibly unmetered) rather than
@@ -1092,7 +1095,7 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
     logger.warning(
         "Public run quota gate saw unexpected auth_mode %r; admitting", auth_mode
     )
-    return True
+    return None
 
 
 def _check_task_run_gate_on_event_loop(
@@ -2982,21 +2985,21 @@ class AgentServiceManager:
         # gated; fails open (availability) like the run gate above, with the
         # same pool-timeout escalation so a stalled pool doesn't cascade.
         if tracker_task_id:
-            quota_auth_mode: str | None = None
+            quota_config: Mapping[str, Any] | None = None
             try:
                 quota_config = await run_db_io_cancellation_safe(
                     lambda: _load_task_public_run_quota_config_isolated(
                         int(tracker_task_id)
                     )
                 )
-                if quota_config is not None:
-                    raw_mode = quota_config.get("auth_mode")
-                    quota_auth_mode = raw_mode if isinstance(raw_mode, str) else None
-                if quota_config is not None and not _admit_public_run(quota_config):
+                denied_channel = (
+                    _deny_public_run(quota_config) if quota_config is not None else None
+                )
+                if denied_channel is not None:
                     # Channel-specific copy + error_code: a widget visitor on a
                     # third-party page has no "shared link", and analytics need
                     # to tell which public channel was throttled.
-                    if quota_auth_mode == "widget":
+                    if denied_channel == "widget":
                         reason_message = (
                             "This widget has reached its usage limit. "
                             "Please try again later."
@@ -3027,9 +3030,14 @@ class AgentServiceManager:
                         exc_info=True,
                     )
                     raise
+                failed_mode = (
+                    quota_config.get("auth_mode")
+                    if isinstance(quota_config, Mapping)
+                    else None
+                )
                 logger.warning(
                     "Public run quota check failed open (auth_mode=%s)",
-                    quota_auth_mode,
+                    failed_mode,
                     exc_info=True,
                 )
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1017,6 +1017,23 @@ def _load_task_public_run_quota_config_isolated(
         return None
 
 
+def _coerce_optional_entity_id(value: Any) -> int | None:
+    """Coerce an agent_config entity marker to ``int``, or ``None`` if it can't.
+
+    A malformed marker (non-numeric, injected junk) must degrade to "unkeyable"
+    — the caller then admits that one task — rather than raising into the
+    chokepoint's broad ``except``, which would log a scary "failed open" and
+    disable the gate outright. ``bool`` is rejected explicitly: ``True`` is an
+    ``int`` subclass that would otherwise coerce to ``1``.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
     """Apply the per-entity run quota for a public (share/widget) task.
 
@@ -1032,6 +1049,11 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
     rolling entity quota and lock every other visitor out. Tasks created
     before the IP marker existed carry ``None`` and are bounded by the entity
     quota alone.
+
+    Entity markers are coerced defensively: the widget-create path stamps them
+    server-side and the sanitizer strips the client copies, but a malformed
+    value must degrade to "unkeyable → admit this task" here rather than take
+    the gate down.
     """
     from ..services.share_rate_limit import (
         entity_rate_limit_key,
@@ -1042,11 +1064,9 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
     limiter = get_share_rate_limiter()
 
     if auth_mode == "widget":
-        widget_agent_id = quota_config.get("widget_agent_id")
-        widget_workforce_id = quota_config.get("widget_workforce_id")
         entity_key = entity_rate_limit_key(
-            int(widget_agent_id) if widget_agent_id is not None else None,
-            int(widget_workforce_id) if widget_workforce_id is not None else None,
+            _coerce_optional_entity_id(quota_config.get("widget_agent_id")),
+            _coerce_optional_entity_id(quota_config.get("widget_workforce_id")),
         )
         if entity_key is None:
             return True
@@ -1057,11 +1077,9 @@ def _admit_public_run(quota_config: Mapping[str, Any]) -> bool:
 
     if auth_mode == "share":
         guest_id = quota_config.get("guest_id")
-        agent_share_id = quota_config.get("share_agent_id")
-        workforce_id = quota_config.get("share_workforce_id")
         share_key = entity_rate_limit_key(
-            int(agent_share_id) if agent_share_id is not None else None,
-            int(workforce_id) if workforce_id is not None else None,
+            _coerce_optional_entity_id(quota_config.get("share_agent_id")),
+            _coerce_optional_entity_id(quota_config.get("share_workforce_id")),
         )
         if not share_key or not isinstance(guest_id, str) or not guest_id:
             return True

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1042,14 +1042,15 @@ def _coerce_optional_entity_id(value: Any) -> int | None:
     return None
 
 
-def _deny_public_run(quota_config: Mapping[str, Any]) -> str | None:
+def _public_run_denial_channel(quota_config: Mapping[str, Any]) -> str | None:
     """Apply the per-entity run quota for a public (share/widget) task.
 
-    Returns the channel whose quota refused the run (``"widget"`` / ``"share"``)
-    so the caller can pick the matching message and error code from one value,
-    or ``None`` when the run is admitted (or cannot be keyed, matching the
-    original share behaviour of falling through rather than blocking a run it
-    cannot attribute).
+    Returns the quota that refused the run — ``"share"``, ``"widget"`` (the
+    owner's budget for that embed), or ``"widget-ip"`` (the per-caller
+    sub-quota within one widget) — so the caller can pick a message the reader
+    can actually act on, or ``None`` when the run is admitted (or cannot be
+    keyed, matching the original share behaviour of falling through rather
+    than blocking a run it cannot attribute).
 
     Share tasks carry a server-minted ``guest_id`` and are gated per link +
     per guest (#973). Widget tasks are gated per entity plus the creator IP
@@ -1082,10 +1083,12 @@ def _deny_public_run(quota_config: Mapping[str, Any]) -> str | None:
         if entity_key is None:
             return None
         client_ip = quota_config.get("widget_client_ip")
-        admitted = limiter.allow_widget_run(
+        reason = limiter.widget_run_denial_reason(
             entity_key, client_ip if isinstance(client_ip, str) and client_ip else None
         )
-        return None if admitted else "widget"
+        if reason is None:
+            return None
+        return "widget-ip" if reason == "ip" else "widget"
 
     if auth_mode == "share":
         guest_id = quota_config.get("guest_id")
@@ -3001,13 +3004,24 @@ class AgentServiceManager:
                     )
                 )
                 denied_channel = (
-                    _deny_public_run(quota_config) if quota_config is not None else None
+                    _public_run_denial_channel(quota_config)
+                    if quota_config is not None
+                    else None
                 )
                 if denied_channel is not None:
                     # Channel-specific copy + error_code: a widget visitor on a
                     # third-party page has no "shared link", and analytics need
-                    # to tell which public channel was throttled.
-                    if denied_channel == "widget":
+                    # to tell which public channel was throttled. The per-caller
+                    # sub-quota gets its own copy because it is the one refusal
+                    # the reader can act on — waiting clears it, whereas an
+                    # exhausted owner budget does not.
+                    if denied_channel == "widget-ip":
+                        reason_message = (
+                            "Too many requests from your network. "
+                            "Please wait a little while and try again."
+                        )
+                        quota_error_code = "widget_run_ip_quota_exceeded"
+                    elif denied_channel == "widget":
                         reason_message = (
                             "This widget has reached its usage limit. "
                             "Please try again later."

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1048,10 +1048,11 @@ def _deny_public_run(quota_config: Mapping[str, Any]) -> str | None:
     per guest (#973). Widget tasks are gated per entity plus the creator IP
     the backend stamped into ``agent_config`` at task creation (#1108) — their
     ``guest_id`` is client-supplied (rotatable at will), so the stamped IP is
-    the per-abuser dimension; without it one caller could drain the whole
-    rolling entity quota and lock every other visitor out. Tasks created
-    before the IP marker existed carry ``None`` and are bounded by the entity
-    quota alone.
+    the per-abuser dimension; without it a single-IP caller could drain the
+    whole rolling entity quota and lock every other visitor out (a multi-IP
+    abuser rotating ~entity/ip addresses still can, same as the share path's
+    per-guest quota). Tasks created before the IP marker existed carry ``None``
+    and are bounded by the entity quota alone.
 
     Entity markers are coerced defensively: the widget-create path stamps them
     server-side and the sanitizer strips the client copies, but a malformed

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -909,7 +909,11 @@ async def create_public_chat_task(
     access_context: PublicChatAccessContext,
     db: Session,
     default_channel_name: str,
-    client_ip: str | None = None,
+    # Required (no default): the server-observed creator IP is the widget run
+    # quota's per-abuser key (#1108), so a caller must consciously pass it —
+    # ``None`` only for a genuinely IP-less path, never by omission. A silent
+    # default would degrade the quota to entity-only without anything failing.
+    client_ip: str | None,
 ) -> TaskCreateResponse:
     if request.runtime_extensions:
         raise HTTPException(

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -851,6 +851,7 @@ async def _create_workforce_widget_chat_task(
     request: TaskCreateRequest,
     access_context: PublicChatAccessContext,
     db: Session,
+    client_ip: str | None,
 ) -> TaskCreateResponse:
     """Guest task creation for a widget-embedded workforce.
 
@@ -884,6 +885,9 @@ async def _create_workforce_widget_chat_task(
             "auth_mode": "widget",
             "widget_workforce_id": int(workforce.id),
             "guest_id": access_context.guest_id,
+            # Server-observed creator IP (#1108): the per-abuser key for the
+            # widget run quota. Stamped by the backend, never client-supplied.
+            "widget_client_ip": client_ip,
         },
     )
     task = result.task
@@ -905,6 +909,7 @@ async def create_public_chat_task(
     access_context: PublicChatAccessContext,
     db: Session,
     default_channel_name: str,
+    client_ip: str | None = None,
 ) -> TaskCreateResponse:
     if request.runtime_extensions:
         raise HTTPException(
@@ -913,7 +918,7 @@ async def create_public_chat_task(
         )
     if access_context.widget_workforce_id is not None:
         return await _create_workforce_widget_chat_task(
-            request=request, access_context=access_context, db=db
+            request=request, access_context=access_context, db=db, client_ip=client_ip
         )
 
     task_description = request.description or ""
@@ -931,6 +936,9 @@ async def create_public_chat_task(
     agent_config = sanitize_client_agent_config(request.agent_config)
     agent_config["guest_id"] = access_context.guest_id
     agent_config["auth_mode"] = "widget"
+    # Server-observed creator IP (#1108): the per-abuser key for the widget
+    # run quota. Stamped by the backend, never client-supplied.
+    agent_config["widget_client_ip"] = client_ip
     if access_context.widget_agent_id is not None:
         agent_config["widget_agent_id"] = access_context.widget_agent_id
 
@@ -1120,12 +1128,14 @@ async def create_share_chat_task(
     )
 
 
-def _widget_entity_key(context: PublicChatAccessContext) -> str | None:
+def widget_entity_key(context: PublicChatAccessContext) -> str | None:
     """Rate-limit key for the widget entity a guest is scoped to (#1056).
 
     Matches the ``allow_widget_upload`` keying: the widget ``guest_id`` is
     client-supplied (rotatable at will), so widget throttles key on the
-    embedded agent/workforce instead.
+    embedded agent/workforce instead. Shared with the widget HTTP endpoints
+    (#1108) so every gate derives the key from the access context the same
+    way.
     """
     return entity_rate_limit_key(context.widget_agent_id, context.widget_workforce_id)
 
@@ -1177,7 +1187,7 @@ async def _authorize_public_chat_websocket(
         lambda: _authorize_chat_websocket_sync(
             load_access_context=load_access_context,
             authorize_task=authorize_task,
-            widget_entity_key=_widget_entity_key,
+            widget_entity_key=widget_entity_key,
         )
     )
 

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -884,6 +884,11 @@ async def _create_workforce_widget_chat_task(
         extra_agent_config={
             "auth_mode": "widget",
             "widget_workforce_id": int(workforce.id),
+            # Null the agent marker for symmetry with the agent path (#1108):
+            # entity_rate_limit_key prefers workforce, so a stray agent id
+            # would be ignored anyway, but stamping both keeps the run-quota
+            # key unambiguous and independent of merge ordering.
+            "widget_agent_id": None,
             "guest_id": access_context.guest_id,
             # Server-observed creator IP (#1108): the per-abuser key for the
             # widget run quota. Stamped by the backend, never client-supplied.

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -939,8 +939,14 @@ async def create_public_chat_task(
     # Server-observed creator IP (#1108): the per-abuser key for the widget
     # run quota. Stamped by the backend, never client-supplied.
     agent_config["widget_client_ip"] = client_ip
-    if access_context.widget_agent_id is not None:
-        agent_config["widget_agent_id"] = access_context.widget_agent_id
+    # Stamp BOTH entity markers from the validated access context, writing the
+    # inapplicable one as None (#1108). The run quota keys off these and
+    # entity_rate_limit_key prefers workforce, so a client-injected
+    # widget_workforce_id must never survive to redirect the bucket. The
+    # sanitizer already strips both, but stamping explicitly keeps this correct
+    # independent of the sanitizer's reserved-key set.
+    agent_config["widget_agent_id"] = access_context.widget_agent_id
+    agent_config["widget_workforce_id"] = access_context.widget_workforce_id
 
     agent_id = request.agent_id
     if agent_id is None and channel and channel.config:

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -591,6 +591,13 @@ async def create_widget_task(
     # owner-billed run). Mirror of the share task-create throttle, but keyed on
     # the widget entity + caller IP, NOT the client-supplied (rotatable) widget
     # guest_id — the same keying as the widget upload / ws-turn gates.
+    #
+    # Unlike /auth, this gate cannot be the first thing that runs: the entity
+    # key comes from the access context, which FastAPI resolves (JWT + DB
+    # lookups) before the handler body. So a throttled caller still pays for
+    # that resolution. Accepted: reaching here at all requires a valid guest
+    # token, and /auth — the surface reachable with no credential — does gate
+    # ahead of every DB touch.
     client_ip = remote_ip_from_request(http_request)
     if not get_share_rate_limiter().allow_widget_task_create(
         widget_entity_key(widget_info), client_ip

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -245,12 +245,14 @@ async def issue_widget_embed_ticket(
         raise HTTPException(status_code=403, detail=WIDGET_KEY_REQUIRED_DETAIL)
     # Abuse control (#1108): ticket minting does DB lookups plus a JWT
     # signature per call, and an ungated mint loop would also let a caller
-    # refresh their auth entity bucket for free. Same buckets as /auth — the
-    # widget key is the stable entity key here — so the two halves of one
-    # page-load handshake draw from one budget. The tight-IP / loose-entity
-    # shape is what keeps this from 429ing ordinary visitors on a busy embed:
-    # widget.js mints a ticket on every page load, and the entity key is shared
-    # by all of a widget's visitors, so the per-visitor bound must be the IP.
+    # refresh their per-IP auth budget for free. Same limiter as /auth: the
+    # per-IP counter IS shared with /auth (one budget across both halves of a
+    # page-load handshake), while the per-entity counter is separate — here it
+    # keys on the widget key, whereas /auth keys on the ticket's owner entity.
+    # The tight-IP / loose-entity shape is what keeps this from 429ing ordinary
+    # visitors on a busy embed: widget.js mints a ticket on every page load and
+    # the entity key is shared by all of a widget's visitors, so the
+    # per-visitor bound must be the IP.
     if not get_share_rate_limiter().allow_widget_auth(
         f"key:{request.widget_key}", remote_ip_from_request(req)
     ):
@@ -419,6 +421,10 @@ def _widget_auth_rate_limit_entity_key(
     bucket is only the loose aggregate backstop, and the tight per-IP bucket
     (which this key does not affect) is the real per-abuser bound. Mirrors
     :func:`_resolve_widget_auth_owner`'s precedence (ticket first).
+
+    A wholly credential-less request returns ``""`` and lets
+    :meth:`ShareRateLimiter._admit_ip_and_entity`'s own falsy-key fallback
+    bucket it (the request 403s right after the gate anyway).
     """
     if embed_ticket:
         try:
@@ -444,9 +450,7 @@ def _widget_auth_rate_limit_entity_key(
         return "invalid-ticket"
     if widget_key:
         return f"key:{widget_key}"
-    # No credential at all: the request 403s right after the gate; bucket the
-    # attempts together so credential-less spam still pays a shared budget.
-    return "missing-credential"
+    return ""
 
 
 @widget_router.post("/auth", response_model=WidgetAuthResponse)

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -28,7 +28,6 @@ from ..models.workforce import Workforce
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.deployments import find_enabled_widget_deployment, get_deployment
 from ..services.share_rate_limit import (
-    entity_rate_limit_key,
     get_share_rate_limiter,
     remote_ip_from_request,
 )
@@ -45,6 +44,7 @@ from .public_chat_access import (
     create_public_chat_task,
     public_chat_websocket_endpoint,
     upload_public_chat_files,
+    widget_entity_key,
 )
 
 widget_router = APIRouter(prefix="/api/widget", tags=["widget"])
@@ -243,6 +243,15 @@ async def issue_widget_embed_ticket(
         # Legacy key-less request (e.g. an old data-agent-id snippet): fail
         # with an actionable error rather than a generic 422.
         raise HTTPException(status_code=403, detail=WIDGET_KEY_REQUIRED_DETAIL)
+    # Abuse control (#1108): ticket minting does DB lookups plus a JWT
+    # signature per call, and an ungated mint loop would also let a caller
+    # refresh their auth credential for free. Same buckets as /auth — the
+    # widget key is the stable credential here — so the two halves of one
+    # page-load handshake draw from one budget.
+    if not get_share_rate_limiter().allow_widget_auth(
+        f"key:{request.widget_key}", remote_ip_from_request(req)
+    ):
+        raise HTTPException(status_code=429, detail="Too many requests")
     owner = _resolve_widget_owner_by_key(db, request.widget_key)
 
     origin = req.headers.get("origin") or req.headers.get("referer", "")
@@ -384,6 +393,56 @@ def _resolve_widget_auth_owner(
     raise HTTPException(status_code=403, detail=WIDGET_CREDENTIAL_REQUIRED_DETAIL)
 
 
+def _widget_auth_rate_limit_credential(
+    embed_ticket: str | None, widget_key: str | None
+) -> str:
+    """Stable rate-limit credential for a widget auth attempt (#1108).
+
+    The per-credential bucket must key on something one caller cannot rotate
+    for free. The raw embed ticket is NOT that: the embedded flow mints a
+    fresh ticket on every page load (no ``jti``, second-resolution ``exp``),
+    so raw-ticket buckets would never accumulate. Instead, decode the ticket's
+    *signed* claims — pure HMAC verification, no DB work — and key on the
+    owner entity they name; forging a different entity requires forging the
+    signature. Expiry is deliberately not checked here: an expired ticket
+    should still land in its stable bucket, and redemption enforces ``exp``.
+
+    Tickets that fail signature/shape checks collapse into one shared
+    ``invalid-ticket`` bucket: they are attacker-only traffic (every legit
+    ticket decodes), so throttling them collectively is a feature. The direct
+    widget-key flow keys on the key string itself, which is already stable;
+    the prefix keeps it from colliding with ticket-derived entity keys.
+    Mirrors :func:`_resolve_widget_auth_owner`'s precedence (ticket first).
+    """
+    if embed_ticket:
+        try:
+            claims = jwt.decode(
+                embed_ticket,
+                JWT_SECRET_KEY,
+                algorithms=[JWT_ALGORITHM],
+                options={"verify_exp": False},
+            )
+        except JWTError:
+            return "invalid-ticket"
+        if claims.get("type") != EMBED_TICKET_TYPE:
+            return "invalid-ticket"
+        owner_type = claims.get("owner_type") or EMBED_TICKET_OWNER_AGENT
+        if owner_type == EMBED_TICKET_OWNER_WORKFORCE:
+            workforce_id = claims.get("workforce_id")
+            if isinstance(workforce_id, int):
+                return f"workforce:{workforce_id}"
+            return "invalid-ticket"
+        agent_id = claims.get("agent_id")
+        if isinstance(agent_id, int):
+            return f"agent:{agent_id}"
+        return "invalid-ticket"
+    if widget_key:
+        return f"key:{widget_key}"
+    # No credential at all: the request 403s right after the gate; bucket the
+    # attempts together so credential-less spam still pays a shared budget.
+    return "missing-credential"
+
+
 @widget_router.post("/auth", response_model=WidgetAuthResponse)
 async def authenticate_widget(
     request: WidgetAuthRequest,
@@ -394,13 +453,12 @@ async def authenticate_widget(
     # Abuse control (#1108): the widget key is public by design, so this
     # unauthenticated endpoint — every call does DB lookups and mints a JWT —
     # is reachable by anyone who can view the hosting page. Bucket per caller
-    # IP + per presented credential before any DB work, mirroring the share
-    # /auth gate. The credential is the raw embed ticket / widget key: the
-    # owning entity is not resolved until below, and the point is to throttle
-    # ahead of that resolution.
+    # IP + per stable credential before any DB work, mirroring the share
+    # /auth gate. Deriving the credential costs one signature check at most;
+    # the DB resolution this gate protects happens below.
     if not get_share_rate_limiter().allow_widget_auth(
+        _widget_auth_rate_limit_credential(request.embed_ticket, request.widget_key),
         remote_ip_from_request(http_request),
-        request.embed_ticket or request.widget_key or "",
     ):
         raise HTTPException(status_code=429, detail="Too many requests")
     owner = _resolve_widget_auth_owner(db, request)
@@ -483,11 +541,8 @@ async def upload_widget_file(
     # widget guest_id is client-supplied, so a guest-keyed bucket is
     # rotatable at will. Matters most for the task-less workforce branch,
     # where each admitted request can mint orphan rows until GC catches up.
-    entity_key = entity_rate_limit_key(
-        widget_info.widget_agent_id, widget_info.widget_workforce_id
-    )
     if not get_share_rate_limiter().allow_widget_upload(
-        entity_key, remote_ip_from_request(request)
+        widget_entity_key(widget_info), remote_ip_from_request(request)
     ):
         raise HTTPException(status_code=429, detail="Too many requests")
     return await upload_public_chat_files(
@@ -514,18 +569,20 @@ async def create_widget_task(
     # owner-billed run). Mirror of the share task-create throttle, but keyed on
     # the widget entity + caller IP, NOT the client-supplied (rotatable) widget
     # guest_id — the same keying as the widget upload / ws-turn gates.
-    entity_key = entity_rate_limit_key(
-        widget_info.widget_agent_id, widget_info.widget_workforce_id
-    )
+    client_ip = remote_ip_from_request(http_request)
     if not get_share_rate_limiter().allow_widget_task_create(
-        entity_key, remote_ip_from_request(http_request)
+        widget_entity_key(widget_info), client_ip
     ):
         raise HTTPException(status_code=429, detail="Too many requests")
+    # client_ip is stamped into agent_config as the per-abuser key for the
+    # widget run quota (#1108): the caller IP is not observable at the async
+    # execute_task chokepoint, so the creating request records it.
     return await create_public_chat_task(
         request=request,
         access_context=widget_info,
         db=db,
         default_channel_name="Web Widget",
+        client_ip=client_ip,
     )
 
 

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -253,8 +253,12 @@ async def issue_widget_embed_ticket(
     # visitors on a busy embed: widget.js mints a ticket on every page load and
     # the entity key is shared by all of a widget's visitors, so the
     # per-visitor bound must be the IP.
+    # Derive the entity key through the same helper /auth uses (widget-key
+    # branch), rather than re-inlining the "key:<...>" scheme; the 403 above
+    # guarantees a non-empty key, so this is identical.
     if not get_share_rate_limiter().allow_widget_auth(
-        f"key:{request.widget_key}", remote_ip_from_request(req)
+        _widget_auth_rate_limit_entity_key(None, request.widget_key),
+        remote_ip_from_request(req),
     ):
         raise HTTPException(status_code=429, detail="Too many requests")
     owner = _resolve_widget_owner_by_key(db, request.widget_key)

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -387,9 +387,22 @@ def _resolve_widget_auth_owner(
 @widget_router.post("/auth", response_model=WidgetAuthResponse)
 async def authenticate_widget(
     request: WidgetAuthRequest,
+    http_request: Request,
     db: Session = Depends(get_db),
 ) -> Any:
     """Authenticate widget and issue a guest token"""
+    # Abuse control (#1108): the widget key is public by design, so this
+    # unauthenticated endpoint — every call does DB lookups and mints a JWT —
+    # is reachable by anyone who can view the hosting page. Bucket per caller
+    # IP + per presented credential before any DB work, mirroring the share
+    # /auth gate. The credential is the raw embed ticket / widget key: the
+    # owning entity is not resolved until below, and the point is to throttle
+    # ahead of that resolution.
+    if not get_share_rate_limiter().allow_widget_auth(
+        remote_ip_from_request(http_request),
+        request.embed_ticket or request.widget_key or "",
+    ):
+        raise HTTPException(status_code=429, detail="Too many requests")
     owner = _resolve_widget_auth_owner(db, request)
 
     if owner.workforce is not None:
@@ -492,10 +505,22 @@ async def upload_widget_file(
 @widget_router.post("/chat/task/create", response_model=TaskCreateResponse)
 async def create_widget_task(
     request: TaskCreateRequest,
+    http_request: Request,
     widget_info: PublicChatAccessContext = Depends(get_current_widget_user_dep),
     db: Session = Depends(get_db),
 ) -> Any:
     """Create new chat task for widget guest."""
+    # Abuse control (#1108): task-create is the costly surface (each spawns an
+    # owner-billed run). Mirror of the share task-create throttle, but keyed on
+    # the widget entity + caller IP, NOT the client-supplied (rotatable) widget
+    # guest_id — the same keying as the widget upload / ws-turn gates.
+    entity_key = entity_rate_limit_key(
+        widget_info.widget_agent_id, widget_info.widget_workforce_id
+    )
+    if not get_share_rate_limiter().allow_widget_task_create(
+        entity_key, remote_ip_from_request(http_request)
+    ):
+        raise HTTPException(status_code=429, detail="Too many requests")
     return await create_public_chat_task(
         request=request,
         access_context=widget_info,

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -425,6 +425,14 @@ def _widget_auth_rate_limit_entity_key(
     A wholly credential-less request returns ``""`` and lets
     :meth:`ShareRateLimiter._admit_ip_and_entity`'s own falsy-key fallback
     bucket it (the request 403s right after the gate anyway).
+
+    NOTE: one widget therefore accumulates its auth backstop into up to two
+    distinct buckets — ``key:<widget_key>`` (direct-visit ``/auth`` and every
+    ``/embed-ticket`` call) and ``agent:<id>``/``workforce:<id>`` (embedded
+    ``/auth`` via ticket) — so the effective aggregate ceiling for one widget
+    is roughly double the single per-entity limit. Resolving both to one key
+    would need a pre-gate DB lookup, which is exactly what this gate runs ahead
+    of. The tight per-IP bound (the real per-abuser control) is unaffected.
     """
     if embed_ticket:
         try:

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -245,9 +245,12 @@ async def issue_widget_embed_ticket(
         raise HTTPException(status_code=403, detail=WIDGET_KEY_REQUIRED_DETAIL)
     # Abuse control (#1108): ticket minting does DB lookups plus a JWT
     # signature per call, and an ungated mint loop would also let a caller
-    # refresh their auth credential for free. Same buckets as /auth — the
-    # widget key is the stable credential here — so the two halves of one
-    # page-load handshake draw from one budget.
+    # refresh their auth entity bucket for free. Same buckets as /auth — the
+    # widget key is the stable entity key here — so the two halves of one
+    # page-load handshake draw from one budget. The tight-IP / loose-entity
+    # shape is what keeps this from 429ing ordinary visitors on a busy embed:
+    # widget.js mints a ticket on every page load, and the entity key is shared
+    # by all of a widget's visitors, so the per-visitor bound must be the IP.
     if not get_share_rate_limiter().allow_widget_auth(
         f"key:{request.widget_key}", remote_ip_from_request(req)
     ):
@@ -393,26 +396,29 @@ def _resolve_widget_auth_owner(
     raise HTTPException(status_code=403, detail=WIDGET_CREDENTIAL_REQUIRED_DETAIL)
 
 
-def _widget_auth_rate_limit_credential(
+def _widget_auth_rate_limit_entity_key(
     embed_ticket: str | None, widget_key: str | None
 ) -> str:
-    """Stable rate-limit credential for a widget auth attempt (#1108).
+    """Stable per-widget key for the auth gate's loose-entity backstop (#1108).
 
-    The per-credential bucket must key on something one caller cannot rotate
-    for free. The raw embed ticket is NOT that: the embedded flow mints a
-    fresh ticket on every page load (no ``jti``, second-resolution ``exp``),
-    so raw-ticket buckets would never accumulate. Instead, decode the ticket's
-    *signed* claims — pure HMAC verification, no DB work — and key on the
-    owner entity they name; forging a different entity requires forging the
+    The entity backstop must key on something one caller cannot rotate for
+    free. The raw embed ticket is NOT that: the embedded flow mints a fresh
+    ticket on every page load (no ``jti``, second-resolution ``exp``), so
+    raw-ticket buckets would never accumulate. Instead, decode the ticket's
+    *signed* claims — pure HMAC verification, no DB work — and key on the owner
+    entity they name; forging a different entity requires forging the
     signature. Expiry is deliberately not checked here: an expired ticket
     should still land in its stable bucket, and redemption enforces ``exp``.
 
     Tickets that fail signature/shape checks collapse into one shared
-    ``invalid-ticket`` bucket: they are attacker-only traffic (every legit
-    ticket decodes), so throttling them collectively is a feature. The direct
-    widget-key flow keys on the key string itself, which is already stable;
-    the prefix keeps it from colliding with ticket-derived entity keys.
-    Mirrors :func:`_resolve_widget_auth_owner`'s precedence (ticket first).
+    ``invalid-ticket`` bucket. The direct widget-key flow keys on the key
+    string itself (already stable; the prefix avoids colliding with
+    ticket-derived entity keys). A bogus/nonexistent key does NOT collapse —
+    that would need a pre-gate DB lookup — so an attacker rotating fake keys
+    gets a fresh *entity* bucket per key; that is acceptable because the entity
+    bucket is only the loose aggregate backstop, and the tight per-IP bucket
+    (which this key does not affect) is the real per-abuser bound. Mirrors
+    :func:`_resolve_widget_auth_owner`'s precedence (ticket first).
     """
     if embed_ticket:
         try:
@@ -453,11 +459,11 @@ async def authenticate_widget(
     # Abuse control (#1108): the widget key is public by design, so this
     # unauthenticated endpoint — every call does DB lookups and mints a JWT —
     # is reachable by anyone who can view the hosting page. Bucket per caller
-    # IP + per stable credential before any DB work, mirroring the share
-    # /auth gate. Deriving the credential costs one signature check at most;
-    # the DB resolution this gate protects happens below.
+    # IP (tight per-visitor bound) + per widget entity (loose aggregate
+    # backstop) before any DB work. Deriving the entity key costs one signature
+    # check at most; the DB resolution this gate protects happens below.
     if not get_share_rate_limiter().allow_widget_auth(
-        _widget_auth_rate_limit_credential(request.embed_ticket, request.widget_key),
+        _widget_auth_rate_limit_entity_key(request.embed_ticket, request.widget_key),
         remote_ip_from_request(http_request),
     ):
         raise HTTPException(status_code=429, detail="Too many requests")

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -103,7 +103,7 @@ _WIDGET_UPLOAD_IP_NAMESPACE = "widget-upload-ip"
 _WIDGET_WS_TURN_ENTITY_NAMESPACE = "widget-ws-turn"
 _WIDGET_WS_TURN_IP_NAMESPACE = "widget-ws-turn-ip"
 _WIDGET_WS_CONNECT_IP_NAMESPACE = "widget-ws-connect-ip"
-_WIDGET_AUTH_CREDENTIAL_NAMESPACE = "widget-auth"
+_WIDGET_AUTH_ENTITY_NAMESPACE = "widget-auth"
 _WIDGET_AUTH_IP_NAMESPACE = "widget-auth-ip"
 _WIDGET_TASK_CREATE_ENTITY_NAMESPACE = "widget-task-create"
 _WIDGET_TASK_CREATE_IP_NAMESPACE = "widget-task-create-ip"
@@ -202,8 +202,8 @@ class ShareRateLimiter:
         self._widget_ws_turn_entity_limit = _parse_rate(
             get_widget_ws_turn_rate_limit(), fallback="240/minute"
         )
-        self._widget_auth_credential_limit = _parse_rate(
-            get_widget_auth_rate_limit(), fallback="60/minute"
+        self._widget_auth_entity_limit = _parse_rate(
+            get_widget_auth_rate_limit(), fallback="600/minute"
         )
         self._widget_auth_ip_limit = _parse_rate(
             get_widget_auth_ip_rate_limit(), fallback="300/minute"
@@ -342,29 +342,33 @@ class ShareRateLimiter:
         )
 
     @_fail_open
-    def allow_widget_auth(self, credential: str, remote_ip: str | None) -> bool:
-        """Count one widget auth attempt; False when a bucket is exceeded (#1108).
+    def allow_widget_auth(self, entity_key: str, remote_ip: str | None) -> bool:
+        """Count one widget auth / embed-ticket attempt; False when exceeded (#1108).
 
-        The widget mirror of :meth:`allow_auth`, in its own buckets so probes
-        against one public channel cannot consume the other's budget. Two
-        buckets must both admit: per caller IP (across all widget keys) and per
-        presented credential. The credential must be a *stable* key derived
-        without DB work — the widget key itself, or the owner entity decoded
-        from the embed ticket's signed claims (pure crypto) — NOT the raw
-        ticket string: the embedded flow mints a fresh ticket on every page
-        load, so a raw-ticket bucket would never accumulate hits from one
-        caller. Per caller IP first (like :meth:`allow_auth`), so credential
-        rotation cannot escape the per-IP ceiling.
+        Uses the tight-IP / loose-entity pairing every other widget gate uses,
+        NOT the share-``auth`` loose-IP / tight-credential shape. The auth and
+        embed-ticket endpoints fire on *every* widget page load, and the entity
+        key is shared by all of one widget's visitors, so a tight per-entity
+        bucket would 429 ordinary visitors on a busy embed. Instead the per-IP
+        bucket is the per-visitor / per-abuser bound (visitors have distinct
+        IPs), and the per-entity bucket is a loose aggregate backstop across
+        all callers of one widget.
+
+        ``entity_key`` must be *stable*, derived without DB work — the widget
+        key, or the owner entity decoded from the embed ticket's signed claims
+        (pure crypto) — NOT the raw ticket, which the embedded flow mints fresh
+        per page load (a raw-ticket bucket would never accumulate). Both buckets
+        are tested non-destructively and only consumed when both admit, so an
+        entity-backstop denial never burns the caller's per-IP allowance for
+        *other* widgets (the :meth:`allow_widget_upload` shape).
         """
-        ip_key = remote_ip or "unknown"
-        if not self._limiter.hit(
-            self._widget_auth_ip_limit, _WIDGET_AUTH_IP_NAMESPACE, ip_key
-        ):
-            return False
-        return self._limiter.hit(
-            self._widget_auth_credential_limit,
-            _WIDGET_AUTH_CREDENTIAL_NAMESPACE,
-            credential or "unknown",
+        return self._admit_ip_and_entity(
+            self._widget_auth_ip_limit,
+            _WIDGET_AUTH_IP_NAMESPACE,
+            remote_ip,
+            self._widget_auth_entity_limit,
+            _WIDGET_AUTH_ENTITY_NAMESPACE,
+            entity_key,
         )
 
     @_fail_open

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -203,7 +203,7 @@ class ShareRateLimiter:
             get_widget_ws_turn_rate_limit(), fallback="240/minute"
         )
         self._widget_auth_entity_limit = _parse_rate(
-            get_widget_auth_rate_limit(), fallback="600/minute"
+            get_widget_auth_rate_limit(), fallback="1200/minute"
         )
         self._widget_auth_ip_limit = _parse_rate(
             get_widget_auth_ip_rate_limit(), fallback="300/minute"

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -43,6 +43,11 @@ from ...config import (
     get_share_upload_rate_limit,
     get_share_ws_connect_ip_rate_limit,
     get_share_ws_turn_rate_limit,
+    get_widget_auth_ip_rate_limit,
+    get_widget_auth_rate_limit,
+    get_widget_run_quota,
+    get_widget_task_create_ip_rate_limit,
+    get_widget_task_create_rate_limit,
     get_widget_upload_ip_rate_limit,
     get_widget_upload_rate_limit,
     get_widget_ws_connect_ip_rate_limit,
@@ -94,8 +99,13 @@ _WIDGET_UPLOAD_IP_NAMESPACE = "widget-upload-ip"
 _WIDGET_WS_TURN_ENTITY_NAMESPACE = "widget-ws-turn"
 _WIDGET_WS_TURN_IP_NAMESPACE = "widget-ws-turn-ip"
 _WIDGET_WS_CONNECT_IP_NAMESPACE = "widget-ws-connect-ip"
+_WIDGET_AUTH_CREDENTIAL_NAMESPACE = "widget-auth"
+_WIDGET_AUTH_IP_NAMESPACE = "widget-auth-ip"
+_WIDGET_TASK_CREATE_ENTITY_NAMESPACE = "widget-task-create"
+_WIDGET_TASK_CREATE_IP_NAMESPACE = "widget-task-create-ip"
 _RUN_SHARE_NAMESPACE = "share-run"
 _RUN_GUEST_NAMESPACE = "share-run-guest"
+_WIDGET_RUN_NAMESPACE = "widget-run"
 
 
 def _parse_rate(value: str, *, fallback: str) -> RateLimitItem:
@@ -187,10 +197,23 @@ class ShareRateLimiter:
         self._widget_ws_turn_entity_limit = _parse_rate(
             get_widget_ws_turn_rate_limit(), fallback="240/minute"
         )
+        self._widget_auth_credential_limit = _parse_rate(
+            get_widget_auth_rate_limit(), fallback="60/minute"
+        )
+        self._widget_auth_ip_limit = _parse_rate(
+            get_widget_auth_ip_rate_limit(), fallback="300/minute"
+        )
+        self._widget_task_create_entity_limit = _parse_rate(
+            get_widget_task_create_rate_limit(), fallback="120/minute"
+        )
+        self._widget_task_create_ip_limit = _parse_rate(
+            get_widget_task_create_ip_rate_limit(), fallback="60/minute"
+        )
         self._run_share_limit = _parse_rate(get_share_run_quota(), fallback="500/day")
         self._run_guest_limit = _parse_rate(
             get_share_run_guest_quota(), fallback="60/hour"
         )
+        self._widget_run_limit = _parse_rate(get_widget_run_quota(), fallback="500/day")
 
     @_fail_open
     def allow_auth(self, share_token: str, remote_ip: str | None) -> bool:
@@ -311,6 +334,30 @@ class ShareRateLimiter:
         )
 
     @_fail_open
+    def allow_widget_auth(self, remote_ip: str | None, credential: str) -> bool:
+        """Count one widget auth attempt; False when a bucket is exceeded (#1108).
+
+        The widget mirror of :meth:`allow_auth`, in its own buckets so probes
+        against one public channel cannot consume the other's budget. Two
+        buckets must both admit: per caller IP (across all widget keys) and per
+        presented credential. The credential is the raw embed ticket / widget
+        key string, not a resolved entity, because this gate runs *before* the
+        DB lookups and JWT mint it is meant to throttle — the entity is not
+        known yet. Per caller IP first (like :meth:`allow_auth`), so credential
+        rotation cannot escape the per-IP ceiling.
+        """
+        ip_key = remote_ip or "unknown"
+        if not self._limiter.hit(
+            self._widget_auth_ip_limit, _WIDGET_AUTH_IP_NAMESPACE, ip_key
+        ):
+            return False
+        return self._limiter.hit(
+            self._widget_auth_credential_limit,
+            _WIDGET_AUTH_CREDENTIAL_NAMESPACE,
+            credential or "unknown",
+        )
+
+    @_fail_open
     def allow_upload(self, guest_id: str) -> bool:
         """Count one share upload for a guest; False when exceeded."""
         return self._limiter.hit(
@@ -333,6 +380,29 @@ class ShareRateLimiter:
             remote_ip,
             self._widget_upload_entity_limit,
             _WIDGET_UPLOAD_ENTITY_NAMESPACE,
+            entity_key,
+        )
+
+    @_fail_open
+    def allow_widget_task_create(
+        self, entity_key: str | None, remote_ip: str | None
+    ) -> bool:
+        """Count one widget task-create; False when a bucket is exceeded (#1108).
+
+        The widget mirror of :meth:`allow_task_create`. Keyed on the widget
+        entity (``agent:<id>`` / ``workforce:<id>``) plus the caller IP — NOT
+        the widget ``guest_id``, which unlike the share path is client-supplied
+        and therefore rotatable at will (the same reasoning as
+        :meth:`allow_widget_upload`). Task-create is the costly surface (each
+        spawns an owner-billed run), so the per-IP bucket is the tight
+        per-abuser gate and the per-entity bucket the loose backstop.
+        """
+        return self._admit_ip_and_entity(
+            self._widget_task_create_ip_limit,
+            _WIDGET_TASK_CREATE_IP_NAMESPACE,
+            remote_ip,
+            self._widget_task_create_entity_limit,
+            _WIDGET_TASK_CREATE_ENTITY_NAMESPACE,
             entity_key,
         )
 
@@ -364,6 +434,24 @@ class ShareRateLimiter:
         self._limiter.hit(self._run_share_limit, _RUN_SHARE_NAMESPACE, share_key)
         self._limiter.hit(self._run_guest_limit, _RUN_GUEST_NAMESPACE, guest_id)
         return True
+
+    @_fail_open
+    def allow_widget_run(self, entity_key: str | None) -> bool:
+        """Count one owner-billed widget run; False when the quota is exceeded.
+
+        The widget mirror of :meth:`allow_run`, in its own bucket so a
+        popular/abused widget cannot drain the owner's whole team quota. Keyed
+        on the widget entity (``agent:<id>`` / ``workforce:<id>``) only: unlike
+        the share path there is no per-guest sub-quota, because the widget
+        ``guest_id`` is client-supplied (rotatable at will) and the caller IP
+        is not available at the async ``execute_task`` chokepoint where this
+        gate runs. Per-abuser bursts are bounded instead by the per-IP widget
+        task-create and websocket-turn gates. Rolling, not cumulative, so a
+        busy-but-legitimate widget self-clears rather than being bricked.
+        """
+        return self._limiter.hit(
+            self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key or "unknown"
+        )
 
 
 _lock = threading.Lock()

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -154,6 +154,35 @@ def _fail_open(method: _F) -> _F:
     return wrapper  # type: ignore[return-value]
 
 
+_D = TypeVar("_D", bound=Callable[..., "str | None"])
+
+
+def _fail_open_denial(method: _D) -> _D:
+    """:func:`_fail_open` for gates that return a denial reason, not a bool.
+
+    Same contract — a raising storage backend must admit rather than 500 a
+    public surface — expressed as ``None`` ("no bucket refused") instead of
+    ``True``.
+    """
+
+    @functools.wraps(method)
+    def wrapper(
+        self: "ShareRateLimiter", *args: object, **kwargs: object
+    ) -> str | None:
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as exc:
+            logger.warning(
+                "Share rate limiter (%s) failed open: %s",
+                method.__name__,
+                exc,
+                exc_info=True,
+            )
+            return None
+
+    return wrapper  # type: ignore[return-value]
+
+
 class ShareRateLimiter:
     """Moving-window limiter over Redis or in-process memory for share channels."""
 
@@ -240,7 +269,7 @@ class ShareRateLimiter:
         )
         self._widget_run_limit = _parse_rate(get_widget_run_quota(), fallback="500/day")
         self._widget_run_ip_limit = _parse_rate(
-            get_widget_run_ip_quota(), fallback="60/hour"
+            get_widget_run_ip_quota(), fallback="120/hour"
         )
 
     @_fail_open
@@ -295,6 +324,31 @@ class ShareRateLimiter:
         return self._limiter.hit(
             self._ws_connect_ip_limit, _WS_CONNECT_IP_NAMESPACE, remote_ip or "unknown"
         )
+
+    def _denial_from_ip_and_entity(
+        self,
+        ip_limit: RateLimitItem,
+        ip_namespace: str,
+        ip_key: str,
+        entity_limit: RateLimitItem,
+        entity_namespace: str,
+        entity_key: str,
+    ) -> str | None:
+        """Paired-bucket admission reporting *which* bucket refused.
+
+        ``None`` admits; ``"ip"`` / ``"entity"`` name the bucket that refused,
+        so a caller can tell a per-caller throttle (the visitor should retry)
+        apart from an owner-budget exhaustion (the visitor cannot act on it).
+        Keys arrive pre-normalized. See :meth:`_admit_ip_and_entity` for the
+        non-destructive test→hit contract this implements.
+        """
+        if not self._limiter.test(ip_limit, ip_namespace, ip_key):
+            return "ip"
+        if not self._limiter.test(entity_limit, entity_namespace, entity_key):
+            return "entity"
+        self._limiter.hit(ip_limit, ip_namespace, ip_key)
+        self._limiter.hit(entity_limit, entity_namespace, entity_key)
+        return None
 
     def _admit_ip_and_entity(
         self,
@@ -469,38 +523,54 @@ class ShareRateLimiter:
         self._limiter.hit(self._run_guest_limit, _RUN_GUEST_NAMESPACE, guest_id)
         return True
 
-    @_fail_open
-    def allow_widget_run(self, entity_key: str, client_ip: str | None) -> bool:
-        """Count one owner-billed widget run; False when a quota is exceeded.
+    @_fail_open_denial
+    def widget_run_denial_reason(
+        self, entity_key: str, client_ip: str | None
+    ) -> str | None:
+        """Count one owner-billed widget run; name the bucket that refused it.
+
+        Returns ``None`` when admitted, ``"ip"`` when the per-caller sub-quota
+        refused (the visitor can retry later), or ``"entity"`` when the
+        widget's own budget is exhausted (only the owner can act) — the caller
+        needs the distinction to show copy the reader can act on.
 
         The widget mirror of :meth:`allow_run`, in its own buckets so a
         popular/abused widget cannot drain the owner's whole team quota. Keyed
         on the widget entity (``agent:<id>`` / ``workforce:<id>``) plus the IP
         the server observed when the task was created (stamped into
         ``agent_config``; never client-supplied) — NOT the widget ``guest_id``,
-        which is client-supplied and rotatable at will. The IP sub-quota is the
-        per-abuser dimension: without it, one caller could drain the whole
-        rolling entity quota (e.g. 60 turns/min against 500/day ≈ nine
-        minutes) and lock every other visitor out for a day. Both buckets use
-        the non-destructive test→hit pairing, so an IP-window denial never
-        burns an entity slot.
+        which is client-supplied and rotatable at will.
 
-        The sole caller (the ``chat.py`` chokepoint) short-circuits before
-        calling when it cannot form an ``entity_key``, so this takes a
-        non-empty ``str`` — no ``"unknown"`` fallback. ``client_ip`` is
-        ``None`` for tasks created before the marker existed; those are bounded
-        by the entity quota alone rather than collapsing every legacy task into
-        one shared IP bucket. Rolling, not cumulative, so a busy-but-legitimate
-        widget self-clears rather than being bricked.
+        The IP sub-quota is scoped ``entity|ip``, NOT bare IP: this gate is
+        charged per *turn*, so a bare-IP bucket would make one NAT/CGNAT egress
+        share a single budget across every widget on the instance, and one busy
+        embed would lock that whole network out of unrelated widgets. Scoping
+        to the widget keeps the per-abuser bound while confining its blast
+        radius to the entity whose budget it protects. Its window is
+        deliberately far tighter than the per-minute burst gates (widget WS
+        turn / task-create, both 60/minute per IP): those bound *rate*, this
+        bounds one caller's share of a rolling owner-billed *budget*, so it is
+        sized as a fraction of the entity quota rather than to match them.
+
+        Both buckets use the non-destructive test→hit pairing, so an IP-window
+        denial never burns an entity slot. The sole caller (the ``chat.py``
+        chokepoint) short-circuits before calling when it cannot form an
+        ``entity_key``, so this takes a non-empty ``str`` — no ``"unknown"``
+        fallback. ``client_ip`` is ``None`` for tasks created before the marker
+        existed; those are bounded by the entity quota alone rather than
+        collapsing every legacy task into one shared IP bucket. Rolling, not
+        cumulative, so a busy-but-legitimate widget self-clears rather than
+        being bricked.
         """
         if client_ip is None:
-            return self._limiter.hit(
+            admitted = self._limiter.hit(
                 self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key
             )
-        return self._admit_ip_and_entity(
+            return None if admitted else "entity"
+        return self._denial_from_ip_and_entity(
             self._widget_run_ip_limit,
             _WIDGET_RUN_IP_NAMESPACE,
-            client_ip,
+            f"{entity_key}|{client_ip}",
             self._widget_run_limit,
             _WIDGET_RUN_NAMESPACE,
             entity_key,

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -45,6 +45,7 @@ from ...config import (
     get_share_ws_turn_rate_limit,
     get_widget_auth_ip_rate_limit,
     get_widget_auth_rate_limit,
+    get_widget_run_ip_quota,
     get_widget_run_quota,
     get_widget_task_create_ip_rate_limit,
     get_widget_task_create_rate_limit,
@@ -77,8 +78,11 @@ def entity_rate_limit_key(agent_id: int | None, workforce_id: int | None) -> str
     / ``"workforce:<id>"``), shared by the widget upload/turn gates and the
     share run quota so the shape can never drift between call sites.
     Workforce wins when both ids are set (callers guarantee at most one is).
-    Returns ``None`` when neither id is set; the ``allow_*`` gates degrade
-    that to their shared ``"unknown"`` bucket rather than admitting freely.
+    Returns ``None`` when neither id is set; the request-throttle ``allow_*``
+    gates degrade that to their shared ``"unknown"`` bucket rather than
+    admitting freely, while the run-quota chokepoint (chat.py) instead admits
+    a task it cannot attribute — matching the original share-gate behaviour of
+    never blocking a run on a missing marker.
     """
     if workforce_id is not None:
         return f"workforce:{workforce_id}"
@@ -106,6 +110,7 @@ _WIDGET_TASK_CREATE_IP_NAMESPACE = "widget-task-create-ip"
 _RUN_SHARE_NAMESPACE = "share-run"
 _RUN_GUEST_NAMESPACE = "share-run-guest"
 _WIDGET_RUN_NAMESPACE = "widget-run"
+_WIDGET_RUN_IP_NAMESPACE = "widget-run-ip"
 
 
 def _parse_rate(value: str, *, fallback: str) -> RateLimitItem:
@@ -214,6 +219,9 @@ class ShareRateLimiter:
             get_share_run_guest_quota(), fallback="60/hour"
         )
         self._widget_run_limit = _parse_rate(get_widget_run_quota(), fallback="500/day")
+        self._widget_run_ip_limit = _parse_rate(
+            get_widget_run_ip_quota(), fallback="60/hour"
+        )
 
     @_fail_open
     def allow_auth(self, share_token: str, remote_ip: str | None) -> bool:
@@ -334,16 +342,18 @@ class ShareRateLimiter:
         )
 
     @_fail_open
-    def allow_widget_auth(self, remote_ip: str | None, credential: str) -> bool:
+    def allow_widget_auth(self, credential: str, remote_ip: str | None) -> bool:
         """Count one widget auth attempt; False when a bucket is exceeded (#1108).
 
         The widget mirror of :meth:`allow_auth`, in its own buckets so probes
         against one public channel cannot consume the other's budget. Two
         buckets must both admit: per caller IP (across all widget keys) and per
-        presented credential. The credential is the raw embed ticket / widget
-        key string, not a resolved entity, because this gate runs *before* the
-        DB lookups and JWT mint it is meant to throttle — the entity is not
-        known yet. Per caller IP first (like :meth:`allow_auth`), so credential
+        presented credential. The credential must be a *stable* key derived
+        without DB work — the widget key itself, or the owner entity decoded
+        from the embed ticket's signed claims (pure crypto) — NOT the raw
+        ticket string: the embedded flow mints a fresh ticket on every page
+        load, so a raw-ticket bucket would never accumulate hits from one
+        caller. Per caller IP first (like :meth:`allow_auth`), so credential
         rotation cannot escape the per-IP ceiling.
         """
         ip_key = remote_ip or "unknown"
@@ -436,21 +446,41 @@ class ShareRateLimiter:
         return True
 
     @_fail_open
-    def allow_widget_run(self, entity_key: str | None) -> bool:
-        """Count one owner-billed widget run; False when the quota is exceeded.
+    def allow_widget_run(self, entity_key: str | None, client_ip: str | None) -> bool:
+        """Count one owner-billed widget run; False when a quota is exceeded.
 
-        The widget mirror of :meth:`allow_run`, in its own bucket so a
+        The widget mirror of :meth:`allow_run`, in its own buckets so a
         popular/abused widget cannot drain the owner's whole team quota. Keyed
-        on the widget entity (``agent:<id>`` / ``workforce:<id>``) only: unlike
-        the share path there is no per-guest sub-quota, because the widget
-        ``guest_id`` is client-supplied (rotatable at will) and the caller IP
-        is not available at the async ``execute_task`` chokepoint where this
-        gate runs. Per-abuser bursts are bounded instead by the per-IP widget
-        task-create and websocket-turn gates. Rolling, not cumulative, so a
-        busy-but-legitimate widget self-clears rather than being bricked.
+        on the widget entity (``agent:<id>`` / ``workforce:<id>``) plus the IP
+        the server observed when the task was created (stamped into
+        ``agent_config``; never client-supplied) — NOT the widget ``guest_id``,
+        which is client-supplied and rotatable at will. The IP sub-quota is the
+        per-abuser dimension: without it, one caller could drain the whole
+        rolling entity quota (e.g. 60 turns/min against 500/day ≈ nine
+        minutes) and lock every other visitor out for a day. Both buckets use
+        the non-destructive test→hit pairing, so an IP-window denial never
+        burns an entity slot.
+
+        ``client_ip`` is ``None`` for tasks created before the marker existed;
+        those are bounded by the entity quota alone rather than collapsing
+        every legacy task into one shared IP bucket. Rolling, not cumulative,
+        so a busy-but-legitimate widget self-clears rather than being bricked.
         """
-        return self._limiter.hit(
-            self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key or "unknown"
+        # entity_key is None only if a caller bypasses the chokepoint's
+        # short-circuit (chat.py admits unkeyable widget tasks before calling
+        # this); the "unknown" degradation is defense-in-depth for any future
+        # direct caller, not a path production reaches today.
+        if client_ip is None:
+            return self._limiter.hit(
+                self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key or "unknown"
+            )
+        return self._admit_ip_and_entity(
+            self._widget_run_ip_limit,
+            _WIDGET_RUN_IP_NAMESPACE,
+            client_ip,
+            self._widget_run_limit,
+            _WIDGET_RUN_NAMESPACE,
+            entity_key,
         )
 
 

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -160,8 +160,28 @@ class ShareRateLimiter:
     def __init__(self) -> None:
         redis_url = get_redis_url()
         if redis_url:
-            self.storage = storage_from_string(redis_url)
-            self.backend = "redis"
+            # Degrade to in-process memory if the Redis URL is unusable
+            # (invalid scheme, unreachable at build time) rather than letting
+            # storage_from_string raise: this constructor runs lazily on the
+            # first request to a public endpoint, outside the per-call
+            # @_fail_open boundary, so an exception here would 500 the auth /
+            # task-create / embed-ticket surfaces instead of failing open. A
+            # process-local limiter still throttles (per-worker, not shared),
+            # which is strictly better than no gate. Mirrors the hot-path
+            # cache's degrade-to-memory fallback.
+            try:
+                self.storage = storage_from_string(redis_url)
+                self.backend = "redis"
+            except Exception as exc:
+                logger.warning(
+                    "Share rate limiter: Redis storage %r unusable (%s); "
+                    "falling back to in-process memory",
+                    redis_url,
+                    exc,
+                    exc_info=True,
+                )
+                self.storage = MemoryStorage()
+                self.backend = "memory"
         else:
             self.storage = MemoryStorage()
             self.backend = "memory"
@@ -209,7 +229,7 @@ class ShareRateLimiter:
             get_widget_auth_ip_rate_limit(), fallback="300/minute"
         )
         self._widget_task_create_entity_limit = _parse_rate(
-            get_widget_task_create_rate_limit(), fallback="120/minute"
+            get_widget_task_create_rate_limit(), fallback="240/minute"
         )
         self._widget_task_create_ip_limit = _parse_rate(
             get_widget_task_create_ip_rate_limit(), fallback="60/minute"

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -450,7 +450,7 @@ class ShareRateLimiter:
         return True
 
     @_fail_open
-    def allow_widget_run(self, entity_key: str | None, client_ip: str | None) -> bool:
+    def allow_widget_run(self, entity_key: str, client_ip: str | None) -> bool:
         """Count one owner-billed widget run; False when a quota is exceeded.
 
         The widget mirror of :meth:`allow_run`, in its own buckets so a
@@ -465,18 +465,17 @@ class ShareRateLimiter:
         the non-destructive test→hit pairing, so an IP-window denial never
         burns an entity slot.
 
-        ``client_ip`` is ``None`` for tasks created before the marker existed;
-        those are bounded by the entity quota alone rather than collapsing
-        every legacy task into one shared IP bucket. Rolling, not cumulative,
-        so a busy-but-legitimate widget self-clears rather than being bricked.
+        The sole caller (the ``chat.py`` chokepoint) short-circuits before
+        calling when it cannot form an ``entity_key``, so this takes a
+        non-empty ``str`` — no ``"unknown"`` fallback. ``client_ip`` is
+        ``None`` for tasks created before the marker existed; those are bounded
+        by the entity quota alone rather than collapsing every legacy task into
+        one shared IP bucket. Rolling, not cumulative, so a busy-but-legitimate
+        widget self-clears rather than being bricked.
         """
-        # entity_key is None only if a caller bypasses the chokepoint's
-        # short-circuit (chat.py admits unkeyable widget tasks before calling
-        # this); the "unknown" degradation is defense-in-depth for any future
-        # direct caller, not a path production reaches today.
         if client_ip is None:
             return self._limiter.hit(
-                self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key or "unknown"
+                self._widget_run_limit, _WIDGET_RUN_NAMESPACE, entity_key
             )
         return self._admit_ip_and_entity(
             self._widget_run_ip_limit,

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -62,12 +62,27 @@ TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY = "runtime_extension_bindings"
 # wholesale, so anything the server later reads back as authoritative has to be
 # stripped from that copy first -- otherwise a client can pre-seed it.
 #
-# Only the binding record is listed today. Other reserved keys on this column
-# (``execution_scope``, ``a2a_context_id``, ``auth_mode``, ``guest_id``) are
-# pass-through by long-standing behavior and are tracked separately; add them
-# here once that change is in scope and every boundary picks it up at once.
+# The public-channel identity/quota markers are stripped here because the run
+# quota (#1108) now reads them back as authoritative at the ``execute_task``
+# chokepoint: an anonymous widget/share guest must not be able to inject an
+# ``auth_mode`` or an entity id (which selects the run-quota bucket) into their
+# own task-create body. Every seeding boundary re-stamps the markers it owns
+# *after* calling this helper, so stripping can never drop a server value. The
+# widget-create path additionally writes both entity markers explicitly (one as
+# ``None``) as belt-and-suspenders. ``execution_scope`` / ``a2a_context_id``
+# remain pass-through by long-standing behavior and are tracked separately.
 CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
-    {TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY}
+    {
+        TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
+        "auth_mode",
+        "guest_id",
+        "widget_agent_id",
+        "widget_workforce_id",
+        "widget_client_ip",
+        "share_agent_id",
+        "share_workforce_id",
+        "share_token",
+    }
 )
 logger = logging.getLogger(__name__)
 

--- a/src/xagent/web/services/trigger_rate_limit.py
+++ b/src/xagent/web/services/trigger_rate_limit.py
@@ -12,6 +12,7 @@ window) via should_audit_rate_limited.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 import threading
@@ -205,4 +206,18 @@ def remote_ip_from_request(request: object) -> str | None:
     # The rightmost entry was appended by the nearest trusted proxy; walking
     # `hops` entries from the right lands on the last untrusted client.
     index = max(0, len(entries) - hops)
-    return entries[index]
+    candidate = entries[index]
+    # Only return an actually IP-shaped value. The selected entry is
+    # client-controlled whenever `hops` over-counts the real proxy chain, and
+    # callers use this as rate-limit key material and persist it (#1108's
+    # `widget_client_ip`), so an unvalidated header could inject an unbounded
+    # arbitrary string. Fall back to the peer address rather than trusting it.
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-IP X-Forwarded-For entry %r; using peer address",
+            candidate[:64],
+        )
+        return peer_ip
+    return candidate

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1742,7 +1742,7 @@ class TestShareRateLimitConfig:
         (
             "get_widget_auth_rate_limit",
             "XAGENT_WIDGET_AUTH_RATE_LIMIT",
-            "600/minute",
+            "1200/minute",
         ),
         (
             "get_widget_auth_ip_rate_limit",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1739,6 +1739,27 @@ class TestShareRateLimitConfig:
             "XAGENT_WIDGET_WS_TURN_RATE_LIMIT",
             "240/minute",
         ),
+        (
+            "get_widget_auth_rate_limit",
+            "XAGENT_WIDGET_AUTH_RATE_LIMIT",
+            "60/minute",
+        ),
+        (
+            "get_widget_auth_ip_rate_limit",
+            "XAGENT_WIDGET_AUTH_IP_RATE_LIMIT",
+            "300/minute",
+        ),
+        (
+            "get_widget_task_create_rate_limit",
+            "XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT",
+            "120/minute",
+        ),
+        (
+            "get_widget_task_create_ip_rate_limit",
+            "XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT",
+            "60/minute",
+        ),
+        ("get_widget_run_quota", "XAGENT_WIDGET_RUN_QUOTA", "500/day"),
     ]
 
     @pytest.mark.parametrize("func_name,env_var,default", _CASES)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1760,7 +1760,7 @@ class TestShareRateLimitConfig:
             "60/minute",
         ),
         ("get_widget_run_quota", "XAGENT_WIDGET_RUN_QUOTA", "500/day"),
-        ("get_widget_run_ip_quota", "XAGENT_WIDGET_RUN_IP_QUOTA", "60/hour"),
+        ("get_widget_run_ip_quota", "XAGENT_WIDGET_RUN_IP_QUOTA", "120/hour"),
     ]
 
     @pytest.mark.parametrize("func_name,env_var,default", _CASES)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1742,7 +1742,7 @@ class TestShareRateLimitConfig:
         (
             "get_widget_auth_rate_limit",
             "XAGENT_WIDGET_AUTH_RATE_LIMIT",
-            "60/minute",
+            "600/minute",
         ),
         (
             "get_widget_auth_ip_rate_limit",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1760,6 +1760,7 @@ class TestShareRateLimitConfig:
             "60/minute",
         ),
         ("get_widget_run_quota", "XAGENT_WIDGET_RUN_QUOTA", "500/day"),
+        ("get_widget_run_ip_quota", "XAGENT_WIDGET_RUN_IP_QUOTA", "60/hour"),
     ]
 
     @pytest.mark.parametrize("func_name,env_var,default", _CASES)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1752,7 +1752,7 @@ class TestShareRateLimitConfig:
         (
             "get_widget_task_create_rate_limit",
             "XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT",
-            "120/minute",
+            "240/minute",
         ),
         (
             "get_widget_task_create_ip_rate_limit",

--- a/tests/web/api/test_public_runtime_extensions.py
+++ b/tests/web/api/test_public_runtime_extensions.py
@@ -31,6 +31,7 @@ async def test_public_widget_rejects_task_runtime_extensions() -> None:
             access_context=context,
             db=object(),  # type: ignore[arg-type]
             default_channel_name="Public",
+            client_ip=None,
         )
 
     assert exc_info.value.status_code == 400

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -165,6 +165,83 @@ def test_share_upload_returns_429_over_limit(
     assert _upload().status_code == 429
 
 
+def _widget_agent_key(name: str) -> str:
+    """Create a published agent, enable its widget, and return the widget key."""
+    db = _direct_db_session()
+    try:
+        agent = Agent(
+            user_id=_user_id(),
+            name=name,
+            description="d",
+            instructions="i",
+            execution_mode="balanced",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        agent_id = int(agent.id)
+    finally:
+        db.close()
+    resp = client.put(
+        f"/api/agents/{agent_id}",
+        headers=_admin_headers(),
+        json={"widget_enabled": True, "allowed_domains": ["*"]},
+    )
+    assert resp.status_code == 200, resp.text
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        assert agent.widget_key
+        return str(agent.widget_key)
+    finally:
+        db.close()
+
+
+def _widget_guest_headers(widget_key: str) -> dict[str, str]:
+    resp = client.post(
+        "/api/widget/auth",
+        json={"guest_id": "rl-widget-guest", "widget_key": widget_key},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def test_widget_auth_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _widget_agent_key("RL Widget Auth Agent")
+
+    # Tighten the per-credential bucket only after the key exists; the IP
+    # ceiling (300/min default) stays clear so this proves the credential gate.
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    body = {"guest_id": "g", "widget_key": key}
+    first = client.post("/api/widget/auth", json=body)
+    assert first.status_code == 200, first.text
+    second = client.post("/api/widget/auth", json=body)
+    assert second.status_code == 429, second.text
+
+
+def test_widget_task_create_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _widget_agent_key("RL Widget Create Agent")
+    guest = _widget_guest_headers(key)
+
+    # Tighten the per-caller-IP bucket (the tight abuser gate) after the guest
+    # token is minted, since auth has its own separate bucket.
+    monkeypatch.setenv("XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    body = {"title": "hi", "description": "hi"}
+    first = client.post("/api/widget/chat/task/create", headers=guest, json=body)
+    assert first.status_code == 200, first.text
+    second = client.post("/api/widget/chat/task/create", headers=guest, json=body)
+    assert second.status_code == 429, second.text
+
+
 class _FakeWebSocket:
     """Minimal websocket double: yields queued frames, then disconnects."""
 

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -252,6 +252,28 @@ def test_widget_task_create_returns_429_over_limit(
         db.close()
 
 
+def test_widget_task_create_ignores_spoofed_forwarded_for() -> None:
+    """#1108 F3: the stamped creator IP is a durable quota key, so a client
+    must not be able to choose it. Under the default XAGENT_TRUSTED_PROXY_HOPS=0
+    the header is ignored entirely and the peer address is stamped."""
+    key = _widget_agent_key("RL Widget XFF Agent")
+    guest = _widget_guest_headers(key)
+
+    resp = client.post(
+        "/api/widget/chat/task/create",
+        headers={**guest, "X-Forwarded-For": "9.9.9.9"},
+        json={"title": "hi", "description": "hi"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == int(resp.json()["task_id"])).one()
+        assert task.agent_config.get("widget_client_ip") == "testclient"
+    finally:
+        db.close()
+
+
 def test_widget_task_create_ignores_client_injected_entity_markers() -> None:
     """#1108 F1: a widget guest must not be able to inject entity/identity
     markers into their own task-create body — they select the run-quota bucket

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -213,8 +213,8 @@ def test_widget_auth_returns_429_over_limit(
 ) -> None:
     key = _widget_agent_key("RL Widget Auth Agent")
 
-    # Tighten the per-credential bucket only after the key exists; the IP
-    # ceiling (300/min default) stays clear so this proves the credential gate.
+    # Tighten the loose per-entity backstop only after the key exists; the IP
+    # bound (300/min default) stays clear so this proves the entity gate.
     monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
     reset_share_rate_limiter()
 
@@ -252,13 +252,58 @@ def test_widget_task_create_returns_429_over_limit(
         db.close()
 
 
+def test_widget_task_create_ignores_client_injected_entity_markers() -> None:
+    """#1108 F1: a widget guest must not be able to inject entity/identity
+    markers into their own task-create body — they select the run-quota bucket
+    (entity_rate_limit_key prefers workforce), so a client-controlled value
+    would fully bypass or misdirect the quota. The server stamps them."""
+    key = _widget_agent_key("RL Widget Inject Agent")
+    guest = _widget_guest_headers(key)
+
+    forged = {
+        "title": "hi",
+        "description": "hi",
+        "agent_config": {
+            # A forged workforce id would win over the real agent entity.
+            "widget_workforce_id": 999999,
+            "widget_agent_id": 888888,
+            "widget_client_ip": "1.2.3.4",
+            "auth_mode": "share",
+            "guest_id": "injected-guest",
+            "share_agent_id": 777777,
+            "share_token": "forged",
+        },
+    }
+    resp = client.post("/api/widget/chat/task/create", headers=guest, json=forged)
+    assert resp.status_code == 200, resp.text
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == int(resp.json()["task_id"])).one()
+        cfg = task.agent_config
+        # Entity markers: server-stamped, workforce cleared to None on the agent
+        # path, agent id is the real one — never the injected values.
+        assert cfg.get("widget_workforce_id") is None
+        assert cfg.get("widget_agent_id") != 888888
+        assert cfg.get("widget_agent_id") is not None
+        # Identity/quota markers: server values win, injected copies stripped.
+        assert cfg.get("auth_mode") == "widget"
+        assert cfg.get("guest_id") == "rl-widget-guest"
+        assert cfg.get("widget_client_ip") == "testclient"
+        assert "share_agent_id" not in cfg
+        assert "share_token" not in cfg
+    finally:
+        db.close()
+
+
 def test_widget_auth_rate_limits_invalid_credentials_before_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The auth gate must run BEFORE credential resolution: repeated attempts
     with an *invalid* key get 429 once the bucket trips, not an endless
-    sequence of DB-backed 403s."""
-    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    sequence of DB-backed 403s. Tightened on the per-IP bound since one client
+    (one IP) is the abuser here."""
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_IP_RATE_LIMIT", "1/minute")
     reset_share_rate_limiter()
 
     body = {"guest_id": "g", "widget_key": "no-such-widget-key"}
@@ -268,12 +313,12 @@ def test_widget_auth_rate_limits_invalid_credentials_before_resolution(
     assert second.status_code == 429, second.text
 
 
-def test_widget_auth_ticket_rotation_shares_one_credential_bucket(
+def test_widget_auth_ticket_rotation_shares_one_entity_bucket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The per-credential bucket keys on the ticket's signed owner claims, not
-    the raw ticket string: the embedded flow mints a fresh ticket per page
-    load, so rotating tickets for one agent must land in one bucket."""
+    """The per-entity backstop keys on the ticket's signed owner claims, not the
+    raw ticket string: the embedded flow mints a fresh ticket per page load, so
+    rotating tickets for one agent must land in one bucket."""
     key = _widget_agent_key("RL Widget Ticket Agent")
 
     def _mint_ticket() -> str:
@@ -286,11 +331,13 @@ def test_widget_auth_ticket_rotation_shares_one_credential_bucket(
         return str(resp.json()["ticket"])
 
     # Mint both tickets before tightening: /embed-ticket shares the auth
-    # buckets (its credential is the widget key, distinct from the ticket's
-    # agent entity, but the per-IP ceiling is common).
+    # buckets (its entity key is the widget key, distinct from the ticket's
+    # agent entity, but they share the bucket family).
     ticket_a = _mint_ticket()
     ticket_b = _mint_ticket()
 
+    # Tighten the loose per-entity backstop; the ticket flow keys it on the
+    # agent entity, so two distinct tickets for one agent collide there.
     monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
     reset_share_rate_limiter()
 
@@ -309,10 +356,11 @@ def test_widget_embed_ticket_returns_429_over_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ticket minting is gated too (#1108): an ungated mint loop would do free
-    DB work + JWT signatures and refresh the caller's auth credential."""
+    DB work + JWT signatures and refresh the caller's auth budget. One IP mints
+    repeatedly, so the per-IP bound is what trips."""
     key = _widget_agent_key("RL Widget Ticket Mint Agent")
 
-    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_IP_RATE_LIMIT", "1/minute")
     reset_share_rate_limiter()
 
     def _mint():

--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.task import Task
 from xagent.web.models.user import User
 from xagent.web.services.share_rate_limit import reset_share_rate_limiter
 
@@ -240,6 +241,89 @@ def test_widget_task_create_returns_429_over_limit(
     assert first.status_code == 200, first.text
     second = client.post("/api/widget/chat/task/create", headers=guest, json=body)
     assert second.status_code == 429, second.text
+
+    # The admitted task carries the server-observed creator IP (#1108): the
+    # per-abuser key the run-quota gate reads back at the async chokepoint.
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == int(first.json()["task_id"])).one()
+        assert task.agent_config.get("widget_client_ip") == "testclient"
+    finally:
+        db.close()
+
+
+def test_widget_auth_rate_limits_invalid_credentials_before_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The auth gate must run BEFORE credential resolution: repeated attempts
+    with an *invalid* key get 429 once the bucket trips, not an endless
+    sequence of DB-backed 403s."""
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    body = {"guest_id": "g", "widget_key": "no-such-widget-key"}
+    first = client.post("/api/widget/auth", json=body)
+    assert first.status_code == 403, first.text
+    second = client.post("/api/widget/auth", json=body)
+    assert second.status_code == 429, second.text
+
+
+def test_widget_auth_ticket_rotation_shares_one_credential_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-credential bucket keys on the ticket's signed owner claims, not
+    the raw ticket string: the embedded flow mints a fresh ticket per page
+    load, so rotating tickets for one agent must land in one bucket."""
+    key = _widget_agent_key("RL Widget Ticket Agent")
+
+    def _mint_ticket() -> str:
+        resp = client.post(
+            "/api/widget/embed-ticket",
+            json={"widget_key": key},
+            headers={"origin": "https://any-site.example"},
+        )
+        assert resp.status_code == 200, resp.text
+        return str(resp.json()["ticket"])
+
+    # Mint both tickets before tightening: /embed-ticket shares the auth
+    # buckets (its credential is the widget key, distinct from the ticket's
+    # agent entity, but the per-IP ceiling is common).
+    ticket_a = _mint_ticket()
+    ticket_b = _mint_ticket()
+
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    first = client.post(
+        "/api/widget/auth", json={"guest_id": "g", "embed_ticket": ticket_a}
+    )
+    assert first.status_code == 200, first.text
+    # A *different* ticket for the same agent must hit the same bucket.
+    second = client.post(
+        "/api/widget/auth", json={"guest_id": "g", "embed_ticket": ticket_b}
+    )
+    assert second.status_code == 429, second.text
+
+
+def test_widget_embed_ticket_returns_429_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ticket minting is gated too (#1108): an ungated mint loop would do free
+    DB work + JWT signatures and refresh the caller's auth credential."""
+    key = _widget_agent_key("RL Widget Ticket Mint Agent")
+
+    monkeypatch.setenv("XAGENT_WIDGET_AUTH_RATE_LIMIT", "1/minute")
+    reset_share_rate_limiter()
+
+    def _mint():
+        return client.post(
+            "/api/widget/embed-ticket",
+            json={"widget_key": key},
+            headers={"origin": "https://any-site.example"},
+        )
+
+    assert _mint().status_code == 200
+    assert _mint().status_code == 429
 
 
 class _FakeWebSocket:

--- a/tests/web/api/test_trigger_rate_limits.py
+++ b/tests/web/api/test_trigger_rate_limits.py
@@ -276,6 +276,21 @@ class TestRemoteIpDerivation:
         request = self._request("10.0.0.1", "1.2.3.4, 203.0.113.7")
         assert remote_ip_from_request(request) == "203.0.113.7"
 
+    def test_non_ip_forwarded_entry_falls_back_to_peer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1108 F3: the selected entry is client-controlled when hops
+        over-counts the real chain, and callers now persist this value and use
+        it as rate-limit key material — so a non-IP-shaped entry must be
+        rejected in favour of the peer address rather than passed through."""
+        monkeypatch.setenv("XAGENT_TRUSTED_PROXY_HOPS", "1")
+        for forged in ("not-an-ip", "a" * 5000, "203.0.113.7 evil", ""):
+            request = self._request("10.0.0.1", forged or None)
+            assert remote_ip_from_request(request) == "10.0.0.1", forged
+        # A genuine IPv6 entry still resolves normally.
+        request = self._request("10.0.0.1", "2001:db8::1")
+        assert remote_ip_from_request(request) == "2001:db8::1"
+
     def test_missing_forwarded_header_falls_back_to_peer(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/web/api/test_widget_auth_entity_key.py
+++ b/tests/web/api/test_widget_auth_entity_key.py
@@ -1,0 +1,78 @@
+"""Unit tests for the widget auth rate-limit entity-key derivation (#1108).
+
+``_widget_auth_rate_limit_entity_key`` picks the loose-entity backstop bucket
+for the widget auth / embed-ticket gate from a *signed* ticket's claims (no DB
+work), so a per-page-load ticket rotation cannot escape it. These pin each
+branch — agent ticket, workforce ticket, legacy (no owner_type), tampered /
+wrong-type / malformed tickets, the direct widget-key flow, and the empty
+fallback — directly, without standing up the HTTP widget flow.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from xagent.web.api.auth import create_access_token
+from xagent.web.api.widget import (
+    EMBED_TICKET_OWNER_WORKFORCE,
+    EMBED_TICKET_TYPE,
+    _widget_auth_rate_limit_entity_key,
+)
+
+
+def _mint(claims: dict) -> str:
+    return create_access_token(claims, expires_delta=timedelta(seconds=60))
+
+
+def test_agent_ticket_keys_on_agent_entity() -> None:
+    ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 42})
+    assert _widget_auth_rate_limit_entity_key(ticket, None) == "agent:42"
+
+
+def test_workforce_ticket_keys_on_workforce_entity() -> None:
+    ticket = _mint(
+        {
+            "type": EMBED_TICKET_TYPE,
+            "owner_type": EMBED_TICKET_OWNER_WORKFORCE,
+            "workforce_id": 7,
+        }
+    )
+    assert _widget_auth_rate_limit_entity_key(ticket, None) == "workforce:7"
+
+
+def test_legacy_ticket_without_owner_type_is_treated_as_agent() -> None:
+    # Tickets minted before workforce support carried only agent_id.
+    ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 5})
+    assert _widget_auth_rate_limit_entity_key(ticket, None) == "agent:5"
+
+
+def test_tampered_ticket_collapses_to_invalid_bucket() -> None:
+    ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 42})
+    assert (
+        _widget_auth_rate_limit_entity_key(ticket + "tamper", None) == "invalid-ticket"
+    )
+
+
+def test_wrong_type_ticket_collapses_to_invalid_bucket() -> None:
+    ticket = _mint({"type": "not-an-embed-ticket", "agent_id": 42})
+    assert _widget_auth_rate_limit_entity_key(ticket, None) == "invalid-ticket"
+
+
+def test_workforce_ticket_without_id_collapses_to_invalid_bucket() -> None:
+    ticket = _mint(
+        {"type": EMBED_TICKET_TYPE, "owner_type": EMBED_TICKET_OWNER_WORKFORCE}
+    )
+    assert _widget_auth_rate_limit_entity_key(ticket, None) == "invalid-ticket"
+
+
+def test_direct_widget_key_flow_keys_on_prefixed_key() -> None:
+    assert _widget_auth_rate_limit_entity_key(None, "wk_abc") == "key:wk_abc"
+
+
+def test_ticket_wins_over_widget_key() -> None:
+    ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 9})
+    assert _widget_auth_rate_limit_entity_key(ticket, "wk_abc") == "agent:9"
+
+
+def test_no_credential_returns_empty_shared_fallback() -> None:
+    assert _widget_auth_rate_limit_entity_key(None, None) == ""

--- a/tests/web/api/test_widget_auth_entity_key.py
+++ b/tests/web/api/test_widget_auth_entity_key.py
@@ -25,6 +25,9 @@ def _mint(claims: dict) -> str:
 
 
 def test_agent_ticket_keys_on_agent_entity() -> None:
+    # No owner_type is the agent branch, which is also the legacy shape: tickets
+    # minted before workforce support carried only agent_id and no owner_type,
+    # so this covers both (missing and agent owner_type take the same branch).
     ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 42})
     assert _widget_auth_rate_limit_entity_key(ticket, None) == "agent:42"
 
@@ -38,12 +41,6 @@ def test_workforce_ticket_keys_on_workforce_entity() -> None:
         }
     )
     assert _widget_auth_rate_limit_entity_key(ticket, None) == "workforce:7"
-
-
-def test_legacy_ticket_without_owner_type_is_treated_as_agent() -> None:
-    # Tickets minted before workforce support carried only agent_id.
-    ticket = _mint({"type": EMBED_TICKET_TYPE, "agent_id": 5})
-    assert _widget_auth_rate_limit_entity_key(ticket, None) == "agent:5"
 
 
 def test_tampered_ticket_collapses_to_invalid_bucket() -> None:

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -581,6 +581,11 @@ def test_widget_task_create_starts_workforce_run(
         assert task.agent_config.get("auth_mode") == "widget"
         assert int(task.agent_config.get("widget_workforce_id")) == workforce_id
         assert task.agent_config.get("guest_id") == "guest_test"
+        # The server-observed creator IP is stamped on the workforce path too
+        # (#1108): it is the widget run quota's per-abuser key, and a future
+        # snapshot key collision in _merge_agent_config would silently drop it,
+        # degrading the sub-quota to entity-only. Regression-lock it here.
+        assert task.agent_config.get("widget_client_ip") == "testclient"
 
         run = db.query(WorkforceRun).filter(WorkforceRun.task_id == task_id).one()
         assert int(run.workforce_id) == workforce_id

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -235,6 +235,19 @@ def test_widget_auth_entity_ceiling_is_loose_across_ips(
     assert limiter.allow_widget_auth("agent:8", "4.4.4.4") is True
 
 
+def test_widget_auth_malformed_env_falls_back_to_1200_not_600(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N1: a malformed XAGENT_WIDGET_AUTH_RATE_LIMIT must fall back to the same
+    1200/min default the getter uses (the 4:1 ratio F1 set), not the old 600 —
+    otherwise the degraded path silently halves the backstop, reintroducing
+    the exact ratio problem F1 fixed."""
+    limiter = _limiter_with(
+        monkeypatch, XAGENT_WIDGET_AUTH_RATE_LIMIT="not-a-valid-rate"
+    )
+    assert limiter._widget_auth_entity_limit.amount == 1200
+
+
 def test_widget_auth_entity_denial_does_not_burn_ip_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -267,6 +280,38 @@ def test_widget_auth_is_isolated_from_share_auth(
     assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is False
     # Same IP + token on the share endpoint still admits from its own budget.
     assert limiter.allow_auth("tok", "1.1.1.1") is True
+
+
+def test_widget_gates_use_disjoint_namespaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exhausting one widget gate must not block the others for the same
+    entity+IP (a copy-paste typo collapsing two widget namespaces would
+    otherwise pass CI). Every widget limit is 1 so each gate trips on its
+    second call in isolation."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_UPLOAD_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_UPLOAD_IP_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_RUN_QUOTA="1/day",
+        XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
+    )
+    # Exhaust the auth gate for one entity + IP.
+    assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is False
+    # The other widget gates for the SAME entity + IP still admit once each —
+    # they live in their own namespaces, unconsumed by the auth gate.
+    assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
+    # And each is now independently exhausted, confirming they are distinct.
+    assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is False
+    assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is False
+    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is False
 
 
 def test_widget_task_create_per_ip_bucket_trips_across_entities(

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -25,6 +25,19 @@ def _limiter_with(monkeypatch: pytest.MonkeyPatch, **env: str) -> ShareRateLimit
     return get_share_rate_limiter()
 
 
+def test_construction_degrades_to_memory_on_unusable_redis_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N12: an invalid XAGENT_REDIS_URL must not 500 the public endpoints.
+    Construction runs lazily on first request, outside the per-call fail-open
+    boundary, so a raising storage backend has to degrade to in-process memory
+    here instead of propagating."""
+    limiter = _limiter_with(monkeypatch, XAGENT_REDIS_URL="not-a-valid-scheme://x")
+    assert limiter.backend == "memory"
+    # And the gates still function on the fallback storage.
+    assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is True
+
+
 def test_auth_per_token_bucket_trips(monkeypatch: pytest.MonkeyPatch) -> None:
     limiter = _limiter_with(
         monkeypatch,
@@ -248,6 +261,18 @@ def test_widget_auth_malformed_env_falls_back_to_1200_not_600(
     assert limiter._widget_auth_entity_limit.amount == 1200
 
 
+def test_widget_task_create_malformed_env_falls_back_to_240_not_120(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N13: the task-create entity fallback must match the getter's 240/min
+    default (4:1), not the old 120 — otherwise a malformed env var silently
+    runs the highest-value gate at 2:1, the same drift N1 fixed for auth."""
+    limiter = _limiter_with(
+        monkeypatch, XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="not-a-valid-rate"
+    )
+    assert limiter._widget_task_create_entity_limit.amount == 240
+
+
 def test_widget_auth_entity_denial_does_not_burn_ip_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -287,8 +312,12 @@ def test_widget_gates_use_disjoint_namespaces(
 ) -> None:
     """Exhausting one widget gate must not block the others for the same
     entity+IP (a copy-paste typo collapsing two widget namespaces would
-    otherwise pass CI). Every widget limit is 1 so each gate trips on its
-    second call in isolation."""
+    otherwise pass CI). N6: every widget limit — including the run and WS
+    gates — is set to the SAME 1/minute shape, because ``limits``' MemoryStorage
+    key encodes the rate-limit item, so two gates with different shapes never
+    collide observably even under a merged namespace; only same-shape gates can.
+    Production defaults already make ws-turn-ip / task-create-ip / upload-ip all
+    60/min, so a real merge there would take effect."""
     limiter = _limiter_with(
         monkeypatch,
         XAGENT_WIDGET_AUTH_RATE_LIMIT="1/minute",
@@ -297,20 +326,28 @@ def test_widget_gates_use_disjoint_namespaces(
         XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="1/minute",
         XAGENT_WIDGET_UPLOAD_RATE_LIMIT="1/minute",
         XAGENT_WIDGET_UPLOAD_IP_RATE_LIMIT="1/minute",
-        XAGENT_WIDGET_RUN_QUOTA="1/day",
-        XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
+        XAGENT_WIDGET_WS_TURN_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_WS_TURN_IP_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_WS_CONNECT_IP_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_RUN_QUOTA="1/minute",
+        XAGENT_WIDGET_RUN_IP_QUOTA="1/minute",
     )
     # Exhaust the auth gate for one entity + IP.
     assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is True
     assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is False
     # The other widget gates for the SAME entity + IP still admit once each —
-    # they live in their own namespaces, unconsumed by the auth gate.
+    # they live in their own namespaces, unconsumed by the auth gate. All are
+    # 1/minute now, so a namespace merged onto auth's would be observable here.
     assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
     assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_ws_connect("1.1.1.1") is True
     assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
     # And each is now independently exhausted, confirming they are distinct.
     assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is False
     assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is False
+    assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is False
+    assert limiter.allow_widget_ws_connect("1.1.1.1") is False
     assert limiter.allow_widget_run("agent:1", "1.1.1.1") is False
 
 

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -208,11 +208,11 @@ def test_widget_auth_per_credential_bucket_trips(
         XAGENT_WIDGET_AUTH_RATE_LIMIT="2/minute",
         XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="100/minute",
     )
-    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is True
-    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is True
-    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is False
+    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is False
     # A different credential on the same IP has an independent bucket.
-    assert limiter.allow_widget_auth("1.1.1.1", "key-b") is True
+    assert limiter.allow_widget_auth("key-b", "1.1.1.1") is True
 
 
 def test_widget_auth_per_ip_ceiling_trips_across_credentials(
@@ -224,9 +224,9 @@ def test_widget_auth_per_ip_ceiling_trips_across_credentials(
         XAGENT_WIDGET_AUTH_RATE_LIMIT="100/minute",
         XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="2/minute",
     )
-    assert limiter.allow_widget_auth("9.9.9.9", "key-a") is True
-    assert limiter.allow_widget_auth("9.9.9.9", "key-b") is True
-    assert limiter.allow_widget_auth("9.9.9.9", "key-c") is False
+    assert limiter.allow_widget_auth("key-a", "9.9.9.9") is True
+    assert limiter.allow_widget_auth("key-b", "9.9.9.9") is True
+    assert limiter.allow_widget_auth("key-c", "9.9.9.9") is False
 
 
 def test_widget_auth_is_isolated_from_share_auth(
@@ -240,8 +240,8 @@ def test_widget_auth_is_isolated_from_share_auth(
         XAGENT_SHARE_AUTH_RATE_LIMIT="5/minute",
         XAGENT_SHARE_AUTH_IP_RATE_LIMIT="5/minute",
     )
-    assert limiter.allow_widget_auth("1.1.1.1", "tok") is True
-    assert limiter.allow_widget_auth("1.1.1.1", "tok") is False
+    assert limiter.allow_widget_auth("tok", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("tok", "1.1.1.1") is False
     # Same IP + token on the share endpoint still admits from its own budget.
     assert limiter.allow_auth("tok", "1.1.1.1") is True
 
@@ -300,12 +300,52 @@ def test_widget_task_create_ip_denial_does_not_consume_entity_slot(
 def test_widget_run_quota_per_entity_trips(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    limiter = _limiter_with(monkeypatch, XAGENT_WIDGET_RUN_QUOTA="2/day")
-    assert limiter.allow_widget_run("agent:1") is True
-    assert limiter.allow_widget_run("agent:1") is True
-    assert limiter.allow_widget_run("agent:1") is False
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_RUN_QUOTA="2/day",
+        XAGENT_WIDGET_RUN_IP_QUOTA="100/hour",
+    )
+    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_run("agent:1", "2.2.2.2") is True
+    assert limiter.allow_widget_run("agent:1", "3.3.3.3") is False
     # A different widget entity has its own rolling quota.
-    assert limiter.allow_widget_run("workforce:2") is True
+    assert limiter.allow_widget_run("workforce:2", "4.4.4.4") is True
+
+
+def test_widget_run_ip_quota_bounds_one_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-creating-IP window trips before the entity quota for one
+    caller — a single IP can no longer drain a widget's whole rolling quota
+    and lock other visitors out."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_RUN_QUOTA="3/day",
+        XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
+    )
+    assert limiter.allow_widget_run("agent:1", "9.9.9.9") is True  # entity=1, ip=1
+    assert limiter.allow_widget_run("agent:1", "9.9.9.9") is False  # ip window blocks
+    # The denial didn't consume entity slots: two other visitors still fit.
+    assert limiter.allow_widget_run("agent:1", "8.8.8.8") is True  # entity=2
+    assert limiter.allow_widget_run("agent:1", "7.7.7.7") is True  # entity=3
+    assert limiter.allow_widget_run("agent:1", "6.6.6.6") is False  # entity quota hit
+
+
+def test_widget_run_quota_without_ip_marker_is_entity_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tasks created before the IP marker existed (client_ip=None) are bounded
+    by the entity quota alone — they must not collapse into one shared IP
+    bucket."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_RUN_QUOTA="2/day",
+        XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
+    )
+    # Two legacy runs pass despite the 1/hour IP window (no IP → no IP bucket).
+    assert limiter.allow_widget_run("agent:1", None) is True
+    assert limiter.allow_widget_run("agent:1", None) is True
+    assert limiter.allow_widget_run("agent:1", None) is False  # entity quota (2)
 
 
 def test_widget_run_quota_is_isolated_from_share_run(
@@ -319,8 +359,8 @@ def test_widget_run_quota_is_isolated_from_share_run(
         XAGENT_SHARE_RUN_QUOTA="5/day",
         XAGENT_SHARE_RUN_GUEST_QUOTA="5/hour",
     )
-    assert limiter.allow_widget_run("agent:1") is True
-    assert limiter.allow_widget_run("agent:1") is False
+    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_run("agent:1", "2.2.2.2") is False
     # The share run quota under the same entity key still admits.
     assert limiter.allow_run("agent:1", "g1") is True
 
@@ -392,6 +432,7 @@ def test_all_gates_fail_open_on_backend_error(
     assert limiter.allow_widget_ws_connect("1.1.1.1") is True
     assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is True
     assert limiter.allow_run("agent:1", "g") is True
-    assert limiter.allow_widget_auth("1.1.1.1", "key") is True
+    assert limiter.allow_widget_auth("key", "1.1.1.1") is True
     assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1") is True
+    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_run("agent:1", None) is True

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -200,33 +200,56 @@ def test_widget_ws_turn_entity_ceiling_trips_across_ips(
     assert limiter.allow_widget_ws_turn("workforce:8", "4.4.4.4") is True
 
 
-def test_widget_auth_per_credential_bucket_trips(
+def test_widget_auth_per_ip_bucket_trips_across_entities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    limiter = _limiter_with(
-        monkeypatch,
-        XAGENT_WIDGET_AUTH_RATE_LIMIT="2/minute",
-        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="100/minute",
-    )
-    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is True
-    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is True
-    assert limiter.allow_widget_auth("key-a", "1.1.1.1") is False
-    # A different credential on the same IP has an independent bucket.
-    assert limiter.allow_widget_auth("key-b", "1.1.1.1") is True
-
-
-def test_widget_auth_per_ip_ceiling_trips_across_credentials(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Rotating the widget key/ticket must not escape the per-IP ceiling."""
+    """Per-IP is the tight per-visitor/per-abuser bound (#1108 F2): rotating
+    the entity key (fake widget keys, forged tickets) must not escape it."""
     limiter = _limiter_with(
         monkeypatch,
         XAGENT_WIDGET_AUTH_RATE_LIMIT="100/minute",
         XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="2/minute",
     )
-    assert limiter.allow_widget_auth("key-a", "9.9.9.9") is True
-    assert limiter.allow_widget_auth("key-b", "9.9.9.9") is True
-    assert limiter.allow_widget_auth("key-c", "9.9.9.9") is False
+    assert limiter.allow_widget_auth("agent:1", "9.9.9.9") is True
+    assert limiter.allow_widget_auth("key:rotated", "9.9.9.9") is True
+    assert limiter.allow_widget_auth("agent:2", "9.9.9.9") is False
+    # A different caller is unaffected.
+    assert limiter.allow_widget_auth("agent:1", "8.8.8.8") is True
+
+
+def test_widget_auth_entity_ceiling_is_loose_across_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-entity is the loose aggregate backstop across a widget's visitors:
+    distinct-IP visitors of one widget share it, so it must not 429 them until
+    the loose cap — the F2 fix that keeps busy embeds working."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="2/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="100/minute",
+    )
+    assert limiter.allow_widget_auth("agent:7", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("agent:7", "2.2.2.2") is True
+    assert limiter.allow_widget_auth("agent:7", "3.3.3.3") is False
+    # A different widget entity has its own backstop.
+    assert limiter.allow_widget_auth("agent:8", "4.4.4.4") is True
+
+
+def test_widget_auth_entity_denial_does_not_burn_ip_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4: a per-entity denial must not consume the caller's per-IP allowance,
+    so the same IP can still reach *other* widgets (non-destructive test→hit)."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="3/minute",
+    )
+    assert limiter.allow_widget_auth("agent:1", "9.9.9.9") is True  # entity=1, ip=1
+    assert limiter.allow_widget_auth("agent:1", "9.9.9.9") is False  # entity backstop
+    # The denial didn't burn the IP budget: the same IP reaches other widgets.
+    assert limiter.allow_widget_auth("agent:2", "9.9.9.9") is True
+    assert limiter.allow_widget_auth("agent:3", "9.9.9.9") is True
 
 
 def test_widget_auth_is_isolated_from_share_auth(
@@ -240,8 +263,8 @@ def test_widget_auth_is_isolated_from_share_auth(
         XAGENT_SHARE_AUTH_RATE_LIMIT="5/minute",
         XAGENT_SHARE_AUTH_IP_RATE_LIMIT="5/minute",
     )
-    assert limiter.allow_widget_auth("tok", "1.1.1.1") is True
-    assert limiter.allow_widget_auth("tok", "1.1.1.1") is False
+    assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_auth("agent:1", "1.1.1.1") is False
     # Same IP + token on the share endpoint still admits from its own budget.
     assert limiter.allow_auth("tok", "1.1.1.1") is True
 

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -342,13 +342,13 @@ def test_widget_gates_use_disjoint_namespaces(
     assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is True
     assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is True
     assert limiter.allow_widget_ws_connect("1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
+    assert limiter.widget_run_denial_reason("agent:1", "1.1.1.1") is None
     # And each is now independently exhausted, confirming they are distinct.
     assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is False
     assert limiter.allow_widget_upload("agent:1", "1.1.1.1") is False
     assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is False
     assert limiter.allow_widget_ws_connect("1.1.1.1") is False
-    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is False
+    assert limiter.widget_run_denial_reason("agent:1", "1.1.1.1") is not None
 
 
 def test_widget_task_create_per_ip_bucket_trips_across_entities(
@@ -410,11 +410,11 @@ def test_widget_run_quota_per_entity_trips(
         XAGENT_WIDGET_RUN_QUOTA="2/day",
         XAGENT_WIDGET_RUN_IP_QUOTA="100/hour",
     )
-    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1", "2.2.2.2") is True
-    assert limiter.allow_widget_run("agent:1", "3.3.3.3") is False
+    assert limiter.widget_run_denial_reason("agent:1", "1.1.1.1") is None
+    assert limiter.widget_run_denial_reason("agent:1", "2.2.2.2") is None
+    assert limiter.widget_run_denial_reason("agent:1", "3.3.3.3") == "entity"
     # A different widget entity has its own rolling quota.
-    assert limiter.allow_widget_run("workforce:2", "4.4.4.4") is True
+    assert limiter.widget_run_denial_reason("workforce:2", "4.4.4.4") is None
 
 
 def test_widget_run_ip_quota_bounds_one_caller(
@@ -428,12 +428,34 @@ def test_widget_run_ip_quota_bounds_one_caller(
         XAGENT_WIDGET_RUN_QUOTA="3/day",
         XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
     )
-    assert limiter.allow_widget_run("agent:1", "9.9.9.9") is True  # entity=1, ip=1
-    assert limiter.allow_widget_run("agent:1", "9.9.9.9") is False  # ip window blocks
+    assert limiter.widget_run_denial_reason("agent:1", "9.9.9.9") is None
+    # The IP window refuses, and says so — the caller needs "ip" vs "entity" to
+    # tell a retryable per-caller throttle from an exhausted owner budget.
+    assert limiter.widget_run_denial_reason("agent:1", "9.9.9.9") == "ip"
     # The denial didn't consume entity slots: two other visitors still fit.
-    assert limiter.allow_widget_run("agent:1", "8.8.8.8") is True  # entity=2
-    assert limiter.allow_widget_run("agent:1", "7.7.7.7") is True  # entity=3
-    assert limiter.allow_widget_run("agent:1", "6.6.6.6") is False  # entity quota hit
+    assert limiter.widget_run_denial_reason("agent:1", "8.8.8.8") is None  # entity=2
+    assert limiter.widget_run_denial_reason("agent:1", "7.7.7.7") is None  # entity=3
+    assert limiter.widget_run_denial_reason("agent:1", "6.6.6.6") == "entity"
+
+
+def test_widget_run_ip_quota_is_scoped_per_widget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D1/F1: the IP sub-quota bucket is keyed ``entity|ip``, not bare IP, so
+    one caller exhausting their budget on one widget must not lock that whole
+    network (NAT/CGNAT egress) out of every *other* widget on the instance.
+    This gate is charged per turn, so a platform-wide bucket would be
+    collateral damage on ordinary shared-egress traffic."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_RUN_QUOTA="100/day",
+        XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
+    )
+    assert limiter.widget_run_denial_reason("agent:1", "9.9.9.9") is None
+    assert limiter.widget_run_denial_reason("agent:1", "9.9.9.9") == "ip"
+    # Same IP, different widgets: unaffected by the exhausted agent:1 bucket.
+    assert limiter.widget_run_denial_reason("agent:2", "9.9.9.9") is None
+    assert limiter.widget_run_denial_reason("workforce:3", "9.9.9.9") is None
 
 
 def test_widget_run_quota_without_ip_marker_is_entity_only(
@@ -448,9 +470,9 @@ def test_widget_run_quota_without_ip_marker_is_entity_only(
         XAGENT_WIDGET_RUN_IP_QUOTA="1/hour",
     )
     # Two legacy runs pass despite the 1/hour IP window (no IP → no IP bucket).
-    assert limiter.allow_widget_run("agent:1", None) is True
-    assert limiter.allow_widget_run("agent:1", None) is True
-    assert limiter.allow_widget_run("agent:1", None) is False  # entity quota (2)
+    assert limiter.widget_run_denial_reason("agent:1", None) is None
+    assert limiter.widget_run_denial_reason("agent:1", None) is None
+    assert limiter.widget_run_denial_reason("agent:1", None) == "entity"
 
 
 def test_widget_run_quota_is_isolated_from_share_run(
@@ -464,8 +486,8 @@ def test_widget_run_quota_is_isolated_from_share_run(
         XAGENT_SHARE_RUN_QUOTA="5/day",
         XAGENT_SHARE_RUN_GUEST_QUOTA="5/hour",
     )
-    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1", "2.2.2.2") is False
+    assert limiter.widget_run_denial_reason("agent:1", "1.1.1.1") is None
+    assert limiter.widget_run_denial_reason("agent:1", "2.2.2.2") == "entity"
     # The share run quota under the same entity key still admits.
     assert limiter.allow_run("agent:1", "g1") is True
 
@@ -539,5 +561,5 @@ def test_all_gates_fail_open_on_backend_error(
     assert limiter.allow_run("agent:1", "g") is True
     assert limiter.allow_widget_auth("key", "1.1.1.1") is True
     assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1", "1.1.1.1") is True
-    assert limiter.allow_widget_run("agent:1", None) is True
+    assert limiter.widget_run_denial_reason("agent:1", "1.1.1.1") is None
+    assert limiter.widget_run_denial_reason("agent:1", None) is None

--- a/tests/web/services/test_share_rate_limit.py
+++ b/tests/web/services/test_share_rate_limit.py
@@ -200,6 +200,131 @@ def test_widget_ws_turn_entity_ceiling_trips_across_ips(
     assert limiter.allow_widget_ws_turn("workforce:8", "4.4.4.4") is True
 
 
+def test_widget_auth_per_credential_bucket_trips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="2/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="100/minute",
+    )
+    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is True
+    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is True
+    assert limiter.allow_widget_auth("1.1.1.1", "key-a") is False
+    # A different credential on the same IP has an independent bucket.
+    assert limiter.allow_widget_auth("1.1.1.1", "key-b") is True
+
+
+def test_widget_auth_per_ip_ceiling_trips_across_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotating the widget key/ticket must not escape the per-IP ceiling."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="100/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="2/minute",
+    )
+    assert limiter.allow_widget_auth("9.9.9.9", "key-a") is True
+    assert limiter.allow_widget_auth("9.9.9.9", "key-b") is True
+    assert limiter.allow_widget_auth("9.9.9.9", "key-c") is False
+
+
+def test_widget_auth_is_isolated_from_share_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The widget auth buckets must not consume the share auth budget."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_AUTH_RATE_LIMIT="1/minute",
+        XAGENT_WIDGET_AUTH_IP_RATE_LIMIT="1/minute",
+        XAGENT_SHARE_AUTH_RATE_LIMIT="5/minute",
+        XAGENT_SHARE_AUTH_IP_RATE_LIMIT="5/minute",
+    )
+    assert limiter.allow_widget_auth("1.1.1.1", "tok") is True
+    assert limiter.allow_widget_auth("1.1.1.1", "tok") is False
+    # Same IP + token on the share endpoint still admits from its own budget.
+    assert limiter.allow_auth("tok", "1.1.1.1") is True
+
+
+def test_widget_task_create_per_ip_bucket_trips_across_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-IP is the tight abuser bucket: the widget guest_id is client-supplied
+    (rotatable), so rotating the entity must not escape the per-caller gate."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="100/minute",
+        XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="2/minute",
+    )
+    assert limiter.allow_widget_task_create("agent:1", "9.9.9.9") is True
+    assert limiter.allow_widget_task_create("workforce:2", "9.9.9.9") is True
+    assert limiter.allow_widget_task_create("agent:3", "9.9.9.9") is False
+    # A different caller is unaffected.
+    assert limiter.allow_widget_task_create("agent:1", "8.8.8.8") is True
+
+
+def test_widget_task_create_entity_ceiling_trips_across_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-entity is the loose backstop bounding total task-create volume through
+    one widget, across many callers."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="2/minute",
+        XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="100/minute",
+    )
+    assert limiter.allow_widget_task_create("workforce:7", "1.1.1.1") is True
+    assert limiter.allow_widget_task_create("workforce:7", "2.2.2.2") is True
+    assert limiter.allow_widget_task_create("workforce:7", "3.3.3.3") is False
+    # A different widget entity has its own bucket.
+    assert limiter.allow_widget_task_create("workforce:8", "4.4.4.4") is True
+
+
+def test_widget_task_create_ip_denial_does_not_consume_entity_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-IP denial must not burn an entity slot (paired non-destructive
+    test→hit), so other callers of the same widget still fit."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_TASK_CREATE_RATE_LIMIT="3/minute",
+        XAGENT_WIDGET_TASK_CREATE_IP_RATE_LIMIT="1/minute",
+    )
+    assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is False  # IP trips
+    # The denials above didn't consume the entity budget: two fresh callers fit.
+    assert limiter.allow_widget_task_create("agent:1", "2.2.2.2") is True
+    assert limiter.allow_widget_task_create("agent:1", "3.3.3.3") is True
+
+
+def test_widget_run_quota_per_entity_trips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _limiter_with(monkeypatch, XAGENT_WIDGET_RUN_QUOTA="2/day")
+    assert limiter.allow_widget_run("agent:1") is True
+    assert limiter.allow_widget_run("agent:1") is True
+    assert limiter.allow_widget_run("agent:1") is False
+    # A different widget entity has its own rolling quota.
+    assert limiter.allow_widget_run("workforce:2") is True
+
+
+def test_widget_run_quota_is_isolated_from_share_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The widget run quota must not consume the share run budget (same key
+    string is a different namespace)."""
+    limiter = _limiter_with(
+        monkeypatch,
+        XAGENT_WIDGET_RUN_QUOTA="1/day",
+        XAGENT_SHARE_RUN_QUOTA="5/day",
+        XAGENT_SHARE_RUN_GUEST_QUOTA="5/hour",
+    )
+    assert limiter.allow_widget_run("agent:1") is True
+    assert limiter.allow_widget_run("agent:1") is False
+    # The share run quota under the same entity key still admits.
+    assert limiter.allow_run("agent:1", "g1") is True
+
+
 def test_run_quota_per_share_and_per_guest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -267,3 +392,6 @@ def test_all_gates_fail_open_on_backend_error(
     assert limiter.allow_widget_ws_connect("1.1.1.1") is True
     assert limiter.allow_widget_ws_turn("agent:1", "1.1.1.1") is True
     assert limiter.allow_run("agent:1", "g") is True
+    assert limiter.allow_widget_auth("1.1.1.1", "key") is True
+    assert limiter.allow_widget_task_create("agent:1", "1.1.1.1") is True
+    assert limiter.allow_widget_run("agent:1") is True

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -415,7 +415,7 @@ async def test_execute_task_workforce_pool_timeout_stops_tracker_checkout(
             # lease acquisition; stub its checkout like the run gate's so the
             # pool timeout under test still lands on the workforce stage.
             patch(
-                "xagent.web.api.chat._load_task_share_quota_config_isolated",
+                "xagent.web.api.chat._load_task_public_run_quota_config_isolated",
                 return_value=None,
             ),
             patch(

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -219,9 +219,11 @@ async def test_widget_run_quota_blocks_workforce_widget_task(
 async def test_widget_run_quota_fails_open_on_malformed_marker(
     db_session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A malformed (non-integer) widget entity marker must fail open — the
-    int() coercion raises, the chokepoint's broad except admits the run —
-    rather than 500ing or blocking."""
+    """A malformed (non-integer) widget entity marker must admit the run rather
+    than 500 or block: _coerce_optional_entity_id catches the coercion error
+    and returns None, so the entity is unkeyable and _deny_public_run takes
+    its "unkeyable -> admit this task" branch — without falling through to the
+    chokepoint's broad except."""
     monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
     reset_share_rate_limiter()
 

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -157,7 +157,11 @@ async def test_widget_run_ip_quota_blocks_one_creator(
 ) -> None:
     """The per-creating-IP sub-quota (#1108) gates a task whose agent_config
     carries the server-stamped widget_client_ip, even with the entity quota
-    wide open — one caller cannot drain the widget for everyone else."""
+    wide open — one caller cannot drain the widget for everyone else.
+
+    The refusal must be reported as the per-caller sub-quota, NOT the owner's
+    budget: waiting clears this one, so the visitor gets copy they can act on
+    instead of being told the widget owner is out of quota (D1/F1)."""
     monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "500/day")
     monkeypatch.setenv("XAGENT_WIDGET_RUN_IP_QUOTA", "0/hour")
     reset_share_rate_limiter()
@@ -181,7 +185,10 @@ async def test_widget_run_ip_quota_blocks_one_creator(
     )
 
     assert result["success"] is False
-    assert result["error_code"] == "widget_run_quota_exceeded"
+    assert result["error_code"] == "widget_run_ip_quota_exceeded"
+    assert "your network" in result["output"]
+    # Not the owner-budget copy, which the visitor cannot act on.
+    assert "widget has reached its usage limit" not in result["output"]
 
 
 @pytest.mark.asyncio
@@ -221,7 +228,7 @@ async def test_widget_run_quota_fails_open_on_malformed_marker(
 ) -> None:
     """A malformed (non-integer) widget entity marker must admit the run rather
     than 500 or block: _coerce_optional_entity_id catches the coercion error
-    and returns None, so the entity is unkeyable and _deny_public_run takes
+    and returns None, so the entity is unkeyable and _public_run_denial_channel takes
     its "unkeyable -> admit this task" branch — without falling through to the
     chokepoint's broad except."""
     monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
@@ -347,3 +354,44 @@ def test_coerce_optional_entity_id_rejects_non_positive_int_inputs() -> None:
         ["1"],
     ):
         assert _coerce_optional_entity_id(bad) is None, bad
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_is_charged_per_turn_not_per_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the accounting semantics (D1/F1): the gate sits in execute_task,
+    which runs once per conversation turn, so a second turn on the SAME task
+    consumes another slot. With a 1/day entity quota the first turn is admitted
+    and the second is refused — this is deliberate (the quota bounds
+    owner-billed runs, and every turn is one), and the per-IP sub-quota is
+    sized against it accordingly."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "1/day")
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_IP_QUOTA", "100/hour")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "g",
+            "widget_agent_id": 4242,
+            "widget_client_ip": "203.0.113.11",
+        },
+    )
+
+    async def _run_one_turn():
+        return await AgentServiceManager().execute_task(
+            agent_service=_FakeAgentService(),
+            task="hello",
+            tracking_task_id=str(task.id),
+            db_session=db_session,
+            manage_task_lease=False,
+        )
+
+    first = await _run_one_turn()
+    assert first["success"] is True
+
+    second = await _run_one_turn()
+    assert second["success"] is False
+    assert second["error_code"] == "widget_run_quota_exceeded"

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -308,4 +308,42 @@ async def test_widget_run_quota_admits_when_entity_unkeyable(
         manage_task_lease=False,
     )
 
-    assert result.get("error_code") != "share_run_quota_exceeded"
+    # N15: assert the run actually ran, not merely that it dodged the (widget-
+    # unreachable) share error code — otherwise a wrong widget_run_quota_exceeded
+    # would still pass.
+    assert result["success"] is True
+    assert result.get("error_code") not in (
+        "widget_run_quota_exceeded",
+        "share_run_quota_exceeded",
+    )
+
+
+def test_coerce_optional_entity_id_rejects_non_positive_int_inputs() -> None:
+    """N14: entity markers are positive DB primary keys, so floats (which would
+    truncate onto a real entity's bucket), 0/negatives (impossible buckets),
+    inf (whose int() raises OverflowError, escaping the narrow except), and
+    junk all degrade to None ("unkeyable → admit") rather than keying a wrong
+    bucket or crashing. Genuine positive ints and digit strings pass through."""
+    from xagent.web.api.chat import _coerce_optional_entity_id
+
+    assert _coerce_optional_entity_id(42) == 42
+    assert _coerce_optional_entity_id("42") == 42
+    # Rejected: float (no silent truncation onto agent:1), zero, negatives,
+    # bool, inf/nan, signed or decimal strings, and outright junk.
+    for bad in (
+        1.9,
+        0,
+        -5,
+        True,
+        False,
+        float("inf"),
+        float("nan"),
+        "1.9",
+        "-5",
+        "0",
+        "",
+        "abc",
+        None,
+        ["1"],
+    ):
+        assert _coerce_optional_entity_id(bad) is None, bad

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -248,6 +248,42 @@ async def test_widget_run_quota_fails_open_on_malformed_marker(
         "widget_run_quota_exceeded",
         "share_run_quota_exceeded",
     )
+    # Positive assertion (F4): the run was actually admitted and executed —
+    # this fails if the malformed-marker handling were removed and the run
+    # blocked, which the negative error_code check alone would not catch.
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_admits_bool_entity_marker(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``bool`` widget entity marker must be rejected by
+    _coerce_optional_entity_id (``isinstance(True, int)`` is True and would
+    otherwise coerce to ``agent:1``), so the entity is unkeyable and the run is
+    admitted rather than billed to a wrong bucket."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "g",
+            "widget_agent_id": True,
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is True
+    assert result.get("error_code") != "widget_run_quota_exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -118,9 +118,11 @@ async def test_share_run_quota_skips_non_share_task(
 async def test_widget_run_quota_blocks_widget_task(
     db_session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The widget run quota (#1108) is keyed on the entity only; "0/day" leaves
-    # no room, so the very first widget run is refused. The share quota stays
-    # wide open, proving the widget bucket gates independently.
+    # "0/day" on the widget entity quota leaves no room, so the very first
+    # widget run is refused — with widget-specific copy and error_code, not
+    # the share wording. The share quota stays wide open, proving the widget
+    # bucket gates independently. No widget_client_ip marker: this is the
+    # legacy-task path, bounded by the entity quota alone.
     monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
     monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "500/day")
     reset_share_rate_limiter()
@@ -145,8 +147,105 @@ async def test_widget_run_quota_blocks_widget_task(
 
     assert result["success"] is False
     assert result["status"] == "quota_exceeded"
-    assert result["error_code"] == "share_run_quota_exceeded"
-    assert "usage limit" in result["output"]
+    assert result["error_code"] == "widget_run_quota_exceeded"
+    assert "widget has reached its usage limit" in result["output"]
+
+
+@pytest.mark.asyncio
+async def test_widget_run_ip_quota_blocks_one_creator(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The per-creating-IP sub-quota (#1108) gates a task whose agent_config
+    carries the server-stamped widget_client_ip, even with the entity quota
+    wide open — one caller cannot drain the widget for everyone else."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "500/day")
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_IP_QUOTA", "0/hour")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "rotatable-guest",
+            "widget_agent_id": 4242,
+            "widget_client_ip": "203.0.113.9",
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "widget_run_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_blocks_workforce_widget_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The workforce widget marker keys the quota too (entity_rate_limit_key
+    prefers workforce over agent)."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "rotatable-guest",
+            "widget_workforce_id": 77,
+            "widget_client_ip": "203.0.113.10",
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "widget_run_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_fails_open_on_malformed_marker(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed (non-integer) widget entity marker must fail open — the
+    int() coercion raises, the chokepoint's broad except admits the run —
+    rather than 500ing or blocking."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "g",
+            "widget_agent_id": "not-an-int",
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result.get("error_code") not in (
+        "widget_run_quota_exceeded",
+        "share_run_quota_exceeded",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -112,3 +112,63 @@ async def test_share_run_quota_skips_non_share_task(
     )
 
     assert result.get("error_code") != "share_run_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_blocks_widget_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The widget run quota (#1108) is keyed on the entity only; "0/day" leaves
+    # no room, so the very first widget run is refused. The share quota stays
+    # wide open, proving the widget bucket gates independently.
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
+    monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "500/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "widget",
+            # Client-supplied guest_id must NOT be what gates the run.
+            "guest_id": "rotatable-guest",
+            "widget_agent_id": 4242,
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "quota_exceeded"
+    assert result["error_code"] == "share_run_quota_exceeded"
+    assert "usage limit" in result["output"]
+
+
+@pytest.mark.asyncio
+async def test_widget_run_quota_admits_when_entity_unkeyable(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A widget task with no entity marker cannot be attributed, so it falls
+    through rather than being blocked (matches the share fall-through)."""
+    monkeypatch.setenv("XAGENT_WIDGET_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={"auth_mode": "widget", "guest_id": "g"},
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result.get("error_code") != "share_run_quota_exceeded"


### PR DESCRIPTION
Closes #1108. Spun out of #1056 (whose two widget websocket limiters landed in #1113). The widget public surfaces were added after the #973/#993 share hardening and never picked up three of its abuse controls. This adds them on the shared `get_share_rate_limiter()` substrate, in namespaces and env vars kept separate from the share buckets so the two public channels cannot consume each other's budgets.

## Gaps closed

| # | Surface | Gate | Keying | Defaults |
|---|---------|------|--------|----------|
| 2 | `POST /api/widget/auth` + `POST /api/widget/embed-ticket` | `allow_widget_auth(entity_key, ip)` | tight per-IP (per-visitor bound) + loose per-entity backstop; entity is the widget key or the owner entity decoded from the ticket's **signed claims** (pure HMAC check, no DB) | 300/min IP, 1200/min entity |
| 3 | widget `POST /chat/task/create` | `allow_widget_task_create(entity_key, ip)` | per-entity (loose) + per-caller-IP (tight), non-destructive test→hit | 240/min entity, 60/min IP |
| 1 | run quota at the `execute_task` chokepoint | `widget_run_denial_reason(entity_key, creator_ip)` | rolling per-entity ceiling + a per-creating-IP sub-quota keyed `entity\|ip` (per-abuser dimension, scoped to one widget) | 500/day entity, 120/hour IP |

## Design constraint

Every widget gate uses the **tight-per-IP / loose-per-entity** shape: the caller IP is the per-visitor / per-abuser bound (the widget `guest_id` is client-supplied and rotatable, so it is never a limiter key), and the per-entity bucket is a loose aggregate backstop across one widget's visitors. Both buckets are tested non-destructively and only consumed when both admit, so a backstop denial never burns the caller's per-IP allowance for other widgets. This is the same reasoning `allow_widget_upload` / `allow_widget_ws_turn` already document, applied to the three new gates.

## 1 — run quota

The caller IP is not observable at the async `execute_task` chokepoint, so the creating request **stamps the server-observed IP** into `agent_config` (`widget_client_ip`, assigned after `sanitize_client_agent_config`, so a client value can never survive). The chokepoint reads it back and gates entity + creating-IP; one abuser trips their own IP window (default 120/hour) without draining the whole rolling entity quota and locking other visitors out. That IP bucket is keyed `entity|ip`, so exhausting it on one widget never blocks the same network (NAT/CGNAT egress) on another — this gate is charged per conversation turn, so a platform-wide bucket would be collateral damage on ordinary shared-egress traffic. A per-caller refusal is reported separately from an exhausted owner budget (`widget_run_ip_quota_exceeded` vs `widget_run_quota_exceeded`), since only the former clears by waiting. Pre-marker (legacy) tasks are bounded by the entity quota alone. The share path is unchanged (per-link + per-guest with its server-minted `guest_id`).

## 2 — auth / embed-ticket

Both endpoints fire on every widget page load and their entity key is shared by all of a widget's visitors, so the **tight bucket must be per-IP, not per-entity** — otherwise a busy embed 429s ordinary visitors (each visitor has a distinct IP; the entity backstop is deliberately loose at 1200/min, a 4:1 entity:IP ratio matching the sibling widget gates). The entity key is derived from the ticket's *signed* claims (`agent:<id>` / `workforce:<id>`; forging a different bucket requires forging the signature), never the raw ticket, which the embedded flow mints fresh per page load. `/api/widget/embed-ticket` shares the same bucket family, closing the free mint-a-ticket loop. widget.js distinguishes a 429 (transient, retry) from the 403 domain-allowlist/stale-snippet case.

## Anti-injection hardening

The run quota reads identity/entity markers back from `agent_config` as authoritative, so an anonymous guest must not be able to inject them. Three layers:
1. `sanitize_client_agent_config` strips the full public-channel marker set (`auth_mode`, `guest_id`, `widget_agent_id`, `widget_workforce_id`, `widget_client_ip`, `share_agent_id`, `share_workforce_id`, `share_token`) from every client body before any server stamping.
2. The widget-create path stamps **both** widget entity markers server-side (the inapplicable one as `None`), so a client-injected `widget_workforce_id` (which `entity_rate_limit_key` would prefer) can never redirect the bucket.
3. The chokepoint coerces entity ids defensively (`_coerce_optional_entity_id`, rejects non-numeric and `bool`): a malformed marker degrades to "unkeyable → admit this one task" rather than raising into the broad `except` and disabling the gate.

## Implementation notes

- The chokepoint loader `_load_task_share_quota_config_isolated` is generalized to `_load_task_public_run_quota_config_isolated` (matches `auth_mode` in `share` | `widget`); the branch logic lives in `_admit_public_run` with explicit per-mode branches — an unexpected mode admits with a warning rather than borrowing another channel's keys.
- Widget quota rejections return widget-specific copy and `error_code: "widget_run_quota_exceeded"`; share tasks are unchanged. Fail-open logs carry the `auth_mode`.
- New config getters follow the documented `config.py` env-var → default pattern; `example.env` documents each var and the `XAGENT_TRUSTED_PROXY_HOPS` interaction (with 0 trusted hops behind a reverse proxy, every per-IP bucket collapses onto the proxy's IP).

## Deploy note (operators)

The widget run quota applies to **already-live widget tasks as soon as this deploys**; there is no feature flag — the opt-out is raising `XAGENT_WIDGET_RUN_QUOTA` / `XAGENT_WIDGET_RUN_IP_QUOTA`.

A precise note on what pre-deploy tasks carry (correcting an earlier over-broad claim): a pre-#1124 **agent-widget** task carries the server-stamped `auth_mode` / `guest_id` / `widget_agent_id`, but **not** a server-owned `widget_workforce_id` or `widget_client_ip` — at baseline those keys were client-plantable (the sanitizer stripped only three keys and the create path never stamped them). So on a pre-deploy task the quota's entity/IP key can reflect a planted value rather than the real entity. #1124 closes this for all **new** tasks (the sanitizer now strips the full marker set and the create paths re-stamp server-side); existing rows are not backfilled here. The existing-task cleanup — a deploy-time backfill, or (better) deriving the run-quota entity at the chokepoint from normalized columns (`Task.agent_id` / `WorkforceRun`) the way the WS auth path already does — is tracked in #1131 alongside the retroactive-activation runbook.

## Tests

- Limiter unit tests: tight-IP vs loose-entity for all three gates, non-destructive test→hit (auth/run/task-create denials don't burn the other bucket), cross-limiter isolation, legacy no-IP entity-only run behaviour, fail-open.
- Endpoint tests: 429s for auth / task-create / embed-ticket; gate-runs-before-credential-resolution (invalid key → 403 then 429); ticket rotation for one agent lands in one entity bucket; **F1 injection regression** (forged `widget_workforce_id` + identity markers never survive into the persisted config); created tasks carry the server-stamped creator IP.
- Run-quota gate tests: agent + workforce branches blocked at 0/day, per-creating-IP sub-quota, unkeyable-entity fall-through, malformed-marker admit-this-task.
- `mypy` / `ruff` clean; `tests/web -k "widget or share or public_chat"` and the task-create/chat/execute_task sweep pass (pre-existing env-dependent failures — cairosvg, sandbox, RAG LanceDB, node/pptxgenjs — reproduce on `main`).

## Follow-ups

#1131 (retroactive-application runbook / kill-switch), #1132 (share-path injection hardening + test), #1133 (F5/F7/F8/SIMP2 cleanups).

## Relationship to #1056 / #1113

#1113 covered the two widget websocket limiters. This PR covers the remaining HTTP/quota controls on the shared substrate.

