### PR TITLE
feat: fall back to the channel's configured default agent

### DIFF
--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -64,6 +64,10 @@ class ChannelOwnerSnapshot:
     """Detached owner identity after channel authorization."""
 
     user_id: int
+    # Optional per-channel default Agent Builder agent (``config`` key
+    # ``default_agent_id``): used by ``prepare_channel_task`` when the
+    # transport passes no explicit agent selection.
+    default_agent_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -303,7 +307,25 @@ def _load_channel_owner_sync(
         allowed_user_ids = {str(value) for value in allowed_users}
         if external_user_id not in allowed_user_ids:
             raise ChannelAuthorizationError("Channel sender is not authorized")
-    return ChannelOwnerSnapshot(user_id=owner_id)
+    return ChannelOwnerSnapshot(
+        user_id=owner_id,
+        default_agent_id=_coerce_agent_id(channel.config.get("default_agent_id")),
+    )
+
+
+def _coerce_agent_id(value: object) -> int | None:
+    """Best-effort int coercion for the free-form config value.
+
+    ``config`` is an unconstrained JSON dict, so the id may arrive as a
+    string or garbage; a malformed value must degrade to "no default"
+    rather than fail every turn on the channel.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _claim_legacy_active_telegram_task_sync(
@@ -635,6 +657,13 @@ def _prepare_channel_task_sync(
                 raise ChannelAuthorizationError(
                     "Channel owner changed during sender authorization"
                 )
+            explicit_agent_requested = agent_id is not None
+            if agent_id is None:
+                # No explicit selection from the transport (Slack has no agent
+                # picker; Telegram only passes one after /agents): fall back to
+                # the channel's configured default. A stale id degrades through
+                # the missing-agent path below, never fails the turn.
+                agent_id = owner.default_agent_id
 
             is_telegram = str(channel.channel_type) == "telegram"
             if is_telegram:
@@ -690,7 +719,18 @@ def _prepare_channel_task_sync(
                     .filter(Agent.id == int(agent_id))
                     .first()
                 )
-                requested_agent_missing = agent_row is None
+                # The missing-agent flag drives transport UX for a selection
+                # the USER made (Telegram clears the stored pick and says so).
+                # A stale channel-config default is an operator concern, not a
+                # user action — log it instead of blaming the user's choice.
+                requested_agent_missing = agent_row is None and explicit_agent_requested
+                if agent_row is None and not explicit_agent_requested:
+                    logger.warning(
+                        "Channel %s default_agent_id %s is not selectable; "
+                        "falling back to the default assistant",
+                        channel_id,
+                        agent_id,
+                    )
                 if task is not None:
                     if agent_row is None:
                         # Evict to a clean default task; never fail the turn.

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -314,18 +314,24 @@ def _load_channel_owner_sync(
 
 
 def _coerce_agent_id(value: object) -> int | None:
-    """Best-effort int coercion for the free-form config value.
+    """Strict int coercion for the free-form config value.
 
     ``config`` is an unconstrained JSON dict, so the id may arrive as a
     string or garbage; a malformed value must degrade to "no default"
-    rather than fail every turn on the channel.
+    rather than fail every turn on the channel. Only true integers and
+    integer strings are accepted — ``int(12.5)`` would silently truncate
+    to a valid but WRONG agent id, which is worse than no default.
     """
-    if value is None or isinstance(value, bool):
+    if isinstance(value, bool):
         return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
 
 
 def _claim_legacy_active_telegram_task_sync(

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -115,6 +115,191 @@ async def test_prepare_channel_task_binds_owned_agent(
     engine.dispose()
 
 
+def _set_channel_config_value(SessionLocal, channel_id: int, key: str, value) -> None:
+    with SessionLocal() as db:
+        channel = db.query(UserChannel).filter(UserChannel.id == channel_id).one()
+        channel.config = {**channel.config, key: value}
+        db.commit()
+
+
+@pytest.mark.asyncio
+async def test_prepare_channel_task_uses_channel_default_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """A transport that passes no agent selection binds the channel's
+    configured default agent (config key ``default_agent_id``)."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Toby")
+    _set_channel_config_value(SessionLocal, channel_id, "default_agent_id", agent_id)
+    monkeypatch.setattr(
+        "xagent.web.services.channel_runtime.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="hello",
+        channel_name="Telegram",
+    )
+
+    assert prepared is not None
+    assert prepared.requested_agent_missing is False
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == prepared.task_id).one()
+        assert task.agent_id == agent_id
+
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_agent_selection_wins_over_channel_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    default_agent_id = _add_agent(SessionLocal, user_id=user_id, name="Toby")
+    explicit_agent_id = _add_agent(SessionLocal, user_id=user_id, name="Research Agent")
+    _set_channel_config_value(
+        SessionLocal, channel_id, "default_agent_id", default_agent_id
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.channel_runtime.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="hello",
+        channel_name="Telegram",
+        agent_id=explicit_agent_id,
+    )
+
+    assert prepared is not None
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == prepared.task_id).one()
+        assert task.agent_id == explicit_agent_id
+
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", ["not-a-number", True, None, {"id": 1}])
+async def test_malformed_channel_default_agent_degrades_to_no_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+    bad_value,
+) -> None:
+    """config is free-form JSON: a malformed default must not fail the turn."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    _set_channel_config_value(SessionLocal, channel_id, "default_agent_id", bad_value)
+    monkeypatch.setattr(
+        "xagent.web.services.channel_runtime.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="hello",
+        channel_name="Telegram",
+    )
+
+    assert prepared is not None
+    assert prepared.requested_agent_missing is False
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == prepared.task_id).one()
+        assert task.agent_id is None
+
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stale_channel_default_agent_falls_back_to_default_task(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """A default pointing at a deleted/unowned agent degrades to the default
+    assistant with an operator-facing log — WITHOUT raising the missing-agent
+    flag, which drives user-facing "your selected agent is gone" UX for
+    selections the user actually made (e.g. Telegram clears the stored pick)."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    _set_channel_config_value(SessionLocal, channel_id, "default_agent_id", 999_999)
+    monkeypatch.setattr(
+        "xagent.web.services.channel_runtime.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="hello",
+        channel_name="Telegram",
+    )
+
+    assert prepared is not None
+    assert prepared.requested_agent_missing is False
+    with SessionLocal() as db:
+        task = db.query(Task).filter(Task.id == prepared.task_id).one()
+        assert task.agent_id is None
+
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_stale_selection_still_reports_missing_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """The user-facing missing-agent contract for explicit selections must
+    survive the default-agent fallback."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    monkeypatch.setattr(
+        "xagent.web.services.channel_runtime.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="hello",
+        channel_name="Telegram",
+        agent_id=999_999,
+    )
+
+    assert prepared is not None
+    assert prepared.requested_agent_missing is True
+
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("foreign_owner", [False, True])
 async def test_prepare_channel_task_falls_back_when_agent_not_selectable(

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -196,7 +196,7 @@ async def test_explicit_agent_selection_wins_over_channel_default(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("bad_value", ["not-a-number", True, None, {"id": 1}])
+@pytest.mark.parametrize("bad_value", ["not-a-number", True, None, {"id": 1}, 12.5])
 async def test_malformed_channel_default_agent_degrades_to_no_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

When a transport passes no explicit agent selection, `prepare_channel_task` now falls back to the channel's `config["default_agent_id"]`. Slack and Feishu have no agent picker, so today every conversation on those channels runs the generic default agent with no way to pin a Builder agent; Telegram keeps its explicit `/agents` selection, which takes precedence over the config default.

- `ChannelOwnerSnapshot` gains `default_agent_id`, populated from the channel config with best-effort int coercion — config is free-form JSON, so a malformed value degrades to "no default" instead of failing every turn on the channel
- a stale default (agent deleted / not owner-visible) flows through the existing requested-agent-missing path: the turn falls back to a clean default task, never errors
- generic capability, no product coupling: any caller can set the key via the existing `PUT /api/channels/{id}` (it is not one of the Slack server-managed identity keys)

## Why

The immediate consumer is workspace provisioning in xagent-saas (xorbitsai/xagent-saas#385, #413): after onboarding, the provisioned Builder agent is pinned as the Slack channel's default so DMs/@mentions run it. The mechanism (`prepare_channel_task(agent_id=...)`, owner-visibility validation, task eviction on agent change) already existed — this only adds the config-sourced fallback.

## Validation

- `pytest tests/web/services/test_channel_runtime.py` — 30 passed (7 new: config-default binding, explicit-selection precedence, malformed-value degradation ×4, stale-default fallback)
- ruff check / format clean; mypy on the touched module
