### PR TITLE
feat: make sidebar nav groups collapsible with configurable default state

### DIFF
--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,13 +1,18 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { Globe } from "lucide-react"
 import React from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { NavigationGroup } from "@/lib/sidebar-navigation"
 
 import { Sidebar } from "./sidebar"
 
 const authState = vi.hoisted(() => ({ logout: vi.fn<() => Promise<boolean>>(), user: { id: "1", username: "alice" } }))
 const toast = vi.hoisted(() => ({ error: vi.fn() }))
+const routeState = vi.hoisted(() => ({ pathname: "/task" }))
+const navState = vi.hoisted(() => ({ groups: [] as unknown[] }))
 
-vi.mock("next/navigation", () => ({ usePathname: () => "/task", useRouter: () => ({ push: vi.fn() }) }))
+vi.mock("next/navigation", () => ({ usePathname: () => routeState.pathname, useRouter: () => ({ push: vi.fn() }) }))
 vi.mock("next/image", () => ({ default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} /> }))
 vi.mock("next/link", () => ({ default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a> }))
 vi.mock("@/contexts/auth-context", () => ({ useAuth: () => authState }))
@@ -17,7 +22,7 @@ vi.mock("@/components/ui/sonner", () => ({ toast }))
 vi.mock("@/lib/branding", () => ({ getBrandingFromEnv: () => ({ appName: "Xagent" }) }))
 vi.mock("@/lib/extra-nav", () => ({ default: [] }))
 vi.mock("@/lib/sidebar-navigation", () => ({
-  getNavigationGroupsForUser: () => [], getUserMenuItemsForUser: () => [],
+  getNavigationGroupsForUser: () => navState.groups, getUserMenuItemsForUser: () => [],
 }))
 
 describe("Sidebar logout", () => {
@@ -25,9 +30,14 @@ describe("Sidebar logout", () => {
     authState.logout.mockReset()
     toast.error.mockReset()
     authState.logout.mockResolvedValue(false)
+    routeState.pathname = "/task"
+    navState.groups = []
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })))
   })
-  afterEach(() => vi.unstubAllGlobals())
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
 
   it("keeps the menu open and reports a localized failure when logout cannot clear auth", async () => {
     render(<Sidebar />)
@@ -36,5 +46,55 @@ describe("Sidebar logout", () => {
     await waitFor(() => expect(authState.logout).toHaveBeenCalledOnce())
     expect(toast.error).toHaveBeenCalledWith("sidebar.user.logoutFailed")
     expect(screen.getByRole("button", { name: "sidebar.user.logoutTitle" })).toBeInTheDocument()
+  })
+})
+
+describe("Sidebar collapsible nav groups", () => {
+  const RESOURCES_GROUP: NavigationGroup = {
+    title: "Resources",
+    defaultCollapsed: true,
+    items: [{ name: "Knowledge Base", href: "/kb", icon: Globe }],
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })))
+    navState.groups = [RESOURCES_GROUP]
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it("collapses a defaultCollapsed group by default and expands on click", () => {
+    routeState.pathname = "/task"
+    render(<Sidebar />)
+
+    const header = screen.getByRole("button", { name: "Resources" })
+    expect(header).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("link", { name: "Knowledge Base" })).not.toBeInTheDocument()
+
+    fireEvent.click(header)
+    expect(header).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("link", { name: "Knowledge Base" })).toBeInTheDocument()
+  })
+
+  it("auto-expands a defaultCollapsed group when it owns the active route", () => {
+    routeState.pathname = "/kb"
+    render(<Sidebar />)
+
+    expect(screen.getByRole("button", { name: "Resources" })).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("link", { name: "Knowledge Base" })).toBeInTheDocument()
+  })
+
+  it("keeps an explicit collapse even while the group owns the active route", () => {
+    routeState.pathname = "/kb"
+    render(<Sidebar />)
+
+    const header = screen.getByRole("button", { name: "Resources" })
+    expect(header).toHaveAttribute("aria-expanded", "true")
+
+    fireEvent.click(header)
+    expect(header).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("link", { name: "Knowledge Base" })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -241,6 +241,20 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
 
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedMenus, setExpandedMenus] = useState<string[]>(["/agent"]) // Use href as a stable key
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(navigationGroups.filter(g => g.defaultCollapsed).map(g => g.title))
+  )
+  const toggleGroupCollapse = useCallback((title: string) => {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(title)) {
+        next.delete(title)
+      } else {
+        next.add(title)
+      }
+      return next
+    })
+  }, [])
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [isAboutOpen, setIsAboutOpen] = useState(false)
   const sidebarRef = useRef<HTMLDivElement | null>(null)
@@ -521,7 +535,7 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
       }, 100)
       return () => clearTimeout(timer)
     }
-  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded])
+  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, collapsedGroups])
 
   useEffect(() => {
     if (isHistoryExpanded) {
@@ -723,11 +737,18 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
           className="z-10 bg-transparent py-1"
         >
           {/* Groups */}
-          {navigationGroups.map((group, groupIndex) => (
+          {navigationGroups.map((group, groupIndex) => {
+            const isGroupCollapsed = collapsedGroups.has(group.title)
+            return (
             <div key={group.title} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
-              <div className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em]">
-                {group.titleKey ? t(group.titleKey) : group.title}
+              <div
+                className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none"
+                onClick={() => toggleGroupCollapse(group.title)}
+              >
+                <span>{group.titleKey ? t(group.titleKey) : group.title}</span>
+                {isGroupCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
               </div>
+              {!isGroupCollapsed && (
               <div className="space-y-0.5">
                 {group.items.map((item: NavigationItem) => {
                   const isActive = isItemActive(item)
@@ -803,8 +824,10 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
                   )
                 })}
               </div>
+              )}
             </div>
-          ))}
+            )
+          })}
         </nav>
 
         {/* History Section */}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -241,19 +241,12 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
 
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedMenus, setExpandedMenus] = useState<string[]>(["/agent"]) // Use href as a stable key
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
-    () => new Set(navigationGroups.filter(g => g.defaultCollapsed).map(g => g.title))
-  )
-  const toggleGroupCollapse = useCallback((title: string) => {
-    setCollapsedGroups(prev => {
-      const next = new Set(prev)
-      if (next.has(title)) {
-        next.delete(title)
-      } else {
-        next.add(title)
-      }
-      return next
-    })
+  const [groupCollapseOverrides, setGroupCollapseOverrides] = useState<Record<string, boolean>>({})
+  const toggleGroupCollapse = useCallback((title: string, defaultCollapsed?: boolean) => {
+    setGroupCollapseOverrides(prev => ({
+      ...prev,
+      [title]: !(title in prev ? prev[title] : !!defaultCollapsed),
+    }))
   }, [])
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [isAboutOpen, setIsAboutOpen] = useState(false)
@@ -535,7 +528,7 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
       }, 100)
       return () => clearTimeout(timer)
     }
-  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, collapsedGroups])
+  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, groupCollapseOverrides])
 
   useEffect(() => {
     if (isHistoryExpanded) {
@@ -738,12 +731,23 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
         >
           {/* Groups */}
           {navigationGroups.map((group, groupIndex) => {
-            const isGroupCollapsed = collapsedGroups.has(group.title)
+            const isGroupCollapsed = group.title in groupCollapseOverrides
+              ? groupCollapseOverrides[group.title]
+              : !!group.defaultCollapsed
             return (
             <div key={group.title} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
               <div
-                className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none"
-                onClick={() => toggleGroupCollapse(group.title)}
+                role="button"
+                tabIndex={0}
+                aria-expanded={!isGroupCollapsed}
+                className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none outline-none"
+                onClick={() => toggleGroupCollapse(group.title, group.defaultCollapsed)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    toggleGroupCollapse(group.title, group.defaultCollapsed)
+                  }
+                }}
               >
                 <span>{group.titleKey ? t(group.titleKey) : group.title}</span>
                 {isGroupCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -246,12 +246,12 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
   // an active-route auto-expand, or a previous toggle) so a click always changes what
   // the user sees — recomputing from defaultCollapsed here would make the first click
   // a no-op whenever the group was auto-expanded by the active route.
-  const toggleGroupCollapse = useCallback((title: string, currentCollapsed: boolean) => {
+  const toggleGroupCollapse = (key: string, currentCollapsed: boolean) => {
     setGroupCollapseOverrides(prev => ({
       ...prev,
-      [title]: !currentCollapsed,
+      [key]: !currentCollapsed,
     }))
-  }, [])
+  }
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [isAboutOpen, setIsAboutOpen] = useState(false)
   const sidebarRef = useRef<HTMLDivElement | null>(null)
@@ -532,9 +532,10 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
       }, 100)
       return () => clearTimeout(timer)
     }
-    // groupCollapseOverrides isn't read above — it's a re-measure trigger: toggling a group
+    // groupCollapseOverrides and pathname aren't read above — they're re-measure triggers:
+    // toggling a group, or navigating to/from a route that auto-expands/collapses a group,
     // changes contentScrollRef's scrollHeight, so this effect must re-run to re-check the fill.
-  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, groupCollapseOverrides])
+  }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, groupCollapseOverrides, pathname])
 
   useEffect(() => {
     if (isHistoryExpanded) {
@@ -737,30 +738,26 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
         >
           {/* Groups */}
           {navigationGroups.map((group, groupIndex) => {
+            // Groups without a stable `id` (e.g. extra-nav overlays) fall back to `title` —
+            // matches the pre-`id` behavior for anything that hasn't opted in yet.
+            const groupKey = group.id ?? group.title
             // An active route overrides only the *default* collapsed state, so the current
             // page is never hidden inside a collapsed group on first load — but an explicit
             // user toggle always wins over that, so the group can still be collapsed manually.
-            const isGroupCollapsed = group.title in groupCollapseOverrides
-              ? groupCollapseOverrides[group.title]
+            const isGroupCollapsed = groupKey in groupCollapseOverrides
+              ? groupCollapseOverrides[groupKey]
               : !!group.defaultCollapsed && !group.items.some(isItemActive)
             return (
-              <div key={group.title} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
-                <div
-                  role="button"
-                  tabIndex={0}
+              <div key={groupKey} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
+                <button
+                  type="button"
                   aria-expanded={!isGroupCollapsed}
-                  className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none rounded transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  onClick={() => toggleGroupCollapse(group.title, isGroupCollapsed)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault()
-                      toggleGroupCollapse(group.title, isGroupCollapsed)
-                    }
-                  }}
+                  className="w-full px-2 py-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between text-left cursor-pointer select-none rounded transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => toggleGroupCollapse(groupKey, isGroupCollapsed)}
                 >
                   <span>{group.titleKey ? t(group.titleKey) : group.title}</span>
                   {isGroupCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-                </div>
+                </button>
                 {!isGroupCollapsed && (
                   <div className="space-y-0.5">
                     {group.items.map((item: NavigationItem) => {

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -242,10 +242,14 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedMenus, setExpandedMenus] = useState<string[]>(["/agent"]) // Use href as a stable key
   const [groupCollapseOverrides, setGroupCollapseOverrides] = useState<Record<string, boolean>>({})
-  const toggleGroupCollapse = useCallback((title: string, defaultCollapsed?: boolean) => {
+  // Flip from the collapsed state currently rendered (which may come from the default,
+  // an active-route auto-expand, or a previous toggle) so a click always changes what
+  // the user sees — recomputing from defaultCollapsed here would make the first click
+  // a no-op whenever the group was auto-expanded by the active route.
+  const toggleGroupCollapse = useCallback((title: string, currentCollapsed: boolean) => {
     setGroupCollapseOverrides(prev => ({
       ...prev,
-      [title]: !(title in prev ? prev[title] : !!defaultCollapsed),
+      [title]: !currentCollapsed,
     }))
   }, [])
   const [showUserMenu, setShowUserMenu] = useState(false)
@@ -528,6 +532,8 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
       }, 100)
       return () => clearTimeout(timer)
     }
+    // groupCollapseOverrides isn't read above — it's a re-measure trigger: toggling a group
+    // changes contentScrollRef's scrollHeight, so this effect must re-run to re-check the fill.
   }, [tasks, hasMore, isLoadingMore, isLoadingTasks, page, loadTasks, isHistoryExpanded, groupCollapseOverrides])
 
   useEffect(() => {
@@ -731,105 +737,108 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
         >
           {/* Groups */}
           {navigationGroups.map((group, groupIndex) => {
+            // An active route overrides only the *default* collapsed state, so the current
+            // page is never hidden inside a collapsed group on first load — but an explicit
+            // user toggle always wins over that, so the group can still be collapsed manually.
             const isGroupCollapsed = group.title in groupCollapseOverrides
               ? groupCollapseOverrides[group.title]
-              : !!group.defaultCollapsed
+              : !!group.defaultCollapsed && !group.items.some(isItemActive)
             return (
-            <div key={group.title} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
-              <div
-                role="button"
-                tabIndex={0}
-                aria-expanded={!isGroupCollapsed}
-                className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none outline-none"
-                onClick={() => toggleGroupCollapse(group.title, group.defaultCollapsed)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    toggleGroupCollapse(group.title, group.defaultCollapsed)
-                  }
-                }}
-              >
-                <span>{group.titleKey ? t(group.titleKey) : group.title}</span>
-                {isGroupCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-              </div>
-              {!isGroupCollapsed && (
-              <div className="space-y-0.5">
-                {group.items.map((item: NavigationItem) => {
-                  const isActive = isItemActive(item)
-                  const hasChildren = item.children && item.children.length > 0
-                  const isExpanded = isMenuExpanded(item.href)
+              <div key={group.title} className={cn("mb-4", groupIndex === 0 && "mt-0")}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={!isGroupCollapsed}
+                  className="px-2 pb-1.5 text-[10.5px] font-semibold text-muted-foreground uppercase tracking-[0.08em] flex items-center justify-between cursor-pointer select-none rounded transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => toggleGroupCollapse(group.title, isGroupCollapsed)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      toggleGroupCollapse(group.title, isGroupCollapsed)
+                    }
+                  }}
+                >
+                  <span>{group.titleKey ? t(group.titleKey) : group.title}</span>
+                  {isGroupCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+                </div>
+                {!isGroupCollapsed && (
+                  <div className="space-y-0.5">
+                    {group.items.map((item: NavigationItem) => {
+                      const isActive = isItemActive(item)
+                      const hasChildren = item.children && item.children.length > 0
+                      const isExpanded = isMenuExpanded(item.href)
 
-                  const activeStyle = "bg-primary/[0.09] text-[hsl(var(--sidebar-active-text))] font-semibold rounded-[7px]"
-                  const inactiveStyle = "text-muted-foreground hover:bg-accent hover:text-foreground rounded-[7px]"
+                      const activeStyle = "bg-primary/[0.09] text-[hsl(var(--sidebar-active-text))] font-semibold rounded-[7px]"
+                      const inactiveStyle = "text-muted-foreground hover:bg-accent hover:text-foreground rounded-[7px]"
 
-                  if (hasChildren) {
-                    return (
-                      <Popover key={item.name} open={isExpanded} onOpenChange={() => toggleMenu(item.href)}>
-                        <PopoverTrigger asChild>
-                          <button
-                            className={cn(
-                              "group flex items-center justify-between px-2.5 py-2 text-[13.5px] transition-colors relative w-full",
-                              isActive ? activeStyle : inactiveStyle
+                      if (hasChildren) {
+                        return (
+                          <Popover key={item.name} open={isExpanded} onOpenChange={() => toggleMenu(item.href)}>
+                            <PopoverTrigger asChild>
+                              <button
+                                className={cn(
+                                  "group flex items-center justify-between px-2.5 py-2 text-[13.5px] transition-colors relative w-full",
+                                  isActive ? activeStyle : inactiveStyle
+                                )}
+                              >
+                                <div className="flex items-center gap-2.5">
+                                  <item.icon className={cn("h-4 w-4", isActive ? "text-[hsl(var(--sidebar-active-text))]" : "text-muted-foreground")} />
+                                  {item.nameKey ? t(item.nameKey) : item.name}
+                                </div>
+                                <ChevronRight className="h-3 w-3 opacity-50" />
+                              </button>
+                            </PopoverTrigger>
+                            {item.children && (
+                              <PopoverContent
+                                side="right"
+                                align="start"
+                                sideOffset={8}
+                                className="w-56 rounded-xl border border-border bg-popover p-2 shadow-lg"
+                              >
+                                <div className="space-y-0.5">
+                                  {item.children.map((child: NavigationItem) => {
+                                    const isChildActive = pathname === child.href
+                                    return (
+                                      <Link
+                                        key={child.href}
+                                        href={child.href}
+                                        onClick={() => toggleMenu(item.href)}
+                                        className={cn(
+                                          "flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-[13.5px] font-medium transition-colors",
+                                          isChildActive
+                                            ? "bg-primary/[0.09] text-[hsl(var(--sidebar-active-text))]"
+                                            : "text-foreground hover:bg-accent"
+                                        )}
+                                      >
+                                        <child.icon className="h-4 w-4 text-muted-foreground" />
+                                        {child.nameKey ? t(child.nameKey) : child.name}
+                                      </Link>
+                                    )
+                                  })}
+                                </div>
+                              </PopoverContent>
                             )}
-                          >
-                            <div className="flex items-center gap-2.5">
-                              <item.icon className={cn("h-4 w-4", isActive ? "text-[hsl(var(--sidebar-active-text))]" : "text-muted-foreground")} />
-                              {item.nameKey ? t(item.nameKey) : item.name}
-                            </div>
-                            <ChevronRight className="h-3 w-3 opacity-50" />
-                          </button>
-                        </PopoverTrigger>
-                        {item.children && (
-                          <PopoverContent
-                            side="right"
-                            align="start"
-                            sideOffset={8}
-                            className="w-56 rounded-xl border border-border bg-popover p-2 shadow-lg"
-                          >
-                            <div className="space-y-0.5">
-                              {item.children.map((child: NavigationItem) => {
-                                const isChildActive = pathname === child.href
-                                return (
-                                  <Link
-                                    key={child.href}
-                                    href={child.href}
-                                    onClick={() => toggleMenu(item.href)}
-                                    className={cn(
-                                      "flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-[13.5px] font-medium transition-colors",
-                                      isChildActive
-                                        ? "bg-primary/[0.09] text-[hsl(var(--sidebar-active-text))]"
-                                        : "text-foreground hover:bg-accent"
-                                    )}
-                                  >
-                                    <child.icon className="h-4 w-4 text-muted-foreground" />
-                                    {child.nameKey ? t(child.nameKey) : child.name}
-                                  </Link>
-                                )
-                              })}
-                            </div>
-                          </PopoverContent>
-                        )}
-                      </Popover>
-                    )
-                  }
+                          </Popover>
+                        )
+                      }
 
-                  return (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      className={cn(
-                        "group flex items-center px-2.5 py-2 text-[13.5px] font-medium transition-colors",
-                        isActive ? activeStyle : inactiveStyle
-                      )}
-                    >
-                      <item.icon className={cn("h-4 w-4 mr-2.5", isActive ? "text-[hsl(var(--sidebar-active-text))]" : "text-muted-foreground")} />
-                      {item.nameKey ? t(item.nameKey) : item.name}
-                    </Link>
-                  )
-                })}
+                      return (
+                        <Link
+                          key={item.name}
+                          href={item.href}
+                          className={cn(
+                            "group flex items-center px-2.5 py-2 text-[13.5px] font-medium transition-colors",
+                            isActive ? activeStyle : inactiveStyle
+                          )}
+                        >
+                          <item.icon className={cn("h-4 w-4 mr-2.5", isActive ? "text-[hsl(var(--sidebar-active-text))]" : "text-muted-foreground")} />
+                          {item.nameKey ? t(item.nameKey) : item.name}
+                        </Link>
+                      )
+                    })}
+                  </div>
+                )}
               </div>
-              )}
-            </div>
             )
           })}
         </nav>

--- a/frontend/src/lib/sidebar-navigation.test.ts
+++ b/frontend/src/lib/sidebar-navigation.test.ts
@@ -24,4 +24,24 @@ describe("sidebar navigation", () => {
     )
     expect(conversationLogs?.icon).not.toBe(channels?.icon)
   })
+
+  it("collapses Resources by default and gives each built-in group a stable id", () => {
+    const groups = getNavigationGroupsForUser({ is_admin: false })
+    const agentDevelopment = groups.find((group) => group.titleKey === "nav.sections.agentDevelopment")
+    const resources = groups.find((group) => group.titleKey === "nav.sections.resources")
+
+    expect(agentDevelopment?.id).toBe("agent-development")
+    expect(agentDevelopment?.defaultCollapsed).toBeFalsy()
+    expect(resources?.id).toBe("resources")
+    expect(resources?.defaultCollapsed).toBe(true)
+  })
+
+  it("keeps the admin-only routes free of trailing slashes so active-route matching works", () => {
+    const groups = getNavigationGroupsForUser({ is_admin: true })
+    const resources = groups.find((group) => group.titleKey === "nav.sections.resources")
+    const more = resources?.items.find((item) => item.href === "__resources_more__")
+
+    expect(more?.children?.find((item) => item.name === "User Management")?.href).toBe("/users")
+    expect(more?.children?.find((item) => item.name === "Public MCP Apps")?.href).toBe("/admin-mcp")
+  })
 })

--- a/frontend/src/lib/sidebar-navigation.ts
+++ b/frontend/src/lib/sidebar-navigation.ts
@@ -39,6 +39,8 @@ export interface NavigationGroup {
     title: string
     titleKey?: TranslationKey
     items: NavigationItem[]
+    /** Whether this group's items are hidden behind a collapse toggle by default. */
+    defaultCollapsed?: boolean
 }
 
 const baseMoreResourceItems: NavigationItem[] = [
@@ -140,6 +142,7 @@ export const getNavigationGroupsForUser = (user?: SidebarUser | null): Navigatio
     {
         title: "Resources",
         titleKey: "nav.sections.resources",
+        defaultCollapsed: true,
         items: [
             {
                 name: "Knowledge Base",

--- a/frontend/src/lib/sidebar-navigation.ts
+++ b/frontend/src/lib/sidebar-navigation.ts
@@ -41,6 +41,12 @@ export interface NavigationGroup {
     items: NavigationItem[]
     /** Whether this group's items are hidden behind a collapse toggle by default. */
     defaultCollapsed?: boolean
+    /**
+     * Stable identity for this group, used instead of `title` for React keys and collapse
+     * state so a downstream-injected group (e.g. via extra-nav) sharing a display title
+     * doesn't collide with a built-in group's identity. Falls back to `title` when unset.
+     */
+    id?: string
 }
 
 const baseMoreResourceItems: NavigationItem[] = [
@@ -88,14 +94,14 @@ const getMoreResourceItemsForUser = (user?: SidebarUser | null): NavigationItem[
         items.push({
             name: "User Management",
             nameKey: "nav.userManagement",
-            href: "/users/",
+            href: "/users",
             icon: Users,
             color: "text-blue-400"
         })
         items.push({
             name: "Public MCP Apps",
             nameKey: "nav.adminMcp",
-            href: "/admin-mcp/",
+            href: "/admin-mcp",
             icon: Server,
             color: "text-blue-400"
         })
@@ -106,6 +112,7 @@ const getMoreResourceItemsForUser = (user?: SidebarUser | null): NavigationItem[
 
 export const getNavigationGroupsForUser = (user?: SidebarUser | null): NavigationGroup[] => [
     {
+        id: "agent-development",
         title: "Agent Development",
         titleKey: "nav.sections.agentDevelopment",
         items: [
@@ -140,6 +147,7 @@ export const getNavigationGroupsForUser = (user?: SidebarUser | null): Navigatio
         ]
     },
     {
+        id: "resources",
         title: "Resources",
         titleKey: "nav.sections.resources",
         defaultCollapsed: true,


### PR DESCRIPTION
## Summary
- Nav groups in the left sidebar ("Agent Development", "Resources") are now
  individually collapsible, matching the existing History section's
  chevron-toggle UX. This addresses the sidebar feeling crowded and pushing
  the task history list out of view.
- Which groups start collapsed is driven by an optional `defaultCollapsed`
  flag on `NavigationGroup` (set on "Resources") instead of a hardcoded group
  title, so nav groups injected via the `extra-nav` overlay (e.g. in
  xagent-saas) can opt into a collapsed-by-default state without any change
  to this repo.
- Fixed a missing dependency in the "auto-load next page if content doesn't
  fill the container" effect so it re-evaluates after a group toggle changes
  the scroll container's height.

## Test plan
- [x] `tsc --noEmit` passes with no new errors
- [x] Registered a test account and logged in locally; confirmed "Resources"
      starts collapsed, "Agent Development" starts expanded, and both toggle
      independently
- [x] Confirmed task history list is now visible without scrolling once
      "Resources" is collapsed
- [x] Checked browser console/network — no errors, `/api/chat/tasks` loads
      normally