### PR TITLE
docs(deepdoc): document remote Xinference parsing configuration

### DIFF
--- a/example.env
+++ b/example.env
@@ -246,6 +246,21 @@ OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
 # MILVUS_DB_NAME=""
 
 # ===========================================
+# DeepDoc Remote Inference (Xinference)
+# ===========================================
+# Offload DeepDoc document parsing (OCR/layout/table models) to a remote
+# Xinference server with a GPU. When set, ALL DeepDoc-supported formats are
+# parsed remotely; when unset, parsing runs locally. On remote failure xagent
+# logs a warning and falls back to local parsing automatically.
+# XAGENT_DEEPDOC_XINFERENCE_URL="http://gpu-host:9997"
+
+# API key; falls back to XINFERENCE_API_KEY if unset.
+# XAGENT_DEEPDOC_XINFERENCE_API_KEY=""
+
+# Request timeout in seconds for one whole-document parse (default: 1800).
+# XAGENT_DEEPDOC_XINFERENCE_TIMEOUT_SECONDS="1800"
+
+# ===========================================
 # Other Configuration
 # ===========================================
 # JWT Authentication (required for production)


### PR DESCRIPTION
Closes #1167 · Part of #1161 (step S6)

## What

Adds a `DeepDoc Remote Inference (Xinference)` section to `example.env` documenting the three environment variables that control remote DeepDoc document parsing:

- `XAGENT_DEEPDOC_XINFERENCE_URL` — Xinference base URL; unset means parsing runs locally.
- `XAGENT_DEEPDOC_XINFERENCE_API_KEY` — optional, falls back to `XINFERENCE_API_KEY`.
- `XAGENT_DEEPDOC_XINFERENCE_TIMEOUT_SECONDS` — per-document parse timeout, default `1800`.

## Why

`CLAUDE.md` requires new configuration to be reflected in `example.env`, which is the discovery surface operators read when setting up a deployment. Offloading the OCR/layout/table models to a GPU-backed Xinference server is opt-in and invisible without this, so the section also states the two behaviors that are easy to get wrong: setting the URL routes **all** DeepDoc-supported formats remotely, and a remote failure logs a warning and falls back to local parsing rather than failing the parse.

All three variables are optional, so all three assignments stay commented out — matching the file's convention that uncommented lines are values a deployment must actually set.

## Notes

- Documentation only: `example.env` is the sole file touched, additions only.
- The config getters that read these variables land in #1162; the variable names here were cross-checked against section 5 of `docs/deepdoc-remote-parsing.md` (added by the umbrella PR #1169).
- Placed after the embedding/vector-store block so it sits with the other model-inference configuration rather than at the end of the file.

## Verification

- All three names match the requirements doc exactly.
- `end-of-file-fixer` / `trailing-whitespace` invariants verified (single trailing newline, no trailing whitespace, no CRLF); `pre-commit run` could not bootstrap its mypy mirror in this sandbox, but no hook applies to `.env` beyond those two.
