### PR TITLE
fix(ssh): skip the agent binding fetch when the user is not in a team

### DIFF
--- a/frontend/src/components/build/agent-ssh-bindings.test.tsx
+++ b/frontend/src/components/build/agent-ssh-bindings.test.tsx
@@ -38,10 +38,12 @@ afterEach(() => {
 })
 
 describe("AgentSshBindings", () => {
-  it("skips the bindings fetch when the user is not in a team", async () => {
+  it("skips the bindings fetch when the user is not in a team", () => {
     inTeamMock.value = false
     render(<AgentSshBindings agentId="agent-1" />)
-    await waitFor(() => expect(apiRequestMock).not.toHaveBeenCalled())
+    // render flushes the effect synchronously and the guard returns before any
+    // await, so the absence of a call is observable without waitFor.
+    expect(apiRequestMock).not.toHaveBeenCalled()
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/build/agent-ssh-bindings.test.tsx
+++ b/frontend/src/components/build/agent-ssh-bindings.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, render, waitFor } from "@testing-library/react"
+import { act, cleanup, render, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // The OSS build ships no SSH routes, so the bindings fetch 404s and used to
@@ -21,9 +21,13 @@ vi.mock("@/components/ui/sonner", () => ({
 vi.mock("@/contexts/auth-context", () => ({
   useAuth: () => ({ inTeam: inTeamMock.value }),
 }))
-vi.mock("@/contexts/i18n-context", () => ({
-  useI18n: () => ({ t: (key: string) => key }),
-}))
+// The i18n return value must be referentially stable: `load` is keyed on `t`,
+// so a per-render `t` identity turns the mount effect into an unbounded
+// fetch/render loop (same hazard documented in agent-builder-publish-errors).
+vi.mock("@/contexts/i18n-context", () => {
+  const i18n = { locale: "en", t: (key: string) => key }
+  return { useI18n: () => i18n }
+})
 
 import { AgentSshBindings } from "./agent-ssh-bindings"
 
@@ -37,14 +41,27 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+/** Let the load() promise chain settle so its catch branch can run. */
+async function flushLoad() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
 describe("AgentSshBindings", () => {
-  it("skips the bindings fetch when the user is not in a team", () => {
+  it("skips the bindings fetch when the user is not in a team", async () => {
     inTeamMock.value = false
-    render(<AgentSshBindings agentId="agent-1" />)
-    // render flushes the effect synchronously and the guard returns before any
-    // await, so the absence of a call is observable without waitFor.
+    const { container } = render(<AgentSshBindings agentId="agent-1" />)
+
+    // toast.error only fires from load()'s catch, two awaits in, so the
+    // absence of a toast is only meaningful once those microtasks have run.
+    await flushLoad()
     expect(apiRequestMock).not.toHaveBeenCalled()
     expect(toastErrorMock).not.toHaveBeenCalled()
+    // The render-level guard still renders nothing — the premise for leaving
+    // the targets-dropdown effect keyed on dialogOpen alone.
+    expect(container).toBeEmptyDOMElement()
   })
 
   it("loads bindings when the user is in a team", async () => {
@@ -56,5 +73,20 @@ describe("AgentSshBindings", () => {
     expect(apiRequestMock).toHaveBeenCalledWith(
       "http://api.local/api/agents/agent-1/ssh-targets",
     )
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("loads once the user joins a team after mount", async () => {
+    inTeamMock.value = false
+    apiRequestMock.mockResolvedValue({ ok: true, json: async () => [] })
+    const { rerender } = render(<AgentSshBindings agentId="agent-1" />)
+    await flushLoad()
+    expect(apiRequestMock).not.toHaveBeenCalled()
+
+    // `inTeam` belongs in load()'s deps, not just the render guard: dropping it
+    // from the array leaves the fetch stuck on its mount-time value.
+    inTeamMock.value = true
+    rerender(<AgentSshBindings agentId="agent-1" />)
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(1))
   })
 })

--- a/frontend/src/components/build/agent-ssh-bindings.test.tsx
+++ b/frontend/src/components/build/agent-ssh-bindings.test.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { cleanup, render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// The OSS build ships no SSH routes, so the bindings fetch 404s and used to
+// toast "loadFailed" on every builder open: the `!inTeam` guard sat in the
+// render path, which hooks run before.
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+const inTeamMock = vi.hoisted(() => ({ value: false }))
+
+vi.mock("@/lib/api-wrapper", () => ({ apiRequest: apiRequestMock }))
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return { ...actual, getApiUrl: () => "http://api.local" }
+})
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}))
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ inTeam: inTeamMock.value }),
+}))
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+import { AgentSshBindings } from "./agent-ssh-bindings"
+
+// The component compiles with the classic JSX runtime under vitest.
+beforeEach(() => {
+  vi.stubGlobal("React", React)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("AgentSshBindings", () => {
+  it("skips the bindings fetch when the user is not in a team", async () => {
+    inTeamMock.value = false
+    render(<AgentSshBindings agentId="agent-1" />)
+    await waitFor(() => expect(apiRequestMock).not.toHaveBeenCalled())
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("loads bindings when the user is in a team", async () => {
+    inTeamMock.value = true
+    apiRequestMock.mockResolvedValue({ ok: true, json: async () => [] })
+    const onCount = vi.fn()
+    render(<AgentSshBindings agentId="agent-1" onCount={onCount} />)
+    await waitFor(() => expect(onCount).toHaveBeenCalledWith(0))
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/agents/agent-1/ssh-targets",
+    )
+  })
+})

--- a/frontend/src/components/build/agent-ssh-bindings.tsx
+++ b/frontend/src/components/build/agent-ssh-bindings.tsx
@@ -71,7 +71,9 @@ export function AgentSshBindings({ agentId, readOnly = false, onCount }: AgentSs
   const { inTeam } = useAuth()
 
   const load = useCallback(async () => {
-    if (!agentId) return
+    // Same gate as the render-level `!inTeam` early return: hooks run before it,
+    // so without this the OSS build (no SSH routes) fetches and toasts a 404.
+    if (!agentId || !inTeam) return
     try {
       const res = await apiRequest(`${getApiUrl()}/api/agents/${agentId}/ssh-targets`)
       if (!res.ok) throw new Error(await res.text())
@@ -84,7 +86,7 @@ export function AgentSshBindings({ agentId, readOnly = false, onCount }: AgentSs
       // bindings exist server-side, since onCount never fires.
       toast.error(t("ssh.bindings.loadFailed"))
     }
-  }, [agentId, onCount, t])
+  }, [agentId, inTeam, onCount, t])
 
   useEffect(() => {
     load()


### PR DESCRIPTION
## Problem

Opening any agent in the builder pops a red toast: "Could not load SSH bindings. Reload before saving to avoid dropping the SSH tools." — even though the OSS build ships no SSH feature at all.

`AgentSshBindings` gates itself with `if (!inTeam) return null`, but that guard lives in the render path, and React runs hooks before it. The `useEffect` that calls `load()` therefore fires on every mount, hits `GET /api/agents/{id}/ssh-targets` (a route that only exists in the hosted build), gets a 404, and toasts the failure. The component itself never renders — only the error does.

## Fix

Apply the same gate at the fetch site:

```ts
if (!agentId || !inTeam) return
```

The targets-dropdown effect needs no change: it only runs when the dialog opens, and the dialog is unreachable when `!inTeam`.

## Tests

New `agent-ssh-bindings.test.tsx`:
- not in a team → no request, no toast
- in a team → bindings load and `onCount` fires

## Verification

- `npx vitest run src/components/build/agent-ssh-bindings.test.tsx` — 2 passed
- pre-commit: npm lint, npm type-check passed
