### PR TITLE
fix: safely render errors from non-update builder actions

### DIFF
--- a/frontend/src/components/build/agent-builder-publish-errors.test.tsx
+++ b/frontend/src/components/build/agent-builder-publish-errors.test.tsx
@@ -4,9 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // Issue #969: the non-update builder actions (publish, unpublish, publish from
 // the creation success dialog, optimize instructions) must never pass a raw
-// `detail` payload to toast.error. Each action renders only displayable
-// strings, keeps its own localized fallback for unreadable or malformed
-// responses, and leaves the builder mounted after the failure.
+// `detail` payload to toast.error. sonner is mocked here, so each case asserts
+// two things: the exact string handed to the toaster is displayable, and the
+// builder is still mounted afterwards.
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
@@ -114,7 +114,15 @@ vi.mock("@/hooks/use-file-mention", () => ({
 vi.mock("@/components/ui/multi-select", () => ({
   MultiSelect: () => <div data-testid="multi-select" />,
 }))
-vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+// The model Select is the only place `modelConfig.general` reaches the DOM
+// (agent-builder.tsx renders it at the `models.length > 0` branch of the config
+// form). Mirroring the value onto data-value gives the create flow a readiness
+// signal it can wait on instead of retrying clicks.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ value }: { value?: string }) => (
+    <div data-testid="model-select" data-value={value ?? ""} />
+  ),
+}))
 vi.mock("@/components/build/build-file-preview-sheet", () => ({
   BuildFilePreviewSheet: () => null,
 }))
@@ -154,7 +162,17 @@ function agentResponse(status: "draft" | "published") {
 // instead of handing the raw payload to the toaster.
 const FALLBACK = "__ACTION_FALLBACK__"
 
-const ERROR_CASES = [
+type ErrorCase = {
+  name: string
+  body: string | null
+  expected: string
+  // Default to a FastAPI validation failure; a case overrides these when the
+  // transport shape itself is part of the fixture.
+  status?: number
+  contentType?: string
+}
+
+const ERROR_CASES: ErrorCase[] = [
   {
     name: "a plain string detail",
     body: JSON.stringify({ detail: " Action failed with string detail " }),
@@ -164,6 +182,19 @@ const ERROR_CASES = [
     name: "a structured detail message",
     body: JSON.stringify({ detail: { message: "Action failed", context: [] } }),
     expected: "Action failed",
+  },
+  {
+    name: "a structured detail msg",
+    body: JSON.stringify({ detail: { msg: "  Action failed with detail msg  " } }),
+    expected: "Action failed with detail msg",
+  },
+  {
+    name: "a detail msg alongside a top-level message",
+    body: JSON.stringify({
+      detail: { msg: "Detail wins" },
+      message: "Top-level loses",
+    }),
+    expected: "Detail wins",
   },
   {
     name: "a detail object without a readable message",
@@ -188,6 +219,11 @@ const ERROR_CASES = [
     expected: FALLBACK,
   },
   {
+    name: "a bare top-level message",
+    body: JSON.stringify({ message: "  Top-level failure  " }),
+    expected: "Top-level failure",
+  },
+  {
     name: "an empty response body",
     body: null,
     expected: FALLBACK,
@@ -196,76 +232,99 @@ const ERROR_CASES = [
     name: "a non-JSON response body",
     body: "<html>Bad Gateway</html>",
     expected: FALLBACK,
+    status: 502,
+    contentType: "text/html",
   },
-] as const
+]
 
-function errorResponse(body: string | null) {
-  return new Response(body, {
-    status: 422,
-    headers: { "Content-Type": "application/json" },
+// The one model the create flow resolves to, both as the available-model list
+// entry and as the user's general default.
+const DEFAULT_MODEL = {
+  id: 10,
+  model_id: "test/model",
+  model_name: "Test Model",
+  model_provider: "test",
+  category: "llm",
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), { status })
+}
+
+function errorResponse(errorCase: ErrorCase) {
+  return new Response(errorCase.body, {
+    status: errorCase.status ?? 422,
+    headers: { "Content-Type": errorCase.contentType ?? "application/json" },
   })
+}
+
+type ApiOverride = (
+  url: string,
+  opts?: { method?: string }
+) => Promise<Response> | null
+
+// Mount-time API surface every suite needs to resolve before the builder
+// settles. `overrides` is consulted first and returns null to fall through, so
+// a suite only states what it actually changes.
+function installBaseApiMocks(overrides: ApiOverride) {
+  apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+    const override = overrides(url, opts)
+    if (override) return override
+    if (url.endsWith("/api/kb/collections"))
+      return Promise.resolve(jsonResponse({ collections: [] }))
+    if (url.endsWith("/api/skills/")) return Promise.resolve(jsonResponse([]))
+    if (url.endsWith("/api/tools/available"))
+      return Promise.resolve(jsonResponse({ tools: [] }))
+    if (url.endsWith("/api/models/?category=llm"))
+      return Promise.resolve(jsonResponse([]))
+    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+      return Promise.resolve(jsonResponse([]))
+    if (url.includes("/api/mcp/servers")) return Promise.resolve(jsonResponse([]))
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+// The transport-failure suite injects its rejection by wrapping the installed
+// implementation, so it needs a failing path that never matches.
+const NO_FAILING_RESPONSE: ErrorCase = {
+  name: "unused",
+  body: null,
+  expected: FALLBACK,
 }
 
 function installEditModeApi(
   status: "draft" | "published",
   failingPath: string,
-  failingBody: string | null
+  failingCase: ErrorCase
 ) {
-  apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+  installBaseApiMocks((url, opts) => {
     if (opts?.method === "POST" && url.endsWith(failingPath))
-      return Promise.resolve(errorResponse(failingBody))
-    if (url.endsWith("/api/kb/collections"))
-      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
-    if (url.endsWith("/api/skills/"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    if (url.endsWith("/api/tools/available"))
-      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
-    if (url.endsWith("/api/models/?category=llm"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      return Promise.resolve(errorResponse(failingCase))
     if (url.endsWith("/api/models/user-default"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      return Promise.resolve(jsonResponse([]))
     if (url.endsWith(`/api/agents/${AGENT_ID}`))
-      return Promise.resolve(
-        new Response(JSON.stringify(agentResponse(status)), { status: 200 })
-      )
-    if (url.includes("/api/mcp/servers"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      return Promise.resolve(jsonResponse(agentResponse(status)))
+    return null
   })
 }
 
 // Create-mode mock for the success-dialog publish path: agent creation
 // succeeds (which opens the dialog), publish fails with the payload under test.
-function installCreateModeApi(failingBody: string | null) {
-  apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+// The model list and the user default both resolve to DEFAULT_MODEL, so the
+// builder reaches a creatable state without any model interaction.
+function installCreateModeApi(failingCase: ErrorCase) {
+  installBaseApiMocks((url, opts) => {
     if (opts?.method === "POST" && url.endsWith(`/api/agents/${AGENT_ID}/publish`))
-      return Promise.resolve(errorResponse(failingBody))
+      return Promise.resolve(errorResponse(failingCase))
     if (opts?.method === "POST" && url.endsWith("/api/agents"))
-      return Promise.resolve(
-        new Response(JSON.stringify(agentResponse("draft")), { status: 200 })
-      )
-    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    if (url.endsWith("/api/kb/collections"))
-      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
-    if (url.endsWith("/api/skills/"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    if (url.endsWith("/api/tools/available"))
-      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+      return Promise.resolve(jsonResponse(agentResponse("draft")))
     if (url.endsWith("/api/models/?category=llm"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      return Promise.resolve(jsonResponse([DEFAULT_MODEL]))
     if (url.endsWith("/api/models/user-default"))
       return Promise.resolve(
-        new Response(
-          JSON.stringify([{ config_type: "general", model: { id: 10 } }]),
-          { status: 200 }
-        )
+        jsonResponse([{ config_type: "general", model: { id: DEFAULT_MODEL.id } }])
       )
-    if (url.includes("/api/mcp/servers"))
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
-    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    return null
   })
 }
 
@@ -277,9 +336,11 @@ async function waitForLoadedBuilder() {
   )
 }
 
+// Exactly one error toast per failure: a second call would mean the action ran
+// twice, or that a validation toast leaked in before the action under test.
 async function expectToast(expected: string) {
   await waitFor(() => {
-    expect(toastErrorMock).toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
     expect(toastErrorMock.mock.calls.at(-1)?.[0]).toBe(expected)
   })
 }
@@ -292,29 +353,59 @@ beforeEach(() => {
 
 afterEach(() => cleanup())
 
-describe("AgentBuilder publish error handling (issue #969)", () => {
-  it.each(ERROR_CASES)(
-    "handles $name without unmounting the builder",
-    async ({ body, expected }) => {
-      installEditModeApi("draft", `/api/agents/${AGENT_ID}/publish`, body)
-      render(<AgentBuilder agentId={AGENT_ID} />)
-      await waitForLoadedBuilder()
+// The three edit-mode actions differ only in which agent status they load,
+// which POST fails, which control triggers them and which localized fallback
+// they own.
+const EDIT_MODE_ACTIONS = [
+  {
+    actionName: "publish",
+    status: "draft",
+    failingPath: `/api/agents/${AGENT_ID}/publish`,
+    clickText: "builds.editor.header.publish",
+    fallbackKey: "builds.publication.publishFailed",
+  },
+  {
+    actionName: "unpublish",
+    status: "published",
+    failingPath: `/api/agents/${AGENT_ID}/unpublish`,
+    clickText: "builds.editor.header.unpublish",
+    fallbackKey: "builds.publication.unpublishFailed",
+  },
+  {
+    actionName: "optimize instructions",
+    status: "draft",
+    failingPath: "/api/agents/optimize-instructions",
+    clickText: "builds.configForm.instructions.optimize",
+    fallbackKey: "builds.configForm.instructions.optimizeError",
+  },
+] as const
 
-      fireEvent.click(screen.getByText("builds.editor.header.publish"))
+describe.each(EDIT_MODE_ACTIONS)(
+  "AgentBuilder $actionName error handling (issue #969)",
+  ({ status, failingPath, clickText, fallbackKey }) => {
+    it.each(ERROR_CASES)(
+      "surfaces a displayable message for $name",
+      async (errorCase) => {
+        installEditModeApi(status, failingPath, errorCase)
+        render(<AgentBuilder agentId={AGENT_ID} />)
+        await waitForLoadedBuilder()
 
-      await expectToast(
-        expected === FALLBACK ? "builds.publication.publishFailed" : expected
-      )
-      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
-    }
-  )
-})
+        fireEvent.click(screen.getByText(clickText))
+
+        await expectToast(
+          errorCase.expected === FALLBACK ? fallbackKey : errorCase.expected
+        )
+        expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
+      }
+    )
+  }
+)
 
 describe("AgentBuilder network failure handling (issue #969)", () => {
   it("uses the generic fallback when the publish request itself rejects", async () => {
     // A transport-level rejection must not be swallowed by the response-body
     // parsing path: it hits the outer catch and shows the generic fallback.
-    installEditModeApi("draft", "__no_failing_path__", null)
+    installEditModeApi("draft", "__no_failing_path__", NO_FAILING_RESPONSE)
     const base = apiRequestMock.getMockImplementation()!
     apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
       if (opts?.method === "POST" && url.endsWith(`/api/agents/${AGENT_ID}/publish`))
@@ -331,49 +422,13 @@ describe("AgentBuilder network failure handling (issue #969)", () => {
   })
 })
 
-describe("AgentBuilder unpublish error handling (issue #969)", () => {
-  it.each(ERROR_CASES)(
-    "handles $name without unmounting the builder",
-    async ({ body, expected }) => {
-      installEditModeApi("published", `/api/agents/${AGENT_ID}/unpublish`, body)
-      render(<AgentBuilder agentId={AGENT_ID} />)
-      await waitForLoadedBuilder()
-
-      fireEvent.click(screen.getByText("builds.editor.header.unpublish"))
-
-      await expectToast(
-        expected === FALLBACK ? "builds.publication.unpublishFailed" : expected
-      )
-      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
-    }
-  )
-})
-
-describe("AgentBuilder optimize instructions error handling (issue #969)", () => {
-  it.each(ERROR_CASES)(
-    "handles $name without unmounting the builder",
-    async ({ body, expected }) => {
-      installEditModeApi("draft", "/api/agents/optimize-instructions", body)
-      render(<AgentBuilder agentId={AGENT_ID} />)
-      await waitForLoadedBuilder()
-
-      fireEvent.click(screen.getByText("builds.configForm.instructions.optimize"))
-
-      await expectToast(
-        expected === FALLBACK
-          ? "builds.configForm.instructions.optimizeError"
-          : expected
-      )
-      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
-    }
-  )
-})
-
+// Kept separate from the edit-mode table: this path has to create the agent
+// first, so it shares no setup with the three header actions.
 describe("AgentBuilder success-dialog publish error handling (issue #969)", () => {
   it.each(ERROR_CASES)(
-    "handles $name without unmounting the builder",
-    async ({ body, expected }) => {
-      installCreateModeApi(body)
+    "surfaces a displayable message for $name",
+    async (errorCase) => {
+      installCreateModeApi(errorCase)
       render(<AgentBuilder />)
 
       const nameInput = await screen.findByPlaceholderText(
@@ -387,22 +442,28 @@ describe("AgentBuilder success-dialog publish error handling (issue #969)", () =
       editor.textContent = "You are a new agent."
       fireEvent.input(editor)
 
-      // The default model arrives asynchronously from /api/models/user-default;
-      // retry the create click until validation passes and the dialog opens.
-      // After creation the header shows its own (disabled) publish button, so
-      // scope the click to the success dialog.
-      await waitFor(() => {
-        if (!screen.queryByRole("dialog")) {
-          fireEvent.click(screen.getByText("builds.editor.header.create"))
-        }
-        expect(screen.getByRole("dialog")).toBeInTheDocument()
-      })
-      fireEvent.click(
-        within(screen.getByRole("dialog")).getByText("builds.editor.header.publish")
+      // Creation is rejected while the general model is unset, and that value
+      // only lands once /api/models/user-default has been applied. The model
+      // Select mirrors it into data-value, so waiting for the id here ensures
+      // the state is committed before the one create click below.
+      await waitFor(() =>
+        expect(screen.getByTestId("model-select")).toHaveAttribute(
+          "data-value",
+          String(DEFAULT_MODEL.id)
+        )
       )
 
+      fireEvent.click(screen.getByText("builds.editor.header.create"))
+
+      // After creation the header keeps its own publish button, so scope the
+      // click to the success dialog.
+      const dialog = await screen.findByRole("dialog")
+      fireEvent.click(within(dialog).getByText("builds.editor.header.publish"))
+
       await expectToast(
-        expected === FALLBACK ? "builds.publication.publishFailed" : expected
+        errorCase.expected === FALLBACK
+          ? "builds.publication.publishFailed"
+          : errorCase.expected
       )
       // The background form is aria-hidden behind the dialog overlay, so
       // assert survival via the dialog staying mounted after the failure.

--- a/frontend/src/components/build/agent-builder-publish-errors.test.tsx
+++ b/frontend/src/components/build/agent-builder-publish-errors.test.tsx
@@ -1,0 +1,412 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Issue #969: the non-update builder actions (publish, unpublish, publish from
+// the creation success dialog, optimize instructions) must never pass a raw
+// `detail` payload to toast.error. Each action renders only displayable
+// strings, keeps its own localized fallback for unreadable or malformed
+// responses, and leaves the builder mounted after the failure.
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://api.local",
+    getWsUrl: () => "ws://api.local",
+  }
+})
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    state: {
+      messages: [],
+      traceEvents: [],
+      currentTask: null,
+      isProcessing: false,
+      isHistoryLoading: false,
+      taskId: null,
+      filePreview: { isOpen: false },
+      dagExecution: null,
+      steps: [],
+    },
+    setTaskId: vi.fn(),
+    sendMessage: vi.fn(),
+    dispatch: vi.fn(),
+    closeFilePreview: vi.fn(),
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    openFilePreview: vi.fn(),
+    requestStatus: vi.fn(),
+  }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token", user: { id: "1", is_admin: false } }),
+}))
+
+// The i18n return value must be referentially stable: AgentSshBindings keys a
+// fetch effect on `t`, so a per-render `t` identity turns that effect into an
+// unbounded fetch/render loop under jsdom.
+vi.mock("@/contexts/i18n-context", () => {
+  const i18n = {
+    locale: "en",
+    t: (key: string, vars?: Record<string, string>) =>
+      vars?.appName ? `${key}:${vars.appName}` : key,
+  }
+  return { useI18n: () => i18n }
+})
+
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => ({ apps: [], getAppIcon: () => null }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: toastErrorMock, success: vi.fn() } }))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("@/components/layout/resizable-three-column-layout", () => ({
+  ResizableThreeColumnLayout: ({ middlePanel }: { middlePanel: React.ReactNode }) => (
+    <div>{middlePanel}</div>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => null,
+}))
+
+vi.mock("@/components/build/agent-builder-chat", () => ({ AgentBuilderChat: () => null }))
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+vi.mock("@/components/mcp/connect-mcp-dialog", () => ({
+  ConnectMcpDialog: () => null,
+}))
+vi.mock("@/components/chat/FileMentionDropdown", () => ({ FileMentionDropdown: () => null }))
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    isOpen: false,
+    items: [],
+    selectedIndex: 0,
+    selectItem: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+vi.mock("@/components/ui/multi-select", () => ({
+  MultiSelect: () => <div data-testid="multi-select" />,
+}))
+vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+vi.mock("@/components/build/build-file-preview-sheet", () => ({
+  BuildFilePreviewSheet: () => null,
+}))
+
+import { AgentBuilder } from "./agent-builder"
+
+const AGENT_ID = "5"
+
+function agentResponse(status: "draft" | "published") {
+  return {
+    id: Number(AGENT_ID),
+    user_id: 1,
+    team_id: null,
+    name: "Existing Agent",
+    description: "",
+    instructions: "You are an existing agent.",
+    execution_mode: "balanced",
+    models: { general: "10" },
+    knowledge_bases: [],
+    skills: [],
+    tool_categories: ["basic"],
+    suggested_prompts: [],
+    logo_url: null,
+    status,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    widget_enabled: false,
+    allowed_domains: [],
+    share_enabled: false,
+    share_updated_at: null,
+    can_edit: true,
+  }
+}
+
+// Error payload matrix shared by every action: each case must surface
+// `expected` (with `FALLBACK` replaced by the action-specific i18n key)
+// instead of handing the raw payload to the toaster.
+const FALLBACK = "__ACTION_FALLBACK__"
+
+const ERROR_CASES = [
+  {
+    name: "a plain string detail",
+    body: JSON.stringify({ detail: " Action failed with string detail " }),
+    expected: "Action failed with string detail",
+  },
+  {
+    name: "a structured detail message",
+    body: JSON.stringify({ detail: { message: "Action failed", context: [] } }),
+    expected: "Action failed",
+  },
+  {
+    name: "a detail object without a readable message",
+    body: JSON.stringify({ detail: { code: 123 } }),
+    expected: FALLBACK,
+  },
+  {
+    name: "FastAPI validation detail messages",
+    body: JSON.stringify({
+      detail: [
+        { msg: " Field is required " },
+        " Invalid value ",
+        { message: " Unsupported option " },
+        { msg: " " },
+      ],
+    }),
+    expected: "Field is required; Invalid value; Unsupported option",
+  },
+  {
+    name: "a detail array without readable entries",
+    body: JSON.stringify({ detail: [1, true, null, { msg: " " }] }),
+    expected: FALLBACK,
+  },
+  {
+    name: "an empty response body",
+    body: null,
+    expected: FALLBACK,
+  },
+  {
+    name: "a non-JSON response body",
+    body: "<html>Bad Gateway</html>",
+    expected: FALLBACK,
+  },
+] as const
+
+function errorResponse(body: string | null) {
+  return new Response(body, {
+    status: 422,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function installEditModeApi(
+  status: "draft" | "published",
+  failingPath: string,
+  failingBody: string | null
+) {
+  apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+    if (opts?.method === "POST" && url.endsWith(failingPath))
+      return Promise.resolve(errorResponse(failingBody))
+    if (url.endsWith("/api/kb/collections"))
+      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
+    if (url.endsWith("/api/skills/"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/tools/available"))
+      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+    if (url.endsWith("/api/models/?category=llm"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/models/user-default"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith(`/api/agents/${AGENT_ID}`))
+      return Promise.resolve(
+        new Response(JSON.stringify(agentResponse(status)), { status: 200 })
+      )
+    if (url.includes("/api/mcp/servers"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+  })
+}
+
+// Create-mode mock for the success-dialog publish path: agent creation
+// succeeds (which opens the dialog), publish fails with the payload under test.
+function installCreateModeApi(failingBody: string | null) {
+  apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+    if (opts?.method === "POST" && url.endsWith(`/api/agents/${AGENT_ID}/publish`))
+      return Promise.resolve(errorResponse(failingBody))
+    if (opts?.method === "POST" && url.endsWith("/api/agents"))
+      return Promise.resolve(
+        new Response(JSON.stringify(agentResponse("draft")), { status: 200 })
+      )
+    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/kb/collections"))
+      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
+    if (url.endsWith("/api/skills/"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/tools/available"))
+      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+    if (url.endsWith("/api/models/?category=llm"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/models/user-default"))
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([{ config_type: "general", model: { id: 10 } }]),
+          { status: 200 }
+        )
+      )
+    if (url.includes("/api/mcp/servers"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+  })
+}
+
+async function waitForLoadedBuilder() {
+  await waitFor(() =>
+    expect(
+      screen.getByPlaceholderText("builds.configForm.name.placeholder")
+    ).toHaveValue("Existing Agent")
+  )
+}
+
+async function expectToast(expected: string) {
+  await waitFor(() => {
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(toastErrorMock.mock.calls.at(-1)?.[0]).toBe(expected)
+  })
+}
+
+beforeEach(() => {
+  apiRequestMock.mockReset()
+  toastErrorMock.mockReset()
+  globalThis.WebSocket = vi.fn() as unknown as typeof WebSocket
+})
+
+afterEach(() => cleanup())
+
+describe("AgentBuilder publish error handling (issue #969)", () => {
+  it.each(ERROR_CASES)(
+    "handles $name without unmounting the builder",
+    async ({ body, expected }) => {
+      installEditModeApi("draft", `/api/agents/${AGENT_ID}/publish`, body)
+      render(<AgentBuilder agentId={AGENT_ID} />)
+      await waitForLoadedBuilder()
+
+      fireEvent.click(screen.getByText("builds.editor.header.publish"))
+
+      await expectToast(
+        expected === FALLBACK ? "builds.publication.publishFailed" : expected
+      )
+      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
+    }
+  )
+})
+
+describe("AgentBuilder network failure handling (issue #969)", () => {
+  it("uses the generic fallback when the publish request itself rejects", async () => {
+    // A transport-level rejection must not be swallowed by the response-body
+    // parsing path: it hits the outer catch and shows the generic fallback.
+    installEditModeApi("draft", "__no_failing_path__", null)
+    const base = apiRequestMock.getMockImplementation()!
+    apiRequestMock.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (opts?.method === "POST" && url.endsWith(`/api/agents/${AGENT_ID}/publish`))
+        return Promise.reject(new TypeError("network down"))
+      return base(url, opts)
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await waitForLoadedBuilder()
+
+    fireEvent.click(screen.getByText("builds.editor.header.publish"))
+
+    await expectToast("builds.editor.error.unknown")
+    expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
+  })
+})
+
+describe("AgentBuilder unpublish error handling (issue #969)", () => {
+  it.each(ERROR_CASES)(
+    "handles $name without unmounting the builder",
+    async ({ body, expected }) => {
+      installEditModeApi("published", `/api/agents/${AGENT_ID}/unpublish`, body)
+      render(<AgentBuilder agentId={AGENT_ID} />)
+      await waitForLoadedBuilder()
+
+      fireEvent.click(screen.getByText("builds.editor.header.unpublish"))
+
+      await expectToast(
+        expected === FALLBACK ? "builds.publication.unpublishFailed" : expected
+      )
+      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
+    }
+  )
+})
+
+describe("AgentBuilder optimize instructions error handling (issue #969)", () => {
+  it.each(ERROR_CASES)(
+    "handles $name without unmounting the builder",
+    async ({ body, expected }) => {
+      installEditModeApi("draft", "/api/agents/optimize-instructions", body)
+      render(<AgentBuilder agentId={AGENT_ID} />)
+      await waitForLoadedBuilder()
+
+      fireEvent.click(screen.getByText("builds.configForm.instructions.optimize"))
+
+      await expectToast(
+        expected === FALLBACK
+          ? "builds.configForm.instructions.optimizeError"
+          : expected
+      )
+      expect(screen.getByDisplayValue("Existing Agent")).toBeInTheDocument()
+    }
+  )
+})
+
+describe("AgentBuilder success-dialog publish error handling (issue #969)", () => {
+  it.each(ERROR_CASES)(
+    "handles $name without unmounting the builder",
+    async ({ body, expected }) => {
+      installCreateModeApi(body)
+      render(<AgentBuilder />)
+
+      const nameInput = await screen.findByPlaceholderText(
+        "builds.configForm.name.placeholder"
+      )
+      fireEvent.change(nameInput, { target: { value: "New Agent" } })
+
+      // Instructions live in a contentEditable div, not a form control.
+      const editor = document.querySelector("[contenteditable]") as HTMLElement
+      expect(editor).toBeTruthy()
+      editor.textContent = "You are a new agent."
+      fireEvent.input(editor)
+
+      // The default model arrives asynchronously from /api/models/user-default;
+      // retry the create click until validation passes and the dialog opens.
+      // After creation the header shows its own (disabled) publish button, so
+      // scope the click to the success dialog.
+      await waitFor(() => {
+        if (!screen.queryByRole("dialog")) {
+          fireEvent.click(screen.getByText("builds.editor.header.create"))
+        }
+        expect(screen.getByRole("dialog")).toBeInTheDocument()
+      })
+      fireEvent.click(
+        within(screen.getByRole("dialog")).getByText("builds.editor.header.publish")
+      )
+
+      await expectToast(
+        expected === FALLBACK ? "builds.publication.publishFailed" : expected
+      )
+      // The background form is aria-hidden behind the dialog overlay, so
+      // assert survival via the dialog staying mounted after the failure.
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    }
+  )
+})

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -152,7 +152,11 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null
 }
 
-function getAgentUpdateErrorMessage(error: unknown, fallback: string): string {
+// Safe error-message path for the builder's response-body error branches:
+// only displayable strings may reach toast.error; objects and arrays are
+// reduced to their readable messages and anything else falls back to the
+// caller's localized message.
+function getBuilderErrorMessage(error: unknown, fallback: string): string {
   if (!isJsonRecord(error)) return fallback
 
   const detail = error.detail
@@ -1574,7 +1578,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       } else {
         const error: unknown = await response.json().catch(() => null)
         toast.error(
-          getAgentUpdateErrorMessage(error, t("builds.editor.error.unknown"))
+          getBuilderErrorMessage(error, t("builds.editor.error.unknown"))
         )
       }
     } catch (error) {
@@ -1602,8 +1606,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         })
         toast.success(t("builds.editor.success.published"))
       } else {
-        const error = await response.json()
-        toast.error(error.detail || t("builds.publication.publishFailed"))
+        const error: unknown = await response.json().catch(() => null)
+        toast.error(
+          getBuilderErrorMessage(error, t("builds.publication.publishFailed"))
+        )
       }
     } catch (error) {
       console.error("Failed to publish agent:", error)
@@ -1630,8 +1636,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         })
         toast.success(t("builds.editor.success.unpublished"))
       } else {
-        const error = await response.json()
-        toast.error(error.detail || t("builds.publication.unpublishFailed"))
+        const error: unknown = await response.json().catch(() => null)
+        toast.error(
+          getBuilderErrorMessage(error, t("builds.publication.unpublishFailed"))
+        )
       }
     } catch (error) {
       console.error("Failed to unpublish agent:", error)
@@ -1659,8 +1667,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           navPendingRef.current = true
         }
       } else {
-        const error = await response.json()
-        toast.error(error.detail || t("builds.publication.publishFailed"))
+        const error: unknown = await response.json().catch(() => null)
+        toast.error(
+          getBuilderErrorMessage(error, t("builds.publication.publishFailed"))
+        )
       }
     } catch (error) {
       console.error("Failed to publish agent:", error)
@@ -1706,8 +1716,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         setInstructions(data.optimized_instructions)
         toast.success(t("builds.configForm.instructions.optimizeSuccess"))
       } else {
-        const error = await response.json()
-        toast.error(error.detail || t("builds.configForm.instructions.optimizeError"))
+        const error: unknown = await response.json().catch(() => null)
+        toast.error(
+          getBuilderErrorMessage(
+            error,
+            t("builds.configForm.instructions.optimizeError")
+          )
+        )
       }
     } catch (error) {
       console.error("Failed to optimize instructions:", error)

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -152,19 +152,21 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null
 }
 
-// Safe error-message path for the builder's response-body error branches:
-// only displayable strings may reach toast.error; objects and arrays are
-// reduced to their readable messages and anything else falls back to the
-// caller's localized message.
-function getBuilderErrorMessage(error: unknown, fallback: string): string {
-  if (!isJsonRecord(error)) return fallback
+// Reduces a parsed error response body to a string that is safe to render.
+// Accepts, in order: a string `detail`, the readable message of an object
+// `detail`, the joined readable messages of an array `detail`, and a top-level
+// `message`. Anything else — including a body that failed to parse — yields the
+// supplied fallback, so an object or an array can never reach toast.error.
+function getBuilderErrorMessage(body: unknown, fallback: string): string {
+  if (!isJsonRecord(body)) return fallback
 
-  const detail = error.detail
+  const detail = body.detail
   const detailMessage = readNonEmptyString(detail)
   if (detailMessage) return detailMessage
 
   if (isJsonRecord(detail)) {
-    const message = readNonEmptyString(detail.message)
+    const message =
+      readNonEmptyString(detail.msg) ?? readNonEmptyString(detail.message)
     if (message) return message
   }
 
@@ -180,7 +182,7 @@ function getBuilderErrorMessage(error: unknown, fallback: string): string {
     if (messages.length > 0) return messages.join("; ")
   }
 
-  return readNonEmptyString(error.message) ?? fallback
+  return readNonEmptyString(body.message) ?? fallback
 }
 
 // One-time reveal of auto-generated webhook secrets. Rendered both inside the


### PR DESCRIPTION
## Summary

- route the four non-update Agent Builder actions (publish, unpublish, publish from the creation success dialog, optimize instructions) through the builder's single safe error-message path instead of passing `error.detail` straight to the toaster
- a structured FastAPI `detail` object or validation array can no longer crash the page; only displayable strings reach `toast.error`, with objects and arrays reduced to their readable messages
- parse failed response bodies without assuming valid JSON: each `response.json()` gets `.catch(() => null)`, matching the existing update path

The safe path is the helper PR #961 introduced for the update action (`getAgentUpdateErrorMessage`), renamed to `getBuilderErrorMessage` now that it serves the update path and all four non-update actions. The page's `throw new Error(...detail...)` branches in the ownership/save flow render degraded copy at worst and stay with #960 (see Scope).

Fixes #969. Related to #960, which tracks the backend error-contract standardization and the shared frontend error helper; this PR keeps backend contracts unchanged.

## Behavior change

Empty and non-JSON error bodies previously threw inside the handler and surfaced the generic `builds.editor.error.unknown` toast. They now fall back to each action's own localized message (`publishFailed` / `unpublishFailed` / `optimizeError`), per the issue's acceptance criteria. No test pinned the old behavior. Transport-level failures (fetch rejection) still reach the outer catch and the generic message; a regression test covers that boundary.

A top-level `message` field in an error response body is now surfaced for publish, unpublish and optimize instructions; previously these actions inspected only `detail`, so such a body fell back to the generic localized message. An object `detail` carrying `msg` is also read now (same precedence as the validation-array branch: `msg` before `message`, `detail` before the top-level field), and both paths are pinned by fixtures.

## Scope

The issue names exactly these four actions. Remaining unsafe `detail` consumers are intentionally untouched and belong to #960:

- same crash class (`toast.error(x.detail || ...)`): `app/tools/page.tsx` (5 sites), `components/mcp/connect-mcp-dialog.tsx` (2 sites)
- degraded-copy class (`throw new Error(x.detail ...)`, renders `[object Object]` but cannot crash): sites in `agent-builder.tsx` (update/ownership branches), `channels/page.tsx`, `public-agent-chat-page.tsx`, `knowledge-base-detail.tsx`, `workforce-edit-dialogs.tsx`, `deploy-agent-dialog.tsx`, `user-management.tsx`, `models.tsx`, `model-management-dialog.tsx`, `lib/agent-widget-config.ts`, `lib/models.ts`

`app/build/page.tsx`'s publish/unpublish path never reads `detail` (it renders fixed localized keys), so it needs no change.

## Validation

- new `agent-builder-publish-errors.test.tsx`: 41 tests — 4 actions x 10 payload shapes (string detail, structured detail via `message` or `msg`, detail-over-top-level precedence, unreadable object, validation array, unreadable array, bare top-level message, empty body, non-JSON 502 body) plus a fetch-rejection case; the original 7-shape matrix fails 26/28 against the previous code, and each case asserts exactly one toast call
- mutation checks: reverting any single call site to `error.detail ||` fails its 7 cases; removing `.catch(() => null)` from publish fails the empty/non-JSON cases; swapping an action's fallback key fails 4 cases. On the optimize action, removing `.catch(() => null)` is behavior-neutral (its outer catch uses the same `optimizeError` key), so that single mutation survives by design rather than by a coverage gap
- `tsc --noEmit` passes; the new test file is ESLint-clean (the repo's lint baseline has pre-existing errors elsewhere in `agent-builder.tsx`, untouched here); `src/i18n/translations.test.ts` passes (it pins the source-level usage counts of the publication keys)
- all four fallback keys verified present in both `en` and `zh` translations
- the pre-existing agent-builder test files have a known local-only failure on current main that is unrelated to this change; the new suite is self-contained and green
- note: CI's frontend lanes do not currently run `src/components/build/` tests (a pre-existing gap that also covers the other agent-builder suites), so this suite guards regressions in local runs until that lane is widened
