### PR TITLE
feat: add Growth Marketing Workforce template with type filtering

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1806,7 +1806,7 @@ describe("Home", () => {
 
       expect(templateDecoder.match(/return \{/g)).toHaveLength(1)
       expect(templateDecoder).toMatch(
-        /connections\.push\(\{ name: connection\.name, logo: connection\.logo \}\);[\s\S]*?return \{\s*id: value\.id,\s*name: value\.name,\s*category: value\.category,\s*description: value\.description,\s*features: \[\.\.\.value\.features\],\s*connections,\s*setup_time: value\.setup_time,\s*likes: value\.likes,\s*used_count: value\.used_count,\s*\};/,
+        /connections\.push\(\{ name: connection\.name, logo: connection\.logo \}\);[\s\S]*?return \{\s*id: value\.id,\s*name: value\.name,\s*category: value\.category,\s*description: value\.description,\s*features: \[\.\.\.value\.features\],\s*connections,\s*setup_time: value\.setup_time,\s*likes: value\.likes,\s*used_count: value\.used_count,[\s\S]*?type: typeof value\.type === "string" \? value\.type : "agent",\s*\};/,
       )
       expect(recentDecoder.match(/return \{/g)).toHaveLength(1)
       expect(recentDecoder).toMatch(

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -50,6 +50,7 @@ interface HomeTemplateCard {
   setup_time: string;
   likes: number;
   used_count: number;
+  type: string;
 }
 
 interface RecentTask {
@@ -99,6 +100,9 @@ function decodeHomeTemplateCard(value: unknown): HomeTemplateCard | null {
     setup_time: value.setup_time,
     likes: value.likes,
     used_count: value.used_count,
+    // Optional on the wire (older cached responses, other clients); default
+    // to "agent" like the backend does everywhere else.
+    type: typeof value.type === "string" ? value.type : "agent",
   };
 }
 
@@ -108,6 +112,12 @@ function decodeHomeTemplates(value: unknown): HomeTemplateCard[] | null {
   for (const template of value) {
     const decoded = decodeHomeTemplateCard(template);
     if (!decoded) return null;
+    // The home page's "Use Template" button only knows how to build a
+    // single agent (/build/new?template=). Workforce templates need the
+    // dedicated instantiation flow on the Templates page instead, so they
+    // are left out of this surface rather than silently producing a
+    // broken, empty-instruction agent (PR #1127 review).
+    if (decoded.type === "workforce") continue;
     templates.push(decoded);
   }
   return templates;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -116,7 +116,7 @@ function decodeHomeTemplates(value: unknown): HomeTemplateCard[] | null {
     // single agent (/build/new?template=). Workforce templates need the
     // dedicated instantiation flow on the Templates page instead, so they
     // are left out of this surface rather than silently producing a
-    // broken, empty-instruction agent (PR #1127 review).
+    // broken, empty-instruction agent.
     if (decoded.type === "workforce") continue;
     templates.push(decoded);
   }

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -80,7 +80,14 @@ function TaskHomePageContent() {
       const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`);
       if (response.ok) {
         const data = await response.json();
-        setTemplates(Array.isArray(data) ? data : []);
+        // Quick-access resolves a template straight into a single published
+        // agent (POST /api/agents/from-template/resolve) - a workforce
+        // template has no single-agent config to resolve, so it's excluded
+        // here rather than surfacing as a broken agent (PR #1127 review).
+        const agentTemplates = Array.isArray(data)
+          ? data.filter((template) => template?.type !== "workforce")
+          : [];
+        setTemplates(agentTemplates);
       } else {
         setTemplatesError(true);
       }

--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -83,7 +83,7 @@ function TaskHomePageContent() {
         // Quick-access resolves a template straight into a single published
         // agent (POST /api/agents/from-template/resolve) - a workforce
         // template has no single-agent config to resolve, so it's excluded
-        // here rather than surfacing as a broken agent (PR #1127 review).
+        // here rather than surfacing as a broken agent.
         const agentTemplates = Array.isArray(data)
           ? data.filter((template) => template?.type !== "workforce")
           : [];

--- a/frontend/src/app/templates/page.test.tsx
+++ b/frontend/src/app/templates/page.test.tsx
@@ -1,0 +1,254 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequestMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+const routerPushMock = vi.hoisted(() => vi.fn());
+const searchParamsMock = vi.hoisted(() => ({ value: new URLSearchParams() }));
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  );
+  return { ...actual, apiRequest: apiRequestMock };
+});
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return { ...actual, getApiUrl: () => "http://api.local" };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: toastErrorMock },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock, replace: vi.fn() }),
+  useSearchParams: () => searchParamsMock.value,
+}));
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string, vars?: Record<string, string | number>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+    locale: "en",
+  }),
+}));
+
+import TemplatesPage from "./page";
+import type { Template } from "@/types/template";
+
+function makeTemplate(overrides: Partial<Template> = {}): Template {
+  return {
+    id: "sales_assistant",
+    name: "Sales Assistant",
+    category: "Sales",
+    description: "A sales agent template",
+    features: [],
+    connections: [],
+    setup_time: "5 min setup",
+    tags: [],
+    author: "Xagent",
+    version: "1.0",
+    views: 0,
+    likes: 0,
+    used_count: 0,
+    type: "agent",
+    ...overrides,
+  };
+}
+
+const AGENT_TEMPLATE = makeTemplate();
+const WORKFORCE_TEMPLATE = makeTemplate({
+  id: "growth_workforce",
+  name: "Growth Marketing Workforce",
+  category: "Marketing",
+  description: "A workforce template",
+  type: "workforce",
+  agent_count: 3,
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Dispatches the page's requests by URL; POST behavior is injectable. */
+function installApiMock(
+  onUseAsWorkforce: () => Promise<Response> | Response = () =>
+    jsonResponse({ workforce_id: 7 })
+) {
+  apiRequestMock.mockImplementation(async (url: string, options?: RequestInit) => {
+    if (url.includes("/use-as-workforce")) return onUseAsWorkforce();
+    if (url.includes("/api/templates/?lang=")) {
+      return jsonResponse([AGENT_TEMPLATE, WORKFORCE_TEMPLATE]);
+    }
+    // Legacy /use analytics ping and anything else.
+    void options;
+    return jsonResponse({});
+  });
+}
+
+function cardOf(name: string): HTMLElement {
+  const card = screen.getByText(name).closest('[role="button"]');
+  expect(card).not.toBeNull();
+  return card as HTMLElement;
+}
+
+async function renderPage() {
+  render(<TemplatesPage />);
+  await waitFor(() => {
+    expect(screen.getByText("Sales Assistant")).toBeInTheDocument();
+  });
+}
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  toastErrorMock.mockReset();
+  routerPushMock.mockReset();
+  searchParamsMock.value = new URLSearchParams();
+});
+
+afterEach(cleanup);
+
+describe("TemplatesPage type filtering", () => {
+  it("shows all templates by default and filters to workforce-only via the type tab", async () => {
+    installApiMock();
+    await renderPage();
+
+    expect(screen.getByText("Growth Marketing Workforce")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "templates.typeFilter.workforce" })
+    );
+
+    expect(screen.getByText("Growth Marketing Workforce")).toBeInTheDocument();
+    expect(screen.queryByText("Sales Assistant")).not.toBeInTheDocument();
+  });
+
+  it("seeds the type filter from the ?type= query param", async () => {
+    searchParamsMock.value = new URLSearchParams("type=workforce");
+    installApiMock();
+    render(<TemplatesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Growth Marketing Workforce")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Sales Assistant")).not.toBeInTheDocument();
+  });
+});
+
+describe("TemplatesPage workforce creation", () => {
+  it("POSTs to use-as-workforce with the locale and navigates to the new canvas", async () => {
+    installApiMock(() => jsonResponse({ workforce_id: 7 }));
+    await renderPage();
+
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/workforces/7?view=canvas");
+    });
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/templates/growth_workforce/use-as-workforce?lang=en",
+      { method: "POST" }
+    );
+  });
+
+  it("maps the structured unpublished-agent error to a toast naming the agent", async () => {
+    installApiMock(() =>
+      jsonResponse(
+        {
+          detail: {
+            code: "workforce_worker_unpublished",
+            message: "unused by the frontend",
+            params: { agent_name: "GA Analyzer" },
+          },
+        },
+        400
+      )
+    );
+    await renderPage();
+
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'templates.errors.useWorkforceUnpublishedAgent:{"agentName":"GA Analyzer"}'
+      );
+    });
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it("maps the structured conflict code and falls back to the generic message otherwise", async () => {
+    installApiMock(() =>
+      jsonResponse(
+        { detail: { code: "workforce_create_conflict", message: "unused" } },
+        409
+      )
+    );
+    await renderPage();
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("templates.errors.useWorkforceRetry");
+    });
+
+    // Plain-string details (other endpoints' errors) fall back to generic.
+    toastErrorMock.mockReset();
+    installApiMock(() =>
+      jsonResponse({ detail: "Template is not a workforce template" }, 400)
+    );
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "templates.errors.useWorkforceFailed"
+      );
+    });
+  });
+
+  it("disables every other card while a workforce is being created", async () => {
+    let resolveUse: (response: Response) => void = () => {};
+    installApiMock(
+      () => new Promise<Response>((resolve) => (resolveUse = resolve))
+    );
+    await renderPage();
+
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+
+    await waitFor(() => {
+      expect(cardOf("Sales Assistant")).toHaveAttribute("aria-disabled", "true");
+    });
+
+    // Clicking the disabled agent card is inert: no /use ping, no navigation.
+    const callsBefore = apiRequestMock.mock.calls.length;
+    fireEvent.click(cardOf("Sales Assistant"));
+    expect(apiRequestMock.mock.calls.length).toBe(callsBefore);
+    expect(routerPushMock).not.toHaveBeenCalled();
+
+    resolveUse(jsonResponse({ workforce_id: 7 }));
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/workforces/7?view=canvas");
+    });
+  });
+
+  it("does not navigate or toast when the request completes after unmount", async () => {
+    let resolveUse: (response: Response) => void = () => {};
+    installApiMock(
+      () => new Promise<Response>((resolve) => (resolveUse = resolve))
+    );
+    await renderPage();
+
+    fireEvent.click(cardOf("Growth Marketing Workforce"));
+    cleanup();
+
+    resolveUse(jsonResponse({ workforce_id: 7 }));
+    // Give the resolved promise chain a tick to (incorrectly) fire if the
+    // mounted guard were missing.
+    await new Promise((tick) => setTimeout(tick, 0));
+
+    expect(routerPushMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useState, useEffect, useMemo } from "react";
 import { getApiUrl } from "@/lib/utils";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiRequest } from "@/lib/api-wrapper";
+import { toast } from "sonner";
 import { SearchInput } from "@/components/ui/search-input";
 import { PageHeader } from "@/components/ui/page-header";
 import { SegmentedTabs } from "@/components/ui/segmented-tabs";
@@ -58,6 +59,8 @@ function TemplatesPageContent() {
   const [selectedCategory, setSelectedCategory] = useState(
     () => searchParams.get("category") || "All"
   );
+  const [selectedType, setSelectedType] = useState("All");
+  const [creatingWorkforceId, setCreatingWorkforceId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
@@ -86,6 +89,11 @@ function TemplatesPageContent() {
     return key ? t(key) : formatFallbackLabel(c);
   };
 
+  const formatAgentsCount = (count: number) =>
+    count === 1
+      ? t("templates.agentsCountOne", { count })
+      : t("templates.agentsCountOther", { count });
+
   const categories = useMemo(() => {
     const preferred = ["Sales", "Marketing", "Support", "Research", "Productivity"];
     const dynamic = Array.from(new Set(templates.map((template) => template.category).filter(Boolean)));
@@ -100,6 +108,15 @@ function TemplatesPageContent() {
     ];
   }, [t, templates]);
 
+  const typeTabs = useMemo(
+    () => [
+      { id: "All", label: t("templates.typeFilter.all") },
+      { id: "agent", label: t("templates.typeFilter.agent") },
+      { id: "workforce", label: t("templates.typeFilter.workforce") },
+    ],
+    [t]
+  );
+
   const featuredTemplates = useMemo(
     () => templates.filter((template) => template.featured),
     [templates]
@@ -109,19 +126,22 @@ function TemplatesPageContent() {
     () =>
       templates.filter((template) => {
         const matchesCategory = selectedCategory === "All" || template.category === selectedCategory;
+        const matchesType =
+          selectedType === "All" || (template.type || "agent") === selectedType;
         const matchesSearch =
           !searchQuery ||
           template.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
           template.description.toLowerCase().includes(searchQuery.toLowerCase());
-        return matchesCategory && matchesSearch;
+        return matchesCategory && matchesType && matchesSearch;
       }),
-    [searchQuery, selectedCategory, templates]
+    [searchQuery, selectedCategory, selectedType, templates]
   );
 
   const sections = useMemo(() => {
     const grouped: Record<string, Template[]> = {};
     const featuredIds = new Set(featuredTemplates.map((template) => template.id));
-    const shouldHideFeaturedFromSections = selectedCategory === "All" && !searchQuery;
+    const shouldHideFeaturedFromSections =
+      selectedCategory === "All" && selectedType === "All" && !searchQuery;
 
     filteredTemplates.forEach((template) => {
       if (shouldHideFeaturedFromSections && featuredIds.has(template.id)) {
@@ -155,9 +175,38 @@ function TemplatesPageContent() {
     });
 
     return orderedSections;
-  }, [categories, featuredTemplates, filteredTemplates, searchQuery, selectedCategory]);
+  }, [categories, featuredTemplates, filteredTemplates, searchQuery, selectedCategory, selectedType]);
 
   const handleUseTemplate = async (templateId: string) => {
+    const template = templates.find((item) => item.id === templateId);
+    if (template?.type === "workforce") {
+      // Guards against a repeat click firing a second creation request while
+      // the first is still in flight (the card also disables itself via
+      // creatingWorkforceId, but that state update isn't synchronous).
+      if (creatingWorkforceId) return;
+      setCreatingWorkforceId(templateId);
+      try {
+        const response = await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use-as-workforce`, {
+          method: "POST",
+        });
+        if (response.ok) {
+          const data = await response.json();
+          router.push(`/workforces/${data.workforce_id}?view=canvas`);
+          return;
+        }
+        let message = t("templates.errors.useWorkforceFailed");
+        try {
+          const body = await response.json();
+          if (typeof body?.detail === "string" && body.detail) message = body.detail;
+        } catch { }
+        toast.error(message);
+      } catch {
+        toast.error(t("templates.errors.useWorkforceFailed"));
+      } finally {
+        setCreatingWorkforceId(null);
+      }
+      return;
+    }
     try {
       await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use`, { method: "POST" });
     } catch { }
@@ -191,17 +240,28 @@ function TemplatesPageContent() {
       />
 
       <div className="px-6 py-6 md:px-8">
-      {/* Segmented category filter */}
+      {/* Segmented category + type filters */}
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <SegmentedTabs
-          items={categories}
-          value={selectedCategory}
-          onValueChange={setSelectedCategory}
-          listClassName="gap-0.5 rounded-[13px] bg-muted p-1"
-          triggerClassName="rounded-[10px] px-4 py-2 text-sm duration-300"
-          activeTriggerClassName="bg-background font-semibold text-foreground shadow-sm"
-          inactiveTriggerClassName="font-medium text-muted-foreground hover:text-foreground"
-        />
+        <div className="flex flex-wrap items-center gap-3">
+          <SegmentedTabs
+            items={categories}
+            value={selectedCategory}
+            onValueChange={setSelectedCategory}
+            listClassName="gap-0.5 rounded-[13px] bg-muted p-1"
+            triggerClassName="rounded-[10px] px-4 py-2 text-sm duration-300"
+            activeTriggerClassName="bg-background font-semibold text-foreground shadow-sm"
+            inactiveTriggerClassName="font-medium text-muted-foreground hover:text-foreground"
+          />
+          <SegmentedTabs
+            items={typeTabs}
+            value={selectedType}
+            onValueChange={setSelectedType}
+            listClassName="gap-0.5 rounded-[13px] bg-muted p-1"
+            triggerClassName="rounded-[10px] px-4 py-2 text-sm duration-300"
+            activeTriggerClassName="bg-background font-semibold text-foreground shadow-sm"
+            inactiveTriggerClassName="font-medium text-muted-foreground hover:text-foreground"
+          />
+        </div>
         <span className="rounded-full bg-muted px-3 py-1.5 text-[13px] font-medium text-muted-foreground">
           {filteredTemplates.length === 1
             ? t("templates.countOne", { count: filteredTemplates.length })
@@ -217,7 +277,7 @@ function TemplatesPageContent() {
       ) : (
         <div className="flex flex-col gap-12">
           {/* Featured section */}
-          {selectedCategory === "All" && !searchQuery && featuredTemplates.length > 0 && (
+          {selectedCategory === "All" && selectedType === "All" && !searchQuery && featuredTemplates.length > 0 && (
             <TemplateSection
               title={t("templates.categoryTitles.featured")}
               count={featuredTemplates.length}
@@ -225,6 +285,10 @@ function TemplatesPageContent() {
               categoryLabel={categoryLabel}
               useLabel={t("templates.useTemplate")}
               defaultSetupTime={t("templates.defaultSetupTime")}
+              workforceBadgeLabel={t("templates.workforceBadge")}
+              formatAgentsCount={formatAgentsCount}
+              creatingWorkforceId={creatingWorkforceId}
+              busyLabel={t("templates.creatingWorkforce")}
               onUse={handleUseTemplate}
               onLike={handleLikeTemplate}
             />
@@ -240,6 +304,10 @@ function TemplatesPageContent() {
               categoryLabel={categoryLabel}
               useLabel={t("templates.useTemplate")}
               defaultSetupTime={t("templates.defaultSetupTime")}
+              workforceBadgeLabel={t("templates.workforceBadge")}
+              formatAgentsCount={formatAgentsCount}
+              creatingWorkforceId={creatingWorkforceId}
+              busyLabel={t("templates.creatingWorkforce")}
               onUse={handleUseTemplate}
               onLike={handleLikeTemplate}
             />
@@ -264,6 +332,10 @@ interface TemplateSectionProps {
   categoryLabel: (category: string) => string;
   useLabel: string;
   defaultSetupTime: string;
+  workforceBadgeLabel: string;
+  formatAgentsCount: (count: number) => string;
+  creatingWorkforceId: string | null;
+  busyLabel: string;
   onUse: (templateId: string) => void;
   onLike: (templateId: string, event: React.MouseEvent<HTMLButtonElement>) => void;
 }
@@ -275,6 +347,10 @@ function TemplateSection({
   categoryLabel,
   useLabel,
   defaultSetupTime,
+  workforceBadgeLabel,
+  formatAgentsCount,
+  creatingWorkforceId,
+  busyLabel,
   onUse,
   onLike,
 }: TemplateSectionProps) {
@@ -295,6 +371,10 @@ function TemplateSection({
             categoryLabel={categoryLabel(template.category)}
             useLabel={useLabel}
             defaultSetupTime={defaultSetupTime}
+            workforceBadgeLabel={workforceBadgeLabel}
+            formatAgentsCount={formatAgentsCount}
+            isBusy={creatingWorkforceId === template.id}
+            busyLabel={busyLabel}
             onUse={onUse}
             onLike={onLike}
           />

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -46,9 +46,9 @@ const formatFallbackLabel = (category: string) =>
 // src/xagent/web/services/workforce_creator.py), mapped here by machine
 // code rather than by byte-matching human-readable English strings - a
 // backend wording change used to silently degrade every mapped error to
-// the generic toast (PR #1127 re-review, m4). Any error without a mapped
-// code (including plain-string details from other paths) falls back to
-// the generic translated message rather than leaking raw English.
+// the generic toast. Any error without a mapped code (including
+// plain-string details from other paths) falls back to the generic
+// translated message rather than leaking raw English.
 const WORKFORCE_USE_ERROR_CODE_KEYS: Record<string, TranslationKey> = {
   workforce_create_access_denied: "templates.errors.useWorkforceAccessDenied",
   workforce_create_conflict: "templates.errors.useWorkforceRetry",
@@ -56,7 +56,7 @@ const WORKFORCE_USE_ERROR_CODE_KEYS: Record<string, TranslationKey> = {
 
 // Unlike the codes above, this error can never be resolved by retrying, so
 // it renders its own message interpolating the agent's name from
-// detail.params rather than a static translation (PR #1127 re-review, F1).
+// detail.params rather than a static translation.
 const WORKFORCE_WORKER_UNPUBLISHED_CODE = "workforce_worker_unpublished";
 
 export default function TemplatesPage() {
@@ -92,7 +92,7 @@ function TemplatesPageContent() {
   // in flight, the request still resolves - without this guard, its
   // .then()/finally would call setState and router.push on an unmounted
   // page, yanking the user back to the just-created workforce's canvas
-  // with no way to know why (PR #1127 re-review, M3).
+  // with no way to know why.
   const isMountedRef = useRef(true);
   useEffect(() => {
     isMountedRef.current = true;
@@ -217,8 +217,7 @@ function TemplatesPageContent() {
     // A workforce creation in flight locks EVERY card, not just other
     // workforce cards - clicking a plain Agent card mid-creation used to
     // still work, landing the user on /build/new only to be redirected back
-    // to the just-created workforce's canvas once that request resolved
-    // (PR #1127 re-review, M3).
+    // to the just-created workforce's canvas once that request resolved.
     if (creatingWorkforceId) return;
 
     const template = templates.find((item) => item.id === templateId);
@@ -431,7 +430,7 @@ function TemplateSection({
             busyLabel={busyLabel}
             // Locks every OTHER card - agent or workforce - while a
             // workforce is being created, matching the same-scoped lock
-            // handleUseTemplate now enforces (PR #1127 re-review, M3).
+            // handleUseTemplate enforces.
             disabled={
               creatingWorkforceId !== null && creatingWorkforceId !== template.id
             }

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -52,6 +52,16 @@ const WORKFORCE_USE_ERROR_KEYS: Record<string, TranslationKey> = {
     "templates.errors.useWorkforceRetry",
 };
 
+// Must match UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX in
+// src/xagent/web/services/workforce_creator.py exactly - a stable marker
+// for a message whose remainder (the agent's name) is too dynamic to be a
+// WORKFORCE_USE_ERROR_KEYS key. Unlike that map's generic 409, this error
+// can never be resolved by retrying, so it needs its own specific,
+// translated message rather than falling back to the generic one
+// (PR #1127 re-review, F1).
+const UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX =
+  "This workforce needs an agent that is currently unpublished: ";
+
 export default function TemplatesPage() {
   return (
     <Suspense fallback={null}>
@@ -203,7 +213,7 @@ function TemplatesPageContent() {
       if (creatingWorkforceId) return;
       setCreatingWorkforceId(templateId);
       try {
-        const response = await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use-as-workforce`, {
+        const response = await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use-as-workforce?lang=${locale}`, {
           method: "POST",
         });
         if (response.ok) {
@@ -213,8 +223,20 @@ function TemplatesPageContent() {
         }
         const parsed = await parseApiResponse(response);
         const rawDetail = getApiErrorMessage(response, parsed, "");
-        const messageKey = rawDetail ? WORKFORCE_USE_ERROR_KEYS[rawDetail] : undefined;
-        toast.error(messageKey ? t(messageKey) : t("templates.errors.useWorkforceFailed"));
+        if (rawDetail.startsWith(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX)) {
+          // The backend appends a fixed ". Republish it..." sentence after
+          // the agent's name; strip it by locating that known suffix from
+          // the END rather than splitting on the first ". " - an agent
+          // named e.g. "Mr. Smith Analyzer" must not be truncated to "Mr".
+          // Falls back to the whole remainder if the suffix ever changes.
+          const remainder = rawDetail.slice(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX.length);
+          const suffixStart = remainder.lastIndexOf(". Republish it");
+          const agentName = suffixStart > 0 ? remainder.slice(0, suffixStart) : remainder;
+          toast.error(t("templates.errors.useWorkforceUnpublishedAgent", { agentName }));
+        } else {
+          const messageKey = rawDetail ? WORKFORCE_USE_ERROR_KEYS[rawDetail] : undefined;
+          toast.error(messageKey ? t(messageKey) : t("templates.errors.useWorkforceFailed"));
+        }
       } catch {
         toast.error(t("templates.errors.useWorkforceFailed"));
       } finally {

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react";
 import { Suspense, useState, useEffect, useMemo } from "react";
 import { getApiUrl } from "@/lib/utils";
 import { useRouter, useSearchParams } from "next/navigation";
-import { apiRequest } from "@/lib/api-wrapper";
+import { apiRequest, getApiErrorMessage, parseApiResponse } from "@/lib/api-wrapper";
 import { toast } from "sonner";
 import { SearchInput } from "@/components/ui/search-input";
 import { PageHeader } from "@/components/ui/page-header";
@@ -41,6 +41,17 @@ const formatFallbackLabel = (category: string) =>
     .replace(/_/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
+// The backend's HTTPException `detail` strings are English-only and not
+// meant to be shown as-is to a zh-locale user. Only the exact, static
+// messages we control are mapped to a translated string; anything else
+// (including the dynamic template-id messages) falls back to the generic
+// translated error below rather than leaking raw English (PR #1127 review).
+const WORKFORCE_USE_ERROR_KEYS: Record<string, TranslationKey> = {
+  "Access denied": "templates.errors.useWorkforceAccessDenied",
+  "Could not create the workforce's worker agents due to a concurrent request; please try again.":
+    "templates.errors.useWorkforceRetry",
+};
+
 export default function TemplatesPage() {
   return (
     <Suspense fallback={null}>
@@ -59,7 +70,13 @@ function TemplatesPageContent() {
   const [selectedCategory, setSelectedCategory] = useState(
     () => searchParams.get("category") || "All"
   );
-  const [selectedType, setSelectedType] = useState("All");
+  // Same one-way seeding as selectedCategory above, for a ?type=<id> link.
+  // Neither is written back to the URL on change today, so - like
+  // selectedCategory - the current filter combination still isn't
+  // shareable via the address bar once the user changes it in-page.
+  const [selectedType, setSelectedType] = useState(
+    () => searchParams.get("type") || "All"
+  );
   const [creatingWorkforceId, setCreatingWorkforceId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [templates, setTemplates] = useState<Template[]>([]);
@@ -194,12 +211,10 @@ function TemplatesPageContent() {
           router.push(`/workforces/${data.workforce_id}?view=canvas`);
           return;
         }
-        let message = t("templates.errors.useWorkforceFailed");
-        try {
-          const body = await response.json();
-          if (typeof body?.detail === "string" && body.detail) message = body.detail;
-        } catch { }
-        toast.error(message);
+        const parsed = await parseApiResponse(response);
+        const rawDetail = getApiErrorMessage(response, parsed, "");
+        const messageKey = rawDetail ? WORKFORCE_USE_ERROR_KEYS[rawDetail] : undefined;
+        toast.error(messageKey ? t(messageKey) : t("templates.errors.useWorkforceFailed"));
       } catch {
         toast.error(t("templates.errors.useWorkforceFailed"));
       } finally {
@@ -375,6 +390,11 @@ function TemplateSection({
             formatAgentsCount={formatAgentsCount}
             isBusy={creatingWorkforceId === template.id}
             busyLabel={busyLabel}
+            disabled={
+              template.type === "workforce" &&
+              creatingWorkforceId !== null &&
+              creatingWorkforceId !== template.id
+            }
             onUse={onUse}
             onLike={onLike}
           />

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -2,10 +2,10 @@
 
 import { useI18n } from "@/contexts/i18n-context";
 import { Loader2 } from "lucide-react";
-import { Suspense, useState, useEffect, useMemo } from "react";
+import React, { Suspense, useState, useEffect, useMemo, useRef } from "react";
 import { getApiUrl } from "@/lib/utils";
 import { useRouter, useSearchParams } from "next/navigation";
-import { apiRequest, getApiErrorMessage, parseApiResponse } from "@/lib/api-wrapper";
+import { apiRequest, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
 import { toast } from "sonner";
 import { SearchInput } from "@/components/ui/search-input";
 import { PageHeader } from "@/components/ui/page-header";
@@ -41,26 +41,23 @@ const formatFallbackLabel = (category: string) =>
     .replace(/_/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
-// The backend's HTTPException `detail` strings are English-only and not
-// meant to be shown as-is to a zh-locale user. Only the exact, static
-// messages we control are mapped to a translated string; anything else
-// (including the dynamic template-id messages) falls back to the generic
-// translated error below rather than leaking raw English (PR #1127 review).
-const WORKFORCE_USE_ERROR_KEYS: Record<string, TranslationKey> = {
-  "Access denied": "templates.errors.useWorkforceAccessDenied",
-  "Could not create the workforce's worker agents due to a concurrent request; please try again.":
-    "templates.errors.useWorkforceRetry",
+// The workforce-creation error paths return a structured
+// `detail: {code, message, params}` (see the WORKFORCE_*_CODE constants in
+// src/xagent/web/services/workforce_creator.py), mapped here by machine
+// code rather than by byte-matching human-readable English strings - a
+// backend wording change used to silently degrade every mapped error to
+// the generic toast (PR #1127 re-review, m4). Any error without a mapped
+// code (including plain-string details from other paths) falls back to
+// the generic translated message rather than leaking raw English.
+const WORKFORCE_USE_ERROR_CODE_KEYS: Record<string, TranslationKey> = {
+  workforce_create_access_denied: "templates.errors.useWorkforceAccessDenied",
+  workforce_create_conflict: "templates.errors.useWorkforceRetry",
 };
 
-// Must match UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX in
-// src/xagent/web/services/workforce_creator.py exactly - a stable marker
-// for a message whose remainder (the agent's name) is too dynamic to be a
-// WORKFORCE_USE_ERROR_KEYS key. Unlike that map's generic 409, this error
-// can never be resolved by retrying, so it needs its own specific,
-// translated message rather than falling back to the generic one
-// (PR #1127 re-review, F1).
-const UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX =
-  "This workforce needs an agent that is currently unpublished: ";
+// Unlike the codes above, this error can never be resolved by retrying, so
+// it renders its own message interpolating the agent's name from
+// detail.params rather than a static translation (PR #1127 re-review, F1).
+const WORKFORCE_WORKER_UNPUBLISHED_CODE = "workforce_worker_unpublished";
 
 export default function TemplatesPage() {
   return (
@@ -91,6 +88,18 @@ function TemplatesPageContent() {
   const [searchQuery, setSearchQuery] = useState("");
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
+  // If the user navigates away while a workforce creation request is still
+  // in flight, the request still resolves - without this guard, its
+  // .then()/finally would call setState and router.push on an unmounted
+  // page, yanking the user back to the just-created workforce's canvas
+  // with no way to know why (PR #1127 re-review, M3).
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     const fetchTemplates = async () => {
@@ -205,48 +214,56 @@ function TemplatesPageContent() {
   }, [categories, featuredTemplates, filteredTemplates, searchQuery, selectedCategory, selectedType]);
 
   const handleUseTemplate = async (templateId: string) => {
+    // A workforce creation in flight locks EVERY card, not just other
+    // workforce cards - clicking a plain Agent card mid-creation used to
+    // still work, landing the user on /build/new only to be redirected back
+    // to the just-created workforce's canvas once that request resolved
+    // (PR #1127 re-review, M3).
+    if (creatingWorkforceId) return;
+
     const template = templates.find((item) => item.id === templateId);
     if (template?.type === "workforce") {
-      // Guards against a repeat click firing a second creation request while
-      // the first is still in flight (the card also disables itself via
-      // creatingWorkforceId, but that state update isn't synchronous).
-      if (creatingWorkforceId) return;
       setCreatingWorkforceId(templateId);
       try {
         const response = await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use-as-workforce?lang=${locale}`, {
           method: "POST",
         });
+        // The user may have navigated away while this request was in
+        // flight; the workforce still got created (or not) server-side
+        // either way, but this page must not act on that anymore.
+        if (!isMountedRef.current) return;
         if (response.ok) {
           const data = await response.json();
+          if (!isMountedRef.current) return;
           router.push(`/workforces/${data.workforce_id}?view=canvas`);
           return;
         }
         const parsed = await parseApiResponse(response);
-        const rawDetail = getApiErrorMessage(response, parsed, "");
-        if (rawDetail.startsWith(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX)) {
-          // The backend appends a fixed ". Republish it..." sentence after
-          // the agent's name; strip it by locating that known suffix from
-          // the END rather than splitting on the first ". " - an agent
-          // named e.g. "Mr. Smith Analyzer" must not be truncated to "Mr".
-          // Falls back to the whole remainder if the suffix ever changes.
-          const remainder = rawDetail.slice(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX.length);
-          const suffixStart = remainder.lastIndexOf(". Republish it");
-          const agentName = suffixStart > 0 ? remainder.slice(0, suffixStart) : remainder;
+        const detail = isJsonRecord(parsed.data) ? parsed.data.detail : null;
+        const code =
+          isJsonRecord(detail) && typeof detail.code === "string" ? detail.code : null;
+        if (code === WORKFORCE_WORKER_UNPUBLISHED_CODE) {
+          const params = isJsonRecord(detail) ? detail.params : null;
+          const agentName =
+            isJsonRecord(params) && typeof params.agent_name === "string"
+              ? params.agent_name
+              : "";
           toast.error(t("templates.errors.useWorkforceUnpublishedAgent", { agentName }));
         } else {
-          const messageKey = rawDetail ? WORKFORCE_USE_ERROR_KEYS[rawDetail] : undefined;
+          const messageKey = code ? WORKFORCE_USE_ERROR_CODE_KEYS[code] : undefined;
           toast.error(messageKey ? t(messageKey) : t("templates.errors.useWorkforceFailed"));
         }
       } catch {
-        toast.error(t("templates.errors.useWorkforceFailed"));
+        if (isMountedRef.current) toast.error(t("templates.errors.useWorkforceFailed"));
       } finally {
-        setCreatingWorkforceId(null);
+        if (isMountedRef.current) setCreatingWorkforceId(null);
       }
       return;
     }
     try {
       await apiRequest(`${getApiUrl()}/api/templates/${templateId}/use`, { method: "POST" });
     } catch { }
+    if (!isMountedRef.current) return;
     router.push(`/build/new?template=${templateId}`);
   };
 
@@ -412,10 +429,11 @@ function TemplateSection({
             formatAgentsCount={formatAgentsCount}
             isBusy={creatingWorkforceId === template.id}
             busyLabel={busyLabel}
+            // Locks every OTHER card - agent or workforce - while a
+            // workforce is being created, matching the same-scoped lock
+            // handleUseTemplate now enforces (PR #1127 re-review, M3).
             disabled={
-              template.type === "workforce" &&
-              creatingWorkforceId !== null &&
-              creatingWorkforceId !== template.id
+              creatingWorkforceId !== null && creatingWorkforceId !== template.id
             }
             onUse={onUse}
             onLike={onLike}

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -921,6 +921,16 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         )
         if (response.ok) {
           const template = await response.json()
+          if (template.type === "workforce") {
+            // This builder only knows how to configure a single agent.
+            // A workforce template's agent_config is always null (see
+            // TemplateManager._enrich_template) - bail out loudly instead
+            // of silently publishing an agent with empty instructions
+            // (PR #1127 review).
+            toast.error(t("builds.editor.error.templateIsWorkforce"))
+            router.replace("/templates")
+            return
+          }
           setName(template.name || "")
           setDescription(template.description || "")
           setInstructions(template.agent_config?.instructions || "")

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -925,8 +925,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             // This builder only knows how to configure a single agent.
             // A workforce template's agent_config is always null (see
             // TemplateManager._enrich_template) - bail out loudly instead
-            // of silently publishing an agent with empty instructions
-            // (PR #1127 review).
+            // of silently publishing an agent with empty instructions.
             toast.error(t("builds.editor.error.templateIsWorkforce"))
             router.replace("/templates")
             return

--- a/frontend/src/components/templates/library-template-card.test.tsx
+++ b/frontend/src/components/templates/library-template-card.test.tsx
@@ -49,8 +49,7 @@ describe("LibraryTemplateCard", () => {
       <LibraryTemplateCard
         template={makeTemplate({
           type: "workforce",
-          manager_name: "Growth Marketing Manager",
-          worker_names: ["GA Analyzer", "Ads Recommendation"],
+          agent_count: 3,
         })}
         useLabel="Use Template"
         defaultSetupTime="5 min setup"

--- a/frontend/src/components/templates/library-template-card.test.tsx
+++ b/frontend/src/components/templates/library-template-card.test.tsx
@@ -41,7 +41,10 @@ describe("LibraryTemplateCard", () => {
     expect(screen.queryByText("Workforce")).not.toBeInTheDocument();
   });
 
-  it("shows the workforce badge with the worker count for a workforce template", () => {
+  it("shows the workforce badge with the total agent count (manager + workers)", () => {
+    // The badge label reads "N agents" - the count must include the
+    // manager, or it undercounts against what "Use" actually creates
+    // (PR #1127 re-review, F6a).
     render(
       <LibraryTemplateCard
         template={makeTemplate({
@@ -58,7 +61,7 @@ describe("LibraryTemplateCard", () => {
     );
 
     expect(screen.getByText(/Workforce/)).toBeInTheDocument();
-    expect(screen.getByText(/2 agents/)).toBeInTheDocument();
+    expect(screen.getByText(/3 agents/)).toBeInTheDocument();
   });
 
   it("calls onUse when the card is clicked", () => {

--- a/frontend/src/components/templates/library-template-card.test.tsx
+++ b/frontend/src/components/templates/library-template-card.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LibraryTemplateCard } from "./library-template-card";
+import type { Template } from "@/types/template";
+
+function makeTemplate(overrides: Partial<Template> = {}): Template {
+  return {
+    id: "tmpl-1",
+    name: "Test Template",
+    category: "Marketing",
+    description: "A test template",
+    features: [],
+    connections: [],
+    setup_time: "5 min setup",
+    tags: [],
+    author: "Xagent",
+    version: "1.0",
+    views: 0,
+    likes: 0,
+    used_count: 0,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("LibraryTemplateCard", () => {
+  it("does not show the workforce badge for a plain agent template", () => {
+    render(
+      <LibraryTemplateCard
+        template={makeTemplate({ type: "agent" })}
+        useLabel="Use Template"
+        defaultSetupTime="5 min setup"
+        workforceBadgeLabel="Workforce"
+        onUse={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Workforce")).not.toBeInTheDocument();
+  });
+
+  it("shows the workforce badge with the worker count for a workforce template", () => {
+    render(
+      <LibraryTemplateCard
+        template={makeTemplate({
+          type: "workforce",
+          manager_name: "Growth Marketing Manager",
+          worker_names: ["GA Analyzer", "Ads Recommendation"],
+        })}
+        useLabel="Use Template"
+        defaultSetupTime="5 min setup"
+        workforceBadgeLabel="Workforce"
+        formatAgentsCount={(count) => `${count} agents`}
+        onUse={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/Workforce/)).toBeInTheDocument();
+    expect(screen.getByText(/2 agents/)).toBeInTheDocument();
+  });
+
+  it("calls onUse when the card is clicked", () => {
+    const onUse = vi.fn();
+    render(
+      <LibraryTemplateCard
+        template={makeTemplate({ id: "tmpl-42" })}
+        useLabel="Use Template"
+        defaultSetupTime="5 min setup"
+        onUse={onUse}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Use Template" }));
+
+    expect(onUse).toHaveBeenCalledWith("tmpl-42");
+  });
+
+  it("disables activation and shows the busy label while isBusy is true", () => {
+    const onUse = vi.fn();
+    const { container } = render(
+      <LibraryTemplateCard
+        template={makeTemplate({ id: "tmpl-42", type: "workforce" })}
+        useLabel="Use Template"
+        defaultSetupTime="5 min setup"
+        isBusy
+        busyLabel="Creating..."
+        onUse={onUse}
+      />
+    );
+
+    expect(screen.getByText("Creating...")).toBeInTheDocument();
+    // The card also has a "like" button; the "Use" button is the last of
+    // the two native <button>s. The outer clickable wrapper is a
+    // <div role="button">, whose computed accessible name also contains
+    // "Creating...", so querying by role/name here would be ambiguous.
+    const buttons = container.querySelectorAll("button");
+    const useButton = buttons[buttons.length - 1];
+    expect(useButton).toBeDisabled();
+
+    fireEvent.click(useButton!);
+    // The whole card is also clickable; clicking anywhere on it while busy
+    // must not fire onUse either.
+    fireEvent.click(container.querySelector('[role="button"]')!);
+
+    expect(onUse).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -110,7 +110,7 @@ export function LibraryTemplateCard({
   };
   const isWorkforce = template.type === "workforce";
   // Server-computed manager + workers total, matching what "Use" actually
-  // creates (PR #1127 re-review, F6a).
+  // creates.
   const totalAgentCount = template.agent_count || 0;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type KeyboardEvent, type MouseEvent } from "react";
-import { Clock, Heart, Play } from "lucide-react";
+import { Clock, Heart, Loader2, Play, Users } from "lucide-react";
 import type { Template } from "@/types/template";
 import { cn } from "@/lib/utils";
 import { isNestedInteractiveElement } from "./template-card-utils";
@@ -11,6 +11,14 @@ interface LibraryTemplateCardProps {
   categoryLabel?: string;
   useLabel: string;
   defaultSetupTime: string;
+  workforceBadgeLabel?: string;
+  formatAgentsCount?: (count: number) => string;
+  /** True while this specific template's "Use" action is in flight (currently only
+   * meaningful for workforce templates, which create real records server-side and
+   * can take a few seconds). Disables activation and swaps the button to a spinner
+   * so a slow request can't be re-triggered by an impatient repeat click. */
+  isBusy?: boolean;
+  busyLabel?: string;
   onUse: (templateId: string) => void;
   onLike?: (templateId: string, event: MouseEvent<HTMLButtonElement>) => void;
   className?: string;
@@ -79,11 +87,22 @@ export function LibraryTemplateCard({
   categoryLabel,
   useLabel,
   defaultSetupTime,
+  workforceBadgeLabel,
+  formatAgentsCount,
+  isBusy,
+  busyLabel,
   onUse,
   onLike,
   className,
 }: LibraryTemplateCardProps) {
-  const handleActivate = () => onUse(template.id);
+  const handleActivate = () => {
+    if (isBusy) return;
+    onUse(template.id);
+  };
+  const isWorkforce = template.type === "workforce";
+  // First entry is the manager (see get_workforce_agent_names on the
+  // backend); the rest are the workers this workforce actually runs.
+  const workerCount = Math.max((template.workforce_agents?.length || 0) - 1, 0);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (isNestedInteractiveElement(event.target, event.currentTarget)) {
@@ -103,24 +122,36 @@ export function LibraryTemplateCard({
     <div
       role="button"
       tabIndex={0}
+      aria-disabled={isBusy || undefined}
+      aria-busy={isBusy || undefined}
       onClick={handleActivate}
       onKeyDown={handleKeyDown}
       className={cn(
         "group flex h-full cursor-pointer flex-col rounded-[18px] border border-border bg-card p-5 shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-transparent hover:shadow-[0_16px_40px_rgba(0,0,0,0.11)]",
+        isBusy && "cursor-wait opacity-70",
         className
       )}
     >
-      {/* Category pill + setup time */}
+      {/* Category pill + workforce badge + setup time */}
       <div className="mb-3.5 flex items-center justify-between gap-2">
-        <span
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-[9px] py-1 text-[11.5px] font-semibold",
-            pill
-          )}
-        >
-          <span className="h-[5px] w-[5px] rounded-full bg-current" />
-          {categoryLabel || template.category}
-        </span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-[9px] py-1 text-[11.5px] font-semibold",
+              pill
+            )}
+          >
+            <span className="h-[5px] w-[5px] rounded-full bg-current" />
+            {categoryLabel || template.category}
+          </span>
+          {isWorkforce ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-teal-50 px-[9px] py-1 text-[11.5px] font-semibold text-teal-700 dark:bg-teal-950/50 dark:text-teal-300">
+              <Users className="h-3 w-3 flex-shrink-0" />
+              {workforceBadgeLabel}
+              {workerCount > 0 && formatAgentsCount ? ` · ${formatAgentsCount(workerCount)}` : ""}
+            </span>
+          ) : null}
+        </div>
         {template.setup_time || defaultSetupTime ? (
           <span className="flex items-center gap-1 whitespace-nowrap text-[11.5px] font-medium text-muted-foreground">
             <Clock className="h-3 w-3 flex-shrink-0" />
@@ -176,13 +207,21 @@ export function LibraryTemplateCard({
 
       <button
         type="button"
-        className="mt-4 h-[38px] rounded-[10px] bg-primary/10 text-[13.5px] font-semibold text-primary transition-all duration-300 hover:bg-primary hover:text-primary-foreground active:scale-[0.98]"
+        disabled={isBusy}
+        className="mt-4 flex h-[38px] items-center justify-center gap-1.5 rounded-[10px] bg-primary/10 text-[13.5px] font-semibold text-primary transition-all duration-300 hover:bg-primary hover:text-primary-foreground active:scale-[0.98] disabled:cursor-wait disabled:opacity-70 disabled:hover:bg-primary/10 disabled:hover:text-primary"
         onClick={(event) => {
           event.stopPropagation();
           handleActivate();
         }}
       >
-        {useLabel}
+        {isBusy ? (
+          <>
+            <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" />
+            {busyLabel || useLabel}
+          </>
+        ) : (
+          useLabel
+        )}
       </button>
     </div>
   );

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type KeyboardEvent, type MouseEvent } from "react";
+import React, { type KeyboardEvent, type MouseEvent } from "react";
 import { Clock, Heart, Loader2, Play, Users } from "lucide-react";
 import type { Template } from "@/types/template";
 import { cn } from "@/lib/utils";
@@ -19,6 +19,13 @@ interface LibraryTemplateCardProps {
    * so a slow request can't be re-triggered by an impatient repeat click. */
   isBusy?: boolean;
   busyLabel?: string;
+  /** True when a *different* workforce template is currently being created
+   * (creatingWorkforceId is a single global lock, not per-card - see
+   * templates/page.tsx). Blocks activation like isBusy, but without
+   * claiming this card itself is the one in flight: no spinner, no label
+   * swap, just a visibly disabled state instead of a click that silently
+   * does nothing. */
+  disabled?: boolean;
   onUse: (templateId: string) => void;
   onLike?: (templateId: string, event: MouseEvent<HTMLButtonElement>) => void;
   className?: string;
@@ -91,18 +98,18 @@ export function LibraryTemplateCard({
   formatAgentsCount,
   isBusy,
   busyLabel,
+  disabled,
   onUse,
   onLike,
   className,
 }: LibraryTemplateCardProps) {
+  const isBlocked = isBusy || disabled;
   const handleActivate = () => {
-    if (isBusy) return;
+    if (isBlocked) return;
     onUse(template.id);
   };
   const isWorkforce = template.type === "workforce";
-  // First entry is the manager (see get_workforce_agent_names on the
-  // backend); the rest are the workers this workforce actually runs.
-  const workerCount = Math.max((template.workforce_agents?.length || 0) - 1, 0);
+  const workerCount = template.worker_names?.length || 0;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (isNestedInteractiveElement(event.target, event.currentTarget)) {
@@ -122,13 +129,14 @@ export function LibraryTemplateCard({
     <div
       role="button"
       tabIndex={0}
-      aria-disabled={isBusy || undefined}
+      aria-disabled={isBlocked || undefined}
       aria-busy={isBusy || undefined}
       onClick={handleActivate}
       onKeyDown={handleKeyDown}
       className={cn(
         "group flex h-full cursor-pointer flex-col rounded-[18px] border border-border bg-card p-5 shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-transparent hover:shadow-[0_16px_40px_rgba(0,0,0,0.11)]",
         isBusy && "cursor-wait opacity-70",
+        disabled && !isBusy && "cursor-not-allowed opacity-50",
         className
       )}
     >
@@ -207,8 +215,11 @@ export function LibraryTemplateCard({
 
       <button
         type="button"
-        disabled={isBusy}
-        className="mt-4 flex h-[38px] items-center justify-center gap-1.5 rounded-[10px] bg-primary/10 text-[13.5px] font-semibold text-primary transition-all duration-300 hover:bg-primary hover:text-primary-foreground active:scale-[0.98] disabled:cursor-wait disabled:opacity-70 disabled:hover:bg-primary/10 disabled:hover:text-primary"
+        disabled={isBlocked}
+        className={cn(
+          "mt-4 flex h-[38px] items-center justify-center gap-1.5 rounded-[10px] bg-primary/10 text-[13.5px] font-semibold text-primary transition-all duration-300 hover:bg-primary hover:text-primary-foreground active:scale-[0.98] disabled:opacity-70 disabled:hover:bg-primary/10 disabled:hover:text-primary",
+          isBusy ? "disabled:cursor-wait" : "disabled:cursor-not-allowed"
+        )}
         onClick={(event) => {
           event.stopPropagation();
           handleActivate();

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -109,7 +109,11 @@ export function LibraryTemplateCard({
     onUse(template.id);
   };
   const isWorkforce = template.type === "workforce";
-  const workerCount = template.worker_names?.length || 0;
+  // Manager + workers - the badge label reads "N agents", so the count
+  // must include the manager too, or it undercounts by one against what
+  // "Use" actually creates (PR #1127 re-review, F6a).
+  const totalAgentCount =
+    (template.worker_names?.length || 0) + (template.manager_name ? 1 : 0);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (isNestedInteractiveElement(event.target, event.currentTarget)) {
@@ -156,7 +160,7 @@ export function LibraryTemplateCard({
             <span className="inline-flex items-center gap-1 rounded-full bg-teal-50 px-[9px] py-1 text-[11.5px] font-semibold text-teal-700 dark:bg-teal-950/50 dark:text-teal-300">
               <Users className="h-3 w-3 flex-shrink-0" />
               {workforceBadgeLabel}
-              {workerCount > 0 && formatAgentsCount ? ` · ${formatAgentsCount(workerCount)}` : ""}
+              {totalAgentCount > 0 && formatAgentsCount ? ` · ${formatAgentsCount(totalAgentCount)}` : ""}
             </span>
           ) : null}
         </div>

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -109,11 +109,9 @@ export function LibraryTemplateCard({
     onUse(template.id);
   };
   const isWorkforce = template.type === "workforce";
-  // Manager + workers - the badge label reads "N agents", so the count
-  // must include the manager too, or it undercounts by one against what
-  // "Use" actually creates (PR #1127 re-review, F6a).
-  const totalAgentCount =
-    (template.worker_names?.length || 0) + (template.manager_name ? 1 : 0);
+  // Server-computed manager + workers total, matching what "Use" actually
+  // creates (PR #1127 re-review, F6a).
+  const totalAgentCount = template.agent_count || 0;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (isNestedInteractiveElement(event.target, event.currentTarget)) {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1584,7 +1584,8 @@ Build when you need.`,
     errors: {
       useWorkforceFailed: "Couldn't create the workforce from this template. Please try again.",
       useWorkforceAccessDenied: "You don't have permission to create a workforce.",
-      useWorkforceRetry: "Too many concurrent requests for this template. Please try again."
+      useWorkforceRetry: "Too many concurrent requests for this template. Please try again.",
+      useWorkforceUnpublishedAgent: "The \"{agentName}\" agent this workforce needs is currently unpublished. Republish it from your Agents list, then try again."
     }
   },
   sidebar: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1582,7 +1582,9 @@ Build when you need.`,
     agentsCountOther: "{count} agents",
     creatingWorkforce: "Creating...",
     errors: {
-      useWorkforceFailed: "Couldn't create the workforce from this template. Please try again."
+      useWorkforceFailed: "Couldn't create the workforce from this template. Please try again.",
+      useWorkforceAccessDenied: "You don't have permission to create a workforce.",
+      useWorkforceRetry: "Too many concurrent requests for this template. Please try again."
     }
   },
   sidebar: {
@@ -2464,6 +2466,7 @@ Build when you need.`,
         unknown: "An unknown error occurred",
         notFound: "Agent not found",
         notFoundDesc: "The agent you are looking for does not exist or has been deleted.",
+        templateIsWorkforce: "This template creates a workforce, not a single agent. Use it from the Templates page instead.",
       },
       kbToolWarning: {
         title: "Knowledge Tools Required",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1572,6 +1572,18 @@ Build when you need.`,
       knowledge: "Knowledge & Research",
       sales: "Sales & Outreach"
     },
+    typeFilter: {
+      all: "All types",
+      agent: "Agent",
+      workforce: "Workforce"
+    },
+    workforceBadge: "Workforce",
+    agentsCountOne: "{count} agent",
+    agentsCountOther: "{count} agents",
+    creatingWorkforce: "Creating...",
+    errors: {
+      useWorkforceFailed: "Couldn't create the workforce from this template. Please try again."
+    }
   },
   sidebar: {
     tasks: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1582,7 +1582,9 @@ const zh = {
     agentsCountOther: "{count} 个智能体",
     creatingWorkforce: "创建中…",
     errors: {
-      useWorkforceFailed: "从该模版创建工作组失败，请重试。"
+      useWorkforceFailed: "从该模版创建工作组失败，请重试。",
+      useWorkforceAccessDenied: "你没有权限创建工作组。",
+      useWorkforceRetry: "该模版当前并发请求过多，请重试。"
     }
   },
   sidebar: {
@@ -2464,6 +2466,7 @@ const zh = {
         unknown: "发生未知错误",
         notFound: "Agent 不存在",
         notFoundDesc: "该 Agent 不存在或已被删除",
+        templateIsWorkforce: "该模版会创建一个工作组，而不是单个智能体，请在 Templates 页面使用它。",
       },
       kbToolWarning: {
         title: "需要启用知识库工具",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1572,6 +1572,18 @@ const zh = {
       knowledge: "知识与研究",
       sales: "销售与外联"
     },
+    typeFilter: {
+      all: "全部类型",
+      agent: "智能体",
+      workforce: "工作组"
+    },
+    workforceBadge: "工作组",
+    agentsCountOne: "{count} 个智能体",
+    agentsCountOther: "{count} 个智能体",
+    creatingWorkforce: "创建中…",
+    errors: {
+      useWorkforceFailed: "从该模版创建工作组失败，请重试。"
+    }
   },
   sidebar: {
     tasks: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1584,7 +1584,8 @@ const zh = {
     errors: {
       useWorkforceFailed: "从该模版创建工作组失败，请重试。",
       useWorkforceAccessDenied: "你没有权限创建工作组。",
-      useWorkforceRetry: "该模版当前并发请求过多，请重试。"
+      useWorkforceRetry: "该模版当前并发请求过多，请重试。",
+      useWorkforceUnpublishedAgent: "该工作组需要的智能体「{agentName}」当前未发布，请在你的智能体列表中重新发布它，然后再试一次。"
     }
   },
   sidebar: {

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -39,8 +39,10 @@ export interface Template {
   is_liked?: boolean;
   /** "agent" (default) for a single-agent template, "workforce" for a manager + worker-agents template. */
   type?: TemplateType;
-  /** Manager + worker agent display names, manager first. Empty for "agent"-type templates. */
-  workforce_agents?: string[];
+  /** Display name of the manager agent. Null/absent for "agent"-type templates. */
+  manager_name?: string | null;
+  /** Display names of the worker agents. Empty for "agent"-type templates. */
+  worker_names?: string[];
 }
 
 export interface TemplateDetail extends Template {

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -39,10 +39,8 @@ export interface Template {
   is_liked?: boolean;
   /** "agent" (default) for a single-agent template, "workforce" for a manager + worker-agents template. */
   type?: TemplateType;
-  /** Display name of the manager agent. Null/absent for "agent"-type templates. */
-  manager_name?: string | null;
-  /** Display names of the worker agents. Empty for "agent"-type templates. */
-  worker_names?: string[];
+  /** Total agents (manager + workers) a "workforce"-type template creates. 0 for "agent"-type templates. */
+  agent_count?: number;
 }
 
 export interface TemplateDetail extends Template {

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -18,6 +18,8 @@ export interface SamplePrompt {
   highlights?: string[];
 }
 
+export type TemplateType = "agent" | "workforce";
+
 export interface Template {
   id: string;
   name: string;
@@ -35,10 +37,17 @@ export interface Template {
   likes: number;
   used_count: number;
   is_liked?: boolean;
+  /** "agent" (default) for a single-agent template, "workforce" for a manager + worker-agents template. */
+  type?: TemplateType;
+  /** Manager + worker agent display names, manager first. Empty for "agent"-type templates. */
+  workforce_agents?: string[];
 }
 
 export interface TemplateDetail extends Template {
-  agent_config: AgentConfig;
+  /** Populated for an "agent"-type template. Null/absent for "workforce"-type templates,
+   * which are configured via `workforce_config` instead. */
+  agent_config?: AgentConfig | null;
+  workforce_config?: Record<string, unknown> | null;
 }
 
 export type TemplateWithStats = Template;

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -43,8 +43,8 @@ sample_prompts:
 # of what marketing-google-analytics-analyzer and
 # marketing-google-ads-recommendation actually declare under their own
 # `connections:`, so the card doesn't advertise an integration this
-# workforce doesn't have (PR #1127 re-review, F7: this previously listed
-# "Google Analytics", which neither sub-template connects to at all).
+# workforce doesn't have (this previously listed "Google Analytics",
+# which neither sub-template connects to at all).
 connections:
 - name: Google Docs
   logo: https://www.google.com/s2/favicons?domain=docs.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -36,12 +36,20 @@ sample_prompts:
     - 重新运行 GA Analyzer
 # Display-only for this workforce template: the connection icons shown on
 # its Templates gallery card. Unlike an 'agent'-type template, these are
-# NOT merged into any agent's tool_categories - the manager's own tools
-# come from workforce_config.manager.tool_categories below, and its
-# workers' tools come from their own referenced single-agent templates.
+# NOT merged into any agent's tool_categories - GET /{id} nulls agent_config
+# for a workforce type, the manager's own tools come from
+# workforce_config.manager.tool_categories below, and its workers' tools
+# come from their own referenced single-agent templates. Kept as the union
+# of what marketing-google-analytics-analyzer and
+# marketing-google-ads-recommendation actually declare under their own
+# `connections:`, so the card doesn't advertise an integration this
+# workforce doesn't have (PR #1127 re-review, F7: this previously listed
+# "Google Analytics", which neither sub-template connects to at all).
 connections:
-- name: Google Analytics
-  logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64
+- name: Google Docs
+  logo: https://www.google.com/s2/favicons?domain=docs.google.com&sz=64
+- name: Google Slides
+  logo: https://www.google.com/s2/favicons?domain=slides.google.com&sz=64
 - name: Google Ads
   logo: https://www.google.com/s2/favicons?domain=ads.google.com&sz=64
 setup_time:

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -34,6 +34,11 @@ sample_prompts:
     prompt: 我已经按照你上次的建议调整了广告——重新运行 GA Analyzer 来测量效果。
     highlights:
     - 重新运行 GA Analyzer
+# Display-only for this workforce template: the connection icons shown on
+# its Templates gallery card. Unlike an 'agent'-type template, these are
+# NOT merged into any agent's tool_categories - the manager's own tools
+# come from workforce_config.manager.tool_categories below, and its
+# workers' tools come from their own referenced single-agent templates.
 connections:
 - name: Google Analytics
   logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -1,0 +1,100 @@
+id: marketing-growth-marketing-workforce
+name: Growth Marketing Workforce
+category: Marketing
+type: workforce
+featured: false
+descriptions:
+  en: The Growth Marketing Manager orchestrates two specialist sub-agents in a closed loop that ties on-site performance to ad spend — Google Analytics Analyzer explains what's happening, Google Ads Recommendation proposes what to do — measure, recommend, wait for your approval, then measure again.
+  zh: Growth Marketing Manager 编排两个专业子智能体，形成一个将网站端表现与广告投放绑定的闭环——Google Analytics Analyzer 负责解释发生了什么，Google Ads Recommendation 负责提出应对方案——测量、推荐、等待您审批，再次测量。
+features:
+  en:
+  - Growth Marketing Manager orchestrates the GA Analyzer and Ads Recommendation agents as a single point of contact — you get one consolidated report, not two
+  - Closed loop — GA Analyzer measures on-site performance and emits a 'Signals for Ads' table; Ads Recommendation joins those signals with ad spend and ranks fixes by revenue impact
+  - Recommend-only, never applies changes — pauses after each round for your approval, then re-measures impact once you've made the changes
+  zh:
+  - Growth Marketing Manager 统一编排 GA Analyzer 与 Ads Recommendation，作为唯一对接窗口——您收到的是一份合并报告，而不是两份独立报告
+  - 闭环流程——GA Analyzer 测量网站端表现并输出「广告信号」表格；Ads Recommendation 将这些信号与广告花费结合，按收入影响对优化项排序
+  - 仅推荐、从不自动执行——每一轮结束后暂停等待您审批，待您完成调整后再次测量效果
+sample_prompts:
+  en:
+  - title: Run this week's growth loop
+    prompt: Run the measure-then-recommend loop for this week — tell me what changed in GA4 and which ad changes you'd prioritize.
+    highlights:
+    - measure-then-recommend loop
+  - title: Re-measure after my changes
+    prompt: I've made the ad changes you recommended last time — re-run the GA Analyzer to measure the impact.
+    highlights:
+    - re-run the GA Analyzer
+  zh:
+  - title: 运行本周的增长闭环
+    prompt: 运行本周的测量-推荐闭环——告诉我 GA4 有哪些变化，以及你会优先推荐哪些广告调整。
+    highlights:
+    - 测量-推荐闭环
+  - title: 调整后重新测量
+    prompt: 我已经按照你上次的建议调整了广告——重新运行 GA Analyzer 来测量效果。
+    highlights:
+    - 重新运行 GA Analyzer
+connections:
+- name: Google Analytics
+  logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64
+- name: Google Ads
+  logo: https://www.google.com/s2/favicons?domain=ads.google.com&sz=64
+setup_time:
+  en: 10 min setup
+  zh: 10分钟配置
+workforce_config:
+  manager:
+    name: Growth Marketing Manager
+    description: Orchestrates the GA Analyzer and Ads Recommendation sub-agents in a measure, recommend, human-input, measure loop.
+    execution_mode: think
+    tool_categories:
+    - basic
+    skills: []
+    instructions: |
+      # Role & Purpose
+
+      You are the Growth Marketing Manager — the workforce lead. You orchestrate two specialists, the Google Analytics Analyzer and the Google Ads Recommendation agent, and you are the single point of contact for the user: you reply once, with one consolidated report.
+
+      # Goal
+
+      Run a measure → recommend → wait for the user → measure loop that ties on-site performance (GA4) to paid spend (Google Ads). You never change ad accounts yourself; the user applies the changes.
+
+      # Responsibilities
+
+      1. **Delegate to GA Analyzer** — Ask the GA Analyzer to produce 'Signals for Ads' (on-site performance by campaign / source).
+      2. **Pass signals to Ads Recommendation** — Hand those signals to the Ads Recommendation agent to generate prioritized optimizations.
+      3. **Assemble one report** — Combine what's happening (GA) with what to do (Ads) into a single consolidated report, with numbers reconciled between the two agents.
+      4. **Pause for approval** — Do not apply anything. Present the recommendations and pause — the user makes the ad changes themselves.
+      5. **Re-measure** — When the user confirms changes are done, re-run the GA Analyzer to measure impact, then repeat the loop.
+
+      # Operating Guidelines
+
+      - **Diagnosis before recommendation** — Always run the GA Analyzer before the Ads Recommendation agent.
+      - **Missing signals** — If GA signals are missing, tell the Ads Recommendation agent to proceed ads-only and flag it in your report.
+      - **Hold the loop** — Stop at the approval step until the user returns; never loop on your own.
+      - **Data contract** — The GA Analyzer emits, per campaign / source: sessions · CVR · conversions · value · verdict (winning / underperforming). The Ads Recommendation agent consumes it keyed by campaign / UTM. Keep these column names as-is when passing data between them.
+      - **Recommend only** — Never auto-apply ad changes or touch spend / account settings, and don't let either sub-agent do so either.
+      - **Reconcile numbers** — Both agents may report similar figures from different sources (on-site vs ad-platform); call out and resolve any discrepancy before presenting the combined report.
+      - **One consolidated reply** — Never forward the two agents' raw outputs separately; merge them into a single report.
+      - **Confirm before re-measuring** — Ask the user to confirm changes are live before you re-run the GA Analyzer to measure impact.
+      - **Cite date ranges** — Always state the date range each part of the report covers.
+
+      # Tone & Personality
+
+      Decisive and synthesis-first. Lead with the combined picture — what changed and what to do about it — before handing over agent-by-agent detail.
+
+      # Reminders
+
+      - You are the only agent the user talks to; the GA Analyzer and Ads Recommendation agent work for you, not the user directly.
+      - Never apply ad changes. Always pause for explicit user approval before considering a round complete.
+  agents:
+  - template_id: marketing-google-analytics-analyzer
+    name: Google Analytics Analyzer
+    alias: GA Analyzer
+    assignment_instructions: |
+      Produce a 'Signals for Ads' table: for each campaign / source, report sessions, CVR, conversions, value, and a verdict (winning / underperforming), comparing the current period to the prior period of equal length. Ask the Growth Marketing Manager for the GA4 export or period range if you don't already have it.
+  - template_id: marketing-google-ads-recommendation
+    name: Google Ads Recommendation
+    alias: Ads Recommendation
+    assignment_instructions: |
+      Using the 'Signals for Ads' table from the GA Analyzer joined with Google Ads performance data (spend, CTR, CPA, conversions, search terms) by campaign / UTM, produce a ranked list of budget, keyword, negative-keyword and copy recommendations for approval. Never apply changes automatically.

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -204,12 +204,12 @@ class TemplateManager:
         that YAML happened to parse for one of these fields used to slip
         through load-time validation and only surface downstream - as a
         garbage prompt or template id, or as an `AttributeError` → 500 when
-        `normalize_text(...).strip()` hit a non-string `description`/`alias`
-        (PR #1127 re-review, m1). Writing the stripped value back also
-        keeps the duplicate-check and the runtime lookup seeing the same
-        `template_id` - previously a template id with surrounding
-        whitespace was stripped for the duplicate check but looked up raw,
-        guaranteeing a "references an unknown template" 400 at use time.
+        `normalize_text(...).strip()` hit a non-string `description`/`alias`.
+        Writing the stripped value back also keeps the duplicate-check and
+        the runtime lookup seeing the same `template_id` - previously a
+        template id with surrounding whitespace was stripped for the
+        duplicate check but looked up raw, guaranteeing a "references an
+        unknown template" 400 at use time.
         """
         value = container.get(key)
         if value is None and not required:
@@ -246,7 +246,7 @@ class TemplateManager:
             # validation - a typo here would only surface as a broken
             # manager agent at instantiation time, out of step with how
             # carefully the rest of workforce_config is checked at load
-            # time (PR #1127 re-review, F10).
+            # time.
             raise ValueError(
                 "'workforce_config.manager.execution_mode' must be one of "
                 f"{sorted(_VALID_EXECUTION_MODES)}, got {execution_mode!r}"
@@ -285,7 +285,7 @@ class TemplateManager:
                 # worker agent make the template permanently unusable: the
                 # second create_workforce_worker() call 409s on the
                 # (workforce_id, agent_id) unique constraint every time this
-                # template is instantiated (PR #1127 review).
+                # template is instantiated.
                 raise ValueError(
                     f"'workforce_config.agents' has a duplicate template_id: "
                     f"{template_id!r}"
@@ -350,8 +350,7 @@ class TemplateManager:
         remembering to check `type` first - a workforce template's
         `agent_config` used to leak real (if useless) `instructions`/
         `tool_categories` here, which is exactly what silently produced a
-        published, empty-instruction agent on every un-gated path (PR
-        #1127 review).
+        published, empty-instruction agent on every un-gated path.
         """
         connections = template.get("connections", [])
         template_type = template.get("type", "agent")

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -193,14 +193,40 @@ class TemplateManager:
 
         return data
 
+    @staticmethod
+    def _require_string(
+        container: Dict[str, Any], key: str, *, path: str, required: bool = True
+    ) -> None:
+        """Enforce that `container[key]` is a real (optionally absent)
+        string, and write the stripped value back in place.
+
+        Strict `isinstance` rather than `str(...)` coercion: a list/dict/int
+        that YAML happened to parse for one of these fields used to slip
+        through load-time validation and only surface downstream - as a
+        garbage prompt or template id, or as an `AttributeError` → 500 when
+        `normalize_text(...).strip()` hit a non-string `description`/`alias`
+        (PR #1127 re-review, m1). Writing the stripped value back also
+        keeps the duplicate-check and the runtime lookup seeing the same
+        `template_id` - previously a template id with surrounding
+        whitespace was stripped for the duplicate check but looked up raw,
+        guaranteeing a "references an unknown template" 400 at use time.
+        """
+        value = container.get(key)
+        if value is None and not required:
+            return
+        if not isinstance(value, str) or not value.strip():
+            requirement = "a non-empty string" if required else "a string or omitted"
+            raise ValueError(f"'{path}.{key}' must be {requirement}")
+        container[key] = value.strip()
+
     def _validate_workforce_config(self, workforce_config: Any) -> None:
         """Validate the shape of `workforce_config` for a workforce-type
-        template. A workforce template is instantiated as a fresh manager
-        agent (defined inline via `manager.instructions`) plus one worker
-        agent per `agents[]` entry, each reused/created from an existing
-        template id (`agents[].template_id`) - see
-        `create_workforce_from_template` in
-        `xagent.web.services.workforce_creator`.
+        template, normalizing (stripping) its string fields in place. A
+        workforce template is instantiated as a fresh manager agent
+        (defined inline via `manager.instructions`) plus one worker agent
+        per `agents[]` entry, each reused/created from an existing template
+        id (`agents[].template_id`) - see `create_workforce_from_template`
+        in `xagent.web.services.workforce_creator`.
         """
         if not isinstance(workforce_config, dict):
             raise ValueError(
@@ -208,17 +234,12 @@ class TemplateManager:
             )
 
         manager = workforce_config.get("manager")
-        if (
-            not isinstance(manager, dict)
-            or not str(manager.get("instructions") or "").strip()
-        ):
-            raise ValueError(
-                "'workforce_config.manager.instructions' must be a non-empty string"
-            )
-        if not str(manager.get("name") or "").strip():
-            raise ValueError(
-                "'workforce_config.manager.name' must be a non-empty string"
-            )
+        if not isinstance(manager, dict):
+            raise ValueError("'workforce_config.manager' must be a mapping")
+        manager_path = "workforce_config.manager"
+        self._require_string(manager, "instructions", path=manager_path)
+        self._require_string(manager, "name", path=manager_path)
+        self._require_string(manager, "description", path=manager_path, required=False)
         execution_mode = manager.get("execution_mode")
         if execution_mode is not None and execution_mode not in _VALID_EXECUTION_MODES:
             # Passed straight into AgentStore.add_agent with no further
@@ -249,11 +270,16 @@ class TemplateManager:
                 raise ValueError(
                     f"'workforce_config.agents[{index}]' must be a mapping"
                 )
-            template_id = str(agent.get("template_id") or "").strip()
-            if not template_id:
-                raise ValueError(
-                    f"'workforce_config.agents[{index}].template_id' must be a non-empty string"
-                )
+            agent_path = f"workforce_config.agents[{index}]"
+            self._require_string(agent, "template_id", path=agent_path)
+            self._require_string(agent, "assignment_instructions", path=agent_path)
+            self._require_string(agent, "alias", path=agent_path, required=False)
+            # Required so every worker has a stable display name - the
+            # card's agent-count badge used to silently omit a nameless
+            # worker rather than surface the gap, undercounting.
+            self._require_string(agent, "name", path=agent_path)
+
+            template_id = agent["template_id"]
             if template_id in seen_template_ids:
                 # Two agents[] entries resolving to the same quick-access
                 # worker agent make the template permanently unusable: the
@@ -265,18 +291,6 @@ class TemplateManager:
                     f"{template_id!r}"
                 )
             seen_template_ids.add(template_id)
-            if not str(agent.get("name") or "").strip():
-                # Required so every worker has a stable display name -
-                # `get_workforce_agent_names` used to silently omit a
-                # nameless worker rather than surface the gap, which
-                # undercounted the card's agent-count badge.
-                raise ValueError(
-                    f"'workforce_config.agents[{index}].name' must be a non-empty string"
-                )
-            if not str(agent.get("assignment_instructions") or "").strip():
-                raise ValueError(
-                    f"'workforce_config.agents[{index}].assignment_instructions' must be a non-empty string"
-                )
 
     def _validate_sample_prompts(self, sample_prompts: Any) -> None:
         """Validate the (optional) sample_prompts shape at parse time, the
@@ -342,48 +356,31 @@ class TemplateManager:
         connections = template.get("connections", [])
         template_type = template.get("type", "agent")
 
-        if template_type != "agent":
-            return {
-                "id": template["id"],
-                "name": template["name"],
-                "category": template.get("category", ""),
-                "featured": template.get("featured", False),
-                "descriptions": template.get("descriptions", {}),
-                "features": template.get("features", {}),
-                "sample_prompts": template.get("sample_prompts", {}),
-                "connections": connections,
-                "setup_time": template.get("setup_time", "5 min setup"),
-                "tags": template.get("tags", {}),
-                "author": template.get("author", ""),
-                "version": template.get("version", ""),
-                "agent_config": None,
-                "type": template_type,
-                "workforce_config": template.get("workforce_config"),
-            }
+        agent_config_dict: Optional[Dict[str, Any]] = None
+        if template_type == "agent":
+            # The agent_config could be an AgentConfig pydantic model or a dict
+            agent_config = template.get("agent_config", {})
 
-        # The agent_config could be an AgentConfig pydantic model or a dict
-        agent_config = template.get("agent_config", {})
+            if hasattr(agent_config, "model_dump"):
+                agent_config_dict = agent_config.model_dump()
+            elif hasattr(agent_config, "dict"):
+                agent_config_dict = agent_config.dict()
+            else:
+                agent_config_dict = dict(agent_config)
 
-        if hasattr(agent_config, "model_dump"):
-            agent_config_dict = agent_config.model_dump()
-        elif hasattr(agent_config, "dict"):
-            agent_config_dict = agent_config.dict()
-        else:
-            agent_config_dict = dict(agent_config)
+            tool_categories = agent_config_dict.get("tool_categories", [])
+            if not isinstance(tool_categories, list):
+                tool_categories = list(tool_categories) if tool_categories else []
 
-        tool_categories = agent_config_dict.get("tool_categories", [])
-        if not isinstance(tool_categories, list):
-            tool_categories = list(tool_categories) if tool_categories else []
+            for conn in connections:
+                conn_name = conn.get("name") if isinstance(conn, dict) else conn
+                if not conn_name:
+                    continue
+                mcp_category = f"mcp:{conn_name}"
+                if mcp_category not in tool_categories:
+                    tool_categories.append(mcp_category)
 
-        for conn in connections:
-            conn_name = conn.get("name") if isinstance(conn, dict) else conn
-            if not conn_name:
-                continue
-            mcp_category = f"mcp:{conn_name}"
-            if mcp_category not in tool_categories:
-                tool_categories.append(mcp_category)
-
-        agent_config_dict["tool_categories"] = tool_categories
+            agent_config_dict["tool_categories"] = tool_categories
 
         return {
             "id": template["id"],

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -88,11 +88,14 @@ class TemplateManager:
     def _warn_on_dangling_workforce_references(self) -> None:
         """A workforce template's `workforce_config.agents[].template_id`
         values are only checked at parse time for being non-empty strings
-        (per-file validation can't know about other files yet). Once every
-        template is loaded, cross-check each one against the full cache so a
-        typo'd reference is logged loudly at startup instead of only
+        (per-file validation can't know about other files yet, and can't
+        know the referenced template's own `type`). Once every template is
+        loaded, cross-check each one against the full cache so a typo'd or
+        wrongly-typed reference is logged loudly at startup instead of only
         surfacing as a 400 the first time a user clicks "Use" on that
-        template.
+        template. Logged at `warning`, not `error`: this is a template
+        authoring problem the process can fully continue past, not a
+        request-time failure.
         """
         for template in self._templates_cache.values():
             if template.get("type") != "workforce":
@@ -100,13 +103,31 @@ class TemplateManager:
             workforce_config = template.get("workforce_config") or {}
             for agent in workforce_config.get("agents") or []:
                 referenced_id = agent.get("template_id")
-                if referenced_id and referenced_id not in self._templates_cache:
-                    logger.error(
+                if not referenced_id:
+                    continue
+                referenced_template = self._templates_cache.get(referenced_id)
+                if referenced_template is None:
+                    logger.warning(
                         "Workforce template %r references unknown template_id "
                         "%r in workforce_config.agents - instantiating it will "
                         "fail until this is fixed",
                         template.get("id"),
                         referenced_id,
+                    )
+                elif referenced_template.get("type", "agent") != "agent":
+                    # A worker must resolve to a single-agent template - see
+                    # the matching runtime guard in
+                    # workforce_creator._get_or_create_quick_access_worker_agent,
+                    # which would otherwise try to read a null agent_config
+                    # off the referenced (workforce-type) template.
+                    logger.warning(
+                        "Workforce template %r references template_id %r in "
+                        "workforce_config.agents, but that template's type is "
+                        "%r, not 'agent' - instantiating it will fail until "
+                        "this is fixed",
+                        template.get("id"),
+                        referenced_id,
+                        referenced_template.get("type"),
                     )
 
     def _parse_yaml_file(self, yaml_file: Path) -> Dict[str, Any]:
@@ -197,14 +218,35 @@ class TemplateManager:
         agents = workforce_config.get("agents")
         if not isinstance(agents, list) or not agents:
             raise ValueError("'workforce_config.agents' must be a non-empty list")
+        seen_template_ids: set[str] = set()
         for index, agent in enumerate(agents):
             if not isinstance(agent, dict):
                 raise ValueError(
                     f"'workforce_config.agents[{index}]' must be a mapping"
                 )
-            if not str(agent.get("template_id") or "").strip():
+            template_id = str(agent.get("template_id") or "").strip()
+            if not template_id:
                 raise ValueError(
                     f"'workforce_config.agents[{index}].template_id' must be a non-empty string"
+                )
+            if template_id in seen_template_ids:
+                # Two agents[] entries resolving to the same quick-access
+                # worker agent make the template permanently unusable: the
+                # second create_workforce_worker() call 409s on the
+                # (workforce_id, agent_id) unique constraint every time this
+                # template is instantiated (PR #1127 review).
+                raise ValueError(
+                    f"'workforce_config.agents' has a duplicate template_id: "
+                    f"{template_id!r}"
+                )
+            seen_template_ids.add(template_id)
+            if not str(agent.get("name") or "").strip():
+                # Required so every worker has a stable display name -
+                # `get_workforce_agent_names` used to silently omit a
+                # nameless worker rather than surface the gap, which
+                # undercounted the card's agent-count badge.
+                raise ValueError(
+                    f"'workforce_config.agents[{index}].name' must be a non-empty string"
                 )
             if not str(agent.get("assignment_instructions") or "").strip():
                 raise ValueError(
@@ -255,8 +297,44 @@ class TemplateManager:
                     )
 
     def _enrich_template(self, template: Dict[str, Any]) -> Dict[str, Any]:
-        """Merge connections into agent_config.tool_categories"""
+        """Merge connections into agent_config.tool_categories.
+
+        `agent_config` is only meaningful for an 'agent'-type template; a
+        'workforce'-type template's real configuration lives in
+        `workforce_config` instead (its own top-level `agent_config` is an
+        unused parse-time placeholder - see `_parse_yaml_file`). Nulling it
+        out here, rather than in each caller, is deliberate: every consumer
+        of a template dict (the Templates API, the home page feed, the
+        /task quick-access resolver, the v1 SDK API, and anything added
+        later) reads this same enriched dict, and a non-agent template
+        must fail safe by construction rather than by every caller
+        remembering to check `type` first - a workforce template's
+        `agent_config` used to leak real (if useless) `instructions`/
+        `tool_categories` here, which is exactly what silently produced a
+        published, empty-instruction agent on every un-gated path (PR
+        #1127 review).
+        """
         connections = template.get("connections", [])
+        template_type = template.get("type", "agent")
+
+        if template_type != "agent":
+            return {
+                "id": template["id"],
+                "name": template["name"],
+                "category": template.get("category", ""),
+                "featured": template.get("featured", False),
+                "descriptions": template.get("descriptions", {}),
+                "features": template.get("features", {}),
+                "sample_prompts": template.get("sample_prompts", {}),
+                "connections": connections,
+                "setup_time": template.get("setup_time", "5 min setup"),
+                "tags": template.get("tags", {}),
+                "author": template.get("author", ""),
+                "version": template.get("version", ""),
+                "agent_config": None,
+                "type": template_type,
+                "workforce_config": template.get("workforce_config"),
+            }
 
         # The agent_config could be an AgentConfig pydantic model or a dict
         agent_config = template.get("agent_config", {})
@@ -296,7 +374,7 @@ class TemplateManager:
             "author": template.get("author", ""),
             "version": template.get("version", ""),
             "agent_config": agent_config_dict,
-            "type": template.get("type", "agent"),
+            "type": template_type,
             "workforce_config": template.get("workforce_config"),
         }
 

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -11,6 +11,11 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# Mirrors xagent.web.models.agent.ExecutionMode's values. Not imported
+# directly to avoid pulling the SQLAlchemy-backed web.models layer into
+# this DB-agnostic YAML loader for one small, stable set of literals.
+_VALID_EXECUTION_MODES = frozenset({"flash", "balanced", "think", "auto"})
+
 
 class TemplateManager:
     """Core manager for the Template system"""
@@ -214,6 +219,26 @@ class TemplateManager:
             raise ValueError(
                 "'workforce_config.manager.name' must be a non-empty string"
             )
+        execution_mode = manager.get("execution_mode")
+        if execution_mode is not None and execution_mode not in _VALID_EXECUTION_MODES:
+            # Passed straight into AgentStore.add_agent with no further
+            # validation - a typo here would only surface as a broken
+            # manager agent at instantiation time, out of step with how
+            # carefully the rest of workforce_config is checked at load
+            # time (PR #1127 re-review, F10).
+            raise ValueError(
+                "'workforce_config.manager.execution_mode' must be one of "
+                f"{sorted(_VALID_EXECUTION_MODES)}, got {execution_mode!r}"
+            )
+        for list_field in ("tool_categories", "skills"):
+            value = manager.get(list_field)
+            if value is not None and (
+                not isinstance(value, list)
+                or not all(isinstance(v, str) for v in value)
+            ):
+                raise ValueError(
+                    f"'workforce_config.manager.{list_field}' must be a list of strings"
+                )
 
         agents = workforce_config.get("agents")
         if not isinstance(agents, list) or not agents:

--- a/src/xagent/templates/manager.py
+++ b/src/xagent/templates/manager.py
@@ -81,7 +81,33 @@ class TemplateManager:
             except Exception as e:
                 logger.error(f"  ✗ Error loading {yaml_file.name}: {e}", exc_info=True)
 
+        self._warn_on_dangling_workforce_references()
+
         logger.info(f"Total templates loaded: {len(self._templates_cache)}")
+
+    def _warn_on_dangling_workforce_references(self) -> None:
+        """A workforce template's `workforce_config.agents[].template_id`
+        values are only checked at parse time for being non-empty strings
+        (per-file validation can't know about other files yet). Once every
+        template is loaded, cross-check each one against the full cache so a
+        typo'd reference is logged loudly at startup instead of only
+        surfacing as a 400 the first time a user clicks "Use" on that
+        template.
+        """
+        for template in self._templates_cache.values():
+            if template.get("type") != "workforce":
+                continue
+            workforce_config = template.get("workforce_config") or {}
+            for agent in workforce_config.get("agents") or []:
+                referenced_id = agent.get("template_id")
+                if referenced_id and referenced_id not in self._templates_cache:
+                    logger.error(
+                        "Workforce template %r references unknown template_id "
+                        "%r in workforce_config.agents - instantiating it will "
+                        "fail until this is fixed",
+                        template.get("id"),
+                        referenced_id,
+                    )
 
     def _parse_yaml_file(self, yaml_file: Path) -> Dict[str, Any]:
         """Parse a single YAML file"""
@@ -127,7 +153,63 @@ class TemplateManager:
         agent_config.setdefault("tool_categories", [])
         agent_config.setdefault("execution_mode", "balanced")
 
+        # type distinguishes a single-agent template (default) from a
+        # workforce template, which is instantiated as a manager agent plus
+        # N worker agents rather than a single agent.
+        data.setdefault("type", "agent")
+        if data["type"] not in ("agent", "workforce"):
+            raise ValueError(
+                f"'type' must be 'agent' or 'workforce', got {data['type']!r}"
+            )
+        data.setdefault("workforce_config", None)
+        if data["type"] == "workforce":
+            self._validate_workforce_config(data["workforce_config"])
+
         return data
+
+    def _validate_workforce_config(self, workforce_config: Any) -> None:
+        """Validate the shape of `workforce_config` for a workforce-type
+        template. A workforce template is instantiated as a fresh manager
+        agent (defined inline via `manager.instructions`) plus one worker
+        agent per `agents[]` entry, each reused/created from an existing
+        template id (`agents[].template_id`) - see
+        `create_workforce_from_template` in
+        `xagent.web.services.workforce_creator`.
+        """
+        if not isinstance(workforce_config, dict):
+            raise ValueError(
+                "'workforce_config' is required and must be a mapping when 'type' is 'workforce'"
+            )
+
+        manager = workforce_config.get("manager")
+        if (
+            not isinstance(manager, dict)
+            or not str(manager.get("instructions") or "").strip()
+        ):
+            raise ValueError(
+                "'workforce_config.manager.instructions' must be a non-empty string"
+            )
+        if not str(manager.get("name") or "").strip():
+            raise ValueError(
+                "'workforce_config.manager.name' must be a non-empty string"
+            )
+
+        agents = workforce_config.get("agents")
+        if not isinstance(agents, list) or not agents:
+            raise ValueError("'workforce_config.agents' must be a non-empty list")
+        for index, agent in enumerate(agents):
+            if not isinstance(agent, dict):
+                raise ValueError(
+                    f"'workforce_config.agents[{index}]' must be a mapping"
+                )
+            if not str(agent.get("template_id") or "").strip():
+                raise ValueError(
+                    f"'workforce_config.agents[{index}].template_id' must be a non-empty string"
+                )
+            if not str(agent.get("assignment_instructions") or "").strip():
+                raise ValueError(
+                    f"'workforce_config.agents[{index}].assignment_instructions' must be a non-empty string"
+                )
 
     def _validate_sample_prompts(self, sample_prompts: Any) -> None:
         """Validate the (optional) sample_prompts shape at parse time, the
@@ -214,6 +296,8 @@ class TemplateManager:
             "author": template.get("author", ""),
             "version": template.get("version", ""),
             "agent_config": agent_config_dict,
+            "type": template.get("type", "agent"),
+            "workforce_config": template.get("workforce_config"),
         }
 
     async def list_templates(self) -> List[Dict]:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -39,6 +39,7 @@ from ..services.agent_management import (
     DuplicateAgentNameError,
     TemplateNotFoundError,
     TemplateQuickAccessRaceError,
+    WorkforceTemplateNotSupportedError,
     is_agent_name_unique_violation,
 )
 from ..services.agent_store import (
@@ -570,6 +571,12 @@ async def resolve_agent_from_template(
         )
     except TemplateNotFoundError:
         raise HTTPException(status_code=404, detail="Template not found")
+    except WorkforceTemplateNotSupportedError:
+        raise HTTPException(
+            status_code=400,
+            detail="This template creates a workforce, not a single agent; "
+            "use it from the Templates page instead",
+        )
     except DuplicateAgentNameError:
         raise HTTPException(
             status_code=400, detail="Agent with this name already exists"
@@ -629,6 +636,12 @@ async def create_agent_from_template(
         return AgentResponse.model_validate(result.agent.to_response_dict())
     except TemplateNotFoundError:
         raise HTTPException(status_code=404, detail="Template not found")
+    except WorkforceTemplateNotSupportedError:
+        raise HTTPException(
+            status_code=400,
+            detail="This template creates a workforce, not a single agent; "
+            "use it from the Templates page instead",
+        )
     except DuplicateAgentNameError:
         raise HTTPException(
             status_code=400, detail="Agent with this name already exists"

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -184,6 +184,14 @@ class AgentShareLinkResponse(BaseModel):
     share_updated_at: Optional[str]
 
 
+def _workforce_template_not_supported_response() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail="This template creates a workforce, not a single agent; "
+        "use it from the Templates page instead",
+    )
+
+
 def _unshared_error_response(
     error: UnsharedConnectorsError | UnsharedKnowledgeBasesError,
 ) -> HTTPException:
@@ -572,11 +580,7 @@ async def resolve_agent_from_template(
     except TemplateNotFoundError:
         raise HTTPException(status_code=404, detail="Template not found")
     except WorkforceTemplateNotSupportedError:
-        raise HTTPException(
-            status_code=400,
-            detail="This template creates a workforce, not a single agent; "
-            "use it from the Templates page instead",
-        )
+        raise _workforce_template_not_supported_response()
     except DuplicateAgentNameError:
         raise HTTPException(
             status_code=400, detail="Agent with this name already exists"
@@ -637,11 +641,7 @@ async def create_agent_from_template(
     except TemplateNotFoundError:
         raise HTTPException(status_code=404, detail="Template not found")
     except WorkforceTemplateNotSupportedError:
-        raise HTTPException(
-            status_code=400,
-            detail="This template creates a workforce, not a single agent; "
-            "use it from the Templates page instead",
-        )
+        raise _workforce_template_not_supported_response()
     except DuplicateAgentNameError:
         raise HTTPException(
             status_code=400, detail="Agent with this name already exists"

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -119,11 +119,15 @@ class TemplateInfo(BaseModel):
         description="'agent' for a single-agent template, 'workforce' for a "
         "manager + worker-agents template",
     )
-    workforce_agents: list[str] = Field(
+    manager_name: Optional[str] = Field(
+        default=None,
+        description="Display name of the manager agent a 'workforce'-type "
+        "template creates. None for 'agent'-type templates.",
+    )
+    worker_names: list[str] = Field(
         default_factory=list,
-        description="Display names of the manager + worker agents this "
-        "workforce template creates, in orchestration order (manager first). "
-        "Empty for 'agent'-type templates.",
+        description="Display names of the worker agents a 'workforce'-type "
+        "template creates. Empty for 'agent'-type templates.",
     )
 
 
@@ -148,6 +152,14 @@ class LikeResponse(BaseModel):
 
     liked: bool = Field(..., description="Whether the template is liked")
     likes: int = Field(..., description="Total number of likes")
+
+
+class UseAsWorkforceResponse(BaseModel):
+    """Response for POST /{template_id}/use-as-workforce"""
+
+    message: str = Field(..., description="Human-readable confirmation")
+    template_id: str = Field(..., description="ID of the template that was used")
+    workforce_id: int = Field(..., description="ID of the newly created workforce")
 
 
 # ===== Router =====
@@ -248,24 +260,35 @@ def increment_template_likes(db: Session, template_id: str) -> None:
     )
 
 
-def get_workforce_agent_names(template: dict[str, Any]) -> list[str]:
-    """Manager + worker display names for a workforce-type template, in
-    orchestration order (manager first). Derived entirely from static YAML
-    fields (no per-agent template lookups), since this runs for every
-    template on every `GET /api/templates/` page load.
+def get_workforce_agent_names(
+    template: dict[str, Any],
+) -> tuple[Optional[str], list[str]]:
+    """(manager_name, worker_names) for a workforce-type template. Split
+    into two fields rather than one flat list so "which one is the manager"
+    is structural, not "index 0 by convention" - and a worker with no name
+    would previously be silently dropped from a single list rather than
+    visibly changing the count (PR #1127 review; template loading now
+    rejects a missing agents[].name outright, but this stays defensive).
+    Derived entirely from static YAML fields (no per-agent template
+    lookups), since this runs for every template on every
+    `GET /api/templates/` page load.
     """
     workforce_config = template.get("workforce_config")
     if not isinstance(workforce_config, dict):
-        return []
+        return None, []
 
-    names: list[str] = []
     manager = workforce_config.get("manager")
-    if isinstance(manager, dict) and manager.get("name"):
-        names.append(str(manager["name"]))
-    for agent in workforce_config.get("agents") or []:
-        if isinstance(agent, dict) and agent.get("name"):
-            names.append(str(agent["name"]))
-    return names
+    manager_name = (
+        str(manager["name"])
+        if isinstance(manager, dict) and manager.get("name")
+        else None
+    )
+    worker_names = [
+        str(agent["name"])
+        for agent in workforce_config.get("agents") or []
+        if isinstance(agent, dict) and agent.get("name")
+    ]
+    return manager_name, worker_names
 
 
 # ===== Endpoints =====
@@ -311,6 +334,7 @@ async def list_templates(
         )
         connections = template.get("connections", [])
         tags = get_localized_value(template.get("tags", {}), lang, [])
+        manager_name, worker_names = get_workforce_agent_names(template)
 
         result.append(
             TemplateInfo(
@@ -331,7 +355,8 @@ async def list_templates(
                 used_count=stats.used_count,
                 is_liked=template_id in liked_template_ids,
                 type=template.get("type", "agent"),
-                workforce_agents=get_workforce_agent_names(template),
+                manager_name=manager_name,
+                worker_names=worker_names,
             )
         )
 
@@ -381,6 +406,7 @@ async def get_template(
     )
     connections = template.get("connections", [])
     tags = get_localized_value(template.get("tags", {}), lang, [])
+    manager_name, worker_names = get_workforce_agent_names(template)
 
     return TemplateDetail(
         id=template["id"],
@@ -400,7 +426,8 @@ async def get_template(
         used_count=stats.used_count,
         is_liked=is_template_liked(db, int(current_user.id), template_id),
         type=template.get("type", "agent"),
-        workforce_agents=get_workforce_agent_names(template),
+        manager_name=manager_name,
+        worker_names=worker_names,
         agent_config=(
             {
                 "instructions": template["agent_config"].get("instructions", ""),
@@ -522,13 +549,13 @@ async def use_template(
     }
 
 
-@router.post("/{template_id}/use-as-workforce")
+@router.post("/{template_id}/use-as-workforce", response_model=UseAsWorkforceResponse)
 async def use_template_as_workforce(
     template_id: str,
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> dict:
+) -> UseAsWorkforceResponse:
     """
     Instantiate a 'workforce'-type template: creates the manager agent plus
     one worker agent per template.workforce_config.agents entry (reusing an
@@ -558,12 +585,26 @@ async def use_template_as_workforce(
         db, current_user, template_manager, template
     )
 
-    stats = get_or_create_template_stats(db, template_id)
-    stats.used_count += 1
-    db.commit()
+    # The workforce (and its manager/worker agents) is already committed at
+    # this point. This is purely an analytics counter, so a failure here
+    # must be logged, not surfaced as a request failure - the caller would
+    # otherwise see a 500 for an operation that actually already succeeded,
+    # with no way to discover the workforce it already created.
+    try:
+        stats = get_or_create_template_stats(db, template_id)
+        stats.used_count += 1
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "Failed to record used_count for template_id=%s after "
+            "successfully creating workforce_id=%s",
+            template_id,
+            workforce.id,
+        )
 
-    return {
-        "message": "Workforce created from template",
-        "template_id": template_id,
-        "workforce_id": workforce.id,
-    }
+    return UseAsWorkforceResponse(
+        message="Workforce created from template",
+        template_id=template_id,
+        workforce_id=workforce.id,
+    )

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -262,10 +262,9 @@ def increment_template_used_count(db: Session, template_id: str) -> None:
     under concurrent successes on the same template (two concurrent
     `use-as-workforce` calls could both read used_count=0 and both write 1,
     losing one), and its `TemplateStats` row-creation race was swallowed by
-    a broad `except IntegrityError` with no compensating re-read (PR #1127
-    re-review, m3). Callers must `db.commit()` then `db.refresh(stats)` to
-    see the post-increment value, matching `increment_template_likes`'s
-    existing callers.
+    a broad `except IntegrityError` with no compensating re-read. Callers
+    must `db.commit()` then `db.refresh(stats)` to see the post-increment
+    value, matching `increment_template_likes`'s existing callers.
     """
     db.query(TemplateStats).filter(TemplateStats.template_id == template_id).update(
         {TemplateStats.used_count: TemplateStats.used_count + 1},
@@ -276,9 +275,9 @@ def increment_template_used_count(db: Session, template_id: str) -> None:
 def get_workforce_agent_count(template: dict[str, Any]) -> int:
     """Total agents (1 manager + N workers) a workforce-type template
     creates - the card badge's only need, computed server-side rather than
-    shipping name lists the frontend would just count (PR #1127 re-review
-    simplification; this replaced a manager_name/worker_names pair whose
-    only consumer read lengths/presence). 0 for agent-type templates.
+    shipping name lists the frontend would just count (this replaced a
+    manager_name/worker_names pair whose only consumer read
+    lengths/presence). 0 for agent-type templates.
     Derived entirely from static YAML fields (no per-agent template
     lookups), since this runs for every template on every
     `GET /api/templates/` page load.
@@ -540,10 +539,10 @@ async def use_template(
         # Every other agent-creation surface (the service-layer raises,
         # the v1 400, the home/task/builder filters) already refuses a
         # workforce template - this legacy endpoint was left ungated,
-        # returning 200 "Template usage recorded" while creating nothing
-        # (PR #1127 re-review, m2). It predates the workforce type and
-        # frontend code only calls /use-as-workforce for one, but external
-        # API consumers could still hit it directly.
+        # returning 200 "Template usage recorded" while creating nothing.
+        # It predates the workforce type and frontend code only calls
+        # /use-as-workforce for one, but external API consumers could
+        # still hit it directly.
         raise HTTPException(
             status_code=400,
             detail="This template creates a workforce, not a single agent; "

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -555,6 +555,7 @@ async def use_template_as_workforce(
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    lang: Optional[str] = Query(None, description="Language code (e.g., 'en', 'zh')"),
 ) -> UseAsWorkforceResponse:
     """
     Instantiate a 'workforce'-type template: creates the manager agent plus
@@ -564,6 +565,7 @@ async def use_template_as_workforce(
 
     Args:
         template_id: ID of the workforce template to instantiate
+        lang: Optional language code for the new Workforce's description
 
     Returns:
         The new workforce's id, for the frontend to navigate to its canvas
@@ -582,7 +584,7 @@ async def use_template_as_workforce(
         )
 
     workforce = await create_workforce_from_template(
-        db, current_user, template_manager, template
+        db, current_user, template_manager, template, lang=lang
     )
 
     # The workforce (and its manager/worker agents) is already committed at

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -5,7 +5,7 @@ Provides REST API endpoints for managing and using agent templates.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -114,20 +114,15 @@ class TemplateInfo(BaseModel):
     is_liked: bool = Field(
         default=False, description="Whether the current user liked this template"
     )
-    type: str = Field(
+    type: Literal["agent", "workforce"] = Field(
         default="agent",
         description="'agent' for a single-agent template, 'workforce' for a "
         "manager + worker-agents template",
     )
-    manager_name: Optional[str] = Field(
-        default=None,
-        description="Display name of the manager agent a 'workforce'-type "
-        "template creates. None for 'agent'-type templates.",
-    )
-    worker_names: list[str] = Field(
-        default_factory=list,
-        description="Display names of the worker agents a 'workforce'-type "
-        "template creates. Empty for 'agent'-type templates.",
+    agent_count: int = Field(
+        default=0,
+        description="Total number of agents (manager + workers) a "
+        "'workforce'-type template creates. 0 for 'agent'-type templates.",
     )
 
 
@@ -260,35 +255,44 @@ def increment_template_likes(db: Session, template_id: str) -> None:
     )
 
 
-def get_workforce_agent_names(
-    template: dict[str, Any],
-) -> tuple[Optional[str], list[str]]:
-    """(manager_name, worker_names) for a workforce-type template. Split
-    into two fields rather than one flat list so "which one is the manager"
-    is structural, not "index 0 by convention" - and a worker with no name
-    would previously be silently dropped from a single list rather than
-    visibly changing the count (PR #1127 review; template loading now
-    rejects a missing agents[].name outright, but this stays defensive).
+def increment_template_used_count(db: Session, template_id: str) -> None:
+    """Increment template used_count atomically in the database - the same
+    UPDATE-in-place pattern as `increment_template_likes` above. The
+    previous `stats.used_count += 1` ORM read-modify-write lost increments
+    under concurrent successes on the same template (two concurrent
+    `use-as-workforce` calls could both read used_count=0 and both write 1,
+    losing one), and its `TemplateStats` row-creation race was swallowed by
+    a broad `except IntegrityError` with no compensating re-read (PR #1127
+    re-review, m3). Callers must `db.commit()` then `db.refresh(stats)` to
+    see the post-increment value, matching `increment_template_likes`'s
+    existing callers.
+    """
+    db.query(TemplateStats).filter(TemplateStats.template_id == template_id).update(
+        {TemplateStats.used_count: TemplateStats.used_count + 1},
+        synchronize_session=False,
+    )
+
+
+def get_workforce_agent_count(template: dict[str, Any]) -> int:
+    """Total agents (1 manager + N workers) a workforce-type template
+    creates - the card badge's only need, computed server-side rather than
+    shipping name lists the frontend would just count (PR #1127 re-review
+    simplification; this replaced a manager_name/worker_names pair whose
+    only consumer read lengths/presence). 0 for agent-type templates.
     Derived entirely from static YAML fields (no per-agent template
     lookups), since this runs for every template on every
     `GET /api/templates/` page load.
     """
+    if template.get("type") != "workforce":
+        # An agent-type template carrying a stray workforce_config block
+        # (unvalidated for that type) must not advertise a count.
+        return 0
     workforce_config = template.get("workforce_config")
     if not isinstance(workforce_config, dict):
-        return None, []
-
-    manager = workforce_config.get("manager")
-    manager_name = (
-        str(manager["name"])
-        if isinstance(manager, dict) and manager.get("name")
-        else None
-    )
-    worker_names = [
-        str(agent["name"])
-        for agent in workforce_config.get("agents") or []
-        if isinstance(agent, dict) and agent.get("name")
-    ]
-    return manager_name, worker_names
+        return 0
+    workers = workforce_config.get("agents")
+    worker_count = len(workers) if isinstance(workers, list) else 0
+    return 1 + worker_count
 
 
 # ===== Endpoints =====
@@ -334,7 +338,6 @@ async def list_templates(
         )
         connections = template.get("connections", [])
         tags = get_localized_value(template.get("tags", {}), lang, [])
-        manager_name, worker_names = get_workforce_agent_names(template)
 
         result.append(
             TemplateInfo(
@@ -355,8 +358,7 @@ async def list_templates(
                 used_count=stats.used_count,
                 is_liked=template_id in liked_template_ids,
                 type=template.get("type", "agent"),
-                manager_name=manager_name,
-                worker_names=worker_names,
+                agent_count=get_workforce_agent_count(template),
             )
         )
 
@@ -406,7 +408,6 @@ async def get_template(
     )
     connections = template.get("connections", [])
     tags = get_localized_value(template.get("tags", {}), lang, [])
-    manager_name, worker_names = get_workforce_agent_names(template)
 
     return TemplateDetail(
         id=template["id"],
@@ -426,8 +427,7 @@ async def get_template(
         used_count=stats.used_count,
         is_liked=is_template_liked(db, int(current_user.id), template_id),
         type=template.get("type", "agent"),
-        manager_name=manager_name,
-        worker_names=worker_names,
+        agent_count=get_workforce_agent_count(template),
         agent_config=(
             {
                 "instructions": template["agent_config"].get("instructions", ""),
@@ -536,11 +536,24 @@ async def use_template(
 
     if not template:
         raise HTTPException(status_code=404, detail="Template not found")
+    if template.get("type") == "workforce":
+        # Every other agent-creation surface (the service-layer raises,
+        # the v1 400, the home/task/builder filters) already refuses a
+        # workforce template - this legacy endpoint was left ungated,
+        # returning 200 "Template usage recorded" while creating nothing
+        # (PR #1127 re-review, m2). It predates the workforce type and
+        # frontend code only calls /use-as-workforce for one, but external
+        # API consumers could still hit it directly.
+        raise HTTPException(
+            status_code=400,
+            detail="This template creates a workforce, not a single agent; "
+            "use POST /{template_id}/use-as-workforce instead",
+        )
 
-    # Increment used count
     stats = get_or_create_template_stats(db, template_id)
-    stats.used_count += 1
+    increment_template_used_count(db, template_id)
     db.commit()
+    db.refresh(stats)
 
     return {
         "message": "Template usage recorded",
@@ -593,8 +606,8 @@ async def use_template_as_workforce(
     # otherwise see a 500 for an operation that actually already succeeded,
     # with no way to discover the workforce it already created.
     try:
-        stats = get_or_create_template_stats(db, template_id)
-        stats.used_count += 1
+        get_or_create_template_stats(db, template_id)
+        increment_template_used_count(db, template_id)
         db.commit()
     except Exception:
         db.rollback()

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -16,6 +16,7 @@ from ..auth_dependencies import get_current_user
 from ..models.database import get_db
 from ..models.template_stats import TemplateStats, UserTemplateRelation
 from ..models.user import User
+from ..services.workforce_creator import create_workforce_from_template
 
 logger = logging.getLogger(__name__)
 
@@ -113,12 +114,33 @@ class TemplateInfo(BaseModel):
     is_liked: bool = Field(
         default=False, description="Whether the current user liked this template"
     )
+    type: str = Field(
+        default="agent",
+        description="'agent' for a single-agent template, 'workforce' for a "
+        "manager + worker-agents template",
+    )
+    workforce_agents: list[str] = Field(
+        default_factory=list,
+        description="Display names of the manager + worker agents this "
+        "workforce template creates, in orchestration order (manager first). "
+        "Empty for 'agent'-type templates.",
+    )
 
 
 class TemplateDetail(TemplateInfo):
     """Detailed template response including agent configuration"""
 
-    agent_config: dict[str, Any] = Field(..., description="Agent configuration")
+    agent_config: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Agent configuration for an 'agent'-type template. None "
+        "for a 'workforce'-type template, which is configured via "
+        "`workforce_config` instead.",
+    )
+    workforce_config: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Manager + worker agent configuration for a 'workforce'-type "
+        "template. None for 'agent'-type templates.",
+    )
 
 
 class LikeResponse(BaseModel):
@@ -226,6 +248,26 @@ def increment_template_likes(db: Session, template_id: str) -> None:
     )
 
 
+def get_workforce_agent_names(template: dict[str, Any]) -> list[str]:
+    """Manager + worker display names for a workforce-type template, in
+    orchestration order (manager first). Derived entirely from static YAML
+    fields (no per-agent template lookups), since this runs for every
+    template on every `GET /api/templates/` page load.
+    """
+    workforce_config = template.get("workforce_config")
+    if not isinstance(workforce_config, dict):
+        return []
+
+    names: list[str] = []
+    manager = workforce_config.get("manager")
+    if isinstance(manager, dict) and manager.get("name"):
+        names.append(str(manager["name"]))
+    for agent in workforce_config.get("agents") or []:
+        if isinstance(agent, dict) and agent.get("name"):
+            names.append(str(agent["name"]))
+    return names
+
+
 # ===== Endpoints =====
 
 
@@ -288,6 +330,8 @@ async def list_templates(
                 likes=stats.likes,
                 used_count=stats.used_count,
                 is_liked=template_id in liked_template_ids,
+                type=template.get("type", "agent"),
+                workforce_agents=get_workforce_agent_names(template),
             )
         )
 
@@ -355,14 +399,21 @@ async def get_template(
         likes=stats.likes,
         used_count=stats.used_count,
         is_liked=is_template_liked(db, int(current_user.id), template_id),
-        agent_config={
-            "instructions": template["agent_config"].get("instructions", ""),
-            "skills": template["agent_config"].get("skills", []),
-            "tool_categories": template["agent_config"].get("tool_categories", []),
-            "execution_mode": template["agent_config"].get(
-                "execution_mode", "balanced"
-            ),
-        },
+        type=template.get("type", "agent"),
+        workforce_agents=get_workforce_agent_names(template),
+        agent_config=(
+            {
+                "instructions": template["agent_config"].get("instructions", ""),
+                "skills": template["agent_config"].get("skills", []),
+                "tool_categories": template["agent_config"].get("tool_categories", []),
+                "execution_mode": template["agent_config"].get(
+                    "execution_mode", "balanced"
+                ),
+            }
+            if template.get("type", "agent") == "agent"
+            else None
+        ),
+        workforce_config=template.get("workforce_config"),
     )
 
 
@@ -468,4 +519,51 @@ async def use_template(
         "message": "Template usage recorded",
         "template_id": template_id,
         "used_count": stats.used_count,
+    }
+
+
+@router.post("/{template_id}/use-as-workforce")
+async def use_template_as_workforce(
+    template_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    Instantiate a 'workforce'-type template: creates the manager agent plus
+    one worker agent per template.workforce_config.agents entry (reusing an
+    existing quick-access instance per-worker-template if the user already
+    has one), assembles them into a new Workforce, and records usage.
+
+    Args:
+        template_id: ID of the workforce template to instantiate
+
+    Returns:
+        The new workforce's id, for the frontend to navigate to its canvas
+
+    Raises:
+        HTTPException: If template not found or is not a workforce template
+    """
+    template_manager = request.app.state.template_manager
+    template = await template_manager.get_template(template_id)
+
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    if template.get("type") != "workforce":
+        raise HTTPException(
+            status_code=400, detail="Template is not a workforce template"
+        )
+
+    workforce = await create_workforce_from_template(
+        db, current_user, template_manager, template
+    )
+
+    stats = get_or_create_template_stats(db, template_id)
+    stats.used_count += 1
+    db.commit()
+
+    return {
+        "message": "Workforce created from template",
+        "template_id": template_id,
+        "workforce_id": workforce.id,
     }

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -20,6 +20,7 @@ from ...services.agent_management import (
     InvalidKnowledgeBaseError,
     RuntimeKeySnapshot,
     TemplateNotFoundError,
+    WorkforceTemplateNotSupportedError,
 )
 from ...services.api_keys import KeyRotationConflict
 from .deps import (
@@ -153,6 +154,13 @@ async def create_agent_from_template(
         )
     except TemplateNotFoundError:
         raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)
+    except WorkforceTemplateNotSupportedError:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            "This template creates a workforce, not a single agent, and "
+            "cannot be used with this endpoint.",
+        )
     except DuplicateAgentNameError:
         raise V1ApiError(
             V1ErrorCode.INVALID_INPUT, 400, "Agent with this name already exists."

--- a/src/xagent/web/api/v1/templates.py
+++ b/src/xagent/web/api/v1/templates.py
@@ -45,6 +45,7 @@ def _template_summary(template: dict[str, Any]) -> V1TemplateSummary:
         tags=_localized(template.get("tags")) or [],
         author=template.get("author", ""),
         version=template.get("version", ""),
+        type=template.get("type", "agent"),
     )
 
 
@@ -73,7 +74,10 @@ async def get_template(
     if template is None:
         raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)
     summary = _template_summary(template)
+    is_agent_template = summary.type == "agent"
     return V1TemplateDetail(
         **summary.model_dump(),
-        agent_config=template.get("agent_config") or {},
+        agent_config=(template.get("agent_config") or {})
+        if is_agent_template
+        else None,
     )

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -231,10 +231,20 @@ class V1TemplateSummary(BaseModel):
     tags: list[str] = Field(default_factory=list)
     author: str = ""
     version: str = ""
+    type: str = Field(
+        default="agent",
+        description="'agent' for a single-agent template, 'workforce' for a "
+        "manager + worker-agents template that this API does not yet "
+        "support instantiating.",
+    )
 
 
 class V1TemplateDetail(V1TemplateSummary):
-    agent_config: dict[str, Any]
+    agent_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Agent configuration for an 'agent'-type template. None "
+        "for a 'workforce'-type template.",
+    )
 
 
 class CreateTaskResponse(BaseModel):

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -231,7 +231,7 @@ class V1TemplateSummary(BaseModel):
     tags: list[str] = Field(default_factory=list)
     author: str = ""
     version: str = ""
-    type: str = Field(
+    type: Literal["agent", "workforce"] = Field(
         default="agent",
         description="'agent' for a single-agent template, 'workforce' for a "
         "manager + worker-agents template that this API does not yet "

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -79,6 +79,17 @@ class TemplateNotFoundError(LookupError):
     """Raised when a template id cannot be resolved."""
 
 
+class WorkforceTemplateNotSupportedError(ValueError):
+    """Raised when a template's `type` is "workforce" but the caller only
+    knows how to create a single Agent from it.
+
+    A workforce template's `agent_config` carries no real instructions (see
+    `TemplateManager._enrich_template`), so without this gate every one of
+    these single-agent creation paths would silently publish an agent with
+    empty instructions instead of failing (PR #1127 review).
+    """
+
+
 class InvalidAgentModelConfigError(ValueError):
     """Raised when the agent model slot payload does not match DB id shape."""
 
@@ -759,6 +770,8 @@ class AgentManagementService:
         template = await self.template_manager.get_template(template_id)
         if template is None:
             raise TemplateNotFoundError(template_id)
+        if template.get("type", "agent") != "agent":
+            raise WorkforceTemplateNotSupportedError(template_id)
 
         agent_config = template.get("agent_config") or {}
         final_name = name or template.get("name") or template_id
@@ -1235,6 +1248,8 @@ class AgentManagementRuntime:
         template = await self.template_manager.get_template(template_id)
         if template is None:
             raise TemplateNotFoundError(template_id)
+        if template.get("type", "agent") != "agent":
+            raise WorkforceTemplateNotSupportedError(template_id)
 
         agent_config = template.get("agent_config") or {}
         final_description = description

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -86,7 +86,7 @@ class WorkforceTemplateNotSupportedError(ValueError):
     A workforce template's `agent_config` carries no real instructions (see
     `TemplateManager._enrich_template`), so without this gate every one of
     these single-agent creation paths would silently publish an agent with
-    empty instructions instead of failing (PR #1127 review).
+    empty instructions instead of failing.
     """
 
 

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -288,6 +288,40 @@ def _find_quick_access_worker_agent(
     )
 
 
+# Stable English prefix the frontend matches on to render a translated,
+# agent-name-specific message (see WORKFORCE_USE_ERROR_KEYS in
+# templates/page.tsx) - the variable part (the agent's name) is
+# deliberately appended as its own sentence after it, not interpolated
+# into the middle of the fixed text, so that prefix match stays exact
+# regardless of the name's contents.
+UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX = (
+    "This workforce needs an agent that is currently unpublished: "
+)
+
+
+def _ensure_published_quick_access_agent(agent: Agent) -> Agent:
+    """A quick-access worker agent the caller separately unpublished (a
+    supported, deliberate user action - see
+    `AgentManagementService._resolve_agent_from_template_sync`'s B3
+    rationale for why the /task quick-access flow never auto-republishes a
+    found draft either) must not be silently reused as-is: it would pass
+    this check, then fail downstream in `create_workforce_worker`'s
+    `ensure_agent_access(..., require_published=True)` with a generic 400
+    the frontend can only render as "please retry" - which can never
+    succeed, since retrying resolves to the same unpublished agent every
+    time (PR #1127 re-review, F1). Raise here instead, with a message
+    specific enough to actually be actionable.
+    """
+    if agent.status != AgentStatus.PUBLISHED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX}{agent.name}. "
+            "Republish it from your Agents list, then try this workforce "
+            "template again.",
+        )
+    return agent
+
+
 async def _get_or_create_quick_access_worker_agent(
     db: Session,
     template_manager: Any,
@@ -327,7 +361,7 @@ async def _get_or_create_quick_access_worker_agent(
         db, user_id=user_id, template_id=template_id
     )
     if existing is not None:
-        return existing
+        return _ensure_published_quick_access_agent(existing)
 
     worker_template = await template_manager.get_template(template_id)
     if not worker_template:
@@ -347,6 +381,24 @@ async def _get_or_create_quick_access_worker_agent(
             f"worker: {template_id}",
         )
     agent_config = worker_template.get("agent_config") or {}
+    # Populate the same fields the /task quick-access resolver
+    # (`AgentManagementRuntime._spec_from_template`) does for a freshly
+    # minted quick-access agent - both write the same (user_id, template_id,
+    # quick-access-origin) row, so leaving these hardcoded to empty here
+    # would silently strand them the first time this path (rather than
+    # /task) happens to create the row first (PR #1127 re-review, F2).
+    # Deliberate exception: `knowledge_bases` stays empty. KB ids are
+    # user-scoped runtime entities the /task path validates per-user via
+    # `_validate_agent_knowledge_bases` (rejecting the template with a 400
+    # if they don't resolve) - this path has no equivalent check, so
+    # passing them through raw would silently create an agent with
+    # dangling KB references instead. No built-in template declares
+    # knowledge_bases today; if one ever does, this path needs the same
+    # validation before it may forward them.
+    worker_descriptions = worker_template.get("descriptions") or {}
+    worker_description = (
+        worker_descriptions.get("en") if isinstance(worker_descriptions, dict) else None
+    )
 
     for attempt in range(TEMPLATE_RESOLVE_RACE_RETRIES):
         try:
@@ -358,14 +410,14 @@ async def _get_or_create_quick_access_worker_agent(
                         user_id=user_id,
                         name=str(worker_template.get("name") or template_id),
                     ),
-                    description=None,
+                    description=worker_description,
                     instructions=agent_config.get("instructions", ""),
                     execution_mode=agent_config.get("execution_mode", "balanced"),
-                    models=None,
+                    models=agent_config.get("models"),
                     knowledge_bases=[],
                     skills=agent_config.get("skills", []),
                     tool_categories=agent_config.get("tool_categories", []),
-                    suggested_prompts=[],
+                    suggested_prompts=agent_config.get("suggested_prompts") or [],
                     origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
                     status=AgentStatus.PUBLISHED,
                     widget_enabled=False,
@@ -388,7 +440,7 @@ async def _get_or_create_quick_access_worker_agent(
                     db, user_id=user_id, template_id=template_id
                 )
                 if existing is not None:
-                    return existing
+                    return _ensure_published_quick_access_agent(existing)
                 logger.warning(
                     "Quick-access worker agent insert collided on the "
                     "quick-access index without a resolvable row (attempt "
@@ -427,6 +479,7 @@ async def create_workforce_from_template(
     user: User,
     template_manager: Any,
     template: dict[str, Any],
+    lang: str | None = None,
 ) -> Workforce:
     """Instantiate a workforce-type template: a fresh manager agent (from
     `workforce_config.manager`) plus one worker agent per
@@ -456,6 +509,19 @@ async def create_workforce_from_template(
             scope_id=scope_id,
             name=str(template.get("name") or "Workforce"),
         )
+        # Unlike the worker-resolution loop below, this insert is NOT
+        # wrapped in its own `db.begin_nested()` - a concurrent collision
+        # here would propagate straight out of the outer `try`, rolling
+        # back the whole workforce creation instead of just this insert.
+        # That is safe only because `uq_agents_user_id_name_active`
+        # (`AGENT_NAME_UNIQUE_INDEX` in `xagent/web/models/agent.py`) is a
+        # partial index whose predicate excludes
+        # `origin='workforce_generated_manager'` rows entirely, so two
+        # concurrent managers can even share a name without ever hitting a
+        # unique-constraint collision in the first place. If that predicate
+        # ever changes, concurrent workforce instantiation would need the
+        # same SAVEPOINT-retry treatment as the worker path (PR #1127
+        # re-review, F11).
         manager_agent = AgentStore(db).add_agent(
             user_id=owner_user_id,
             name=resolve_unique_agent_name(
@@ -485,7 +551,8 @@ async def create_workforce_from_template(
             scope_id=scope_id,
             name=name,
             description=normalize_text(
-                cast(str | None, get_localized_description(template)), "description"
+                cast(str | None, get_localized_description(template, lang)),
+                "description",
             ),
             manager_agent_id=int(manager_agent.id),
             status="draft",
@@ -529,20 +596,30 @@ async def create_workforce_from_template(
     return workforce
 
 
-def get_localized_description(template: dict[str, Any]) -> str | None:
+def get_localized_description(
+    template: dict[str, Any], lang: str | None = None
+) -> str | None:
     """Best-effort description for a newly created Workforce's
-    `description` column, which - unlike the template gallery response - is
-    not locale-aware. `descriptions` is always a {en, zh, ...} dict here -
-    `TemplateManager._parse_yaml_file` raises ValueError for any other
-    shape, so a template dict reaching this function can't carry a plain
-    string instead. Prefers English but falls back to any other populated
-    locale rather than leaving the Workforce's description empty - the key
-    check in `_parse_yaml_file` only requires an 'en' key to be present, not
-    a non-empty value.
+    `description` column. Unlike the template gallery response, this was
+    never locale-aware at all - `create_workforce_from_template` had no way
+    to know the caller's locale, so every Workforce got its English
+    description regardless of the creating user's UI language (PR #1127
+    re-review, F4). `lang` threads the same query param the sibling GET
+    endpoints already accept. `descriptions` is always a {en, zh, ...} dict
+    here - `TemplateManager._parse_yaml_file` raises ValueError for any
+    other shape, so a template dict reaching this function can't carry a
+    plain string instead.
+
+    Preference order: the caller's `lang` if populated, else English, else
+    any other populated locale rather than leaving the Workforce's
+    description empty - the key check in `_parse_yaml_file` only requires
+    an 'en' key to be *present*, not a non-empty value.
     """
     descriptions = template.get("descriptions")
     if not isinstance(descriptions, dict):
         return None
+    if lang and descriptions.get(lang):
+        return str(descriptions[lang])
     value = descriptions.get("en")
     if value:
         return str(value)

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -297,9 +297,8 @@ def _find_quick_access_worker_agent(
 # ("agent_in_use_by_workforce") and mcp.py. The frontend maps these codes
 # to translated messages instead of byte-matching human-readable English
 # detail strings, which silently degraded to a generic toast on any
-# backend wording change (PR #1127 re-review, m4). `params` carries the
-# variable parts (e.g. the agent's name) separately so translations can
-# interpolate them.
+# backend wording change. `params` carries the variable parts (e.g. the
+# agent's name) separately so translations can interpolate them.
 WORKFORCE_CREATE_ACCESS_DENIED_CODE = "workforce_create_access_denied"
 WORKFORCE_CREATE_CONFLICT_CODE = "workforce_create_conflict"
 WORKFORCE_WORKER_UNPUBLISHED_CODE = "workforce_worker_unpublished"
@@ -315,8 +314,8 @@ def _ensure_published_quick_access_agent(agent: Agent) -> Agent:
     `ensure_agent_access(..., require_published=True)` with a generic 400
     the frontend can only render as "please retry" - which can never
     succeed, since retrying resolves to the same unpublished agent every
-    time (PR #1127 re-review, F1). Raise here instead, with a message
-    specific enough to actually be actionable.
+    time. Raise here instead, with a message specific enough to actually
+    be actionable.
     """
     if agent.status != AgentStatus.PUBLISHED:
         raise HTTPException(
@@ -396,7 +395,7 @@ async def _get_or_create_quick_access_worker_agent(
     # minted quick-access agent - both write the same (user_id, template_id,
     # quick-access-origin) row, so leaving these hardcoded to empty here
     # would silently strand them the first time this path (rather than
-    # /task) happens to create the row first (PR #1127 re-review, F2).
+    # /task) happens to create the row first.
     # Deliberate exception: `knowledge_bases` stays empty. KB ids are
     # user-scoped runtime entities the /task path validates per-user via
     # `_validate_agent_knowledge_bases` (rejecting the template with a 400
@@ -442,7 +441,7 @@ async def _get_or_create_quick_access_worker_agent(
             # name collision as this template's quick-access race, which
             # burns every retry on a re-select that can never find a row
             # (nothing else raced for *this* template_id) and returns a
-            # misleading 409 (PR #1127 review).
+            # misleading 409.
             if is_agent_template_quick_access_unique_violation(exc):
                 # A concurrent request won the (user_id, template_id)
                 # quick-access race; its row should now be visible.
@@ -522,11 +521,12 @@ async def create_workforce_from_template(
 
     owner_user_id = int(user.id)
     try:
+        base_name = str(template.get("name") or "Workforce")
         name = resolve_unique_workforce_name(
             db,
             scope_type=scope_type,
             scope_id=scope_id,
-            name=str(template.get("name") or "Workforce"),
+            name=base_name,
         )
         # The manager-agent insert (unlike the Workforce insert just below)
         # is NOT wrapped in its own `db.begin_nested()` - that is safe only
@@ -536,8 +536,7 @@ async def create_workforce_from_template(
         # entirely, so two concurrent managers can even share a name
         # without ever hitting a unique-constraint collision in the first
         # place. If that predicate ever changes, this insert would need the
-        # same SAVEPOINT-retry treatment as the Workforce insert below (PR
-        # #1127 re-review, F11).
+        # same SAVEPOINT-retry treatment as the Workforce insert below.
         manager_agent = AgentStore(db).add_agent(
             user_id=owner_user_id,
             name=resolve_unique_agent_name(
@@ -572,7 +571,7 @@ async def create_workforce_from_template(
         # LLM-generated one, so this collision is not just theoretical) can
         # both resolve the same name and race to insert it. Retry inside a
         # SAVEPOINT so a collision only unwinds this insert, not the
-        # manager agent already created above (PR #1127 re-review, M1).
+        # manager agent already created above.
         workforce: Workforce | None = None
         for attempt in range(TEMPLATE_RESOLVE_RACE_RETRIES):
             try:
@@ -601,8 +600,15 @@ async def create_workforce_from_template(
                     scope_type,
                     scope_id,
                 )
+                # Re-resolve from the template's RAW name, never from a
+                # resolved (possibly suffixed) one - resolving from a
+                # suffixed name compounds suffixes ("X 2" -> "X 2 2")
+                # instead of advancing to "X 3". That holds both for the
+                # collided `name` from this loop and for the initial
+                # resolution above, which itself already carries a suffix
+                # whenever the user instantiated this template before.
                 name = resolve_unique_workforce_name(
-                    db, scope_type=scope_type, scope_id=scope_id, name=name
+                    db, scope_type=scope_type, scope_id=scope_id, name=base_name
                 )
         else:
             raise HTTPException(
@@ -658,9 +664,9 @@ def get_localized_description(
     `description` column. Unlike the template gallery response, this was
     never locale-aware at all - `create_workforce_from_template` had no way
     to know the caller's locale, so every Workforce got its English
-    description regardless of the creating user's UI language (PR #1127
-    re-review, F4). `lang` threads the same query param the sibling GET
-    endpoints already accept. `descriptions` is always a {en, zh, ...} dict
+    description regardless of the creating user's UI language. `lang`
+    threads the same query param the sibling GET endpoints already accept.
+    `descriptions` is always a {en, zh, ...} dict
     here - `TemplateManager._parse_yaml_file` raises ValueError for any
     other shape, so a template dict reaching this function can't carry a
     plain string instead.

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -530,17 +530,25 @@ async def create_workforce_from_template(
 
 
 def get_localized_description(template: dict[str, Any]) -> str | None:
-    """Best-effort English description for a newly created Workforce's
+    """Best-effort description for a newly created Workforce's
     `description` column, which - unlike the template gallery response - is
     not locale-aware. `descriptions` is always a {en, zh, ...} dict here -
     `TemplateManager._parse_yaml_file` raises ValueError for any other
     shape, so a template dict reaching this function can't carry a plain
-    string instead.
+    string instead. Prefers English but falls back to any other populated
+    locale rather than leaving the Workforce's description empty - the key
+    check in `_parse_yaml_file` only requires an 'en' key to be present, not
+    a non-empty value.
     """
     descriptions = template.get("descriptions")
-    if isinstance(descriptions, dict):
-        value = descriptions.get("en")
-        return str(value) if value else None
+    if not isinstance(descriptions, dict):
+        return None
+    value = descriptions.get("en")
+    if value:
+        return str(value)
+    for other_value in descriptions.values():
+        if other_value:
+            return str(other_value)
     return None
 
 

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -10,7 +10,11 @@ from sqlalchemy.orm import Session
 
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.user import User
-from xagent.web.services.agent_management import TEMPLATE_RESOLVE_RACE_RETRIES
+from xagent.web.services.agent_management import (
+    TEMPLATE_RESOLVE_RACE_RETRIES,
+    is_agent_name_unique_violation,
+    is_agent_template_quick_access_unique_violation,
+)
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
 from ..models.workforce import Workforce, WorkforceBuilderMessage
@@ -303,10 +307,21 @@ async def _get_or_create_quick_access_worker_agent(
     attempt therefore runs in its own SAVEPOINT (`db.begin_nested()`) so a
     collision only unwinds that attempt - not the manager agent / Workforce
     already staged in the caller's outer transaction - and we retry by
-    re-reading the row the winning concurrent request just committed.
-    Mirrors `AgentManagementService._resolve_agent_from_template_sync`'s
-    retry loop, which hardens the same (user_id, template_id, quick-access
-    origin) uniqueness for the /task quick-access flow.
+    re-reading the row the winning concurrent request just committed - which
+    depends on the connection's isolation level being READ COMMITTED (the
+    default for both SQLite and PostgreSQL here; nothing in this codebase
+    overrides it). Under REPEATABLE READ the re-select could still miss the
+    just-committed row and this would exhaust its retries.
+
+    Same intent as `AgentManagementService._resolve_agent_from_template_sync`,
+    which hardens the same (user_id, template_id, quick-access origin)
+    uniqueness for the /task quick-access flow, but not the same mechanism:
+    that resolver does a full `db.rollback()` per attempt (it owns its own
+    session), while this one uses a SAVEPOINT (`db.begin_nested()`) so a
+    collision only unwinds this attempt - not the manager agent / Workforce
+    already staged in the caller's outer transaction. Both discriminate the
+    same two constraints via `is_agent_template_quick_access_unique_violation`
+    / `is_agent_name_unique_violation` before deciding how to retry.
     """
     existing = _find_quick_access_worker_agent(
         db, user_id=user_id, template_id=template_id
@@ -320,7 +335,18 @@ async def _get_or_create_quick_access_worker_agent(
             status_code=400,
             detail=f"Workforce template references an unknown template: {template_id}",
         )
-    agent_config = worker_template.get("agent_config", {})
+    if worker_template.get("type", "agent") != "agent":
+        # A workforce template's agents[] must reference single-agent
+        # templates. TemplateManager._enrich_template nulls agent_config for
+        # any non-agent template, so without this check a workforce
+        # referencing another workforce would crash below on
+        # `None.get(...)` instead of failing with a clear message.
+        raise HTTPException(
+            status_code=400,
+            detail=f"Workforce template references a non-agent template as a "
+            f"worker: {template_id}",
+        )
+    agent_config = worker_template.get("agent_config") or {}
 
     for attempt in range(TEMPLATE_RESOLVE_RACE_RETRIES):
         try:
@@ -347,22 +373,47 @@ async def _get_or_create_quick_access_worker_agent(
                     template_id=template_id,
                 )
             return agent
-        except IntegrityError:
+        except IntegrityError as exc:
             # The savepoint rollback above already discarded our failed
-            # insert; a concurrent request won the race, so its row should
-            # now be visible.
-            existing = _find_quick_access_worker_agent(
-                db, user_id=user_id, template_id=template_id
-            )
-            if existing is not None:
-                return existing
-            logger.warning(
-                "Quick-access worker agent insert collided without a "
-                "resolvable row (attempt %s/%s) for template_id=%s",
-                attempt + 1,
-                TEMPLATE_RESOLVE_RACE_RETRIES,
-                template_id,
-            )
+            # insert. Which constraint fired determines what a retry should
+            # even do - conflating them previously misdiagnosed a genuine
+            # name collision as this template's quick-access race, which
+            # burns every retry on a re-select that can never find a row
+            # (nothing else raced for *this* template_id) and returns a
+            # misleading 409 (PR #1127 review).
+            if is_agent_template_quick_access_unique_violation(exc):
+                # A concurrent request won the (user_id, template_id)
+                # quick-access race; its row should now be visible.
+                existing = _find_quick_access_worker_agent(
+                    db, user_id=user_id, template_id=template_id
+                )
+                if existing is not None:
+                    return existing
+                logger.warning(
+                    "Quick-access worker agent insert collided on the "
+                    "quick-access index without a resolvable row (attempt "
+                    "%s/%s) for template_id=%s",
+                    attempt + 1,
+                    TEMPLATE_RESOLVE_RACE_RETRIES,
+                    template_id,
+                )
+            elif is_agent_name_unique_violation(exc):
+                # resolve_unique_agent_name's own check-then-insert lost a
+                # race for the name it picked - not a quick-access race at
+                # all. Retrying picks a fresh name via the next iteration's
+                # resolve_unique_agent_name call.
+                logger.warning(
+                    "Quick-access worker agent name collided (attempt "
+                    "%s/%s) for template_id=%s; retrying with a new name",
+                    attempt + 1,
+                    TEMPLATE_RESOLVE_RACE_RETRIES,
+                    template_id,
+                )
+            else:
+                # An unrecognized constraint (e.g. a widget_key collision or
+                # an unrelated FK failure) - don't misdiagnose it as either
+                # race above.
+                raise
 
     raise HTTPException(
         status_code=409,
@@ -459,6 +510,7 @@ async def create_workforce_from_template(
                 assignment_instructions=str(agent_spec["assignment_instructions"]),
                 enabled=True,
                 sort_order=index + 1,
+                template_id=str(agent_spec["template_id"]),
             )
 
         manager_agent_id = int(manager_agent.id)
@@ -480,15 +532,15 @@ async def create_workforce_from_template(
 def get_localized_description(template: dict[str, Any]) -> str | None:
     """Best-effort English description for a newly created Workforce's
     `description` column, which - unlike the template gallery response - is
-    not locale-aware. `descriptions` is the same {en, zh, ...} dict shape
-    validated by `TemplateManager._parse_yaml_file`.
+    not locale-aware. `descriptions` is always a {en, zh, ...} dict here -
+    `TemplateManager._parse_yaml_file` raises ValueError for any other
+    shape, so a template dict reaching this function can't carry a plain
+    string instead.
     """
     descriptions = template.get("descriptions")
     if isinstance(descriptions, dict):
         value = descriptions.get("en")
         return str(value) if value else None
-    if isinstance(descriptions, str):
-        return descriptions
     return None
 
 

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -25,7 +25,11 @@ from .workforce_access import (
     can_create_workforce,
     resolve_create_scope,
 )
-from .workforce_names import resolve_unique_agent_name, resolve_unique_workforce_name
+from .workforce_names import (
+    is_workforce_name_unique_violation,
+    resolve_unique_agent_name,
+    resolve_unique_workforce_name,
+)
 from .workforce_snapshot import normalize_text
 from .workforce_workers import create_workforce_worker
 
@@ -288,15 +292,17 @@ def _find_quick_access_worker_agent(
     )
 
 
-# Stable English prefix the frontend matches on to render a translated,
-# agent-name-specific message (see WORKFORCE_USE_ERROR_KEYS in
-# templates/page.tsx) - the variable part (the agent's name) is
-# deliberately appended as its own sentence after it, not interpolated
-# into the middle of the fixed text, so that prefix match stays exact
-# regardless of the name's contents.
-UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX = (
-    "This workforce needs an agent that is currently unpublished: "
-)
+# Machine-readable error codes for the workforce-from-template flow,
+# following the structured-detail pattern already used by agents.py
+# ("agent_in_use_by_workforce") and mcp.py. The frontend maps these codes
+# to translated messages instead of byte-matching human-readable English
+# detail strings, which silently degraded to a generic toast on any
+# backend wording change (PR #1127 re-review, m4). `params` carries the
+# variable parts (e.g. the agent's name) separately so translations can
+# interpolate them.
+WORKFORCE_CREATE_ACCESS_DENIED_CODE = "workforce_create_access_denied"
+WORKFORCE_CREATE_CONFLICT_CODE = "workforce_create_conflict"
+WORKFORCE_WORKER_UNPUBLISHED_CODE = "workforce_worker_unpublished"
 
 
 def _ensure_published_quick_access_agent(agent: Agent) -> Agent:
@@ -315,9 +321,13 @@ def _ensure_published_quick_access_agent(agent: Agent) -> Agent:
     if agent.status != AgentStatus.PUBLISHED:
         raise HTTPException(
             status_code=400,
-            detail=f"{UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX}{agent.name}. "
-            "Republish it from your Agents list, then try this workforce "
-            "template again.",
+            detail={
+                "code": WORKFORCE_WORKER_UNPUBLISHED_CODE,
+                "message": f"This workforce needs an agent that is "
+                f"currently unpublished: {agent.name}. Republish it from "
+                "your Agents list, then try this workforce template again.",
+                "params": {"agent_name": agent.name},
+            },
         )
     return agent
 
@@ -469,8 +479,11 @@ async def _get_or_create_quick_access_worker_agent(
 
     raise HTTPException(
         status_code=409,
-        detail="Could not create the workforce's worker agents due to a "
-        "concurrent request; please try again.",
+        detail={
+            "code": WORKFORCE_CREATE_CONFLICT_CODE,
+            "message": "Could not create the workforce's worker agents due "
+            "to a concurrent request; please try again.",
+        },
     )
 
 
@@ -499,7 +512,13 @@ async def create_workforce_from_template(
 
     scope_type, scope_id = resolve_create_scope(db, user)
     if not can_create_workforce(db, user, scope_type, scope_id):
-        raise HTTPException(status_code=403, detail="Access denied")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": WORKFORCE_CREATE_ACCESS_DENIED_CODE,
+                "message": "Access denied",
+            },
+        )
 
     owner_user_id = int(user.id)
     try:
@@ -509,19 +528,16 @@ async def create_workforce_from_template(
             scope_id=scope_id,
             name=str(template.get("name") or "Workforce"),
         )
-        # Unlike the worker-resolution loop below, this insert is NOT
-        # wrapped in its own `db.begin_nested()` - a concurrent collision
-        # here would propagate straight out of the outer `try`, rolling
-        # back the whole workforce creation instead of just this insert.
-        # That is safe only because `uq_agents_user_id_name_active`
-        # (`AGENT_NAME_UNIQUE_INDEX` in `xagent/web/models/agent.py`) is a
-        # partial index whose predicate excludes
-        # `origin='workforce_generated_manager'` rows entirely, so two
-        # concurrent managers can even share a name without ever hitting a
-        # unique-constraint collision in the first place. If that predicate
-        # ever changes, concurrent workforce instantiation would need the
-        # same SAVEPOINT-retry treatment as the worker path (PR #1127
-        # re-review, F11).
+        # The manager-agent insert (unlike the Workforce insert just below)
+        # is NOT wrapped in its own `db.begin_nested()` - that is safe only
+        # because `uq_agents_user_id_name_active` (`AGENT_NAME_UNIQUE_INDEX`
+        # in `xagent/web/models/agent.py`) is a partial index whose
+        # predicate excludes `origin='workforce_generated_manager'` rows
+        # entirely, so two concurrent managers can even share a name
+        # without ever hitting a unique-constraint collision in the first
+        # place. If that predicate ever changes, this insert would need the
+        # same SAVEPOINT-retry treatment as the Workforce insert below (PR
+        # #1127 re-review, F11).
         manager_agent = AgentStore(db).add_agent(
             user_id=owner_user_id,
             name=resolve_unique_agent_name(
@@ -545,20 +561,59 @@ async def create_workforce_from_template(
             allowed_domains=[],
         )
 
-        workforce = Workforce(
-            owner_user_id=owner_user_id,
-            scope_type=scope_type,
-            scope_id=scope_id,
-            name=name,
-            description=normalize_text(
-                cast(str | None, get_localized_description(template, lang)),
-                "description",
-            ),
-            manager_agent_id=int(manager_agent.id),
-            status="draft",
+        workforce_description = normalize_text(
+            cast(str | None, get_localized_description(template, lang)),
+            "description",
         )
-        db.add(workforce)
-        db.flush()
+        # `name` came from an unlocked check-then-insert
+        # (`resolve_unique_workforce_name`), same shape as the worker-agent
+        # race below - two concurrent instantiations of the SAME template
+        # (this template's name is fixed, unlike `create_workforce_from_prompt`'s
+        # LLM-generated one, so this collision is not just theoretical) can
+        # both resolve the same name and race to insert it. Retry inside a
+        # SAVEPOINT so a collision only unwinds this insert, not the
+        # manager agent already created above (PR #1127 re-review, M1).
+        workforce: Workforce | None = None
+        for attempt in range(TEMPLATE_RESOLVE_RACE_RETRIES):
+            try:
+                with db.begin_nested():
+                    workforce = Workforce(
+                        owner_user_id=owner_user_id,
+                        scope_type=scope_type,
+                        scope_id=scope_id,
+                        name=name,
+                        description=workforce_description,
+                        manager_agent_id=int(manager_agent.id),
+                        status="draft",
+                    )
+                    db.add(workforce)
+                    db.flush()
+                break
+            except IntegrityError as exc:
+                if not is_workforce_name_unique_violation(exc):
+                    raise
+                logger.warning(
+                    "Workforce name %r collided (attempt %s/%s) for "
+                    "scope_type=%s scope_id=%s; retrying with a new name",
+                    name,
+                    attempt + 1,
+                    TEMPLATE_RESOLVE_RACE_RETRIES,
+                    scope_type,
+                    scope_id,
+                )
+                name = resolve_unique_workforce_name(
+                    db, scope_type=scope_type, scope_id=scope_id, name=name
+                )
+        else:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": WORKFORCE_CREATE_CONFLICT_CODE,
+                    "message": "Could not create the workforce due to a "
+                    "concurrent request; please try again.",
+                },
+            )
+        assert workforce is not None
 
         for index, agent_spec in enumerate(agent_specs):
             worker_agent = await _get_or_create_quick_access_worker_agent(

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -5,10 +5,12 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.user import User
+from xagent.web.services.agent_management import TEMPLATE_RESOLVE_RACE_RETRIES
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
 from ..models.workforce import Workforce, WorkforceBuilderMessage
@@ -265,6 +267,229 @@ def _create_manager_agent_from_plan(
         widget_enabled=False,
         allowed_domains=[],
     )
+
+
+def _find_quick_access_worker_agent(
+    db: Session, *, user_id: int, template_id: str
+) -> Agent | None:
+    return (
+        db.query(Agent)
+        .filter(
+            Agent.user_id == user_id,
+            Agent.template_id == template_id,
+            Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+        )
+        .order_by(Agent.id)
+        .first()
+    )
+
+
+async def _get_or_create_quick_access_worker_agent(
+    db: Session,
+    template_manager: Any,
+    *,
+    user_id: int,
+    template_id: str,
+) -> Agent:
+    """Reuse the caller's existing quick-access instance of `template_id` if
+    one exists, else create+publish a new one. Mirrors the get-or-create
+    query `AgentManagementService.resolve_agent_from_template` uses for the
+    /task quick-access flow, so instantiating the same workforce template
+    twice does not mint duplicate worker agents.
+
+    A plain select-then-insert here would race: two concurrent calls (e.g. a
+    double-clicked "Use") can both miss the SELECT and then collide on
+    `uq_agents_user_id_template_id_quick_access` at INSERT. Each insert
+    attempt therefore runs in its own SAVEPOINT (`db.begin_nested()`) so a
+    collision only unwinds that attempt - not the manager agent / Workforce
+    already staged in the caller's outer transaction - and we retry by
+    re-reading the row the winning concurrent request just committed.
+    Mirrors `AgentManagementService._resolve_agent_from_template_sync`'s
+    retry loop, which hardens the same (user_id, template_id, quick-access
+    origin) uniqueness for the /task quick-access flow.
+    """
+    existing = _find_quick_access_worker_agent(
+        db, user_id=user_id, template_id=template_id
+    )
+    if existing is not None:
+        return existing
+
+    worker_template = await template_manager.get_template(template_id)
+    if not worker_template:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Workforce template references an unknown template: {template_id}",
+        )
+    agent_config = worker_template.get("agent_config", {})
+
+    for attempt in range(TEMPLATE_RESOLVE_RACE_RETRIES):
+        try:
+            with db.begin_nested():
+                agent = AgentStore(db).add_agent(
+                    user_id=user_id,
+                    name=resolve_unique_agent_name(
+                        db,
+                        user_id=user_id,
+                        name=str(worker_template.get("name") or template_id),
+                    ),
+                    description=None,
+                    instructions=agent_config.get("instructions", ""),
+                    execution_mode=agent_config.get("execution_mode", "balanced"),
+                    models=None,
+                    knowledge_bases=[],
+                    skills=agent_config.get("skills", []),
+                    tool_categories=agent_config.get("tool_categories", []),
+                    suggested_prompts=[],
+                    origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+                    status=AgentStatus.PUBLISHED,
+                    widget_enabled=False,
+                    allowed_domains=[],
+                    template_id=template_id,
+                )
+            return agent
+        except IntegrityError:
+            # The savepoint rollback above already discarded our failed
+            # insert; a concurrent request won the race, so its row should
+            # now be visible.
+            existing = _find_quick_access_worker_agent(
+                db, user_id=user_id, template_id=template_id
+            )
+            if existing is not None:
+                return existing
+            logger.warning(
+                "Quick-access worker agent insert collided without a "
+                "resolvable row (attempt %s/%s) for template_id=%s",
+                attempt + 1,
+                TEMPLATE_RESOLVE_RACE_RETRIES,
+                template_id,
+            )
+
+    raise HTTPException(
+        status_code=409,
+        detail="Could not create the workforce's worker agents due to a "
+        "concurrent request; please try again.",
+    )
+
+
+async def create_workforce_from_template(
+    db: Session,
+    user: User,
+    template_manager: Any,
+    template: dict[str, Any],
+) -> Workforce:
+    """Instantiate a workforce-type template: a fresh manager agent (from
+    `workforce_config.manager`) plus one worker agent per
+    `workforce_config.agents[]` entry, reused/created from that entry's own
+    `template_id` (see `_get_or_create_quick_access_worker_agent`), then
+    assembled into a new `Workforce`. Mirrors the transaction shape of
+    `create_workforce_from_prompt` above: everything commits together, or
+    rolls back together.
+    """
+    workforce_config = template.get("workforce_config") or {}
+    manager_spec = cast(dict[str, Any], workforce_config.get("manager") or {})
+    agent_specs = cast(list[dict[str, Any]], workforce_config.get("agents") or [])
+    if not manager_spec.get("instructions") or not agent_specs:
+        raise HTTPException(
+            status_code=400, detail="Template is missing workforce configuration"
+        )
+
+    scope_type, scope_id = resolve_create_scope(db, user)
+    if not can_create_workforce(db, user, scope_type, scope_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    owner_user_id = int(user.id)
+    try:
+        name = resolve_unique_workforce_name(
+            db,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=str(template.get("name") or "Workforce"),
+        )
+        manager_agent = AgentStore(db).add_agent(
+            user_id=owner_user_id,
+            name=resolve_unique_agent_name(
+                db,
+                user_id=owner_user_id,
+                name=str(manager_spec.get("name") or f"{name} Manager"),
+            ),
+            description=normalize_text(
+                cast(str | None, manager_spec.get("description")), "description"
+            ),
+            instructions=str(manager_spec["instructions"]),
+            execution_mode=str(manager_spec.get("execution_mode") or "think"),
+            models=None,
+            knowledge_bases=[],
+            skills=cast(list[str], manager_spec.get("skills") or []),
+            tool_categories=cast(list[str], manager_spec.get("tool_categories") or []),
+            suggested_prompts=[],
+            origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            status=AgentStatus.PUBLISHED,
+            widget_enabled=False,
+            allowed_domains=[],
+        )
+
+        workforce = Workforce(
+            owner_user_id=owner_user_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=name,
+            description=normalize_text(
+                cast(str | None, get_localized_description(template)), "description"
+            ),
+            manager_agent_id=int(manager_agent.id),
+            status="draft",
+        )
+        db.add(workforce)
+        db.flush()
+
+        for index, agent_spec in enumerate(agent_specs):
+            worker_agent = await _get_or_create_quick_access_worker_agent(
+                db,
+                template_manager,
+                user_id=owner_user_id,
+                template_id=str(agent_spec["template_id"]),
+            )
+            create_workforce_worker(
+                db,
+                workforce,
+                user,
+                source_type="existing",
+                agent_id=int(worker_agent.id),
+                alias=cast(str | None, agent_spec.get("alias")),
+                assignment_instructions=str(agent_spec["assignment_instructions"]),
+                enabled=True,
+                sort_order=index + 1,
+            )
+
+        manager_agent_id = int(manager_agent.id)
+        workforce_id = int(workforce.id)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    else:
+        invalidate_workforce_creation_cache(
+            owner_user_id=owner_user_id,
+            manager_agent_id=manager_agent_id,
+            workforce_id=workforce_id,
+        )
+    db.refresh(workforce)
+    return workforce
+
+
+def get_localized_description(template: dict[str, Any]) -> str | None:
+    """Best-effort English description for a newly created Workforce's
+    `description` column, which - unlike the template gallery response - is
+    not locale-aware. `descriptions` is the same {en, zh, ...} dict shape
+    validated by `TemplateManager._parse_yaml_file`.
+    """
+    descriptions = template.get("descriptions")
+    if isinstance(descriptions, dict):
+        value = descriptions.get("en")
+        return str(value) if value else None
+    if isinstance(descriptions, str):
+        return descriptions
+    return None
 
 
 def invalidate_workforce_creation_cache(

--- a/src/xagent/web/services/workforce_names.py
+++ b/src/xagent/web/services/workforce_names.py
@@ -9,6 +9,38 @@ from ..models.workforce import Workforce
 from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .workforce_snapshot import normalize_text
 
+# Shared with workforce_creator.py's SAVEPOINT retry around Workforce
+# creation, which needs to tell "a concurrent request took this exact name"
+# apart from any other IntegrityError.
+WORKFORCE_SCOPE_NAME_UNIQUE_INDEX = "uq_workforce_scope_name"
+
+
+def is_workforce_name_unique_violation(error: BaseException) -> bool:
+    """Recognize the authoritative (scope_type, scope_id, name) unique
+    constraint failure - the `Workforce` counterpart to
+    `is_agent_name_unique_violation` in `agent_management.py`. Postgres
+    includes the constraint name in its error message; sqlite instead names
+    the columns. Matching either keeps this from misclassifying an
+    unrelated IntegrityError (e.g. a manager_agent_id FK violation) as a
+    name collision.
+    """
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if WORKFORCE_SCOPE_NAME_UNIQUE_INDEX.lower() in message:
+            return True
+        if (
+            "workforces.scope_type" in message
+            and "workforces.scope_id" in message
+            and "workforces.name" in message
+            and ("unique" in message or "duplicate" in message)
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
 
 def workforce_name_exists(
     db: Session,

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -45,6 +45,7 @@ def create_workforce_worker(
     enabled: bool = True,
     sort_order: int | None = None,
     canvas_position: dict[str, Any] | None = None,
+    template_id: str | None = None,
 ) -> WorkforceAgent:
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
     ensure_supported_source_type(source_type)
@@ -98,6 +99,7 @@ def create_workforce_worker(
         if sort_order is not None
         else next_worker_sort_order(db, workforce_id),
         canvas_position=canvas_position,
+        template_id=template_id,
     )
     db.add(worker)
     db.flush()

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -558,12 +558,36 @@ sample_prompts:
         "mutate,match",
         [
             (lambda c: "not a dict", "must be a mapping"),
-            (lambda c: {**c, "manager": None}, "manager.instructions"),
+            (lambda c: {**c, "manager": None}, "manager.*must be a mapping"),
             (
                 lambda c: {**c, "manager": {"name": "M", "instructions": "  "}},
                 "manager.instructions",
             ),
             (lambda c: {**c, "manager": {"instructions": "Go"}}, "manager.name"),
+            # Strict isinstance(str) - str(...) coercion used to let YAML
+            # lists/ints through load-time validation, only to surface as
+            # garbage prompts/ids (or an AttributeError -> 500 for the
+            # normalize_text'd optional fields) at instantiation time
+            # (PR #1127 re-review, m1).
+            (
+                lambda c: {
+                    **c,
+                    "manager": {**c["manager"], "instructions": ["not", "a", "str"]},
+                },
+                "manager.instructions",
+            ),
+            (
+                lambda c: {**c, "manager": {**c["manager"], "description": 123}},
+                "manager.description",
+            ),
+            (
+                lambda c: {**c, "agents": [{**c["agents"][0], "template_id": 42}]},
+                r"agents\[0\]\.template_id",
+            ),
+            (
+                lambda c: {**c, "agents": [{**c["agents"][0], "alias": ["GA"]}]},
+                r"agents\[0\]\.alias",
+            ),
             (lambda c: {**c, "agents": None}, "agents.*non-empty list"),
             (lambda c: {**c, "agents": []}, "agents.*non-empty list"),
             (lambda c: {**c, "agents": ["not a dict"]}, r"agents\[0\].*mapping"),
@@ -620,6 +644,22 @@ sample_prompts:
         config = mutate(self._valid_workforce_config())
         with pytest.raises(ValueError, match=match):
             manager._validate_workforce_config(config)
+
+    def test_workforce_config_strings_are_normalized_in_place(self, tmp_path):
+        """Validation strips string fields in place. A template_id with
+        surrounding whitespace used to be stripped for the duplicate check
+        but looked up RAW at instantiation time, guaranteeing a
+        "references an unknown template" 400 the moment anyone used the
+        template (PR #1127 re-review, m1)."""
+        manager = TemplateManager(templates_root=tmp_path)
+        config = self._valid_workforce_config()
+        config["agents"][0]["template_id"] = "  ga-analyzer  "
+        config["manager"]["name"] = " Growth Manager "
+
+        manager._validate_workforce_config(config)
+
+        assert config["agents"][0]["template_id"] == "ga-analyzer"
+        assert config["manager"]["name"] == "Growth Manager"
 
     @pytest.mark.asyncio
     async def test_workforce_type_template_requires_workforce_config(self, tmp_path):

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -529,7 +529,13 @@ sample_prompts:
     @staticmethod
     def _valid_workforce_config():
         return {
-            "manager": {"name": "Growth Manager", "instructions": "Orchestrate."},
+            "manager": {
+                "name": "Growth Manager",
+                "instructions": "Orchestrate.",
+                "execution_mode": "think",
+                "tool_categories": ["basic"],
+                "skills": [],
+            },
             "agents": [
                 {
                     "template_id": "ga-analyzer",
@@ -588,6 +594,24 @@ sample_prompts:
                     ],
                 },
                 "duplicate template_id",
+            ),
+            (
+                lambda c: {
+                    **c,
+                    "manager": {**c["manager"], "execution_mode": "sonic"},
+                },
+                "manager.execution_mode",
+            ),
+            (
+                lambda c: {
+                    **c,
+                    "manager": {**c["manager"], "tool_categories": "basic"},
+                },
+                "manager.tool_categories",
+            ),
+            (
+                lambda c: {**c, "manager": {**c["manager"], "skills": [123]}},
+                "manager.skills",
             ),
         ],
     )

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -523,3 +523,258 @@ sample_prompts:
         templates = await manager.list_templates()
 
         assert len(templates) == 0
+
+    # ----- workforce_config validation (PR #1127 review: zero coverage) -----
+
+    @staticmethod
+    def _valid_workforce_config():
+        return {
+            "manager": {"name": "Growth Manager", "instructions": "Orchestrate."},
+            "agents": [
+                {
+                    "template_id": "ga-analyzer",
+                    "name": "GA Analyzer",
+                    "assignment_instructions": "Measure performance.",
+                },
+                {
+                    "template_id": "ads-recommendation",
+                    "name": "Ads Recommendation",
+                    "assignment_instructions": "Recommend spend changes.",
+                },
+            ],
+        }
+
+    def test_valid_workforce_config_does_not_raise(self, tmp_path):
+        manager = TemplateManager(templates_root=tmp_path)
+        manager._validate_workforce_config(self._valid_workforce_config())
+
+    @pytest.mark.parametrize(
+        "mutate,match",
+        [
+            (lambda c: "not a dict", "must be a mapping"),
+            (lambda c: {**c, "manager": None}, "manager.instructions"),
+            (
+                lambda c: {**c, "manager": {"name": "M", "instructions": "  "}},
+                "manager.instructions",
+            ),
+            (lambda c: {**c, "manager": {"instructions": "Go"}}, "manager.name"),
+            (lambda c: {**c, "agents": None}, "agents.*non-empty list"),
+            (lambda c: {**c, "agents": []}, "agents.*non-empty list"),
+            (lambda c: {**c, "agents": ["not a dict"]}, r"agents\[0\].*mapping"),
+            (
+                lambda c: {**c, "agents": [{**c["agents"][0], "template_id": ""}]},
+                r"agents\[0\]\.template_id",
+            ),
+            (
+                lambda c: {**c, "agents": [{**c["agents"][0], "name": ""}]},
+                r"agents\[0\]\.name",
+            ),
+            (
+                lambda c: {
+                    **c,
+                    "agents": [{**c["agents"][0], "assignment_instructions": ""}],
+                },
+                r"agents\[0\]\.assignment_instructions",
+            ),
+            (
+                lambda c: {
+                    **c,
+                    "agents": [
+                        c["agents"][0],
+                        {
+                            **c["agents"][1],
+                            "template_id": c["agents"][0]["template_id"],
+                        },
+                    ],
+                },
+                "duplicate template_id",
+            ),
+        ],
+    )
+    def test_invalid_workforce_config_raises(self, tmp_path, mutate, match):
+        manager = TemplateManager(templates_root=tmp_path)
+        config = mutate(self._valid_workforce_config())
+        with pytest.raises(ValueError, match=match):
+            manager._validate_workforce_config(config)
+
+    @pytest.mark.asyncio
+    async def test_workforce_type_template_requires_workforce_config(self, tmp_path):
+        """A `type: workforce` template with no workforce_config at all must
+        fail to load (not silently become a broken, config-less template)."""
+        (tmp_path / "broken_workforce.yaml").write_text(
+            """
+id: broken_workforce
+name: Broken Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: Missing workforce_config entirely.
+"""
+        )
+        manager = TemplateManager(templates_root=tmp_path)
+        await manager.initialize()
+
+        assert await manager.get_template("broken_workforce") is None
+
+    @pytest.mark.asyncio
+    async def test_agent_type_template_never_sees_workforce_validation(self, tmp_path):
+        """type defaults to 'agent' and must not trip workforce_config
+        validation just because a template happens to omit it (the common
+        case for every pre-existing template)."""
+        (tmp_path / "plain_agent.yaml").write_text(
+            """
+id: plain_agent
+name: Plain Agent
+category: General
+descriptions:
+  en: A normal single-agent template.
+agent_config:
+  instructions: You help with things.
+"""
+        )
+        manager = TemplateManager(templates_root=tmp_path)
+        await manager.initialize()
+
+        template = await manager.get_template("plain_agent")
+        assert template is not None
+        assert template["type"] == "agent"
+        assert template["workforce_config"] is None
+        assert template["agent_config"]["instructions"]
+
+    # ----- _warn_on_dangling_workforce_references -----
+
+    @pytest.mark.asyncio
+    async def test_dangling_workforce_reference_warns_but_still_loads(
+        self, tmp_path, caplog
+    ):
+        (tmp_path / "wf.yaml").write_text(
+            """
+id: wf
+name: WF
+category: Marketing
+type: workforce
+descriptions:
+  en: A workforce with a typo'd worker reference.
+workforce_config:
+  manager:
+    name: Manager
+    instructions: Orchestrate.
+  agents:
+  - template_id: does-not-exist
+    name: Ghost Worker
+    assignment_instructions: Do the thing.
+"""
+        )
+        manager = TemplateManager(templates_root=tmp_path)
+        with caplog.at_level("WARNING"):
+            await manager.initialize()
+
+        assert await manager.get_template("wf") is not None
+        assert any(
+            "does-not-exist" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_workforce_referencing_another_workforce_warns(
+        self, tmp_path, caplog
+    ):
+        """agents[].template_id must resolve to an 'agent'-type template - a
+        workforce referencing another workforce as a worker would crash at
+        instantiation time (that template's agent_config is null), so this
+        must be flagged at load time too, not just guarded at the point of
+        use."""
+        (tmp_path / "inner.yaml").write_text(
+            """
+id: inner
+name: Inner
+category: Marketing
+type: workforce
+descriptions:
+  en: Another workforce, wrongly used as a worker below.
+workforce_config:
+  manager:
+    name: Inner Manager
+    instructions: Orchestrate.
+  agents:
+  - template_id: leaf
+    name: Leaf
+    assignment_instructions: Do the thing.
+"""
+        )
+        (tmp_path / "leaf.yaml").write_text(
+            """
+id: leaf
+name: Leaf
+category: Marketing
+descriptions:
+  en: A normal single-agent template.
+agent_config:
+  instructions: You help with things.
+"""
+        )
+        (tmp_path / "outer.yaml").write_text(
+            """
+id: outer
+name: Outer
+category: Marketing
+type: workforce
+descriptions:
+  en: References 'inner' (a workforce) as if it were a single agent.
+workforce_config:
+  manager:
+    name: Outer Manager
+    instructions: Orchestrate.
+  agents:
+  - template_id: inner
+    name: Nested Workforce
+    assignment_instructions: Do the thing.
+"""
+        )
+        manager = TemplateManager(templates_root=tmp_path)
+        with caplog.at_level("WARNING"):
+            await manager.initialize()
+
+        assert any(
+            "outer" in record.message
+            and "inner" in record.message
+            and "not 'agent'" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_builtin_workforce_template_references_resolve(self):
+        """The real shipped YAML never loaded in any test before this - a
+        typo'd `workforce_config.agents[].template_id` on the built-in
+        Growth Marketing Workforce template would not have failed CI. Load
+        the actual built_in/ directory and assert every workforce
+        template's references resolve to a loaded 'agent'-type template."""
+        built_in_dir = (
+            Path(__file__).resolve().parents[2] / "src/xagent/templates/built_in"
+        )
+        manager = TemplateManager(templates_root=built_in_dir)
+        await manager.initialize()
+        templates = {t["id"]: t for t in await manager.list_templates()}
+
+        workforce_templates = [
+            t for t in templates.values() if t["type"] == "workforce"
+        ]
+        assert workforce_templates, "expected at least one built-in workforce template"
+
+        offenders: list[str] = []
+        for template in workforce_templates:
+            workforce_config = template.get("workforce_config") or {}
+            for agent in workforce_config.get("agents") or []:
+                referenced_id = agent.get("template_id")
+                referenced = templates.get(referenced_id)
+                if referenced is None:
+                    offenders.append(
+                        f"{template['id']} -> unknown template_id {referenced_id!r}"
+                    )
+                elif referenced.get("type", "agent") != "agent":
+                    offenders.append(
+                        f"{template['id']} -> {referenced_id!r} has type="
+                        f"{referenced.get('type')!r}, not 'agent'"
+                    )
+
+        assert not offenders, "\n".join(offenders)

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -752,6 +752,13 @@ class TestUseTemplateAsWorkforce:
                     .all()
                 )
                 assert len(workers) == 2
+                # WorkforceAgent.template_id records provenance - which
+                # template's workforce_config.agents[] entry created this
+                # worker link (PR #1127 review: previously always NULL).
+                assert {w.template_id for w in workers} == {
+                    "ga_analyzer",
+                    "ads_recommendation",
+                }
                 worker_agent_ids = {w.agent_id for w in workers}
                 worker_agents = (
                     db.query(Agent).filter(Agent.id.in_(worker_agent_ids)).all()
@@ -831,5 +838,79 @@ class TestUseTemplateAsWorkforce:
                     .count()
                 )
                 assert quick_access_count == 2
+            finally:
+                db.close()
+
+    def test_rejects_when_workforce_creation_is_not_allowed(
+        self, workforce_mock_app_state, admin_headers
+    ):
+        """403 when the workforce access policy (can_create_workforce)
+        denies the request - not covered before this test (PR #1127
+        review)."""
+        with (
+            patch.object(client.app, "state", workforce_mock_app_state),
+            patch(
+                "xagent.web.services.workforce_creator.can_create_workforce",
+                return_value=False,
+            ),
+        ):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 403
+
+    def test_rejects_unknown_worker_template_at_use_time(self, tmp_path, admin_headers):
+        """workforce_config.agents[].template_id is only checked for being a
+        non-empty string at load time (cross-file references can't be
+        validated per-file) - a dangling reference must surface as a clean
+        400 when the template is actually used, not an unhandled crash
+        (PR #1127 review)."""
+        import asyncio
+
+        from xagent.templates.manager import TemplateManager
+
+        templates_dir = tmp_path / "dangling_workforce_templates"
+        templates_dir.mkdir()
+        (templates_dir / "dangling_workforce.yaml").write_text(
+            """
+id: dangling_workforce
+name: Dangling Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: References a worker template that does not exist.
+author: Xagent
+version: "1.0"
+
+workforce_config:
+  manager:
+    name: Dangling Manager
+    instructions: |
+      You are the manager.
+  agents:
+  - template_id: ghost_agent
+    name: Ghost Worker
+    assignment_instructions: Do the thing.
+"""
+        )
+        template_manager = TemplateManager(templates_root=templates_dir)
+        asyncio.run(template_manager.initialize())
+        mock_state = MagicMock()
+        mock_state.template_manager = template_manager
+
+        with patch.object(client.app, "state", mock_state):
+            response = client.post(
+                "/api/templates/dangling_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 400
+
+            db = next(get_db())
+            try:
+                # The failed attempt must not have left a partial
+                # manager/Workforce behind.
+                assert db.query(Workforce).count() == 0
+                assert db.query(Agent).count() == 0
             finally:
                 db.close()

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -12,7 +12,9 @@ from sqlalchemy.exc import IntegrityError
 
 from xagent.web.api.auth import auth_router, hash_password
 from xagent.web.api.templates import (
+    get_or_create_template_stats,
     increment_template_likes,
+    increment_template_used_count,
 )
 from xagent.web.api.templates import router as templates_router
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
@@ -650,6 +652,64 @@ class TestTemplatesAPI:
             )
             assert response.json()["used_count"] == 1
 
+    def test_use_rejects_workforce_template(
+        self, workforce_mock_app_state, admin_headers
+    ):
+        """The legacy POST /use only knows how to record usage for an
+        agent-creation flow (the frontend never calls it for a workforce
+        template today, but nothing stopped an external caller from
+        hitting it directly and getting a misleading 200 "recorded" while
+        creating nothing - every other agent-creation surface already
+        refuses workforce templates) (PR #1127 re-review, m2)."""
+        with patch.object(client.app, "state", workforce_mock_app_state):
+            response = client.post(
+                "/api/templates/growth_workforce/use", headers=admin_headers
+            )
+            assert response.status_code == 400
+
+            detail = client.get(
+                "/api/templates/growth_workforce", headers=admin_headers
+            ).json()
+            assert detail["used_count"] == 0
+
+    def test_use_count_increments_atomically_under_concurrent_reads(
+        self, mock_app_state, admin_headers
+    ):
+        """`stats.used_count += 1` is an ORM read-modify-write: two sessions
+        that both read used_count=0 before either commits would both write
+        1, losing an increment. `increment_template_used_count` (mirroring
+        the existing `increment_template_likes` pattern) uses an atomic
+        `UPDATE ... SET used_count = used_count + 1` instead - simulate two
+        already-open sessions racing to prove the count doesn't stall at 1
+        (PR #1127 re-review, m3)."""
+        with patch.object(client.app, "state", mock_app_state):
+            db1 = next(get_db())
+            db2 = next(get_db())
+            try:
+                stats1 = get_or_create_template_stats(db1, "customer_support")
+                stats2 = get_or_create_template_stats(db2, "customer_support")
+                assert stats1.used_count == 0
+                assert stats2.used_count == 0
+
+                increment_template_used_count(db1, "customer_support")
+                db1.commit()
+                increment_template_used_count(db2, "customer_support")
+                db2.commit()
+            finally:
+                db1.close()
+                db2.close()
+
+            db = next(get_db())
+            try:
+                stats = (
+                    db.query(TemplateStats)
+                    .filter(TemplateStats.template_id == "customer_support")
+                    .one()
+                )
+                assert stats.used_count == 2
+            finally:
+                db.close()
+
     def test_get_template_increments_views(self, mock_app_state, admin_headers):
         """测试获取模板详情增加访问次数"""
         with patch.object(client.app, "state", mock_app_state):
@@ -967,9 +1027,8 @@ workforce_config:
         "please try again" a retry can never resolve - and the failed
         attempt must not leave a stray manager/Workforce behind
         (PR #1127 re-review, F1)."""
-        from xagent.web.models.agent import AgentOrigin, AgentStatus
         from xagent.web.services.workforce_creator import (
-            UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX,
+            WORKFORCE_WORKER_UNPUBLISHED_CODE,
         )
 
         db = next(get_db())
@@ -995,10 +1054,13 @@ workforce_config:
                 headers=admin_headers,
             )
             assert response.status_code == 400
-            assert response.json()["detail"].startswith(
-                UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX
-            )
-            assert "GA Analyzer" in response.json()["detail"]
+            # Structured {code, message, params} detail - the frontend maps
+            # the machine code and interpolates params.agent_name rather
+            # than parsing the English message (PR #1127 re-review, m4).
+            detail = response.json()["detail"]
+            assert detail["code"] == WORKFORCE_WORKER_UNPUBLISHED_CODE
+            assert detail["params"]["agent_name"] == "GA Analyzer"
+            assert "GA Analyzer" in detail["message"]
 
             db = next(get_db())
             try:
@@ -1008,3 +1070,205 @@ workforce_config:
                 assert db.query(Agent).count() == 1
             finally:
                 db.close()
+
+    def test_recovers_from_a_genuine_concurrent_workforce_name_collision(
+        self, workforce_mock_app_state, admin_headers, admin_user
+    ):
+        """Two concurrent instantiations of THIS SAME template resolve the
+        SAME Workforce name - unlike `create_workforce_from_prompt`'s
+        LLM-generated name, a workforce template's name is fixed, so this
+        collision is the realistic case, not a theoretical one. Uses a
+        genuinely separate session (not a row staged inside the same
+        SAVEPOINT scope, which a first attempt at this test class of
+        problem already proved gets rolled back right along with the
+        failed insert - see the worker-resolution race tests) to commit a
+        colliding `Workforce` row between our own `resolve_unique_workforce_name`
+        check and our own insert, reproducing the exact TOCTOU window a
+        double-click, a double-tab, or a retried request can hit
+        (PR #1127 re-review, M1)."""
+        from sqlalchemy.orm import sessionmaker
+
+        from xagent.web.models.database import get_engine
+        from xagent.web.services import workforce_creator
+
+        real_resolve_unique_workforce_name = (
+            workforce_creator.resolve_unique_workforce_name
+        )
+        session_factory = sessionmaker(bind=get_engine())
+        call_count = {"n": 0}
+        competitor_manager_id: dict[str, int] = {}
+
+        def _collide_once_then_resolve(db, *, scope_type, scope_id, name):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                competitor_session = session_factory()
+                try:
+                    # This engine enforces FK constraints (PRAGMA
+                    # foreign_keys=ON, see src/xagent/db/sqlite.py) -
+                    # manager_agent_id needs a real Agent row.
+                    competitor_manager = Agent(
+                        user_id=admin_user["id"],
+                        name="Competitor Manager",
+                        instructions="from the concurrent winner",
+                        execution_mode="think",
+                        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+                        status=AgentStatus.PUBLISHED,
+                    )
+                    competitor_session.add(competitor_manager)
+                    competitor_session.flush()
+                    competitor_manager_id["id"] = competitor_manager.id
+                    competitor_session.add(
+                        Workforce(
+                            owner_user_id=admin_user["id"],
+                            scope_type=scope_type,
+                            scope_id=scope_id,
+                            name=name,
+                            manager_agent_id=competitor_manager.id,
+                            status="draft",
+                        )
+                    )
+                    competitor_session.commit()
+                finally:
+                    competitor_session.close()
+                return name
+            return real_resolve_unique_workforce_name(
+                db, scope_type=scope_type, scope_id=scope_id, name=name
+            )
+
+        with (
+            patch.object(client.app, "state", workforce_mock_app_state),
+            patch.object(
+                workforce_creator,
+                "resolve_unique_workforce_name",
+                side_effect=_collide_once_then_resolve,
+            ),
+        ):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        assert call_count["n"] == 2
+
+        db = next(get_db())
+        try:
+            workforces = db.query(Workforce).all()
+            assert len(workforces) == 2
+            # The competitor's manager agent is a fixture of this test, not
+            # the real request's - so whichever row does NOT point at it is
+            # the real request's Workforce, and it must have gotten a
+            # disambiguated name rather than colliding again.
+            real_workforce = next(
+                w
+                for w in workforces
+                if w.manager_agent_id != competitor_manager_id["id"]
+            )
+            competitor_workforce = next(
+                w
+                for w in workforces
+                if w.manager_agent_id == competitor_manager_id["id"]
+            )
+            assert competitor_workforce.name == "Growth Marketing Workforce"
+            assert real_workforce.name != "Growth Marketing Workforce"
+            assert real_workforce.name.startswith("Growth Marketing Workforce")
+        finally:
+            db.close()
+
+    def test_recovers_from_a_genuine_concurrent_worker_agent_collision(
+        self, workforce_mock_app_state, admin_headers, admin_user
+    ):
+        """Two-session counterpart of the worker-resolution unit tests
+        (which run on a shared-connection in-memory DB): the competing
+        quick-access GA Analyzer is committed by a genuinely separate
+        session/transaction against the file-backed test DB, and only the
+        resolver's initial SELECT miss is simulated - so the INSERT
+        collision, the SAVEPOINT rollback, the constraint classification,
+        and the recovery re-read all run against a real concurrent
+        transaction's committed row (PR #1127 re-review, m5).
+
+        The competitor must commit BEFORE the request starts: by the time
+        worker resolution runs, the request's transaction already holds
+        the manager-agent/Workforce writes, and SQLite's single-writer
+        model blocks any other session's commit until that transaction
+        ends ("database is locked" - reproduced). Interleaving a
+        mid-transaction competitor commit is only physically possible on
+        PostgreSQL; this is the maximal genuine reproduction SQLite
+        permits.
+        """
+        from sqlalchemy.orm import sessionmaker
+
+        from xagent.web.models.database import get_engine
+        from xagent.web.services import workforce_creator
+
+        real_find = workforce_creator._find_quick_access_worker_agent
+        session_factory = sessionmaker(bind=get_engine())
+        competitor_agent_id: dict[str, int] = {}
+        ga_lookups = {"n": 0}
+
+        competitor_session = session_factory()
+        try:
+            competitor = Agent(
+                user_id=admin_user["id"],
+                name="GA Analyzer",
+                instructions="from the concurrent winner",
+                execution_mode="balanced",
+                template_id="ga_analyzer",
+                origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+                status=AgentStatus.PUBLISHED,
+            )
+            competitor_session.add(competitor)
+            competitor_session.commit()
+            competitor_agent_id["id"] = competitor.id
+        finally:
+            competitor_session.close()
+
+        def _miss_once_then_delegate(db, *, user_id, template_id):
+            if template_id != "ga_analyzer":
+                return real_find(db, user_id=user_id, template_id=template_id)
+            ga_lookups["n"] += 1
+            if ga_lookups["n"] == 1:
+                # Simulates the TOCTOU window: this SELECT ran before the
+                # concurrent winner's commit became visible.
+                return None
+            return real_find(db, user_id=user_id, template_id=template_id)
+
+        with (
+            patch.object(client.app, "state", workforce_mock_app_state),
+            patch.object(
+                workforce_creator,
+                "_find_quick_access_worker_agent",
+                side_effect=_miss_once_then_delegate,
+            ),
+        ):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        # Initial miss + the post-IntegrityError recovery re-read.
+        assert ga_lookups["n"] == 2
+
+        db = next(get_db())
+        try:
+            workforce_id = response.json()["workforce_id"]
+            worker_agent_ids = {
+                w.agent_id
+                for w in db.query(WorkforceAgent).filter(
+                    WorkforceAgent.workforce_id == workforce_id
+                )
+            }
+            # The concurrent winner's row was reused, not duplicated.
+            assert competitor_agent_id["id"] in worker_agent_ids
+            assert (
+                db.query(Agent)
+                .filter(
+                    Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+                    Agent.template_id == "ga_analyzer",
+                )
+                .count()
+                == 1
+            )
+        finally:
+            db.close()

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -15,9 +15,11 @@ from xagent.web.api.templates import (
     increment_template_likes,
 )
 from xagent.web.api.templates import router as templates_router
+from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.template_stats import TemplateStats, UserTemplateRelation
 from xagent.web.models.user import User
+from xagent.web.models.workforce import Workforce, WorkforceAgent
 
 
 def override_get_db():
@@ -194,6 +196,101 @@ def mock_app_state(template_manager):
     # Create mock app state
     mock_state = MagicMock()
     mock_state.template_manager = template_manager
+    return mock_state
+
+
+@pytest.fixture(scope="function")
+def workforce_templates_dir(tmp_path):
+    """A separate templates directory (not shared with `templates_dir`,
+    whose exact template count other tests assert on) holding a
+    workforce-type template plus the two single-agent templates its
+    `workforce_config.agents[].template_id` entries reference.
+    """
+    templates_dir = tmp_path / "workforce_templates"
+    templates_dir.mkdir()
+
+    (templates_dir / "ga_analyzer.yaml").write_text(
+        """
+id: ga_analyzer
+name: GA Analyzer
+category: Marketing
+descriptions:
+  en: Explains GA4 trends.
+author: Xagent
+version: "1.0"
+
+agent_config:
+  instructions: |
+    You are the GA Analyzer.
+  skills: []
+  tool_categories: []
+"""
+    )
+    (templates_dir / "ads_recommendation.yaml").write_text(
+        """
+id: ads_recommendation
+name: Ads Recommendation
+category: Marketing
+descriptions:
+  en: Recommends ad optimizations.
+author: Xagent
+version: "1.0"
+
+agent_config:
+  instructions: |
+    You are the Ads Recommendation agent.
+  skills: []
+  tool_categories: []
+"""
+    )
+    (templates_dir / "growth_workforce.yaml").write_text(
+        """
+id: growth_workforce
+name: Growth Marketing Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: Orchestrates GA Analyzer and Ads Recommendation.
+author: Xagent
+version: "1.0"
+
+workforce_config:
+  manager:
+    name: Growth Marketing Manager
+    description: Orchestrates the workforce.
+    instructions: |
+      You are the Growth Marketing Manager.
+  agents:
+  - template_id: ga_analyzer
+    name: GA Analyzer
+    alias: GA Analyzer
+    assignment_instructions: Produce a Signals for Ads table.
+  - template_id: ads_recommendation
+    name: Ads Recommendation
+    alias: Ads Recommendation
+    assignment_instructions: Recommend ad changes using the Signals for Ads table.
+"""
+    )
+    return templates_dir
+
+
+@pytest.fixture(scope="function")
+def workforce_template_manager(workforce_templates_dir):
+    """Create a TemplateManager fixture over `workforce_templates_dir`"""
+    from xagent.templates.manager import TemplateManager
+
+    return TemplateManager(templates_root=workforce_templates_dir)
+
+
+@pytest.fixture(scope="function")
+def workforce_mock_app_state(workforce_template_manager):
+    """Mock app.state.template_manager backed by the workforce templates dir"""
+    import asyncio
+
+    asyncio.run(workforce_template_manager.initialize())
+
+    mock_state = MagicMock()
+    mock_state.template_manager = workforce_template_manager
     return mock_state
 
 
@@ -604,3 +701,135 @@ class TestTemplatesAPI:
             ]
             for field in required_fields:
                 assert field in template, f"Missing field: {field}"
+
+
+class TestUseTemplateAsWorkforce:
+    """测试 POST /api/templates/{id}/use-as-workforce"""
+
+    def test_rejects_non_workforce_template(self, mock_app_state, admin_headers):
+        with patch.object(client.app, "state", mock_app_state):
+            response = client.post(
+                "/api/templates/customer_support/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 400
+
+    def test_rejects_unknown_template(self, mock_app_state, admin_headers):
+        with patch.object(client.app, "state", mock_app_state):
+            response = client.post(
+                "/api/templates/nonexistent/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 404
+
+    def test_creates_manager_and_worker_agents(
+        self, workforce_mock_app_state, admin_headers
+    ):
+        with patch.object(client.app, "state", workforce_mock_app_state):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 200, response.text
+            payload = response.json()
+            assert payload["template_id"] == "growth_workforce"
+            workforce_id = payload["workforce_id"]
+
+            db = next(get_db())
+            try:
+                workforce = db.get(Workforce, workforce_id)
+                assert workforce is not None
+
+                manager = db.get(Agent, workforce.manager_agent_id)
+                assert manager is not None
+                assert manager.origin == AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+                assert manager.status == AgentStatus.PUBLISHED
+                assert "Growth Marketing Manager" in manager.instructions
+
+                workers = (
+                    db.query(WorkforceAgent)
+                    .filter(WorkforceAgent.workforce_id == workforce_id)
+                    .all()
+                )
+                assert len(workers) == 2
+                worker_agent_ids = {w.agent_id for w in workers}
+                worker_agents = (
+                    db.query(Agent).filter(Agent.id.in_(worker_agent_ids)).all()
+                )
+                assert len(worker_agents) == 2
+                assert all(
+                    agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value
+                    for agent in worker_agents
+                )
+                assert all(
+                    agent.status == AgentStatus.PUBLISHED for agent in worker_agents
+                )
+                assert {agent.template_id for agent in worker_agents} == {
+                    "ga_analyzer",
+                    "ads_recommendation",
+                }
+            finally:
+                db.close()
+
+            # Usage is recorded, same as the single-agent /use endpoint.
+            detail = client.get(
+                "/api/templates/growth_workforce", headers=admin_headers
+            ).json()
+            assert detail["used_count"] == 1
+
+    def test_reuses_worker_agents_across_two_instantiations(
+        self, workforce_mock_app_state, admin_headers
+    ):
+        """Instantiating the same workforce template twice must mint a new
+        manager + Workforce each time (each run gets its own orchestrator)
+        but must NOT mint duplicate worker agents - the second call should
+        reuse the first call's quick-access GA Analyzer / Ads Recommendation
+        agents (see AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX)."""
+        with patch.object(client.app, "state", workforce_mock_app_state):
+            first = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert first.status_code == 200, first.text
+            second = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert second.status_code == 200, second.text
+
+            first_workforce_id = first.json()["workforce_id"]
+            second_workforce_id = second.json()["workforce_id"]
+            assert first_workforce_id != second_workforce_id
+
+            db = next(get_db())
+            try:
+                first_workforce = db.get(Workforce, first_workforce_id)
+                second_workforce = db.get(Workforce, second_workforce_id)
+                # Two distinct, freshly-minted managers.
+                assert (
+                    first_workforce.manager_agent_id
+                    != second_workforce.manager_agent_id
+                )
+
+                first_worker_ids = {
+                    w.agent_id
+                    for w in db.query(WorkforceAgent).filter(
+                        WorkforceAgent.workforce_id == first_workforce_id
+                    )
+                }
+                second_worker_ids = {
+                    w.agent_id
+                    for w in db.query(WorkforceAgent).filter(
+                        WorkforceAgent.workforce_id == second_workforce_id
+                    )
+                }
+                assert first_worker_ids == second_worker_ids
+
+                quick_access_count = (
+                    db.query(Agent)
+                    .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)
+                    .count()
+                )
+                assert quick_access_count == 2
+            finally:
+                db.close()

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -251,6 +251,7 @@ category: Marketing
 type: workforce
 descriptions:
   en: Orchestrates GA Analyzer and Ads Recommendation.
+  zh: 编排 GA Analyzer 和 Ads Recommendation。
 author: Xagent
 version: "1.0"
 
@@ -667,12 +668,22 @@ class TestTemplatesAPI:
             assert response.json()["views"] == 2
 
     def test_unauthorized_access(self, mock_app_state):
-        """Test unauthorized access returns 403"""
+        """Test unauthorized access is rejected"""
         with patch.object(client.app, "state", mock_app_state):
             response = client.get("/api/templates/")
 
-            # Unauthorized access returns 403 Forbidden
-            assert response.status_code == 403
+            # A request with no Authorization header is rejected by
+            # HTTPBearer's own dependency resolution before get_current_user
+            # ever runs. Which status it gets depends on the installed
+            # FastAPI: older versions raised 403 for a missing header, newer
+            # ones raise 401 "Not authenticated" (corrected for RFC 6750
+            # compliance; 0.135.1 returns 401 - verified via a standalone
+            # HTTPBearer repro, not test ordering/pollution). pyproject only
+            # pins `fastapi >= 0.35.0`, so both behaviors are legitimately
+            # installable; hardcoding either status just fails on the other
+            # side of the version line. What this test actually protects is
+            # "no auth header never reaches the handler".
+            assert response.status_code in (401, 403)
 
     def test_template_data_structure(self, mock_app_state, admin_headers):
         """测试模板数据结构完整性"""
@@ -784,6 +795,31 @@ class TestUseTemplateAsWorkforce:
             ).json()
             assert detail["used_count"] == 1
 
+    def test_lang_query_param_localizes_the_new_workforces_description(
+        self, workforce_mock_app_state, admin_headers
+    ):
+        """Every sibling GET endpoint accepts ?lang= and localizes through
+        get_localized_value; this endpoint previously had no way to know
+        the caller's locale at all, so a zh-locale user's new Workforce
+        always got the English description regardless (PR #1127
+        re-review, F4)."""
+        with patch.object(client.app, "state", workforce_mock_app_state):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce?lang=zh",
+                headers=admin_headers,
+            )
+            assert response.status_code == 200, response.text
+            workforce_id = response.json()["workforce_id"]
+
+            db = next(get_db())
+            try:
+                workforce = db.get(Workforce, workforce_id)
+                assert (
+                    workforce.description == "编排 GA Analyzer 和 Ads Recommendation。"
+                )
+            finally:
+                db.close()
+
     def test_reuses_worker_agents_across_two_instantiations(
         self, workforce_mock_app_state, admin_headers
     ):
@@ -791,7 +827,15 @@ class TestUseTemplateAsWorkforce:
         manager + Workforce each time (each run gets its own orchestrator)
         but must NOT mint duplicate worker agents - the second call should
         reuse the first call's quick-access GA Analyzer / Ads Recommendation
-        agents (see AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX)."""
+        agents (see AGENT_TEMPLATE_QUICK_ACCESS_UNIQUE_INDEX).
+
+        This is deliberate, not an oversight: there is no server-side
+        idempotency on the Workforce + manager themselves, only on workers.
+        A double-click or a retried request will leave a duplicate draft
+        Workforce plus a stray published manager agent - the client-side
+        `creatingWorkforceId` lock is the only guard, and it isn't atomic
+        against network retries or two tabs. Flagged as a product question
+        in the PR #1127 re-review (F5), not changed here."""
         with patch.object(client.app, "state", workforce_mock_app_state):
             first = client.post(
                 "/api/templates/growth_workforce/use-as-workforce",
@@ -912,5 +956,55 @@ workforce_config:
                 # manager/Workforce behind.
                 assert db.query(Workforce).count() == 0
                 assert db.query(Agent).count() == 0
+            finally:
+                db.close()
+
+    def test_rejects_with_actionable_message_when_worker_agent_is_unpublished(
+        self, workforce_mock_app_state, admin_headers, admin_user
+    ):
+        """A user who separately unpublished their quick-access GA Analyzer
+        agent must get a specific, actionable 400 - not the generic
+        "please try again" a retry can never resolve - and the failed
+        attempt must not leave a stray manager/Workforce behind
+        (PR #1127 re-review, F1)."""
+        from xagent.web.models.agent import AgentOrigin, AgentStatus
+        from xagent.web.services.workforce_creator import (
+            UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX,
+        )
+
+        db = next(get_db())
+        try:
+            db.add(
+                Agent(
+                    user_id=admin_user["id"],
+                    name="GA Analyzer",
+                    instructions="You are the GA Analyzer.",
+                    execution_mode="balanced",
+                    template_id="ga_analyzer",
+                    origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+                    status=AgentStatus.DRAFT,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        with patch.object(client.app, "state", workforce_mock_app_state):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 400
+            assert response.json()["detail"].startswith(
+                UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX
+            )
+            assert "GA Analyzer" in response.json()["detail"]
+
+            db = next(get_db())
+            try:
+                assert db.query(Workforce).count() == 0
+                # Only the pre-existing draft agent - no manager, no
+                # duplicate worker created for the failed attempt.
+                assert db.query(Agent).count() == 1
             finally:
                 db.close()

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -1019,6 +1019,100 @@ workforce_config:
             finally:
                 db.close()
 
+    def test_rejects_a_worker_that_is_itself_a_workforce_template(
+        self, tmp_path, admin_headers
+    ):
+        """`workforce_config.agents[].template_id` must resolve to an
+        'agent'-type template. TemplateManager._enrich_template nulls
+        agent_config for any non-agent template, so without this runtime
+        guard a workforce referencing another workforce as a worker would
+        crash on `None.get(...)` instead of failing with a clear 400 - only
+        the load-time warning for this case had a test before this."""
+        import asyncio
+
+        from xagent.templates.manager import TemplateManager
+
+        templates_dir = tmp_path / "nested_workforce_templates"
+        templates_dir.mkdir()
+        (templates_dir / "inner_workforce.yaml").write_text(
+            """
+id: inner_workforce
+name: Inner Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: A workforce, wrongly referenced as a worker below.
+author: Xagent
+version: "1.0"
+
+workforce_config:
+  manager:
+    name: Inner Manager
+    instructions: |
+      You are the inner manager.
+  agents:
+  - template_id: leaf_agent
+    name: Leaf
+    assignment_instructions: Do the thing.
+"""
+        )
+        (templates_dir / "leaf_agent.yaml").write_text(
+            """
+id: leaf_agent
+name: Leaf Agent
+category: Marketing
+descriptions:
+  en: A normal single-agent template.
+author: Xagent
+version: "1.0"
+
+agent_config:
+  instructions: |
+    You help with things.
+"""
+        )
+        (templates_dir / "outer_workforce.yaml").write_text(
+            """
+id: outer_workforce
+name: Outer Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: References inner_workforce (a workforce) as if it were a single agent.
+author: Xagent
+version: "1.0"
+
+workforce_config:
+  manager:
+    name: Outer Manager
+    instructions: |
+      You are the outer manager.
+  agents:
+  - template_id: inner_workforce
+    name: Nested Workforce
+    assignment_instructions: Do the thing.
+"""
+        )
+        template_manager = TemplateManager(templates_root=templates_dir)
+        asyncio.run(template_manager.initialize())
+        mock_state = MagicMock()
+        mock_state.template_manager = template_manager
+
+        with patch.object(client.app, "state", mock_state):
+            response = client.post(
+                "/api/templates/outer_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+            assert response.status_code == 400
+            assert "inner_workforce" in response.json()["detail"]
+
+            db = next(get_db())
+            try:
+                assert db.query(Workforce).count() == 0
+                assert db.query(Agent).count() == 0
+            finally:
+                db.close()
+
     def test_rejects_with_actionable_message_when_worker_agent_is_unpublished(
         self, workforce_mock_app_state, admin_headers, admin_user
     ):
@@ -1172,6 +1266,189 @@ workforce_config:
             assert competitor_workforce.name == "Growth Marketing Workforce"
             assert real_workforce.name != "Growth Marketing Workforce"
             assert real_workforce.name.startswith("Growth Marketing Workforce")
+        finally:
+            db.close()
+
+    def test_second_collision_advances_the_suffix_instead_of_compounding_it(
+        self, workforce_mock_app_state, admin_headers, admin_user
+    ):
+        """The retry loop must re-resolve from the ORIGINAL base name on
+        every collision, not from the previous (already-suffixed) attempt.
+        Feeding the suffixed name back in would compound suffixes on a
+        second collision within the same request ("X 2" -> "X 2 2")
+        instead of advancing to "X 3" - reachable since
+        TEMPLATE_RESOLVE_RACE_RETRIES allows more than one retry.
+
+        Pre-seeds two already-taken names ("Growth Marketing Workforce" and
+        "...  2") and makes the first two `resolve_unique_workforce_name`
+        calls lie that each is free (forcing two real INSERT collisions),
+        then lets the third call resolve for real - so the *result* proves
+        which base name the retry loop actually passed in.
+        """
+        from sqlalchemy.orm import sessionmaker
+
+        from xagent.web.models.database import get_engine
+        from xagent.web.services import workforce_creator
+
+        real_resolve_unique_workforce_name = (
+            workforce_creator.resolve_unique_workforce_name
+        )
+        session_factory = sessionmaker(bind=get_engine())
+
+        seed_session = session_factory()
+        try:
+            for taken_name in (
+                "Growth Marketing Workforce",
+                "Growth Marketing Workforce 2",
+            ):
+                manager = Agent(
+                    user_id=admin_user["id"],
+                    name=f"Manager for {taken_name}",
+                    instructions="pre-seeded",
+                    execution_mode="think",
+                    origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+                    status=AgentStatus.PUBLISHED,
+                )
+                seed_session.add(manager)
+                seed_session.flush()
+                seed_session.add(
+                    Workforce(
+                        owner_user_id=admin_user["id"],
+                        scope_type="user",
+                        scope_id=str(admin_user["id"]),
+                        name=taken_name,
+                        manager_agent_id=manager.id,
+                        status="draft",
+                    )
+                )
+            seed_session.commit()
+        finally:
+            seed_session.close()
+
+        call_args: list[str] = []
+
+        def _lie_twice_then_resolve_for_real(db, *, scope_type, scope_id, name):
+            call_args.append(name)
+            if len(call_args) == 1:
+                return "Growth Marketing Workforce"  # actually taken
+            if len(call_args) == 2:
+                return "Growth Marketing Workforce 2"  # actually taken
+            return real_resolve_unique_workforce_name(
+                db, scope_type=scope_type, scope_id=scope_id, name=name
+            )
+
+        with (
+            patch.object(client.app, "state", workforce_mock_app_state),
+            patch.object(
+                workforce_creator,
+                "resolve_unique_workforce_name",
+                side_effect=_lie_twice_then_resolve_for_real,
+            ),
+        ):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        # All three calls resolved from the same original base name - never
+        # from a previously-suffixed attempt.
+        assert call_args == ["Growth Marketing Workforce"] * 3
+
+        db = next(get_db())
+        try:
+            workforce = db.get(Workforce, response.json()["workforce_id"])
+            assert workforce.name == "Growth Marketing Workforce 3"
+        finally:
+            db.close()
+
+    def test_collision_after_an_already_suffixed_initial_resolution(
+        self, workforce_mock_app_state, admin_headers, admin_user
+    ):
+        """The retry's base name must be the TEMPLATE's raw name, not the
+        initial resolution's result - the initial resolution itself already
+        carries a suffix whenever the user instantiated this template
+        before ("Growth Marketing Workforce 2" on the second run). A retry
+        that re-resolved from that resolved name would compound
+        ("X 2" -> "X 2 2") even with the loop's own collided names handled
+        correctly.
+
+        Pre-seeds "X" and "X 2" as taken, has the initial resolution lie
+        that "X 2" is free (as if it resolved before a concurrent winner
+        committed it), and lets the retry resolve for real: from the raw
+        base it must skip both taken names and land on "X 3".
+        """
+        from sqlalchemy.orm import sessionmaker
+
+        from xagent.web.models.database import get_engine
+        from xagent.web.services import workforce_creator
+
+        real_resolve_unique_workforce_name = (
+            workforce_creator.resolve_unique_workforce_name
+        )
+        session_factory = sessionmaker(bind=get_engine())
+
+        seed_session = session_factory()
+        try:
+            for taken_name in (
+                "Growth Marketing Workforce",
+                "Growth Marketing Workforce 2",
+            ):
+                manager = Agent(
+                    user_id=admin_user["id"],
+                    name=f"Manager for {taken_name}",
+                    instructions="pre-seeded",
+                    execution_mode="think",
+                    origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+                    status=AgentStatus.PUBLISHED,
+                )
+                seed_session.add(manager)
+                seed_session.flush()
+                seed_session.add(
+                    Workforce(
+                        owner_user_id=admin_user["id"],
+                        scope_type="user",
+                        scope_id=str(admin_user["id"]),
+                        name=taken_name,
+                        manager_agent_id=manager.id,
+                        status="draft",
+                    )
+                )
+            seed_session.commit()
+        finally:
+            seed_session.close()
+
+        call_args: list[str] = []
+
+        def _lie_once_then_resolve_for_real(db, *, scope_type, scope_id, name):
+            call_args.append(name)
+            if len(call_args) == 1:
+                return "Growth Marketing Workforce 2"  # actually taken
+            return real_resolve_unique_workforce_name(
+                db, scope_type=scope_type, scope_id=scope_id, name=name
+            )
+
+        with (
+            patch.object(client.app, "state", workforce_mock_app_state),
+            patch.object(
+                workforce_creator,
+                "resolve_unique_workforce_name",
+                side_effect=_lie_once_then_resolve_for_real,
+            ),
+        ):
+            response = client.post(
+                "/api/templates/growth_workforce/use-as-workforce",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        # The retry received the raw template name, not "...2".
+        assert call_args == ["Growth Marketing Workforce"] * 2
+
+        db = next(get_db())
+        try:
+            workforce = db.get(Workforce, response.json()["workforce_id"])
+            assert workforce.name == "Growth Marketing Workforce 3"
         finally:
             db.close()
 

--- a/tests/web/api/v1/test_templates.py
+++ b/tests/web/api/v1/test_templates.py
@@ -1,0 +1,141 @@
+"""Tests for the /v1/templates SDK endpoints.
+
+Covers a gap left by PR #1127: the v1 schemas (`V1TemplateSummary`,
+`V1TemplateDetail`) had no `type` field and always populated `agent_config`,
+so an external SDK caller hitting a workforce-type template would get the
+same "published agent with empty instructions" outcome the internal API's
+`type` gate was added to prevent - just with no way to even detect it from
+the response shape.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xagent.templates.manager import TemplateManager
+from xagent.web.api.v1.deps import (
+    PersonalApiKeySnapshot,
+    UserPrincipalSnapshot,
+    get_user_from_personal_key,
+)
+from xagent.web.api.v1.templates import router as v1_templates_router
+
+
+@pytest.fixture()
+def templates_dir(tmp_path):
+    (tmp_path / "plain_agent.yaml").write_text(
+        """
+id: plain_agent
+name: Plain Agent
+category: Support
+descriptions:
+  en: A normal single-agent template.
+author: Xagent
+version: "1.0"
+
+agent_config:
+  instructions: |
+    You help with things.
+  skills: []
+  tool_categories: []
+"""
+    )
+    (tmp_path / "ga_analyzer.yaml").write_text(
+        """
+id: ga_analyzer
+name: GA Analyzer
+category: Marketing
+descriptions:
+  en: Explains GA4 trends.
+author: Xagent
+version: "1.0"
+
+agent_config:
+  instructions: |
+    You are the GA Analyzer.
+  skills: []
+  tool_categories: []
+"""
+    )
+    (tmp_path / "growth_workforce.yaml").write_text(
+        """
+id: growth_workforce
+name: Growth Marketing Workforce
+category: Marketing
+type: workforce
+descriptions:
+  en: Orchestrates GA Analyzer.
+author: Xagent
+version: "1.0"
+
+workforce_config:
+  manager:
+    name: Growth Marketing Manager
+    instructions: |
+      You are the Growth Marketing Manager.
+  agents:
+  - template_id: ga_analyzer
+    name: GA Analyzer
+    assignment_instructions: Produce a Signals for Ads table.
+"""
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def test_app(templates_dir):
+    template_manager = TemplateManager(templates_root=templates_dir)
+    asyncio.run(template_manager.initialize())
+
+    app = FastAPI()
+    app.state.template_manager = template_manager
+    app.include_router(v1_templates_router, prefix="/v1")
+    app.dependency_overrides[get_user_from_personal_key] = lambda: (
+        UserPrincipalSnapshot(id=1, username="sdk-user", email=None, is_admin=False),
+        PersonalApiKeySnapshot(key_prefix="xa_test"),
+    )
+    return app
+
+
+@pytest.fixture()
+def client(test_app):
+    return TestClient(test_app)
+
+
+def test_list_includes_type_defaulting_to_agent(client):
+    response = client.get("/v1/templates", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 200, response.text
+    by_id = {item["id"]: item for item in response.json()}
+
+    assert by_id["plain_agent"]["type"] == "agent"
+    assert by_id["ga_analyzer"]["type"] == "agent"
+    assert by_id["growth_workforce"]["type"] == "workforce"
+
+
+def test_agent_template_detail_has_agent_config(client):
+    response = client.get(
+        "/v1/templates/plain_agent", headers={"Authorization": "Bearer x"}
+    )
+    assert response.status_code == 200, response.text
+    detail = response.json()
+
+    assert detail["type"] == "agent"
+    assert "you help with things" in detail["agent_config"]["instructions"].lower()
+
+
+def test_workforce_template_detail_has_null_agent_config(client):
+    """Before this fix, agent_config was always `template.get("agent_config")
+    or {}` - a workforce template's enriched agent_config is None, so this
+    would have silently coerced to `{}` (a populated-looking but empty
+    config) instead of the caller being able to tell from the response that
+    this template isn't a single-agent template at all."""
+    response = client.get(
+        "/v1/templates/growth_workforce", headers={"Authorization": "Bearer x"}
+    )
+    assert response.status_code == 200, response.text
+    detail = response.json()
+
+    assert detail["type"] == "workforce"
+    assert detail["agent_config"] is None

--- a/tests/web/test_workforce_creator_plan.py
+++ b/tests/web/test_workforce_creator_plan.py
@@ -8,6 +8,7 @@ keeps its instructions.
 from xagent.web.services.workforce_creator import (
     _clean_creation_plan,
     _fallback_creation_plan,
+    get_localized_description,
 )
 
 
@@ -37,3 +38,25 @@ def test_fallback_creation_plan_has_no_top_level_manager_instructions() -> None:
 
     assert "manager_instructions" not in plan
     assert plan["manager"]["instructions"]
+
+
+def test_get_localized_description_prefers_english() -> None:
+    template = {"descriptions": {"en": "English description", "zh": "中文描述"}}
+
+    assert get_localized_description(template) == "English description"
+
+
+def test_get_localized_description_falls_back_to_another_locale() -> None:
+    """`_parse_yaml_file` only requires an 'en' *key* to be present, not a
+    non-empty value, so a template can carry an empty English description
+    alongside a populated one in another locale - the Workforce's
+    description shouldn't end up empty just because English is blank."""
+    template = {"descriptions": {"en": "", "zh": "中文描述"}}
+
+    assert get_localized_description(template) == "中文描述"
+
+
+def test_get_localized_description_returns_none_when_nothing_is_populated() -> None:
+    assert get_localized_description({"descriptions": {"en": "", "zh": ""}}) is None
+    assert get_localized_description({"descriptions": "not a dict"}) is None
+    assert get_localized_description({}) is None

--- a/tests/web/test_workforce_creator_worker_resolution.py
+++ b/tests/web/test_workforce_creator_worker_resolution.py
@@ -107,6 +107,109 @@ def test_repeat_call_reuses_the_same_agent(db_session) -> None:
     )
 
 
+def test_creates_agent_with_description_and_models_from_template(db_session) -> None:
+    """The /task quick-access resolver (`_spec_from_template`) populates
+    description/models/suggested_prompts from the template; this resolver
+    used to hardcode them all to empty even though it writes the exact same
+    (user_id, template_id, quick-access-origin) row - so whichever flow ran
+    first silently won, permanently, for every field the other flow would
+    have set (PR #1127 re-review, F2).
+
+    `knowledge_bases` is the deliberate exception: the /task path validates
+    template KBs per-user (`_validate_agent_knowledge_bases`) before
+    attaching them, and this path has no equivalent check - so it must NOT
+    forward them raw (that would silently attach dangling KB ids instead of
+    failing loudly the way /task does)."""
+
+    class _RichFakeTemplateManager:
+        async def get_template(self, template_id: str) -> dict:
+            return {
+                "name": "GA Analyzer",
+                "descriptions": {"en": "Explains GA4 trends."},
+                "agent_config": {
+                    "instructions": "You are the GA Analyzer.",
+                    "execution_mode": "balanced",
+                    "skills": [],
+                    "tool_categories": [],
+                    "models": {"general": "gpt-4o"},
+                    "knowledge_bases": ["kb-1"],
+                    "suggested_prompts": ["Summarize this week's traffic"],
+                },
+            }
+
+    user = _create_user(db_session)
+
+    resolved = asyncio.run(
+        _get_or_create_quick_access_worker_agent(
+            db_session,
+            _RichFakeTemplateManager(),
+            user_id=user.id,
+            template_id="ga_analyzer",
+        )
+    )
+
+    assert resolved.description == "Explains GA4 trends."
+    assert resolved.models == {"general": "gpt-4o"}
+    assert resolved.suggested_prompts == ["Summarize this week's traffic"]
+    # Never forwarded without per-user validation - see docstring.
+    assert resolved.knowledge_bases == []
+
+
+def test_reuse_raises_specific_error_when_existing_agent_is_unpublished(
+    db_session,
+) -> None:
+    """A user can unpublish their quick-access agent for a template a
+    workforce also depends on (a normal, supported action). Reusing it
+    as-is would pass this resolver only to fail downstream in
+    create_workforce_worker's require_published=True check with a generic
+    400 that the frontend renders as "please retry" - which can never
+    succeed, since every retry resolves to the same unpublished agent
+    (PR #1127 re-review, F1). The resolver must raise a specific,
+    actionable error instead of returning the unpublished agent.
+    """
+    from fastapi import HTTPException
+
+    from xagent.web.services.workforce_creator import (
+        UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX,
+    )
+
+    user = _create_user(db_session)
+    unpublished = Agent(
+        user_id=user.id,
+        name="GA Analyzer",
+        instructions="You are the GA Analyzer.",
+        execution_mode="balanced",
+        template_id="ga_analyzer",
+        origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+        status=AgentStatus.DRAFT,
+    )
+    db_session.add(unpublished)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            _get_or_create_quick_access_worker_agent(
+                db_session,
+                _FakeTemplateManager(),
+                user_id=user.id,
+                template_id="ga_analyzer",
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail.startswith(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX)
+    assert "GA Analyzer" in exc_info.value.detail
+    # Never silently republished or replaced.
+    db_session.refresh(unpublished)
+    assert unpublished.status == AgentStatus.DRAFT
+    assert (
+        db_session.query(Agent)
+        .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)
+        .count()
+        == 1
+    )
+
+
 def test_race_retry_reuses_row_committed_by_concurrent_winner(db_session) -> None:
     """Simulates the exact TOCTOU window a double-clicked "Use" can hit:
     the initial SELECT misses the row (as if a concurrent request hadn't

--- a/tests/web/test_workforce_creator_worker_resolution.py
+++ b/tests/web/test_workforce_creator_worker_resolution.py
@@ -170,7 +170,7 @@ def test_reuse_raises_specific_error_when_existing_agent_is_unpublished(
     from fastapi import HTTPException
 
     from xagent.web.services.workforce_creator import (
-        UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX,
+        WORKFORCE_WORKER_UNPUBLISHED_CODE,
     )
 
     user = _create_user(db_session)
@@ -197,8 +197,9 @@ def test_reuse_raises_specific_error_when_existing_agent_is_unpublished(
         )
 
     assert exc_info.value.status_code == 400
-    assert exc_info.value.detail.startswith(UNPUBLISHED_WORKER_AGENT_DETAIL_PREFIX)
-    assert "GA Analyzer" in exc_info.value.detail
+    assert exc_info.value.detail["code"] == WORKFORCE_WORKER_UNPUBLISHED_CODE
+    assert exc_info.value.detail["params"]["agent_name"] == "GA Analyzer"
+    assert "GA Analyzer" in exc_info.value.detail["message"]
     # Never silently republished or replaced.
     db_session.refresh(unpublished)
     assert unpublished.status == AgentStatus.DRAFT

--- a/tests/web/test_workforce_creator_worker_resolution.py
+++ b/tests/web/test_workforce_creator_worker_resolution.py
@@ -1,0 +1,201 @@
+"""Tests for the race-safe get-or-create used when instantiating a workforce
+template's worker agents (`_get_or_create_quick_access_worker_agent` in
+`xagent.web.services.workforce_creator`).
+
+A plain select-then-insert here would race: two concurrent callers (e.g. a
+double-clicked "Use" on a workforce template) can both miss the initial
+SELECT and then collide on `uq_agents_user_id_template_id_quick_access`
+(the (user_id, template_id, quick-access-origin) unique index) at INSERT.
+The resolver must recover by re-reading the winner's row instead of letting
+the IntegrityError propagate as an unhandled 500.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.web.models import Agent, Base, User
+from xagent.web.models.agent import AgentOrigin, AgentStatus
+from xagent.web.services import workforce_creator
+from xagent.web.services.workforce_creator import (
+    _find_quick_access_worker_agent,
+    _get_or_create_quick_access_worker_agent,
+)
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _create_user(db) -> User:
+    user = User(username="race-user", password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+class _FakeTemplateManager:
+    async def get_template(self, template_id: str) -> dict:
+        return {
+            "name": "GA Analyzer",
+            "agent_config": {
+                "instructions": "You are the GA Analyzer.",
+                "execution_mode": "balanced",
+                "skills": [],
+                "tool_categories": [],
+            },
+        }
+
+
+def test_no_collision_creates_and_returns_a_new_agent(db_session) -> None:
+    user = _create_user(db_session)
+
+    resolved = asyncio.run(
+        _get_or_create_quick_access_worker_agent(
+            db_session,
+            _FakeTemplateManager(),
+            user_id=user.id,
+            template_id="ga_analyzer",
+        )
+    )
+
+    assert resolved.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value
+    assert resolved.status == AgentStatus.PUBLISHED
+    assert resolved.template_id == "ga_analyzer"
+
+
+def test_repeat_call_reuses_the_same_agent(db_session) -> None:
+    user = _create_user(db_session)
+    template_manager = _FakeTemplateManager()
+
+    first = asyncio.run(
+        _get_or_create_quick_access_worker_agent(
+            db_session, template_manager, user_id=user.id, template_id="ga_analyzer"
+        )
+    )
+    second = asyncio.run(
+        _get_or_create_quick_access_worker_agent(
+            db_session, template_manager, user_id=user.id, template_id="ga_analyzer"
+        )
+    )
+
+    assert first.id == second.id
+    assert (
+        db_session.query(Agent)
+        .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)
+        .count()
+        == 1
+    )
+
+
+def test_race_retry_reuses_row_committed_by_concurrent_winner(db_session) -> None:
+    """Simulates the exact TOCTOU window a double-clicked "Use" can hit:
+    the initial SELECT misses the row (as if a concurrent request hadn't
+    committed yet), then the real INSERT collides with a row that a
+    concurrent winner already committed - the resolver must recover by
+    re-reading that row rather than raising IntegrityError.
+    """
+    user = _create_user(db_session)
+
+    competitor = Agent(
+        user_id=user.id,
+        name="GA Analyzer",
+        instructions="from the concurrent winner",
+        execution_mode="balanced",
+        template_id="ga_analyzer",
+        origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(competitor)
+    db_session.commit()
+
+    call_count = {"n": 0}
+
+    def _miss_once_then_delegate(db, *, user_id, template_id):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return None
+        return _find_quick_access_worker_agent(
+            db, user_id=user_id, template_id=template_id
+        )
+
+    with patch.object(
+        workforce_creator,
+        "_find_quick_access_worker_agent",
+        side_effect=_miss_once_then_delegate,
+    ):
+        resolved = asyncio.run(
+            _get_or_create_quick_access_worker_agent(
+                db_session,
+                _FakeTemplateManager(),
+                user_id=user.id,
+                template_id="ga_analyzer",
+            )
+        )
+
+    assert resolved.id == competitor.id
+    # One missed pre-check, one successful retry lookup after the real
+    # INSERT hit the real unique-constraint violation.
+    assert call_count["n"] == 2
+    assert (
+        db_session.query(Agent)
+        .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)
+        .count()
+        == 1
+    )
+
+
+def test_gives_up_with_409_if_retries_are_exhausted(db_session) -> None:
+    """If every retry's re-lookup keeps missing the row (a pathological
+    case, e.g. persistent contention), the resolver must surface a clear
+    409 rather than retrying forever or letting IntegrityError escape.
+    """
+    from fastapi import HTTPException
+
+    user = _create_user(db_session)
+
+    competitor = Agent(
+        user_id=user.id,
+        name="GA Analyzer",
+        instructions="from the concurrent winner",
+        execution_mode="balanced",
+        template_id="ga_analyzer",
+        origin=AgentOrigin.TEMPLATE_QUICK_ACCESS.value,
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(competitor)
+    db_session.commit()
+
+    with patch.object(
+        workforce_creator,
+        "_find_quick_access_worker_agent",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                _get_or_create_quick_access_worker_agent(
+                    db_session,
+                    _FakeTemplateManager(),
+                    user_id=user.id,
+                    template_id="ga_analyzer",
+                )
+            )
+
+    assert exc_info.value.status_code == 409

--- a/tests/web/test_workforce_creator_worker_resolution.py
+++ b/tests/web/test_workforce_creator_worker_resolution.py
@@ -15,12 +15,14 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from xagent.web.models import Agent, Base, User
 from xagent.web.models.agent import AgentOrigin, AgentStatus
 from xagent.web.services import workforce_creator
+from xagent.web.services.agent_store import AgentStore
 from xagent.web.services.workforce_creator import (
     _find_quick_access_worker_agent,
     _get_or_create_quick_access_worker_agent,
@@ -111,6 +113,14 @@ def test_race_retry_reuses_row_committed_by_concurrent_winner(db_session) -> Non
     committed yet), then the real INSERT collides with a row that a
     concurrent winner already committed - the resolver must recover by
     re-reading that row rather than raising IntegrityError.
+
+    Also stages a stand-in for the manager agent / Workforce that
+    `create_workforce_from_template` flushes into the *same* session before
+    ever calling this resolver, and asserts it survives the retry. The
+    resolver recovers via a SAVEPOINT (`db.begin_nested()`) specifically so
+    a collision only unwinds its own failed insert; a regression to a
+    plain `db.rollback()` would pass every other assertion in this test
+    while silently discarding that staged-but-uncommitted outer row too.
     """
     user = _create_user(db_session)
 
@@ -125,6 +135,22 @@ def test_race_retry_reuses_row_committed_by_concurrent_winner(db_session) -> Non
     )
     db_session.add(competitor)
     db_session.commit()
+
+    # Stand-in for the manager agent create_workforce_from_template flushes
+    # into its outer transaction before resolving any worker agents -
+    # staged (flushed) but deliberately never committed here, matching the
+    # caller's real sequencing.
+    outer_manager = Agent(
+        user_id=user.id,
+        name="Growth Marketing Manager",
+        instructions="orchestrator",
+        execution_mode="think",
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(outer_manager)
+    db_session.flush()
+    outer_manager_id = outer_manager.id
 
     call_count = {"n": 0}
 
@@ -154,6 +180,75 @@ def test_race_retry_reuses_row_committed_by_concurrent_winner(db_session) -> Non
     # One missed pre-check, one successful retry lookup after the real
     # INSERT hit the real unique-constraint violation.
     assert call_count["n"] == 2
+    assert (
+        db_session.query(Agent)
+        .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)
+        .count()
+        == 1
+    )
+
+    # The staged outer row must still be visible in-session after the
+    # SAVEPOINT recovery, and must still be there once the caller's outer
+    # transaction actually commits.
+    assert (
+        db_session.query(Agent).filter(Agent.id == outer_manager_id).first() is not None
+    )
+    db_session.commit()
+    assert (
+        db_session.query(Agent).filter(Agent.id == outer_manager_id).first() is not None
+    )
+
+
+def test_race_retry_recovers_from_a_genuine_name_collision(db_session) -> None:
+    """A concurrent, unrelated agent create (different origin, no
+    template_id) can win a race for the exact name
+    resolve_unique_agent_name just certified as free, in the window
+    between that check and our own INSERT - a real (user_id, name)
+    collision, not this template's (user_id, template_id) quick-access
+    race. The resolver must recognize this via is_agent_name_unique_violation
+    and retry (the next resolve_unique_agent_name call picks a fresh name),
+    not misdiagnose it as the quick-access race - whose re-select would
+    find nothing here and burn every retry on a 409 that retrying can
+    never fix.
+
+    A first attempt at this test tried to simulate the collision by
+    inserting the competing row from inside the mocked
+    resolve_unique_agent_name call - but that call happens *inside* the
+    resolver's own `db.begin_nested()`, so the SAVEPOINT rollback undid
+    that competing row right along with the failed insert, and the retry
+    then succeeded with the original, undisambiguated name (proving the
+    retry mechanism works, but not testing this branch's classification
+    at all). Raising a pre-built IntegrityError directly is the reliable
+    way to exercise the classification logic without depending on
+    SAVEPOINT/rollback timing.
+    """
+    user = _create_user(db_session)
+    real_add_agent = AgentStore.add_agent
+    call_count = {"n": 0}
+
+    def _fail_once_with_name_violation(self, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise IntegrityError(
+                "INSERT INTO agents (...)",
+                {},
+                Exception("UNIQUE constraint failed: agents.user_id, agents.name"),
+            )
+        return real_add_agent(self, **kwargs)
+
+    with patch.object(AgentStore, "add_agent", _fail_once_with_name_violation):
+        resolved = asyncio.run(
+            _get_or_create_quick_access_worker_agent(
+                db_session,
+                _FakeTemplateManager(),
+                user_id=user.id,
+                template_id="ga_analyzer",
+            )
+        )
+
+    assert call_count["n"] == 2
+    assert resolved.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value
+    assert resolved.template_id == "ga_analyzer"
     assert (
         db_session.query(Agent)
         .filter(Agent.origin == AgentOrigin.TEMPLATE_QUICK_ACCESS.value)


### PR DESCRIPTION
## Summary
- Add a "Growth Marketing Workforce" built-in template (Growth Marketing
  Manager orchestrating the existing GA Analyzer + Ads Recommendation
  agents in a measure → recommend → approve → re-measure loop), plus a
  new `type: workforce` template schema (`workforce_config.manager` /
  `workforce_config.agents[]`) alongside the existing single-agent
  template type.
- Add `POST /api/templates/{id}/use-as-workforce`, which instantiates a
  workforce template into a real Workforce (fresh manager agent + one
  worker agent per referenced sub-template, reusing an existing
  quick-access instance if the caller already has one). Worker-agent
  resolution is race-safe: a concurrent/double-clicked request retries
  via a SAVEPOINT instead of surfacing an unhandled 500 on a unique-key
  collision.
- Add an Agent/Workforce type filter on the Templates page alongside the
  existing category filter, a "Workforce" badge + agent count on the
  template card, and a loading/disabled state + error toast while a
  workforce is being created from a template.
- `TemplateManager` now warns at startup if a workforce template
  references an unknown `template_id`, instead of only failing the
  first time a user clicks "Use".

## Test plan
- [x] `pytest tests/web/api/test_templates_api.py
  tests/web/test_workforce_creator_worker_resolution.py
  tests/web/test_workforce_creator_plan.py tests/templates` — all pass
  except one pre-existing, unrelated failure
  (`test_unauthorized_access`, fails identically on `main`).
- [x] `npx tsc --noEmit` (frontend) — clean.
- [x] `python -m py_compile` on the changed backend modules.
- [x] Manual click-through of "Use" on the Growth Marketing Workforce
  card in the browser.