### PR TITLE
fix: replace flaky wall-clock budgets in Pytest Fast (web) tests

### DIFF
--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -104,10 +104,11 @@ def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
 # Anti-hang bounds, not latency assertions. Nothing here is measuring speed:
 # these handlers finish in milliseconds, and the budgets only exist so a
 # deadlock fails as a test error instead of hanging the run. They are therefore
-# set far above any plausible runtime on a contended CI runner, and a
-# cross-thread handshake must expire *before* the handler deadline so the
-# failure is reported by the specific assertion rather than a bare TimeoutError.
-_HANDSHAKE_DEADLINE_SECONDS = 10.0
+# set far above any plausible runtime on a contended CI runner. A wait on a
+# signal crossing the loop/worker-thread boundary must expire *before* the
+# handler deadline, so a stall is reported by the specific assertion that owns
+# the signal rather than by a bare TimeoutError on the whole handler.
+_THREAD_SIGNAL_DEADLINE_SECONDS = 10.0
 _HANDLER_DEADLINE_SECONDS = 30.0
 
 
@@ -116,10 +117,13 @@ class _EventLoopLivenessProbe:
 
     Wrapping a synchronous step in :meth:`gate` makes that step block until the
     event loop answers back. If the step runs off the loop (in a worker thread)
-    the probe task answers immediately and ``loop_ran_during_step`` is True. If
-    the step runs *on* the loop thread, nothing can answer, the handshake
-    expires and the flag stays False. The verdict therefore depends on where
-    the work ran, not on how fast the machine is.
+    the probe task is scheduled on the next loop pass and answers, leaving
+    ``loop_ran_during_step`` True. If the step runs *on* the loop thread,
+    nothing can answer, the wait expires and the flag stays False. The verdict
+    therefore depends on where the work ran, not on how fast the machine is.
+
+    The gate is entered once per test. Both events latch, so a second gated
+    call is answered from the first handshake rather than probed again.
     """
 
     def __init__(self) -> None:
@@ -153,7 +157,7 @@ class _EventLoopLivenessProbe:
             self.step_ran = True
             self._step_entered.set()
             self.loop_ran_during_step = self._loop_answered.wait(
-                timeout=_HANDSHAKE_DEADLINE_SECONDS
+                timeout=_THREAD_SIGNAL_DEADLINE_SECONDS
             )
             return step(*args, **kwargs)
 
@@ -472,9 +476,9 @@ async def test_chat_turn_releases_one_slot_pool_before_task_info_broadcast(
         begin_turn,
     )
 
-    # The gate replaces the artificial sleep that used to make loop blocking
-    # observable. Overlap detection is separate and unchanged: the one-slot
-    # pool raises on a task-info checkout that collides with preparation.
+    # The gate holds preparation open long enough for loop blocking to be
+    # observable. Overlap detection is a separate mechanism: the one-slot pool
+    # raises on a task-info checkout that collides with preparation.
     async with _EventLoopLivenessProbe() as probe:
         monkeypatch.setattr(
             websocket_api,
@@ -948,7 +952,7 @@ async def test_missing_task_cancel_after_atomic_create_never_leaves_pending(
     def blocked_prepare_turn(**kwargs):
         preparation = prepare_turn(**kwargs)
         worker_finished.set()
-        assert release_worker.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
+        assert release_worker.wait(timeout=_THREAD_SIGNAL_DEADLINE_SECONDS)
         return preparation
 
     schedule = AsyncMock()
@@ -978,7 +982,7 @@ async def test_missing_task_cancel_after_atomic_create_never_leaves_pending(
     )
     try:
         assert await asyncio.to_thread(
-            worker_finished.wait, _HANDSHAKE_DEADLINE_SECONDS
+            worker_finished.wait, _THREAD_SIGNAL_DEADLINE_SECONDS
         )
         handler.cancel()
         release_worker.set()
@@ -1819,7 +1823,7 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
 
     def mark_delivery(*_args, **_kwargs) -> None:
         marker_started.set()
-        assert marker_release.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
+        assert marker_release.wait(timeout=_THREAD_SIGNAL_DEADLINE_SECONDS)
 
     async def resume_forever(*_args, **_kwargs) -> None:
         try:
@@ -1860,7 +1864,9 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
                 },
             )
         )
-        assert await asyncio.to_thread(marker_started.wait, 5)
+        assert await asyncio.to_thread(
+            marker_started.wait, _THREAD_SIGNAL_DEADLINE_SECONDS
+        )
         handling.cancel()
         marker_release.set()
         with pytest.raises(asyncio.CancelledError):
@@ -2179,7 +2185,7 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
 
     def blocking_mark_delivery(*_args, **_kwargs) -> None:
         persistence_started.set()
-        assert allow_persistence.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
+        assert allow_persistence.wait(timeout=_THREAD_SIGNAL_DEADLINE_SECONDS)
         persistence_finished.set()
 
     with (
@@ -2206,7 +2212,7 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
         # Without the assert a slow runner silently proceeds to cancel before
         # persistence started, which changes what the rest of the test proves.
         assert await asyncio.to_thread(
-            persistence_started.wait, _HANDSHAKE_DEADLINE_SECONDS
+            persistence_started.wait, _THREAD_SIGNAL_DEADLINE_SECONDS
         )
         handling.cancel()
         await asyncio.sleep(0)

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Callable
 from dataclasses import is_dataclass
 from types import SimpleNamespace
+from typing import Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -111,52 +113,36 @@ def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
 _THREAD_SIGNAL_DEADLINE_SECONDS = 10.0
 _HANDLER_DEADLINE_SECONDS = 30.0
 
+_T = TypeVar("_T")
+
 
 class _EventLoopLivenessProbe:
     """Deterministic replacement for counting event-loop ticks.
 
-    Wrapping a synchronous step in :meth:`gate` makes that step block until the
-    event loop answers back. If the step runs off the loop (in a worker thread)
-    the probe task is scheduled on the next loop pass and answers, leaving
-    ``loop_ran_during_step`` True. If the step runs *on* the loop thread,
-    nothing can answer, the wait expires and the flag stays False. The verdict
-    therefore depends on where the work ran, not on how fast the machine is.
-
-    The gate is entered once per test. Both events latch, so a second gated
-    call is answered from the first handshake rather than probed again.
+    Wrapping a synchronous step in :meth:`gate` makes that step queue an answer
+    on the event loop and then block until the loop delivers it. Off the loop
+    (in a worker thread) the loop runs the callback on its next pass. On the
+    loop thread the queued callback cannot run, because the loop thread is the
+    one blocking, so the wait expires. The verdict therefore depends on where
+    the work ran, not on how fast the machine is.
     """
 
     def __init__(self) -> None:
-        self._step_entered = threading.Event()
-        self._loop_answered = threading.Event()
-        self._task: asyncio.Task[None] | None = None
+        # Captured here rather than inside the gate: the gated step may run in
+        # a worker thread, where get_running_loop() raises.
+        self._loop = asyncio.get_running_loop()
+        self._answered = threading.Event()
         self.step_ran = False
         self.loop_ran_during_step = False
 
-    async def __aenter__(self) -> _EventLoopLivenessProbe:
-        async def _answer() -> None:
-            while not self._step_entered.is_set():
-                await asyncio.sleep(0.001)
-            self._loop_answered.set()
+    def gate(self, step: Callable[..., _T]) -> Callable[..., _T]:
+        """Wrap ``step`` so it holds until the event loop answers."""
 
-        self._task = asyncio.create_task(_answer())
-        return self
-
-    async def __aexit__(self, *_exc_info: object) -> None:
-        assert self._task is not None
-        self._task.cancel()
-        try:
-            await self._task
-        except asyncio.CancelledError:
-            pass
-
-    def gate(self, step):
-        """Wrap ``step`` so it holds until the loop answers the handshake."""
-
-        def gated(*args, **kwargs):
+        def gated(*args: Any, **kwargs: Any) -> _T:
+            assert not self.step_ran, "the probe gates a single call"
             self.step_ran = True
-            self._step_entered.set()
-            self.loop_ran_during_step = self._loop_answered.wait(
+            self._loop.call_soon_threadsafe(self._answered.set)
+            self.loop_ran_during_step = self._answered.wait(
                 timeout=_THREAD_SIGNAL_DEADLINE_SECONDS
             )
             return step(*args, **kwargs)
@@ -479,28 +465,28 @@ async def test_chat_turn_releases_one_slot_pool_before_task_info_broadcast(
     # The gate holds preparation open long enough for loop blocking to be
     # observable. Overlap detection is a separate mechanism: the one-slot pool
     # raises on a task-info checkout that collides with preparation.
-    async with _EventLoopLivenessProbe() as probe:
-        monkeypatch.setattr(
-            websocket_api,
-            "_prepare_websocket_turn_sync",
-            probe.gate(prepare_turn),
+    probe = _EventLoopLivenessProbe()
+    monkeypatch.setattr(
+        websocket_api,
+        "_prepare_websocket_turn_sync",
+        probe.gate(prepare_turn),
+    )
+    try:
+        await asyncio.wait_for(
+            _handle_chat_message_unserialized(
+                websocket,  # type: ignore[arg-type]
+                task_id,
+                {
+                    "message": "follow-up",
+                    "client_message_id": "broadcast-pool-turn",
+                    "user": SimpleNamespace(id=actor_user_id, is_admin=False),
+                    "files": [],
+                },
+            ),
+            timeout=_HANDLER_DEADLINE_SECONDS,
         )
-        try:
-            await asyncio.wait_for(
-                _handle_chat_message_unserialized(
-                    websocket,  # type: ignore[arg-type]
-                    task_id,
-                    {
-                        "message": "follow-up",
-                        "client_message_id": "broadcast-pool-turn",
-                        "user": SimpleNamespace(id=actor_user_id, is_admin=False),
-                        "files": [],
-                    },
-                ),
-                timeout=_HANDLER_DEADLINE_SECONDS,
-            )
-        finally:
-            engine.dispose()
+    finally:
+        engine.dispose()
 
     probe.assert_loop_stayed_responsive("WebSocket preparation")
     begin_turn.assert_awaited_once()
@@ -590,29 +576,29 @@ async def test_pause_accepted_wait_releases_one_slot_pool_before_previous_run(
     )
 
     websocket_api._mark_task_pause_accepted(task_id)
-    async with _EventLoopLivenessProbe() as probe:
-        monkeypatch.setattr(
-            websocket_api,
-            "_prepare_websocket_turn_sync",
-            probe.gate(prepare_turn),
+    probe = _EventLoopLivenessProbe()
+    monkeypatch.setattr(
+        websocket_api,
+        "_prepare_websocket_turn_sync",
+        probe.gate(prepare_turn),
+    )
+    try:
+        await asyncio.wait_for(
+            _handle_chat_message_unserialized(
+                MagicMock(),
+                task_id,
+                {
+                    "message": "continue after pause",
+                    "client_message_id": "pause-pool-turn",
+                    "user": SimpleNamespace(id=actor_user_id, is_admin=False),
+                    "files": [],
+                },
+            ),
+            timeout=_HANDLER_DEADLINE_SECONDS,
         )
-        try:
-            await asyncio.wait_for(
-                _handle_chat_message_unserialized(
-                    MagicMock(),
-                    task_id,
-                    {
-                        "message": "continue after pause",
-                        "client_message_id": "pause-pool-turn",
-                        "user": SimpleNamespace(id=actor_user_id, is_admin=False),
-                        "files": [],
-                    },
-                ),
-                timeout=_HANDLER_DEADLINE_SECONDS,
-            )
-        finally:
-            websocket_api._clear_task_pause_accepted(task_id)
-            engine.dispose()
+    finally:
+        websocket_api._clear_task_pause_accepted(task_id)
+        engine.dispose()
 
     probe.assert_loop_stayed_responsive("pause settlement preparation")
     # The settlement itself is guarded by the one-slot pool: it opens its own

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import time
 from dataclasses import is_dataclass
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -100,6 +99,69 @@ def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
     db.commit()
     db.refresh(t)
     return t
+
+
+# Anti-hang bounds, not latency assertions. Nothing here is measuring speed:
+# these handlers finish in milliseconds, and the budgets only exist so a
+# deadlock fails as a test error instead of hanging the run. They are therefore
+# set far above any plausible runtime on a contended CI runner, and a
+# cross-thread handshake must expire *before* the handler deadline so the
+# failure is reported by the specific assertion rather than a bare TimeoutError.
+_HANDSHAKE_DEADLINE_SECONDS = 10.0
+_HANDLER_DEADLINE_SECONDS = 30.0
+
+
+class _EventLoopLivenessProbe:
+    """Deterministic replacement for counting event-loop ticks.
+
+    Wrapping a synchronous step in :meth:`gate` makes that step block until the
+    event loop answers back. If the step runs off the loop (in a worker thread)
+    the probe task answers immediately and ``loop_ran_during_step`` is True. If
+    the step runs *on* the loop thread, nothing can answer, the handshake
+    expires and the flag stays False. The verdict therefore depends on where
+    the work ran, not on how fast the machine is.
+    """
+
+    def __init__(self) -> None:
+        self._step_entered = threading.Event()
+        self._loop_answered = threading.Event()
+        self._task: asyncio.Task[None] | None = None
+        self.step_ran = False
+        self.loop_ran_during_step = False
+
+    async def __aenter__(self) -> _EventLoopLivenessProbe:
+        async def _answer() -> None:
+            while not self._step_entered.is_set():
+                await asyncio.sleep(0.001)
+            self._loop_answered.set()
+
+        self._task = asyncio.create_task(_answer())
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        assert self._task is not None
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+
+    def gate(self, step):
+        """Wrap ``step`` so it holds until the loop answers the handshake."""
+
+        def gated(*args, **kwargs):
+            self.step_ran = True
+            self._step_entered.set()
+            self.loop_ran_during_step = self._loop_answered.wait(
+                timeout=_HANDSHAKE_DEADLINE_SECONDS
+            )
+            return step(*args, **kwargs)
+
+        return gated
+
+    def assert_loop_stayed_responsive(self, what: str) -> None:
+        assert self.step_ran, f"{what} never ran"
+        assert self.loop_ran_during_step, f"{what} blocked the asyncio event loop"
 
 
 @pytest.mark.asyncio
@@ -399,56 +461,44 @@ async def test_chat_turn_releases_one_slot_pool_before_task_info_broadcast(
     local_manager = websocket_api.ConnectionManager()
     local_manager.register_connection(websocket, task_id)  # type: ignore[arg-type]
     begin_turn = AsyncMock()
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
 
     monkeypatch.setattr(websocket_api, "get_db", local_get_db)
     monkeypatch.setattr(websocket_api, "get_session_local", lambda: SessionLocal)
     monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
     prepare_turn = websocket_api._prepare_websocket_turn_sync
-
-    def slow_prepare_turn(**kwargs):
-        time.sleep(0.05)
-        return prepare_turn(**kwargs)
-
-    monkeypatch.setattr(
-        websocket_api,
-        "_prepare_websocket_turn_sync",
-        slow_prepare_turn,
-    )
     monkeypatch.setattr(websocket_api, "manager", local_manager)
     monkeypatch.setattr(
         "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
         begin_turn,
     )
 
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await asyncio.wait_for(
-            _handle_chat_message_unserialized(
-                websocket,  # type: ignore[arg-type]
-                task_id,
-                {
-                    "message": "follow-up",
-                    "client_message_id": "broadcast-pool-turn",
-                    "user": SimpleNamespace(id=actor_user_id, is_admin=False),
-                    "files": [],
-                },
-            ),
-            timeout=1.0,
+    # The gate replaces the artificial sleep that used to make loop blocking
+    # observable. Overlap detection is separate and unchanged: the one-slot
+    # pool raises on a task-info checkout that collides with preparation.
+    async with _EventLoopLivenessProbe() as probe:
+        monkeypatch.setattr(
+            websocket_api,
+            "_prepare_websocket_turn_sync",
+            probe.gate(prepare_turn),
         )
-        assert ticks >= 3, "WebSocket preparation blocked the asyncio event loop"
-    finally:
-        ticker_stop.set()
-        await ticker_task
-        engine.dispose()
+        try:
+            await asyncio.wait_for(
+                _handle_chat_message_unserialized(
+                    websocket,  # type: ignore[arg-type]
+                    task_id,
+                    {
+                        "message": "follow-up",
+                        "client_message_id": "broadcast-pool-turn",
+                        "user": SimpleNamespace(id=actor_user_id, is_admin=False),
+                        "files": [],
+                    },
+                ),
+                timeout=_HANDLER_DEADLINE_SECONDS,
+            )
+        finally:
+            engine.dispose()
 
+    probe.assert_loop_stayed_responsive("WebSocket preparation")
     begin_turn.assert_awaited_once()
 
 
@@ -519,29 +569,11 @@ async def test_pause_accepted_wait_releases_one_slot_pool_before_previous_run(
         send_personal_message=AsyncMock(),
     )
     begin_turn = AsyncMock()
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
 
     monkeypatch.setattr(websocket_api, "get_db", local_get_db)
     monkeypatch.setattr(websocket_api, "get_session_local", lambda: SessionLocal)
     monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
     prepare_turn = websocket_api._prepare_websocket_turn_sync
-
-    def slow_prepare_turn(**kwargs):
-        time.sleep(0.05)
-        return prepare_turn(**kwargs)
-
-    monkeypatch.setattr(
-        websocket_api,
-        "_prepare_websocket_turn_sync",
-        slow_prepare_turn,
-    )
     monkeypatch.setattr(websocket_api, "manager", ws_manager)
     monkeypatch.setattr(
         websocket_api,
@@ -554,28 +586,34 @@ async def test_pause_accepted_wait_releases_one_slot_pool_before_previous_run(
     )
 
     websocket_api._mark_task_pause_accepted(task_id)
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await asyncio.wait_for(
-            _handle_chat_message_unserialized(
-                MagicMock(),
-                task_id,
-                {
-                    "message": "continue after pause",
-                    "client_message_id": "pause-pool-turn",
-                    "user": SimpleNamespace(id=actor_user_id, is_admin=False),
-                    "files": [],
-                },
-            ),
-            timeout=1.0,
+    async with _EventLoopLivenessProbe() as probe:
+        monkeypatch.setattr(
+            websocket_api,
+            "_prepare_websocket_turn_sync",
+            probe.gate(prepare_turn),
         )
-        assert ticks >= 3, "pause settlement checkout blocked the event loop"
-    finally:
-        websocket_api._clear_task_pause_accepted(task_id)
-        ticker_stop.set()
-        await ticker_task
-        engine.dispose()
+        try:
+            await asyncio.wait_for(
+                _handle_chat_message_unserialized(
+                    MagicMock(),
+                    task_id,
+                    {
+                        "message": "continue after pause",
+                        "client_message_id": "pause-pool-turn",
+                        "user": SimpleNamespace(id=actor_user_id, is_admin=False),
+                        "files": [],
+                    },
+                ),
+                timeout=_HANDLER_DEADLINE_SECONDS,
+            )
+        finally:
+            websocket_api._clear_task_pause_accepted(task_id)
+            engine.dispose()
 
+    probe.assert_loop_stayed_responsive("pause settlement preparation")
+    # The settlement itself is guarded by the one-slot pool: it opens its own
+    # session, so it can only succeed if the handler released its checkout
+    # before awaiting the previous run.
     background_manager.wait_for_previous.assert_awaited_once_with(task_id)
     begin_turn.assert_awaited_once()
     assert begin_turn.await_args.kwargs["kind"].value == "append"
@@ -910,7 +948,7 @@ async def test_missing_task_cancel_after_atomic_create_never_leaves_pending(
     def blocked_prepare_turn(**kwargs):
         preparation = prepare_turn(**kwargs)
         worker_finished.set()
-        assert release_worker.wait(timeout=2)
+        assert release_worker.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
         return preparation
 
     schedule = AsyncMock()
@@ -939,7 +977,9 @@ async def test_missing_task_cancel_after_atomic_create_never_leaves_pending(
         )
     )
     try:
-        assert await asyncio.to_thread(worker_finished.wait, 2)
+        assert await asyncio.to_thread(
+            worker_finished.wait, _HANDSHAKE_DEADLINE_SECONDS
+        )
         handler.cancel()
         release_worker.set()
         with pytest.raises(asyncio.CancelledError):
@@ -1779,7 +1819,7 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
 
     def mark_delivery(*_args, **_kwargs) -> None:
         marker_started.set()
-        assert marker_release.wait(timeout=5)
+        assert marker_release.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
 
     async def resume_forever(*_args, **_kwargs) -> None:
         try:
@@ -2139,7 +2179,7 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
 
     def blocking_mark_delivery(*_args, **_kwargs) -> None:
         persistence_started.set()
-        assert allow_persistence.wait(timeout=2)
+        assert allow_persistence.wait(timeout=_HANDSHAKE_DEADLINE_SECONDS)
         persistence_finished.set()
 
     with (
@@ -2163,9 +2203,10 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
                 },
             )
         )
-        await asyncio.wait_for(
-            asyncio.to_thread(persistence_started.wait, 1),
-            timeout=1,
+        # Without the assert a slow runner silently proceeds to cancel before
+        # persistence started, which changes what the rest of the test proves.
+        assert await asyncio.to_thread(
+            persistence_started.wait, _HANDSHAKE_DEADLINE_SECONDS
         )
         handling.cancel()
         await asyncio.sleep(0)

--- a/tests/web/api/test_workforce_share_link.py
+++ b/tests/web/api/test_workforce_share_link.py
@@ -35,6 +35,13 @@ from .conftest import (
 
 pytestmark = pytest.mark.usefixtures("_test_db")
 
+# Anti-hang bounds, not latency assertions. The WS handler and the detached
+# command it enqueues settle in milliseconds; these budgets exist only so a
+# deadlock or a lost command fails as a test error instead of hanging the run,
+# so they are set far above any plausible runtime on a contended CI runner.
+_DEADLINE_SECONDS = 30.0
+_SETTLE_POLL_SECONDS = 0.01
+
 
 def _user_id(username: str = "admin") -> int:
     db = _direct_db_session()
@@ -799,10 +806,19 @@ async def test_ws_append_syncs_workforce_run_back_to_running(
                 )
             )
             try:
-                await asyncio.wait_for(turn_started.wait(), timeout=1.0)
-                await asyncio.wait_for(asyncio.shield(handler_task), timeout=1.0)
+                await asyncio.wait_for(turn_started.wait(), timeout=_DEADLINE_SECONDS)
+                await asyncio.wait_for(
+                    asyncio.shield(handler_task), timeout=_DEADLINE_SECONDS
+                )
 
-                for _ in range(100):
+                # The command is applied by a detached background task, so the
+                # only observable signal is the committed row. Poll against a
+                # wall-clock deadline rather than a fixed iteration count: a
+                # loaded runner slows each iteration down, which would shrink a
+                # count-based budget exactly when it needs to be widest.
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + _DEADLINE_SECONDS
+                while True:
                     command_db = _direct_db_session()
                     try:
                         run_status = (
@@ -819,14 +835,15 @@ async def test_ws_append_syncs_workforce_run_back_to_running(
                         command_db.close()
                     if run_status == "running" and command_status == "completed":
                         break
-                    await asyncio.sleep(0.01)
-                else:
-                    raise AssertionError(
-                        "detached APPEND command did not project the WorkforceRun "
-                        "to running"
-                    )
+                    if loop.time() >= deadline:
+                        raise AssertionError(
+                            "detached APPEND command did not project the "
+                            f"WorkforceRun to running (run_status={run_status!r}, "
+                            f"command_status={command_status!r})"
+                        )
+                    await asyncio.sleep(_SETTLE_POLL_SECONDS)
             finally:
                 if not handler_task.done():
-                    await asyncio.wait_for(handler_task, timeout=1.0)
+                    await asyncio.wait_for(handler_task, timeout=_DEADLINE_SECONDS)
     finally:
         db.close()


### PR DESCRIPTION
## Problem

`Pytest Fast (web)` fails intermittently with `TimeoutError` on tests that assert against hard wall-clock budgets. Two properties were being measured through timing proxies that a contended CI runner can violate with no regression in the code under test:

- `asyncio.wait_for(..., timeout=1.0)` anti-hang bounds, thin enough that a loaded shared runner trips them.
- `assert ticks >= 3` on a 0.01s ticker as a proxy for "preparation did not block the event loop".

Closes #1152.

## Changes

**Tick counting is replaced with a deterministic handshake.** `_EventLoopLivenessProbe` wraps the synchronous step under test so it blocks until the event loop answers back. Off the loop (in a worker thread) the probe task is scheduled and answers; on the loop thread nothing can answer and the wait expires. The verdict depends on *where* the work ran, not on how fast the machine is, and the assertion is now scoped to the preparation step rather than to the whole handler.

This also let the deliberate `time.sleep(0.05)` calls go away — the handshake creates the overlap window on its own.

**Remaining budgets are named for what they are.** `_THREAD_SIGNAL_DEADLINE_SECONDS = 10.0` and `_HANDLER_DEADLINE_SECONDS = 30.0`. These are anti-hang bounds, not latency assertions; a thread-signal wait must expire before the handler deadline so a stall surfaces as the specific assertion that owns the signal rather than a bare `TimeoutError`.

**Count-based polling becomes deadline-based.** `for _ in range(100): await asyncio.sleep(0.01)` gave the detached APPEND command a budget that shrank precisely when the runner was slowest. It now polls against a `loop.time()` deadline, and the failure message reports the observed statuses.

`pool_timeout=0.25` is left alone, per the issue's direction 3: it is load-bearing for overlap detection and only fires when checkouts actually collide.

## Scope beyond the two tests named in the issue

- `test_pause_accepted_wait_releases_one_slot_pool_before_previous_run` carried the identical pattern (`time.sleep(0.05)` + `pool_timeout=0.25` + `wait_for(1.0)` + `ticks >= 3`). Fixing only the two reported tests would have left the same flake live.
- `test_delivery_failure_persistence_drains_before_cancellation` had `await asyncio.wait_for(asyncio.to_thread(persistence_started.wait, 1), timeout=1)` with no assertion on the result. On a slow runner the inner wait returns `False` and the test proceeds to cancel before persistence started, silently changing what the rest of the test proves. Now asserted.

## Verification

Local runs on macOS with Python 3.12 and `uv sync --all-extras`:

- Full `tests/web` with the CI invocation (`-m "not slow and not postgresql" -n 4 --dist=loadscope`): 0 failures. The 20 skips are all local-environment gates (no Docker daemon, no Postgres, no Pub/Sub emulator).
- `ruff check` and `ruff format --check` clean on both files.
- **Non-vacuity.** With `run_db_io_cancellation_safe` temporarily patched to run its operation inline on the event loop instead of via `asyncio.to_thread`, both probe tests fail with their named assertion (`... blocked the asyncio event loop`) rather than a bare `TimeoutError`, confirming the 10s/30s ordering behaves as intended.
- **Under contention.** 20 busy loops saturating 10 cores (load average ~30-40), the three tests repeated 8 times: 8/8 green.

For the record, the old `ticks >= 3` assertion also caught the injected regression above. The window-scoping weakness is real in principle, but this change's demonstrated benefit is determinism, not broader detection.

## Not included

`tests/web/api/test_websocket_owner_actor.py` still has 13 further `for _ in range(100): await asyncio.sleep(0.01)` poll loops with the same count-as-budget shape. None have been reported flaky and they fall outside this issue's acceptance criteria, so they are left for a separate change.
