### PR TITLE
feat: tell the Slack agent who is talking to it

### DIFF
--- a/example.env
+++ b/example.env
@@ -278,6 +278,9 @@ XAGENT_PASSWORD_MIN_LENGTH="6"
 # message.channels, message.groups, message.im, message.mpim, plus
 # app_uninstalled and tokens_revoked so Xagent can deactivate the channel
 # when a workspace removes the app.
+# The bot scopes include users:read so the agent can resolve who is talking
+# to it (sender display name/title). Installs made before this scope existed
+# keep working with unattributed messages until the app is reinstalled.
 # Workspace tokens are encrypted at rest with ENCRYPTION_KEY (see the security
 # section); the OAuth install flow refuses to start while ENCRYPTION_KEY is
 # unset or still the built-in dev default. Generate one with:

--- a/src/xagent/web/api/channel.py
+++ b/src/xagent/web/api/channel.py
@@ -67,6 +67,10 @@ SLACK_OAUTH_SCOPES = (
     "mpim:history",
     "channels:history",
     "groups:history",
+    # Sender-identity resolution (users.info): lets the agent address the
+    # person it is talking to. Installs that predate this scope degrade to
+    # unattributed messages until reinstalled.
+    "users:read",
 )
 
 

--- a/src/xagent/web/channels/slack/bot.py
+++ b/src/xagent/web/channels/slack/bot.py
@@ -70,8 +70,8 @@ _CONTROL_START_COMMANDS = {"/start", "start"}
 _CONTROL_NEW_COMMANDS = {"/new", "new", "new task"}
 _MAX_FILE_DOWNLOAD_REDIRECTS = 5
 _MAX_RECENT_EVENT_IDS = 1000
-# Senders whose resolved identity headers are kept per bot instance. Bounded
-# only as a runaway guard; real workspaces stay far below this.
+# Senders whose resolved identity headers are kept per bot instance. At the
+# cap the oldest entry is evicted (FIFO); real workspaces stay far below this.
 _MAX_SENDER_CONTEXT_CACHE = 10_000
 # Slack rejects message text over 4000 characters. Chunk the source below that
 # and clamp again after conversion, since entity escaping can expand text.
@@ -460,8 +460,12 @@ class SlackBotInstance:
                 slack_user_id,
                 exc_info=True,
             )
-        if len(self._sender_contexts) < _MAX_SENDER_CONTEXT_CACHE:
-            self._sender_contexts[slack_user_id] = sender_context
+        if len(self._sender_contexts) >= _MAX_SENDER_CONTEXT_CACHE:
+            # Evict the oldest entry (dicts preserve insertion order) so
+            # senders arriving after the cap still get cached instead of
+            # paying a users.info call on every message.
+            self._sender_contexts.pop(next(iter(self._sender_contexts)))
+        self._sender_contexts[slack_user_id] = sender_context
         return sender_context
 
     async def _process_event(

--- a/src/xagent/web/channels/slack/bot.py
+++ b/src/xagent/web/channels/slack/bot.py
@@ -70,6 +70,9 @@ _CONTROL_START_COMMANDS = {"/start", "start"}
 _CONTROL_NEW_COMMANDS = {"/new", "new", "new task"}
 _MAX_FILE_DOWNLOAD_REDIRECTS = 5
 _MAX_RECENT_EVENT_IDS = 1000
+# Senders whose resolved identity headers are kept per bot instance. Bounded
+# only as a runaway guard; real workspaces stay far below this.
+_MAX_SENDER_CONTEXT_CACHE = 10_000
 # Slack rejects message text over 4000 characters. Chunk the source below that
 # and clamp again after conversion, since entity escaping can expand text.
 _MAX_SOURCE_CHUNK_CHARS = 3500
@@ -166,6 +169,11 @@ class SlackBotInstance:
         self.event_tasks: dict[str, asyncio.Task[None]] = {}
         self._recent_event_ids: deque[str] = deque(maxlen=_MAX_RECENT_EVENT_IDS)
         self._recent_event_id_set: set[str] = set()
+        # slack_user_id -> "[From: ...]" header (None = resolution failed).
+        # Failures are cached too: a workspace whose install predates the
+        # users:read scope must degrade to unattributed messages, not one
+        # failing API call per message.
+        self._sender_contexts: dict[str, str | None] = {}
         self._accepting = True
         self._deactivation_sync_task: asyncio.Task[None] | None = None
         self._run_forever = asyncio.Event()
@@ -414,6 +422,48 @@ class SlackBotInstance:
             value = event.get("thread_ts") or event.get("ts")
         return str(value) if value else None
 
+    async def _resolve_sender_context(self, slack_user_id: str) -> str | None:
+        """A one-line identity header for the agent-facing prompt.
+
+        Slack events carry only the sender's opaque user id, so without this
+        the agent cannot address the person or tell workspace members apart
+        in a shared channel. The profile is fetched once per sender per
+        instance; a failed lookup (most commonly an install that predates the
+        users:read scope) is cached as None so the turn proceeds
+        unattributed instead of retrying the API on every message.
+        """
+        if slack_user_id in self._sender_contexts:
+            return self._sender_contexts[slack_user_id]
+        sender_context: str | None = None
+        try:
+            response = await self.web_client.users_info(user=slack_user_id)
+            user = response.get("user")
+            user = user if isinstance(user, dict) else {}
+            profile = user.get("profile")
+            profile = profile if isinstance(profile, dict) else {}
+            name = str(
+                profile.get("display_name")
+                or profile.get("real_name")
+                or user.get("real_name")
+                or user.get("name")
+                or ""
+            ).strip()
+            if name:
+                title = str(profile.get("title") or "").strip()
+                sender_context = (
+                    f"[From: {name} ({title})]" if title else f"[From: {name}]"
+                )
+        except Exception:
+            logger.info(
+                "Slack users.info failed for %s; messages will be unattributed"
+                " (is the users:read scope granted?)",
+                slack_user_id,
+                exc_info=True,
+            )
+        if len(self._sender_contexts) < _MAX_SENDER_CONTEXT_CACHE:
+            self._sender_contexts[slack_user_id] = sender_context
+        return sender_context
+
     async def _process_event(
         self,
         conversation_key: str,
@@ -521,7 +571,13 @@ class SlackBotInstance:
             turn_id = str(uuid4())
             context: dict[str, Any] = {"turn_id": turn_id}
             display_message = text
-            execution_text = prompt_text
+            # Agent-facing text only: the persisted transcript and the Slack
+            # UI keep the raw message; the identity header lets the agent
+            # address the sender and tell workspace members apart.
+            sender_context = await self._resolve_sender_context(slack_user_id)
+            execution_text = (
+                f"{sender_context}\n{prompt_text}" if sender_context else prompt_text
+            )
             persisted_attachments: list[dict[str, Any]] = []
 
             if files:
@@ -542,7 +598,7 @@ class SlackBotInstance:
                     names = ", ".join(str(item["name"]) for item in uploaded_info)
                     display_message = f"Attached file(s): {names}"
                 execution_text = append_uploaded_files_context(
-                    prompt_text,
+                    execution_text,
                     build_uploaded_files_context(uploaded_info),
                 )
                 if is_new_task:

--- a/tests/web/test_slack_channel.py
+++ b/tests/web/test_slack_channel.py
@@ -1549,3 +1549,30 @@ async def test_sender_identity_survives_the_attachment_context(
     task_text = executed[0]["task"]
     assert task_text.startswith("[From: Dana Reyes]\nplease review")
     assert "report.pdf" in task_text  # the files context still follows
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_cache_evicts_oldest_when_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full cache must rotate out the oldest sender, not stop caching:
+    a refuse-to-cache guard would make every sender past the cap pay a
+    users.info call on each of their messages, forever."""
+    bot = make_bot()
+
+    calls: list[str] = []
+
+    async def users_info(*, user: str) -> dict[str, Any]:
+        calls.append(user)
+        return {"user": {"profile": {"display_name": f"Person {user}"}}}
+
+    bot.web_client = SimpleNamespace(users_info=users_info)  # type: ignore[assignment]
+    monkeypatch.setattr("xagent.web.channels.slack.bot._MAX_SENDER_CONTEXT_CACHE", 2)
+
+    assert await bot._resolve_sender_context("U1") == "[From: Person U1]"
+    assert await bot._resolve_sender_context("U2") == "[From: Person U2]"
+    assert await bot._resolve_sender_context("U3") == "[From: Person U3]"
+    assert list(bot._sender_contexts) == ["U2", "U3"]  # U1 was evicted
+
+    assert await bot._resolve_sender_context("U3") == "[From: Person U3]"
+    assert calls == ["U1", "U2", "U3"]  # the repeat U3 lookup hit the cache

--- a/tests/web/test_slack_channel.py
+++ b/tests/web/test_slack_channel.py
@@ -59,6 +59,7 @@ def make_bot() -> SlackBotInstance:
     bot._recent_event_ids = []
     bot._recent_event_id_set = set()
     bot._accepting = True
+    bot._sender_contexts = {}
     return bot
 
 
@@ -1332,3 +1333,219 @@ async def test_successful_slack_turn_reuses_channel_runtime(
         }
     ]
     assert managed.closed is True
+
+
+def _run_turn_harness(
+    monkeypatch: pytest.MonkeyPatch,
+    bot: SlackBotInstance,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Wire the minimal fakes for a full _process_event turn and return the
+    (execute_task kwargs, persisted messages) recorders."""
+    bot._save_active_tasks = lambda: None  # type: ignore[method-assign]
+    lease = TaskLease(task_id=45, runner_id="runner-a", run_id="run-a")
+
+    class FakeManagedLease:
+        heartbeat_task = None
+
+        def __init__(self) -> None:
+            self.lease = lease
+
+        async def finalize_result(self, **_kwargs: Any) -> bool:
+            return True
+
+        async def close(self) -> bool:
+            return True
+
+    async def prepare(**_kwargs: Any) -> Any:
+        return SimpleNamespace(
+            user_id=5,
+            task_id=45,
+            is_new_task=True,
+            managed_lease=FakeManagedLease(),
+        )
+
+    class FakeTracer:
+        def __init__(self) -> None:
+            self.handlers: list[Any] = []
+
+        def add_handler(self, handler: Any) -> None:
+            self.handlers.append(handler)
+
+    agent_service = SimpleNamespace(
+        workspace=None,
+        tracer=FakeTracer(),
+        set_conversation_history=lambda _messages: None,
+        set_execution_context_messages=lambda _messages: None,
+        set_recovered_skill_context=lambda _context: None,
+    )
+    executed: list[dict[str, Any]] = []
+    persisted: list[dict[str, Any]] = []
+
+    class FakeAgentManager:
+        async def get_agent_for_task(self, *_args: Any, **_kwargs: Any) -> Any:
+            return agent_service
+
+        async def execute_task(self, **kwargs: Any) -> dict[str, Any]:
+            executed.append(kwargs)
+            return {"success": True, "output": "Slack reply"}
+
+    async def persist(**kwargs: Any) -> None:
+        persisted.append(kwargs)
+
+    async def send_text(*_args: Any, **_kwargs: Any) -> str:
+        return "loading-ts"
+
+    async def send_final_text(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.web.channels.slack.bot.prepare_channel_task", prepare)
+    monkeypatch.setattr(
+        "xagent.web.channels.slack.bot.load_task_setup_snapshot_sync",
+        lambda *_args: SimpleNamespace(
+            runtime_user=None,
+            conversation_history=(),
+            execution_recovery=TaskExecutionRecoverySnapshot(),
+        ),
+    )
+    monkeypatch.setattr(
+        "xagent.web.channels.slack.bot.get_agent_manager",
+        lambda: FakeAgentManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.channels.slack.bot.persist_channel_user_message", persist
+    )
+    bot._send_text = send_text  # type: ignore[method-assign]
+    bot._send_final_text = send_final_text  # type: ignore[method-assign]
+    return executed, persisted
+
+
+def _im_event(user: str = "U1", text: str = "hello") -> dict[str, Any]:
+    return {
+        "type": "message",
+        "channel_type": "im",
+        "channel": "D1",
+        "user": user,
+        "ts": "1.0",
+        "text": text,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_prefixes_the_agent_text_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The agent sees who is talking; the persisted transcript keeps the raw
+    message the user actually typed."""
+    bot = make_bot()
+    executed, persisted = _run_turn_harness(monkeypatch, bot)
+    calls: list[str] = []
+
+    async def users_info(*, user: str) -> dict[str, Any]:
+        calls.append(user)
+        return {
+            "user": {
+                "name": "dana",
+                "profile": {"display_name": "Dana Reyes", "title": "Data Scientist"},
+            }
+        }
+
+    bot.web_client = SimpleNamespace(users_info=users_info)  # type: ignore[assignment]
+
+    await bot._process_event("T1:D1:U1:direct", {}, _im_event())
+    bot.active_tasks.clear()
+    await bot._process_event("T1:D1:U1:direct", {}, _im_event(text="second"))
+
+    assert executed[0]["task"] == "[From: Dana Reyes (Data Scientist)]\nhello"
+    assert executed[1]["task"] == "[From: Dana Reyes (Data Scientist)]\nsecond"
+    assert persisted[0]["content"] == "hello"
+    assert persisted[1]["content"] == "second"
+    assert calls == ["U1"]  # cached after the first resolution
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_failure_degrades_to_unattributed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing users.info (e.g. an install predating the users:read scope)
+    must not fail the turn, and must not retry the API per message."""
+    bot = make_bot()
+    executed, persisted = _run_turn_harness(monkeypatch, bot)
+    calls: list[str] = []
+
+    async def users_info(*, user: str) -> dict[str, Any]:
+        calls.append(user)
+        raise RuntimeError("missing_scope")
+
+    bot.web_client = SimpleNamespace(users_info=users_info)  # type: ignore[assignment]
+
+    await bot._process_event("T1:D1:U1:direct", {}, _im_event())
+    bot.active_tasks.clear()
+    await bot._process_event("T1:D1:U1:direct", {}, _im_event(text="second"))
+
+    assert executed[0]["task"] == "hello"
+    assert executed[1]["task"] == "second"
+    assert persisted[0]["content"] == "hello"
+    assert calls == ["U1"]  # the failure is cached, not retried per message
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_without_title_uses_name_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bot = make_bot()
+    executed, _persisted = _run_turn_harness(monkeypatch, bot)
+
+    async def users_info(*, user: str) -> dict[str, Any]:
+        del user
+        return {"user": {"real_name": "Gerard Soto", "profile": {}}}
+
+    bot.web_client = SimpleNamespace(users_info=users_info)  # type: ignore[assignment]
+
+    await bot._process_event("T1:D1:U1:direct", {}, _im_event())
+
+    assert executed[0]["task"] == "[From: Gerard Soto]\nhello"
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_survives_the_attachment_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The uploaded-files context is appended to the attributed text; building
+    it from the raw prompt would silently drop the identity header whenever a
+    message carries attachments."""
+    bot = make_bot()
+    executed, _persisted = _run_turn_harness(monkeypatch, bot)
+
+    async def users_info(*, user: str) -> dict[str, Any]:
+        del user
+        return {"user": {"profile": {"display_name": "Dana Reyes"}}}
+
+    bot.web_client = SimpleNamespace(users_info=users_info)  # type: ignore[assignment]
+
+    async def download(**_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "file_id": "f1",
+                "name": "report.pdf",
+                "path": "/tmp/report.pdf",
+                "type": "application/pdf",
+                "size": 10,
+            }
+        ]
+
+    bot._download_and_register_files = download  # type: ignore[method-assign]
+
+    async def update_fields(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "xagent.web.channels.slack.bot.update_channel_task_fields", update_fields
+    )
+
+    event = _im_event(text="please review")
+    event["files"] = [{"id": "F1", "name": "report.pdf"}]
+    await bot._process_event("T1:D1:U1:direct", {}, event)
+
+    task_text = executed[0]["task"]
+    assert task_text.startswith("[From: Dana Reyes]\nplease review")
+    assert "report.pdf" in task_text  # the files context still follows


### PR DESCRIPTION
## Summary

Slack events carry only the sender's opaque user id, so the agent had no idea who it was talking to — it could not address the person and, in a shared channel, could not tell workspace members apart. This closes that gap:

- the bot resolves the sender's profile via `users.info` once per sender per instance (cached — including failures, so an install that predates the new scope degrades to unattributed messages instead of one failing API call per message)
- the agent-facing text gets a `[From: Dana Reyes (Data Scientist)]` header; the persisted transcript and everything the user sees keep the raw message
- the header survives the uploaded-files context (the files branch now appends to the attributed text), and resolution runs only after the sender passes channel authorization, so unauthorized senders never trigger an API call
- `users:read` joins the OAuth install scopes; `example.env` documents the reinstall note

Orthogonal to #1130: that PR decides *which agent* answers a channel; this one tells the agent *who is asking*.

## Why

The immediate consumer is Toby (xorbitsai/xagent-saas#385), whose product spec literally opens with "Hey Gerard! … I hear you're the Data Scientist & AI Manager here" — impossible without sender identity. The capability is generic though: any Slack workspace agent benefits, and nothing here is product-specific.

## Validation

- `pytest tests/web/test_slack_channel.py` — 54 passed (4 new: header on the agent text with the transcript unchanged plus per-sender caching, failure degradation without per-message retries, name-only formatting, attachment-context interaction)
- ruff check / format clean

## Notes for reviewers

- The header is prepended to user-controlled text, so a user could type a fake `[From: …]` line in their own message body; it carries exactly the same trust as the rest of their message, which the agent already treats as user input.
- Existing installs lack `users:read` until reinstalled through the OAuth flow; behaviour is unchanged for them (log line at INFO, one per sender).
