### PR TITLE
feat: add Notion as a built-in remote-MCP connector

### DIFF
--- a/src/xagent/migrations/versions/20260807_seed_notion_mcp_app.py
+++ b/src/xagent/migrations/versions/20260807_seed_notion_mcp_app.py
@@ -1,0 +1,81 @@
+"""seed built-in Notion (remote MCP, DCR OAuth) connector
+
+Revision ID: 20260807_seed_notion_mcp_app
+Revises: 20260806_seed_google_sheets_mcp_app
+Create Date: 2026-08-07 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260807_seed_notion_mcp_app"
+down_revision: Union[str, None] = "20260806_seed_google_sheets_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "notion"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Notion",
+    "description": "Connect to Notion to search your workspace and read, create and update pages and databases through Notion's hosted MCP server.",
+    "icon": "https://www.google.com/s2/favicons?domain=notion.so&sz=128",
+    "transport": "streamable_http",
+    "provider_name": None,
+    "category": "Productivity",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "url": "https://mcp.notion.com/mcp",
+        "auth": {"type": "mcp_oauth"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. No oauth_providers row exists for
+    # Notion (auth is per-user Dynamic Client Registration, not a shared
+    # static client), and any MCPServer/UserMCPServer/MCPOAuth* rows created
+    # by users who already connected are intentionally left in place —
+    # connect-driven rows are not owned by this migration and are cleaned up
+    # through the normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -515,6 +515,27 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "notion",
+            "name": "Notion",
+            "description": "Connect to Notion to search your workspace and read, create and update pages and databases through Notion's hosted MCP server.",
+            "icon": "https://www.google.com/s2/favicons?domain=notion.so&sz=128",
+            "transport": "streamable_http",
+            "provider_name": None,
+            "category": "Productivity",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            # Remote MCP (mcp_oauth), same shape as Granola: Notion hosts the
+            # MCP server itself and exposes its own tools — there is no local
+            # module to launch. Users connect via POST
+            # /api/mcp/apps/{id}/oauth/connect (per-user OAuth Authorization
+            # Code + PKCE); Notion supports Dynamic Client Registration, so no
+            # static client credentials are required.
+            "launch_config": {
+                "url": "https://mcp.notion.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        },
+        {
             "app_id": "aws",
             "name": "AWS",
             "description": "Connect to AWS to check CloudWatch alarms/metrics/logs, DynamoDB health, and SQS queue depth.",

--- a/tests/alembic/test_20260807_seed_notion_mcp_app.py
+++ b/tests/alembic/test_20260807_seed_notion_mcp_app.py
@@ -1,6 +1,7 @@
 """Tests for the Notion remote-MCP connector seed migration."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -68,8 +69,17 @@ def test_upgrade_inserts_notion(tmp_path):
         ).first()
         assert row[0] == "streamable_http"
         assert row[1] is None
-        assert "https://mcp.notion.com/mcp" in str(row[2])
-        assert "mcp_oauth" in str(row[2])
+        # Exact comparison (not substring checks): the seeded config must not
+        # carry any field beyond the remote URL and auth type — an unexpected
+        # extra field (e.g. a local command) would change how the connector
+        # is classified and launched.
+        launch_config = row[2]
+        if isinstance(launch_config, str):
+            launch_config = json.loads(launch_config)
+        assert launch_config == {
+            "url": "https://mcp.notion.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
 
 
 def test_upgrade_is_idempotent(tmp_path):

--- a/tests/alembic/test_20260807_seed_notion_mcp_app.py
+++ b/tests/alembic/test_20260807_seed_notion_mcp_app.py
@@ -1,0 +1,122 @@
+"""Tests for the Notion remote-MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260807_seed_notion_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_notion_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_notion(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "notion" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps WHERE app_id='notion'"
+            )
+        ).first()
+        assert row[0] == "streamable_http"
+        assert row[1] is None
+        assert "https://mcp.notion.com/mcp" in str(row[2])
+        assert "mcp_oauth" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='notion'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    notion row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "notion"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_seed_row_classifies_as_mcp_oauth(tmp_path):
+    """The seeded shape must classify as a remote-MCP OAuth connector — an
+    "unconnectable" classification would make the catalog entry dead on
+    arrival (no connect endpoint accepts it)."""
+    from xagent.web.mcp_apps import classify_app_auth
+
+    migration = _load_migration_module()
+    assert (
+        classify_app_auth(migration.ROW["transport"], migration.ROW["launch_config"])
+        == "mcp_oauth"
+    )
+
+
+def test_downgrade_removes_notion(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "notion" not in _app_ids(connection)

--- a/tests/alembic/test_20260807_seed_notion_mcp_app.py
+++ b/tests/alembic/test_20260807_seed_notion_mcp_app.py
@@ -18,8 +18,9 @@ def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
         "seed_notion_migration", migration_file
     )
-    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
     assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
@@ -96,7 +97,7 @@ def test_upgrade_is_idempotent(tmp_path):
         assert rows == 1
 
 
-def test_seed_row_matches_registry(tmp_path):
+def test_seed_row_matches_registry():
     """The migration snapshot and the runtime registry must define the same
     notion row (the migration is a frozen copy; this catches drift)."""
     from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
@@ -108,7 +109,7 @@ def test_seed_row_matches_registry(tmp_path):
     assert migration.ROW == registry_row
 
 
-def test_seed_row_classifies_as_mcp_oauth(tmp_path):
+def test_seed_row_classifies_as_mcp_oauth():
     """The seeded shape must classify as a remote-MCP OAuth connector — an
     "unconnectable" classification would make the catalog entry dead on
     arrival (no connect endpoint accepts it)."""

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -771,6 +771,13 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
         "auth": {"type": "mcp_oauth"},
     }
 
+    # Remote MCP: Notion hosts the server itself, same shape as Granola.
+    assert rows_by_app_id["notion"]["transport"] == "streamable_http"
+    assert rows_by_app_id["notion"]["launch_config"] == {
+        "url": "https://mcp.notion.com/mcp",
+        "auth": {"type": "mcp_oauth"},
+    }
+
     assert rows_by_app_id["aws"]["launch_config"] == {
         "command": "python",
         "args": ["-m", "xagent.web.tools.mcp.aws"],
@@ -778,14 +785,15 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
     }
 
 
-def test_builtin_registry_classifies_granola_as_mcp_oauth() -> None:
+@pytest.mark.parametrize("app_id", ["granola", "notion"])
+def test_builtin_registry_classifies_remote_mcp_apps_as_mcp_oauth(app_id) -> None:
     """The registry shape must classify as mcp_oauth — anything else means the
     catalog entry is uninstallable (connect_mcp_app rejects non-api_key apps
     and generic_oauth_login rejects non-"oauth" transports)."""
     from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
     from xagent.web.mcp_apps import classify_app_auth
 
-    row = next(r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "granola")
+    row = next(r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == app_id)
     assert classify_app_auth(row["transport"], row["launch_config"]) == "mcp_oauth"
 
 


### PR DESCRIPTION
## Summary

Adds Notion to the built-in connector catalog as the second remote-MCP OAuth
connector (after Granola, #92a25006-era work): `transport: streamable_http`
pointing at Notion's hosted MCP server (`https://mcp.notion.com/mcp`) with
`auth.type: mcp_oauth`.

Notion supports per-user OAuth (Authorization Code + PKCE) with Dynamic
Client Registration, so this needs **no static client credentials** — no
Notion developer app, no `NOTION_*` env vars, and no `oauth_providers` row.
No local tool module either: Notion's server exposes its own workspace tools
(search, fetch, page/database create and update). Zero frontend changes —
the connector UI is fully data-driven.

## Changes

- `src/xagent/web/builtin_mcp_registry.py` — add the `notion` catalog entry
  (Productivity, visible in connector, same launch_config shape as granola)
- `src/xagent/migrations/versions/20260807_seed_notion_mcp_app.py` — seed
  migration (catalog row only), chained onto
  `20260806_seed_google_sheets_mcp_app`; idempotent upgrade, downgrade
  removes only the catalog row
- `tests/alembic/test_20260807_seed_notion_mcp_app.py` — upgrade/downgrade
  round-trip, idempotency, migration-snapshot-vs-registry drift guard, and
  mcp_oauth classification tests
- `tests/web/api/test_public_mcp_connector_visibility.py` — notion
  launch_config assertions in the remote-MCP block; the granola-only
  classification test is parametrized over both remote connectors

## Testing

- `pytest tests/alembic/test_20260807_seed_notion_mcp_app.py
  tests/alembic/test_20260731_seed_granola_mcp_app.py
  tests/web/api/test_public_mcp_connector_visibility.py` — all passing
- `alembic upgrade head` → `downgrade -1` → `upgrade head` verified on a
  clean SQLite database; single head confirmed
- Verified end to end against Notion's production server: DCR client
  registration, consent + PKCE token exchange, and live tool calls
  (`notion_fetch`) all succeed with no pre-registered client