### PR TITLE
fix(gmail): drop DISTINCT from the trigger lookup over json config

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -217,8 +217,7 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pip install pytest-asyncio
-          pytest tests/web/services/test_gmail_provisioning.py \
-            -k "contend or postgresql_gmail_trigger_lookup" -q
+          pytest tests/web/services/test_gmail_provisioning.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -213,11 +213,12 @@ jobs:
         env:
           DATABASE_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
-      - name: Test Gmail provisioning row-lock contention (Postgres-only)
+      - name: Test Gmail provisioning Postgres-only behavior
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pip install pytest-asyncio
-          pytest tests/web/services/test_gmail_provisioning.py -k contend -q
+          pytest tests/web/services/test_gmail_provisioning.py \
+            -k "contend or postgresql_gmail_trigger_lookup" -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -255,6 +255,10 @@ def _referenced_gmail_oauth_account_ids(
         AgentTrigger.config["oauth_account_id"].as_string(),
         String,
     )
+    # No DISTINCT here: the projection selects the ``json`` config column, and
+    # PostgreSQL has no equality operator for ``json``, so SELECT DISTINCT
+    # fails there while passing on SQLite. Duplicate rows are harmless because
+    # the loop below accumulates into a set.
     candidate_rows = (
         db.query(AgentTrigger.config, AgentTrigger.resource_id)
         .filter(
@@ -265,7 +269,6 @@ def _referenced_gmail_oauth_account_ids(
                 func.lower(AgentTrigger.resource_id).in_(account_ids_by_email),
             ),
         )
-        .distinct()
         .all()
     )
 

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -2068,6 +2068,7 @@ def pg_session():
         Base.metadata.drop_all(bind=engine)
 
 
+@pytest.mark.postgresql
 def test_postgresql_transition_lock_contends_per_oauth_account(
     pg_session: Session,
 ) -> None:
@@ -2131,6 +2132,7 @@ def test_postgresql_transition_lock_contends_per_oauth_account(
     assert errors == []
 
 
+@pytest.mark.postgresql
 def test_release_and_reprovision_contend_on_the_watch_state_lock(
     pg_session: Session,
 ) -> None:
@@ -2277,6 +2279,7 @@ def test_first_time_creation_race_adopts_winner_row(
     assert db_session.query(GmailWatchState).count() == 1
 
 
+@pytest.mark.postgresql
 def test_concurrent_first_time_creations_race_on_the_unique_constraint(
     pg_session: Session,
 ) -> None:
@@ -2343,7 +2346,8 @@ def test_concurrent_first_time_creations_race_on_the_unique_constraint(
     assert rows[0].email == "owner@gmail.example"
 
 
-def test_postgresql_gmail_trigger_lookup_selects_the_json_config(
+@pytest.mark.postgresql
+def test_gmail_trigger_lookup_resolves_bindings_on_postgresql(
     pg_session: Session,
 ) -> None:
     """Resolve trigger bindings on the engine that rejects ``json`` equality.

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -1545,7 +1545,9 @@ def test_reconcile_bounds_gmail_trigger_lookup_to_each_watch_page(
     assert result.changed == 2
     assert len(trigger_selects) == 2
     assert all(" IN (" in statement for statement in trigger_selects)
-    assert all("SELECT DISTINCT" in statement for statement in trigger_selects)
+    # The projection includes the ``json`` config column, which PostgreSQL
+    # cannot compare, so the lookup must never be a SELECT DISTINCT.
+    assert not any("DISTINCT" in statement.upper() for statement in trigger_selects)
     assert len(watch_selects) == 3
     assert all("LIMIT" in statement for statement in watch_selects)
 
@@ -2339,6 +2341,33 @@ def test_concurrent_first_time_creations_race_on_the_unique_constraint(
     assert str(rows[0].callback_id) == results["a"]
     assert rows[0].status == TriggerProvisioningStatus.PENDING.value
     assert rows[0].email == "owner@gmail.example"
+
+
+def test_postgresql_gmail_trigger_lookup_selects_the_json_config(
+    pg_session: Session,
+) -> None:
+    """Resolve trigger bindings on the engine that rejects ``json`` equality.
+
+    The lookup projects ``agent_triggers.config``, a ``JSON`` column. SQLite
+    compares it happily, so only PostgreSQL can prove the query never asks for
+    an equality operator the type does not have: a SELECT DISTINCT here fails
+    with "could not identify an equality operator for type json", which broke
+    every Gmail OAuth (re)connect, the retry sweep, and push reconciliation.
+    Two triggers share one binding so deduplication is still covered.
+    """
+    db = pg_session
+    user = _create_user(db)
+    agent = _create_agent(db, user)
+    account = _create_oauth(db, user)
+    _create_gmail_trigger(db, user, agent, account)
+    _create_gmail_trigger(db, user, agent, account)
+
+    referenced = gmail_provisioning._referenced_gmail_oauth_account_ids(
+        db,
+        [(int(account.id), str(account.email or ""))],
+    )
+
+    assert referenced == {int(account.id)}
 
 
 def test_provisioning_requires_account_email(db_session: Session) -> None:


### PR DESCRIPTION
## Summary

Connecting (or reconnecting) a Gmail account on any PostgreSQL deployment
fails. The OAuth token is stored correctly, then the callback dies and the
browser shows `Authentication Failed`:

```
(psycopg2.errors.UndefinedFunction) could not identify an equality operator
for type json
[SQL: SELECT DISTINCT agent_triggers.config AS agent_triggers_config,
 agent_triggers.resource_id AS agent_triggers_resource_id
 FROM agent_triggers WHERE agent_triggers.type = %(type_1)s
 AND agent_triggers.enabled IS true AND (...)]
```

## Root cause

`_referenced_gmail_oauth_account_ids` projects `agent_triggers.config`, which
is a `Column(JSON)`, and wrapped the query in `SELECT DISTINCT`. PostgreSQL
has no equality operator for `json`, so it cannot deduplicate that
projection. SQLite has no such restriction, which is why local runs and CI
stayed green.

Introduced by 478333c0 (#1024).

## Blast radius

Three call sites share the helper, so the failure is not limited to the
connect flow:

| Call site | Trigger | Effect |
| --- | --- | --- |
| `best_effort_provision_gmail_watches_for_user` | after an OAuth Gmail (re)connect | callback 500s; the docstring's "never raised" guarantee is broken because the lookup runs outside the per-account guard |
| `sweep_gmail_provisioning` | periodic retry of pending/failed watches | sweep raises, so failed watches are never retried |
| `reconcile_gmail_push_endpoints` | the operator command in xagent-saas#322's rollout steps 4 and 5 | reconciliation cannot run |

Verified on staging (`main-f1eeb5f7`, PostgreSQL 16): the Gmail token lands in
`user_oauth` with `gmail.modify`, and the callback still fails. Production
images predate #1024 and are unaffected today, but the next deploy that
carries #1024 - the same deploy that fixes regional push callbacks - would
break Gmail connects in both regions.

## Fix

Drop the `.distinct()`. It was redundant: the caller accumulates matches into
`referenced: set[int]`, so duplicate candidate rows already collapse in
Python. Results are identical on both engines and no schema change is needed.

## Tests

- New `test_postgresql_gmail_trigger_lookup_selects_the_json_config` runs the
  helper against real PostgreSQL with two triggers bound to one account, so it
  covers both the rejected operator and the surviving deduplication. It fails
  with the production error before this change.
- The Postgres job's selector was `-k contend`, which would never have picked
  the new test up, so it is now
  `-k "contend or postgresql_gmail_trigger_lookup"`. The job's path filter
  already includes `gmail_provisioning.py` and its test file, so it runs for
  this PR.
- `test_reconcile_bounds_gmail_trigger_lookup_to_each_watch_page` asserted
  `SELECT DISTINCT` was present. That expectation encoded the bug; it now
  asserts DISTINCT is absent, which keeps an always-on guard in the SQLite
  job. Its original intent - one bounded `IN (...)` lookup per watch page - is
  unchanged.
- Full file: 49 passed, 4 PostgreSQL-only skipped locally. Ruff, ruff format,
  mypy, isort and codespell pass.