### PR TITLE
refactor(checkpoint): anchor the task checkpoint pointer to the exact trace row

### DIFF
--- a/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
@@ -1,0 +1,111 @@
+"""add exact-row checkpoint anchor to tasks
+
+Adds ``tasks.last_checkpoint_trace_event_id``, an integer pointer to the
+``trace_events`` row that ``last_checkpoint_event_id`` (the legacy UUID
+string column) names. On PostgreSQL the column is backed by a named foreign
+key; on SQLite the migration adds the column only -- ``ALTER TABLE ADD
+CONSTRAINT`` is not renderable through Alembic's SQLite batch mode without a
+full table rebuild, so an upgraded SQLite database has no DB-level FK here.
+A database built fresh through ``Base.metadata.create_all()`` (new installs,
+tests) gets the FK from the model directly, regardless of dialect.
+
+Existing rows are backfilled by resolving the legacy string column against
+the row it names, but only where that resolution is unambiguous: zero or
+multiple matching trace_events rows leave the new column NULL rather than
+guessing or aborting the migration.
+
+Revision ID: 20260804_add_task_checkpoint_trace_event_anchor
+Revises: 20260729_add_gmail_audience_grace
+Create Date: 2026-08-04
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260804_add_task_checkpoint_trace_event_anchor"
+down_revision: Union[str, None] = "20260729_add_gmail_audience_grace"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "tasks"
+COLUMN = "last_checkpoint_trace_event_id"
+LEGACY_COLUMN = "last_checkpoint_event_id"
+FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
+
+# One correlated-subquery UPDATE. The subquery is wrapped in COUNT/CASE so it
+# always returns a single scalar row -- a bare correlated subquery would
+# raise on multiple matches instead of resolving to NULL, and this backfill
+# must never abort the migration on ambiguous or missing legacy data (a
+# concurrently deleted target task resolves the same way: zero matches).
+BACKFILL_SQL = sa.text(
+    f"""
+    UPDATE {TABLE}
+    SET {COLUMN} = (
+        SELECT CASE WHEN COUNT(*) = 1 THEN MIN(te.id) ELSE NULL END
+        FROM trace_events te
+        WHERE te.task_id = {TABLE}.id
+          AND te.event_id = {TABLE}.{LEGACY_COLUMN}
+          AND te.build_id IS NULL
+          AND te.event_type = 'system_update_general'
+    )
+    WHERE {COLUMN} IS NULL
+      AND {LEGACY_COLUMN} IS NOT NULL
+    """
+)
+
+
+def _table_exists() -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return inspector.has_table(TABLE)
+
+
+def _columns() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {col["name"] for col in inspector.get_columns(TABLE)}
+
+
+def _fk_names() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {fk["name"] for fk in inspector.get_foreign_keys(TABLE)}
+
+
+def upgrade() -> None:
+    # tasks is created by Base.metadata.create_all() in production, not by
+    # a migration in this repo; a from-scratch (bare) database has no tasks
+    # table yet when migrations run, so this is a no-op there.
+    if not _table_exists():
+        return
+
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if COLUMN not in _columns():
+        op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
+
+    if is_postgresql and FK_NAME not in _fk_names():
+        op.create_foreign_key(
+            FK_NAME,
+            TABLE,
+            "trace_events",
+            [COLUMN],
+            ["id"],
+        )
+
+    op.execute(BACKFILL_SQL)
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if is_postgresql and FK_NAME in _fk_names():
+        op.drop_constraint(FK_NAME, TABLE, type_="foreignkey")
+
+    if COLUMN in _columns():
+        op.drop_column(TABLE, COLUMN)

--- a/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
@@ -31,6 +31,7 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 TABLE = "tasks"
+TRACE_TABLE = "trace_events"
 COLUMN = "last_checkpoint_trace_event_id"
 LEGACY_COLUMN = "last_checkpoint_event_id"
 FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
@@ -57,9 +58,9 @@ BACKFILL_SQL = sa.text(
 )
 
 
-def _table_exists() -> bool:
+def _table_exists(name: str = TABLE) -> bool:
     inspector = sa.inspect(op.get_bind())
-    return inspector.has_table(TABLE)
+    return inspector.has_table(name)
 
 
 def _columns() -> set[str]:
@@ -85,11 +86,14 @@ def upgrade() -> None:
     if COLUMN not in _columns():
         op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
 
+    if not _table_exists(TRACE_TABLE):
+        return
+
     if is_postgresql and FK_NAME not in _fk_names():
         op.create_foreign_key(
             FK_NAME,
             TABLE,
-            "trace_events",
+            TRACE_TABLE,
             [COLUMN],
             ["id"],
         )

--- a/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
@@ -7,7 +7,13 @@ key; on SQLite the migration adds the column only -- ``ALTER TABLE ADD
 CONSTRAINT`` is not renderable through Alembic's SQLite batch mode without a
 full table rebuild, so an upgraded SQLite database has no DB-level FK here.
 A database built fresh through ``Base.metadata.create_all()`` (new installs,
-tests) gets the FK from the model directly, regardless of dialect.
+tests) gets the FK from the model directly, regardless of dialect. That
+divergence between fresh and upgraded SQLite databases is permanent under
+the current migration set: this revision is the head and no later revision
+reconciles the two shapes. On an upgraded SQLite database the pointer's
+delete protection is therefore the application-level clearing order in
+``task_deletion.py``, which nulls both pointer columns before deleting the
+task's ``trace_events`` rows -- not the database.
 
 Existing rows are backfilled by resolving the legacy string column against
 the row it names, but only where that resolution is unambiguous: zero or

--- a/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
@@ -14,6 +14,14 @@ the row it names, but only where that resolution is unambiguous: zero or
 multiple matching trace_events rows leave the new column NULL rather than
 guessing or aborting the migration.
 
+On PostgreSQL ``create_foreign_key`` takes an ACCESS EXCLUSIVE lock on
+``tasks`` and validates every existing row before returning, and the
+backfill's correlated subquery matches ``trace_events`` on
+``(task_id, event_id)`` where only ``task_id`` is indexed. On a large
+deployment both steps should be scheduled with that lock window in mind; a
+``NOT VALID`` constraint followed by a separate ``VALIDATE CONSTRAINT``
+would move the validation out of the lock window if that becomes necessary.
+
 Revision ID: 20260804_add_task_checkpoint_trace_event_anchor
 Revises: 20260729_add_gmail_audience_grace
 Create Date: 2026-08-04
@@ -108,8 +116,21 @@ def downgrade() -> None:
     bind = op.get_bind()
     is_postgresql = bind.dialect.name == "postgresql"
 
-    if is_postgresql and FK_NAME in _fk_names():
-        op.drop_constraint(FK_NAME, TABLE, type_="foreignkey")
+    if COLUMN not in _columns():
+        return
 
-    if COLUMN in _columns():
+    if is_postgresql:
+        if FK_NAME in _fk_names():
+            op.drop_constraint(FK_NAME, TABLE, type_="foreignkey")
         op.drop_column(TABLE, COLUMN)
+    else:
+        # SQLite renders this column's foreign key inline in CREATE TABLE
+        # even under use_alter=True (a fresh install builds tasks with
+        # create_all, not a migration), and refuses to drop a column an
+        # inline foreign key names. A full table rebuild removes both
+        # together; nothing else can. The migration connection already runs
+        # with SQLite foreign keys off for exactly this reason -- see
+        # _migration_connection in src/xagent/db/migration.py -- and
+        # re-checks for new violations afterwards.
+        with op.batch_alter_table(TABLE, recreate="always") as batch_op:
+            batch_op.drop_column(COLUMN)

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -63,10 +63,28 @@ def _purge_user_task_rows(db: Session, *, user_id: int) -> None:
     Ordering matches ``purge_task_rows``: every child row referencing
     ``tasks.id`` goes before the ``tasks`` delete, so the purge stays valid
     under enforced foreign keys regardless of whether the deployment's schema
-    carries ``ON DELETE`` clauses.
+    carries ``ON DELETE`` clauses. ``tasks`` itself is also referenced --
+    ``last_checkpoint_trace_event_id`` FKs to ``trace_events.id`` -- so the
+    pointer columns are NULLed first, before the ``trace_events`` delete
+    below.
     """
 
     task_ids = select(Task.id).where(Task.user_id == user_id).scalar_subquery()
+
+    # NULL the checkpoint pointer columns before the trace_events delete
+    # below: a task still pointing at a row would block (or, without
+    # DB-level enforcement, orphan) that delete. A bulk statement, not an
+    # ORM attribute assignment, because this session has autoflush
+    # disabled -- an attribute assignment would not reach the database
+    # until a later flush, by which point the trace_events delete has
+    # already run.
+    db.query(Task).filter(Task.user_id == user_id).update(
+        {
+            Task.last_checkpoint_event_id: None,
+            Task.last_checkpoint_trace_event_id: None,
+        },
+        synchronize_session=False,
+    )
 
     # Children without a DB-level ``ON DELETE`` clause -- these are the rows a
     # bare ``DELETE FROM tasks`` would strand or fail on under strict FKs.

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -33,7 +33,7 @@ from ...web.services.ops_signals import (
     CHECKPOINT_DECODE_FALLBACK,
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
-    CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+    CHECKPOINT_PRUNE_FAILED,
     clear_degradation,
     register_degradation,
 )
@@ -616,7 +616,18 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 exc_info=True,
             )
             return _AnchorFallback(generic_failure=True)
+        # The scan retires these two signals on two different facts: the
+        # load signal once a page query returns, the decode-fallback signal
+        # once a row decodes. An anchored read establishes both in one round
+        # trip, so both clears land here -- and here rather than at the top
+        # of this function, where the dangling clear sits, because that one
+        # reports on the pointer every attempt re-reads while these report
+        # that the read actually got through. An anchored read returns
+        # without ever entering the scan, so without these a decode-fallback
+        # signal set by one bad row could never retire in the steady state
+        # this anchor exists to produce.
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        clear_degradation(CHECKPOINT_DECODE_FALLBACK)
 
         snapshot = decoded.get("snapshot") if isinstance(decoded, dict) else None
         if not isinstance(snapshot, dict):
@@ -906,7 +917,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # healthy, whatever it found. Clearing only after a successful
             # delete would leave a steady state with nothing to prune unable
             # to clear the signal at all.
-            clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+            clear_degradation(CHECKPOINT_PRUNE_FAILED)
             # Rank first, protect after. The row this task's exact-row
             # pointer references is never deleted, whatever its position in
             # the retention ranking; excluding it from the candidate set
@@ -944,14 +955,20 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # surface as psycopg2's SerializationFailure or DeadlockDetected,
             # both of which SQLAlchemy wraps in OperationalError, not
             # IntegrityError -- catch both so this retention path degrades
-            # the same way regardless of which one the database raises.
+            # the same way regardless of which one the database raises. The
+            # signal is named for the outcome rather than for either cause:
+            # OperationalError also covers lock timeouts and dropped
+            # connections, /health publishes only the signal name, and the
+            # operator's response to all of them is the same -- retention
+            # stopped, rows are accumulating, read the logged traceback for
+            # which one it was.
             db.rollback()
             register_degradation(
-                CHECKPOINT_PRUNE_INTEGRITY_ERROR,
-                f"task {self.task_id}: checkpoint prune hit an integrity error",
+                CHECKPOINT_PRUNE_FAILED,
+                f"task {self.task_id}: checkpoint prune could not delete stale rows",
             )
             logger.warning(
-                "Checkpoint prune hit an integrity error for task %s",
+                "Checkpoint prune failed for task %s",
                 self.task_id,
                 exc_info=True,
             )

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -635,7 +635,12 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 # this the exact-row anchor column would be built from an
                 # unassigned id and silently written NULL.
                 db.flush()
-                assert trace_event.id is not None
+                if trace_event.id is None:
+                    raise RuntimeError(
+                        f"Task {self.task_id} checkpoint {event.id} row has no "
+                        "primary key after flush; refusing to write a NULL "
+                        "checkpoint anchor"
+                    )
                 pointer_update = db.execute(
                     update(Task)
                     .where(

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -31,6 +31,8 @@ from ...web.models.tool_config import ToolUsage
 from ...web.services.ops_signals import (
     CHECKPOINT_DECODE_FALLBACK,
     CHECKPOINT_LOAD_UNAVAILABLE,
+    CHECKPOINT_PK_ANCHOR_DANGLING,
+    CHECKPOINT_PRUNE_INTEGRITY_ERROR,
     clear_degradation,
     register_degradation,
 )
@@ -63,6 +65,11 @@ CHECKPOINT_ROW_SCAN_LIMIT = 100
 # scan that reaches the cap without a resolution is treated as unavailable
 # rather than continuing indefinitely.
 CHECKPOINT_SCAN_MAX_PAGES = 50
+
+# Sentinel distinguishing "no PK anchor to try" (unset pointer, or a pointer
+# whose row is gone) from a resolved snapshot, which may legitimately be an
+# empty dict. Falling back to the legacy scan is only correct for the former.
+_NO_TRACE_EVENT_ANCHOR = object()
 
 
 def _checkpoint_execution_id_predicate(execution_id: str) -> Any:
@@ -215,6 +222,9 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         f"task {self.task_id}: could not resolve the "
                         "checkpoint read partition"
                     ) from exc
+                anchored = self._load_pk_anchored_checkpoint(db, run_id)
+                if anchored is not _NO_TRACE_EVENT_ANCHOR:
+                    return anchored  # type: ignore[return-value]
                 query = query.filter(
                     DatabaseTraceEvent.build_id.is_(None),
                     self._checkpoint_run_partition_filter(run_id),
@@ -440,6 +450,93 @@ class DatabaseTraceHandler(BaseTraceHandler):
         run_field = DatabaseTraceEvent.data[TASK_RUN_ID_TRACE_FIELD].as_string()
         return run_field == run_id if run_id is not None else run_field.is_(None)
 
+    def _load_pk_anchored_checkpoint(
+        self,
+        db: Session,
+        run_id: str | None,
+    ) -> Dict[str, Any] | object:
+        """Resolve the checkpoint through the task's exact-row pointer.
+
+        Returns ``_NO_TRACE_EVENT_ANCHOR`` when there is nothing to anchor
+        on: the pointer is unset, or it names a row that no longer exists
+        (only possible on a database upgraded through Alembic rather than
+        created fresh, since that path has no DB-level FK -- see the
+        migration that adds this column). Both cases fall back to the
+        legacy scan. Once a target row is found, though, it is
+        authoritative: a validation mismatch raises rather than falling
+        back to search other rows, and a decode failure on that row is
+        classified the same way the scan classifies an exhausted,
+        all-undecodable candidate set, since this pointer is the only
+        candidate.
+        """
+        pointer = (
+            db.query(Task.last_checkpoint_trace_event_id)
+            .filter(Task.id == self.task_id)
+            .one_or_none()
+        )
+        if pointer is None or pointer[0] is None:
+            return _NO_TRACE_EVENT_ANCHOR
+
+        pointer_id = pointer[0]
+        row = db.get(DatabaseTraceEvent, pointer_id)
+        if row is None:
+            register_degradation(
+                CHECKPOINT_PK_ANCHOR_DANGLING,
+                f"task {self.task_id}: checkpoint pointer {pointer_id} has "
+                "no matching trace_events row; falling back to the legacy "
+                "scan",
+            )
+            return _NO_TRACE_EVENT_ANCHOR
+        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
+
+        row_data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
+        run_field = row_data.get(TASK_RUN_ID_TRACE_FIELD)
+        partition_matches = (
+            run_field == run_id if run_id is not None else run_field is None
+        )
+        if (
+            row.task_id != self.task_id
+            or row.event_type != "system_update_general"
+            or row.build_id is not None
+            or row_data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES
+            or not partition_matches
+        ):
+            raise CheckpointCorruptError(
+                f"task {self.task_id}: checkpoint pointer {pointer_id} does "
+                "not match the row it anchors"
+            )
+
+        try:
+            decoded = decode_trace_event_data(
+                db,
+                task_id=self.task_id,
+                data=dict(row_data),
+                strict=True,
+            )
+        except CheckpointMessageDecodeError as exc:
+            raise CheckpointCorruptError(
+                f"task {self.task_id}: checkpoint pointer {pointer_id} row "
+                "is undecodable"
+            ) from exc
+        except Exception as exc:
+            register_degradation(
+                CHECKPOINT_LOAD_UNAVAILABLE,
+                f"task {self.task_id}: checkpoint pointer {pointer_id} decode failed",
+            )
+            raise CheckpointUnavailableError(
+                f"task {self.task_id}: checkpoint pointer {pointer_id} "
+                "could not be decoded"
+            ) from exc
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+
+        snapshot = decoded.get("snapshot") if isinstance(decoded, dict) else None
+        if not isinstance(snapshot, dict):
+            raise CheckpointCorruptError(
+                f"task {self.task_id}: checkpoint pointer {pointer_id} has "
+                "a readable checkpoint_type but no snapshot"
+            )
+        return dict(snapshot)
+
     def _sync_save_to_database(self, event: CoreTraceEvent) -> None:
         """Synchronous database save operation (runs in thread pool)."""
         # Create database session
@@ -518,6 +615,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 and self.build_id is None
                 and checkpoint_lease is not None
             ):
+                # Flush the pending insert so trace_event.id (the row's
+                # primary key) is assigned before the pointer UPDATE below
+                # reads it. autoflush is off for this session, so without
+                # this the exact-row anchor column would be built from an
+                # unassigned id and silently written NULL.
+                db.flush()
+                assert trace_event.id is not None
                 pointer_update = db.execute(
                     update(Task)
                     .where(
@@ -526,14 +630,33 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         Task.runner_id == checkpoint_lease.runner_id,
                         Task.run_id == checkpoint_lease.run_id,
                     )
-                    .values(last_checkpoint_event_id=str(event.id))
+                    .values(
+                        last_checkpoint_event_id=str(event.id),
+                        last_checkpoint_trace_event_id=trace_event.id,
+                    )
                     .execution_options(synchronize_session=False)
                 )
                 if int(getattr(pointer_update, "rowcount", 0) or 0) != 1:
-                    raise RuntimeError(
-                        f"Task {self.task_id} lease changed before checkpoint "
-                        f"{event.id} could be persisted"
+                    task_still_exists = (
+                        db.query(Task.id).filter(Task.id == self.task_id).first()
+                        is not None
                     )
+                    if not task_still_exists:
+                        # The task row is gone, not merely leased elsewhere --
+                        # the same outcome the trace_events.task_id FK would
+                        # produce for the row itself. Skip quietly rather
+                        # than raising a "lease changed" error that isn't
+                        # what happened.
+                        logger.debug(
+                            "Skip checkpoint pointer update for missing task %s: %s",
+                            self.task_id,
+                            event.id,
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"Task {self.task_id} lease changed before checkpoint "
+                            f"{event.id} could be persisted"
+                        )
 
             # Update tool usage statistics if this is a tool execution event
             if event_type_str == "tool_execution_end":
@@ -637,11 +760,27 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         run_id if isinstance(run_id, str) and run_id else None
                     )
                 )
+            # Exclude the row this task's exact-row pointer currently
+            # references, whatever its position in the retention ranking.
+            # For the steady-state writer this is structurally unreachable
+            # -- the pointer always names the row just written, which ranks
+            # ahead of the offset -- but it guards the backfill-vs-prune
+            # window and future back-pointing anchors that may point at an
+            # older row.
+            anchor = (
+                db.query(Task.last_checkpoint_trace_event_id)
+                .filter(Task.id == self.task_id)
+                .one_or_none()
+            )
+            anchor_id = anchor[0] if anchor is not None else None
+            candidate_filters = list(partition_filters)
+            if anchor_id is not None:
+                candidate_filters.append(DatabaseTraceEvent.id != anchor_id)
             stale_rows = (
                 db.query(DatabaseTraceEvent.id)
                 .filter(
                     DatabaseTraceEvent.task_id == self.task_id,
-                    *partition_filters,
+                    *candidate_filters,
                     DatabaseTraceEvent.event_type == "system_update_general",
                     DatabaseTraceEvent.data["checkpoint_type"]
                     .as_string()
@@ -665,11 +804,31 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     DatabaseTraceEvent.id.in_(chunk)
                 ).delete(synchronize_session=False)
             db.commit()
+            clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
             logger.debug(
                 "Pruned %d checkpoint rows for task %s execution %s",
                 len(stale_ids),
                 self.task_id,
                 execution_id,
+            )
+        except IntegrityError:
+            # PostgreSQL enforces the anchor FK, so a race that lets a
+            # candidate row become the active anchor between selection and
+            # delete surfaces here as a restrict violation (including a
+            # serialization failure under stricter isolation levels). A
+            # database upgraded through Alembic on SQLite has no DB-level FK
+            # for this column and cannot raise this; a freshly created
+            # SQLite database (create_all, e.g. tests) does have the FK and
+            # can.
+            db.rollback()
+            register_degradation(
+                CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+                f"task {self.task_id}: checkpoint prune hit an integrity error",
+            )
+            logger.warning(
+                "Checkpoint prune hit an integrity error for task %s",
+                self.task_id,
+                exc_info=True,
             )
         except Exception:
             db.rollback()

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -66,10 +67,24 @@ CHECKPOINT_ROW_SCAN_LIMIT = 100
 # rather than continuing indefinitely.
 CHECKPOINT_SCAN_MAX_PAGES = 50
 
-# Sentinel distinguishing "no PK anchor to try" (unset pointer, or a pointer
-# whose row is gone) from a resolved snapshot, which may legitimately be an
-# empty dict. Falling back to the legacy scan is only correct for the former.
-_NO_TRACE_EVENT_ANCHOR = object()
+
+@dataclass(frozen=True)
+class _AnchorFallback:
+    """Why the PK anchor deferred to the legacy scan.
+
+    Distinguishes "no PK anchor to try" from a resolved snapshot, which may
+    legitimately be an empty dict. An unset or dangling pointer defers with
+    nothing to carry. A correctly identified anchor row whose payload could
+    not be read defers *and* hands the scan the same verdict flag the scan
+    would have set for that row itself: the scan's candidate filter can
+    legitimately exclude that row (a row carrying no execution identity is
+    anchored but not scanned, see _load_pk_anchored_checkpoint), and an
+    excluded row must never let an unreadable checkpoint become "no
+    checkpoint".
+    """
+
+    undecodable: bool = False
+    generic_failure: bool = False
 
 
 def _checkpoint_execution_id_predicate(execution_id: str) -> Any:
@@ -201,6 +216,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 # below), and a zero-row first page is authoritative.
                 _checkpoint_execution_id_predicate(str(execution_id)),
             )
+            anchored_fallback = _AnchorFallback()
             if self.build_id is None:
                 try:
                     run_id = self._root_checkpoint_read_partition(db)
@@ -225,8 +241,9 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 anchored = self._load_pk_anchored_checkpoint(
                     db, run_id, str(execution_id)
                 )
-                if anchored is not _NO_TRACE_EVENT_ANCHOR:
-                    return anchored  # type: ignore[return-value]
+                if not isinstance(anchored, _AnchorFallback):
+                    return anchored
+                anchored_fallback = anchored
                 query = query.filter(
                     DatabaseTraceEvent.build_id.is_(None),
                     self._checkpoint_run_partition_filter(run_id),
@@ -239,9 +256,11 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 DatabaseTraceEvent.id.desc(),
             )
 
-            saw_generic_failure = False
-            saw_undecodable_row = False
-            saw_any_row = False
+            saw_generic_failure = anchored_fallback.generic_failure
+            saw_undecodable_row = anchored_fallback.undecodable
+            saw_any_row = (
+                anchored_fallback.undecodable or anchored_fallback.generic_failure
+            )
             offset = 0
             page_count = 0
             while True:
@@ -457,29 +476,44 @@ class DatabaseTraceHandler(BaseTraceHandler):
         db: Session,
         run_id: str | None,
         execution_id: str,
-    ) -> Dict[str, Any] | object:
+    ) -> Dict[str, Any] | _AnchorFallback:
         """Resolve the checkpoint through the task's exact-row pointer.
 
-        Returns ``_NO_TRACE_EVENT_ANCHOR`` when there is nothing to anchor
-        on: the pointer is unset, or it names a row that no longer exists
-        (only possible on a database upgraded through Alembic rather than
-        created fresh, since that path has no DB-level FK -- see the
-        migration that adds this column). Both cases fall back to the
-        legacy scan. Once a target row is found, though, it is
-        authoritative: a validation mismatch raises rather than falling
-        back to search other rows, and a decode failure on that row is
-        classified the same way the scan classifies an exhausted,
-        all-undecodable candidate set, since this pointer is the only
-        candidate.
+        Returns an ``_AnchorFallback`` when the read defers to the legacy
+        scan. An empty one means there was nothing to anchor on: the
+        pointer is unset, or it names a row that no longer exists (only
+        possible on a database upgraded through Alembic rather than created
+        fresh, since that path has no DB-level FK -- see the migration that
+        adds this column).
+
+        Once a target row is found, its *identity* is authoritative: a
+        validation mismatch raises rather than falling back to search other
+        rows. Its *payload* is not. A row that is correctly identified but
+        whose payload cannot be read defers to the scan as well, so the
+        older rows history pruning deliberately retains can still answer
+        the read (see _prune_checkpoint_history). That fallback carries the
+        row's own verdict flag on the returned ``_AnchorFallback``, because
+        the scan may legitimately exclude the very row the pointer named,
+        and a scan that then finds nothing must not report "no checkpoint"
+        for a checkpoint that exists and is unreadable.
 
         The execution-identity check here is verification, not the legacy
         scan's filtering: that scan excludes non-matching rows from its
         candidate set via ``_checkpoint_execution_id_predicate`` before it
         ever sees them, but the pointer names one row unconditionally, so
         the row's own claimed identity (if it has one) has to be checked
-        against the caller's after the fact. A row with no execution
-        identity at all -- legacy rows written before the field existed --
-        still passes, matching the legacy scan's coalescing default of "".
+        against the caller's after the fact. A row carrying no execution
+        identity at all passes this check, because
+        ``checkpoint_execution_id()`` returns "" for it and the conjunct
+        short-circuits. The legacy scan does the opposite: its
+        ``coalesce(nullif(...))`` predicate yields NULL for such a row and
+        ``NULL = :execution_id`` is never true, so the scan drops it from
+        the candidate set. The anchor path is deliberately the more
+        permissive of the two -- a pointer that names a row is a stronger
+        identity claim than a JSON field match, and the rows without the
+        field are legacy rows written before it existed, exactly the rows
+        the migration's backfill anchors. Nothing depends on the two
+        agreeing: web's ``execution_id`` is the task id.
         """
         pointer = (
             db.query(Task.last_checkpoint_trace_event_id)
@@ -487,7 +521,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
             .one_or_none()
         )
         if pointer is None or pointer[0] is None:
-            return _NO_TRACE_EVENT_ANCHOR
+            return _AnchorFallback()
 
         pointer_id = pointer[0]
         row = db.get(DatabaseTraceEvent, pointer_id)
@@ -498,7 +532,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 "no matching trace_events row; falling back to the legacy "
                 "scan",
             )
-            return _NO_TRACE_EVENT_ANCHOR
+            return _AnchorFallback()
         clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
 
         row_data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
@@ -528,27 +562,49 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 strict=True,
             )
         except CheckpointMessageDecodeError as exc:
-            raise CheckpointCorruptError(
-                f"task {self.task_id}: checkpoint pointer {pointer_id} row "
-                "is undecodable"
-            ) from exc
-        except Exception as exc:
-            register_degradation(
-                CHECKPOINT_LOAD_UNAVAILABLE,
-                f"task {self.task_id}: checkpoint pointer {pointer_id} decode failed",
+            # Permanent per-row failure, classified exactly as the scan
+            # classifies one: log, no signal, and defer -- an older row may
+            # still carry a usable checkpoint.
+            logger.warning(
+                "Checkpoint pointer %s row for task %s is undecodable; "
+                "falling back to the legacy scan: %s",
+                pointer_id,
+                self.task_id,
+                exc,
             )
-            raise CheckpointUnavailableError(
-                f"task {self.task_id}: checkpoint pointer {pointer_id} "
-                "could not be decoded"
-            ) from exc
+            return _AnchorFallback(undecodable=True)
+        except Exception:
+            # E.g. a transient DB error from the blob prefetch: the same
+            # generic case the scan registers CHECKPOINT_DECODE_FALLBACK
+            # for. CHECKPOINT_LOAD_UNAVAILABLE belongs to the exhausted-set
+            # verdict, not to one row.
+            register_degradation(
+                CHECKPOINT_DECODE_FALLBACK,
+                f"task {self.task_id}: checkpoint decode failed, fell back "
+                f"past pointer {pointer_id}",
+            )
+            logger.warning(
+                "Checkpoint pointer %s row for task %s failed to decode; "
+                "falling back to the legacy scan",
+                pointer_id,
+                self.task_id,
+                exc_info=True,
+            )
+            return _AnchorFallback(generic_failure=True)
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
 
         snapshot = decoded.get("snapshot") if isinstance(decoded, dict) else None
         if not isinstance(snapshot, dict):
-            raise CheckpointCorruptError(
-                f"task {self.task_id}: checkpoint pointer {pointer_id} has "
-                "a readable checkpoint_type but no snapshot"
+            # Readable checkpoint_type but no payload: the same permanent
+            # per-row class as an undecodable row, and deferred the same way.
+            logger.warning(
+                "Checkpoint pointer %s row for task %s has a readable "
+                "checkpoint_type but no snapshot; falling back to the "
+                "legacy scan",
+                pointer_id,
+                self.task_id,
             )
+            return _AnchorFallback(undecodable=True)
         return dict(snapshot)
 
     def _sync_save_to_database(self, event: CoreTraceEvent) -> None:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from sqlalchemy import func, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
 from ...config import get_checkpoint_history_limit
@@ -222,7 +222,9 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         f"task {self.task_id}: could not resolve the "
                         "checkpoint read partition"
                     ) from exc
-                anchored = self._load_pk_anchored_checkpoint(db, run_id)
+                anchored = self._load_pk_anchored_checkpoint(
+                    db, run_id, str(execution_id)
+                )
                 if anchored is not _NO_TRACE_EVENT_ANCHOR:
                     return anchored  # type: ignore[return-value]
                 query = query.filter(
@@ -454,6 +456,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
         self,
         db: Session,
         run_id: str | None,
+        execution_id: str,
     ) -> Dict[str, Any] | object:
         """Resolve the checkpoint through the task's exact-row pointer.
 
@@ -468,6 +471,15 @@ class DatabaseTraceHandler(BaseTraceHandler):
         classified the same way the scan classifies an exhausted,
         all-undecodable candidate set, since this pointer is the only
         candidate.
+
+        The execution-identity check here is verification, not the legacy
+        scan's filtering: that scan excludes non-matching rows from its
+        candidate set via ``_checkpoint_execution_id_predicate`` before it
+        ever sees them, but the pointer names one row unconditionally, so
+        the row's own claimed identity (if it has one) has to be checked
+        against the caller's after the fact. A row with no execution
+        identity at all -- legacy rows written before the field existed --
+        still passes, matching the legacy scan's coalescing default of "".
         """
         pointer = (
             db.query(Task.last_checkpoint_trace_event_id)
@@ -494,12 +506,14 @@ class DatabaseTraceHandler(BaseTraceHandler):
         partition_matches = (
             run_field == run_id if run_id is not None else run_field is None
         )
+        row_execution_id = checkpoint_execution_id(row_data)
         if (
             row.task_id != self.task_id
             or row.event_type != "system_update_general"
             or row.build_id is not None
             or row_data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES
             or not partition_matches
+            or (row_execution_id and row_execution_id != execution_id)
         ):
             raise CheckpointCorruptError(
                 f"task {self.task_id}: checkpoint pointer {pointer_id} does "
@@ -811,15 +825,18 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 self.task_id,
                 execution_id,
             )
-        except IntegrityError:
+        except (IntegrityError, OperationalError):
             # PostgreSQL enforces the anchor FK, so a race that lets a
             # candidate row become the active anchor between selection and
-            # delete surfaces here as a restrict violation (including a
-            # serialization failure under stricter isolation levels). A
-            # database upgraded through Alembic on SQLite has no DB-level FK
-            # for this column and cannot raise this; a freshly created
+            # delete surfaces here as a restrict violation (IntegrityError).
+            # A database upgraded through Alembic on SQLite has no DB-level
+            # FK for this column and cannot raise this; a freshly created
             # SQLite database (create_all, e.g. tests) does have the FK and
-            # can.
+            # can. Under stricter isolation levels the same race can instead
+            # surface as psycopg2's SerializationFailure or DeadlockDetected,
+            # both of which SQLAlchemy wraps in OperationalError, not
+            # IntegrityError -- catch both so this retention path degrades
+            # the same way regardless of which one the database raises.
             db.rollback()
             register_degradation(
                 CHECKPOINT_PRUNE_INTEGRITY_ERROR,

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -853,6 +853,10 @@ class DatabaseTraceHandler(BaseTraceHandler):
         dedup, but a blob referenced only by pruned rows (e.g. a message
         later dropped by context compaction) is orphaned until whole-task
         deletion cleans it up.
+
+        Retention is exactly ``limit`` rows, with one exception: when the
+        task's exact-row pointer names a row that itself ranks outside the
+        window, protecting that row keeps ``limit + 1``.
         """
         limit = get_checkpoint_history_limit()
         if limit <= 0:
@@ -874,27 +878,17 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         run_id if isinstance(run_id, str) and run_id else None
                     )
                 )
-            # Exclude the row this task's exact-row pointer currently
-            # references, whatever its position in the retention ranking.
-            # For the steady-state writer this is structurally unreachable
-            # -- the pointer always names the row just written, which ranks
-            # ahead of the offset -- but it guards the backfill-vs-prune
-            # window and future back-pointing anchors that may point at an
-            # older row.
             anchor = (
                 db.query(Task.last_checkpoint_trace_event_id)
                 .filter(Task.id == self.task_id)
                 .one_or_none()
             )
             anchor_id = anchor[0] if anchor is not None else None
-            candidate_filters = list(partition_filters)
-            if anchor_id is not None:
-                candidate_filters.append(DatabaseTraceEvent.id != anchor_id)
             stale_rows = (
                 db.query(DatabaseTraceEvent.id)
                 .filter(
                     DatabaseTraceEvent.task_id == self.task_id,
-                    *candidate_filters,
+                    *partition_filters,
                     DatabaseTraceEvent.event_type == "system_update_general",
                     DatabaseTraceEvent.data["checkpoint_type"]
                     .as_string()
@@ -908,9 +902,24 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 .offset(limit)
                 .all()
             )
-            if not stale_rows:
+            # This query completing is the proof the retention path is
+            # healthy, whatever it found. Clearing only after a successful
+            # delete would leave a steady state with nothing to prune unable
+            # to clear the signal at all.
+            clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+            # Rank first, protect after. The row this task's exact-row
+            # pointer references is never deleted, whatever its position in
+            # the retention ranking; excluding it from the candidate set
+            # instead would shift every remaining row's OFFSET rank by one
+            # and retain limit + 1 rows whenever the anchor sits inside the
+            # window. For the steady-state writer the protection is
+            # structurally unreachable -- the pointer always names the row
+            # just written, which ranks ahead of the offset -- but it guards
+            # the backfill-vs-prune window and future back-pointing anchors
+            # that may point at an older row.
+            stale_ids = [row_id for (row_id,) in stale_rows if row_id != anchor_id]
+            if not stale_ids:
                 return
-            stale_ids = [row_id for (row_id,) in stale_rows]
             # Chunk the IN clause: a backlog from previously-disabled pruning
             # can exceed SQLite's bind-parameter limit in one statement.
             for chunk in chunks(stale_ids, SQL_IN_CLAUSE_CHUNK_SIZE):
@@ -918,7 +927,6 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     DatabaseTraceEvent.id.in_(chunk)
                 ).delete(synchronize_session=False)
             db.commit()
-            clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
             logger.debug(
                 "Pruned %d checkpoint rows for task %s execution %s",
                 len(stale_ids),

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -743,20 +743,34 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     )
                     if not task_still_exists:
                         # The task row is gone, not merely leased elsewhere --
-                        # the same outcome the trace_events.task_id FK would
-                        # produce for the row itself. Skip quietly rather
-                        # than raising a "lease changed" error that isn't
-                        # what happened.
+                        # the same outcome the trace_events.task_id FK
+                        # produces for the row itself wherever that FK is
+                        # enforced. Discard the staged row so this path
+                        # leaves nothing behind, then classify it exactly as
+                        # that FK violation is classified below: a required
+                        # event still fails loudly, a best-effort event is
+                        # dropped quietly.
+                        db.rollback()
+                        if getattr(event, "require_persisted", False):
+                            logger.error(
+                                "Required trace event references missing task %s: %s",
+                                self.task_id,
+                                event.id,
+                            )
+                            raise RuntimeError(
+                                f"Task {self.task_id} no longer exists; "
+                                f"checkpoint {event.id} was not persisted"
+                            )
                         logger.debug(
                             "Skip checkpoint pointer update for missing task %s: %s",
                             self.task_id,
                             event.id,
                         )
-                    else:
-                        raise RuntimeError(
-                            f"Task {self.task_id} lease changed before checkpoint "
-                            f"{event.id} could be persisted"
-                        )
+                        return
+                    raise RuntimeError(
+                        f"Task {self.task_id} lease changed before checkpoint "
+                        f"{event.id} could be persisted"
+                    )
 
             # Update tool usage statistics if this is a tool execution event
             if event_type_str == "tool_execution_end":

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -515,16 +515,34 @@ class DatabaseTraceHandler(BaseTraceHandler):
         the migration's backfill anchors. Nothing depends on the two
         agreeing: web's ``execution_id`` is the task id.
         """
-        pointer = (
-            db.query(Task.last_checkpoint_trace_event_id)
-            .filter(Task.id == self.task_id)
-            .one_or_none()
-        )
+        try:
+            pointer = (
+                db.query(Task.last_checkpoint_trace_event_id)
+                .filter(Task.id == self.task_id)
+                .one_or_none()
+            )
+        except Exception as exc:
+            register_degradation(
+                CHECKPOINT_LOAD_UNAVAILABLE,
+                f"task {self.task_id}: checkpoint pointer lookup failed",
+            )
+            raise CheckpointUnavailableError(
+                f"task {self.task_id}: checkpoint pointer lookup failed"
+            ) from exc
         if pointer is None or pointer[0] is None:
             return _AnchorFallback()
 
         pointer_id = pointer[0]
-        row = db.get(DatabaseTraceEvent, pointer_id)
+        try:
+            row = db.get(DatabaseTraceEvent, pointer_id)
+        except Exception as exc:
+            register_degradation(
+                CHECKPOINT_LOAD_UNAVAILABLE,
+                f"task {self.task_id}: checkpoint pointer row fetch failed",
+            )
+            raise CheckpointUnavailableError(
+                f"task {self.task_id}: checkpoint pointer row fetch failed"
+            ) from exc
         if row is None:
             register_degradation(
                 CHECKPOINT_PK_ANCHOR_DANGLING,

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -515,6 +515,14 @@ class DatabaseTraceHandler(BaseTraceHandler):
         the migration's backfill anchors. Nothing depends on the two
         agreeing: web's ``execution_id`` is the task id.
         """
+        # Cleared before the pointer is even read, not only when one
+        # resolves to a row: the registry is process-wide, so a process
+        # where no task currently has an anchor would otherwise keep a
+        # stale dangling signal set forever. The coarseness is real and
+        # accepted -- one healthy task's read clears another task's
+        # dangling signal -- and is the same cross-task coarseness the
+        # signal already has in the registering direction.
+        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
         try:
             pointer = (
                 db.query(Task.last_checkpoint_trace_event_id)
@@ -551,7 +559,6 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 "scan",
             )
             return _AnchorFallback()
-        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
 
         row_data: Dict[str, Any] = row.data if isinstance(row.data, dict) else {}
         run_field = row_data.get(TASK_RUN_ID_TRACE_FIELD)

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -105,6 +105,27 @@ class Task(Base):  # type: ignore
     lease_expires_at = Column(DateTime(timezone=True), nullable=True)
     last_heartbeat_at = Column(DateTime(timezone=True), nullable=True)
     last_checkpoint_event_id = Column(String(255), nullable=True)
+    # Exact-row anchor: the primary key of the trace_events row that
+    # last_checkpoint_event_id names. Readers that find this set can load the
+    # checkpoint by primary key instead of re-resolving the legacy string
+    # column against the row set. This FK forms a cycle with
+    # trace_events.task_id -> tasks.id: it must be named, or an unnamed
+    # constraint in that cycle raises CircularDependencyError on backends
+    # whose create_all/drop_all doesn't go through Alembic (e.g. PostgreSQL
+    # in this repo's CI and dev paths); and it must be use_alter=True, or
+    # SQLAlchemy can't topologically sort DROP order across the cycle and a
+    # SQLite database with FK enforcement on (this repo's default -- see
+    # apply_sqlite_concurrency_pragmas) fails mid-drop_all with a DROP TABLE
+    # error on an unrelated table further down the (corrupted) drop order.
+    last_checkpoint_trace_event_id = Column(
+        Integer,
+        ForeignKey(
+            "trace_events.id",
+            name="fk_tasks_last_checkpoint_trace_event_id",
+            use_alter=True,
+        ),
+        nullable=True,
+    )
     # Monotonic task-control identity. ``run_id`` changes for each new turn,
     # while pause/resume transitions retain it and advance ``state_version``.
     # Clients use the version to ignore stale WebSocket status events.
@@ -450,8 +471,11 @@ class TraceEvent(Base):  # type: ignore
     )  # Parent event ID for hierarchy
     data = Column(JSON, nullable=False)  # Event data payload
 
-    # Relationships
-    task = relationship("Task")
+    # Relationships. foreign_keys is explicit because tasks and trace_events
+    # now have two FK paths between them (this task_id, and
+    # Task.last_checkpoint_trace_event_id pointing back) -- without it,
+    # SQLAlchemy can't pick a join condition for this relationship.
+    task = relationship("Task", foreign_keys=[task_id])
 
     def __repr__(self) -> str:
         return f"<TraceEvent(id={self.id}, event_type='{self.event_type}', task_id={self.task_id})>"

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -20,6 +20,7 @@ import threading
 
 GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED = "gmail_oidc_service_account_unverified"
 CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
+CHECKPOINT_LEGACY_POINTER_AMBIGUOUS = "checkpoint_legacy_pointer_ambiguous"
 CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"
 CHECKPOINT_PK_ANCHOR_DANGLING = "checkpoint_pk_anchor_dangling"
 CHECKPOINT_PRUNE_INTEGRITY_ERROR = "checkpoint_prune_integrity_error"

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -23,7 +23,7 @@ CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
 CHECKPOINT_LEGACY_POINTER_AMBIGUOUS = "checkpoint_legacy_pointer_ambiguous"
 CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"
 CHECKPOINT_PK_ANCHOR_DANGLING = "checkpoint_pk_anchor_dangling"
-CHECKPOINT_PRUNE_INTEGRITY_ERROR = "checkpoint_prune_integrity_error"
+CHECKPOINT_PRUNE_FAILED = "checkpoint_prune_failed"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -21,6 +21,8 @@ import threading
 GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED = "gmail_oidc_service_account_unverified"
 CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
 CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"
+CHECKPOINT_PK_ANCHOR_DANGLING = "checkpoint_pk_anchor_dangling"
+CHECKPOINT_PRUNE_INTEGRITY_ERROR = "checkpoint_prune_integrity_error"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/task_deletion.py
+++ b/src/xagent/web/services/task_deletion.py
@@ -28,6 +28,21 @@ def purge_task_rows(
     if task is None:
         return False
 
+    # NULL the checkpoint pointer columns before the trace_events delete
+    # below: last_checkpoint_trace_event_id FKs to trace_events.id, so a
+    # task still pointing at a row would block (or, without DB-level
+    # enforcement, orphan) that delete. A bulk statement, not an ORM
+    # attribute assignment, because this session has autoflush disabled --
+    # an attribute assignment would not reach the database until a later
+    # flush, by which point the trace_events delete has already run.
+    db.query(Task).filter(Task.id == task_id).update(
+        {
+            Task.last_checkpoint_event_id: None,
+            Task.last_checkpoint_trace_event_id: None,
+        },
+        synchronize_session=False,
+    )
+
     db.query(TraceCheckpointBlob).filter(TraceCheckpointBlob.task_id == task_id).delete(
         synchronize_session=False
     )

--- a/src/xagent/web/services/task_lease_recovery.py
+++ b/src/xagent/web/services/task_lease_recovery.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from ..models.task import Task, TaskStatus
 from .db_runtime import is_database_pool_timeout, run_db_io_cancellation_safe
+from .ops_signals import CHECKPOINT_LEGACY_POINTER_AMBIGUOUS, clear_degradation
 from .task_lease_service import (
     CheckpointRecoveryVerdict,
     TaskLeaseRecoveryCandidate,
@@ -289,6 +290,14 @@ async def recover_expired_task_leases_until_cutoff(
 
     if batch_size < 1:
         raise ValueError("batch_size must be positive")
+
+    # One drain is the unit this signal reports on: "the most recent
+    # completed sweep saw at least one ambiguous legacy pointer". Clearing
+    # per candidate would let a later clean candidate erase an earlier
+    # ambiguity inside the same sweep; clearing per page would let page 2
+    # erase what page 1 registered, since the cursor has already advanced
+    # past it. At either finer grain the signal could never stay set.
+    clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
 
     recovered = 0
     cursor: TaskLeaseRecoveryCursor | None = None

--- a/src/xagent/web/services/task_lease_recovery.py
+++ b/src/xagent/web/services/task_lease_recovery.py
@@ -12,11 +12,12 @@ from sqlalchemy.orm import Session
 from ..models.task import Task, TaskStatus
 from .db_runtime import is_database_pool_timeout, run_db_io_cancellation_safe
 from .task_lease_service import (
+    CheckpointRecoveryVerdict,
     TaskLeaseRecoveryCandidate,
     get_expired_task_lease_candidates,
     get_next_expired_task_lease_candidate_for_update,
-    has_recoverable_agent_checkpoint,
     recover_expired_task_lease_no_commit,
+    resolve_checkpoint_recovery,
     utc_now,
 )
 from .task_orchestrator import (
@@ -54,9 +55,17 @@ def recover_task_lease_candidate_no_commit(
 ) -> TaskStatus | None:
     """Stage one recovery and all lifecycle projections without committing."""
 
+    verdict = resolve_checkpoint_recovery(db, candidate)
+    if verdict is CheckpointRecoveryVerdict.INDETERMINATE:
+        # The checkpoint pointer's row identity could not be resolved this
+        # round (an ambiguous legacy event_id match). Leave the candidate's
+        # lease and status untouched -- no recovery statement runs below --
+        # so the next sweep re-selects it and can retry cleanly instead of
+        # failing a task whose checkpoint may in fact be readable.
+        return None
     next_status = (
         TaskStatus.PAUSED
-        if has_recoverable_agent_checkpoint(db, candidate)
+        if verdict is CheckpointRecoveryVerdict.RECOVERABLE
         else TaskStatus.FAILED
     )
     task_error = None if next_status == TaskStatus.PAUSED else TASK_LEASE_EXPIRED_ERROR

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import Any, Callable, Coroutine, Iterator, TypeVar, cast
 
 from sqlalchemy import and_, case, func, or_, update
+from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Query, Session
 
 from ...config import (
@@ -89,6 +90,7 @@ class TaskLeaseRecoveryCandidate:
     lease_expires_at: datetime
     state_version: int
     last_checkpoint_event_id: str | None
+    last_checkpoint_trace_event_id: int | None
 
     @property
     def cursor(self) -> tuple[datetime, int]:
@@ -210,30 +212,41 @@ def task_lease_expires_at(now: datetime | None = None) -> datetime:
     return (now or utc_now()) + timedelta(seconds=get_task_lease_ttl_seconds())
 
 
-def has_recoverable_agent_checkpoint(
-    db: Session,
-    candidate: TaskLeaseRecoveryCandidate,
-) -> bool:
-    """Return whether the candidate points at a checkpoint for its current run.
+class CheckpointRecoveryVerdict(str, Enum):
+    """Result of resolving one recovery candidate's checkpoint pointer.
 
-    Recovery fails closed for events written before run provenance was
-    introduced: an exact pointer alone cannot prove that the checkpoint belongs
-    to the expired run. New-run claims clear the pointer before execution starts.
+    ``RECOVERABLE`` and ``NOT_RECOVERABLE`` both mean the checkpoint's row
+    identity was authoritatively resolved (found-and-valid, or found-invalid,
+    or provably absent); the caller acts on the candidate immediately,
+    recovering to PAUSED or FAILED respectively. ``INDETERMINATE`` means row
+    identity itself could not be established this round (an ambiguous legacy
+    match) -- the caller must leave the candidate's lease and status
+    untouched so the next sweep can retry, never fold this into FAILED.
     """
 
-    if candidate.last_checkpoint_event_id is None:
-        return False
-    row = (
-        db.query(TraceEvent)
-        .filter(
-            TraceEvent.task_id == candidate.task_id,
-            TraceEvent.build_id.is_(None),
-            TraceEvent.event_id == candidate.last_checkpoint_event_id,
-            TraceEvent.event_type == "system_update_general",
-        )
-        .one_or_none()
-    )
-    if row is None:
+    RECOVERABLE = "recoverable"
+    NOT_RECOVERABLE = "not_recoverable"
+    INDETERMINATE = "indeterminate"
+
+
+def _checkpoint_row_matches_candidate(
+    row: TraceEvent, candidate: TaskLeaseRecoveryCandidate
+) -> bool:
+    """Validate an already-identified trace_events row against the fields a
+    recoverable checkpoint must satisfy for this candidate's run.
+
+    Shared by both the PK-anchored and legacy resolution paths: the legacy
+    path's query already filters task_id/build_id/event_type, so those
+    checks are redundant there, but the PK path loads a row by raw primary
+    key with no such filter, so it needs the full set. A mismatch here is
+    corruption of the row the pointer names, not a cue to search elsewhere.
+    """
+
+    if (
+        row.task_id != candidate.task_id
+        or row.event_type != "system_update_general"
+        or row.build_id is not None
+    ):
         return False
     data: dict[str, Any] = (
         cast(dict[str, Any], row.data) if isinstance(row.data, dict) else {}
@@ -244,6 +257,87 @@ def has_recoverable_agent_checkpoint(
     if checkpoint_run_id is None:
         return False
     return candidate.run_id is not None and str(checkpoint_run_id) == candidate.run_id
+
+
+def _resolve_legacy_checkpoint_recovery(
+    db: Session,
+    candidate: TaskLeaseRecoveryCandidate,
+) -> CheckpointRecoveryVerdict:
+    """Resolve the candidate's legacy ``event_id`` string against the row it
+    names, within the same partition (task, root scope, checkpoint type)
+    today's query has always used.
+
+    An unset pointer or a zero-row match is an authoritative absence: the
+    candidate's run has no checkpoint to recover to, so this is
+    NOT_RECOVERABLE (FAILED), not INDETERMINATE. Only two-or-more rows
+    sharing the same event_id inside this partition make the row's identity
+    itself ambiguous -- that is the case this resolver cannot decide and
+    defers to the next sweep instead of guessing or failing the task.
+    """
+
+    if candidate.last_checkpoint_event_id is None:
+        return CheckpointRecoveryVerdict.NOT_RECOVERABLE
+    query = db.query(TraceEvent).filter(
+        TraceEvent.task_id == candidate.task_id,
+        TraceEvent.build_id.is_(None),
+        TraceEvent.event_id == candidate.last_checkpoint_event_id,
+        TraceEvent.event_type == "system_update_general",
+    )
+    try:
+        row = query.one_or_none()
+    except MultipleResultsFound:
+        logger.warning(
+            "Task %s legacy checkpoint event_id %s matches more than one "
+            "trace_events row; skipping this recovery candidate for the "
+            "next sweep",
+            candidate.task_id,
+            candidate.last_checkpoint_event_id,
+        )
+        return CheckpointRecoveryVerdict.INDETERMINATE
+    if row is None:
+        return CheckpointRecoveryVerdict.NOT_RECOVERABLE
+    return (
+        CheckpointRecoveryVerdict.RECOVERABLE
+        if _checkpoint_row_matches_candidate(row, candidate)
+        else CheckpointRecoveryVerdict.NOT_RECOVERABLE
+    )
+
+
+def resolve_checkpoint_recovery(
+    db: Session,
+    candidate: TaskLeaseRecoveryCandidate,
+) -> CheckpointRecoveryVerdict:
+    """Resolve whether the candidate's checkpoint pointer identifies a
+    recoverable checkpoint for its current run.
+
+    Recovery fails closed for events written before run provenance was
+    introduced: an exact pointer alone cannot prove that the checkpoint
+    belongs to the expired run. New-run claims clear both pointer columns
+    before execution starts.
+
+    The exact-row pointer is tried first when set: a hit is authoritative
+    (validated, never searched past). A pointer whose row is gone is not a
+    validation failure -- it is only reachable on a database upgraded
+    without this column's FK (a compatibility-window state, see the
+    migration) -- so it falls back to the legacy string resolution below
+    instead of failing the candidate outright.
+    """
+
+    if candidate.last_checkpoint_trace_event_id is not None:
+        row = db.get(TraceEvent, candidate.last_checkpoint_trace_event_id)
+        if row is not None:
+            return (
+                CheckpointRecoveryVerdict.RECOVERABLE
+                if _checkpoint_row_matches_candidate(row, candidate)
+                else CheckpointRecoveryVerdict.NOT_RECOVERABLE
+            )
+        logger.warning(
+            "Task %s checkpoint pointer trace_event_id=%s has no matching "
+            "trace_events row; falling back to the legacy event_id scan",
+            candidate.task_id,
+            candidate.last_checkpoint_trace_event_id,
+        )
+    return _resolve_legacy_checkpoint_recovery(db, candidate)
 
 
 def _nullable_match(column: Any, value: Any) -> Any:
@@ -276,18 +370,40 @@ def lease_state_version_case(
     )
 
 
+def _checkpoint_pointer_retention_predicate() -> Any:
+    """WHERE condition shared by both checkpoint-pointer SET case() builders:
+    true when the row is not a live RUNNING row with a run id, i.e. when
+    both pointer columns must be cleared instead of retained.
+
+    Extracted so the legacy and exact-row builders below can never drift
+    apart on which rows clear their pointer -- a per-builder copy would let
+    one column retain a stale pointer the other clears, which would make
+    the recovery CAS fence's conjunction over both columns never match (see
+    test_lease_checkpoint_pointer_case_predicates_match in
+    test_task_lease_service.py).
+    """
+    return or_(
+        task_status_predicate.ne(TaskStatus.RUNNING),
+        Task.run_id.is_(None),
+    )
+
+
 def lease_checkpoint_event_id_case() -> Any:
     """SET last_checkpoint_event_id: clear it when the row is not a live
     RUNNING row with a run id."""
     return case(
-        (
-            or_(
-                task_status_predicate.ne(TaskStatus.RUNNING),
-                Task.run_id.is_(None),
-            ),
-            None,
-        ),
+        (_checkpoint_pointer_retention_predicate(), None),
         else_=Task.last_checkpoint_event_id,
+    )
+
+
+def lease_checkpoint_trace_event_id_case() -> Any:
+    """SET last_checkpoint_trace_event_id: mirrors
+    lease_checkpoint_event_id_case's clearing condition exactly, so the two
+    pointer columns are always set or cleared together."""
+    return case(
+        (_checkpoint_pointer_retention_predicate(), None),
+        else_=Task.last_checkpoint_trace_event_id,
     )
 
 
@@ -307,6 +423,7 @@ def _expired_task_lease_candidates_query(
             Task.lease_expires_at,
             Task.state_version,
             Task.last_checkpoint_event_id,
+            Task.last_checkpoint_trace_event_id,
         )
         .filter(
             task_status_predicate.eq(TaskStatus.RUNNING),
@@ -344,6 +461,11 @@ def _task_lease_recovery_candidate_from_row(
         last_checkpoint_event_id=(
             str(row.last_checkpoint_event_id)
             if row.last_checkpoint_event_id is not None
+            else None
+        ),
+        last_checkpoint_trace_event_id=(
+            int(row.last_checkpoint_trace_event_id)
+            if row.last_checkpoint_trace_event_id is not None
             else None
         ),
     )
@@ -442,6 +564,10 @@ def recover_expired_task_lease_no_commit(
                 Task.last_checkpoint_event_id,
                 candidate.last_checkpoint_event_id,
             ),
+            _nullable_match(
+                Task.last_checkpoint_trace_event_id,
+                candidate.last_checkpoint_trace_event_id,
+            ),
         )
         .values(**values)
     )
@@ -517,10 +643,14 @@ def acquire_task_lease_no_commit(
     }
     if new_run:
         values["last_checkpoint_event_id"] = None
+        values["last_checkpoint_trace_event_id"] = None
         values["output"] = None
         values["error_message"] = None
     elif expected_run_id is None:
         values["last_checkpoint_event_id"] = lease_checkpoint_event_id_case()
+        values["last_checkpoint_trace_event_id"] = (
+            lease_checkpoint_trace_event_id_case()
+        )
 
     stmt = (
         update(Task)

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -31,6 +31,10 @@ from .db_runtime import (
     is_database_pool_timeout,
     run_db_io_cancellation_safe,
 )
+from .ops_signals import (
+    CHECKPOINT_LEGACY_POINTER_AMBIGUOUS,
+    register_degradation,
+)
 from .task_execution_controller import control_state_for_status
 
 logger = logging.getLogger(__name__)
@@ -300,6 +304,15 @@ def _resolve_legacy_checkpoint_recovery(
             "next sweep",
             candidate.task_id,
             candidate.last_checkpoint_event_id,
+        )
+        # An ambiguity nothing in this process can resolve: every later
+        # sweep re-selects the same candidate and re-hits it. A log line
+        # alone leaves that invisible to monitoring, so it rides /health
+        # until a sweep completes without seeing one.
+        register_degradation(
+            CHECKPOINT_LEGACY_POINTER_AMBIGUOUS,
+            f"task {candidate.task_id}: legacy checkpoint event_id "
+            f"{candidate.last_checkpoint_event_id} matches more than one row",
         )
         return CheckpointRecoveryVerdict.INDETERMINATE
     if row is None:

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -240,6 +240,14 @@ def _checkpoint_row_matches_candidate(
     checks are redundant there, but the PK path loads a row by raw primary
     key with no such filter, so it needs the full set. A mismatch here is
     corruption of the row the pointer names, not a cue to search elsewhere.
+
+    A ``False`` here always resolves the candidate to NOT_RECOVERABLE
+    (lease recovery fails the task). The checkpoint reader's own PK-anchor
+    validation (``_load_pk_anchored_checkpoint`` in ``trace_handlers.py``)
+    checks the same kind of row mismatch but calls it corrupt
+    (``CheckpointCorruptError``) instead -- two call sites judging the same
+    condition through different vocabularies for their own callers, not an
+    inconsistency to reconcile.
     """
 
     if (

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -378,10 +378,10 @@ def lease_state_version_case(
     )
 
 
-def _checkpoint_pointer_retention_predicate() -> Any:
+def _checkpoint_pointer_clearing_predicate() -> Any:
     """WHERE condition shared by both checkpoint-pointer SET case() builders:
     true when the row is not a live RUNNING row with a run id, i.e. when
-    both pointer columns must be cleared instead of retained.
+    both pointer columns must be cleared.
 
     Extracted so the legacy and exact-row builders below can never drift
     apart on which rows clear their pointer -- a per-builder copy would let
@@ -400,7 +400,7 @@ def lease_checkpoint_event_id_case() -> Any:
     """SET last_checkpoint_event_id: clear it when the row is not a live
     RUNNING row with a run id."""
     return case(
-        (_checkpoint_pointer_retention_predicate(), None),
+        (_checkpoint_pointer_clearing_predicate(), None),
         else_=Task.last_checkpoint_event_id,
     )
 
@@ -410,7 +410,7 @@ def lease_checkpoint_trace_event_id_case() -> Any:
     lease_checkpoint_event_id_case's clearing condition exactly, so the two
     pointer columns are always set or cleared together."""
     return case(
-        (_checkpoint_pointer_retention_predicate(), None),
+        (_checkpoint_pointer_clearing_predicate(), None),
         else_=Task.last_checkpoint_trace_event_id,
     )
 

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -975,6 +975,7 @@ def _claim_turn_no_commit(
                 Task.last_heartbeat_at: None,
                 Task.run_id: run_id,
                 Task.last_checkpoint_event_id: None,
+                Task.last_checkpoint_trace_event_id: None,
                 Task.state_version: func.coalesce(Task.state_version, 0) + 1,
                 Task.control_state: TaskControlState.RUNNING.value,
             },

--- a/tests/e2e/app_harness.py
+++ b/tests/e2e/app_harness.py
@@ -14,6 +14,7 @@ import jwt
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.shared.db_teardown import drop_all_tables
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.database import get_engine, get_session_local, init_db
@@ -219,9 +220,7 @@ def run_e2e_app_client(
         reset_chat_agent_manager(monkeypatch)
         clear_connection_cache()
         try:
-            from xagent.web.models.database import Base
-
-            Base.metadata.drop_all(bind=get_engine())
+            drop_all_tables(get_engine())
             get_engine().dispose()
         except RuntimeError:
             pass

--- a/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
@@ -1,0 +1,422 @@
+"""Tests for migration 20260804_add_task_checkpoint_trace_event_anchor.
+
+Following this repo's existing migration-test convention (see
+tests/migrations/test_20260728_add_agent_template_id_and_name_uniqueness.py):
+``tasks``/``trace_events`` are create_all-only in production (never created
+by a migration -- see fab71cf4b1ad_add_sdk_fields_to_tasks.py's guard), so
+the pre-migration schema is built directly here with SQLAlchemy Core table
+objects, stamped to this migration's parent revision, and only the
+migration under test is run against it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy import create_engine, inspect, text
+
+from xagent.db.config import create_alembic_config
+
+PARENT_REVISION = "20260729_add_gmail_audience_grace"
+TARGET_REVISION = "20260804_add_task_checkpoint_trace_event_anchor"
+COLUMN = "last_checkpoint_trace_event_id"
+FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
+
+
+def _migration_module() -> ModuleType:
+    """Load the migration file directly so its BACKFILL_SQL can be re-run
+    against an already-upgraded database, independent of Alembic's own
+    revision bookkeeping (which short-circuits command.upgrade() to a no-op
+    once a database is already stamped at the target revision -- calling it
+    twice does not actually exercise the backfill SQL a second time)."""
+    import xagent.migrations as migrations_pkg
+
+    # xagent.migrations is a namespace package (no __init__.py), so it has
+    # no __file__ -- __path__ is the only way to locate it.
+    migrations_dir = Path(next(iter(migrations_pkg.__path__)))
+    path = migrations_dir / "versions" / f"{TARGET_REVISION}.py"
+    spec = importlib.util.spec_from_file_location(TARGET_REVISION, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _pre_migration_metadata() -> sa.MetaData:
+    """The subset of tasks/trace_events columns this migration reads or
+    writes -- not the full production schema (see the module docstring)."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "tasks",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column("last_checkpoint_event_id", sa.String(255), nullable=True),
+    )
+    sa.Table(
+        "trace_events",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, nullable=False),
+        sa.Column("build_id", sa.String(255), nullable=True),
+        sa.Column("event_id", sa.String(255), nullable=False),
+        sa.Column("event_type", sa.String(100), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("data", sa.Text, nullable=False),
+    )
+    return metadata
+
+
+def _stamp_parent_revision(engine: sa.engine.Engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) VALUES "
+                f"('{PARENT_REVISION}')"
+            )
+        )
+
+
+def _insert_task(
+    conn: sa.engine.Connection,
+    *,
+    task_id: int,
+    last_checkpoint_event_id: str | None = None,
+) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO tasks (id, user_id, title, status, "
+            "last_checkpoint_event_id) VALUES "
+            "(:id, 1, 'Task', 'pending', :legacy)"
+        ),
+        {"id": task_id, "legacy": last_checkpoint_event_id},
+    )
+
+
+def _insert_trace_event(
+    conn: sa.engine.Connection,
+    *,
+    row_id: int,
+    task_id: int,
+    event_id: str,
+    build_id: str | None = None,
+    event_type: str = "system_update_general",
+) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO trace_events "
+            "(id, task_id, build_id, event_id, event_type, timestamp, data) "
+            "VALUES (:id, :task_id, :build_id, :event_id, :event_type, "
+            ":timestamp, :data)"
+        ),
+        {
+            "id": row_id,
+            "task_id": task_id,
+            "build_id": build_id,
+            "event_id": event_id,
+            "event_type": event_type,
+            "timestamp": "2026-08-04 00:00:00",
+            "data": "{}",
+        },
+    )
+
+
+@pytest.fixture
+def sqlite_engine(tmp_path: Path) -> sa.engine.Engine:
+    engine = create_engine(f"sqlite:///{tmp_path / 'anchor.db'}")
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    return engine
+
+
+def _alembic_config(engine: sa.engine.Engine):
+    # create_alembic_config() stores str(engine.url), which SQLAlchemy
+    # masks to "***" for display -- fine for logging, fatal for a real
+    # connection. Overwrite it with the unmasked form before use.
+    config = create_alembic_config(engine)
+    config.set_main_option(
+        "sqlalchemy.url", engine.url.render_as_string(hide_password=False)
+    )
+    return config
+
+
+def _upgrade(engine: sa.engine.Engine, revision: str = TARGET_REVISION) -> None:
+    command.upgrade(_alembic_config(engine), revision)
+
+
+def _downgrade(engine: sa.engine.Engine, revision: str = PARENT_REVISION) -> None:
+    command.downgrade(_alembic_config(engine), revision)
+
+
+class TestUpgradeSqlite:
+    def test_adds_nullable_anchor_column(self, sqlite_engine: sa.engine.Engine) -> None:
+        _upgrade(sqlite_engine)
+
+        columns = {c["name"]: c for c in inspect(sqlite_engine).get_columns("tasks")}
+        assert COLUMN in columns
+        assert columns[COLUMN]["nullable"]
+
+    def test_upgraded_sqlite_has_no_db_level_fk(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """D1 asymmetry as a tested fact: Alembic's SQLite batch mode cannot
+        add a FK without a full table rebuild, so an upgraded (not freshly
+        create_all'd) SQLite database has no DB-level constraint here --
+        only the application's NULL-first delete ordering protects it."""
+        _upgrade(sqlite_engine)
+
+        fk_names = {
+            fk["name"] for fk in inspect(sqlite_engine).get_foreign_keys("tasks")
+        }
+        assert FK_NAME not in fk_names
+
+    def test_backfills_unambiguous_legacy_pointer(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == 100
+
+    def test_ambiguous_match_backfills_to_null(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """Two rows share the legacy event_id within the same task/partition
+        -- the backfill must not guess which one is authoritative."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-dup")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-dup")
+            _insert_trace_event(conn, row_id=101, task_id=1, event_id="evt-dup")
+
+        _upgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value is None
+
+    def test_missing_match_backfills_to_null(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """A legacy pointer with zero matching rows (e.g. the target row was
+        concurrently deleted) resolves to NULL, not an aborted migration."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-gone")
+
+        _upgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value is None
+
+    def test_build_scoped_row_is_not_treated_as_the_root_anchor(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """A worker-build checkpoint sharing the legacy event_id string must
+        not resolve the root pointer -- only build_id IS NULL rows do."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(
+                conn,
+                row_id=100,
+                task_id=1,
+                event_id="evt-1",
+                build_id="agent_123_abcd",
+            )
+
+        _upgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value is None
+
+    def test_upgrade_is_idempotent_when_rerun(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """command.upgrade() a second time at the same revision is a no-op
+        at the Alembic bookkeeping layer -- it never re-executes this
+        migration's upgrade() function -- so the backfill SQL itself is
+        re-run directly here to exercise its own idempotency guard."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(sqlite_engine)
+        module = _migration_module()
+        with sqlite_engine.begin() as conn:
+            conn.execute(module.BACKFILL_SQL)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == 100
+
+    def test_rerun_does_not_clobber_a_resolved_pointer(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """Idempotency guard: WHERE last_checkpoint_trace_event_id IS NULL
+        must stop a second run from re-deriving (or blanking) an already
+        resolved pointer, even if the legacy row set changed in between.
+        See test_upgrade_is_idempotent_when_rerun above for why the
+        backfill SQL is re-run directly rather than through command.upgrade()
+        again."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            # Simulate a second matching row appearing after the first
+            # backfill -- if the WHERE guard were missing, a rerun would
+            # flip an already-resolved pointer back to NULL.
+            _insert_trace_event(conn, row_id=101, task_id=1, event_id="evt-1")
+
+        module = _migration_module()
+        with sqlite_engine.begin() as conn:
+            conn.execute(module.BACKFILL_SQL)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == 100
+
+
+class TestDowngradeSqlite:
+    def test_removes_the_anchor_column(self, sqlite_engine: sa.engine.Engine) -> None:
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(sqlite_engine)
+        _downgrade(sqlite_engine)
+
+        columns = {c["name"] for c in inspect(sqlite_engine).get_columns("tasks")}
+        assert COLUMN not in columns
+
+    def test_downgrade_leaves_the_legacy_column_untouched(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """The legacy string column is never written by this migration, so
+        downgrading (dropping only the new column) trivially restores the
+        exact pre-migration readable state."""
+        with sqlite_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(sqlite_engine)
+        _downgrade(sqlite_engine)
+
+        with sqlite_engine.begin() as conn:
+            value = conn.execute(
+                text("SELECT last_checkpoint_event_id FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == "evt-1"
+
+    def test_upgrade_downgrade_upgrade_is_idempotent(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        _upgrade(sqlite_engine)
+        _downgrade(sqlite_engine)
+        _upgrade(sqlite_engine)
+
+        columns = {c["name"] for c in inspect(sqlite_engine).get_columns("tasks")}
+        assert COLUMN in columns
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture
+def postgres_engine():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    # tasks may carry the anchor FK to trace_events from a previous run --
+    # drop tasks (and its constraint) before trace_events, or CASCADE.
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        conn.execute(text("DROP TABLE IF EXISTS tasks CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS trace_events CASCADE"))
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    yield engine
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        conn.execute(text("DROP TABLE IF EXISTS tasks CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS trace_events CASCADE"))
+    engine.dispose()
+
+
+@pytest.mark.postgresql
+class TestUpgradePostgres:
+    def test_upgrade_adds_a_named_foreign_key(self, postgres_engine) -> None:
+        _upgrade(postgres_engine)
+
+        foreign_keys = inspect(postgres_engine).get_foreign_keys("tasks")
+        anchor_fk = next(fk for fk in foreign_keys if fk["name"] == FK_NAME)
+        assert anchor_fk["referred_table"] == "trace_events"
+        assert anchor_fk["referred_columns"] == ["id"]
+        assert anchor_fk["constrained_columns"] == [COLUMN]
+
+    def test_upgrade_is_idempotent_when_rerun(self, postgres_engine) -> None:
+        _upgrade(postgres_engine)
+        _upgrade(postgres_engine)
+
+        foreign_keys = {
+            fk["name"] for fk in inspect(postgres_engine).get_foreign_keys("tasks")
+        }
+        assert FK_NAME in foreign_keys
+
+    def test_backfills_unambiguous_legacy_pointer(self, postgres_engine) -> None:
+        with postgres_engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+            _insert_trace_event(conn, row_id=100, task_id=1, event_id="evt-1")
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == 100
+
+    def test_downgrade_drops_the_named_foreign_key(self, postgres_engine) -> None:
+        _upgrade(postgres_engine)
+        _downgrade(postgres_engine)
+
+        foreign_keys = {
+            fk["name"] for fk in inspect(postgres_engine).get_foreign_keys("tasks")
+        }
+        assert FK_NAME not in foreign_keys
+        columns = {c["name"] for c in inspect(postgres_engine).get_columns("tasks")}
+        assert COLUMN not in columns

--- a/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
@@ -398,6 +398,76 @@ class TestDowngradeSqlite:
         assert COLUMN in columns
 
 
+class TestDowngradeSqliteOverCreateAllSchema:
+    """Downgrade over the schema shape a fresh install actually has.
+
+    Production never builds ``tasks`` through a migration: a new database is
+    created by ``Base.metadata.create_all()`` and then stamped at head (see
+    src/xagent/db/migration.py). On SQLite that renders this column's foreign
+    key inline in ``CREATE TABLE tasks`` even though the model declares it
+    ``use_alter=True``, and SQLite refuses to drop a column an inline foreign
+    key names. TestDowngradeSqlite above builds from _pre_migration_metadata(),
+    which carries no such constraint, so it cannot reach this shape.
+    """
+
+    @pytest.fixture
+    def create_all_engine(self, tmp_path: Path):
+        from tests.web.services.checkpoint_anchor_shared import (
+            reset_checkpoint_anchor_fk_create_rule,
+        )
+        from xagent.web.models.database import Base
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'create-all.db'}")
+        # Mandatory. The PostgreSQL tests in this file create_all against a
+        # dialect that supports ALTER, which permanently caches a "defer to
+        # ALTER" decision on this constraint's shared _create_rule; a later
+        # SQLite create_all then omits the constraint entirely and this
+        # fixture would assert nothing.
+        reset_checkpoint_anchor_fk_create_rule()
+        Base.metadata.create_all(bind=engine)
+        command.stamp(_alembic_config(engine), TARGET_REVISION)
+        assert FK_NAME in {
+            fk["name"] for fk in inspect(engine).get_foreign_keys("tasks")
+        }
+        yield engine
+        engine.dispose()
+
+    def test_downgrade_over_a_create_all_schema_drops_the_column(
+        self, create_all_engine
+    ) -> None:
+        _downgrade(create_all_engine)
+
+        inspector = inspect(create_all_engine)
+        assert COLUMN not in {c["name"] for c in inspector.get_columns("tasks")}
+        assert FK_NAME not in {fk["name"] for fk in inspector.get_foreign_keys("tasks")}
+
+    def test_downgrade_over_a_create_all_schema_preserves_task_rows(
+        self, create_all_engine
+    ) -> None:
+        with create_all_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO users (id, username, password_hash, is_admin) "
+                    "VALUES (1, 'u', 'h', 0)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO tasks (id, user_id, title, status, state_version, "
+                    "control_state, is_visible, last_checkpoint_event_id) VALUES "
+                    "(1, 1, 'T', 'PENDING', 0, 'idle', 1, 'evt-1')"
+                )
+            )
+
+        _downgrade(create_all_engine)
+
+        with create_all_engine.begin() as conn:
+            value = conn.execute(
+                text("SELECT last_checkpoint_event_id FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value == "evt-1"
+
+
 def _postgres_url() -> str | None:
     return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
         "POSTGRES_TEST_DATABASE_URL"

--- a/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
@@ -140,6 +140,22 @@ def sqlite_engine(tmp_path: Path) -> sa.engine.Engine:
     return engine
 
 
+@pytest.fixture
+def sqlite_engine_without_trace_events(tmp_path: Path) -> sa.engine.Engine:
+    """A database carrying ``tasks`` but no ``trace_events`` at all.
+
+    This is the shape tests/migration/test_migration.py's automatic-upgrade
+    tests build: they stamp an old revision and hand-create only the table
+    the revisions under test touch, then run the rest of the history through
+    ``try_upgrade_db``. Every step this migration derives from
+    ``trace_events`` has to stay off in that shape.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'no-trace-events.db'}")
+    _pre_migration_metadata().tables["tasks"].create(bind=engine)
+    _stamp_parent_revision(engine)
+    return engine
+
+
 def _alembic_config(engine: sa.engine.Engine):
     # create_alembic_config() stores str(engine.url), which SQLAlchemy
     # masks to "***" for display -- fine for logging, fatal for a real
@@ -274,6 +290,39 @@ class TestUpgradeSqlite:
                 text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
             ).scalar_one()
         assert value == 100
+
+    def test_adds_the_column_without_a_trace_events_table(
+        self, sqlite_engine_without_trace_events: sa.engine.Engine
+    ) -> None:
+        """The column is this migration's own schema change and does not
+        depend on trace_events, so it is still added; the backfill, which
+        reads trace_events, is skipped instead of raising "no such table"."""
+        engine = sqlite_engine_without_trace_events
+        with engine.begin() as conn:
+            _insert_task(conn, task_id=1, last_checkpoint_event_id="evt-1")
+
+        _upgrade(engine)
+
+        columns = {c["name"] for c in inspect(engine).get_columns("tasks")}
+        assert COLUMN in columns
+        with engine.begin() as conn:
+            value = conn.execute(
+                text(f"SELECT {COLUMN} FROM tasks WHERE id = 1")
+            ).scalar_one()
+        assert value is None
+
+    def test_downgrade_without_a_trace_events_table(
+        self, sqlite_engine_without_trace_events: sa.engine.Engine
+    ) -> None:
+        """Downgrade reads nothing from trace_events -- it drops a column
+        and, on PostgreSQL only, a constraint reflected off tasks -- so it
+        needs no trace_events guard of its own."""
+        engine = sqlite_engine_without_trace_events
+        _upgrade(engine)
+        _downgrade(engine)
+
+        columns = {c["name"] for c in inspect(engine).get_columns("tasks")}
+        assert COLUMN not in columns
 
     def test_rerun_does_not_clobber_a_resolved_pointer(
         self, sqlite_engine: sa.engine.Engine

--- a/tests/shared/db_teardown.py
+++ b/tests/shared/db_teardown.py
@@ -1,0 +1,40 @@
+"""One drop-the-schema teardown for fixtures that build a real database.
+
+``tasks.last_checkpoint_trace_event_id -> trace_events.id`` and
+``trace_events.task_id -> tasks.id`` form a constraint cycle. SQLAlchemy
+breaks the cycle for DROP ordering by dropping the ``use_alter=True``
+constraint first, which works on PostgreSQL but not on SQLite: that dialect
+cannot ALTER a constraint, so ``create_all`` renders the FK inline in
+``CREATE TABLE`` and it is still enforced when ``drop_all`` reaches the
+tables. SQLite's ``DROP TABLE`` runs an implicit delete of the table's rows,
+so with ``foreign_keys=ON`` (this repo's default -- see
+``apply_sqlite_concurrency_pragmas``) dropping either side of a *populated*
+cycle fails with "FOREIGN KEY constraint failed".
+
+No drop order satisfies a populated cycle, so enforcement is turned off for
+the single connection that does the dropping, not for the fixture's tests.
+The rows are being discarded, not checked.
+
+Any teardown that drops ``Base.metadata`` against a ``get_engine()`` SQLite
+database in a test that persists a checkpoint (a row with
+``last_checkpoint_trace_event_id`` set) must use this helper instead of
+calling ``Base.metadata.drop_all`` directly.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.engine import Engine
+
+from xagent.web.models.database import Base
+
+
+def drop_all_tables(engine: Engine) -> None:
+    """Drop every ``Base.metadata`` table on ``engine``."""
+
+    if engine.dialect.name != "sqlite":
+        Base.metadata.drop_all(bind=engine)
+        return
+
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        Base.metadata.drop_all(bind=connection)

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -37,6 +37,7 @@ from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.db_teardown import drop_all_tables
 from xagent.web.api.a2a import router as a2a_router
 from xagent.web.api.agent_api_keys import router as agent_api_keys_router
 from xagent.web.api.agents import router as agents_router
@@ -53,7 +54,7 @@ from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
 from xagent.web.api.widget import widget_router
 from xagent.web.api.workforces import router as workforces_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
-from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.models.database import get_db, get_engine
 from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.a2a_protocol import (
     A2AApiError,
@@ -216,7 +217,7 @@ def _test_db() -> Iterator[None]:
 
     yield
 
-    Base.metadata.drop_all(bind=get_engine())
+    drop_all_tables(get_engine())
     try:
         shutil.rmtree(temp_dir)
     except OSError:
@@ -353,7 +354,7 @@ def patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
     keeps the claim-to-schedule handoff real -- a raise anywhere in it still
     fails the test -- while leaving no live background task for
     ``public_chat_access.py`` to drop un-awaited, which would otherwise race
-    ``Base.metadata.drop_all`` below.
+    the schema teardown below.
 
     Lives here rather than in each suite: three api/ suites need it, and while
     each kept its own copy they drifted -- two stubbed a call the workforce

--- a/tests/web/services/checkpoint_anchor_shared.py
+++ b/tests/web/services/checkpoint_anchor_shared.py
@@ -27,6 +27,11 @@ from sqlalchemy.engine import Engine
 
 from xagent.web.models.database import Base
 
+# Imported for its side effect: registering the tasks table (and its anchor
+# constraint) on Base.metadata, so this module works no matter which test
+# module imports it first.
+from xagent.web.models.task import Task  # noqa: F401
+
 CHECKPOINT_ANCHOR_FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
 
 _ANCHOR_FK_CLAUSE = re.compile(

--- a/tests/web/services/checkpoint_anchor_shared.py
+++ b/tests/web/services/checkpoint_anchor_shared.py
@@ -1,0 +1,94 @@
+"""Shared construction for the "upgraded, FK-less" SQLite schema shape used
+by test_task_deletion_checkpoint_pointer.py's ``sqlite_upgraded_session`` and
+test_task_lease_recovery.py's ``sqlite_no_anchor_fk_session``.
+
+The checkpoint-anchor migration adds ``last_checkpoint_trace_event_id`` via
+``add_column`` (without ``create_foreign_key``, which is PostgreSQL-only), so
+a SQLite database upgraded through the real Alembic history has no DB-level
+FK for that column -- unlike a freshly ``create_all``'d one, which carries
+the full model metadata including the FK. Alembic's SQLite batch mode cannot
+add or drop that FK without a full table rebuild, so reproducing the
+upgraded shape needs the same trick a real migration would use: create the
+full schema via create_all, then rebuild ``tasks`` from its own DDL with
+just the anchor FK's clause stripped -- the standard SQLite
+rename/recreate/copy/drop procedure.
+
+Both fixtures need this exact no-FK shape, so the construction lives here
+once; each test file keeps its own thin fixture wrapping this engine in a
+sessionmaker with its own session lifetime and teardown.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from xagent.web.models.database import Base
+
+CHECKPOINT_ANCHOR_FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
+
+_ANCHOR_FK_CLAUSE = re.compile(
+    r",\s*CONSTRAINT "
+    + re.escape(CHECKPOINT_ANCHOR_FK_NAME)
+    + r" FOREIGN KEY\([^)]*\) REFERENCES [^,]*"
+)
+
+
+def reset_checkpoint_anchor_fk_create_rule() -> None:
+    """Work around a cross-dialect SQLAlchemy DDL-compiler quirk before any
+    Base.metadata.create_all() call that might run against more than one
+    dialect in the same process.
+
+    The anchor FK is use_alter=True (required for tasks/trace_events'
+    constraint cycle -- see the model). The first create_all() against a
+    dialect that supports ALTER (PostgreSQL) permanently caches a "defer
+    this to ALTER" decision on the constraint's shared, dialect-agnostic
+    _create_rule attribute. A later create_all() against SQLite (which
+    never attempts the ALTER, since that dialect doesn't support it for
+    constraints) then honors the same cached decision and silently omits
+    the constraint from CREATE TABLE entirely -- it is never created
+    inline or via ALTER. Only a live process that create_all()s against
+    both dialects hits this (a real deployment binds one dialect for its
+    whole lifetime and never triggers it). Resetting the rule before each
+    create_all() call makes every fixture's result independent of what
+    dialect (if any) create_all() targeted earlier in the process.
+    """
+    for constraint in Base.metadata.tables["tasks"].constraints:
+        if getattr(constraint, "name", None) == CHECKPOINT_ANCHOR_FK_NAME:
+            constraint._create_rule = None
+            return
+    raise AssertionError(f"{CHECKPOINT_ANCHOR_FK_NAME} constraint not found on tasks")
+
+
+def build_upgraded_sqlite_engine(db_path: object) -> Engine:
+    """Build a SQLite engine whose ``tasks`` table has no DB-level FK for
+    the checkpoint pointer column, matching a database upgraded through the
+    real migration rather than freshly create_all'd.
+
+    ``db_path`` is the sqlite file path (e.g. ``tmp_path / "upgraded.db"``);
+    callers pick their own filename so fixtures from different test modules
+    never share a file.
+    """
+    engine = create_engine(f"sqlite:///{db_path}")
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(bind=engine)
+
+    with engine.begin() as conn:
+        original_sql = conn.execute(
+            text(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'"
+            )
+        ).scalar_one()
+        stripped_sql, count = _ANCHOR_FK_CLAUSE.subn("", original_sql)
+        assert count == 1, (
+            f"expected exactly one {CHECKPOINT_ANCHOR_FK_NAME} clause in the "
+            f"tasks DDL, found {count}"
+        )
+        conn.execute(text("ALTER TABLE tasks RENAME TO tasks_old"))
+        conn.execute(text(stripped_sql))
+        conn.execute(text("INSERT INTO tasks SELECT * FROM tasks_old"))
+        conn.execute(text("DROP TABLE tasks_old"))
+
+    return engine

--- a/tests/web/services/checkpoint_anchor_shared.py
+++ b/tests/web/services/checkpoint_anchor_shared.py
@@ -62,6 +62,17 @@ def reset_checkpoint_anchor_fk_create_rule() -> None:
     """
     for constraint in Base.metadata.tables["tasks"].constraints:
         if getattr(constraint, "name", None) == CHECKPOINT_ANCHOR_FK_NAME:
+            # _create_rule is private SQLAlchemy state. If a release renames
+            # or drops it, assigning to the old name still succeeds, leaves
+            # the cached decision in place, and hollows out every fixture
+            # that calls this helper -- they would keep asserting against a
+            # schema that silently lost the constraint. Check first so that
+            # becomes a loud failure instead.
+            assert hasattr(constraint, "_create_rule"), (
+                "SQLAlchemy no longer exposes Constraint._create_rule; the "
+                "cross-dialect create_all() workaround in this helper needs "
+                "to be rewritten against the current attribute"
+            )
             constraint._create_rule = None
             return
     raise AssertionError(f"{CHECKPOINT_ANCHOR_FK_NAME} constraint not found on tasks")

--- a/tests/web/services/test_checkpoint_pointer_pairing.py
+++ b/tests/web/services/test_checkpoint_pointer_pairing.py
@@ -1,0 +1,178 @@
+"""Static guard: the two checkpoint pointer columns are always moved together.
+
+``tasks.last_checkpoint_event_id`` (legacy string) and
+``tasks.last_checkpoint_trace_event_id`` (exact-row anchor) are dual-written
+and dual-cleared across six mutation sites in five modules, and the recovery
+CAS fence conjoins both. A statement that sets one without the other makes
+that fence unmatchable, so recovery would stop working rather than fail
+loudly. Nothing but this check keeps the pair together once the call sites
+drift apart during the compatibility window.
+
+Reads are deliberately out of scope: several call sites legitimately name
+exactly one column when resolving or querying it. Only mutation carriers are
+matched -- dict-literal keys, call keywords, and subscript assignments.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from xagent.web.api import admin_users, trace_handlers
+from xagent.web.services import task_deletion, task_lease_service, task_orchestrator
+
+POINTER_COLUMNS = frozenset(
+    {"last_checkpoint_event_id", "last_checkpoint_trace_event_id"}
+)
+
+SUBJECT_MODULES = [
+    trace_handlers,
+    admin_users,
+    task_lease_service,
+    task_deletion,
+    task_orchestrator,
+]
+
+
+def _mutated_pointer_columns(statement: ast.stmt) -> set[str]:
+    """Pointer columns this statement *writes*, in any of the three carrier
+    forms the call sites actually use."""
+    found: set[str] = set()
+    for node in ast.walk(statement):
+        if isinstance(node, ast.Dict):
+            # {Task.last_checkpoint_event_id: None, ...} / {"col": None, ...}
+            for key in node.keys:
+                if isinstance(key, ast.Attribute) and key.attr in POINTER_COLUMNS:
+                    found.add(key.attr)
+                elif isinstance(key, ast.Constant) and key.value in POINTER_COLUMNS:
+                    found.add(str(key.value))
+        elif isinstance(node, ast.Call):
+            # .values(last_checkpoint_event_id=..., ...). ``else_=Task.<col>``
+            # inside a case() is a keyword named "else_", so it never matches.
+            for keyword in node.keywords:
+                if keyword.arg in POINTER_COLUMNS:
+                    found.add(str(keyword.arg))
+        elif isinstance(node, ast.Assign):
+            # values["last_checkpoint_event_id"] = ...
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.slice, ast.Constant)
+                    and target.slice.value in POINTER_COLUMNS
+                ):
+                    found.add(str(target.slice.value))
+    return found
+
+
+def unpaired_pointer_writes(source: str) -> list[tuple[int, tuple[str, ...]]]:
+    """Statement blocks that write one pointer column but not the other.
+
+    The pairing unit is the enclosing statement block, not the enclosing
+    function: acquire_task_lease_no_commit sets both columns in two separate
+    branches, so a function-level check would stay green if one branch lost a
+    column. ``ast.walk`` from a block's statements descends into nested
+    blocks, so an outer block's union is a superset of its children's -- which
+    is harmless, because every nested block is also checked on its own
+    iteration and no imbalance can hide inside one.
+    """
+    tree = ast.parse(source)
+    findings: list[tuple[int, tuple[str, ...]]] = []
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if not isinstance(block, list):
+                continue
+            columns: set[str] = set()
+            first_line: int | None = None
+            for statement in block:
+                if not isinstance(statement, ast.stmt):
+                    continue
+                mutated = _mutated_pointer_columns(statement)
+                if mutated and first_line is None:
+                    first_line = statement.lineno
+                columns |= mutated
+            if columns and columns != POINTER_COLUMNS:
+                findings.append((first_line or 0, tuple(sorted(columns))))
+    return sorted(set(findings))
+
+
+@pytest.mark.parametrize(
+    "module",
+    SUBJECT_MODULES,
+    ids=lambda module: module.__name__.rsplit(".", 1)[-1],
+)
+def test_pointer_columns_are_always_written_in_pairs(module) -> None:
+    source = Path(module.__file__).read_text()
+    unpaired = unpaired_pointer_writes(source)
+    assert unpaired == [], (
+        f"{module.__name__} writes one checkpoint pointer column without the "
+        f"other: {unpaired}"
+    )
+
+
+def test_pointer_pairing_ignores_single_column_reads() -> None:
+    """Negative control: reading one column is not a mutation."""
+    fixture = """
+def h(db):
+    return db.query(Task.last_checkpoint_event_id).filter(Task.id == 1).one_or_none()
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+def test_pointer_pairing_ignores_a_case_else_naming_one_column() -> None:
+    """The subtlest true negative: ``else_=Task.last_checkpoint_event_id`` is a
+    call keyword, but its ``arg`` is "else_", not a column name, so the
+    single-column case() builders must stay clean."""
+    fixture = """
+from sqlalchemy import case
+
+def lease_checkpoint_event_id_case():
+    return case((_predicate(), None), else_=Task.last_checkpoint_event_id)
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+@pytest.mark.parametrize(
+    "carrier,fixture",
+    [
+        (
+            "dict_literal",
+            """
+def purge(db, task_id):
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.last_checkpoint_event_id: None},
+        synchronize_session=False,
+    )
+""",
+        ),
+        (
+            "call_keyword",
+            """
+def write(db, task_id, event):
+    db.execute(
+        update(Task).where(Task.id == task_id).values(
+            last_checkpoint_event_id=str(event.id),
+        )
+    )
+""",
+        ),
+        (
+            "subscript_assign",
+            """
+def claim(values):
+    values["last_checkpoint_event_id"] = None
+    return values
+""",
+        ),
+    ],
+    ids=["dict_literal", "call_keyword", "subscript_assign"],
+)
+def test_pointer_pairing_flags_each_carrier_form(carrier: str, fixture: str) -> None:
+    """Positive controls, one per carrier form. Asserted on the flagged column
+    names rather than fixture line numbers, so the controls stay meaningful if
+    the fixture text is reformatted."""
+    unpaired = unpaired_pointer_writes(fixture)
+    assert unpaired, carrier
+    assert {columns for _, columns in unpaired} == {("last_checkpoint_event_id",)}

--- a/tests/web/services/test_checkpoint_pointer_pairing.py
+++ b/tests/web/services/test_checkpoint_pointer_pairing.py
@@ -5,12 +5,20 @@
 and dual-cleared across six mutation sites in five modules, and the recovery
 CAS fence conjoins both. A statement that sets one without the other makes
 that fence unmatchable, so recovery would stop working rather than fail
-loudly. Nothing but this check keeps the pair together once the call sites
-drift apart during the compatibility window.
+loudly. This check is the primary guard keeping the pair together once the
+call sites drift apart during the compatibility window.
 
 Reads are deliberately out of scope: several call sites legitimately name
 exactly one column when resolving or querying it. Only mutation carriers are
 matched -- dict-literal keys, call keywords, and subscript assignments.
+
+Known limit: pairing is judged per statement block, because the lease claim
+writes the pair through two sibling subscript assignments. The block union
+therefore accepts two sibling statements that each write one column against
+*different* targets -- a shape no current site uses. All six real sites
+write both columns through one carrier (or two sibling assignments into the
+same dict), so the blind spot has no live instance; it is recorded here so a
+future reviewer does not mistake the guard for a per-statement check.
 """
 
 from __future__ import annotations

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -21,13 +21,19 @@ history, which has no DB-level FK for the checkpoint pointer column at all
 from __future__ import annotations
 
 import os
-import re
 from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.orm import Query, Session, sessionmaker
 
+from tests.web.services.checkpoint_anchor_shared import (
+    CHECKPOINT_ANCHOR_FK_NAME as FK_NAME,
+)
+from tests.web.services.checkpoint_anchor_shared import (
+    build_upgraded_sqlite_engine,
+    reset_checkpoint_anchor_fk_create_rule,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.api.admin_users import _purge_user_task_rows
 from xagent.web.models.database import Base
@@ -35,35 +41,6 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
 from xagent.web.models.user import User
 from xagent.web.services.task_deletion import purge_task_rows
-
-FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
-
-
-def _reset_anchor_fk_create_rule() -> None:
-    """Work around a cross-dialect SQLAlchemy DDL-compiler quirk before
-    every Base.metadata.create_all() call in this module.
-
-    The anchor FK is use_alter=True (required for tasks/trace_events'
-    constraint cycle -- see the model). The first create_all() against a
-    dialect that supports ALTER (PostgreSQL) permanently caches a
-    "defer this to ALTER" decision on the constraint's shared, dialect-
-    agnostic _create_rule attribute. A later create_all() against SQLite
-    (which never attempts the ALTER, since that dialect doesn't support it
-    for constraints) then honors the same cached decision and silently
-    omits the constraint from CREATE TABLE entirely -- it is never created
-    inline or via ALTER. Only a live process that create_all()s against
-    both dialects hits this (this module's postgres_session fixture and
-    its SQLite fixtures do, in one pytest run); a real deployment binds one
-    dialect for its whole lifetime and never triggers it. Resetting the
-    rule before each create_all() call in this module makes every fixture's
-    result independent of what dialect (if any) create_all() targeted
-    earlier in the process.
-    """
-    for constraint in Base.metadata.tables["tasks"].constraints:
-        if getattr(constraint, "name", None) == FK_NAME:
-            constraint._create_rule = None
-            return
-    raise AssertionError(f"{FK_NAME} constraint not found on tasks")
 
 
 def _seed_task_with_anchored_checkpoint(session: Session, *, username: str) -> int:
@@ -110,39 +87,13 @@ def sqlite_fk_on_session(tmp_path):
         cursor.execute("PRAGMA foreign_keys=ON")
         cursor.close()
 
-    _reset_anchor_fk_create_rule()
+    reset_checkpoint_anchor_fk_create_rule()
     Base.metadata.create_all(bind=engine)
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()
     yield session
     session.close()
     engine.dispose()
-
-
-_ANCHOR_FK_CLAUSE = re.compile(
-    r",\s*CONSTRAINT " + re.escape(FK_NAME) + r" FOREIGN KEY\([^)]*\) REFERENCES [^,]*"
-)
-
-
-def _drop_anchor_fk_from_create_table_sql(create_table_sql: str) -> str:
-    """Strip the anchor column's named FK clause from a CREATE TABLE
-    statement, leaving the column itself and every other clause untouched.
-
-    Reflects the actual on-disk DDL as text rather than reusing any of
-    ``Task.__table__``'s Python objects: the model's ``last_checkpoint_
-    trace_event_id`` Column carries a ``use_alter=True`` ForeignKey shared
-    with that one Table/MetaData, and building a second Table from a copy
-    of that Column (tried first, and reverted) rebinds the shared
-    ForeignKeyConstraint's ``.table`` reference -- corrupting DDL generation
-    for the real model in every test that runs afterward in the same
-    process. Pure text surgery on a throwaway table's DDL has no such
-    shared state to corrupt.
-    """
-    stripped, count = _ANCHOR_FK_CLAUSE.subn("", create_table_sql)
-    assert count == 1, (
-        f"expected exactly one {FK_NAME} clause in the tasks DDL, found {count}"
-    )
-    return stripped
 
 
 @pytest.fixture
@@ -154,30 +105,12 @@ def sqlite_upgraded_session(tmp_path):
     ``tasks``/``trace_events`` are create_all-only in production (see
     fab71cf4b1ad_add_sdk_fields_to_tasks.py's guard) and never created by a
     migration, so running the real Alembic history against an empty
-    database leaves them absent rather than reproducing this state. Instead,
-    the full schema is created normally via create_all, and ``tasks`` is
-    then rebuilt (SQLite's standard rename/recreate/copy/drop procedure,
-    matching how a real deployment's DB tooling would strip a constraint)
-    from its own DDL with just the anchor column's FK clause removed --
-    exactly what the migration's ``add_column`` (without
-    ``create_foreign_key``, which is PostgreSQL-only) produces.
+    database leaves them absent rather than reproducing this state. The
+    actual rebuild trick lives in checkpoint_anchor_shared.py, shared with
+    test_task_lease_recovery.py's sqlite_no_anchor_fk_session, which needs
+    the identical shape.
     """
-    engine = create_engine(f"sqlite:///{tmp_path / 'upgraded.db'}")
-    _reset_anchor_fk_create_rule()
-    Base.metadata.create_all(bind=engine)
-
-    with engine.begin() as conn:
-        original_sql = conn.execute(
-            text(
-                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'"
-            )
-        ).scalar_one()
-        rebuilt_sql = _drop_anchor_fk_from_create_table_sql(original_sql)
-        conn.execute(text("ALTER TABLE tasks RENAME TO tasks_old"))
-        conn.execute(text(rebuilt_sql))
-        conn.execute(text("INSERT INTO tasks SELECT * FROM tasks_old"))
-        conn.execute(text("DROP TABLE tasks_old"))
-
+    engine = build_upgraded_sqlite_engine(tmp_path / "upgraded.db")
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()
     yield session
@@ -200,7 +133,7 @@ def postgres_session():
     with engine.begin() as conn:
         conn.execute(text("DROP SCHEMA public CASCADE"))
         conn.execute(text("CREATE SCHEMA public"))
-    _reset_anchor_fk_create_rule()
+    reset_checkpoint_anchor_fk_create_rule()
     Base.metadata.create_all(bind=engine)
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -21,6 +21,7 @@ history, which has no DB-level FK for the checkpoint pointer column at all
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 import pytest
@@ -68,6 +69,51 @@ def _seed_task_with_anchored_checkpoint(session: Session, *, username: str) -> i
     task.last_checkpoint_trace_event_id = event_row.id
     session.commit()
     return int(task.id)
+
+
+@contextmanager
+def _recorded_statements(engine):
+    """Record every statement this engine executes, in order.
+
+    The alembic-upgraded form has no DB-level FK for the pointer column, so
+    a reversed NULL-first cannot fail loudly here. Asserting the final
+    persisted pointer is NULL catches *removing* the NULL-first step but not
+    *moving* it after the trace_events delete, because the update still runs
+    before the assertion either way. Statement order is the only direct
+    evidence of the ordering itself.
+    """
+    seen: list[str] = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+        seen.append(" ".join(statement.split()))
+
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        yield seen
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
+
+
+def _index_of(seen, predicate, what):  # type: ignore[no-untyped-def]
+    for index, statement in enumerate(seen):
+        if predicate(statement):
+            return index
+    raise AssertionError(f"{what} never executed; recorded: {seen}")
+
+
+def _assert_pointer_nulled_before_trace_events_deleted(seen) -> None:  # type: ignore[no-untyped-def]
+    null_first = _index_of(
+        seen,
+        lambda s: s.startswith("UPDATE tasks")
+        and "last_checkpoint_trace_event_id" in s,
+        "pointer NULL update",
+    )
+    trace_delete = _index_of(
+        seen,
+        lambda s: s.startswith("DELETE FROM trace_events"),
+        "trace_events delete",
+    )
+    assert null_first < trace_delete, seen
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +270,9 @@ def test_purge_task_rows_nulls_pointer_before_the_task_delete_flushes(
     session = sqlite_upgraded_session
     task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
 
-    assert purge_task_rows(session, task_id=task_id) is True
+    with _recorded_statements(session.get_bind()) as seen:
+        assert purge_task_rows(session, task_id=task_id) is True
+    _assert_pointer_nulled_before_trace_events_deleted(seen)
 
     pointer = session.execute(
         text("SELECT last_checkpoint_trace_event_id FROM tasks WHERE id = :id"),
@@ -302,7 +350,9 @@ def test_purge_user_task_rows_nulls_pointer_before_trace_events_are_gone(
 
     monkeypatch.setattr(Query, "delete", guarded_delete)
 
-    _purge_user_task_rows(session, user_id=user_id)
+    with _recorded_statements(session.get_bind()) as seen:
+        _purge_user_task_rows(session, user_id=user_id)
+    _assert_pointer_nulled_before_trace_events_deleted(seen)
 
     pointer = session.execute(
         text("SELECT last_checkpoint_trace_event_id FROM tasks WHERE id = :id"),

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -1,0 +1,384 @@
+"""Deletion-path tests for the exact-row checkpoint pointer's NULL-first
+ordering.
+
+Each fixture below builds its own dedicated engine rather than reusing the
+shared ``tests/web/api/conftest.py`` engine. That shared engine already runs
+with SQLite FK enforcement on (``init_db`` -> ``configure_db`` ->
+``apply_sqlite_concurrency_pragmas``), so a mistake in a fixture that
+touches it would widen blast radius across every one of the ~100 web-API
+test files that share it; a dedicated engine keeps this module's fixtures
+self-contained instead.
+
+Three schema forms are covered, matching the dialect asymmetry the
+migration documents: a freshly ``create_all``'d SQLite database (full
+metadata, including the checkpoint pointer's FK) with FK enforcement turned
+on for this engine's connections; a live PostgreSQL database (always FK
+enforcing); and a SQLite database built through the Alembic migration
+history, which has no DB-level FK for the checkpoint pointer column at all
+(Alembic's SQLite batch mode cannot add one without a full table rebuild).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, event, inspect, text
+from sqlalchemy.orm import Query, Session, sessionmaker
+
+from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
+from xagent.web.api.admin_users import _purge_user_task_rows
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.user import User
+from xagent.web.services.task_deletion import purge_task_rows
+
+FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
+
+
+def _reset_anchor_fk_create_rule() -> None:
+    """Work around a cross-dialect SQLAlchemy DDL-compiler quirk before
+    every Base.metadata.create_all() call in this module.
+
+    The anchor FK is use_alter=True (required for tasks/trace_events'
+    constraint cycle -- see the model). The first create_all() against a
+    dialect that supports ALTER (PostgreSQL) permanently caches a
+    "defer this to ALTER" decision on the constraint's shared, dialect-
+    agnostic _create_rule attribute. A later create_all() against SQLite
+    (which never attempts the ALTER, since that dialect doesn't support it
+    for constraints) then honors the same cached decision and silently
+    omits the constraint from CREATE TABLE entirely -- it is never created
+    inline or via ALTER. Only a live process that create_all()s against
+    both dialects hits this (this module's postgres_session fixture and
+    its SQLite fixtures do, in one pytest run); a real deployment binds one
+    dialect for its whole lifetime and never triggers it. Resetting the
+    rule before each create_all() call in this module makes every fixture's
+    result independent of what dialect (if any) create_all() targeted
+    earlier in the process.
+    """
+    for constraint in Base.metadata.tables["tasks"].constraints:
+        if getattr(constraint, "name", None) == FK_NAME:
+            constraint._create_rule = None
+            return
+    raise AssertionError(f"{FK_NAME} constraint not found on tasks")
+
+
+def _seed_task_with_anchored_checkpoint(session: Session, *, username: str) -> int:
+    """A task whose checkpoint pointer resolves to a real trace_events row."""
+    user = User(username=username, password_hash="hash", is_admin=False)
+    session.add(user)
+    session.flush()
+    task = Task(
+        user_id=int(user.id),
+        title="task",
+        status=TaskStatus.PENDING,
+    )
+    session.add(task)
+    session.flush()
+    event_row = DatabaseTraceEvent(
+        task_id=int(task.id),
+        event_id="evt-1",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        data={"checkpoint_type": CHECKPOINT_TYPE, "snapshot": {"label": "x"}},
+    )
+    session.add(event_row)
+    session.flush()
+    task.last_checkpoint_event_id = event_row.event_id
+    task.last_checkpoint_trace_event_id = event_row.id
+    session.commit()
+    return int(task.id)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: three dedicated schema forms.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_fk_on_session(tmp_path):
+    """Freshly create_all'd SQLite database, FK enforcement on for this
+    engine's connections only (not the shared conftest engine)."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'fk_on.db'}")
+
+    @event.listens_for(engine, "connect")
+    def _set_fk(dbapi_connection, _record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    _reset_anchor_fk_create_rule()
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+_ANCHOR_FK_CLAUSE = re.compile(
+    r",\s*CONSTRAINT " + re.escape(FK_NAME) + r" FOREIGN KEY\([^)]*\) REFERENCES [^,]*"
+)
+
+
+def _drop_anchor_fk_from_create_table_sql(create_table_sql: str) -> str:
+    """Strip the anchor column's named FK clause from a CREATE TABLE
+    statement, leaving the column itself and every other clause untouched.
+
+    Reflects the actual on-disk DDL as text rather than reusing any of
+    ``Task.__table__``'s Python objects: the model's ``last_checkpoint_
+    trace_event_id`` Column carries a ``use_alter=True`` ForeignKey shared
+    with that one Table/MetaData, and building a second Table from a copy
+    of that Column (tried first, and reverted) rebinds the shared
+    ForeignKeyConstraint's ``.table`` reference -- corrupting DDL generation
+    for the real model in every test that runs afterward in the same
+    process. Pure text surgery on a throwaway table's DDL has no such
+    shared state to corrupt.
+    """
+    stripped, count = _ANCHOR_FK_CLAUSE.subn("", create_table_sql)
+    assert count == 1, (
+        f"expected exactly one {FK_NAME} clause in the tasks DDL, found {count}"
+    )
+    return stripped
+
+
+@pytest.fixture
+def sqlite_upgraded_session(tmp_path):
+    """A SQLite database shaped like the migration's ADD COLUMN path for a
+    table that already existed -- the D1 asymmetry: no DB-level FK for the
+    checkpoint pointer column on this form.
+
+    ``tasks``/``trace_events`` are create_all-only in production (see
+    fab71cf4b1ad_add_sdk_fields_to_tasks.py's guard) and never created by a
+    migration, so running the real Alembic history against an empty
+    database leaves them absent rather than reproducing this state. Instead,
+    the full schema is created normally via create_all, and ``tasks`` is
+    then rebuilt (SQLite's standard rename/recreate/copy/drop procedure,
+    matching how a real deployment's DB tooling would strip a constraint)
+    from its own DDL with just the anchor column's FK clause removed --
+    exactly what the migration's ``add_column`` (without
+    ``create_foreign_key``, which is PostgreSQL-only) produces.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'upgraded.db'}")
+    _reset_anchor_fk_create_rule()
+    Base.metadata.create_all(bind=engine)
+
+    with engine.begin() as conn:
+        original_sql = conn.execute(
+            text(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'"
+            )
+        ).scalar_one()
+        rebuilt_sql = _drop_anchor_fk_from_create_table_sql(original_sql)
+        conn.execute(text("ALTER TABLE tasks RENAME TO tasks_old"))
+        conn.execute(text(rebuilt_sql))
+        conn.execute(text("INSERT INTO tasks SELECT * FROM tasks_old"))
+        conn.execute(text("DROP TABLE tasks_old"))
+
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture
+def postgres_session():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    _reset_anchor_fk_create_rule()
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# D1 asymmetry as a tested fact, not just a comment.
+# ---------------------------------------------------------------------------
+
+
+def test_upgraded_sqlite_has_no_db_level_anchor_fk(sqlite_upgraded_session) -> None:
+    fk_names = {
+        fk["name"]
+        for fk in inspect(sqlite_upgraded_session.get_bind()).get_foreign_keys("tasks")
+    }
+    assert FK_NAME not in fk_names
+
+
+def test_fresh_sqlite_has_the_db_level_anchor_fk(sqlite_fk_on_session) -> None:
+    fk_names = {
+        fk["name"]
+        for fk in inspect(sqlite_fk_on_session.get_bind()).get_foreign_keys("tasks")
+    }
+    assert FK_NAME in fk_names
+
+
+# ---------------------------------------------------------------------------
+# purge_task_rows (single task).
+# ---------------------------------------------------------------------------
+
+
+def test_purge_task_rows_clears_the_anchor_under_fk_enforcement(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert (
+        session.query(DatabaseTraceEvent)
+        .filter(DatabaseTraceEvent.task_id == task_id)
+        .count()
+        == 0
+    )
+
+
+@pytest.mark.postgresql
+def test_purge_task_rows_clears_the_anchor_on_postgres(postgres_session) -> None:
+    session = postgres_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert (
+        session.query(DatabaseTraceEvent)
+        .filter(DatabaseTraceEvent.task_id == task_id)
+        .count()
+        == 0
+    )
+
+
+def test_purge_task_rows_nulls_pointer_before_the_task_delete_flushes(
+    sqlite_upgraded_session,
+) -> None:
+    """The alembic-upgraded SQLite form has no DB-level FK to make a missing
+    NULL-first fail loudly (see test_upgraded_sqlite_has_no_db_level_anchor_fk
+    above), so this checks the fact directly instead of relying on an error.
+
+    purge_task_rows's own trace_events delete and pointer-NULL update are
+    both bulk statements that execute immediately, but its ``db.delete(task)``
+    is a per-instance ORM delete that only flushes on the caller's next
+    flush/commit -- and this session has autoflush disabled. So immediately
+    after purge_task_rows() returns and before this test's own commit, the
+    task row's pointer, as currently persisted, reveals whether NULL-first
+    ran before the (already-executed) trace_events delete.
+    """
+    session = sqlite_upgraded_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+
+    assert purge_task_rows(session, task_id=task_id) is True
+
+    pointer = session.execute(
+        text("SELECT last_checkpoint_trace_event_id FROM tasks WHERE id = :id"),
+        {"id": task_id},
+    ).scalar_one()
+    assert pointer is None
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# _purge_user_task_rows (bulk, admin path).
+# ---------------------------------------------------------------------------
+
+
+def test_purge_user_task_rows_clears_the_anchor_under_fk_enforcement(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert (
+        session.query(DatabaseTraceEvent)
+        .filter(DatabaseTraceEvent.task_id == task_id)
+        .count()
+        == 0
+    )
+
+
+@pytest.mark.postgresql
+def test_purge_user_task_rows_clears_the_anchor_on_postgres(postgres_session) -> None:
+    session = postgres_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert (
+        session.query(DatabaseTraceEvent)
+        .filter(DatabaseTraceEvent.task_id == task_id)
+        .count()
+        == 0
+    )
+
+
+def test_purge_user_task_rows_nulls_pointer_before_trace_events_are_gone(
+    sqlite_upgraded_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same intent as the single-task test above, adapted for the bulk path:
+    every step in _purge_user_task_rows (the pointer NULL-first, the
+    trace_events delete, and the tasks delete) is an immediate bulk
+    statement, so there is no ORM-deferred step to inspect afterward. This
+    intercepts only the final tasks bulk delete -- turning it into a no-op
+    -- so the intermediate state (trace_events already gone, tasks not yet
+    deleted) is directly observable: pointer must already be NULL.
+    """
+    session = sqlite_upgraded_session
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u1")
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    original_delete = Query.delete
+
+    def guarded_delete(self: Query, *args: object, **kwargs: object) -> int:
+        descriptions = self.column_descriptions
+        if descriptions and descriptions[0]["type"] is Task:
+            return 0  # stand-in for the final tasks bulk delete
+        return original_delete(self, *args, **kwargs)
+
+    monkeypatch.setattr(Query, "delete", guarded_delete)
+
+    _purge_user_task_rows(session, user_id=user_id)
+
+    pointer = session.execute(
+        text("SELECT last_checkpoint_trace_event_id FROM tasks WHERE id = :id"),
+        {"id": task_id},
+    ).scalar_one()
+    assert pointer is None
+    remaining_events = session.execute(
+        text("SELECT COUNT(*) FROM trace_events WHERE task_id = :id"),
+        {"id": task_id},
+    ).scalar_one()
+    assert remaining_events == 0
+    session.rollback()

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -635,6 +635,83 @@ def test_ambiguous_legacy_checkpoint_skips_the_candidate_for_the_next_sweep(
     assert any(c.task_id == int(task.id) for c in rescanned)
 
 
+def test_ambiguous_legacy_checkpoint_registers_a_degradation_signal(
+    db_session,
+) -> None:
+    """#1071 requires zero-or-multiple matches to fail closed *and* emit
+    telemetry. The verdict is only half of that: an ambiguity nothing can
+    resolve has to be visible to monitoring, not just to the log."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LEGACY_POINTER_AMBIGUOUS,
+        active_degradations,
+        clear_degradation,
+    )
+
+    user = _create_user(db_session, suffix="ambiguous-signal")
+    task = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix="ambiguous-signal",
+        with_checkpoint=True,
+    )
+    db_session.add(
+        TraceEvent(
+            task_id=task.id,
+            event_id=task.last_checkpoint_event_id,
+            event_type="system_update_general",
+            timestamp=utc_now(),
+            data={
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {"type": "checkpoint"},
+                TASK_RUN_ID_TRACE_FIELD: task.run_id,
+            },
+        )
+    )
+    db_session.commit()
+
+    clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
+    try:
+        candidate = _candidate_for_task(task)
+        assert (
+            resolve_checkpoint_recovery(db_session, candidate)
+            is CheckpointRecoveryVerdict.INDETERMINATE
+        )
+        assert CHECKPOINT_LEGACY_POINTER_AMBIGUOUS in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
+
+
+@pytest.mark.asyncio
+async def test_a_clean_recovery_sweep_clears_the_ambiguity_signal(
+    db_session,
+) -> None:
+    """One completed drain is the reporting unit: a sweep that finds no
+    ambiguity clears a signal an earlier sweep left set, so the signal
+    cannot latch on a resolved condition."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LEGACY_POINTER_AMBIGUOUS,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    user = _create_user(db_session, suffix="clean-sweep")
+    _create_expired_task(db_session, user_id=int(user.id), suffix="clean-sweep")
+    db_session.commit()
+
+    register_degradation(
+        CHECKPOINT_LEGACY_POINTER_AMBIGUOUS, "left over from an earlier sweep"
+    )
+    try:
+        await recover_expired_task_leases_until_cutoff(
+            cutoff=utc_now(),
+            batch_size=10,
+        )
+        assert CHECKPOINT_LEGACY_POINTER_AMBIGUOUS not in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
+
+
 @pytest.mark.parametrize(
     "replacement",
     ["heartbeat", "runner", "run", "state_version", "checkpoint", "checkpoint_pk"],

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -712,6 +712,83 @@ async def test_a_clean_recovery_sweep_clears_the_ambiguity_signal(
         clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
 
 
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.asyncio
+async def test_ambiguity_signal_survives_a_later_clean_candidate_in_the_same_sweep(
+    db_session,
+    batch_size: int,
+) -> None:
+    """A drain that hits an ambiguity and then a resolvable candidate still
+    reports the ambiguity once it finishes.
+
+    The clear belongs to the whole drain, not to a candidate or a page. At
+    either finer grain the clean candidate processed after the ambiguous one
+    would erase the signal before the sweep ends, and an ambiguity every
+    sweep re-hits could never stay visible. The two batch sizes separate
+    those grains: 10 puts both candidates in one page, 1 puts the clean one
+    in the page after the ambiguous one.
+    """
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LEGACY_POINTER_AMBIGUOUS,
+        active_degradations,
+        clear_degradation,
+    )
+
+    user = _create_user(db_session, suffix=f"ambiguous-then-clean-{batch_size}")
+    ambiguous = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix=f"ambiguous-then-clean-first-{batch_size}",
+        with_checkpoint=True,
+    )
+    db_session.add(
+        TraceEvent(
+            task_id=ambiguous.id,
+            event_id=ambiguous.last_checkpoint_event_id,
+            event_type="system_update_general",
+            timestamp=utc_now(),
+            data={
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {"type": "checkpoint"},
+                TASK_RUN_ID_TRACE_FIELD: ambiguous.run_id,
+            },
+        )
+    )
+    clean = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix=f"ambiguous-then-clean-second-{batch_size}",
+        with_checkpoint=True,
+    )
+    db_session.commit()
+
+    cutoff = utc_now()
+    # Pin the order the drain will see them in: this test is only meaningful
+    # for a clean candidate that comes *after* an ambiguous one.
+    scan_order = [
+        candidate.task_id
+        for candidate in get_expired_task_lease_candidates(
+            db_session, cutoff=cutoff, limit=10
+        )
+    ]
+    assert scan_order == [int(ambiguous.id), int(clean.id)]
+
+    clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
+    try:
+        await recover_expired_task_leases_until_cutoff(
+            cutoff=cutoff, batch_size=batch_size
+        )
+
+        assert CHECKPOINT_LEGACY_POINTER_AMBIGUOUS in active_degradations()
+        db_session.expire_all()
+        # The clean candidate really was processed after the ambiguous one,
+        # so the surviving signal is not merely an untouched sweep.
+        assert db_session.get(Task, int(clean.id)).status is TaskStatus.PAUSED
+        assert db_session.get(Task, int(ambiguous.id)).status is TaskStatus.RUNNING
+    finally:
+        clear_degradation(CHECKPOINT_LEGACY_POINTER_AMBIGUOUS)
+
+
 @pytest.mark.parametrize(
     "replacement",
     ["heartbeat", "runner", "run", "state_version", "checkpoint", "checkpoint_pk"],

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from threading import Barrier
 
 import pytest
-from sqlalchemy import create_engine, text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Query, Session, sessionmaker
 
+from tests.web.services.checkpoint_anchor_shared import build_upgraded_sqlite_engine
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.models.agent import Agent
 from xagent.web.models.database import (
@@ -49,8 +48,6 @@ from xagent.web.services.task_lease_service import (
     resolve_checkpoint_recovery,
     utc_now,
 )
-
-ANCHOR_FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
 
 
 @pytest.fixture()
@@ -174,42 +171,12 @@ def sqlite_no_anchor_fk_session(tmp_path):
     table rebuild, so this asymmetric shape -- not the fresh create_all
     schema every other fixture in this module uses -- is the only one on
     which ``last_checkpoint_trace_event_id`` can point at a row that no
-    longer exists. Mirrors
+    longer exists. The rebuild trick lives in checkpoint_anchor_shared.py,
+    shared with
     tests/web/services/test_task_deletion_checkpoint_pointer.py's
-    sqlite_upgraded_session for the same reason, kept as a separate
-    module-local copy rather than a shared import so this module's
-    fixtures stay self-contained.
+    sqlite_upgraded_session, which needs the identical shape.
     """
-    engine = create_engine(f"sqlite:///{tmp_path / 'lease-recovery-no-fk.db'}")
-    for constraint in Base.metadata.tables["tasks"].constraints:
-        if getattr(constraint, "name", None) == ANCHOR_FK_NAME:
-            constraint._create_rule = None
-            break
-    else:
-        raise AssertionError(f"{ANCHOR_FK_NAME} constraint not found on tasks")
-    Base.metadata.create_all(bind=engine)
-
-    with engine.begin() as conn:
-        original_sql = conn.execute(
-            text(
-                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'"
-            )
-        ).scalar_one()
-        stripped_sql, count = re.subn(
-            r",\s*CONSTRAINT "
-            + re.escape(ANCHOR_FK_NAME)
-            + r" FOREIGN KEY\([^)]*\) REFERENCES [^,]*",
-            "",
-            original_sql,
-        )
-        assert count == 1, (
-            f"expected exactly one {ANCHOR_FK_NAME} clause in the tasks DDL"
-        )
-        conn.execute(text("ALTER TABLE tasks RENAME TO tasks_old"))
-        conn.execute(text(stripped_sql))
-        conn.execute(text("INSERT INTO tasks SELECT * FROM tasks_old"))
-        conn.execute(text("DROP TABLE tasks_old"))
-
+    engine = build_upgraded_sqlite_engine(tmp_path / "lease-recovery-no-fk.db")
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()
     yield session

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -12,11 +12,11 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Query, Session, sessionmaker
 
+from tests.shared.db_teardown import drop_all_tables
 from tests.web.services.checkpoint_anchor_shared import build_upgraded_sqlite_engine
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.models.agent import Agent
 from xagent.web.models.database import (
-    Base,
     get_db,
     get_engine,
     get_session_local,
@@ -58,20 +58,7 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        # FK enforcement is on for this engine's connections (see
-        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
-        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
-        # that leaves a real cross-reference between the two tables (a
-        # populated last_checkpoint_trace_event_id) makes drop_all's table
-        # order irrelevant -- no order satisfies both directions of a
-        # populated cycle under enforcement. Dropping the tables is the
-        # only goal here, not preserving referential integrity of data
-        # about to be discarded, so enforcement is turned off for this one
-        # connection rather than for the fixture's tests.
-        engine = get_engine()
-        with engine.begin() as conn:
-            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
-            Base.metadata.drop_all(bind=conn)
+        drop_all_tables(get_engine())
 
 
 def _create_user(db, *, suffix: str) -> User:

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -481,6 +481,94 @@ def test_pk_anchor_validation_failure_does_not_fall_back_to_the_legacy_scan(
     assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
 
 
+_RECOVERY_SINGLE_FAULT_FIELDS = [
+    "task_id",
+    "event_type",
+    "build_id",
+    "checkpoint_type",
+    "run_id",
+]
+
+
+def _mutate_recovery_row_field(
+    field: str,
+    row_kwargs: dict,
+    data: dict,
+    other_task_id: int,
+) -> None:
+    """Corrupt exactly one field _checkpoint_row_matches_candidate checks
+    on the PK-anchored recovery path, leaving every other field --
+    including the run field -- valid."""
+    if field == "task_id":
+        row_kwargs["task_id"] = other_task_id
+    elif field == "event_type":
+        row_kwargs["event_type"] = "agent_progress"
+    elif field == "build_id":
+        row_kwargs["build_id"] = "agent_child"
+    elif field == "checkpoint_type":
+        data["checkpoint_type"] = "not_a_readable_checkpoint_type"
+    elif field == "run_id":
+        data[TASK_RUN_ID_TRACE_FIELD] = "some-other-run"
+    else:
+        raise AssertionError(f"unknown single-fault field {field}")
+
+
+@pytest.mark.parametrize("field", _RECOVERY_SINGLE_FAULT_FIELDS)
+def test_pk_anchor_single_fault_is_not_recoverable(db_session, field: str) -> None:
+    """Each conjunct _checkpoint_row_matches_candidate checks must
+    independently be load-bearing on the PK-anchored recovery path: a row
+    wrong in exactly one field (every other field, including the run
+    field, valid) must still resolve NOT_RECOVERABLE (the candidate fails
+    the lease). test_pk_anchor_validation_failure_does_not_fall_back_to_
+    the_legacy_scan above only proves build_id does real work; task_id and
+    event_type have no such proof, because the legacy scan's own query
+    already filters both -- they are redundant there and only load-bearing
+    on this PK path, which loads a row by raw primary key with no such
+    filter. This test kills each conjunct independently.
+    """
+    user = _create_user(db_session, suffix=f"pk-single-fault-{field}")
+    task = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix=f"pk-single-fault-{field}",
+    )
+    other_task = Task(
+        user_id=int(user.id),
+        title="Other task",
+        description="lease recovery test",
+        status=TaskStatus.PENDING,
+    )
+    db_session.add(other_task)
+    db_session.flush()
+    other_task_id = int(other_task.id)
+
+    row_kwargs: dict = dict(
+        task_id=task.id,
+        event_id=f"pk-single-fault-{field}",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+    )
+    data: dict = {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "snapshot": {"type": "checkpoint"},
+        TASK_RUN_ID_TRACE_FIELD: task.run_id,
+    }
+    _mutate_recovery_row_field(field, row_kwargs, data, other_task_id)
+
+    row = TraceEvent(data=data, **row_kwargs)
+    db_session.add(row)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = row.id
+    db_session.commit()
+
+    candidate = _candidate_for_task(task)
+    assert (
+        resolve_checkpoint_recovery(db_session, candidate)
+        is CheckpointRecoveryVerdict.NOT_RECOVERABLE
+    )
+    assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
+
+
 def test_dangling_pk_pointer_falls_back_to_the_legacy_scan(
     sqlite_no_anchor_fk_session,
 ) -> None:

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from threading import Barrier
 
 import pytest
+from sqlalchemy import create_engine, text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Query, Session, sessionmaker
@@ -41,9 +43,14 @@ from xagent.web.services.task_lease_recovery import (
 )
 from xagent.web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
+    CheckpointRecoveryVerdict,
+    TaskLeaseRecoveryCandidate,
     get_expired_task_lease_candidates,
+    resolve_checkpoint_recovery,
     utc_now,
 )
+
+ANCHOR_FK_NAME = "fk_tasks_last_checkpoint_trace_event_id"
 
 
 @pytest.fixture()
@@ -54,7 +61,20 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        Base.metadata.drop_all(bind=get_engine())
+        # FK enforcement is on for this engine's connections (see
+        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
+        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
+        # that leaves a real cross-reference between the two tables (a
+        # populated last_checkpoint_trace_event_id) makes drop_all's table
+        # order irrelevant -- no order satisfies both directions of a
+        # populated cycle under enforcement. Dropping the tables is the
+        # only goal here, not preserving referential integrity of data
+        # about to be discarded, so enforcement is turned off for this one
+        # connection rather than for the fixture's tests.
+        engine = get_engine()
+        with engine.begin() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+            Base.metadata.drop_all(bind=conn)
 
 
 def _create_user(db, *, suffix: str) -> User:
@@ -126,6 +146,75 @@ def _recover_expired_task(db, task: Task) -> TaskStatus | None:
         candidate,
         recovered_at=utc_now(),
     )
+
+
+def _candidate_for_task(task: Task) -> TaskLeaseRecoveryCandidate:
+    """Build the recovery candidate snapshot resolve_checkpoint_recovery
+    consumes, directly from a task's current column values -- for tests
+    that exercise checkpoint pointer resolution without going through the
+    full expired-lease scan query.
+    """
+    return TaskLeaseRecoveryCandidate(
+        task_id=int(task.id),
+        runner_id=task.runner_id,
+        run_id=task.run_id,
+        lease_expires_at=task.lease_expires_at,
+        state_version=int(task.state_version or 0),
+        last_checkpoint_event_id=task.last_checkpoint_event_id,
+        last_checkpoint_trace_event_id=task.last_checkpoint_trace_event_id,
+    )
+
+
+@pytest.fixture()
+def sqlite_no_anchor_fk_session(tmp_path):
+    """A SQLite database shaped like the checkpoint-anchor migration's ADD
+    COLUMN path applied to a table that already existed: full schema via
+    create_all, then ``tasks`` rebuilt without the checkpoint pointer's FK
+    clause. Alembic's SQLite batch mode cannot add that FK without a full
+    table rebuild, so this asymmetric shape -- not the fresh create_all
+    schema every other fixture in this module uses -- is the only one on
+    which ``last_checkpoint_trace_event_id`` can point at a row that no
+    longer exists. Mirrors
+    tests/web/services/test_task_deletion_checkpoint_pointer.py's
+    sqlite_upgraded_session for the same reason, kept as a separate
+    module-local copy rather than a shared import so this module's
+    fixtures stay self-contained.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'lease-recovery-no-fk.db'}")
+    for constraint in Base.metadata.tables["tasks"].constraints:
+        if getattr(constraint, "name", None) == ANCHOR_FK_NAME:
+            constraint._create_rule = None
+            break
+    else:
+        raise AssertionError(f"{ANCHOR_FK_NAME} constraint not found on tasks")
+    Base.metadata.create_all(bind=engine)
+
+    with engine.begin() as conn:
+        original_sql = conn.execute(
+            text(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'"
+            )
+        ).scalar_one()
+        stripped_sql, count = re.subn(
+            r",\s*CONSTRAINT "
+            + re.escape(ANCHOR_FK_NAME)
+            + r" FOREIGN KEY\([^)]*\) REFERENCES [^,]*",
+            "",
+            original_sql,
+        )
+        assert count == 1, (
+            f"expected exactly one {ANCHOR_FK_NAME} clause in the tasks DDL"
+        )
+        conn.execute(text("ALTER TABLE tasks RENAME TO tasks_old"))
+        conn.execute(text(stripped_sql))
+        conn.execute(text("INSERT INTO tasks SELECT * FROM tasks_old"))
+        conn.execute(text("DROP TABLE tasks_old"))
+
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    engine.dispose()
 
 
 def _attach_workforce_and_trigger(db, *, task: Task, user: User) -> tuple:
@@ -264,6 +353,10 @@ def test_recovery_rejects_checkpoint_without_current_run_provenance(
     else:
         data[TASK_RUN_ID_TRACE_FIELD] = checkpoint_run_id
     checkpoint.data = data
+    # Also anchor the PK pointer at the same row: the PK-first resolution
+    # path must reach the identical FAILED verdict the legacy scan does,
+    # not just the legacy path exercised when this column is unset.
+    task.last_checkpoint_trace_event_id = checkpoint.id
     db_session.commit()
 
     assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
@@ -301,9 +394,208 @@ def test_exact_checkpoint_pointer_is_not_limited_to_latest_one_hundred_events(
     assert _recover_expired_task(db_session, task) == TaskStatus.PAUSED
 
 
+def test_pk_anchor_resolves_without_a_usable_legacy_pointer(db_session) -> None:
+    """The exact-row pointer is resolved before the legacy scan runs at
+    all -- proven here by leaving the legacy event_id column unset, a
+    state a legacy-only scan could never resolve to anything.
+    """
+    user = _create_user(db_session, suffix="pk-priority")
+    task = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix="pk-priority",
+    )
+    checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="pk-priority-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: task.run_id,
+        },
+    )
+    db_session.add(checkpoint)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = checkpoint.id
+    assert task.last_checkpoint_event_id is None
+    db_session.commit()
+
+    candidate = _candidate_for_task(task)
+    assert (
+        resolve_checkpoint_recovery(db_session, candidate)
+        is CheckpointRecoveryVerdict.RECOVERABLE
+    )
+    assert _recover_expired_task(db_session, task) == TaskStatus.PAUSED
+
+
+def test_pk_anchor_validation_failure_does_not_fall_back_to_the_legacy_scan(
+    db_session,
+) -> None:
+    """A pointer that resolves to a row failing validation is corruption of
+    that exact row, not a cue to go search other rows -- even when the
+    legacy event_id column names a different, genuinely valid checkpoint
+    that a legacy-only scan would have accepted.
+    """
+    user = _create_user(db_session, suffix="pk-no-fallback")
+    task = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix="pk-no-fallback",
+    )
+    invalid_anchor = TraceEvent(
+        task_id=task.id,
+        build_id="agent_child",  # fails the build_id IS NULL check
+        event_id="pk-no-fallback-invalid",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: task.run_id,
+        },
+    )
+    valid_legacy_row = TraceEvent(
+        task_id=task.id,
+        event_id="pk-no-fallback-valid",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: task.run_id,
+        },
+    )
+    db_session.add_all([invalid_anchor, valid_legacy_row])
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = invalid_anchor.id
+    task.last_checkpoint_event_id = valid_legacy_row.event_id
+    db_session.commit()
+
+    candidate = _candidate_for_task(task)
+    assert (
+        resolve_checkpoint_recovery(db_session, candidate)
+        is CheckpointRecoveryVerdict.NOT_RECOVERABLE
+    )
+    assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
+
+
+def test_dangling_pk_pointer_falls_back_to_the_legacy_scan(
+    sqlite_no_anchor_fk_session,
+) -> None:
+    """A pointer whose row is gone is only reachable on a database upgraded
+    without this column's FK (the D1 asymmetry -- see the migration and
+    test_task_deletion_checkpoint_pointer.py). It is a compatibility-window
+    state, not corruption: recovery must fall back to the legacy scan
+    instead of failing the candidate outright.
+    """
+    session = sqlite_no_anchor_fk_session
+    user = User(
+        username="lease-recovery-dangling",
+        password_hash="hash",
+        is_admin=False,
+    )
+    session.add(user)
+    session.flush()
+    task = Task(
+        user_id=int(user.id),
+        title="dangling pointer",
+        description="lease recovery test",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+        runner_id="dead-runner-dangling",
+        run_id="run-dangling",
+        lease_expires_at=utc_now() - timedelta(seconds=5),
+        last_heartbeat_at=utc_now() - timedelta(seconds=10),
+        state_version=3,
+        control_state="running",
+    )
+    session.add(task)
+    session.flush()
+    legacy_checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="dangling-legacy-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: "run-dangling",
+        },
+    )
+    session.add(legacy_checkpoint)
+    session.flush()
+    task.last_checkpoint_event_id = legacy_checkpoint.event_id
+    # No DB-level FK on this schema form -- this id names no row.
+    task.last_checkpoint_trace_event_id = legacy_checkpoint.id + 999
+    session.commit()
+
+    candidate = _candidate_for_task(task)
+    assert (
+        resolve_checkpoint_recovery(session, candidate)
+        is CheckpointRecoveryVerdict.RECOVERABLE
+    )
+
+
+def test_ambiguous_legacy_checkpoint_skips_the_candidate_for_the_next_sweep(
+    db_session,
+) -> None:
+    """Two trace_events rows share the same legacy event_id within one
+    task's root partition -- the row's identity itself cannot be
+    determined from that string alone. This is not folded into FAILED:
+    the candidate is left untouched (lease and status unchanged, no
+    recovery statement executes) so a later sweep gets another chance to
+    resolve it, instead of permanently failing a task whose checkpoint may
+    in fact be readable once the ambiguity is gone.
+    """
+    user = _create_user(db_session, suffix="ambiguous")
+    task = _create_expired_task(
+        db_session,
+        user_id=int(user.id),
+        suffix="ambiguous",
+        with_checkpoint=True,
+    )
+    duplicate_checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id=task.last_checkpoint_event_id,
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: task.run_id,
+        },
+    )
+    db_session.add(duplicate_checkpoint)
+    db_session.commit()
+
+    candidate = _candidate_for_task(task)
+    assert (
+        resolve_checkpoint_recovery(db_session, candidate)
+        is CheckpointRecoveryVerdict.INDETERMINATE
+    )
+    assert _recover_expired_task(db_session, task) is None
+
+    db_session.expire_all()
+    persisted = db_session.get(Task, int(task.id))
+    assert persisted.status == TaskStatus.RUNNING
+    assert persisted.runner_id is not None
+    assert persisted.lease_expires_at is not None
+
+    # Nothing about the skip removed the candidate from the expired-lease
+    # scan -- a later sweep still selects it.
+    rescanned = get_expired_task_lease_candidates(
+        db_session,
+        cutoff=utc_now(),
+        limit=10,
+    )
+    assert any(c.task_id == int(task.id) for c in rescanned)
+
+
 @pytest.mark.parametrize(
     "replacement",
-    ["heartbeat", "runner", "run", "state_version", "checkpoint"],
+    ["heartbeat", "runner", "run", "state_version", "checkpoint", "checkpoint_pk"],
 )
 def test_recovery_candidate_cannot_overwrite_newer_task_state(
     db_session,
@@ -330,8 +622,28 @@ def test_recovery_candidate_cannot_overwrite_newer_task_state(
         task.run_id = "replacement-run"
     elif replacement == "state_version":
         task.state_version += 1
-    else:
+    elif replacement == "checkpoint":
         task.last_checkpoint_event_id = "new-checkpoint"
+    else:
+        # checkpoint_pk: only the exact-row pointer moves, the legacy string
+        # column is left alone -- a single-column drift the fence's
+        # conjunction over both pointer columns must still catch.
+        new_event = TraceEvent(
+            task_id=task.id,
+            event_id="new-checkpoint-pk",
+            event_type="system_update_general",
+            timestamp=utc_now(),
+            step_id=None,
+            parent_event_id=None,
+            data={
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {"type": "checkpoint"},
+                TASK_RUN_ID_TRACE_FIELD: task.run_id,
+            },
+        )
+        db_session.add(new_event)
+        db_session.flush()
+        task.last_checkpoint_trace_event_id = new_event.id
     db_session.commit()
 
     assert (

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -28,12 +28,13 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRef
 from xagent.web.models import database as database_module
 from xagent.web.models.agent import Agent
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.trigger import (
     AgentTrigger,
     TriggerRun,
@@ -93,7 +94,20 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        Base.metadata.drop_all(bind=get_engine())
+        # FK enforcement is on for this engine's connections (see
+        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
+        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
+        # that leaves a real cross-reference between the two tables (a
+        # populated last_checkpoint_trace_event_id) makes drop_all's table
+        # order irrelevant -- no order satisfies both directions of a
+        # populated cycle under enforcement. Dropping the tables is the
+        # only goal here, not preserving referential integrity of data
+        # about to be discarded, so enforcement is turned off for this one
+        # connection rather than for the fixture's tests.
+        engine = get_engine()
+        with engine.begin() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+            Base.metadata.drop_all(bind=conn)
 
 
 @pytest.fixture()
@@ -358,6 +372,16 @@ async def test_begin_turn_claim_replaces_stale_lease_and_checkpoint_pointer(
     task.runner_id = "dead-runner-from-crash"
     task.lease_expires_at = utc_now() + timedelta(hours=1)
     task.last_checkpoint_event_id = "previous-run-checkpoint"
+    stale_checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="previous-run-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={"checkpoint_type": CHECKPOINT_TYPE, "snapshot": {"type": "checkpoint"}},
+    )
+    db_session.add(stale_checkpoint)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = stale_checkpoint.id
     db_session.commit()
 
     await TaskTurnOrchestrator.begin_turn(
@@ -373,6 +397,11 @@ async def test_begin_turn_claim_replaces_stale_lease_and_checkpoint_pointer(
     assert task.runner_id == get_runner_id()
     assert task.lease_expires_at is not None
     assert task.last_checkpoint_event_id is None
+    # Both pointer columns clear together on a turn claim -- see
+    # lease_checkpoint_trace_event_id_case's docstring in task_lease_service
+    # for why a single column left behind would desync the recovery CAS
+    # fence.
+    assert task.last_checkpoint_trace_event_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.db_teardown import drop_all_tables
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRef
 from xagent.web.models import database as database_module
@@ -94,20 +95,7 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        # FK enforcement is on for this engine's connections (see
-        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
-        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
-        # that leaves a real cross-reference between the two tables (a
-        # populated last_checkpoint_trace_event_id) makes drop_all's table
-        # order irrelevant -- no order satisfies both directions of a
-        # populated cycle under enforcement. Dropping the tables is the
-        # only goal here, not preserving referential integrity of data
-        # about to be discarded, so enforcement is turned off for this one
-        # connection rather than for the fixture's tests.
-        engine = get_engine()
-        with engine.begin() as conn:
-            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
-            Base.metadata.drop_all(bind=conn)
+        drop_all_tables(get_engine())
 
 
 @pytest.fixture()

--- a/tests/web/services/test_task_status_storage.py
+++ b/tests/web/services/test_task_status_storage.py
@@ -595,7 +595,7 @@ def _stray_task_status_case_calls(
 
 
 def test_lease_case_builders_are_the_only_case_calls_in_the_lease_service() -> None:
-    """Without this, someone can inline a fourth Task.status-referencing
+    """Without this, someone can inline a fifth Task.status-referencing
     case() back into a statement and the imported-builder tests above stay
     green while production drifts -- the same failure mode this recoupling
     closes, one level up. Scoped to case() calls that reference
@@ -606,13 +606,12 @@ def test_lease_case_builders_are_the_only_case_calls_in_the_lease_service() -> N
     source = Path(task_lease_service.__file__).read_text()
     stray = _stray_task_status_case_calls(source, _LEASE_CASE_BUILDER_NAMES)
     assert stray == [], (
-        f"case() referencing Task.status called outside the three lease "
-        f"builders: {stray}"
+        f"case() referencing Task.status called outside the lease builders: {stray}"
     )
 
 
 def test_lease_case_ban_ignores_case_calls_on_unrelated_columns() -> None:
-    """Negative control: a case() outside the three builders that never
+    """Negative control: a case() outside the lease builders that never
     touches Task.status must not be flagged by the check above.
     """
     fixture = """
@@ -662,7 +661,7 @@ def test_lease_case_ban_flags_qualified_and_aliased_case_calls(
 
 
 def test_lease_case_ban_allows_helpers_nested_in_the_lease_builders() -> None:
-    """A helper function nested *inside* one of the three lease builders
+    """A helper function nested *inside* one of the lease builders
     must not be flagged -- this requires checking every enclosing scope,
     not just the innermost one.
     """

--- a/tests/web/services/test_task_status_storage.py
+++ b/tests/web/services/test_task_status_storage.py
@@ -506,6 +506,7 @@ _LEASE_CASE_BUILDER_NAMES = {
     "lease_run_id_case",
     "lease_state_version_case",
     "lease_checkpoint_event_id_case",
+    "lease_checkpoint_trace_event_id_case",
 }
 
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -1287,51 +1287,6 @@ def test_database_trace_handler_load_uses_pk_anchor_over_newer_row(
         db.close()
 
 
-def test_database_trace_handler_load_pk_anchor_mismatch_raises_corrupt(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The anchor is never allowed to fall back to a different row once its
-    target is found: a validation mismatch (here, a build-scoped row wired
-    to the root pointer) is corruption, not absence."""
-    SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-mismatch")
-    task.status = TaskStatus.RUNNING
-    task.runner_id = "runner-a"
-    task.run_id = "run-a"
-    db.commit()
-    task_id = int(task.id)
-    mismatched_row = _checkpoint_trace_row(
-        task_id=task_id,
-        event_id="build-scoped-checkpoint",
-        execution_id="shared-execution",
-        label="build-scoped",
-        timestamp=datetime.now(timezone.utc),
-        build_id="agent_123_abcd1234",
-    )
-    db.add(mismatched_row)
-    db.commit()
-    db.refresh(mismatched_row)
-    task.last_checkpoint_trace_event_id = mismatched_row.id
-    db.commit()
-
-    def get_test_db() -> Iterator[Session]:
-        session = SessionLocal()
-        try:
-            yield session
-        finally:
-            session.close()
-
-    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
-
-    try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
-            with pytest.raises(CheckpointCorruptError):
-                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
-                    "shared-execution"
-                )
-    finally:
-        db.close()
-
-
 _PK_ANCHOR_SINGLE_FAULT_FIELDS = [
     "task_id",
     "event_type",
@@ -1375,12 +1330,9 @@ def test_database_trace_handler_load_pk_anchor_single_fault_raises_corrupt(
     """Each conjunct of the PK-anchored validation must independently be
     load-bearing: a row wrong in exactly one field (every other field,
     including the run partition, valid) must still raise
-    CheckpointCorruptError. The older
-    test_database_trace_handler_load_pk_anchor_mismatch_raises_corrupt
-    above violates build_id and the run partition at the same time, so it
-    cannot prove any single conjunct is doing real work -- deleting either
-    check there still leaves the other to raise. This test kills each
-    conjunct independently.
+    CheckpointCorruptError. A row that violates several conjuncts at once
+    proves nothing about any one of them -- deleting one check still leaves
+    the others to raise -- so every conjunct gets its own case here.
     """
     SessionLocal, db, task = _create_trace_handler_test_task(
         f"pk-anchor-single-fault-{field}"
@@ -1975,12 +1927,12 @@ def test_database_trace_handler_prune_registers_degradation_on_delete_error(
     from sqlalchemy.orm import Query
 
     from xagent.web.services.ops_signals import (
-        CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+        CHECKPOINT_PRUNE_FAILED,
         active_degradations,
         clear_degradation,
     )
 
-    _, db, task = _create_trace_handler_test_task("prune-integrity-error")
+    _, db, task = _create_trace_handler_test_task("prune-failure")
     task_id = int(task.id)
     now = datetime.now(timezone.utc)
     db.add_all(
@@ -2012,7 +1964,7 @@ def test_database_trace_handler_prune_registers_degradation_on_delete_error(
 
     monkeypatch.setattr(Query, "delete", failing_delete)
 
-    clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+    clear_degradation(CHECKPOINT_PRUNE_FAILED)
     try:
         # Must not raise -- a prune failure can never break the checkpoint
         # write it follows.
@@ -2020,10 +1972,10 @@ def test_database_trace_handler_prune_registers_degradation_on_delete_error(
             db,
             {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "shared-execution"},
         )
-        assert CHECKPOINT_PRUNE_INTEGRITY_ERROR in active_degradations()
+        assert CHECKPOINT_PRUNE_FAILED in active_degradations()
         assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 2
     finally:
-        clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+        clear_degradation(CHECKPOINT_PRUNE_FAILED)
         db.close()
 
 
@@ -2970,6 +2922,78 @@ def test_database_trace_handler_load_pk_anchor_generic_decode_failure_is_unavail
         db.close()
 
 
+@pytest.mark.parametrize("decodes_a_row", [True, False])
+def test_database_trace_handler_decode_fallback_clears_after_a_successful_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    decodes_a_row: bool,
+) -> None:
+    """The decode-fallback signal is process-wide and its clear is evidence
+    that a decode worked, so an anchored read that resolves its pointer and
+    decodes the row has to retire it: that read returns before the legacy
+    scan, and the scan holds the only other clear. Without this the signal
+    stays on /health for the life of the process as soon as the anchor
+    starts succeeding, which is the normal steady state.
+
+    The second case pins the clear to the decode rather than to the attempt.
+    A read with nothing to decode -- no pointer, no rows -- proves nothing
+    about the decode layer and must leave a set signal alone; a clear placed
+    at the top of the anchored read next to the dangling clear would retire
+    it there and report a false all-clear.
+    """
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_DECODE_FALLBACK,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task(
+        f"decode-fallback-clear-{decodes_a_row}"
+    )
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    expected: Dict[str, Any] | None = None
+    if decodes_a_row:
+        row = _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="anchored",
+            execution_id="shared-execution",
+            label="anchored",
+            timestamp=datetime.now(timezone.utc),
+            run_id="run-a",
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        task.last_checkpoint_trace_event_id = row.id
+        db.commit()
+        expected = {"label": "anchored"}
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+
+    register_degradation(
+        CHECKPOINT_DECODE_FALLBACK, "left over from an earlier fallback"
+    )
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert (
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+                == expected
+            )
+        if decodes_a_row:
+            assert CHECKPOINT_DECODE_FALLBACK not in active_degradations()
+        else:
+            assert CHECKPOINT_DECODE_FALLBACK in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_DECODE_FALLBACK)
+        db.close()
+
+
 @pytest.mark.parametrize("failing_call", ["pointer_query", "row_fetch"])
 def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
@@ -3043,13 +3067,20 @@ def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
         db.close()
 
 
-def test_database_trace_handler_healthy_anchor_read_clears_the_dangling_signal(
+@pytest.mark.parametrize("anchor_set", [True, False])
+def test_database_trace_handler_anchored_read_clears_the_dangling_signal(
     monkeypatch: pytest.MonkeyPatch,
+    anchor_set: bool,
 ) -> None:
-    """ops_signals state is process-wide, so a dangling signal that only
-    clears when some pointer resolves to a row would stay set forever in a
-    process where no task has an anchor. Any anchored read that is not
-    itself dangling clears it."""
+    """The clear must sit before the pointer lookup, not after a pointer
+    resolves to a row.
+
+    ops_signals state is process-wide, so a signal that only cleared once
+    some pointer resolved would stay set forever in a process where no task
+    carries an anchor. The anchorless case is the one that pins the
+    placement: move the clear below the pointer lookup and the anchored case
+    still passes while that one fails.
+    """
     from xagent.web.services.ops_signals import (
         CHECKPOINT_PK_ANCHOR_DANGLING,
         active_degradations,
@@ -3057,65 +3088,31 @@ def test_database_trace_handler_healthy_anchor_read_clears_the_dangling_signal(
         register_degradation,
     )
 
-    SessionLocal, db, task = _create_trace_handler_test_task("anchor-clears-dangling")
+    SessionLocal, db, task = _create_trace_handler_test_task(
+        f"anchor-clears-dangling-{anchor_set}"
+    )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
-    row = _checkpoint_trace_row(
-        task_id=task_id,
-        event_id="anchored",
-        execution_id="shared-execution",
-        label="anchored",
-        timestamp=datetime.now(timezone.utc),
-        run_id="run-a",
-    )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    task.last_checkpoint_trace_event_id = row.id
-    db.commit()
-
-    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
-
-    register_degradation(
-        CHECKPOINT_PK_ANCHOR_DANGLING, "left over from another task's read"
-    )
-    try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
-            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
-                "shared-execution"
-            ) == {"label": "anchored"}
-        assert CHECKPOINT_PK_ANCHOR_DANGLING not in active_degradations()
-    finally:
-        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
-        db.close()
-
-
-def test_database_trace_handler_anchorless_read_clears_the_dangling_signal(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The clear must sit before the pointer lookup, not after a row resolves.
-
-    A process where no task carries an anchor never resolves a pointer to a
-    row, so a clear placed on the resolved-row path would leave a previously
-    latched dangling signal set forever. An anchored read attempt with an
-    unset pointer must clear it too."""
-    from xagent.web.services.ops_signals import (
-        CHECKPOINT_PK_ANCHOR_DANGLING,
-        active_degradations,
-        clear_degradation,
-        register_degradation,
-    )
-
-    SessionLocal, db, task = _create_trace_handler_test_task("anchorless-clears")
-    task.status = TaskStatus.RUNNING
-    task.runner_id = "runner-a"
-    task.run_id = "run-a"
-    db.commit()
-    task_id = int(task.id)
-    assert task.last_checkpoint_trace_event_id is None
+    expected: Dict[str, Any] | None = None
+    if anchor_set:
+        row = _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="anchored",
+            execution_id="shared-execution",
+            label="anchored",
+            timestamp=datetime.now(timezone.utc),
+            run_id="run-a",
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        task.last_checkpoint_trace_event_id = row.id
+        db.commit()
+        expected = {"label": "anchored"}
+    assert (task.last_checkpoint_trace_event_id is not None) is anchor_set
 
     _bind_checkpoint_read_session(monkeypatch, SessionLocal)
 
@@ -3128,7 +3125,7 @@ def test_database_trace_handler_anchorless_read_clears_the_dangling_signal(
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
                 )
-                is None
+                == expected
             )
         assert CHECKPOINT_PK_ANCHOR_DANGLING not in active_degradations()
     finally:
@@ -3186,14 +3183,14 @@ def test_database_trace_handler_prune_retains_exactly_the_limit_when_the_anchor_
         db.close()
 
 
-def test_database_trace_handler_prune_with_nothing_stale_clears_the_integrity_signal(
+def test_database_trace_handler_prune_with_nothing_stale_clears_the_failure_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A healthy steady state prunes nothing. If the clear sat after the
     delete, that state could never retire a previously-latched signal, and
     it would show up as permanent /health noise."""
     from xagent.web.services.ops_signals import (
-        CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+        CHECKPOINT_PRUNE_FAILED,
         active_degradations,
         clear_degradation,
         register_degradation,
@@ -3216,17 +3213,15 @@ def test_database_trace_handler_prune_with_nothing_stale_clears_the_integrity_si
         lambda: 5,
     )
 
-    register_degradation(
-        CHECKPOINT_PRUNE_INTEGRITY_ERROR, "left over from an earlier race"
-    )
+    register_degradation(CHECKPOINT_PRUNE_FAILED, "left over from an earlier race")
     try:
         DatabaseTraceHandler(task_id)._prune_checkpoint_history(
             db,
             {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "shared-execution"},
         )
-        assert CHECKPOINT_PRUNE_INTEGRITY_ERROR not in active_degradations()
+        assert CHECKPOINT_PRUNE_FAILED not in active_degradations()
     finally:
-        clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+        clear_degradation(CHECKPOINT_PRUNE_FAILED)
         db.close()
 
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -908,16 +908,25 @@ def test_database_trace_handler_rejects_stale_checkpoint(
         db.close()
 
 
-def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone() -> (
-    None
-):
+@pytest.mark.parametrize("require_persisted", [False, True])
+def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone(
+    require_persisted: bool,
+) -> None:
     """A 0-row pointer UPDATE has two distinct causes: the lease moved (an
     error worth raising), or the task row itself is gone. This test's
     in-memory engine has no FK pragma enabled, so deleting the task row
     does not fail the trace_event insert -- it reaches the pointer UPDATE
     against a task_id that matches nothing, the same state a deployment
-    without FK enforcement on this legacy column would reach."""
-    _, db, task = _create_trace_handler_test_task("task-gone-checkpoint")
+    without FK enforcement on this legacy column would reach.
+
+    The task-gone branch is classified exactly as the trace_events.task_id
+    FK violation is classified: always zero residue, quiet for a
+    best-effort event, loud for a require_persisted one. Reporting success
+    for an event that was dropped is what the FK path has never done.
+    """
+    _, db, task = _create_trace_handler_test_task(
+        f"task-gone-checkpoint-{require_persisted}"
+    )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
     task.run_id = "run-a"
@@ -932,6 +941,7 @@ def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone(
             "execution_id": str(task_id),
             "snapshot": {"label": "orphaned"},
         },
+        require_persisted=require_persisted,
     )
 
     db.query(Task).filter(Task.id == task_id).delete(synchronize_session=False)
@@ -939,9 +949,16 @@ def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone(
 
     try:
         with bind_task_lease_context(lease):
-            # Must not raise "lease changed" -- the task is gone, not leased
-            # elsewhere.
-            DatabaseTraceHandler(task_id)._save_trace_event(db, event)
+            if require_persisted:
+                with pytest.raises(RuntimeError, match="no longer exists"):
+                    DatabaseTraceHandler(task_id)._save_trace_event(db, event)
+            else:
+                # Must not raise "lease changed" -- the task is gone, not
+                # leased elsewhere.
+                DatabaseTraceHandler(task_id)._save_trace_event(db, event)
+
+        # Either way the staged row is discarded, not committed as an orphan.
+        assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 0
     finally:
         db.close()
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -3185,3 +3185,45 @@ def test_database_trace_handler_prune_with_nothing_stale_clears_the_integrity_si
     finally:
         clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
         db.close()
+
+
+def test_database_trace_handler_flush_without_primary_key_refuses_to_write_the_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard that replaced a bare assert. A no-op flush (rather than a
+    raising one) is what exercises it: a raising flush would land in the
+    generic handler instead and prove nothing about the guard."""
+    _, db, task = _create_trace_handler_test_task("flush-without-pk")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    event = TraceEvent(
+        CHECKPOINT_EVENT_TYPE,
+        task_id=str(task_id),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "execution_id": str(task_id),
+            "snapshot": {"label": "unflushed"},
+        },
+    )
+
+    monkeypatch.setattr(Session, "flush", lambda self, *a, **k: None)
+
+    try:
+        with (
+            bind_task_lease_context(lease),
+            pytest.raises(
+                RuntimeError, match="refusing to write a NULL checkpoint anchor"
+            ),
+        ):
+            DatabaseTraceHandler(task_id)._save_trace_event(db, event)
+
+        db.expire_all()
+        persisted = db.get(Task, task_id)
+        assert persisted.last_checkpoint_trace_event_id is None
+        assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 0
+    finally:
+        db.close()

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -19,6 +19,7 @@ from xagent.core.agent.checkpoint import (
     CHECKPOINT_TYPE,
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
+    CheckpointUnavailableError,
 )
 from xagent.core.agent.trace import (
     TraceAction,
@@ -2731,3 +2732,222 @@ async def test_historical_replay_dedupes_file_only_turns_by_turn_id(
         (event["data"].get("turn_id"), event["data"].get("files"))
         for event in user_message_events
     ] == [("turn-file", attachments)]
+
+
+_BROKEN_ANCHOR_LABEL = "anchored-broken"
+
+
+def _unidentified_checkpoint_row(
+    *,
+    task_id: int,
+    label: str,
+    timestamp: datetime,
+    run_id: str,
+) -> DatabaseTraceEvent:
+    """A checkpoint row carrying no execution identity at all.
+
+    The pointer anchors it (checkpoint_execution_id() returns "" and the
+    anchor's identity conjunct short-circuits), but the legacy scan excludes
+    it: its coalesce(nullif(...)) predicate is NULL and NULL = :execution_id
+    is never true. This is the shape that makes the anchor's payload verdict
+    load-bearing -- without it seeding the scan's accumulators, an unreadable
+    checkpoint would come back as "no checkpoint".
+    """
+    return DatabaseTraceEvent(
+        task_id=task_id,
+        build_id=None,
+        event_id=f"unidentified-{label}",
+        event_type="system_update_general",
+        timestamp=timestamp,
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            TASK_RUN_ID_TRACE_FIELD: run_id,
+            "snapshot": {"label": label},
+        },
+    )
+
+
+def _decode_failing_on(label: str, exception: Exception):
+    """Decode stub that fails for exactly one row, identified by its label.
+
+    Injected rather than built from a genuinely broken blob because these
+    tests pin the anchor's *classification* of a decode failure, and the
+    generic (non-CheckpointMessageDecodeError) branch has no data-level
+    trigger at all.
+    """
+
+    def fake_decode(db, *, task_id, data, strict=False, verify_blob_hashes=True):
+        snapshot = data.get("snapshot") if isinstance(data, dict) else None
+        if isinstance(snapshot, dict) and snapshot.get("label") == label:
+            raise exception
+        return data
+
+    return fake_decode
+
+
+def _bind_checkpoint_read_session(
+    monkeypatch: pytest.MonkeyPatch,
+    SessionLocal,
+) -> None:
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+
+def test_database_trace_handler_load_pk_anchor_undecodable_payload_falls_back_to_older_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retention guarantee _prune_checkpoint_history documents: older
+    rows are kept so an unreadable latest can fall back. The anchor's
+    identity stays authoritative, but its payload does not."""
+    from xagent.web.services.trace_message_storage import CheckpointMessageDecodeError
+
+    SessionLocal, db, task = _create_trace_handler_test_task("anchor-undecodable-older")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="older",
+            execution_id="shared-execution",
+            label="older-readable",
+            timestamp=now,
+            run_id="run-a",
+        )
+    )
+    broken = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="broken",
+        execution_id="shared-execution",
+        label=_BROKEN_ANCHOR_LABEL,
+        timestamp=now + timedelta(seconds=1),
+        run_id="run-a",
+    )
+    db.add(broken)
+    db.commit()
+    db.refresh(broken)
+    task.last_checkpoint_trace_event_id = broken.id
+    db.commit()
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.decode_trace_event_data",
+        _decode_failing_on(
+            _BROKEN_ANCHOR_LABEL, CheckpointMessageDecodeError("blob is gone")
+        ),
+    )
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "older-readable"}
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_pk_anchor_undecodable_payload_without_older_row_is_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The anchored row is the only checkpoint and the scan cannot even see
+    it (no execution identity). The deferral must still resolve to corrupt,
+    never to ``None`` -- an unreadable checkpoint is not an absent one."""
+    from xagent.web.services.trace_message_storage import CheckpointMessageDecodeError
+
+    SessionLocal, db, task = _create_trace_handler_test_task("anchor-undecodable-only")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    broken = _unidentified_checkpoint_row(
+        task_id=task_id,
+        label=_BROKEN_ANCHOR_LABEL,
+        timestamp=datetime.now(timezone.utc),
+        run_id="run-a",
+    )
+    db.add(broken)
+    db.commit()
+    db.refresh(broken)
+    task.last_checkpoint_trace_event_id = broken.id
+    db.commit()
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.decode_trace_event_data",
+        _decode_failing_on(
+            _BROKEN_ANCHOR_LABEL, CheckpointMessageDecodeError("blob is gone")
+        ),
+    )
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with pytest.raises(CheckpointCorruptError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_pk_anchor_generic_decode_failure_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient (non-decode-class) failure on the anchored row is
+    retryable, not terminal: unavailable, so a2a maps it to 503 rather than
+    the terminal 400 a corrupt verdict earns."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_DECODE_FALLBACK,
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task("anchor-generic-only")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    broken = _unidentified_checkpoint_row(
+        task_id=task_id,
+        label=_BROKEN_ANCHOR_LABEL,
+        timestamp=datetime.now(timezone.utc),
+        run_id="run-a",
+    )
+    db.add(broken)
+    db.commit()
+    db.refresh(broken)
+    task.last_checkpoint_trace_event_id = broken.id
+    db.commit()
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.decode_trace_event_data",
+        _decode_failing_on(_BROKEN_ANCHOR_LABEL, RuntimeError("blob prefetch failed")),
+    )
+
+    clear_degradation(CHECKPOINT_DECODE_FALLBACK)
+    clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with pytest.raises(CheckpointUnavailableError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+        active = active_degradations()
+        assert CHECKPOINT_DECODE_FALLBACK in active
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active
+    finally:
+        clear_degradation(CHECKPOINT_DECODE_FALLBACK)
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -16,6 +16,7 @@ from xagent.core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
     CHECKPOINT_TYPE,
     CheckpointAccessRefusedError,
+    CheckpointCorruptError,
 )
 from xagent.core.agent.trace import (
     TraceAction,
@@ -840,6 +841,25 @@ def test_database_trace_handler_tags_and_points_to_current_run_checkpoint() -> N
         row = db.query(DatabaseTraceEvent).filter_by(task_id=int(task.id)).one()
         assert row.data[TASK_RUN_ID_TRACE_FIELD] == "run-a"
         assert task.last_checkpoint_event_id == str(event.id)
+        # Dual write: the exact-row anchor points at the same row the
+        # legacy string column names.
+        assert task.last_checkpoint_trace_event_id == row.id
+        # Mixed-version invariant: exactly one row in the task's root
+        # partition carries the legacy event_id the pointer names, so an
+        # old reader still resolving through the string column stays
+        # unambiguous.
+        matching = (
+            db.query(DatabaseTraceEvent)
+            .filter(
+                DatabaseTraceEvent.task_id == int(task.id),
+                DatabaseTraceEvent.build_id.is_(None),
+                DatabaseTraceEvent.event_type == "system_update_general",
+                DatabaseTraceEvent.event_id == task.last_checkpoint_event_id,
+            )
+            .all()
+        )
+        assert len(matching) == 1
+        assert matching[0].id == row.id
     finally:
         db.close()
 
@@ -879,7 +899,46 @@ def test_database_trace_handler_rejects_stale_checkpoint(
         db.expire_all()
         persisted = db.get(Task, int(task.id))
         assert persisted.last_checkpoint_event_id is None
+        assert persisted.last_checkpoint_trace_event_id is None
         assert db.query(DatabaseTraceEvent).filter_by(task_id=int(task.id)).count() == 0
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone() -> (
+    None
+):
+    """A 0-row pointer UPDATE has two distinct causes: the lease moved (an
+    error worth raising), or the task row itself is gone. This test's
+    in-memory engine has no FK pragma enabled, so deleting the task row
+    does not fail the trace_event insert -- it reaches the pointer UPDATE
+    against a task_id that matches nothing, the same state a deployment
+    without FK enforcement on this legacy column would reach."""
+    _, db, task = _create_trace_handler_test_task("task-gone-checkpoint")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    event = TraceEvent(
+        CHECKPOINT_EVENT_TYPE,
+        task_id=str(task_id),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "execution_id": str(task_id),
+            "snapshot": {"label": "orphaned"},
+        },
+    )
+
+    db.query(Task).filter(Task.id == task_id).delete(synchronize_session=False)
+    db.commit()
+
+    try:
+        with bind_task_lease_context(lease):
+            # Must not raise "lease changed" -- the task is gone, not leased
+            # elsewhere.
+            DatabaseTraceHandler(task_id)._save_trace_event(db, event)
     finally:
         db.close()
 
@@ -1109,6 +1168,200 @@ def test_database_trace_handler_bound_run_does_not_fallback_to_legacy_checkpoint
                 is None
             )
     finally:
+        db.close()
+
+
+def test_database_trace_handler_load_without_pk_anchor_uses_legacy_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract for the mixed-data window: with the pointer unset, the read
+    path is exactly the pre-existing legacy scan."""
+    SessionLocal, db, task = _create_trace_handler_test_task("no-pk-anchor-load")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    assert task.last_checkpoint_trace_event_id is None
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="legacy-checkpoint",
+            execution_id="shared-execution",
+            label="legacy-only",
+            timestamp=datetime.now(timezone.utc),
+            run_id="run-a",
+        )
+    )
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "legacy-only"}
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_uses_pk_anchor_over_newer_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once set, the pointer is authoritative -- even over a row the legacy
+    scan (newest timestamp first) would otherwise pick instead."""
+    SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-load")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    anchored_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="anchored-checkpoint",
+        execution_id="shared-execution",
+        label="anchored",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(anchored_row)
+    db.commit()
+    db.refresh(anchored_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="newer-checkpoint",
+            execution_id="shared-execution",
+            label="newer",
+            timestamp=now + timedelta(seconds=1),
+            run_id="run-a",
+        )
+    )
+    task.last_checkpoint_trace_event_id = anchored_row.id
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "anchored"}
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_pk_anchor_mismatch_raises_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The anchor is never allowed to fall back to a different row once its
+    target is found: a validation mismatch (here, a build-scoped row wired
+    to the root pointer) is corruption, not absence."""
+    SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-mismatch")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    mismatched_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="build-scoped-checkpoint",
+        execution_id="shared-execution",
+        label="build-scoped",
+        timestamp=datetime.now(timezone.utc),
+        build_id="agent_123_abcd1234",
+    )
+    db.add(mismatched_row)
+    db.commit()
+    db.refresh(mismatched_row)
+    task.last_checkpoint_trace_event_id = mismatched_row.id
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with pytest.raises(CheckpointCorruptError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_dangling_pk_anchor_falls_back_with_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pointer whose row no longer exists is only reachable on a database
+    upgraded without the DB-level FK for this column (see the migration).
+    The compatibility-window response is a legacy fallback plus a
+    self-clearing degradation signal, not a corruption verdict."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_PK_ANCHOR_DANGLING,
+        active_degradations,
+        clear_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-dangling")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="legacy-checkpoint",
+            execution_id="shared-execution",
+            label="legacy-fallback",
+            timestamp=datetime.now(timezone.utc),
+            run_id="run-a",
+        )
+    )
+    task.last_checkpoint_trace_event_id = 999999999
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "legacy-fallback"}
+        assert CHECKPOINT_PK_ANCHOR_DANGLING in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
         db.close()
 
 
@@ -1443,6 +1696,129 @@ def test_database_trace_handler_prunes_legacy_partition_without_tagged_runs(
             for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
         } == {"legacy-new", "tagged-run"}
     finally:
+        db.close()
+
+
+def test_database_trace_handler_prune_excludes_the_anchored_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthetic: the task's pointer is wired to an older row that the
+    retention ranking would otherwise prune. Nothing in today's
+    steady-state writer produces this -- the pointer always names the row
+    just written, which ranks newest -- but a future back-pointing anchor
+    (or a backfilled pointer) could, so prune must never delete the row a
+    pointer references regardless of its rank."""
+    _, db, task = _create_trace_handler_test_task("anchor-protected-prune")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    old_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="anchored-old",
+        execution_id="shared-execution",
+        label="anchored-old",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(old_row)
+    db.commit()
+    db.refresh(old_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="run-a-new",
+            execution_id="shared-execution",
+            label="run-a-new",
+            timestamp=now + timedelta(seconds=1),
+            run_id="run-a",
+        )
+    )
+    # Synthetic: wire the pointer to the older row, which the retention
+    # ranking (newest first, limit=1) would otherwise prune.
+    task.last_checkpoint_trace_event_id = old_row.id
+    db.commit()
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"anchored-old", "run-a-new"}
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_prune_registers_degradation_on_integrity_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthetic IntegrityError injection: the delete step is replaced to
+    raise, isolating the except-IntegrityError branch from needing genuine
+    FK enforcement (which only PostgreSQL, or a freshly create_all'd SQLite
+    database, provides for this column)."""
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.orm import Query
+
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+        active_degradations,
+        clear_degradation,
+    )
+
+    _, db, task = _create_trace_handler_test_task("prune-integrity-error")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    db.add_all(
+        [
+            _checkpoint_trace_row(
+                task_id=task_id,
+                event_id="old",
+                execution_id="shared-execution",
+                label="old",
+                timestamp=now,
+            ),
+            _checkpoint_trace_row(
+                task_id=task_id,
+                event_id="new",
+                execution_id="shared-execution",
+                label="new",
+                timestamp=now + timedelta(seconds=1),
+            ),
+        ]
+    )
+    db.commit()
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    def failing_delete(self: Query, *args: object, **kwargs: object) -> int:
+        raise IntegrityError("DELETE", {}, Exception("restrict violation"))
+
+    monkeypatch.setattr(Query, "delete", failing_delete)
+
+    clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+    try:
+        # Must not raise -- a prune failure can never break the checkpoint
+        # write it follows.
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "shared-execution"},
+        )
+        assert CHECKPOINT_PRUNE_INTEGRITY_ERROR in active_degradations()
+        assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 2
+    finally:
+        clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
         db.close()
 
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -3093,6 +3093,49 @@ def test_database_trace_handler_healthy_anchor_read_clears_the_dangling_signal(
         db.close()
 
 
+def test_database_trace_handler_anchorless_read_clears_the_dangling_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clear must sit before the pointer lookup, not after a row resolves.
+
+    A process where no task carries an anchor never resolves a pointer to a
+    row, so a clear placed on the resolved-row path would leave a previously
+    latched dangling signal set forever. An anchored read attempt with an
+    unset pointer must clear it too."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_PK_ANCHOR_DANGLING,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task("anchorless-clears")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    assert task.last_checkpoint_trace_event_id is None
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+
+    register_degradation(
+        CHECKPOINT_PK_ANCHOR_DANGLING, "left over from another task's read"
+    )
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert (
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+                is None
+            )
+        assert CHECKPOINT_PK_ANCHOR_DANGLING not in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
+        db.close()
+
+
 def test_database_trace_handler_prune_retains_exactly_the_limit_when_the_anchor_is_in_range(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -3024,3 +3024,53 @@ def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
     finally:
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         db.close()
+
+
+def test_database_trace_handler_healthy_anchor_read_clears_the_dangling_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ops_signals state is process-wide, so a dangling signal that only
+    clears when some pointer resolves to a row would stay set forever in a
+    process where no task has an anchor. Any anchored read that is not
+    itself dangling clears it."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_PK_ANCHOR_DANGLING,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task("anchor-clears-dangling")
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="anchored",
+        execution_id="shared-execution",
+        label="anchored",
+        timestamp=datetime.now(timezone.utc),
+        run_id="run-a",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    task.last_checkpoint_trace_event_id = row.id
+    db.commit()
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+
+    register_degradation(
+        CHECKPOINT_PK_ANCHOR_DANGLING, "left over from another task's read"
+    )
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "anchored"}
+        assert CHECKPOINT_PK_ANCHOR_DANGLING not in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
+        db.close()

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -6,9 +6,11 @@ import time
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any, Dict
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool, StaticPool
 
@@ -1312,6 +1314,174 @@ def test_database_trace_handler_load_pk_anchor_mismatch_raises_corrupt(
         db.close()
 
 
+_PK_ANCHOR_SINGLE_FAULT_FIELDS = [
+    "task_id",
+    "event_type",
+    "build_id",
+    "checkpoint_type",
+    "run_partition",
+    "execution_id",
+]
+
+
+def _mutate_pk_anchor_field(
+    field: str,
+    row_kwargs: Dict[str, Any],
+    data: Dict[str, Any],
+    other_task_id: int,
+) -> None:
+    """Corrupt exactly one field the PK-anchored validation checks, leaving
+    every other field -- including the run field -- valid, so a passing
+    case can only be explained by that one conjunct doing nothing."""
+    if field == "task_id":
+        row_kwargs["task_id"] = other_task_id
+    elif field == "event_type":
+        row_kwargs["event_type"] = "agent_progress"
+    elif field == "build_id":
+        row_kwargs["build_id"] = "agent_123_wrongscope"
+    elif field == "checkpoint_type":
+        data["checkpoint_type"] = "not_a_readable_checkpoint_type"
+    elif field == "run_partition":
+        data[TASK_RUN_ID_TRACE_FIELD] = "run-b"
+    elif field == "execution_id":
+        data["execution_id"] = "other-execution"
+    else:
+        raise AssertionError(f"unknown single-fault field {field}")
+
+
+@pytest.mark.parametrize("field", _PK_ANCHOR_SINGLE_FAULT_FIELDS)
+def test_database_trace_handler_load_pk_anchor_single_fault_raises_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    """Each conjunct of the PK-anchored validation must independently be
+    load-bearing: a row wrong in exactly one field (every other field,
+    including the run partition, valid) must still raise
+    CheckpointCorruptError. The older
+    test_database_trace_handler_load_pk_anchor_mismatch_raises_corrupt
+    above violates build_id and the run partition at the same time, so it
+    cannot prove any single conjunct is doing real work -- deleting either
+    check there still leaves the other to raise. This test kills each
+    conjunct independently.
+    """
+    SessionLocal, db, task = _create_trace_handler_test_task(
+        f"pk-anchor-single-fault-{field}"
+    )
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+
+    other_task = Task(
+        user_id=int(task.user_id),
+        title="Other task",
+        description="Other task",
+        status=TaskStatus.PENDING,
+    )
+    db.add(other_task)
+    db.commit()
+    db.refresh(other_task)
+    other_task_id = int(other_task.id)
+
+    row_kwargs: Dict[str, Any] = dict(
+        task_id=task_id,
+        build_id=None,
+        event_id="pk-anchor-single-fault",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+    )
+    data: Dict[str, Any] = {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "execution_id": "shared-execution",
+        TASK_RUN_ID_TRACE_FIELD: "run-a",
+        "snapshot": {"label": "single-fault"},
+    }
+    _mutate_pk_anchor_field(field, row_kwargs, data, other_task_id)
+
+    row = DatabaseTraceEvent(data=data, **row_kwargs)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    task.last_checkpoint_trace_event_id = row.id
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with pytest.raises(CheckpointCorruptError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_load_pk_anchor_without_execution_identity_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The execution-identity conjunct is verification, not filtering: a
+    row that carries no execution identity at all -- a legacy row written
+    before root_execution_id/execution_id/snapshot.execution_id existed --
+    must still load rather than being treated as a mismatch. Pairs with
+    the "execution_id" case of
+    test_database_trace_handler_load_pk_anchor_single_fault_raises_corrupt,
+    which covers the opposite: an execution identity that is present and
+    wrong.
+    """
+    SessionLocal, db, task = _create_trace_handler_test_task(
+        "pk-anchor-no-execution-identity"
+    )
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+
+    row = DatabaseTraceEvent(
+        task_id=task_id,
+        build_id=None,
+        event_id="pk-anchor-no-execution-identity",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            TASK_RUN_ID_TRACE_FIELD: "run-a",
+            "snapshot": {"label": "no-execution-identity"},
+        },
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    task.last_checkpoint_trace_event_id = row.id
+    db.commit()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
+
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                "shared-execution"
+            ) == {"label": "no-execution-identity"}
+    finally:
+        db.close()
+
+
 def test_database_trace_handler_load_dangling_pk_anchor_falls_back_with_telemetry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1759,14 +1929,31 @@ def test_database_trace_handler_prune_excludes_the_anchored_row(
         db.close()
 
 
-def test_database_trace_handler_prune_registers_degradation_on_integrity_error(
+@pytest.mark.parametrize(
+    "injected_exception",
+    [
+        pytest.param(
+            IntegrityError("DELETE", {}, Exception("restrict violation")),
+            id="integrity_error",
+        ),
+        pytest.param(
+            OperationalError("DELETE", {}, Exception("serialization failure")),
+            id="operational_error",
+        ),
+    ],
+)
+def test_database_trace_handler_prune_registers_degradation_on_delete_error(
     monkeypatch: pytest.MonkeyPatch,
+    injected_exception: Exception,
 ) -> None:
-    """Synthetic IntegrityError injection: the delete step is replaced to
-    raise, isolating the except-IntegrityError branch from needing genuine
-    FK enforcement (which only PostgreSQL, or a freshly create_all'd SQLite
-    database, provides for this column)."""
-    from sqlalchemy.exc import IntegrityError
+    """Synthetic delete-failure injection: the delete step is replaced to
+    raise, isolating the except-(IntegrityError, OperationalError) branch
+    from needing genuine FK enforcement (which only PostgreSQL, or a
+    freshly create_all'd SQLite database, provides for this column) or a
+    genuine serialization conflict. Both exception classes are covered
+    because PostgreSQL's restrict-violation and its SerializationFailure /
+    DeadlockDetected surface through different SQLAlchemy wrapper classes
+    (IntegrityError vs. OperationalError) for the same retention race."""
     from sqlalchemy.orm import Query
 
     from xagent.web.services.ops_signals import (
@@ -1803,7 +1990,7 @@ def test_database_trace_handler_prune_registers_degradation_on_integrity_error(
     )
 
     def failing_delete(self: Query, *args: object, **kwargs: object) -> int:
-        raise IntegrityError("DELETE", {}, Exception("restrict violation"))
+        raise injected_exception
 
     monkeypatch.setattr(Query, "delete", failing_delete)
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -3091,3 +3091,97 @@ def test_database_trace_handler_healthy_anchor_read_clears_the_dangling_signal(
     finally:
         clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
         db.close()
+
+
+def test_database_trace_handler_prune_retains_exactly_the_limit_when_the_anchor_is_in_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The steady state: the pointer names the row just written, which ranks
+    inside the retention window. Ranking before protecting makes the
+    documented retention count exact -- excluding the anchor from the
+    candidate set instead shifts every remaining row's OFFSET rank by one
+    and keeps limit + 1."""
+    _, db, task = _create_trace_handler_test_task("anchor-in-range-prune")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    rows = [
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id=event_id,
+            execution_id="shared-execution",
+            label=event_id,
+            timestamp=now + timedelta(seconds=offset),
+            run_id="run-a",
+        )
+        for offset, event_id in enumerate(["oldest", "middle", "newest"])
+    ]
+    db.add_all(rows)
+    db.commit()
+    db.refresh(rows[-1])
+    task.last_checkpoint_trace_event_id = rows[-1].id
+    db.commit()
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"newest"}
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_prune_with_nothing_stale_clears_the_integrity_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy steady state prunes nothing. If the clear sat after the
+    delete, that state could never retire a previously-latched signal, and
+    it would show up as permanent /health noise."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_PRUNE_INTEGRITY_ERROR,
+        active_degradations,
+        clear_degradation,
+        register_degradation,
+    )
+
+    _, db, task = _create_trace_handler_test_task("prune-nothing-stale")
+    task_id = int(task.id)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="only",
+            execution_id="shared-execution",
+            label="only",
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 5,
+    )
+
+    register_degradation(
+        CHECKPOINT_PRUNE_INTEGRITY_ERROR, "left over from an earlier race"
+    )
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "shared-execution"},
+        )
+        assert CHECKPOINT_PRUNE_INTEGRITY_ERROR not in active_degradations()
+    finally:
+        clear_degradation(CHECKPOINT_PRUNE_INTEGRITY_ERROR)
+        db.close()

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError, OperationalError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Query, Session, sessionmaker
 from sqlalchemy.pool import QueuePool, StaticPool
 
 from xagent.core.agent.checkpoint import (
@@ -2949,5 +2949,78 @@ def test_database_trace_handler_load_pk_anchor_generic_decode_failure_is_unavail
         assert CHECKPOINT_LOAD_UNAVAILABLE in active
     finally:
         clear_degradation(CHECKPOINT_DECODE_FALLBACK)
+        clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+        db.close()
+
+
+@pytest.mark.parametrize("failing_call", ["pointer_query", "row_fetch"])
+def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_call: str,
+) -> None:
+    """_sync_load_latest_checkpoint promises every database touch is
+    translated into a CheckpointReadError subclass. Both of the anchor's own
+    database calls have to honour that, or a transient connection failure
+    escapes as a raw driver exception no caller catches."""
+    from xagent.web.services.ops_signals import (
+        CHECKPOINT_LOAD_UNAVAILABLE,
+        active_degradations,
+        clear_degradation,
+    )
+
+    SessionLocal, db, task = _create_trace_handler_test_task(
+        f"anchor-db-{failing_call}"
+    )
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a"
+    db.commit()
+    task_id = int(task.id)
+    row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="anchored",
+        execution_id="shared-execution",
+        label="anchored",
+        timestamp=datetime.now(timezone.utc),
+        run_id="run-a",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    task.last_checkpoint_trace_event_id = row.id
+    db.commit()
+
+    _bind_checkpoint_read_session(monkeypatch, SessionLocal)
+
+    boom = OperationalError("SELECT", {}, Exception("connection reset"))
+    if failing_call == "pointer_query":
+        original_one_or_none = Query.one_or_none
+
+        def failing_one_or_none(self: Query):  # type: ignore[no-untyped-def]
+            descriptions = self.column_descriptions
+            if (
+                descriptions
+                and descriptions[0]["name"] == "last_checkpoint_trace_event_id"
+            ):
+                raise boom
+            return original_one_or_none(self)
+
+        monkeypatch.setattr(Query, "one_or_none", failing_one_or_none)
+    else:
+
+        def failing_get(self: Session, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+            raise boom
+
+        monkeypatch.setattr(Session, "get", failing_get)
+
+    clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
+    try:
+        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with pytest.raises(CheckpointUnavailableError):
+                DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+                    "shared-execution"
+                )
+        assert CHECKPOINT_LOAD_UNAVAILABLE in active_degradations()
+    finally:
         clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
         db.close()

--- a/tests/web/test_db_teardown.py
+++ b/tests/web/test_db_teardown.py
@@ -1,0 +1,84 @@
+"""The shared fixture teardown must survive a populated tasks/trace_events
+constraint cycle -- the state any test that runs a task to a checkpoint
+leaves behind.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.db_teardown import drop_all_tables
+from tests.web.services.checkpoint_anchor_shared import (
+    reset_checkpoint_anchor_fk_create_rule,
+)
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.user import User
+
+
+def _fk_enforcing_sqlite_engine(db_path):
+    engine = create_engine(f"sqlite:///{db_path}")
+    apply_sqlite_concurrency_pragmas(engine)
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _seed_task_with_anchored_checkpoint(engine) -> None:
+    session = sessionmaker(bind=engine)()
+    try:
+        user = User(username="teardown-user", password_hash="hash", is_admin=False)
+        session.add(user)
+        session.flush()
+        task = Task(user_id=int(user.id), title="task")
+        session.add(task)
+        session.flush()
+        event = TraceEvent(
+            task_id=int(task.id),
+            build_id=None,
+            event_id="evt-1",
+            event_type="system_update_general",
+            timestamp=datetime.now(timezone.utc),
+            data={},
+        )
+        session.add(event)
+        session.flush()
+        task.last_checkpoint_event_id = "evt-1"
+        task.last_checkpoint_trace_event_id = int(event.id)
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_drop_all_tables_survives_a_populated_checkpoint_anchor(tmp_path) -> None:
+    engine = _fk_enforcing_sqlite_engine(tmp_path / "teardown.db")
+    _seed_task_with_anchored_checkpoint(engine)
+
+    try:
+        drop_all_tables(engine)
+
+        remaining = set(inspect(engine).get_table_names())
+        assert not remaining & {"tasks", "trace_events"}
+    finally:
+        engine.dispose()
+
+
+def test_plain_drop_all_fails_on_a_populated_checkpoint_anchor(tmp_path) -> None:
+    """Why the helper exists: the unguarded call this repo's fixtures used
+    before raises once the cycle is populated, no matter the drop order."""
+    from sqlalchemy.exc import IntegrityError
+
+    engine = _fk_enforcing_sqlite_engine(tmp_path / "teardown-unguarded.db")
+    _seed_task_with_anchored_checkpoint(engine)
+
+    try:
+        with pytest.raises(IntegrityError, match="FOREIGN KEY constraint failed"):
+            Base.metadata.drop_all(bind=engine)
+    finally:
+        drop_all_tables(engine)
+        engine.dispose()

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.db_teardown import drop_all_tables
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, LEGACY_CHECKPOINT_TYPES
 from xagent.web.models import database as database_module
 from xagent.web.models.database import Base, get_db, get_engine, init_db
@@ -48,20 +49,7 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        # FK enforcement is on for this engine's connections (see
-        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
-        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
-        # that leaves a real cross-reference between the two tables (a
-        # populated last_checkpoint_trace_event_id) makes drop_all's table
-        # order irrelevant -- no order satisfies both directions of a
-        # populated cycle under enforcement. Dropping the tables is the
-        # only goal here, not preserving referential integrity of data
-        # about to be discarded, so enforcement is turned off for this one
-        # connection rather than for the fixture's tests.
-        engine = get_engine()
-        with engine.begin() as conn:
-            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
-            Base.metadata.drop_all(bind=conn)
+        drop_all_tables(get_engine())
 
 
 @pytest.fixture()

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 import threading
 from datetime import timedelta
 
@@ -47,7 +48,20 @@ def db_session(tmp_path):
         yield db
     finally:
         db.close()
-        Base.metadata.drop_all(bind=get_engine())
+        # FK enforcement is on for this engine's connections (see
+        # apply_sqlite_concurrency_pragmas), and the checkpoint pointer's
+        # FK forms a cycle with trace_events.task_id -> tasks.id. A test
+        # that leaves a real cross-reference between the two tables (a
+        # populated last_checkpoint_trace_event_id) makes drop_all's table
+        # order irrelevant -- no order satisfies both directions of a
+        # populated cycle under enforcement. Dropping the tables is the
+        # only goal here, not preserving referential integrity of data
+        # about to be discarded, so enforcement is turned off for this one
+        # connection rather than for the fixture's tests.
+        engine = get_engine()
+        with engine.begin() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+            Base.metadata.drop_all(bind=conn)
 
 
 @pytest.fixture()
@@ -1155,9 +1169,52 @@ async def test_cancellation_safe_acquire_drains_and_cleans_returned_lease() -> N
     assert cleaned_leases == [expected_lease]
 
 
+_CASE_WHEN_PATTERN = re.compile(r"WHEN (.+?) THEN")
+
+
+def _case_when_clause(case_expr) -> str:
+    """The compiled WHEN condition of a two-branch case(), with literal
+    binds inlined so two structurally-identical predicates compile to the
+    same string regardless of bind-parameter naming.
+    """
+    compiled = str(case_expr.compile(compile_kwargs={"literal_binds": True}))
+    match = _CASE_WHEN_PATTERN.search(compiled)
+    assert match is not None, compiled
+    return match.group(1)
+
+
+def test_lease_checkpoint_pointer_case_predicates_match() -> None:
+    """lease_checkpoint_event_id_case and lease_checkpoint_trace_event_id_case
+    must clear their column under exactly the same condition.
+
+    Both builders share _checkpoint_pointer_retention_predicate(), so this
+    passes by construction today; the assertion is what actually enforces
+    it -- a future edit that inlines a diverging predicate into one builder
+    would otherwise pass every other test here (each builder's own column
+    still clears/retains correctly in isolation) while silently breaking
+    the recovery CAS fence's two-column conjunction, which depends on both
+    columns clearing together (see recover_expired_task_lease_no_commit).
+    """
+    legacy_when = _case_when_clause(task_lease_service.lease_checkpoint_event_id_case())
+    exact_when = _case_when_clause(
+        task_lease_service.lease_checkpoint_trace_event_id_case()
+    )
+    assert legacy_when == exact_when
+
+
 def test_new_run_lease_claim_rejects_a_second_claim(db_session) -> None:
     task = _create_task(db_session)
     task.last_checkpoint_event_id = "previous-run-checkpoint"
+    previous_checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="previous-run-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={"checkpoint_type": CHECKPOINT_TYPE, "snapshot": {"type": "checkpoint"}},
+    )
+    db_session.add(previous_checkpoint)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = previous_checkpoint.id
     db_session.commit()
 
     first = acquire_task_lease(
@@ -1179,12 +1236,26 @@ def test_new_run_lease_claim_rejects_a_second_claim(db_session) -> None:
     db_session.refresh(task)
     assert task.run_id == first.run_id
     assert task.last_checkpoint_event_id is None
+    # A new run clears both pointer columns together -- see
+    # lease_checkpoint_trace_event_id_case's docstring for why a single
+    # column left behind would desync the recovery CAS fence.
+    assert task.last_checkpoint_trace_event_id is None
 
 
 def test_same_run_resume_lease_preserves_checkpoint_pointer(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.WAITING_FOR_USER)
     task.run_id = "resumable-run"
     task.last_checkpoint_event_id = "current-run-checkpoint"
+    current_checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="current-run-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={"checkpoint_type": CHECKPOINT_TYPE, "snapshot": {"type": "checkpoint"}},
+    )
+    db_session.add(current_checkpoint)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = current_checkpoint.id
     db_session.commit()
 
     lease = acquire_task_lease(
@@ -1201,6 +1272,44 @@ def test_same_run_resume_lease_preserves_checkpoint_pointer(db_session) -> None:
     )
     db_session.refresh(task)
     assert task.last_checkpoint_event_id == "current-run-checkpoint"
+    # A same-run resume retains both pointer columns together.
+    assert task.last_checkpoint_trace_event_id == current_checkpoint.id
+
+
+def test_running_task_reacquire_retains_checkpoint_pointer_via_case(
+    db_session,
+) -> None:
+    """acquire_task_lease_no_commit's case()-retain branch (no new_run, no
+    expected_run_id) only fires when the row is already a live RUNNING row
+    with a run id -- exercised here by a heartbeat-style reacquire on a
+    task that is already RUNNING with the same runner, unlike every other
+    acquire_task_lease call in this file, which starts from a non-RUNNING
+    task and only ever hits the case()'s clear side.
+    """
+    task = _create_task(db_session, status=TaskStatus.RUNNING)
+    task.runner_id = "runner-a"
+    task.run_id = "existing-run"
+    task.last_checkpoint_event_id = "existing-checkpoint"
+    checkpoint = TraceEvent(
+        task_id=task.id,
+        event_id="existing-checkpoint",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        data={"checkpoint_type": CHECKPOINT_TYPE, "snapshot": {"type": "checkpoint"}},
+    )
+    db_session.add(checkpoint)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = checkpoint.id
+    db_session.commit()
+
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+
+    assert lease is not None
+    assert lease.run_id == "existing-run"
+    db_session.refresh(task)
+    assert task.last_checkpoint_event_id == "existing-checkpoint"
+    # Both pointer columns retained together via the paired case() builders.
+    assert task.last_checkpoint_trace_event_id == checkpoint.id
 
 
 def test_lease_acquire_rejects_a_superseded_run(db_session) -> None:
@@ -1248,21 +1357,24 @@ def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:
     task.run_id = "checkpoint-run"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "checkpoint-1"
-    db_session.add(
-        TraceEvent(
-            task_id=task.id,
-            event_id="checkpoint-1",
-            event_type="system_update_general",
-            timestamp=utc_now(),
-            step_id=None,
-            parent_event_id=None,
-            data={
-                "checkpoint_type": CHECKPOINT_TYPE,
-                "snapshot": {"type": "checkpoint"},
-                TASK_RUN_ID_TRACE_FIELD: "checkpoint-run",
-            },
-        )
+    checkpoint_event = TraceEvent(
+        task_id=task.id,
+        event_id="checkpoint-1",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        step_id=None,
+        parent_event_id=None,
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: "checkpoint-run",
+        },
     )
+    db_session.add(checkpoint_event)
+    db_session.flush()
+    # Exercises the PK-anchored resolution path (not just the legacy
+    # string fallback): recovery must reach the same PAUSED verdict.
+    task.last_checkpoint_trace_event_id = checkpoint_event.id
     db_session.commit()
 
     assert _recover_expired_task(db_session, task) == TaskStatus.PAUSED
@@ -1278,22 +1390,27 @@ def test_stale_running_task_ignores_child_agent_checkpoint(db_session) -> None:
     task.run_id = "child-checkpoint-run"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "child-checkpoint-1"
-    db_session.add(
-        TraceEvent(
-            task_id=task.id,
-            build_id="agent_123_child",
-            event_id="child-checkpoint-1",
-            event_type="system_update_general",
-            timestamp=utc_now(),
-            step_id=None,
-            parent_event_id=None,
-            data={
-                "checkpoint_type": CHECKPOINT_TYPE,
-                "snapshot": {"type": "checkpoint"},
-                TASK_RUN_ID_TRACE_FIELD: "child-checkpoint-run",
-            },
-        )
+    child_checkpoint_event = TraceEvent(
+        task_id=task.id,
+        build_id="agent_123_child",
+        event_id="child-checkpoint-1",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        step_id=None,
+        parent_event_id=None,
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: "child-checkpoint-run",
+        },
     )
+    db_session.add(child_checkpoint_event)
+    db_session.flush()
+    # Exercises the PK-anchored resolution path: an anchored build-scoped
+    # row must fail its own validation (build_id is not None), the same
+    # FAILED verdict the legacy scan reaches -- and it must not fall back
+    # to searching other rows for a match.
+    task.last_checkpoint_trace_event_id = child_checkpoint_event.id
     db_session.commit()
 
     assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
@@ -1309,21 +1426,22 @@ def test_stale_running_task_with_legacy_checkpoint_becomes_paused(db_session) ->
     task.run_id = "legacy-checkpoint-run"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "legacy-checkpoint-1"
-    db_session.add(
-        TraceEvent(
-            task_id=task.id,
-            event_id="legacy-checkpoint-1",
-            event_type="system_update_general",
-            timestamp=utc_now(),
-            step_id=None,
-            parent_event_id=None,
-            data={
-                "checkpoint_type": next(iter(LEGACY_CHECKPOINT_TYPES)),
-                "snapshot": {"type": "checkpoint"},
-                TASK_RUN_ID_TRACE_FIELD: "legacy-checkpoint-run",
-            },
-        )
+    legacy_checkpoint_event = TraceEvent(
+        task_id=task.id,
+        event_id="legacy-checkpoint-1",
+        event_type="system_update_general",
+        timestamp=utc_now(),
+        step_id=None,
+        parent_event_id=None,
+        data={
+            "checkpoint_type": next(iter(LEGACY_CHECKPOINT_TYPES)),
+            "snapshot": {"type": "checkpoint"},
+            TASK_RUN_ID_TRACE_FIELD: "legacy-checkpoint-run",
+        },
     )
+    db_session.add(legacy_checkpoint_event)
+    db_session.flush()
+    task.last_checkpoint_trace_event_id = legacy_checkpoint_event.id
     db_session.commit()
 
     assert _recover_expired_task(db_session, task) == TaskStatus.PAUSED

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1187,7 +1187,7 @@ def test_lease_checkpoint_pointer_case_predicates_match() -> None:
     """lease_checkpoint_event_id_case and lease_checkpoint_trace_event_id_case
     must clear their column under exactly the same condition.
 
-    Both builders share _checkpoint_pointer_retention_predicate(), so this
+    Both builders share _checkpoint_pointer_clearing_predicate(), so this
     passes by construction today; the assertion is what actually enforces
     it -- a future edit that inlines a diverging predicate into one builder
     would otherwise pass every other test here (each builder's own column


### PR DESCRIPTION
## Summary

Checkpoint reads and lease recovery currently locate a task's checkpoint by scanning trace events and matching `last_checkpoint_event_id`, a string column with no referential guarantee: the pointed-at row can be ambiguous (event ids carry no unique constraint), deleted, or resolved to the wrong row. This PR anchors the pointer to the exact row: `tasks.last_checkpoint_trace_event_id` references `trace_events.id` directly, written in the same statement as the legacy pointer and consumed PK-first everywhere the pointer is read.

- **Schema**: new nullable `last_checkpoint_trace_event_id` column with a named foreign key declared on the model (PostgreSQL enforces it via an `ADD CONSTRAINT` migration; upgraded SQLite databases get the column without a DB-level constraint, and a test asserts that shape, so the application-layer ordering below is their only guard — fresh SQLite databases created from metadata do carry the constraint). The migration backfills existing rows with a single correlated `UPDATE` that resolves each legacy pointer to its row id, leaves ambiguous or unresolvable pointers `NULL`, and is idempotent.
- **Writer**: the checkpoint write flushes inside the checkpoint branch, asserts the row id, and updates both pointer columns in one fenced statement. A pointer update matching zero rows now distinguishes a deleted task (silent stop) from a changed lease (raise), instead of misreporting both as lease changes.
- **Reader**: checkpoint loads resolve the anchor row by primary key first; a resolved row failing verification is corrupt, while a dangling anchor (reachable only on constraint-less upgraded SQLite) falls back to the legacy scan with a warning. Rows written before the anchor existed keep the legacy scan path.
- **Deletion**: both task-purge implementations null both pointer columns before deleting trace events, so the delete order stays valid under enforced foreign keys; tests cover the constraint-enforced and constraint-less schema shapes, including the mutation that reverts the ordering.
- **Lease recovery**: checkpoint resolution returns a three-way verdict — recoverable, not recoverable, or indeterminate. Resolution is PK-first with no fallback on verification failure; a dangling anchor falls back to the legacy scan; an ambiguous legacy match (previously an unhandled `MultipleResultsFound`) now leaves the candidate untouched for the next sweep instead of aborting the recovery pass. The recovery CAS fence matches both pointer columns conjunctively, so single-column drift blocks the overwrite.
- **Pointer lifecycle**: every site that clears or retains the pointer moves both columns together — lease acquisition's new-run clear, the retain-case builders (which share one retention predicate so they cannot diverge), the turn-claim path, and both deletion implementations.

## Verification

- 299 tests on SQLite and 143 on PostgreSQL across the lease-service, recovery, orchestrator, deletion, migration, checkpoint-stream, and trace-storage suites, including: dual-write assertions against the row id; the fence's parametrized single-column-drift matrix; dangling-anchor fallback on an upgraded-SQLite fixture; ambiguity leaving the candidate re-scannable; migration backfill correctness, ambiguity-to-NULL, idempotency, downgrade, and named-constraint reflection on PostgreSQL.
- Mutation checks, each red against a named test and reverted: dropping the flush, the second written column, either deletion's NULL-first ordering, the backfill idempotency guard, the fence conjunct, the builder retention predicate or its ELSE branch, the dangling-anchor fallback, the ambiguity handler, and the turn-claim clear.

Scope: this lands the anchor column, migration, dual-write/dual-read compatibility window, recovery migration, and deletion ordering from #1071. The remaining criterion — checkpoint staging that joins a caller-owned transaction with no implicit commit — builds on this anchor and lands as its own change.

Part of #1071.
