### PR TITLE
test(mcp): tighten granola/notion seed-migration test coverage gaps

### DIFF
--- a/tests/alembic/test_20260731_seed_granola_mcp_app.py
+++ b/tests/alembic/test_20260731_seed_granola_mcp_app.py
@@ -1,13 +1,12 @@
 """Tests for the Granola remote-MCP connector seed migration."""
 
 import importlib.util
-import json
 from pathlib import Path
 from unittest.mock import patch
 
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, select, text
 
 
 def _load_migration_module():
@@ -61,51 +60,24 @@ def test_upgrade_inserts_granola(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-        assert "granola" in _app_ids(connection)
-        row = connection.execute(
-            text(
-                "SELECT name, description, icon, transport, provider_name,"
-                " category, oauth_scopes, is_visible_in_connector, launch_config"
-                " FROM public_mcp_apps WHERE app_id='granola'"
+        # Full-row comparison through the migration's own typed table object:
+        # JSON columns deserialize and booleans come back as real bools, so
+        # the persisted row compares to ROW directly — no field is left
+        # unchecked at the DB level. ROW's content is itself pinned against
+        # the registry by test_seed_row_matches_registry, so deriving the
+        # expectation from it keeps identical coverage without a third
+        # hand-typed copy of the seed data.
+        row = (
+            connection.execute(
+                select(migration.PUBLIC_MCP_APPS_TABLE).where(
+                    migration.PUBLIC_MCP_APPS_TABLE.c.app_id == "granola"
+                )
             )
-        ).first()
-        oauth_scopes = row[6]
-        if isinstance(oauth_scopes, str):
-            oauth_scopes = json.loads(oauth_scopes)
-        # Exact comparison (not substring checks): the seeded config must not
-        # carry any field beyond the remote URL and auth type — an unexpected
-        # extra field (e.g. a local command) would change how the connector
-        # is classified and launched.
-        launch_config = row[8]
-        if isinstance(launch_config, str):
-            launch_config = json.loads(launch_config)
-        # Full-row comparison, not just transport/provider_name/launch_config:
-        # a drifted name/description/icon/category/scopes/visibility would
-        # otherwise pass this test silently.
-        assert (
-            row[0],
-            row[1],
-            row[2],
-            row[3],
-            row[4],
-            row[5],
-            oauth_scopes,
-            bool(row[7]),
-            launch_config,
-        ) == (
-            "Granola",
-            "Connect to Granola to search and read your meeting notes, transcripts and action items through Granola's hosted MCP server.",
-            "https://www.google.com/s2/favicons?domain=granola.ai&sz=128",
-            "streamable_http",
-            None,
-            "Productivity",
-            None,
-            True,
-            {
-                "url": "https://mcp.granola.ai/mcp",
-                "auth": {"type": "mcp_oauth"},
-            },
+            .mappings()
+            .first()
         )
+        assert row is not None
+        assert dict(row) == migration.ROW
 
 
 def test_upgrade_is_idempotent(tmp_path):
@@ -154,15 +126,18 @@ def test_downgrade_removes_granola(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-            # A sentinel row unrelated to this migration must survive the
-            # downgrade — otherwise "granola" missing from _app_ids could
-            # equally mean the whole table was wiped, not just its own row.
-            connection.execute(
-                text(
-                    "INSERT INTO public_mcp_apps (app_id, name) VALUES ('sentinel', 'Sentinel')"
-                )
+        # A sentinel row unrelated to this migration must survive the
+        # downgrade — otherwise "granola" missing from _app_ids could
+        # equally mean the whole table was wiped, not just its own row.
+        # transport is set explicitly: the real column is NOT NULL with no
+        # server default, so the insert must not lean on the default this
+        # test's own _create_table happens to declare.
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport)"
+                " VALUES ('sentinel', 'Sentinel', 'oauth')"
             )
+        )
+        with patch.object(migration, "op", _operations(connection)):
             migration.downgrade()
-        app_ids = _app_ids(connection)
-        assert "granola" not in app_ids
-        assert "sentinel" in app_ids
+        assert _app_ids(connection) == {"sentinel"}

--- a/tests/alembic/test_20260731_seed_granola_mcp_app.py
+++ b/tests/alembic/test_20260731_seed_granola_mcp_app.py
@@ -1,6 +1,7 @@
 """Tests for the Granola remote-MCP connector seed migration."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -63,13 +64,48 @@ def test_upgrade_inserts_granola(tmp_path):
         assert "granola" in _app_ids(connection)
         row = connection.execute(
             text(
-                "SELECT transport, provider_name, launch_config FROM public_mcp_apps WHERE app_id='granola'"
+                "SELECT name, description, icon, transport, provider_name,"
+                " category, oauth_scopes, is_visible_in_connector, launch_config"
+                " FROM public_mcp_apps WHERE app_id='granola'"
             )
         ).first()
-        assert row[0] == "streamable_http"
-        assert row[1] is None
-        assert "https://mcp.granola.ai/mcp" in str(row[2])
-        assert "mcp_oauth" in str(row[2])
+        oauth_scopes = row[6]
+        if isinstance(oauth_scopes, str):
+            oauth_scopes = json.loads(oauth_scopes)
+        # Exact comparison (not substring checks): the seeded config must not
+        # carry any field beyond the remote URL and auth type — an unexpected
+        # extra field (e.g. a local command) would change how the connector
+        # is classified and launched.
+        launch_config = row[8]
+        if isinstance(launch_config, str):
+            launch_config = json.loads(launch_config)
+        # Full-row comparison, not just transport/provider_name/launch_config:
+        # a drifted name/description/icon/category/scopes/visibility would
+        # otherwise pass this test silently.
+        assert (
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+            row[5],
+            oauth_scopes,
+            bool(row[7]),
+            launch_config,
+        ) == (
+            "Granola",
+            "Connect to Granola to search and read your meeting notes, transcripts and action items through Granola's hosted MCP server.",
+            "https://www.google.com/s2/favicons?domain=granola.ai&sz=128",
+            "streamable_http",
+            None,
+            "Productivity",
+            None,
+            True,
+            {
+                "url": "https://mcp.granola.ai/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
 
 
 def test_upgrade_is_idempotent(tmp_path):
@@ -118,5 +154,15 @@ def test_downgrade_removes_granola(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
+            # A sentinel row unrelated to this migration must survive the
+            # downgrade — otherwise "granola" missing from _app_ids could
+            # equally mean the whole table was wiped, not just its own row.
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name) VALUES ('sentinel', 'Sentinel')"
+                )
+            )
             migration.downgrade()
-        assert "granola" not in _app_ids(connection)
+        app_ids = _app_ids(connection)
+        assert "granola" not in app_ids
+        assert "sentinel" in app_ids

--- a/tests/alembic/test_20260807_seed_notion_mcp_app.py
+++ b/tests/alembic/test_20260807_seed_notion_mcp_app.py
@@ -1,13 +1,12 @@
 """Tests for the Notion remote-MCP connector seed migration."""
 
 import importlib.util
-import json
 from pathlib import Path
 from unittest.mock import patch
 
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, select, text
 
 
 def _load_migration_module():
@@ -62,51 +61,24 @@ def test_upgrade_inserts_notion(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-        assert "notion" in _app_ids(connection)
-        row = connection.execute(
-            text(
-                "SELECT name, description, icon, transport, provider_name,"
-                " category, oauth_scopes, is_visible_in_connector, launch_config"
-                " FROM public_mcp_apps WHERE app_id='notion'"
+        # Full-row comparison through the migration's own typed table object:
+        # JSON columns deserialize and booleans come back as real bools, so
+        # the persisted row compares to ROW directly — no field is left
+        # unchecked at the DB level. ROW's content is itself pinned against
+        # the registry by test_seed_row_matches_registry, so deriving the
+        # expectation from it keeps identical coverage without a third
+        # hand-typed copy of the seed data.
+        row = (
+            connection.execute(
+                select(migration.PUBLIC_MCP_APPS_TABLE).where(
+                    migration.PUBLIC_MCP_APPS_TABLE.c.app_id == "notion"
+                )
             )
-        ).first()
-        oauth_scopes = row[6]
-        if isinstance(oauth_scopes, str):
-            oauth_scopes = json.loads(oauth_scopes)
-        # Exact comparison (not substring checks): the seeded config must not
-        # carry any field beyond the remote URL and auth type — an unexpected
-        # extra field (e.g. a local command) would change how the connector
-        # is classified and launched.
-        launch_config = row[8]
-        if isinstance(launch_config, str):
-            launch_config = json.loads(launch_config)
-        # Full-row comparison, not just transport/provider_name/launch_config:
-        # a drifted name/description/icon/category/scopes/visibility would
-        # otherwise pass this test silently.
-        assert (
-            row[0],
-            row[1],
-            row[2],
-            row[3],
-            row[4],
-            row[5],
-            oauth_scopes,
-            bool(row[7]),
-            launch_config,
-        ) == (
-            "Notion",
-            "Connect to Notion to search your workspace and read, create and update pages and databases through Notion's hosted MCP server.",
-            "https://www.google.com/s2/favicons?domain=notion.so&sz=128",
-            "streamable_http",
-            None,
-            "Productivity",
-            None,
-            True,
-            {
-                "url": "https://mcp.notion.com/mcp",
-                "auth": {"type": "mcp_oauth"},
-            },
+            .mappings()
+            .first()
         )
+        assert row is not None
+        assert dict(row) == migration.ROW
 
 
 def test_upgrade_is_idempotent(tmp_path):
@@ -155,15 +127,18 @@ def test_downgrade_removes_notion(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-            # A sentinel row unrelated to this migration must survive the
-            # downgrade — otherwise "notion" missing from _app_ids could
-            # equally mean the whole table was wiped, not just its own row.
-            connection.execute(
-                text(
-                    "INSERT INTO public_mcp_apps (app_id, name) VALUES ('sentinel', 'Sentinel')"
-                )
+        # A sentinel row unrelated to this migration must survive the
+        # downgrade — otherwise "notion" missing from _app_ids could
+        # equally mean the whole table was wiped, not just its own row.
+        # transport is set explicitly: the real column is NOT NULL with no
+        # server default, so the insert must not lean on the default this
+        # test's own _create_table happens to declare.
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport)"
+                " VALUES ('sentinel', 'Sentinel', 'oauth')"
             )
+        )
+        with patch.object(migration, "op", _operations(connection)):
             migration.downgrade()
-        app_ids = _app_ids(connection)
-        assert "notion" not in app_ids
-        assert "sentinel" in app_ids
+        assert _app_ids(connection) == {"sentinel"}

--- a/tests/alembic/test_20260807_seed_notion_mcp_app.py
+++ b/tests/alembic/test_20260807_seed_notion_mcp_app.py
@@ -65,22 +65,48 @@ def test_upgrade_inserts_notion(tmp_path):
         assert "notion" in _app_ids(connection)
         row = connection.execute(
             text(
-                "SELECT transport, provider_name, launch_config FROM public_mcp_apps WHERE app_id='notion'"
+                "SELECT name, description, icon, transport, provider_name,"
+                " category, oauth_scopes, is_visible_in_connector, launch_config"
+                " FROM public_mcp_apps WHERE app_id='notion'"
             )
         ).first()
-        assert row[0] == "streamable_http"
-        assert row[1] is None
+        oauth_scopes = row[6]
+        if isinstance(oauth_scopes, str):
+            oauth_scopes = json.loads(oauth_scopes)
         # Exact comparison (not substring checks): the seeded config must not
         # carry any field beyond the remote URL and auth type — an unexpected
         # extra field (e.g. a local command) would change how the connector
         # is classified and launched.
-        launch_config = row[2]
+        launch_config = row[8]
         if isinstance(launch_config, str):
             launch_config = json.loads(launch_config)
-        assert launch_config == {
-            "url": "https://mcp.notion.com/mcp",
-            "auth": {"type": "mcp_oauth"},
-        }
+        # Full-row comparison, not just transport/provider_name/launch_config:
+        # a drifted name/description/icon/category/scopes/visibility would
+        # otherwise pass this test silently.
+        assert (
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+            row[5],
+            oauth_scopes,
+            bool(row[7]),
+            launch_config,
+        ) == (
+            "Notion",
+            "Connect to Notion to search your workspace and read, create and update pages and databases through Notion's hosted MCP server.",
+            "https://www.google.com/s2/favicons?domain=notion.so&sz=128",
+            "streamable_http",
+            None,
+            "Productivity",
+            None,
+            True,
+            {
+                "url": "https://mcp.notion.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
 
 
 def test_upgrade_is_idempotent(tmp_path):
@@ -129,5 +155,15 @@ def test_downgrade_removes_notion(tmp_path):
         _create_table(connection)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
+            # A sentinel row unrelated to this migration must survive the
+            # downgrade — otherwise "notion" missing from _app_ids could
+            # equally mean the whole table was wiped, not just its own row.
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name) VALUES ('sentinel', 'Sentinel')"
+                )
+            )
             migration.downgrade()
-        assert "notion" not in _app_ids(connection)
+        app_ids = _app_ids(connection)
+        assert "notion" not in app_ids
+        assert "sentinel" in app_ids

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -771,12 +771,13 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
     }
 
 
-def test_remote_mcp_apps_launch_config() -> None:
+def test_builtin_registry_remote_mcp_apps_launch_config() -> None:
     """Granola and Notion have no local launch command at all — they host
     their own MCP server and are reached over streamable_http. This is
-    intentionally split out of test_builtin_registry_uses_runtime_available_
-    launch_commands, whose name is about local launch *commands* and would
-    misdescribe these remote-only entries."""
+    intentionally split out of
+    test_builtin_registry_uses_runtime_available_launch_commands, whose name
+    is about local launch *commands* and would misdescribe these
+    remote-only entries."""
     from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
     rows_by_app_id = {row["app_id"]: row for row in get_builtin_public_mcp_app_rows()}

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -764,24 +764,33 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
         "required_env": ["GOOGLE_MAPS_API_KEY"],
     }
 
-    # Remote MCP (no local command at all): Granola hosts the server itself.
+    assert rows_by_app_id["aws"]["launch_config"] == {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.aws"],
+        "required_env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"],
+    }
+
+
+def test_remote_mcp_apps_launch_config() -> None:
+    """Granola and Notion have no local launch command at all — they host
+    their own MCP server and are reached over streamable_http. This is
+    intentionally split out of test_builtin_registry_uses_runtime_available_
+    launch_commands, whose name is about local launch *commands* and would
+    misdescribe these remote-only entries."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    rows_by_app_id = {row["app_id"]: row for row in get_builtin_public_mcp_app_rows()}
+
     assert rows_by_app_id["granola"]["transport"] == "streamable_http"
     assert rows_by_app_id["granola"]["launch_config"] == {
         "url": "https://mcp.granola.ai/mcp",
         "auth": {"type": "mcp_oauth"},
     }
 
-    # Remote MCP: Notion hosts the server itself, same shape as Granola.
     assert rows_by_app_id["notion"]["transport"] == "streamable_http"
     assert rows_by_app_id["notion"]["launch_config"] == {
         "url": "https://mcp.notion.com/mcp",
         "auth": {"type": "mcp_oauth"},
-    }
-
-    assert rows_by_app_id["aws"]["launch_config"] == {
-        "command": "python",
-        "args": ["-m", "xagent.web.tools.mcp.aws"],
-        "required_env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"],
     }
 
 


### PR DESCRIPTION
Fixes #1189.

## Problem

Raised as three non-blocking nits in the #1188 review (round 3, rogercloud
— that PR was approved and has since merged as 26a654c4). Two of the three
turned out to be pre-existing gaps in
`tests/alembic/test_20260731_seed_granola_mcp_app.py`, not something #1188
introduced, so this fixes both connectors' tests together instead of
letting them drift further apart:

1. `test_downgrade_removes_{granola,notion}` only asserted the seeded
   app_id was gone after `downgrade()`. Since each migration seeds a
   single row into an otherwise-empty test table, that assertion can't
   tell "downgrade deleted only its own row" apart from "downgrade wiped
   the whole table" — both leave the app_id lookup empty either way.
2. The granola/notion `launch_config` assertions lived inside
   `test_builtin_registry_uses_runtime_available_launch_commands` — a name
   about local launch *commands*. Both connectors are remote
   (streamable_http to a hosted server) with no local command at all.
3. `test_upgrade_inserts_{granola,notion}` checked only 3 of ~10 seeded
   columns (`transport`, `provider_name`, `launch_config`) at the
   DB-insert level, leaving `name`/`description`/`icon`/`category`/
   `oauth_scopes`/`is_visible_in_connector` unchecked at that layer.

## Change

- `test_downgrade_removes_granola` / `test_downgrade_removes_notion`: insert
  an unrelated `sentinel` row before calling `downgrade()`, assert it
  survives and only the connector's own row is gone.
- New `test_remote_mcp_apps_launch_config` in
  `test_public_mcp_connector_visibility.py` carries the granola/notion
  `launch_config` assertions, moved out of the local-launch-commands test.
- `test_upgrade_inserts_granola` / `test_upgrade_inserts_notion`: select and
  compare the full seeded row (all columns) instead of three of them. This
  also folds in the earlier exact-dict-equality fix for `launch_config`
  (no more substring checks) for granola, matching what notion already had.

## Tests

`pytest tests/alembic/test_20260807_seed_notion_mcp_app.py
tests/alembic/test_20260731_seed_granola_mcp_app.py
tests/web/api/test_public_mcp_connector_visibility.py` — 58 passed.
