### PR TITLE
fix(tools): resync cached WebToolConfig with the resolved per-turn execution scope

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2746,8 +2746,8 @@ class AgentServiceManager:
         agent = self._agents.get(task_id)
         if agent is None:
             return
-        tool_config = getattr(agent, "tool_config", None)
-        if tool_config is None or not hasattr(tool_config, "set_execution_scope"):
+        tool_config = agent.tool_config
+        if tool_config is None:
             return
         if tool_config.set_execution_scope(scope):
             logger.info(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2227,6 +2227,7 @@ class AgentServiceManager:
                             self._sync_connector_runtime_turn(
                                 task_id, connector_runtime_turn_id
                             )
+                            self._sync_execution_scope(task_id, scope)
                             return self._agents[task_id]
                     except (
                         HTTPException,
@@ -2693,6 +2694,7 @@ class AgentServiceManager:
         self._agent_owner_ids[task_id] = runtime_user_id
         self._agent_scope_fingerprints[task_id] = fingerprint
         self._sync_connector_runtime_turn(task_id, connector_runtime_turn_id)
+        self._sync_execution_scope(task_id, scope)
         return self._agents[task_id]
 
     def _sync_connector_runtime_turn(
@@ -2737,6 +2739,21 @@ class AgentServiceManager:
                 task_id,
                 connector_runtime_turn_id,
             )
+
+    def _sync_execution_scope(
+        self, task_id: int, scope: Optional[ExecutionScope]
+    ) -> None:
+        agent = self._agents.get(task_id)
+        if agent is None:
+            return
+        tool_config = getattr(agent, "tool_config", None)
+        if tool_config is None or not hasattr(tool_config, "set_execution_scope"):
+            return
+        if tool_config.set_execution_scope(scope):
+            logger.info(
+                "Refreshing tools for task %s: execution scope advanced", task_id
+            )
+            agent.invalidate_tools()
 
     def remove_agent(self, task_id: int, user_id: Optional[int] = None) -> None:
         """Remove AgentService instance for completed task"""

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2746,8 +2746,12 @@ class AgentServiceManager:
         agent = self._agents.get(task_id)
         if agent is None:
             return
-        tool_config = agent.tool_config
-        if tool_config is None:
+        # getattr/hasattr, not direct access: pause/resume off-turn builds
+        # store agents whose config is a DefaultToolConfig (no
+        # set_execution_scope), and the cached-return path this runs on must
+        # not blow up into the reconstruct fallback for them.
+        tool_config = getattr(agent, "tool_config", None)
+        if tool_config is None or not hasattr(tool_config, "set_execution_scope"):
             return
         if tool_config.set_execution_scope(scope):
             logger.info(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1583,9 +1583,25 @@ class WebToolConfig(BaseToolConfig):
         serving the first turn's object to the OAuth resolver hook.
         Namespace-affecting changes never reach here -- the caller evicts on a
         fingerprint change before this runs.
+
+        No-op only for the same object, or for two plain base
+        ``ExecutionScope`` instances comparing equal: the base class's
+        compared fields fully describe it, and the persisted-snapshot path
+        decodes a fresh equal instance every turn that must not force a tool
+        rebuild. A subclass instance always swaps (unless identical) --
+        subclasses may carry per-turn payload declared ``compare=False``, so
+        value equality cannot prove freshness for them, and two same-type
+        instances differing only in that payload compare equal.
         """
-        if self._execution_scope == scope and type(self._execution_scope) is type(
-            scope
+        from xagent.core.execution_scope import ExecutionScope
+
+        previous = self._execution_scope
+        if previous is scope:
+            return False
+        if (
+            type(previous) is ExecutionScope
+            and type(scope) is ExecutionScope
+            and previous == scope
         ):
             return False
         self._execution_scope = scope

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1573,6 +1573,27 @@ class WebToolConfig(BaseToolConfig):
         self._pending_runtime_policy = None
         return True
 
+    def set_execution_scope(self, scope: Optional[Any]) -> bool:
+        """Switch the per-turn execution scope for a reused tool config.
+
+        ``WebToolConfig`` is cached with ``AgentService`` by task. The scope is
+        per-turn state exactly like the connector runtime turn id: an embedder
+        resolver may return a scope carrying turn-varying data that the base
+        namespace fingerprint does not cover, and a cached config must not keep
+        serving the first turn's object to the OAuth resolver hook.
+        Namespace-affecting changes never reach here -- the caller evicts on a
+        fingerprint change before this runs.
+        """
+        if self._execution_scope == scope and type(self._execution_scope) is type(
+            scope
+        ):
+            return False
+        self._execution_scope = scope
+        self._cached_mcp_configs = None
+        self._factory_runtime_snapshot = None
+        self._pending_runtime_policy = None
+        return True
+
     def _parse_numeric_task_id(self) -> Optional[int]:
         task_id = self._task_id
         if not isinstance(task_id, str) or not task_id:

--- a/tests/web/api/test_agent_cache_scope_fingerprint.py
+++ b/tests/web/api/test_agent_cache_scope_fingerprint.py
@@ -339,6 +339,76 @@ async def test_stable_scope_does_not_evict_between_turns() -> None:
     assert result is cached_agent
 
 
+class _ScopeTrackingToolConfig:
+    """Minimal ``WebToolConfig`` stand-in: records every scope it is handed
+    without exercising the real swap/cache-drop logic (that logic is pinned
+    separately in ``tests/web/tools/test_web_tool_config_session_factory.py``).
+    """
+
+    def __init__(self, scope: ExecutionScope) -> None:
+        self.scope = scope
+        self.set_calls: list[ExecutionScope] = []
+
+    def set_execution_scope(self, scope: ExecutionScope) -> bool:
+        self.set_calls.append(scope)
+        self.scope = scope
+        return True
+
+
+class _CachedAgentWithToolConfig:
+    def __init__(self, tool_config: _ScopeTrackingToolConfig) -> None:
+        self.tool_config = tool_config
+        self.invalidate_calls = 0
+
+    def invalidate_tools(self) -> None:
+        self.invalidate_calls += 1
+
+    def cleanup_workspace(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cached_agent_service_is_resynced_with_the_turn_execution_scope() -> None:
+    """A same-fingerprint scope change keeps the cached AgentService (no
+    rebuild), but the resolved scope for THIS turn must still reach the
+    cached tool config -- otherwise a resolver that hands back a scope
+    object carrying turn-varying data outside the namespace fingerprint
+    (here: ``strict_memory_isolation``, which ``scope_fingerprint`` doesn't
+    cover) would leave the OAuth resolver hook reading the first turn's
+    scope object forever.
+
+    Also covers the ``connector_runtime_turn_id=None`` case: unlike
+    ``_sync_connector_runtime_turn``, the execution-scope resync must not be
+    gated on a turn id being present.
+    """
+    tool_config = _ScopeTrackingToolConfig(SCOPE_A)
+    cached_agent = _CachedAgentWithToolConfig(tool_config)
+    manager = AgentServiceManager()
+    manager._agents[42] = cached_agent
+    manager._agent_owner_ids[42] = 1
+    manager._agent_scope_fingerprints[42] = scope_fingerprint(SCOPE_A)
+
+    scope_b = ExecutionScope(
+        sandbox_key_suffix="tenant-a", strict_memory_isolation=True
+    )
+    assert scope_fingerprint(scope_b) == scope_fingerprint(SCOPE_A)
+    assert scope_b != SCOPE_A
+
+    result = await manager.get_agent_for_task(
+        task_id=42,
+        db=_build_db_mock(_make_task_row()),
+        user=_make_user(),
+        task_setup_snapshot=_build_snapshot(),
+        connector_runtime_turn_id=None,
+        resolved_execution_scope=scope_b,
+    )
+
+    assert result is cached_agent
+    assert tool_config.scope is scope_b
+    assert tool_config.set_calls == [scope_b]
+    assert cached_agent.invalidate_calls == 1
+
+
 @pytest.mark.asyncio
 async def test_resolver_scope_reaches_sandbox_key_on_build() -> None:
     """End-to-end through the resolver path: a fresh build under a scoped

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -2678,23 +2678,48 @@ class _ScopeWithTurnPayload(ExecutionScope):
         return hash((self.sandbox_key_suffix, self.workspace_segments))
 
 
+def _prime_scope_derived_caches(cfg: WebToolConfig) -> None:
+    cfg._cached_mcp_configs = [{"id": 1, "connector_runtime": {"context": {}}}]
+    cfg._factory_runtime_snapshot = object()
+    cfg._pending_runtime_policy = object()
+
+
+def _assert_scope_derived_caches_primed(cfg: WebToolConfig) -> None:
+    assert cfg._cached_mcp_configs is not None
+    assert cfg._factory_runtime_snapshot is not None
+    assert cfg._pending_runtime_policy is not None
+
+
+def _assert_scope_derived_caches_dropped(cfg: WebToolConfig) -> None:
+    assert cfg._cached_mcp_configs is None
+    assert cfg._factory_runtime_snapshot is None
+    assert cfg._pending_runtime_policy is None
+
+
 def test_set_execution_scope_swaps_the_scope_and_drops_scope_derived_caches():
     scope_a = ExecutionScope(sandbox_key_suffix="tenant-a")
     cfg = WebToolConfig(db=None, request=None, execution_scope=scope_a)
-    cfg._cached_mcp_configs = [{"id": 1, "connector_runtime": {"context": {}}}]
+    _prime_scope_derived_caches(cfg)
 
-    # Same scope object: no-op, scope-derived cache untouched.
+    # Same scope object: no-op, every scope-derived cache untouched.
     assert cfg.set_execution_scope(scope_a) is False
     assert cfg.get_execution_scope() is scope_a
-    assert cfg._cached_mcp_configs is not None
+    _assert_scope_derived_caches_primed(cfg)
+
+    # A fresh base-class instance comparing equal is also a no-op: the
+    # persisted-snapshot path decodes a fresh equal instance every turn and
+    # must not force a tool rebuild.
+    assert (
+        cfg.set_execution_scope(ExecutionScope(sandbox_key_suffix="tenant-a")) is False
+    )
+    assert cfg.get_execution_scope() is scope_a
+    _assert_scope_derived_caches_primed(cfg)
 
     # Different scope: swaps and drops every scope-derived cache.
     scope_b = ExecutionScope(sandbox_key_suffix="tenant-b")
     assert cfg.set_execution_scope(scope_b) is True
     assert cfg.get_execution_scope() is scope_b
-    assert cfg._cached_mcp_configs is None
-    assert cfg._factory_runtime_snapshot is None
-    assert cfg._pending_runtime_policy is None
+    _assert_scope_derived_caches_dropped(cfg)
 
     # Repeating the same scope is a no-op again, leaving state alone.
     cfg._cached_mcp_configs = ["sentinel"]
@@ -2715,6 +2740,28 @@ def test_set_execution_scope_swaps_the_scope_and_drops_scope_derived_caches():
     assert cfg.set_execution_scope(scope_b_with_turn_payload) is True
     assert cfg.get_execution_scope() is scope_b_with_turn_payload
     assert cfg._cached_mcp_configs is None
+
+
+def test_set_execution_scope_swaps_equal_same_subclass_instances():
+    # Two instances of the SAME subclass differing only in payload the
+    # subclass excludes from equality: successive turns of a resolver that
+    # returns a richer scope per turn. Value equality cannot prove freshness
+    # for a subclass, so the setter must swap.
+    turn_1 = _ScopeWithTurnPayload(sandbox_key_suffix="tenant-c", turn_marker="turn-1")
+    cfg = WebToolConfig(db=None, request=None, execution_scope=turn_1)
+    _prime_scope_derived_caches(cfg)
+
+    # The identical object stays a no-op even for a subclass.
+    assert cfg.set_execution_scope(turn_1) is False
+    _assert_scope_derived_caches_primed(cfg)
+
+    turn_2 = _ScopeWithTurnPayload(sandbox_key_suffix="tenant-c", turn_marker="turn-2")
+    assert turn_2 == turn_1
+    assert type(turn_2) is type(turn_1)
+
+    assert cfg.set_execution_scope(turn_2) is True
+    assert cfg.get_execution_scope() is turn_2
+    _assert_scope_derived_caches_dropped(cfg)
 
 
 def test_connector_runtime_view_resolution_errors_fail_closed(monkeypatch):

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import threading
 from collections.abc import Mapping
-from dataclasses import fields, is_dataclass, replace
+from dataclasses import dataclass, field, fields, is_dataclass, replace
 from types import MappingProxyType, SimpleNamespace
 
 import pytest
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.state import InstanceState
 from sqlalchemy.pool import QueuePool
 
+from xagent.core.execution_scope import ExecutionScope
 from xagent.core.task_runtime import TaskRuntimeContext
 from xagent.core.tools.adapters.vibe.config import (
     MCPConfigLoadError,
@@ -2644,6 +2645,75 @@ def test_connector_runtime_turn_switch_invalidates_runtime_caches():
     assert cfg.set_connector_runtime_turn_id("turn-2") is True
     assert cfg._connector_runtime_turn_id == "turn-2"
     assert cfg._connector_runtime_view is None
+    assert cfg._cached_mcp_configs is None
+
+
+@dataclass(frozen=True, eq=False)
+class _ScopeWithTurnPayload(ExecutionScope):
+    """Scope subclass carrying turn-only data outside the namespace fields.
+
+    ``__eq__`` deliberately compares only the inherited namespace fields (the
+    same ones ``ExecutionScope.__eq__`` compares), ignoring ``turn_marker``
+    and class identity -- mirroring a resolver that hands back a richer scope
+    object for the same namespace.
+    """
+
+    turn_marker: str = field(default="", compare=False)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ExecutionScope):
+            return NotImplemented
+        namespace = (
+            "sandbox_key_suffix",
+            "workspace_segments",
+            "sandbox_mount_segments",
+            "strict_memory_isolation",
+            "isolate_external_dirs",
+        )
+        return [getattr(self, f) for f in namespace] == [
+            getattr(other, f) for f in namespace
+        ] and dict(self.memory_dimensions) == dict(other.memory_dimensions)
+
+    def __hash__(self) -> int:
+        return hash((self.sandbox_key_suffix, self.workspace_segments))
+
+
+def test_set_execution_scope_swaps_the_scope_and_drops_scope_derived_caches():
+    scope_a = ExecutionScope(sandbox_key_suffix="tenant-a")
+    cfg = WebToolConfig(db=None, request=None, execution_scope=scope_a)
+    cfg._cached_mcp_configs = [{"id": 1, "connector_runtime": {"context": {}}}]
+
+    # Same scope object: no-op, scope-derived cache untouched.
+    assert cfg.set_execution_scope(scope_a) is False
+    assert cfg.get_execution_scope() is scope_a
+    assert cfg._cached_mcp_configs is not None
+
+    # Different scope: swaps and drops every scope-derived cache.
+    scope_b = ExecutionScope(sandbox_key_suffix="tenant-b")
+    assert cfg.set_execution_scope(scope_b) is True
+    assert cfg.get_execution_scope() is scope_b
+    assert cfg._cached_mcp_configs is None
+    assert cfg._factory_runtime_snapshot is None
+    assert cfg._pending_runtime_policy is None
+
+    # Repeating the same scope is a no-op again, leaving state alone.
+    cfg._cached_mcp_configs = ["sentinel"]
+    assert cfg.set_execution_scope(scope_b) is False
+    assert cfg.get_execution_scope() is scope_b
+    assert cfg._cached_mcp_configs == ["sentinel"]
+
+    # compare=False trap: a subclass instance that compares equal to scope_b
+    # by value (same namespace fields) but carries a different type must
+    # still be swapped in -- a resolver returning a richer scope for an
+    # unchanged namespace must not be dropped as a no-op equality match.
+    scope_b_with_turn_payload = _ScopeWithTurnPayload(
+        sandbox_key_suffix="tenant-b", turn_marker="turn-9"
+    )
+    assert scope_b_with_turn_payload == scope_b
+    assert type(scope_b_with_turn_payload) is not type(scope_b)
+
+    assert cfg.set_execution_scope(scope_b_with_turn_payload) is True
+    assert cfg.get_execution_scope() is scope_b_with_turn_payload
     assert cfg._cached_mcp_configs is None
 
 


### PR DESCRIPTION
## Summary

`WebToolConfig` is cached with `AgentService` per task, keyed on the namespace `scope_fingerprint`. The fingerprint deliberately covers only namespace-affecting fields, so an embedder resolver that returns a scope carrying turn-varying data outside those fields gets a cache hit — and the cached config keeps serving the **first turn's scope object** to every later turn: `_execution_scope` is assigned once in the constructor with no setter, and `set_connector_runtime_turn_id` resets five per-turn fields but not the scope. Consumers of the stale object include the OAuth resolver hook (`TokenRequest.scope`), the resolver-owned MCP connection factory, and nested agent tool construction.

## Change

- `WebToolConfig.set_execution_scope(scope)`: swaps the scope and drops the scope-derived caches (`_cached_mcp_configs`, `_factory_runtime_snapshot`, `_pending_runtime_policy`), mirroring `set_connector_runtime_turn_id`. Returns `False` when the scope is unchanged. The equality check carries an explicit `type(...) is type(...)` guard: scope subclasses may declare their extra fields `compare=False`, so a base scope and a subclass with the same namespace compare equal under dataclass `__eq__` while being materially different objects.
- `AgentServiceManager._sync_execution_scope(task_id, scope)`: called at both cached-agent return points in `get_agent_for_task`, passing the freshly resolved scope; on an actual swap it calls `agent.invalidate_tools()`. Unlike the connector-runtime-turn sync it is not gated on a turn id — callers that pass no turn id still get the resync. On a freshly built agent the setter is a no-op (the constructor already received the same object).

Namespace-affecting changes are unaffected: those still change the fingerprint and evict the whole `AgentService` before this sync runs.

## Testing

- `test_set_execution_scope_swaps_the_scope_and_drops_scope_derived_caches`: no-op on same scope, swap drops the caches, and the `compare=False` subclass trap (equal by value, different type → still swapped).
- `test_cached_agent_service_is_resynced_with_the_turn_execution_scope`: a cached agent under an unchanged fingerprint gets the new scope object and one `invalidate_tools()` call, with `connector_runtime_turn_id=None`.
- Full `tests/web/api/` + `tests/web/tools/`: 298 passed. `ruff`, `isort`, `mypy --package xagent`, `codespell` clean.
