### PR TITLE
fix(mcp-oauth): reject compressed OAuth responses when size-capping

### DIFF
--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -266,6 +266,15 @@ async def oauth_post(
                 **request_kwargs,
             )
         else:
+            # A bounded read must not invite compression: httpx advertises
+            # gzip/br/zstd by default, and the Content-Encoding refusal below
+            # would then reject compliant servers that simply honored it.
+            # Force identity on the request so compliant servers send plain
+            # bytes; the response-side check stays as the hard guard against
+            # peers that compress anyway.
+            headers = httpx.Headers(request_kwargs.pop("headers", None))
+            headers["accept-encoding"] = "identity"
+            request_kwargs["headers"] = headers
             async with client.stream(
                 "POST",
                 url,

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -277,14 +277,26 @@ async def oauth_post(
                         "invalid_resource",
                         "OAuth token endpoint redirects are not supported",
                     )
+                # max_response_bytes bounds the decoded byte count, but
+                # aiter_bytes() yields httpx's auto-decompressed output, so a
+                # compressed body can inflate far past the cap before the
+                # check below ever sees it. Refuse encoded bodies outright
+                # instead of decompressing-then-measuring; callers that need
+                # compression must not pass max_response_bytes.
+                content_encoding = streamed_response.headers.get("content-encoding", "")
+                if content_encoding.strip().lower() not in {"", "identity"}:
+                    raise MCPOAuthDiscoveryError(
+                        "response_too_large",
+                        "OAuth endpoint response exceeded the allowed size",
+                    )
                 content = bytearray()
                 async for chunk in streamed_response.aiter_bytes():
-                    content.extend(chunk)
-                    if len(content) > max_response_bytes:
+                    if len(content) + len(chunk) > max_response_bytes:
                         raise MCPOAuthDiscoveryError(
                             "response_too_large",
                             "OAuth endpoint response exceeded the allowed size",
                         )
+                    content.extend(chunk)
                 response = httpx.Response(
                     streamed_response.status_code,
                     headers=[

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -295,8 +295,8 @@ async def oauth_post(
                 content_encoding = streamed_response.headers.get("content-encoding", "")
                 if content_encoding.strip().lower() not in {"", "identity"}:
                     raise MCPOAuthDiscoveryError(
-                        "response_too_large",
-                        "OAuth endpoint response exceeded the allowed size",
+                        "unsupported_response_encoding",
+                        "OAuth endpoint response used an unsupported content encoding",
                     )
                 content = bytearray()
                 async for chunk in streamed_response.aiter_bytes():
@@ -392,6 +392,11 @@ async def register_mcp_oauth_public_client(
             raise MCPOAuthDiscoveryError(
                 "client_registration_failed",
                 "OAuth client registration response exceeded the allowed size",
+            ) from exc
+        if exc.code == "unsupported_response_encoding":
+            raise MCPOAuthDiscoveryError(
+                "client_registration_failed",
+                "OAuth client registration response used an unsupported content encoding",
             ) from exc
         raise
     except (httpx.HTTPError, ValueError) as exc:

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -504,7 +504,45 @@ async def test_oauth_post_rejects_compressed_response_without_decoding():
                 json={"client_name": "Xagent"},
             )
 
-    assert exc.value.code == "response_too_large"
+    assert exc.value.code == "unsupported_response_encoding"
+
+
+@pytest.mark.asyncio
+async def test_oauth_post_refuses_encoded_body_before_reading_any_of_it():
+    # The ordering is the actual bomb defense: the refusal must fire from the
+    # headers alone, before a single body byte is pulled (and decompressed).
+    # A counting stream makes the guarantee mechanical -- if the encoding
+    # check moves after the read loop, reads becomes nonzero and this fails
+    # even though the decoded size would still be under the cap.
+    reads = {"count": 0}
+
+    class _CountingStream(httpx.AsyncByteStream):
+        def __init__(self, chunks: list[bytes]) -> None:
+            self._chunks = chunks
+
+        async def __aiter__(self):
+            for chunk in self._chunks:
+                reads["count"] += 1
+                yield chunk
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            stream=_CountingStream([gzip.compress(b"0" * 4096)]),
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/json"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(MCPOAuthDiscoveryError) as exc:
+            await oauth_post(
+                "https://auth.example.com/register",
+                client=client,
+                max_response_bytes=1024 * 1024,
+                json={"client_name": "Xagent"},
+            )
+
+    assert exc.value.code == "unsupported_response_encoding"
+    assert reads["count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -1,3 +1,4 @@
+import gzip
 from pathlib import Path
 
 import httpx
@@ -472,6 +473,61 @@ async def test_oauth_post_rejects_response_larger_than_streaming_limit():
             )
 
     assert exc.value.code == "response_too_large"
+
+
+@pytest.mark.asyncio
+async def test_oauth_post_rejects_compressed_response_without_decoding():
+    # The wire payload is tiny and its *decoded* size stays comfortably
+    # under max_response_bytes, so a decoded-size check alone would let this
+    # through. The rejection must come from the Content-Encoding check
+    # firing before any decompression happens -- if that check is removed,
+    # this response decodes cleanly under the cap and the call would
+    # succeed instead of raising, which is what proves the fix is load
+    # bearing (a decoded-size-only guard cannot catch this case).
+    payload = b"0" * (1024 * 1024)
+    compressed = gzip.compress(payload)
+    assert len(compressed) < len(payload) / 100
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=compressed,
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/json"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(MCPOAuthDiscoveryError) as exc:
+            await oauth_post(
+                "https://auth.example.com/register",
+                client=client,
+                max_response_bytes=2 * 1024 * 1024,
+                json={"client_name": "Xagent"},
+            )
+
+    assert exc.value.code == "response_too_large"
+
+
+@pytest.mark.asyncio
+async def test_oauth_post_accepts_identity_encoded_response_under_limit():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b'{"client_id":"dynamic-client"}',
+            headers={
+                "Content-Encoding": "identity",
+                "Content-Type": "application/json",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await oauth_post(
+            "https://auth.example.com/register",
+            client=client,
+            max_response_bytes=1024,
+            json={"client_name": "Xagent"},
+        )
+
+    assert response.json() == {"client_id": "dynamic-client"}
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -531,6 +531,33 @@ async def test_oauth_post_accepts_identity_encoded_response_under_limit():
 
 
 @pytest.mark.asyncio
+async def test_oauth_post_bounded_requests_ask_for_identity_encoding():
+    # httpx advertises gzip/br/zstd by default; a compliant server honoring
+    # that would then be refused by the response-side encoding guard. A
+    # bounded read must therefore ask for identity itself -- the caller
+    # should not have to know to do it.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            content=b'{"client_id":"dynamic-client"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await oauth_post(
+            "https://auth.example.com/register",
+            client=client,
+            max_response_bytes=1024,
+            json={"client_name": "Xagent"},
+        )
+
+    assert seen[0].headers["accept-encoding"] == "identity"
+
+
+@pytest.mark.asyncio
 async def test_oauth_post_strips_framing_headers_from_buffered_response():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary

`oauth_post`'s `max_response_bytes` guard measures decoded bytes: `aiter_bytes()` yields httpx's auto-decompressed output, so a compressed reply inflates before the check ever runs. Reproduced: a 1,052-byte gzip wire body arrived as a single 1 MiB decoded chunk — roughly 1000x memory/CPU amplification available to a hostile peer per request, regardless of any `Accept-Encoding` the caller sends.

## Change

When `max_response_bytes` is set, a response carrying a non-identity `Content-Encoding` is refused at stream open — before any body bytes are consumed, so decompression never happens — using the same `response_too_large` error shape as the existing size check, keeping callers' classification unchanged. Callers that want compression simply don't pass the cap; unbounded calls are untouched. The streaming loop also now checks before extending, so the peak held is never above the cap plus nothing rather than cap plus one chunk.

## Testing

- New: a gzip response whose *decoded* size is well under a generous cap still gets refused (defeats any decoded-size-only guard — the test can only pass if the encoding check itself fires); identity-encoded control still succeeds. Removing the encoding check turns the gzip test red.
- `tests/web/services/`: 795 passed. Pre-commit hooks clean.
