### PR TITLE
perf(kb): search knowledge base collections concurrently off the loop

### DIFF
--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -61,6 +61,7 @@ FILE_DELIVERY_ACCEL_REDIRECT_PREFIX = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFI
 SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 KB_COLLECTIONS_TIMEOUT_SECONDS = "XAGENT_KB_COLLECTIONS_TIMEOUT_SECONDS"
+KB_SEARCH_TIMEOUT_SECONDS = "XAGENT_KB_SEARCH_TIMEOUT_SECONDS"
 DATABASE_URL = "DATABASE_URL"
 DB_POOL_SIZE = "XAGENT_DB_POOL_SIZE"
 DB_MAX_OVERFLOW = "XAGENT_DB_MAX_OVERFLOW"
@@ -1967,6 +1968,32 @@ def get_kb_collections_timeout_seconds() -> int:
         Per-scan timeout in seconds
     """
     return _get_positive_int_env(KB_COLLECTIONS_TIMEOUT_SECONDS, 30)
+
+
+def get_kb_search_timeout_seconds() -> int:
+    """Get the deadline for searching a single knowledge base collection.
+
+    Bounds one ``run_document_search`` call so an agent's knowledge_search does
+    not wait forever on a stuck backend. The collections of one search run
+    concurrently, so each of them holds a shared default-executor worker for as
+    long as it runs; without a deadline an agent bound to N knowledge bases can
+    pin N workers indefinitely. The default is generous because the budget has
+    to cover embedding the query, the LanceDB scan and an optional rerank round
+    trip - the rerank HTTP client has no timeout of its own.
+
+    Known limitation, same as the collection listing endpoint: cancelling the
+    ``asyncio.wait_for`` coroutine does not stop the underlying ``to_thread``
+    worker, so a timed-out search keeps running to completion in the default
+    executor. The deadline frees the caller, not the worker.
+
+    Priority:
+        1. XAGENT_KB_SEARCH_TIMEOUT_SECONDS environment variable
+        2. Default of 60 seconds
+
+    Returns:
+        Per-collection search timeout in seconds
+    """
+    return _get_positive_int_env(KB_SEARCH_TIMEOUT_SECONDS, 60)
 
 
 def get_default_sqlite_db_path() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1979,12 +1979,17 @@ def get_kb_search_timeout_seconds() -> int:
     long as it runs; without a deadline an agent bound to N knowledge bases can
     pin N workers indefinitely. The default is generous because the budget has
     to cover embedding the query, the LanceDB scan and an optional rerank round
-    trip - the rerank HTTP client has no timeout of its own.
+    trip.
 
     Known limitation, same as the collection listing endpoint: cancelling the
     ``asyncio.wait_for`` coroutine does not stop the underlying ``to_thread``
     worker, so a timed-out search keeps running to completion in the default
-    executor. The deadline frees the caller, not the worker.
+    executor. The deadline frees the caller, not the worker. A worker stuck in
+    rerank outlives it by that model's own budget (``RerankModelConfig.timeout``,
+    180s by default).
+    # ponytail: that budget is not clamped to this one - clamping means
+    # threading a per-call timeout through SearchConfig into the rerank
+    # adapter. Do it if leaked workers actually starve the executor.
 
     Priority:
         1. XAGENT_KB_SEARCH_TIMEOUT_SECONDS environment variable

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1986,10 +1986,7 @@ def get_kb_search_timeout_seconds() -> int:
     worker, so a timed-out search keeps running to completion in the default
     executor. The deadline frees the caller, not the worker. A worker stuck in
     rerank outlives it by that model's own budget (``RerankModelConfig.timeout``,
-    180s by default).
-    # ponytail: that budget is not clamped to this one - clamping means
-    # threading a per-call timeout through SearchConfig into the rerank
-    # adapter. Do it if leaked workers actually starve the executor.
+    180s by default), so it can outlast this deadline threefold.
 
     Priority:
         1. XAGENT_KB_SEARCH_TIMEOUT_SECONDS environment variable
@@ -1998,6 +1995,9 @@ def get_kb_search_timeout_seconds() -> int:
     Returns:
         Per-collection search timeout in seconds
     """
+    # ponytail: the rerank budget is not clamped to this one - clamping means
+    # threading a per-call timeout through SearchConfig into the rerank adapter.
+    # Do it if leaked workers actually starve the executor.
     return _get_positive_int_env(KB_SEARCH_TIMEOUT_SECONDS, 60)
 
 

--- a/src/xagent/core/model/rerank/adapter.py
+++ b/src/xagent/core/model/rerank/adapter.py
@@ -40,6 +40,7 @@ def _create_rerank_model(model_config: RerankModelConfig) -> BaseRerank:
         base_url=model_config.base_url,
         top_n=model_config.top_n,
         instruct=model_config.instruct,
+        timeout=model_config.timeout,
     )
 
 

--- a/src/xagent/core/model/rerank/dashscope.py
+++ b/src/xagent/core/model/rerank/dashscope.py
@@ -66,12 +66,18 @@ class DashscopeRerank(BaseRerank):
                 ``model``'s format family.
             top_n: Number of top results to return.
             instruct: Custom instruction for reranking (new-format models).
-            timeout: HTTP request timeout in seconds (default: 60).
+            timeout: HTTP request timeout in seconds. Only direct callers ever
+                hit the 60s fallback: ``create_rerank_adapter`` always passes
+                ``RerankModelConfig.timeout``, whose own default is 180s, so
+                that is the effective timeout in the application.
         """
         self.model = model
         self.api_key = api_key or os.getenv("DASHSCOPE_API_KEY")
         self.top_n = top_n
         self.instruct = instruct
+        # Matches XinferenceRerank's fallback rather than ModelConfig's 180s:
+        # the two providers should not disagree on what a bare instantiation
+        # means, and the adapter overrides it in every real code path anyway.
         self.timeout = float(timeout) if timeout is not None else 60.0
         self.url = base_url or _default_url_for(model)
 

--- a/src/xagent/core/model/rerank/dashscope.py
+++ b/src/xagent/core/model/rerank/dashscope.py
@@ -54,6 +54,7 @@ class DashscopeRerank(BaseRerank):
         base_url: Optional[str] = None,
         top_n: Optional[int] = None,
         instruct: Optional[str] = None,
+        timeout: Optional[float] = None,
     ):
         """
         Initialize Dashscope rerank model.
@@ -65,11 +66,13 @@ class DashscopeRerank(BaseRerank):
                 ``model``'s format family.
             top_n: Number of top results to return.
             instruct: Custom instruction for reranking (new-format models).
+            timeout: HTTP request timeout in seconds (default: 60).
         """
         self.model = model
         self.api_key = api_key or os.getenv("DASHSCOPE_API_KEY")
         self.top_n = top_n
         self.instruct = instruct
+        self.timeout = float(timeout) if timeout is not None else 60.0
         self.url = base_url or _default_url_for(model)
 
         if not self.api_key:
@@ -132,7 +135,9 @@ class DashscopeRerank(BaseRerank):
                 "parameters": {"return_documents": True} | optional_params,
             }
 
-        response = requests.post(self.url, headers=headers, json=payload)
+        response = requests.post(
+            self.url, headers=headers, json=payload, timeout=self.timeout
+        )
         response.raise_for_status()
         data = response.json()
 
@@ -195,7 +200,9 @@ class DashscopeRerank(BaseRerank):
                 "parameters": {"return_documents": True} | optional_params,
             }
 
-        response = requests.post(self.url, headers=headers, json=payload)
+        response = requests.post(
+            self.url, headers=headers, json=payload, timeout=self.timeout
+        )
         response.raise_for_status()
         data = response.json()
 

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -13,6 +13,10 @@ from .RAG_tools.pipelines.document_search import run_document_search
 
 logger = logging.getLogger(__name__)
 
+# Prefix of the serialized READONLY_MODE warning that search_sparse raises
+# unconditionally under readonly=True (see collection_handle.search_sparse).
+_READONLY_WARNING_PREFIX = "READONLY_MODE:"
+
 if TYPE_CHECKING:
     from .RAG_tools.kb import KBToolCompatibilityFacade
 
@@ -371,6 +375,11 @@ async def _search_knowledge_base_impl(
             """
             collection_name = collection_info.name
 
+            def _failure(
+                reason: str,
+            ) -> tuple[list[Dict[str, Any]], Optional[str], Optional[str], int]:
+                return [], f"{collection_name}: {reason}", None, 0
+
             # Per-KB rerank resolution: explicit tool arg wins, otherwise
             # use the collection's bound rerank_model_id; when neither is
             # set, no rerank stage is added for this collection.
@@ -414,18 +423,22 @@ async def _search_knowledge_base_impl(
                         collection_name,
                         error_message,
                     )
-                    return (
-                        [],
-                        f"{collection_name}: {error_message or 'search failed'}",
-                        None,
-                        0,
-                    )
+                    return _failure(f"{error_message or 'search failed'}")
 
+                # The pipeline's message on a non-success status is boilerplate
+                # ("Hybrid search completed with warnings"), so the warning list
+                # has to win or every real diagnostic is masked by it. The
+                # readonly notice is self-inflicted by our own readonly=True and
+                # fires on every search; FTS_INDEX_MISSING, the warning that
+                # reports an actual consequence of it, is kept.
                 warning: Optional[str] = None
-                if result.status != "success" or result.warnings:
-                    warning_message = result.message or "; ".join(result.warnings)
-                    if warning_message:
-                        warning = f"{collection_name}: {warning_message}"
+                warning_message = "; ".join(
+                    w
+                    for w in result.warnings
+                    if not w.startswith(_READONLY_WARNING_PREFIX)
+                )
+                if warning_message:
+                    warning = f"{collection_name}: {warning_message}"
 
                 if not result.results:
                     return [], None, warning, 0
@@ -443,16 +456,10 @@ async def _search_knowledge_base_impl(
                     collection_name,
                     search_timeout_seconds,
                 )
-                return (
-                    [],
-                    f"{collection_name}: search timed out after "
-                    f"{search_timeout_seconds}s",
-                    None,
-                    0,
-                )
+                return _failure(f"search timed out after {search_timeout_seconds}s")
             except Exception as e:
                 logger.warning(f"Failed to search collection '{collection_name}': {e}")
-                return [], f"{collection_name}: {e}", None, 0
+                return _failure(str(e))
 
         # Skip collections with no embeddings before fanning out.
         searchable = []

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 
 # Prefix of the serialized READONLY_MODE warning that search_sparse raises
 # unconditionally under readonly=True (see collection_handle.search_sparse).
+# Matched against the string, not SearchWarning.code: the pipeline flattens
+# warnings to f"{code}: {message}" in _serialize_warnings before they reach us,
+# and the structured object is not plumbed this far. Change that format and this
+# filter silently stops matching - the readonly notice reappears in summaries,
+# which the readonly tests in test_document_search_collection_concurrency catch.
 _READONLY_WARNING_PREFIX = "READONLY_MODE:"
 
 if TYPE_CHECKING:
@@ -348,10 +353,22 @@ async def _search_knowledge_base_impl(
             "top_k": tool_args.top_k,
             "min_score": tool_args.min_score,
             "merge_results": True,
-            # Retrieval must not build indexes: create_index() commits to the
+            # Retrieval must not *build indexes*: create_index() commits to the
             # LanceDB table, and searching collections concurrently can now race
             # that commit (see collection_manager's CommitConflict note).
             # Indexes are built during ingestion, which is where they belong.
+            #
+            # This suppresses both index paths, not just FTS: the readonly branch
+            # of create_index returns before the dense/vector block and before the
+            # FTS block (lancedb_stores.py). Only the sparse path reports it
+            # (READONLY_MODE / FTS_INDEX_MISSING) - dense search hardcodes
+            # warnings=[] on success, so a skipped dense index build is silent.
+            #
+            # Not a claim that the search writes nothing: resolving the embedding
+            # model still stamps last_accessed_at per collection
+            # (collection_manager.mark_collection_accessed). That row-overwrite is
+            # pre-existing and guarded by a per-collection lock, so the N
+            # concurrent searches this fan-out creates land on N distinct keys.
             "readonly": True,
         }
 
@@ -373,32 +390,40 @@ async def _search_knowledge_base_impl(
             Returns (results, error, warning, documents_searched); failures are
             returned rather than raised so one collection cannot fail the batch.
             """
-            collection_name = collection_info.name
+            # Every attribute read lives inside the try below, so this really
+            # cannot raise into the gather. _failure reads the name lazily, so
+            # it stays usable even if that first read is what failed.
+            collection_name = "<unknown>"
 
             def _failure(
                 reason: str,
             ) -> tuple[list[Dict[str, Any]], Optional[str], Optional[str], int]:
                 return [], f"{collection_name}: {reason}", None, 0
 
-            # Per-KB rerank resolution: explicit tool arg wins, otherwise
-            # use the collection's bound rerank_model_id; when neither is
-            # set, no rerank stage is added for this collection.
-            search_config = dict(base_search_config)
-            collection_rerank = getattr(collection_info, "rerank_model_id", None)
-            effective_rerank = tool_args.rerank_model_id or collection_rerank
-            if effective_rerank:
-                search_config["rerank_model_id"] = effective_rerank
-            storage_user_id = getattr(collection_info, "storage_user_id", None)
-
             try:
+                collection_name = collection_info.name
+
+                # Per-KB rerank resolution: explicit tool arg wins, otherwise
+                # use the collection's bound rerank_model_id; when neither is
+                # set, no rerank stage is added for this collection.
+                search_config = dict(base_search_config)
+                collection_rerank = getattr(collection_info, "rerank_model_id", None)
+                effective_rerank = tool_args.rerank_model_id or collection_rerank
+                if effective_rerank:
+                    search_config["rerank_model_id"] = effective_rerank
+                storage_user_id = getattr(collection_info, "storage_user_id", None)
+
                 logger.info(
                     f"Searching collection '{collection_name}' for: {tool_args.query}"
                 )
 
                 # run_document_search is a blocking sync pipeline; running it
                 # inline would pin the event loop for the whole retrieval.
-                # The deadline frees this caller but not the worker: a timed-out
-                # to_thread call keeps running in the shared default executor.
+                # The deadline covers queueing too, not just execution: it starts
+                # when this coroutine is scheduled, so a saturated default
+                # executor can burn it before run_document_search even starts.
+                # And it frees this caller but not the worker - a timed-out
+                # to_thread call keeps running in that shared executor.
                 result = await asyncio.wait_for(
                     asyncio.to_thread(
                         run_document_search,
@@ -474,8 +499,14 @@ async def _search_knowledge_base_impl(
         # Search every collection concurrently: total latency is bounded by the
         # slowest collection instead of the sum of all of them. gather preserves
         # input order, so aggregation order is unchanged.
-        # ponytail: no concurrency cap - an agent binds a handful of KBs; add a
-        # Semaphore if that ever stops being true.
+        # ponytail: no concurrency cap. Holds for the bound-KB paths above, where
+        # the agent's own configuration is the bound. It does NOT hold for the
+        # final fallback branch: with neither `collections` nor
+        # `allowed_collections` set, this fans out over every collection visible
+        # to the caller, which _list_visible_collections unions across owners -
+        # unbounded by anything the agent declared. Add a Semaphore when that
+        # branch gets real traffic, or when fan-out width starves the shared
+        # default executor that every asyncio.to_thread caller draws from.
         for results, error, warning, documents in await asyncio.gather(
             *(_search_one(collection_info) for collection_info in searchable)
         ):

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from ....config import get_kb_search_timeout_seconds
 from .RAG_tools.core.schemas import ListCollectionsResult
 from .RAG_tools.management.collections import list_collections
 from .RAG_tools.pipelines.document_search import run_document_search
@@ -343,6 +344,11 @@ async def _search_knowledge_base_impl(
             "top_k": tool_args.top_k,
             "min_score": tool_args.min_score,
             "merge_results": True,
+            # Retrieval must not build indexes: create_index() commits to the
+            # LanceDB table, and searching collections concurrently can now race
+            # that commit (see collection_manager's CommitConflict note).
+            # Indexes are built during ingestion, which is where they belong.
+            "readonly": True,
         }
 
         if tool_args.embedding_model_id:
@@ -353,6 +359,7 @@ async def _search_knowledge_base_impl(
         collection_errors: list[str] = []
         collection_warnings: list[str] = []
         total_searched = 0
+        search_timeout_seconds = get_kb_search_timeout_seconds()
 
         async def _search_one(
             collection_info: Any,
@@ -381,15 +388,22 @@ async def _search_knowledge_base_impl(
 
                 # run_document_search is a blocking sync pipeline; running it
                 # inline would pin the event loop for the whole retrieval.
-                result = await asyncio.to_thread(
-                    run_document_search,
-                    collection=collection_name,
-                    query_text=tool_args.query,
-                    config=search_config,
-                    user_id=storage_user_id if storage_user_id is not None else user_id,
-                    is_admin=False
-                    if getattr(collection_info, "ownership", "personal") == "team"
-                    else is_admin,
+                # The deadline frees this caller but not the worker: a timed-out
+                # to_thread call keeps running in the shared default executor.
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        run_document_search,
+                        collection=collection_name,
+                        query_text=tool_args.query,
+                        config=search_config,
+                        user_id=storage_user_id
+                        if storage_user_id is not None
+                        else user_id,
+                        is_admin=False
+                        if getattr(collection_info, "ownership", "personal") == "team"
+                        else is_admin,
+                    ),
+                    timeout=search_timeout_seconds,
                 )
 
                 if result.status not in {"success", "partial_success"}:
@@ -423,6 +437,19 @@ async def _search_knowledge_base_impl(
                     results.append(res_dict)
                 return results, None, warning, collection_info.documents
 
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Search of collection '%s' exceeded %ss",
+                    collection_name,
+                    search_timeout_seconds,
+                )
+                return (
+                    [],
+                    f"{collection_name}: search timed out after "
+                    f"{search_timeout_seconds}s",
+                    None,
+                    0,
+                )
             except Exception as e:
                 logger.warning(f"Failed to search collection '{collection_name}': {e}")
                 return [], f"{collection_name}: {e}", None, 0

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -1,5 +1,6 @@
 """Core document search functionality for RAG pipelines."""
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -353,15 +354,15 @@ async def _search_knowledge_base_impl(
         collection_warnings: list[str] = []
         total_searched = 0
 
-        for collection_info in collections_to_iterate:
-            collection_name = collection_info.name
+        async def _search_one(
+            collection_info: Any,
+        ) -> tuple[list[Dict[str, Any]], Optional[str], Optional[str], int]:
+            """Search one collection off the event loop.
 
-            # Skip collections with no embeddings
-            if collection_info.embeddings == 0:
-                logger.debug(
-                    f"Skipping collection with no embeddings: {collection_name}"
-                )
-                continue
+            Returns (results, error, warning, documents_searched); failures are
+            returned rather than raised so one collection cannot fail the batch.
+            """
+            collection_name = collection_info.name
 
             # Per-KB rerank resolution: explicit tool arg wins, otherwise
             # use the collection's bound rerank_model_id; when neither is
@@ -378,7 +379,10 @@ async def _search_knowledge_base_impl(
                     f"Searching collection '{collection_name}' for: {tool_args.query}"
                 )
 
-                result = run_document_search(
+                # run_document_search is a blocking sync pipeline; running it
+                # inline would pin the event loop for the whole retrieval.
+                result = await asyncio.to_thread(
+                    run_document_search,
                     collection=collection_name,
                     query_text=tool_args.query,
                     config=search_config,
@@ -390,36 +394,65 @@ async def _search_knowledge_base_impl(
 
                 if result.status not in {"success", "partial_success"}:
                     error_message = result.message or "; ".join(result.warnings)
-                    collection_errors.append(
-                        f"{collection_name}: {error_message or 'search failed'}"
-                    )
                     logger.warning(
                         "Search pipeline returned status '%s' for collection '%s': %s",
                         result.status,
                         collection_name,
                         error_message,
                     )
-                    continue
+                    return (
+                        [],
+                        f"{collection_name}: {error_message or 'search failed'}",
+                        None,
+                        0,
+                    )
 
+                warning: Optional[str] = None
                 if result.status != "success" or result.warnings:
                     warning_message = result.message or "; ".join(result.warnings)
                     if warning_message:
-                        collection_warnings.append(
-                            f"{collection_name}: {warning_message}"
-                        )
+                        warning = f"{collection_name}: {warning_message}"
 
-                if result.results:
-                    for res in result.results:
-                        res_dict = dict(res)
-                        res_dict["collection"] = collection_name
-                        all_results.append(res_dict)
+                if not result.results:
+                    return [], None, warning, 0
 
-                    total_searched += collection_info.documents
+                results = []
+                for res in result.results:
+                    res_dict = dict(res)
+                    res_dict["collection"] = collection_name
+                    results.append(res_dict)
+                return results, None, warning, collection_info.documents
 
             except Exception as e:
-                collection_errors.append(f"{collection_name}: {e}")
                 logger.warning(f"Failed to search collection '{collection_name}': {e}")
+                return [], f"{collection_name}: {e}", None, 0
+
+        # Skip collections with no embeddings before fanning out.
+        searchable = []
+        for collection_info in collections_to_iterate:
+            if collection_info.embeddings == 0:
+                logger.debug(
+                    f"Skipping collection with no embeddings: {collection_info.name}"
+                )
                 continue
+            searchable.append(collection_info)
+
+        # Search every collection concurrently: total latency is bounded by the
+        # slowest collection instead of the sum of all of them. gather preserves
+        # input order, so aggregation order is unchanged.
+        # ponytail: no concurrency cap - an agent binds a handful of KBs; add a
+        # Semaphore if that ever stops being true.
+        for results, error, warning, documents in await asyncio.gather(
+            *(_search_one(collection_info) for collection_info in searchable)
+        ):
+            if error:
+                collection_errors.append(error)
+                continue
+            if warning:
+                collection_warnings.append(warning)
+            if results:
+                all_results.extend(results)
+                total_searched += documents
 
         if not all_results:
             if collection_errors:

--- a/tests/core/model/rerank/test_adapter.py
+++ b/tests/core/model/rerank/test_adapter.py
@@ -37,6 +37,14 @@ def test_create_rerank_model_routes_to_dashscope():
     assert isinstance(model, DashscopeRerank)
 
 
+def test_dashscope_model_receives_the_configured_timeout():
+    config = _config("dashscope")
+    config.timeout = 7.5
+    model = _create_rerank_model(config)
+    assert isinstance(model, DashscopeRerank)
+    assert model.timeout == 7.5
+
+
 def test_create_rerank_model_default_provider_is_dashscope():
     # ``RerankModelConfig`` defaults to "dashscope".
     config = RerankModelConfig(

--- a/tests/core/model/rerank/test_adapter.py
+++ b/tests/core/model/rerank/test_adapter.py
@@ -45,6 +45,17 @@ def test_dashscope_model_receives_the_configured_timeout():
     assert model.timeout == 7.5
 
 
+def test_dashscope_effective_timeout_is_the_config_default_not_the_fallback():
+    """The adapter always supplies a timeout, so the ctor fallback never wins."""
+    config = _config("dashscope")
+    model = _create_rerank_model(config)
+    assert config.timeout == 180.0
+    assert isinstance(model, DashscopeRerank)
+    assert model.timeout == 180.0
+    # The 60s ctor fallback applies to direct instantiation only.
+    assert DashscopeRerank(api_key="k").timeout == 60.0
+
+
 def test_create_rerank_model_default_provider_is_dashscope():
     # ``RerankModelConfig`` defaults to "dashscope".
     config = RerankModelConfig(

--- a/tests/core/model/rerank/test_dashscope.py
+++ b/tests/core/model/rerank/test_dashscope.py
@@ -34,6 +34,19 @@ class TestDashscopeRerank:
         assert client.model == "qwen3-rerank"
         assert client.top_n is None
         assert client.instruct is None
+        assert client.timeout == 60.0
+
+    def test_requests_carry_the_configured_timeout(self):
+        """Every rerank call must be bounded; an unbounded post hangs retrieval."""
+        client = DashscopeRerank(api_key="test_key", timeout=12.0)
+        response = Mock()
+        response.json.return_value = {"results": [{"index": 0}]}
+
+        with patch("requests.post", return_value=response) as post:
+            client.compress(["doc"], "query")
+            client.compress_with_scores(["doc"], "query")
+
+        assert [call.kwargs["timeout"] for call in post.call_args_list] == [12.0, 12.0]
 
     def test_missing_api_key(self, monkeypatch):
         """Test error when API key is missing and not in env."""

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -42,6 +42,7 @@ from xagent.config import (
     HOT_PATH_CACHE_TTL_SECONDS,
     HOT_PATH_TASK_CACHE_TTL_SECONDS,
     KB_COLLECTIONS_TIMEOUT_SECONDS,
+    KB_SEARCH_TIMEOUT_SECONDS,
     LANCEDB_PATH,
     MAX_TRACE_PAYLOAD_BYTES,
     MAX_UPLOAD_SIZE,
@@ -133,6 +134,7 @@ from xagent.config import (
     get_hot_path_cache_ttl_seconds,
     get_hot_path_task_cache_ttl_seconds,
     get_kb_collections_timeout_seconds,
+    get_kb_search_timeout_seconds,
     get_lancedb_path,
     get_max_trace_payload_bytes,
     get_max_upload_size_bytes,
@@ -1216,6 +1218,29 @@ class TestGetKbCollectionsTimeoutSeconds:
     def test_non_positive_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv(KB_COLLECTIONS_TIMEOUT_SECONDS, "0")
         assert get_kb_collections_timeout_seconds() == 30
+
+
+class TestGetKbSearchTimeoutSeconds:
+    """Test get_kb_search_timeout_seconds() function."""
+
+    def test_env_var_constant(self):
+        assert KB_SEARCH_TIMEOUT_SECONDS == "XAGENT_KB_SEARCH_TIMEOUT_SECONDS"
+
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv(KB_SEARCH_TIMEOUT_SECONDS, raising=False)
+        assert get_kb_search_timeout_seconds() == 60
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(KB_SEARCH_TIMEOUT_SECONDS, "5")
+        assert get_kb_search_timeout_seconds() == 5
+
+    def test_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(KB_SEARCH_TIMEOUT_SECONDS, "not-a-number")
+        assert get_kb_search_timeout_seconds() == 60
+
+    def test_non_positive_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(KB_SEARCH_TIMEOUT_SECONDS, "0")
+        assert get_kb_search_timeout_seconds() == 60
 
 
 class TestGetDefaultSqliteDbPath:

--- a/tests/core/tools/adapters/vibe/test_knowledge_search.py
+++ b/tests/core/tools/adapters/vibe/test_knowledge_search.py
@@ -801,7 +801,9 @@ class TestKnowledgeSearchTool:
         assert "Knowledge base search failed" not in result.summary
         assert "No relevant documents found" in result.summary
         assert "Warnings:" in result.summary
-        assert "Hybrid search completed with warnings" in result.summary
+        # The pipeline message is boilerplate; the warning list is the diagnostic.
+        assert "kb1: FTS fallback used" in result.summary
+        assert "Hybrid search completed with warnings" not in result.summary
 
     @pytest.mark.asyncio
     async def test_search_partial_success_with_results_keeps_results_and_warning(
@@ -858,7 +860,9 @@ class TestKnowledgeSearchTool:
         assert result.results
         assert result.results[0].text == "Recovered result"
         assert "Warnings:" in result.summary
-        assert "Hybrid search completed with warnings" in result.summary
+        # The pipeline message is boilerplate; the warning list is the diagnostic.
+        assert "kb1: FTS fallback used" in result.summary
+        assert "Hybrid search completed with warnings" not in result.summary
         assert "Knowledge base search failed" not in result.summary
 
     @pytest.mark.asyncio

--- a/tests/core/tools/core/test_document_search_collection_concurrency.py
+++ b/tests/core/tools/core/test_document_search_collection_concurrency.py
@@ -50,12 +50,17 @@ def _pipeline_result(collection: str, **overrides: Any) -> SearchPipelineResult:
     return SearchPipelineResult(**payload)
 
 
-def _install_collections(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+def _install_collections(
+    monkeypatch: pytest.MonkeyPatch, *names: str, embeddings: int = 10
+) -> None:
     async def _list(
         user_id: int | None = None, is_admin: bool = False
     ) -> ListCollectionsResult:
         del user_id, is_admin
-        return _collections(*names)
+        listing = _collections(*names)
+        for collection in listing.collections:
+            collection.embeddings = embeddings
+        return listing
 
     monkeypatch.setattr(document_search, "_list_visible_collections", _list)
 
@@ -80,30 +85,39 @@ async def test_collections_are_searched_concurrently_off_the_event_loop(
     def blocking_search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
         with lock:
             worker_thread_ids.add(threading.get_ident())
-        # Only passes if all three searches are simultaneously in flight.
+        # Passing the barrier needs three OS threads resident at once, which is
+        # only possible if the loop dispatched all three without blocking on any.
         barrier.wait()
         return _pipeline_result(collection)
 
     monkeypatch.setattr(document_search, "run_document_search", blocking_search)
 
-    ticks = 0
-
-    async def tick() -> None:
-        nonlocal ticks
-        while True:
-            ticks += 1
-            await asyncio.sleep(0)
-
-    ticker = asyncio.create_task(tick())
-    try:
-        result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
-    finally:
-        ticker.cancel()
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
 
     assert len(result.results) == 3
-    # The loop stayed responsive while the blocking pipeline ran.
-    assert ticks > 0
     assert loop_thread_id not in worker_thread_ids
+
+
+@pytest.mark.asyncio
+async def test_search_runs_readonly_so_retrieval_never_builds_an_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent retrieval must not reach create_index's LanceDB commit."""
+    _install_collections(monkeypatch, "alpha", "beta")
+    configs: list[dict[str, Any]] = []
+
+    def search(
+        *, collection: str, config: dict[str, Any], **_kwargs: Any
+    ) -> SearchPipelineResult:
+        configs.append(config)
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert len(configs) == 2
+    assert all(config["readonly"] is True for config in configs)
 
 
 @pytest.mark.asyncio
@@ -121,8 +135,12 @@ async def test_one_failing_collection_does_not_drop_the_others(
                 collection, status="error", results=[], result_count=0, message="nope"
             )
         if collection == "warned":
+            # Empty message so the warnings list itself has to reach the summary.
             return _pipeline_result(
-                collection, status="partial_success", warnings=["fell back to vector"]
+                collection,
+                status="partial_success",
+                message="",
+                warnings=["fell back to sparse"],
             )
         return _pipeline_result(collection)
 
@@ -133,7 +151,7 @@ async def test_one_failing_collection_does_not_drop_the_others(
     assert [entry.collection for entry in result.results] == ["alpha", "warned"]
     assert "boom: connection reset" in result.summary
     assert "status_error: nope" in result.summary
-    assert "warned: ok" in result.summary
+    assert "warned: fell back to sparse" in result.summary
 
 
 @pytest.mark.asyncio
@@ -141,7 +159,6 @@ async def test_aggregation_order_totals_and_empty_collections_are_preserved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Order follows the collection list and zero-embedding collections are skipped."""
-    _install_collections(monkeypatch, "alpha", "empty", "beta")
 
     async def _list(
         user_id: int | None = None, is_admin: bool = False
@@ -170,3 +187,125 @@ async def test_aggregation_order_totals_and_empty_collections_are_preserved(
     assert [entry.collection for entry in result.results] == ["alpha", "beta"]
     # total_searched counts documents of the two non-empty collections only.
     assert result.summary.startswith("Found 2 relevant results from 6 documents")
+
+
+@pytest.mark.asyncio
+async def test_every_collection_filtered_out_fans_out_to_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An all-empty listing must gather zero tasks, not fail on the empty fan-out."""
+    _install_collections(monkeypatch, "alpha", "beta", embeddings=0)
+
+    def search(**_kwargs: Any) -> SearchPipelineResult:
+        raise AssertionError("collections without embeddings must not be searched")
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert result.results == []
+    assert result.summary.startswith("No relevant documents found")
+    assert "Searched 0 documents" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_all_collections_failing_returns_the_errors_only_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no survivor the summary is the errors branch, not the no-results one."""
+    _install_collections(monkeypatch, "alpha", "beta")
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        raise RuntimeError(f"{collection} is down")
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert result.results == []
+    assert result.summary.startswith("Knowledge base search failed for one or more")
+    assert "alpha: alpha is down" in result.summary
+    assert "beta: beta is down" in result.summary
+    assert "No relevant documents found" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_warnings_survive_when_no_collection_returns_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A warning from an empty-result collection still reaches the summary."""
+    _install_collections(monkeypatch, "alpha")
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        return _pipeline_result(
+            collection,
+            status="partial_success",
+            results=[],
+            result_count=0,
+            message="",
+            warnings=["index still building"],
+        )
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert result.results == []
+    assert result.summary.startswith("No relevant documents found")
+    assert "Warnings: alpha: index still building" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_a_stuck_collection_times_out_without_holding_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-collection deadline bounds the fan-out and spares its siblings."""
+    _install_collections(monkeypatch, "stuck", "fast")
+    monkeypatch.setattr(document_search, "get_kb_search_timeout_seconds", lambda: 0.2)
+    release = threading.Event()
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        if collection == "stuck":
+            release.wait(10)
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    started = time.perf_counter()
+    try:
+        result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+    finally:
+        release.set()
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 5
+    assert [entry.collection for entry in result.results] == ["fast"]
+    assert "stuck: search timed out after 0.2s" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_fan_out_propagates_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the caller must cancel the gather, not surface a partial result."""
+    _install_collections(monkeypatch, "alpha", "beta")
+    started = threading.Event()
+    release = threading.Event()
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        started.set()
+        release.wait(10)
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    task = asyncio.create_task(
+        document_search._search_knowledge_base_impl(_args(), user_id=1)
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release.set()

--- a/tests/core/tools/core/test_document_search_collection_concurrency.py
+++ b/tests/core/tools/core/test_document_search_collection_concurrency.py
@@ -311,6 +311,48 @@ async def test_warnings_survive_when_no_collection_returns_results(
 
 
 @pytest.mark.asyncio
+async def test_a_broken_collection_object_cannot_escape_into_the_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_search_one promises never to raise, including on its attribute reads.
+
+    gather() has no return_exceptions, so an attribute read that escaped would
+    abort the whole batch and leave the sibling tasks running uncancelled.
+    """
+
+    class _Exploding:
+        name = "broken"
+        embeddings = 5
+        documents = 3
+
+        @property
+        def rerank_model_id(self) -> str:
+            # getattr's default only swallows AttributeError, not this.
+            raise RuntimeError("rerank binding is corrupt")
+
+    async def _list(
+        user_id: int | None = None, is_admin: bool = False
+    ) -> ListCollectionsResult:
+        del user_id, is_admin
+        listing = _collections("alpha")
+        listing.collections.append(_Exploding())  # type: ignore[arg-type]
+        return listing
+
+    monkeypatch.setattr(document_search, "_list_visible_collections", _list)
+    monkeypatch.setattr(
+        document_search,
+        "run_document_search",
+        lambda *, collection, **_kwargs: _pipeline_result(collection),
+    )
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    # The healthy sibling still returns; the broken one degrades to an error.
+    assert [entry.collection for entry in result.results] == ["alpha"]
+    assert "broken: rerank binding is corrupt" in result.summary
+
+
+@pytest.mark.asyncio
 async def test_a_stuck_collection_times_out_without_holding_the_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tools/core/test_document_search_collection_concurrency.py
+++ b/tests/core/tools/core/test_document_search_collection_concurrency.py
@@ -149,9 +149,11 @@ async def test_one_failing_collection_does_not_drop_the_others(
     result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
 
     assert [entry.collection for entry in result.results] == ["alpha", "warned"]
-    assert "boom: connection reset" in result.summary
-    assert "status_error: nope" in result.summary
-    assert "warned: fell back to sparse" in result.summary
+    # Split the sections apart so a failure cannot pass as a mere warning.
+    warnings_section, errors_section = result.summary.split("\n\nErrors: ")
+    warnings_section = warnings_section.split("\n\nWarnings: ")[1]
+    assert errors_section == "boom: connection reset | status_error: nope"
+    assert warnings_section == "warned: fell back to sparse"
 
 
 @pytest.mark.asyncio
@@ -227,6 +229,59 @@ async def test_all_collections_failing_returns_the_errors_only_summary(
     assert "alpha: alpha is down" in result.summary
     assert "beta: beta is down" in result.summary
     assert "No relevant documents found" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_real_warnings_are_not_masked_by_the_boilerplate_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """readonly=True makes every hybrid search partial_success with a generic
+    message; the actual diagnostics must still reach the summary."""
+    _install_collections(monkeypatch, "alpha")
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        return _pipeline_result(
+            collection,
+            status="partial_success",
+            # Exactly what the hybrid pipeline sets alongside its warnings.
+            message="Hybrid search completed with warnings",
+            warnings=[
+                "READONLY_MODE: Readonly mode enabled for sparse search on model.",
+                "FTS_INDEX_MISSING: FTS index not found on 'text' column for model.",
+            ],
+        )
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert "alpha: FTS_INDEX_MISSING" in result.summary
+    assert "Hybrid search completed with warnings" not in result.summary
+    # Our own readonly flag is not a diagnostic worth showing the agent.
+    assert "READONLY_MODE" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_the_self_inflicted_readonly_notice_produces_no_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean readonly search must not decorate its summary with a warning."""
+    _install_collections(monkeypatch, "alpha")
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        return _pipeline_result(
+            collection,
+            status="partial_success",
+            message="Hybrid search completed with warnings",
+            warnings=["READONLY_MODE: Readonly mode enabled for sparse search."],
+        )
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert len(result.results) == 1
+    assert "Warnings:" not in result.summary
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/test_document_search_collection_concurrency.py
+++ b/tests/core/tools/core/test_document_search_collection_concurrency.py
@@ -1,0 +1,172 @@
+"""Regression coverage for concurrent multi-collection knowledge base search."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.core import document_search
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    ListCollectionsResult,
+    SearchPipelineResult,
+)
+
+
+def _collections(*names: str) -> ListCollectionsResult:
+    return ListCollectionsResult(
+        status="success",
+        collections=[
+            CollectionInfo(name=name, embeddings=10, documents=3) for name in names
+        ],
+        total_count=len(names),
+        message="ok",
+    )
+
+
+def _pipeline_result(collection: str, **overrides: Any) -> SearchPipelineResult:
+    payload: dict[str, Any] = {
+        "status": "success",
+        "search_type": "dense",
+        "results": [
+            {
+                "doc_id": f"{collection}-doc",
+                "chunk_id": f"{collection}-chunk",
+                "text": f"hit from {collection}",
+                "score": 0.9,
+                "parse_hash": "hash",
+                "model_tag": "model",
+                "metadata": {"source": f"/kb/{collection}.md"},
+            }
+        ],
+        "result_count": 1,
+        "message": "ok",
+    }
+    payload.update(overrides)
+    return SearchPipelineResult(**payload)
+
+
+def _install_collections(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    async def _list(
+        user_id: int | None = None, is_admin: bool = False
+    ) -> ListCollectionsResult:
+        del user_id, is_admin
+        return _collections(*names)
+
+    monkeypatch.setattr(document_search, "_list_visible_collections", _list)
+
+
+def _args(**overrides: Any) -> document_search.KnowledgeSearchArgs:
+    payload: dict[str, Any] = {"query": "what is xagent"}
+    payload.update(overrides)
+    return document_search.KnowledgeSearchArgs(**payload)
+
+
+@pytest.mark.asyncio
+async def test_collections_are_searched_concurrently_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three collections must overlap in flight, none of them on the loop thread."""
+    _install_collections(monkeypatch, "alpha", "beta", "gamma")
+    loop_thread_id = threading.get_ident()
+    barrier = threading.Barrier(3, timeout=5)
+    worker_thread_ids: set[int] = set()
+    lock = threading.Lock()
+
+    def blocking_search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        with lock:
+            worker_thread_ids.add(threading.get_ident())
+        # Only passes if all three searches are simultaneously in flight.
+        barrier.wait()
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", blocking_search)
+
+    ticks = 0
+
+    async def tick() -> None:
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    ticker = asyncio.create_task(tick())
+    try:
+        result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+    finally:
+        ticker.cancel()
+
+    assert len(result.results) == 3
+    # The loop stayed responsive while the blocking pipeline ran.
+    assert ticks > 0
+    assert loop_thread_id not in worker_thread_ids
+
+
+@pytest.mark.asyncio
+async def test_one_failing_collection_does_not_drop_the_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raises, error status and warnings stay per-collection."""
+    _install_collections(monkeypatch, "alpha", "boom", "status_error", "warned")
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        if collection == "boom":
+            raise RuntimeError("connection reset")
+        if collection == "status_error":
+            return _pipeline_result(
+                collection, status="error", results=[], result_count=0, message="nope"
+            )
+        if collection == "warned":
+            return _pipeline_result(
+                collection, status="partial_success", warnings=["fell back to vector"]
+            )
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert [entry.collection for entry in result.results] == ["alpha", "warned"]
+    assert "boom: connection reset" in result.summary
+    assert "status_error: nope" in result.summary
+    assert "warned: ok" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_aggregation_order_totals_and_empty_collections_are_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Order follows the collection list and zero-embedding collections are skipped."""
+    _install_collections(monkeypatch, "alpha", "empty", "beta")
+
+    async def _list(
+        user_id: int | None = None, is_admin: bool = False
+    ) -> ListCollectionsResult:
+        del user_id, is_admin
+        listing = _collections("alpha", "empty", "beta")
+        listing.collections[1].embeddings = 0
+        return listing
+
+    monkeypatch.setattr(document_search, "_list_visible_collections", _list)
+
+    searched: list[str] = []
+    delays = {"alpha": 0.15, "beta": 0.0}
+
+    def search(*, collection: str, **_kwargs: Any) -> SearchPipelineResult:
+        searched.append(collection)
+        time.sleep(delays[collection])
+        return _pipeline_result(collection)
+
+    monkeypatch.setattr(document_search, "run_document_search", search)
+
+    result = await document_search._search_knowledge_base_impl(_args(), user_id=1)
+
+    assert sorted(searched) == ["alpha", "beta"]
+    # Slow "alpha" finishes last but still aggregates first.
+    assert [entry.collection for entry in result.results] == ["alpha", "beta"]
+    # total_searched counts documents of the two non-empty collections only.
+    assert result.summary.startswith("Found 2 relevant results from 6 documents")


### PR DESCRIPTION
Refs #1141

## Problem

`knowledge_search` retrieval is slow. Two compounding causes in `_search_knowledge_base_impl` (`core/tools/core/document_search.py`):

1. **The blocking pipeline runs on the event loop.** `run_document_search` (`RAG_tools/pipelines/document_search.py:944`) is a synchronous `def` called inline from an `async def`. For the whole retrieval the loop is pinned — not just this request, but every other coroutine in the process.

2. **Collections are searched one at a time.** An agent bound to N knowledge bases pays N full pipelines back to back.

These multiply: because the call is synchronous, concurrency was impossible even in principle.

The Web-side `list_collections_api` (`web/api/kb.py:4747`) already went through this fix — per-owner scans moved to `asyncio.gather` and off the loop. The tool path never followed.

## Fix

Extract the per-collection body into an inner `_search_one`, run the blocking pipeline through `asyncio.to_thread`, and fan the collections out with `asyncio.gather`. Total latency becomes the slowest collection instead of the sum, and the loop stays responsive.

Semantics are unchanged: `_search_one` returns `(results, error, warning, documents)` instead of raising, so one failing collection cannot fail the batch, and `gather` preserves input order, so aggregation order matches the serial version. Zero-embedding collections are filtered before fan-out.

Two things the concurrency made necessary, both raised in review:

**Per-collection timeout.** Nothing in the chain bounded a hung backend call. Before, that pinned the event loop — bad, but one at a time. Concurrently it pins one worker of the shared default executor per searched collection, and cancelling the `gather` does not reclaim them. Each `_search_one` is now wrapped in `asyncio.wait_for` with `get_kb_search_timeout_seconds()` (default 60s), built the same way as `get_kb_collections_timeout_seconds`. As that endpoint's comments already note, `wait_for` frees the caller but not the worker — the thread still runs to completion.

Relatedly, `RerankModelConfig.timeout` already existed and `xinference` had always passed it; only `dashscope` skipped it, leaving two `requests.post` calls with no timeout on a path taken whenever a searched collection has a bound rerank model. Wired up, so the timeout above is not just a band-aid over an unbounded thread.

**Readonly search.** The search path reaches `create_index(model_tag, readonly)`, and `SearchConfig.readonly` defaults to False, so retrieval could reach real LanceDB write/commit operations. Serially that was unreachable — both call sites ran bare on the loop, so at most one executed at a time. Concurrently it is a `CommitConflict` race. The pipeline already threads `cfg.readonly` through all three search paths, so setting it here is a one-line fix that short-circuits before any index write.

## Behaviour change worth flagging

`readonly` suppresses **both** index-building paths, not just FTS: `create_index`'s readonly branch returns before reaching either the dense/vector block or the FTS block.

The two are not equally observable. The sparse path emits `READONLY_MODE` and `FTS_INDEX_MISSING` warnings; the dense path hardcodes `warnings=[]` on success, so a skipped dense index build produces **no signal at all**.

Concretely, a collection whose FTS index is missing no longer gets it rebuilt as a side effect of being searched. It degrades per-collection — a warning, the FTS query running unindexed — rather than failing the batch, but it stops self-healing. `search_type` defaults to `hybrid`, so the FTS path is taken on every search; what bounds this is how many collections actually lack the index, not how many searches ask for sparse.

Blast radius is limited: ingestion builds the dense index at the 50,000-row threshold (`DEFAULT_INDEX_ROW_THRESHOLD`) independently of this PR, and failures there are only warn-logged. Tables below that threshold never had a dense index to begin with, so retrieval falls back to brute-force KNN exactly as before.

Note also that `readonly=True` does not mean retrieval stops writing to LanceDB: resolving the embedding model still stamps `last_accessed_at` through `mark_collection_accessed` as a full-row overwrite. That write and its per-collection lock are pre-existing; what is new is N of them landing concurrently on N distinct lock keys.

Scoping readonly to the dense path only is a straightforward alternative if this trade is not wanted.

## Measurement

Local, with `run_document_search` mocked to a fixed 300 ms and 3 collections: **910.8 ms → 305.7 ms**.

This is mock data and only demonstrates the relative change. It does not measure real embedding, vector-search or rerank cost, and does not claim the latency reported in #1141 is resolved — that needs verification against a production-sized deployment, which is why this references rather than closes the issue.

## Tests

`tests/core/tools/core/test_document_search_collection_concurrency.py`: a `threading.Barrier(3)` that only clears if all three searches are genuinely in flight, and that no search ran on the loop thread; per-collection isolation across a raising collection, an error status, and a partial success with warnings; aggregation order, `total_searched`, and the zero-embedding skip; every collection filtered out; every collection failing at once; warnings surviving an empty result set; fan-out cancellation; a stuck collection timing out without holding up the rest; and retrieval running readonly.

Plus timeout coverage for the config accessor, `dashscope`, and the rerank adapter.

```
pytest tests/core/tools/core/ tests/core/model/rerank/ tests/core/test_config.py
```

## Verification

pre-commit: ruff, ruff format, mypy, isort, codespell — all passed
