### PR TITLE
feat: add Google Sheets connector

### DIFF
--- a/src/xagent/migrations/versions/20260806_seed_google_sheets_mcp_app.py
+++ b/src/xagent/migrations/versions/20260806_seed_google_sheets_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Google Sheets (OAuth) MCP connector
 
 Revision ID: 20260806_seed_google_sheets_mcp_app
-Revises: 20260729_add_gmail_audience_grace
+Revises: 20260804_add_task_checkpoint_trace_event_anchor
 Create Date: 2026-08-06 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260806_seed_google_sheets_mcp_app"
-down_revision: Union[str, None] = "20260729_add_gmail_audience_grace"
+down_revision: Union[str, None] = "20260804_add_task_checkpoint_trace_event_anchor"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260806_seed_google_sheets_mcp_app.py
+++ b/src/xagent/migrations/versions/20260806_seed_google_sheets_mcp_app.py
@@ -1,0 +1,84 @@
+"""seed built-in Google Sheets (OAuth) MCP connector
+
+Revision ID: 20260806_seed_google_sheets_mcp_app
+Revises: 20260729_add_gmail_audience_grace
+Create Date: 2026-08-06 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260806_seed_google_sheets_mcp_app"
+down_revision: Union[str, None] = "20260729_add_gmail_audience_grace"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "google-sheets"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Google Sheets",
+    "description": "Connect to Google Sheets to read and update ranges, append rows, manage sheets, and create spreadsheets.",
+    "icon": "https://www.google.com/s2/favicons?domain=sheets.google.com&sz=128",
+    "transport": "oauth",
+    "provider_name": "google",
+    "category": "Productivity",
+    "oauth_scopes": [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive.file",
+    ],
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.google_sheets"],
+        "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. The shared "google" oauth_providers row
+    # is left untouched since it is reused by Gmail/Drive/Calendar/Docs/Slides/Ads/Analytics.
+    # Any MCPServer/UserMCPServer rows created by users who already connected are
+    # intentionally left in place — connect-driven rows are not owned by this
+    # migration and are cleaned up through the normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -260,6 +260,25 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "google-sheets",
+            "name": "Google Sheets",
+            "description": "Connect to Google Sheets to read and update ranges, append rows, manage sheets, and create spreadsheets.",
+            "icon": "https://www.google.com/s2/favicons?domain=sheets.google.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "google",
+            "category": "Productivity",
+            "oauth_scopes": [
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/drive.file",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.google_sheets"],
+                "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
             "app_id": "google-ads",
             "name": "Google Ads",
             "description": "Connect to Google Ads to list accessible accounts, inspect campaigns, and run GAQL reports.",

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -20,6 +20,9 @@ mcp = FastMCP("google-sheets-mcp")
 
 _SPREADSHEET_URL_ID_PATTERN = re.compile(r"/spreadsheets/d/([a-zA-Z0-9_-]+)")
 
+_sheets_service: Any = None
+_drive_service: Any = None
+
 
 def _get_credentials() -> Credentials:
     token = os.environ.get("GOOGLE_ACCESS_TOKEN")
@@ -45,11 +48,21 @@ def _get_credentials() -> Credentials:
 
 
 def get_sheets_service() -> Any:
-    return build("sheets", "v4", credentials=_get_credentials())
+    global _sheets_service
+    if _sheets_service is None:
+        _sheets_service = build(
+            "sheets", "v4", credentials=_get_credentials(), static_discovery=True
+        )
+    return _sheets_service
 
 
 def get_drive_service() -> Any:
-    return build("drive", "v3", credentials=_get_credentials())
+    global _drive_service
+    if _drive_service is None:
+        _drive_service = build(
+            "drive", "v3", credentials=_get_credentials(), static_discovery=True
+        )
+    return _drive_service
 
 
 def _resolve_spreadsheet_id(spreadsheet_id: str) -> str:
@@ -64,12 +77,12 @@ def google_sheets_get_spreadsheet(spreadsheet_id: str) -> str:
     and the list of sheets (tabs) with their sheet_id, title, and grid size.
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         service = get_sheets_service()
         spreadsheet = (
             service.spreadsheets()
             .get(
-                spreadsheetId=sheet_id,
+                spreadsheetId=resolved_spreadsheet_id,
                 fields="spreadsheetId,properties.title,spreadsheetUrl,sheets.properties",
             )
             .execute()
@@ -90,7 +103,9 @@ def google_sheets_get_spreadsheet(spreadsheet_id: str) -> str:
         return json.dumps(
             {
                 "status": "success",
-                "spreadsheet_id": spreadsheet.get("spreadsheetId", sheet_id),
+                "spreadsheet_id": spreadsheet.get(
+                    "spreadsheetId", resolved_spreadsheet_id
+                ),
                 "title": spreadsheet.get("properties", {}).get("title"),
                 "url": spreadsheet.get("spreadsheetUrl"),
                 "sheets": sheets,
@@ -135,13 +150,15 @@ def google_sheets_create_spreadsheet(
                 .get(fileId=spreadsheet["spreadsheetId"], fields="parents")
                 .execute()
             )
-            previous_parents = ",".join(existing_file.get("parents", []))
-            drive.files().update(
-                fileId=spreadsheet["spreadsheetId"],
-                addParents=parent_id,
-                removeParents=previous_parents,
-                fields="id,parents",
-            ).execute()
+            previous_parents = existing_file.get("parents") or []
+            update_kwargs: dict[str, Any] = {
+                "fileId": spreadsheet["spreadsheetId"],
+                "addParents": parent_id,
+                "fields": "id,parents",
+            }
+            if previous_parents:
+                update_kwargs["removeParents"] = ",".join(previous_parents)
+            drive.files().update(**update_kwargs).execute()
 
         return json.dumps(
             {
@@ -163,12 +180,12 @@ def google_sheets_read_range(spreadsheet_id: str, range_name: str) -> str:
     range_name="Sheet1!A1:D10". spreadsheet_id accepts a bare id or full URL.
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         service = get_sheets_service()
         result = (
             service.spreadsheets()
             .values()
-            .get(spreadsheetId=sheet_id, range=range_name)
+            .get(spreadsheetId=resolved_spreadsheet_id, range=range_name)
             .execute()
         )
         return json.dumps(
@@ -198,7 +215,7 @@ def google_sheets_update_range(
     "RAW" (stores every value as a literal string).
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         values = json.loads(values_json)
         if not isinstance(values, list) or not all(
             isinstance(row, list) for row in values
@@ -212,7 +229,7 @@ def google_sheets_update_range(
             service.spreadsheets()
             .values()
             .update(
-                spreadsheetId=sheet_id,
+                spreadsheetId=resolved_spreadsheet_id,
                 range=range_name,
                 valueInputOption=value_input_option,
                 body={"values": values},
@@ -244,7 +261,7 @@ def google_sheets_append_rows(
     rows, e.g. '[["a","b"],["c","d"]]'.
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         values = json.loads(values_json)
         if not isinstance(values, list) or not all(
             isinstance(row, list) for row in values
@@ -258,7 +275,7 @@ def google_sheets_append_rows(
             service.spreadsheets()
             .values()
             .append(
-                spreadsheetId=sheet_id,
+                spreadsheetId=resolved_spreadsheet_id,
                 range=range_name,
                 valueInputOption=value_input_option,
                 insertDataOption="INSERT_ROWS",
@@ -286,12 +303,12 @@ def google_sheets_clear_range(spreadsheet_id: str, range_name: str) -> str:
     removing cell formatting.
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         service = get_sheets_service()
         result = (
             service.spreadsheets()
             .values()
-            .clear(spreadsheetId=sheet_id, range=range_name)
+            .clear(spreadsheetId=resolved_spreadsheet_id, range=range_name)
             .execute()
         )
         return json.dumps(
@@ -313,12 +330,12 @@ def google_sheets_add_sheet(
     Add a new sheet (tab) to an existing spreadsheet.
     """
     try:
-        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         service = get_sheets_service()
         result = (
             service.spreadsheets()
             .batchUpdate(
-                spreadsheetId=sheet_id,
+                spreadsheetId=resolved_spreadsheet_id,
                 body={
                     "requests": [
                         {

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -10,7 +10,6 @@ from mcp.server.fastmcp import FastMCP
 
 from .utils import resolve_id_from_url, setup_proxy_env
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("google-sheets-mcp")
 
 # Ensure standard proxy environment variables are set to prevent hanging requests
@@ -18,10 +17,7 @@ setup_proxy_env()
 
 mcp = FastMCP("google-sheets-mcp")
 
-_SPREADSHEET_URL_ID_PATTERN = re.compile(r"/spreadsheets/d/([a-zA-Z0-9_-]+)")
-
-_sheets_service: Any = None
-_drive_service: Any = None
+_SPREADSHEET_URL_ID_PATTERN = re.compile(r"/spreadsheets/(?:u/\d+/)?d/([a-zA-Z0-9_-]+)")
 
 
 def _get_credentials() -> Credentials:
@@ -48,21 +44,11 @@ def _get_credentials() -> Credentials:
 
 
 def get_sheets_service() -> Any:
-    global _sheets_service
-    if _sheets_service is None:
-        _sheets_service = build(
-            "sheets", "v4", credentials=_get_credentials(), static_discovery=True
-        )
-    return _sheets_service
+    return build("sheets", "v4", credentials=_get_credentials())
 
 
 def get_drive_service() -> Any:
-    global _drive_service
-    if _drive_service is None:
-        _drive_service = build(
-            "drive", "v3", credentials=_get_credentials(), static_discovery=True
-        )
-    return _drive_service
+    return build("drive", "v3", credentials=_get_credentials())
 
 
 def _resolve_spreadsheet_id(spreadsheet_id: str) -> str:
@@ -126,7 +112,10 @@ def google_sheets_create_spreadsheet(
     Create a new Google Sheets spreadsheet with the given title.
     Optionally pass sheet_titles to create additional named sheets (tabs)
     beyond the default first sheet, and parent_id to place the spreadsheet
-    in a specific Drive folder.
+    in a specific Drive folder. Because this connector is authorized with
+    the drive.file scope, parent_id only works for a folder this app has
+    already created or that the user explicitly picked; other folder ids
+    will typically be rejected by the Drive API.
     """
     try:
         service = get_sheets_service()
@@ -142,8 +131,12 @@ def google_sheets_create_spreadsheet(
             )
             .execute()
         )
+    except Exception as e:
+        logger.error(f"Error creating spreadsheet: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
 
-        if parent_id:
+    if parent_id:
+        try:
             drive = get_drive_service()
             existing_file = (
                 drive.files()
@@ -159,18 +152,29 @@ def google_sheets_create_spreadsheet(
             if previous_parents:
                 update_kwargs["removeParents"] = ",".join(previous_parents)
             drive.files().update(**update_kwargs).execute()
+        except Exception as e:
+            logger.error(f"Error moving new spreadsheet to parent_id: {e}")
+            return json.dumps(
+                {
+                    "status": "partial",
+                    "spreadsheet_id": spreadsheet.get("spreadsheetId"),
+                    "title": spreadsheet.get("properties", {}).get("title"),
+                    "url": spreadsheet.get("spreadsheetUrl"),
+                    "message": (
+                        "Spreadsheet was created but could not be moved to "
+                        f"parent_id {parent_id!r}: {e}"
+                    ),
+                }
+            )
 
-        return json.dumps(
-            {
-                "status": "success",
-                "spreadsheet_id": spreadsheet.get("spreadsheetId"),
-                "title": spreadsheet.get("properties", {}).get("title"),
-                "url": spreadsheet.get("spreadsheetUrl"),
-            }
-        )
-    except Exception as e:
-        logger.error(f"Error creating spreadsheet: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+    return json.dumps(
+        {
+            "status": "success",
+            "spreadsheet_id": spreadsheet.get("spreadsheetId"),
+            "title": spreadsheet.get("properties", {}).get("title"),
+            "url": spreadsheet.get("spreadsheetUrl"),
+        }
+    )
 
 
 @mcp.tool()
@@ -204,26 +208,18 @@ def google_sheets_read_range(spreadsheet_id: str, range_name: str) -> str:
 def google_sheets_update_range(
     spreadsheet_id: str,
     range_name: str,
-    values_json: str,
+    values: list[list[Any]],
     value_input_option: str = "USER_ENTERED",
 ) -> str:
     """
     Overwrite cell values in a range, e.g. range_name="Sheet1!A1:B2".
-    values_json must be a JSON-encoded 2D array of rows, e.g.
-    '[["a","b"],["c","d"]]'. value_input_option controls parsing:
-    "USER_ENTERED" (default, parses formulas/numbers like typed input) or
-    "RAW" (stores every value as a literal string).
+    values must be a 2D array of rows, e.g. [["a","b"],["c","d"]].
+    value_input_option controls parsing: "USER_ENTERED" (default, parses
+    formulas/numbers like typed input) or "RAW" (stores every value as a
+    literal string).
     """
     try:
         resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
-        values = json.loads(values_json)
-        if not isinstance(values, list) or not all(
-            isinstance(row, list) for row in values
-        ):
-            raise ValueError(
-                "values_json must be a 2D JSON array of rows (list of lists)"
-            )
-
         service = get_sheets_service()
         result = (
             service.spreadsheets()
@@ -252,24 +248,16 @@ def google_sheets_update_range(
 def google_sheets_append_rows(
     spreadsheet_id: str,
     range_name: str,
-    values_json: str,
+    values: list[list[Any]],
     value_input_option: str = "USER_ENTERED",
 ) -> str:
     """
     Append rows after the last row of data found in range_name, e.g.
-    range_name="Sheet1!A1". values_json must be a JSON-encoded 2D array of
-    rows, e.g. '[["a","b"],["c","d"]]'.
+    range_name="Sheet1!A1". values must be a 2D array of rows, e.g.
+    [["a","b"],["c","d"]].
     """
     try:
         resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
-        values = json.loads(values_json)
-        if not isinstance(values, list) or not all(
-            isinstance(row, list) for row in values
-        ):
-            raise ValueError(
-                "values_json must be a 2D JSON array of rows (list of lists)"
-            )
-
         service = get_sheets_service()
         result = (
             service.spreadsheets()
@@ -354,7 +342,9 @@ def google_sheets_add_sheet(
             )
             .execute()
         )
-        new_sheet = result["replies"][0]["addSheet"]["properties"]
+        new_sheet = (
+            (result.get("replies") or [{}])[0].get("addSheet", {}).get("properties", {})
+        )
         return json.dumps(
             {
                 "status": "success",
@@ -390,4 +380,5 @@ def google_sheets_delete_sheet(spreadsheet_id: str, sheet_id: int) -> str:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     mcp.run()

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -95,11 +95,12 @@ def google_sheets_get_spreadsheet(spreadsheet_id: str) -> str:
                 "title": spreadsheet.get("properties", {}).get("title"),
                 "url": spreadsheet.get("spreadsheetUrl"),
                 "sheets": sheets,
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error getting spreadsheet: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -133,7 +134,7 @@ def google_sheets_create_spreadsheet(
         )
     except Exception as e:
         logger.error(f"Error creating spreadsheet: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     if parent_id:
         try:
@@ -164,7 +165,8 @@ def google_sheets_create_spreadsheet(
                         "Spreadsheet was created but could not be moved to "
                         f"parent_id {parent_id!r}: {e}"
                     ),
-                }
+                },
+                ensure_ascii=False,
             )
 
     return json.dumps(
@@ -173,17 +175,26 @@ def google_sheets_create_spreadsheet(
             "spreadsheet_id": spreadsheet.get("spreadsheetId"),
             "title": spreadsheet.get("properties", {}).get("title"),
             "url": spreadsheet.get("spreadsheetUrl"),
-        }
+        },
+        ensure_ascii=False,
     )
 
 
 @mcp.tool()
-def google_sheets_read_range(spreadsheet_id: str, range_name: str) -> str:
+def google_sheets_read_range(
+    spreadsheet_id: str, range_name: str, max_rows: int = 1000
+) -> str:
     """
     Read cell values from a range in a Google Sheets spreadsheet, e.g.
     range_name="Sheet1!A1:D10". spreadsheet_id accepts a bare id or full URL.
+    A bare tab reference like range_name="Sheet1" is valid A1 notation for
+    the entire sheet, so max_rows caps how many rows are returned; extra
+    rows are dropped and the response sets truncated=true.
     """
     try:
+        if max_rows < 1:
+            raise ValueError("max_rows must be at least 1")
+
         resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         service = get_sheets_service()
         result = (
@@ -192,16 +203,23 @@ def google_sheets_read_range(spreadsheet_id: str, range_name: str) -> str:
             .get(spreadsheetId=resolved_spreadsheet_id, range=range_name)
             .execute()
         )
+        values = result.get("values", [])
+        truncated = len(values) > max_rows
+        if truncated:
+            values = values[:max_rows]
+
         return json.dumps(
             {
                 "status": "success",
                 "range": result.get("range", range_name),
-                "values": result.get("values", []),
-            }
+                "values": values,
+                "truncated": truncated,
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error reading range: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -237,11 +255,12 @@ def google_sheets_update_range(
                 "status": "success",
                 "updated_range": result.get("updatedRange", range_name),
                 "updated_cells": result.get("updatedCells", 0),
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error updating range: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -277,11 +296,12 @@ def google_sheets_append_rows(
                 "status": "success",
                 "updated_range": updates.get("updatedRange", range_name),
                 "updated_rows": updates.get("updatedRows", 0),
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error appending rows: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -303,11 +323,12 @@ def google_sheets_clear_range(spreadsheet_id: str, range_name: str) -> str:
             {
                 "status": "success",
                 "cleared_range": result.get("clearedRange", range_name),
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error clearing range: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -350,11 +371,12 @@ def google_sheets_add_sheet(
                 "status": "success",
                 "sheet_id": new_sheet.get("sheetId"),
                 "title": new_sheet.get("title"),
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error adding sheet: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -372,11 +394,12 @@ def google_sheets_delete_sheet(spreadsheet_id: str, sheet_id: int) -> str:
             body={"requests": [{"deleteSheet": {"sheetId": sheet_id}}]},
         ).execute()
         return json.dumps(
-            {"status": "success", "message": f"Sheet {sheet_id} deleted."}
+            {"status": "success", "message": f"Sheet {sheet_id} deleted."},
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error deleting sheet: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -74,17 +74,18 @@ def google_sheets_get_spreadsheet(spreadsheet_id: str) -> str:
             )
             .execute()
         )
-        sheets = [
-            {
-                "sheet_id": s["properties"]["sheetId"],
-                "title": s["properties"]["title"],
-                "row_count": s["properties"].get("gridProperties", {}).get("rowCount"),
-                "column_count": s["properties"]
-                .get("gridProperties", {})
-                .get("columnCount"),
-            }
-            for s in spreadsheet.get("sheets", [])
-        ]
+        sheets = []
+        for s in spreadsheet.get("sheets", []):
+            properties = s.get("properties", {})
+            grid_properties = properties.get("gridProperties") or {}
+            sheets.append(
+                {
+                    "sheet_id": properties.get("sheetId"),
+                    "title": properties.get("title"),
+                    "row_count": grid_properties.get("rowCount"),
+                    "column_count": grid_properties.get("columnCount"),
+                }
+            )
 
         return json.dumps(
             {
@@ -129,9 +130,16 @@ def google_sheets_create_spreadsheet(
 
         if parent_id:
             drive = get_drive_service()
+            existing_file = (
+                drive.files()
+                .get(fileId=spreadsheet["spreadsheetId"], fields="parents")
+                .execute()
+            )
+            previous_parents = ",".join(existing_file.get("parents", []))
             drive.files().update(
                 fileId=spreadsheet["spreadsheetId"],
                 addParents=parent_id,
+                removeParents=previous_parents,
                 fields="id,parents",
             ).execute()
 
@@ -192,8 +200,12 @@ def google_sheets_update_range(
     try:
         sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         values = json.loads(values_json)
-        if not isinstance(values, list):
-            raise ValueError("values_json must be a JSON array of rows")
+        if not isinstance(values, list) or not all(
+            isinstance(row, list) for row in values
+        ):
+            raise ValueError(
+                "values_json must be a 2D JSON array of rows (list of lists)"
+            )
 
         service = get_sheets_service()
         result = (
@@ -234,8 +246,12 @@ def google_sheets_append_rows(
     try:
         sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
         values = json.loads(values_json)
-        if not isinstance(values, list):
-            raise ValueError("values_json must be a JSON array of rows")
+        if not isinstance(values, list) or not all(
+            isinstance(row, list) for row in values
+        ):
+            raise ValueError(
+                "values_json must be a 2D JSON array of rows (list of lists)"
+            )
 
         service = get_sheets_service()
         result = (

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -1,0 +1,360 @@
+import json
+import logging
+import os
+import re
+from typing import Any
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build  # type: ignore[import-not-found]
+from mcp.server.fastmcp import FastMCP
+
+from .utils import resolve_id_from_url, setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("google-sheets-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("google-sheets-mcp")
+
+_SPREADSHEET_URL_ID_PATTERN = re.compile(r"/spreadsheets/d/([a-zA-Z0-9_-]+)")
+
+
+def _get_credentials() -> Credentials:
+    token = os.environ.get("GOOGLE_ACCESS_TOKEN")
+    refresh_token = os.environ.get("GOOGLE_REFRESH_TOKEN")
+    client_id = os.environ.get("GOOGLE_CLIENT_ID")
+    client_secret = os.environ.get("GOOGLE_CLIENT_SECRET")
+
+    if not token:
+        raise ValueError("GOOGLE_ACCESS_TOKEN environment variable is missing")
+
+    creds_kwargs = {"token": token}
+    if refresh_token and client_id and client_secret:
+        creds_kwargs.update(
+            {
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        )
+
+    return Credentials(**creds_kwargs)
+
+
+def get_sheets_service() -> Any:
+    return build("sheets", "v4", credentials=_get_credentials())
+
+
+def get_drive_service() -> Any:
+    return build("drive", "v3", credentials=_get_credentials())
+
+
+def _resolve_spreadsheet_id(spreadsheet_id: str) -> str:
+    """Accept either a bare spreadsheet id or a full Google Sheets URL."""
+    return resolve_id_from_url(spreadsheet_id, _SPREADSHEET_URL_ID_PATTERN)
+
+
+@mcp.tool()
+def google_sheets_get_spreadsheet(spreadsheet_id: str) -> str:
+    """
+    Get metadata for a Google Sheets spreadsheet by id or full URL: its title
+    and the list of sheets (tabs) with their sheet_id, title, and grid size.
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        service = get_sheets_service()
+        spreadsheet = (
+            service.spreadsheets()
+            .get(
+                spreadsheetId=sheet_id,
+                fields="spreadsheetId,properties.title,spreadsheetUrl,sheets.properties",
+            )
+            .execute()
+        )
+        sheets = [
+            {
+                "sheet_id": s["properties"]["sheetId"],
+                "title": s["properties"]["title"],
+                "row_count": s["properties"].get("gridProperties", {}).get("rowCount"),
+                "column_count": s["properties"]
+                .get("gridProperties", {})
+                .get("columnCount"),
+            }
+            for s in spreadsheet.get("sheets", [])
+        ]
+
+        return json.dumps(
+            {
+                "status": "success",
+                "spreadsheet_id": spreadsheet.get("spreadsheetId", sheet_id),
+                "title": spreadsheet.get("properties", {}).get("title"),
+                "url": spreadsheet.get("spreadsheetUrl"),
+                "sheets": sheets,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error getting spreadsheet: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_create_spreadsheet(
+    title: str,
+    sheet_titles: list[str] | None = None,
+    parent_id: str | None = None,
+) -> str:
+    """
+    Create a new Google Sheets spreadsheet with the given title.
+    Optionally pass sheet_titles to create additional named sheets (tabs)
+    beyond the default first sheet, and parent_id to place the spreadsheet
+    in a specific Drive folder.
+    """
+    try:
+        service = get_sheets_service()
+        body: dict[str, Any] = {"properties": {"title": title}}
+        if sheet_titles:
+            body["sheets"] = [{"properties": {"title": t}} for t in sheet_titles]
+
+        spreadsheet = (
+            service.spreadsheets()
+            .create(
+                body=body,
+                fields="spreadsheetId,properties.title,spreadsheetUrl",
+            )
+            .execute()
+        )
+
+        if parent_id:
+            drive = get_drive_service()
+            drive.files().update(
+                fileId=spreadsheet["spreadsheetId"],
+                addParents=parent_id,
+                fields="id,parents",
+            ).execute()
+
+        return json.dumps(
+            {
+                "status": "success",
+                "spreadsheet_id": spreadsheet.get("spreadsheetId"),
+                "title": spreadsheet.get("properties", {}).get("title"),
+                "url": spreadsheet.get("spreadsheetUrl"),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error creating spreadsheet: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_read_range(spreadsheet_id: str, range_name: str) -> str:
+    """
+    Read cell values from a range in a Google Sheets spreadsheet, e.g.
+    range_name="Sheet1!A1:D10". spreadsheet_id accepts a bare id or full URL.
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .get(spreadsheetId=sheet_id, range=range_name)
+            .execute()
+        )
+        return json.dumps(
+            {
+                "status": "success",
+                "range": result.get("range", range_name),
+                "values": result.get("values", []),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error reading range: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_update_range(
+    spreadsheet_id: str,
+    range_name: str,
+    values_json: str,
+    value_input_option: str = "USER_ENTERED",
+) -> str:
+    """
+    Overwrite cell values in a range, e.g. range_name="Sheet1!A1:B2".
+    values_json must be a JSON-encoded 2D array of rows, e.g.
+    '[["a","b"],["c","d"]]'. value_input_option controls parsing:
+    "USER_ENTERED" (default, parses formulas/numbers like typed input) or
+    "RAW" (stores every value as a literal string).
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        values = json.loads(values_json)
+        if not isinstance(values, list):
+            raise ValueError("values_json must be a JSON array of rows")
+
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .update(
+                spreadsheetId=sheet_id,
+                range=range_name,
+                valueInputOption=value_input_option,
+                body={"values": values},
+            )
+            .execute()
+        )
+        return json.dumps(
+            {
+                "status": "success",
+                "updated_range": result.get("updatedRange", range_name),
+                "updated_cells": result.get("updatedCells", 0),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error updating range: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_append_rows(
+    spreadsheet_id: str,
+    range_name: str,
+    values_json: str,
+    value_input_option: str = "USER_ENTERED",
+) -> str:
+    """
+    Append rows after the last row of data found in range_name, e.g.
+    range_name="Sheet1!A1". values_json must be a JSON-encoded 2D array of
+    rows, e.g. '[["a","b"],["c","d"]]'.
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        values = json.loads(values_json)
+        if not isinstance(values, list):
+            raise ValueError("values_json must be a JSON array of rows")
+
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .append(
+                spreadsheetId=sheet_id,
+                range=range_name,
+                valueInputOption=value_input_option,
+                insertDataOption="INSERT_ROWS",
+                body={"values": values},
+            )
+            .execute()
+        )
+        updates = result.get("updates", {})
+        return json.dumps(
+            {
+                "status": "success",
+                "updated_range": updates.get("updatedRange", range_name),
+                "updated_rows": updates.get("updatedRows", 0),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error appending rows: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_clear_range(spreadsheet_id: str, range_name: str) -> str:
+    """
+    Clear all values in a range, e.g. range_name="Sheet1!A1:D10", without
+    removing cell formatting.
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .clear(spreadsheetId=sheet_id, range=range_name)
+            .execute()
+        )
+        return json.dumps(
+            {
+                "status": "success",
+                "cleared_range": result.get("clearedRange", range_name),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error clearing range: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_add_sheet(
+    spreadsheet_id: str, title: str, rows: int = 1000, columns: int = 26
+) -> str:
+    """
+    Add a new sheet (tab) to an existing spreadsheet.
+    """
+    try:
+        sheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .batchUpdate(
+                spreadsheetId=sheet_id,
+                body={
+                    "requests": [
+                        {
+                            "addSheet": {
+                                "properties": {
+                                    "title": title,
+                                    "gridProperties": {
+                                        "rowCount": rows,
+                                        "columnCount": columns,
+                                    },
+                                }
+                            }
+                        }
+                    ]
+                },
+            )
+            .execute()
+        )
+        new_sheet = result["replies"][0]["addSheet"]["properties"]
+        return json.dumps(
+            {
+                "status": "success",
+                "sheet_id": new_sheet.get("sheetId"),
+                "title": new_sheet.get("title"),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error adding sheet: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_sheets_delete_sheet(spreadsheet_id: str, sheet_id: int) -> str:
+    """
+    Delete a sheet (tab) from a spreadsheet by its numeric sheet_id (see
+    google_sheets_get_spreadsheet for the sheet_id of each tab; this is not
+    the spreadsheet_id string).
+    """
+    try:
+        resolved_spreadsheet_id = _resolve_spreadsheet_id(spreadsheet_id)
+        service = get_sheets_service()
+        service.spreadsheets().batchUpdate(
+            spreadsheetId=resolved_spreadsheet_id,
+            body={"requests": [{"deleteSheet": {"sheetId": sheet_id}}]},
+        ).execute()
+        return json.dumps(
+            {"status": "success", "message": f"Sheet {sheet_id} deleted."}
+        )
+    except Exception as e:
+        logger.error(f"Error deleting sheet: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/alembic/test_20260806_seed_google_sheets_mcp_app.py
+++ b/tests/alembic/test_20260806_seed_google_sheets_mcp_app.py
@@ -1,0 +1,124 @@
+"""Tests for the Google Sheets MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260806_seed_google_sheets_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_google_sheets_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_google_sheets(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "google-sheets" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='google-sheets'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "google"
+        assert "xagent.web.tools.mcp.google_sheets" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='google-sheets'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    google-sheets row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "google-sheets"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_google_sheets(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "google-sheets" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/tools/test_google_sheets_mcp.py
+++ b/tests/web/tools/test_google_sheets_mcp.py
@@ -1,0 +1,341 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import google_sheets
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    # tests/conftest.py force-loads the project .env into the test process, so
+    # any refresh credentials configured there would leak into the "absent"
+    # assertions below.
+    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
+
+
+def _mock_sheets_service(monkeypatch, spreadsheets_mock):
+    service = Mock()
+    service.spreadsheets.return_value = spreadsheets_mock
+    monkeypatch.setattr(google_sheets, "get_sheets_service", lambda: service)
+    return service
+
+
+def test_get_credentials_requires_access_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ACCESS_TOKEN"):
+        google_sheets._get_credentials()
+
+
+def test_get_credentials_omits_refresh_fields_when_absent():
+    creds = google_sheets._get_credentials()
+
+    assert creds.token == "access-token"
+    assert creds.refresh_token is None
+
+
+def test_get_credentials_includes_refresh_fields_when_present(monkeypatch):
+    monkeypatch.setenv("GOOGLE_REFRESH_TOKEN", "refresh-token")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "client-secret")
+
+    creds = google_sheets._get_credentials()
+
+    assert creds.refresh_token == "refresh-token"
+    assert creds.client_id == "client-id"
+    assert creds.client_secret == "client-secret"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc123", "abc123"),
+        ("https://docs.google.com/spreadsheets/d/abc123/edit#gid=0", "abc123"),
+        ("https://docs.google.com/spreadsheets/u/1/d/abc123/edit", "abc123"),
+    ],
+)
+def test_resolve_spreadsheet_id_accepts_bare_id_and_url_forms(value, expected):
+    assert google_sheets._resolve_spreadsheet_id(value) == expected
+
+
+def test_get_spreadsheet_defaults_missing_grid_properties(monkeypatch):
+    """A non-grid sheet (e.g. a chart sheet) can omit gridProperties entirely;
+    parsing must not raise KeyError/AttributeError on that shape."""
+    spreadsheets = Mock()
+    spreadsheets.get.return_value.execute.return_value = {
+        "spreadsheetId": "sid",
+        "properties": {"title": "My Sheet"},
+        "spreadsheetUrl": "https://example.com/sid",
+        "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}],
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_get_spreadsheet("sid"))
+
+    assert result["status"] == "success"
+    assert result["sheets"] == [
+        {"sheet_id": 0, "title": "Sheet1", "row_count": None, "column_count": None}
+    ]
+
+
+def test_get_spreadsheet_returns_error_payload_on_failure(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.get.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_get_spreadsheet("sid"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_create_spreadsheet_without_parent(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.create.return_value.execute.return_value = {
+        "spreadsheetId": "sid",
+        "properties": {"title": "New"},
+        "spreadsheetUrl": "https://example.com/sid",
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_create_spreadsheet("New"))
+
+    assert result["status"] == "success"
+    assert result["spreadsheet_id"] == "sid"
+
+
+def test_create_spreadsheet_moves_to_parent_and_removes_previous_parents(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.create.return_value.execute.return_value = {
+        "spreadsheetId": "sid",
+        "properties": {"title": "New"},
+        "spreadsheetUrl": "https://example.com/sid",
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    drive = Mock()
+    drive.files.return_value.get.return_value.execute.return_value = {
+        "parents": ["root"]
+    }
+    monkeypatch.setattr(google_sheets, "get_drive_service", lambda: drive)
+
+    result = json.loads(
+        google_sheets.google_sheets_create_spreadsheet("New", parent_id="folder123")
+    )
+
+    assert result["status"] == "success"
+    update_kwargs = drive.files.return_value.update.call_args.kwargs
+    assert update_kwargs["addParents"] == "folder123"
+    assert update_kwargs["removeParents"] == "root"
+
+
+def test_create_spreadsheet_returns_partial_status_when_move_fails(monkeypatch):
+    """A failed Drive move must not lose the id of the already-created
+    spreadsheet: the tool must return it with a "partial" status so the
+    caller can recover the file instead of it being silently orphaned in
+    the Drive root with no id to retry against."""
+    spreadsheets = Mock()
+    spreadsheets.create.return_value.execute.return_value = {
+        "spreadsheetId": "sid",
+        "properties": {"title": "New"},
+        "spreadsheetUrl": "https://example.com/sid",
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    drive = Mock()
+    drive.files.return_value.get.return_value.execute.side_effect = RuntimeError(
+        "insufficient permission"
+    )
+    monkeypatch.setattr(google_sheets, "get_drive_service", lambda: drive)
+
+    result = json.loads(
+        google_sheets.google_sheets_create_spreadsheet("New", parent_id="folder123")
+    )
+
+    assert result["status"] == "partial"
+    assert result["spreadsheet_id"] == "sid"
+    assert "insufficient permission" in result["message"]
+
+
+def test_create_spreadsheet_returns_error_payload_when_create_fails(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.create.return_value.execute.side_effect = RuntimeError(
+        "quota exceeded"
+    )
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_create_spreadsheet("New"))
+
+    assert result["status"] == "error"
+    assert "quota exceeded" in result["message"]
+
+
+def test_read_range_returns_values(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.get.return_value.execute.return_value = {
+        "range": "Sheet1!A1:B2",
+        "values": [["a", "b"], ["c", "d"]],
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_read_range("sid", "Sheet1!A1:B2"))
+
+    assert result["status"] == "success"
+    assert result["values"] == [["a", "b"], ["c", "d"]]
+
+
+def test_update_range_sends_values_as_2d_array(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.update.return_value.execute.return_value = {
+        "updatedRange": "Sheet1!A1:B2",
+        "updatedCells": 4,
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_update_range(
+            "sid", "Sheet1!A1:B2", [["a", "b"], ["c", "d"]]
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["updated_cells"] == 4
+    body = spreadsheets.values.return_value.update.call_args.kwargs["body"]
+    assert body == {"values": [["a", "b"], ["c", "d"]]}
+
+
+async def test_update_range_validation_via_mcp_layer(monkeypatch):
+    """The 2D shape contract moved from a manual isinstance check into the
+    values: list[list[Any]] signature, so it is enforced by FastMCP's
+    validation layer — which direct function calls bypass. Exercise the real
+    call path: a 1D list must be rejected before the tool body runs, and a
+    JSON-encoded string (a common LLM behavior) must be pre-parsed into the
+    2D array rather than passed through as a string."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.update.return_value.execute.return_value = {
+        "updatedRange": "Sheet1!A1:B2",
+        "updatedCells": 2,
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    with pytest.raises(ToolError, match="validation error"):
+        await google_sheets.mcp.call_tool(
+            "google_sheets_update_range",
+            {"spreadsheet_id": "sid", "range_name": "Sheet1!A1", "values": ["a", "b"]},
+        )
+    spreadsheets.values.return_value.update.assert_not_called()
+
+    await google_sheets.mcp.call_tool(
+        "google_sheets_update_range",
+        {
+            "spreadsheet_id": "sid",
+            "range_name": "Sheet1!A1:B2",
+            "values": '[["a","b"]]',
+        },
+    )
+    body = spreadsheets.values.return_value.update.call_args.kwargs["body"]
+    assert body == {"values": [["a", "b"]]}
+
+
+def test_update_range_returns_error_payload_on_failure(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.update.return_value.execute.side_effect = (
+        RuntimeError("bad range")
+    )
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_update_range("sid", "Sheet1!A1", [["a"]])
+    )
+
+    assert result["status"] == "error"
+    assert "bad range" in result["message"]
+
+
+def test_append_rows_sends_values_as_2d_array(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.append.return_value.execute.return_value = {
+        "updates": {"updatedRange": "Sheet1!A3:B4", "updatedRows": 2},
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_append_rows("sid", "Sheet1!A1", [["e", "f"]])
+    )
+
+    assert result["status"] == "success"
+    assert result["updated_rows"] == 2
+    body = spreadsheets.values.return_value.append.call_args.kwargs["body"]
+    assert body == {"values": [["e", "f"]]}
+
+
+def test_clear_range(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.clear.return_value.execute.return_value = {
+        "clearedRange": "Sheet1!A1:D10"
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_clear_range("sid", "Sheet1!A1:D10"))
+
+    assert result["status"] == "success"
+    assert result["cleared_range"] == "Sheet1!A1:D10"
+
+
+def test_add_sheet_returns_new_sheet_properties(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.batchUpdate.return_value.execute.return_value = {
+        "replies": [{"addSheet": {"properties": {"sheetId": 42, "title": "Extra"}}}]
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_add_sheet("sid", "Extra"))
+
+    assert result["status"] == "success"
+    assert result["sheet_id"] == 42
+    assert result["title"] == "Extra"
+
+
+def test_add_sheet_handles_missing_replies_without_raising(monkeypatch):
+    """An unexpected/empty replies list must surface as sheet_id=None rather
+    than an unguarded KeyError/IndexError bubbling out as a confusing
+    {"message": "'replies'"} error payload."""
+    spreadsheets = Mock()
+    spreadsheets.batchUpdate.return_value.execute.return_value = {}
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_add_sheet("sid", "Extra"))
+
+    assert result["status"] == "success"
+    assert result["sheet_id"] is None
+    assert result["title"] is None
+
+
+def test_delete_sheet(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.batchUpdate.return_value.execute.return_value = {}
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_delete_sheet("sid", 42))
+
+    assert result["status"] == "success"
+    assert "42" in result["message"]
+
+
+def test_delete_sheet_returns_error_payload_on_failure(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.batchUpdate.return_value.execute.side_effect = RuntimeError(
+        "no such sheet"
+    )
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_delete_sheet("sid", 42))
+
+    assert result["status"] == "error"
+    assert "no such sheet" in result["message"]

--- a/tests/web/tools/test_google_sheets_mcp.py
+++ b/tests/web/tools/test_google_sheets_mcp.py
@@ -62,6 +62,71 @@ def test_resolve_spreadsheet_id_accepts_bare_id_and_url_forms(value, expected):
     assert google_sheets._resolve_spreadsheet_id(value) == expected
 
 
+_URL_WITH_ID = "https://docs.google.com/spreadsheets/d/abc123/edit#gid=0"
+
+
+@pytest.mark.parametrize(
+    ("mock_target", "invoke"),
+    [
+        (
+            lambda sp: sp.get,
+            lambda sid: google_sheets.google_sheets_get_spreadsheet(sid),
+        ),
+        (
+            lambda sp: sp.values.return_value.get,
+            lambda sid: google_sheets.google_sheets_read_range(sid, "Sheet1!A1"),
+        ),
+        (
+            lambda sp: sp.values.return_value.update,
+            lambda sid: google_sheets.google_sheets_update_range(
+                sid, "Sheet1!A1", [["x"]]
+            ),
+        ),
+        (
+            lambda sp: sp.values.return_value.append,
+            lambda sid: google_sheets.google_sheets_append_rows(
+                sid, "Sheet1!A1", [["x"]]
+            ),
+        ),
+        (
+            lambda sp: sp.values.return_value.clear,
+            lambda sid: google_sheets.google_sheets_clear_range(sid, "Sheet1!A1"),
+        ),
+        (
+            lambda sp: sp.batchUpdate,
+            lambda sid: google_sheets.google_sheets_add_sheet(sid, "Extra"),
+        ),
+        (
+            lambda sp: sp.batchUpdate,
+            lambda sid: google_sheets.google_sheets_delete_sheet(sid, 1),
+        ),
+    ],
+    ids=[
+        "get_spreadsheet",
+        "read_range",
+        "update_range",
+        "append_rows",
+        "clear_range",
+        "add_sheet",
+        "delete_sheet",
+    ],
+)
+def test_id_taking_tools_resolve_full_spreadsheet_urls(
+    monkeypatch, mock_target, invoke
+):
+    """Every id-taking tool calls _resolve_spreadsheet_id before hitting the
+    API, but the other tests here all pass an already-bare id, so none of
+    them would notice if that call were deleted from a tool. Drive this
+    through the real call sites with a full URL and assert the *resolved*
+    id is what reached the mocked API call, for each of the 7 tools."""
+    spreadsheets = Mock()
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    invoke(_URL_WITH_ID)
+
+    assert mock_target(spreadsheets).call_args.kwargs["spreadsheetId"] == "abc123"
+
+
 def test_get_spreadsheet_defaults_missing_grid_properties(monkeypatch):
     """A non-grid sheet (e.g. a chart sheet) can omit gridProperties entirely;
     parsing must not raise KeyError/AttributeError on that shape."""
@@ -186,6 +251,58 @@ def test_read_range_returns_values(monkeypatch):
 
     assert result["status"] == "success"
     assert result["values"] == [["a", "b"], ["c", "d"]]
+    assert result["truncated"] is False
+
+
+def test_read_range_defaults_missing_values_key(monkeypatch):
+    """A range with no data at all omits the "values" key entirely rather
+    than sending an empty array; the tool's .get("values", []) default must
+    produce an empty list, not raise."""
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.get.return_value.execute.return_value = {
+        "range": "Sheet1!A1:B2"
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_read_range("sid", "Sheet1!A1:B2"))
+
+    assert result["status"] == "success"
+    assert result["values"] == []
+    assert result["truncated"] is False
+
+
+def test_read_range_caps_rows_and_flags_truncated(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.get.return_value.execute.return_value = {
+        "range": "Sheet1",
+        "values": [[str(i)] for i in range(5)],
+    }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_read_range("sid", "Sheet1", max_rows=3)
+    )
+
+    assert result["status"] == "success"
+    assert result["values"] == [["0"], ["1"], ["2"]]
+    assert result["truncated"] is True
+
+
+@pytest.mark.parametrize("bad_max_rows", [0, -1])
+def test_read_range_rejects_non_positive_max_rows(monkeypatch, bad_max_rows):
+    """A negative max_rows would otherwise flow into values[:max_rows] and
+    silently drop rows from the *end* (values[:-1]) instead of capping —
+    reject it before the API call like google_analytics does for limit."""
+    spreadsheets = Mock()
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_read_range("sid", "Sheet1", max_rows=bad_max_rows)
+    )
+
+    assert result["status"] == "error"
+    assert "max_rows" in result["message"]
+    spreadsheets.values.return_value.get.assert_not_called()
 
 
 def test_update_range_sends_values_as_2d_array(monkeypatch):
@@ -275,11 +392,36 @@ def test_append_rows_sends_values_as_2d_array(monkeypatch):
     assert body == {"values": [["e", "f"]]}
 
 
+def test_append_rows_defaults_missing_updates_key(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.append.return_value.execute.return_value = {}
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(
+        google_sheets.google_sheets_append_rows("sid", "Sheet1!A1", [["e", "f"]])
+    )
+
+    assert result["status"] == "success"
+    assert result["updated_range"] == "Sheet1!A1"
+    assert result["updated_rows"] == 0
+
+
 def test_clear_range(monkeypatch):
     spreadsheets = Mock()
     spreadsheets.values.return_value.clear.return_value.execute.return_value = {
         "clearedRange": "Sheet1!A1:D10"
     }
+    _mock_sheets_service(monkeypatch, spreadsheets)
+
+    result = json.loads(google_sheets.google_sheets_clear_range("sid", "Sheet1!A1:D10"))
+
+    assert result["status"] == "success"
+    assert result["cleared_range"] == "Sheet1!A1:D10"
+
+
+def test_clear_range_defaults_missing_cleared_range_key(monkeypatch):
+    spreadsheets = Mock()
+    spreadsheets.values.return_value.clear.return_value.execute.return_value = {}
     _mock_sheets_service(monkeypatch, spreadsheets)
 
     result = json.loads(google_sheets.google_sheets_clear_range("sid", "Sheet1!A1:D10"))


### PR DESCRIPTION
## Summary
- Add `google_sheets.py` MCP module: read/update/append/clear ranges, add/delete sheets, create spreadsheets, get spreadsheet metadata
- Register `google-sheets` app in `builtin_mcp_registry.py`, reusing the shared `google` OAuth provider (scopes: `spreadsheets`, `drive.file`)
- Seed the catalog entry via a new alembic migration, with a matching migration test

## Test plan
- [x] `ruff check` / `ruff format --check` pass on all new/changed files
- [x] `alembic heads` shows a single head after the new migration
- [x] New migration tests pass (insert / idempotent / downgrade / registry drift check)
- [x] `xagent.web.tools.mcp.google_sheets` imports cleanly
- [x] Enable Google Sheets API in the target GCP project and re-submit OAuth consent screen scopes (`spreadsheets`, `drive.file`) before this connector works end-to-end
- [x] Manually connect Google Sheets in the connector UI and exercise read/update/append against a real spreadsheet