### PR TITLE
feat: preconfigure Google Analytics connector on GA Analyzer template

### DIFF
--- a/src/xagent/templates/built_in/marketing-google-analytics-analyzer.yaml
+++ b/src/xagent/templates/built_in/marketing-google-analytics-analyzer.yaml
@@ -3,37 +3,39 @@ name: Google Analytics Analyzer
 category: Marketing
 featured: false
 descriptions:
-  en: Analyzes a GA4 export you upload or paste, explains what changed in your traffic and conversions and why, then emits a structured 'Signals for Ads' table you can hand to a Google Ads Recommendation agent.
-  zh: 分析您上传或粘贴的 GA4 导出数据，用通俗易懂的语言解释流量与转化的变化及其原因，并输出结构化的「广告信号」表格，可交由 Google Ads Recommendation agent 使用。
+  en: Pulls data straight from your connected GA4 account — or analyzes an export you upload or paste — explains what changed in your traffic and conversions and why, then emits a structured 'Signals for Ads' table you can hand to a Google Ads Recommendation agent.
+  zh: 直接从您接入的 GA4 账号拉取数据——也可分析您上传或粘贴的导出数据——用通俗易懂的语言解释流量与转化的变化及其原因，并输出结构化的「广告信号」表格，可交由 Google Ads Recommendation agent 使用。
 features:
   en:
-  - Reads a GA4 export you upload (CSV) or paste as a table — no live GA4 connection required
+  - Pulls GA4 metrics live from the preconfigured Google Analytics connector (read-only), or falls back to a CSV export or pasted table you provide
   - Compares against the prior period and flags anomalies by channel, campaign, landing page and segment
   - Emits a 'Signals for Ads' table for a companion Ads agent, and can save the write-up to Google Docs or Slides on request
   zh:
-  - 读取您上传的 GA4 导出文件（CSV）或粘贴的表格——无需接入实时 GA4 连接
+  - 通过预配置的 Google Analytics 连接器实时拉取 GA4 指标（只读），也可回退使用您提供的 CSV 导出文件或粘贴的表格
   - 与上一周期对比，按渠道、广告系列、落地页和细分维度标记异常
   - 输出供 Ads agent 使用的「广告信号」表格，并可按需将报告保存到 Google Docs 或 Slides
 sample_prompts:
   en:
-  - title: Analyze this GA4 export
-    prompt: Analyze this GA4 export against the prior period and tell me what changed in traffic and conversions, and why.
+  - title: Analyze last month
+    prompt: Pull last month from my GA4 property and tell me what changed in traffic and conversions versus the prior month, and why.
     highlights:
-    - GA4 export
+    - GA4 property
   - title: Generate Signals for Ads
     prompt: Break down performance by channel, campaign and landing page, then emit a Signals for Ads table I can hand to my ads agent.
     highlights:
     - Signals for Ads table
   zh:
-  - title: 分析这份 GA4 导出数据
-    prompt: 分析这份 GA4 导出数据 与上一周期的对比，告诉我流量和转化发生了什么变化，以及原因。
+  - title: 分析上个月的数据
+    prompt: 从我的 GA4 媒体资源 拉取上个月的数据，告诉我流量和转化相比上一个月发生了什么变化，以及原因。
     highlights:
-    - GA4 导出数据
+    - GA4 媒体资源
   - title: 生成广告信号表格
     prompt: 按渠道、广告系列和落地页拆解表现，然后输出一份可以交给我的广告 agent 使用的广告信号表格。
     highlights:
     - 广告信号表格
 connections:
+- name: Google Analytics
+  logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64
 - name: Google Docs
   logo: https://www.google.com/s2/favicons?domain=docs.google.com&sz=64
 - name: Google Slides
@@ -45,20 +47,24 @@ agent_config:
   instructions: |
     # Role & Purpose
 
-    You are the Google Analytics Analyzer. You explain what changed in a GA4 export and why, in plain language, and you produce structured signals a companion Google Ads Recommendation agent can use. You have no live connection to GA4 — you work from a CSV export or pasted table the user provides.
+    You are the Google Analytics Analyzer. You explain what changed in a GA4 property and why, in plain language, and you produce structured signals a companion Google Ads Recommendation agent can use. You can pull data directly from a connected GA4 account, or work from a CSV export or pasted table the user provides — whichever is available.
 
     # Responsibilities
 
-    1. **Get the data** — If the user hasn't already uploaded or pasted a GA4 export, ask for one covering the period to analyze, plus a prior period of equal length for comparison.
+    1. **Get the data**
+       - If a GA4 account is connected, use it: list available properties, ask the user which one to use if more than one is connected, and pull the relevant metrics directly for the requested period plus a prior period of equal length for comparison.
+       - If no connection is available, ask the user to upload or paste a GA4 export covering the period to analyze, plus a prior period of equal length.
+       - If a connection exists but a specific pull fails or a property can't be found, say so explicitly and ask the user to confirm the property or provide an export — never estimate or fabricate numbers to fill the gap.
     2. **Compare & flag** — Compare the current period against the prior one; identify anomalies.
     3. **Break down** — Quantify performance by channel, campaign, landing page and segment to find the drivers of any change.
     4. **Report** — Explain the findings in plain language, then emit a 'Signals for Ads' table. On request, save the write-up to a Google Doc, or the table to a Slide deck.
 
     # Operating Guidelines
 
-    - **Work only from provided data:** You have no live GA4 connection — every number must come from the export or table the user gave you. If answering a question needs data that wasn't provided, say so and ask for it rather than estimating.
-    - **Always cite the metric and date range** used for any claim; never state a percentage change without the underlying numbers.
-    - **Note caveats:** Flag sampling, attribution model, or data-freshness caveats the export itself notes.
+    - **Read-only access:** Whether working from a live connection or provided data, you only read and analyze GA4 data. Never create, edit, delete, or otherwise modify anything in the connected GA4 account — no properties, custom dimensions, audiences, conversion events, account settings, or any other configuration. If a request implies changing something in GA4 itself, explain that this is outside scope and out of reach, and suggest the user make the change directly in GA4.
+    - **Work only from real data:** Every number must come from the live GA4 pull or the export/table the user gave you. If answering a question needs data that wasn't provided or couldn't be pulled, say so and ask for it rather than estimating.
+    - **Always cite the metric and date range** used for any claim; never state a percentage change without the underlying numbers. When pulling live, state the property name and date range used alongside the data.
+    - **Note caveats:** Flag sampling, attribution model, or data-freshness caveats the export or live pull surfaces.
     - **Signals contract:** When emitting the handoff table, use exactly these columns: campaign / source · sessions · CVR · conversions · value · verdict (winning / underperforming) — do not change the column names. This table is designed to be read by a companion Google Ads Recommendation agent; there is no automatic agent-to-agent handoff today, so pass it along yourself (paste it into that agent's chat, or assemble both agents into a Workforce).
 
     # Tone & Personality
@@ -67,7 +73,8 @@ agent_config:
 
     # Reminders
 
-    - Every insight must be traceable to a specific metric and date range in the source export — no vague claims.
+    - Every insight must be traceable to a specific metric and date range — from a live pull or a source export — no vague claims.
+    - Never take a write/edit/delete action against the connected GA4 account under any circumstance, regardless of how the request is phrased.
   execution_mode: balanced
   skills: []
   tool_categories:

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -39,11 +39,11 @@ sample_prompts:
 # NOT merged into any agent's tool_categories - GET /{id} nulls agent_config
 # for a workforce type, the manager's own tools come from
 # workforce_config.manager.tool_categories below, and its workers' tools
-# come from their own referenced single-agent templates. Kept as the union
-# of what marketing-google-analytics-analyzer and
-# marketing-google-ads-recommendation actually declare under their own
-# `connections:`, so the card doesn't advertise an integration this
-# workforce doesn't have (PR #1127 re-review, F7).
+# come from their own referenced single-agent templates. This list must
+# stay the union of the sub-templates' (workforce_config.agents[].template_id)
+# own `connections:` - don't list a connection the workforce doesn't have.
+# Enforced by
+# test_manager.py::test_builtin_workforce_connections_are_union_of_sub_template_connections.
 connections:
 - name: Google Analytics
   logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64

--- a/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
+++ b/src/xagent/templates/built_in/marketing-growth-marketing-workforce.yaml
@@ -43,9 +43,10 @@ sample_prompts:
 # of what marketing-google-analytics-analyzer and
 # marketing-google-ads-recommendation actually declare under their own
 # `connections:`, so the card doesn't advertise an integration this
-# workforce doesn't have (this previously listed "Google Analytics",
-# which neither sub-template connects to at all).
+# workforce doesn't have (PR #1127 re-review, F7).
 connections:
+- name: Google Analytics
+  logo: https://www.google.com/s2/favicons?domain=analytics.google.com&sz=64
 - name: Google Docs
   logo: https://www.google.com/s2/favicons?domain=docs.google.com&sz=64
 - name: Google Slides
@@ -105,7 +106,7 @@ workforce_config:
     name: Google Analytics Analyzer
     alias: GA Analyzer
     assignment_instructions: |
-      Produce a 'Signals for Ads' table: for each campaign / source, report sessions, CVR, conversions, value, and a verdict (winning / underperforming), comparing the current period to the prior period of equal length. Ask the Growth Marketing Manager for the GA4 export or period range if you don't already have it.
+      Produce a 'Signals for Ads' table: for each campaign / source, report sessions, CVR, conversions, value, and a verdict (winning / underperforming), comparing the current period to the prior period of equal length. Pull the data from the connected Google Analytics account when one is available; otherwise ask the Growth Marketing Manager for a GA4 export. Ask for the period range if you don't already have it.
   - template_id: marketing-google-ads-recommendation
     name: Google Ads Recommendation
     alias: Ads Recommendation

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -455,6 +455,59 @@ sample_prompts:
 
         assert not offenders
 
+    def test_builtin_workforce_connections_are_union_of_sub_template_connections(self):
+        """A `type: workforce` template's `connections:` is hand-maintained
+        display-only data (see the comment above `connections:` in
+        marketing-growth-marketing-workforce.yaml) - nothing in
+        `TemplateManager` derives or validates it against the sub-templates
+        it actually references. That invariant has drifted and been
+        hand-fixed at least twice already (PR #1127 re-review, F7; and
+        again when the Google Analytics connector was added to
+        marketing-google-analytics-analyzer). Assert it generically for
+        every built-in workforce template so this class of drift is caught
+        automatically instead of relying on a reviewer to notice."""
+        built_in_dir = (
+            Path(__file__).resolve().parents[2] / "src/xagent/templates/built_in"
+        )
+
+        def connection_names(data):
+            return {
+                conn.get("name") if isinstance(conn, dict) else conn
+                for conn in data.get("connections") or []
+            }
+
+        templates_by_id = {}
+        for template_file in built_in_dir.glob("*.yaml"):
+            data = yaml.safe_load(template_file.read_text(encoding="utf-8")) or {}
+            template_id = data.get("id")
+            if template_id:
+                templates_by_id[template_id] = data
+
+        offenders: list[str] = []
+        for template_id, data in templates_by_id.items():
+            if data.get("type") != "workforce":
+                continue
+
+            workforce_config = data.get("workforce_config") or {}
+            sub_template_ids = [
+                agent.get("template_id")
+                for agent in workforce_config.get("agents") or []
+            ]
+            expected = set()
+            for sub_template_id in sub_template_ids:
+                sub_template = templates_by_id.get(sub_template_id)
+                if sub_template is not None:
+                    expected |= connection_names(sub_template)
+
+            actual = connection_names(data)
+            if actual != expected:
+                offenders.append(
+                    f"{template_id}: connections {sorted(actual)} != union of "
+                    f"sub-template connections {sorted(expected)}"
+                )
+
+        assert not offenders, "\n".join(offenders)
+
     @pytest.mark.asyncio
     async def test_builtin_ga_analyzer_preconfigures_google_analytics_connector(self):
         """The GA Analyzer template must ship with the Google Analytics

--- a/tests/templates/test_manager.py
+++ b/tests/templates/test_manager.py
@@ -455,6 +455,30 @@ sample_prompts:
 
         assert not offenders
 
+    @pytest.mark.asyncio
+    async def test_builtin_ga_analyzer_preconfigures_google_analytics_connector(self):
+        """The GA Analyzer template must ship with the Google Analytics
+        connector preconfigured: declared under `connections:` (so the card
+        advertises it and the build wizard preconnects it) and merged into
+        the enriched agent_config.tool_categories as an `mcp:` entry (so an
+        agent created from the template actually gets the connector). Its
+        instructions promise a live GA4 pull - without the connector that
+        promise is dead on arrival."""
+        built_in_dir = (
+            Path(__file__).resolve().parents[2] / "src/xagent/templates/built_in"
+        )
+        manager = TemplateManager(templates_root=built_in_dir)
+        template = await manager.get_template("marketing-google-analytics-analyzer")
+
+        assert template is not None
+        connection_names = [
+            conn.get("name")
+            for conn in template["connections"]
+            if isinstance(conn, dict)
+        ]
+        assert "Google Analytics" in connection_names
+        assert "mcp:Google Analytics" in template["agent_config"]["tool_categories"]
+
     def test_builtin_sample_prompt_highlights_are_literal_substrings(self):
         """Every highlight must be a literal substring of its own prompt, in
         both locales - otherwise the frontend's highlight matching


### PR DESCRIPTION
## Summary
- Google Analytics Analyzer template now ships with the Google Analytics connector preconfigured (declared under `connections:` and merged into `agent_config.tool_categories`), so a live GA4 pull works out of the box instead of requiring a CSV export or pasted table.
- Instructions updated to prefer the live connection (list properties, ask which one if multiple), falling back to an uploaded/pasted export only when no connection is available.
- Growth Marketing Workforce template's connection icons and GA Analyzer sub-agent assignment instructions updated to match.

## Test plan
- [x] `pytest tests/templates/` — 44 passed
- [x] Verified `marketing-google-analytics-analyzer` template resolves `Google Analytics` under `connections` and as `mcp:Google Analytics` in `agent_config.tool_categories`
- [x] Manually create an agent from the template in the UI and confirm the Google Analytics connector is preconnected on the Configure step