### PR TITLE
fix(rag): compact fragmented LanceDB tables after ingestion

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Final, Mapping, Sequence
 
 from .schemas import IndexMetric
+
+logger = logging.getLogger(__name__)
 
 # ------------------------- Paths -------------------------
 
@@ -162,6 +165,22 @@ MODEL_SYNONYMS: Final[Mapping[str, str]] = {
 }
 
 
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back on anything else."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid %s=%r; must be positive, using %s", name, raw, default)
+        return default
+    return value
+
+
 @dataclass(frozen=True)
 class IndexPolicy:
     """Index policy configuration for embeddings tables.
@@ -212,10 +231,22 @@ class IndexPolicy:
     enable_immediate_reindex: bool = False
     enable_smart_reindex: bool = True
 
-    # Compaction configuration
-    compact_fragment_threshold: int = 100
-    compact_stale_version_threshold: int = 100
-    version_retention_days: int = 7
+    # Compaction configuration. Env overrides exist because this policy governs
+    # an always-on inline path: raising a threshold is the way to stand it down
+    # without a redeploy.
+    compact_fragment_threshold: int = field(
+        default_factory=lambda: _positive_int_env(
+            "XAGENT_KB_COMPACT_FRAGMENT_THRESHOLD", 100
+        )
+    )
+    compact_stale_version_threshold: int = field(
+        default_factory=lambda: _positive_int_env(
+            "XAGENT_KB_COMPACT_VERSION_THRESHOLD", 100
+        )
+    )
+    version_retention_days: int = field(
+        default_factory=lambda: _positive_int_env("XAGENT_KB_VERSION_RETENTION_DAYS", 7)
+    )
 
     def __post_init__(self) -> None:
         """Validate the compaction thresholds, then fill in default param dicts.

--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -179,7 +179,14 @@ class IndexPolicy:
         enable_immediate_reindex: Whether to reindex immediately after writes.
         enable_smart_reindex: Whether to use smart reindex based on unindexed ratio.
         compact_fragment_threshold: Fragment count at or above which a table is
-            compacted.
+            compacted. Catches append-heavy tables, where reads slow down with
+            the file count. Must be positive.
+        compact_version_threshold: Retained-version count at or above which a
+            table is compacted. Catches update-heavy tables such as
+            ``collection_metadata``, whose ``merge_insert`` upserts rewrite rows
+            instead of appending: their fragment count plateaus around the row
+            count while version history, and the disk it holds, grows without
+            bound. Must be positive.
         version_retention_days: Age below which old table versions are kept; the
             safety margin that protects readers holding an older version. Must be
             positive: zero drops every version but the latest.
@@ -201,24 +208,33 @@ class IndexPolicy:
 
     # Compaction configuration
     compact_fragment_threshold: int = 100
+    compact_version_threshold: int = 1000
     version_retention_days: int = 7
 
     def __post_init__(self) -> None:
-        """Validate the retention window, then fill in default parameter dicts.
+        """Validate the compaction thresholds, then fill in default param dicts.
 
-        This is the only enforcement point for ``version_retention_days``, so
-        every construction path goes through it.
+        This is the only enforcement point for these bounds, so every
+        construction path goes through it.
 
         Raises:
-            ValueError: If ``version_retention_days`` is not positive. A zero or
-                negative window makes the backend delete every table version but
-                the latest, invalidating readers holding an older one.
+            ValueError: If ``version_retention_days`` is not positive -- a zero
+                or negative window makes the backend delete every table version
+                but the latest, invalidating readers holding an older one -- or
+                if either compaction threshold is not positive, which would make
+                every table qualify on every ingestion.
         """
         if self.version_retention_days <= 0:
             raise ValueError(
                 "version_retention_days must be positive; a zero window deletes "
                 "every version but the latest and invalidates concurrent readers"
             )
+        for field_name in ("compact_fragment_threshold", "compact_version_threshold"):
+            if getattr(self, field_name) <= 0:
+                raise ValueError(
+                    f"{field_name} must be positive; a non-positive threshold "
+                    "makes every table qualify for compaction on every write"
+                )
         if self.hnsw_params is None:
             object.__setattr__(self, "hnsw_params", DEFAULT_HNSW_PARAMS.copy())
         if self.ivfpq_params is None:

--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -204,7 +204,16 @@ class IndexPolicy:
     version_retention_days: int = 7
 
     def __post_init__(self) -> None:
-        """Initialize default parameter dicts if None."""
+        """Validate the retention window, then fill in default parameter dicts.
+
+        This is the only enforcement point for ``version_retention_days``, so
+        every construction path goes through it.
+
+        Raises:
+            ValueError: If ``version_retention_days`` is not positive. A zero or
+                negative window makes the backend delete every table version but
+                the latest, invalidating readers holding an older one.
+        """
         if self.version_retention_days <= 0:
             raise ValueError(
                 "version_retention_days must be positive; a zero window deletes "

--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -178,9 +178,11 @@ class IndexPolicy:
         reindex_unindexed_ratio_threshold: Ratio threshold for triggering reindex.
         enable_immediate_reindex: Whether to reindex immediately after writes.
         enable_smart_reindex: Whether to use smart reindex based on unindexed ratio.
-        compact_fragment_threshold: Data-file count above which a table is compacted.
+        compact_fragment_threshold: Fragment count at or above which a table is
+            compacted.
         version_retention_days: Age below which old table versions are kept; the
-            safety margin that protects readers holding an older version.
+            safety margin that protects readers holding an older version. Must be
+            positive: zero drops every version but the latest.
     """
 
     enable_threshold_rows: int = DEFAULT_INDEX_ROW_THRESHOLD
@@ -203,6 +205,11 @@ class IndexPolicy:
 
     def __post_init__(self) -> None:
         """Initialize default parameter dicts if None."""
+        if self.version_retention_days <= 0:
+            raise ValueError(
+                "version_retention_days must be positive; a zero window deletes "
+                "every version but the latest and invalidates concurrent readers"
+            )
         if self.hnsw_params is None:
             object.__setattr__(self, "hnsw_params", DEFAULT_HNSW_PARAMS.copy())
         if self.ivfpq_params is None:

--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -181,12 +181,18 @@ class IndexPolicy:
         compact_fragment_threshold: Fragment count at or above which a table is
             compacted. Catches append-heavy tables, where reads slow down with
             the file count. Must be positive.
-        compact_version_threshold: Retained-version count at or above which a
-            table is compacted. Catches update-heavy tables such as
-            ``collection_metadata``, whose ``merge_insert`` upserts rewrite rows
-            instead of appending: their fragment count plateaus around the row
-            count while version history, and the disk it holds, grows without
-            bound. Must be positive.
+        compact_stale_version_threshold: Number of versions already older than
+            ``version_retention_days`` -- that is, versions the next compaction
+            can actually delete -- at or above which a table is compacted.
+            Catches update-heavy tables such as ``collection_metadata``, whose
+            ``merge_insert`` upserts rewrite rows instead of appending: their
+            fragment count plateaus around the row count while version history,
+            and the disk it holds, grows without bound.
+            Counting only reclaimable versions is what keeps the trigger from
+            ratcheting: counting *all* versions would stay above any threshold
+            forever once crossed, since compaction cannot remove versions still
+            inside the retention window and each run commits another one.
+            Must be positive.
         version_retention_days: Age below which old table versions are kept; the
             safety margin that protects readers holding an older version. Must be
             positive: zero drops every version but the latest.
@@ -208,7 +214,7 @@ class IndexPolicy:
 
     # Compaction configuration
     compact_fragment_threshold: int = 100
-    compact_version_threshold: int = 1000
+    compact_stale_version_threshold: int = 100
     version_retention_days: int = 7
 
     def __post_init__(self) -> None:
@@ -229,7 +235,10 @@ class IndexPolicy:
                 "version_retention_days must be positive; a zero window deletes "
                 "every version but the latest and invalidates concurrent readers"
             )
-        for field_name in ("compact_fragment_threshold", "compact_version_threshold"):
+        for field_name in (
+            "compact_fragment_threshold",
+            "compact_stale_version_threshold",
+        ):
             if getattr(self, field_name) <= 0:
                 raise ValueError(
                     f"{field_name} must be positive; a non-positive threshold "

--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -178,6 +178,9 @@ class IndexPolicy:
         reindex_unindexed_ratio_threshold: Ratio threshold for triggering reindex.
         enable_immediate_reindex: Whether to reindex immediately after writes.
         enable_smart_reindex: Whether to use smart reindex based on unindexed ratio.
+        compact_fragment_threshold: Data-file count above which a table is compacted.
+        version_retention_days: Age below which old table versions are kept; the
+            safety margin that protects readers holding an older version.
     """
 
     enable_threshold_rows: int = DEFAULT_INDEX_ROW_THRESHOLD
@@ -193,6 +196,10 @@ class IndexPolicy:
     reindex_unindexed_ratio_threshold: float = 0.05
     enable_immediate_reindex: bool = False
     enable_smart_reindex: bool = True
+
+    # Compaction configuration
+    compact_fragment_threshold: int = 100
+    version_retention_days: int = 7
 
     def __post_init__(self) -> None:
         """Initialize default parameter dicts if None."""

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -325,17 +325,27 @@ def _record_ingestion_status(
         )
 
 
-def _compact_storage_if_needed() -> None:
+#: Tables every successful ingestion appends to, besides the embeddings table.
+_INGEST_TABLES = ("documents", "parses", "chunks", "collection_metadata")
+
+
+def _compact_storage_if_needed(embedding_model_id: Optional[str]) -> None:
     """Best-effort LanceDB compaction after a successful ingestion.
 
-    Every ingestion appends new data files and read latency scales with the file
-    count, so tables past the threshold get merged and stale versions pruned.
+    Every ingestion appends one file per table and read latency scales with the
+    fragment count, so fragmented tables get merged and stale versions pruned.
+    Scoped to the tables this ingestion wrote: sweeping the whole database on
+    every document (or every crawled page) costs more than it saves.
     Maintenance must never fail the pipeline, hence the blanket except.
     """
     try:
+        from ..LanceDB.model_tag_utils import to_model_tag
         from ..storage.factory import get_vector_index_store
 
-        compacted = get_vector_index_store().compact_tables()
+        tables = list(_INGEST_TABLES)
+        if embedding_model_id:
+            tables.append(f"embeddings_{to_model_tag(embedding_model_id)}")
+        compacted = get_vector_index_store().compact_tables(tables)
         if compacted:
             logger.info("Compacted LanceDB tables: %s", ", ".join(compacted))
     except Exception as exc:  # noqa: BLE001
@@ -1433,7 +1443,7 @@ def _process_document_impl(
             )
             warnings.append(f"Collection statistics update failed: {stat_exc}")
 
-        _compact_storage_if_needed()
+        _compact_storage_if_needed(embedding_config.id if embedding_config else None)
 
         _record_ingestion_status(
             collection,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -328,10 +328,14 @@ def _record_ingestion_status(
 #: Tables every ingestion writes, besides the embeddings table. ``ingestion_runs``
 #: grows fastest of all: :func:`_record_ingestion_status` does a delete plus an
 #: add, so it gains two versions per run, on the failure path as well.
+#: ``collection_config`` is written by the same upload, just before and outside
+#: this pipeline (``_save_collection_config_with_snapshot``), with the same
+#: unconditional delete+add; nothing else would ever compact it.
 _INGEST_TABLES = (
     "documents",
     "parses",
     "chunks",
+    "collection_config",
     "collection_metadata",
     "ingestion_runs",
 )
@@ -350,7 +354,7 @@ def _compact_storage_if_needed(embedding_model_id: Optional[str]) -> None:
     """
     try:
         from ..LanceDB.model_tag_utils import embeddings_table_name, to_model_tag
-        from ..storage.factory import get_vector_index_store
+        from ..storage.factory import StorageFactory
 
         tables = list(_INGEST_TABLES)
         if embedding_model_id:
@@ -363,7 +367,7 @@ def _compact_storage_if_needed(embedding_model_id: Optional[str]) -> None:
                 embeddings_table_name(embedding_model_id),
                 embeddings_table_name(to_model_tag(embedding_model_id)),
             ]
-        store = get_vector_index_store()
+        store = StorageFactory.get_factory().get_vector_index_store()
         compacted = store.compact_tables(list(dict.fromkeys(tables)))
         if compacted:
             logger.info("Compacted LanceDB tables: %s", ", ".join(compacted))

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -338,22 +338,33 @@ _INGEST_TABLES = (
 
 
 def _compact_storage_if_needed(embedding_model_id: Optional[str]) -> None:
-    """Best-effort LanceDB compaction after a successful ingestion.
+    """Best-effort LanceDB compaction once an ingestion finishes, pass or fail.
 
     Every ingestion appends one file per table and read latency scales with the
     fragment count, so fragmented tables get merged and stale versions pruned.
-    Scoped to the tables this ingestion wrote: sweeping the whole database on
-    every document (or every crawled page) costs more than it saves.
-    Maintenance must never fail the pipeline, hence the blanket except.
+    Failed runs fragment too — they still write ``ingestion_runs`` and whatever
+    steps completed — so this runs on both paths. Scoped to the tables this
+    ingestion wrote: sweeping the whole database on every document (or every
+    crawled page) costs more than it saves. Maintenance must never fail the
+    pipeline, hence the blanket except.
     """
     try:
-        from ..LanceDB.model_tag_utils import to_model_tag
+        from ..LanceDB.model_tag_utils import embeddings_table_name, to_model_tag
         from ..storage.factory import get_vector_index_store
 
         tables = list(_INGEST_TABLES)
         if embedding_model_id:
-            tables.append(f"embeddings_{to_model_tag(embedding_model_id)}")
-        compacted = get_vector_index_store().compact_tables(tables)
+            # The write path applies to_model_tag twice (CollectionHandle, then
+            # upsert_embeddings) and it is not idempotent for vendor-prefixed
+            # ids, so probe both spellings — the same compatibility trick as
+            # CollectionHandle._embedding_table_names. Missing tables are a
+            # cheap no-op in should_compact.
+            tables += [
+                embeddings_table_name(embedding_model_id),
+                embeddings_table_name(to_model_tag(embedding_model_id)),
+            ]
+        store = get_vector_index_store()
+        compacted = store.compact_tables(list(dict.fromkeys(tables)))
         if compacted:
             logger.info("Compacted LanceDB tables: %s", ", ".join(compacted))
     except Exception as exc:  # noqa: BLE001
@@ -1451,8 +1462,6 @@ def _process_document_impl(
             )
             warnings.append(f"Collection statistics update failed: {stat_exc}")
 
-        _compact_storage_if_needed(embedding_config.id if embedding_config else None)
-
         _record_ingestion_status(
             collection,
             doc_id,
@@ -1490,3 +1499,9 @@ def _process_document_impl(
             warnings=warnings,
             user_id=user_id,
         )
+
+    finally:
+        # Failed runs fragment the tables too, and a deployment failing often is
+        # exactly the one that must not stop compacting. Never raises, so it
+        # cannot swallow either return above.
+        _compact_storage_if_needed(embedding_config.id if embedding_config else None)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -325,6 +325,23 @@ def _record_ingestion_status(
         )
 
 
+def _compact_storage_if_needed() -> None:
+    """Best-effort LanceDB compaction after a successful ingestion.
+
+    Every ingestion appends new data files and read latency scales with the file
+    count, so tables past the threshold get merged and stale versions pruned.
+    Maintenance must never fail the pipeline, hence the blanket except.
+    """
+    try:
+        from ..storage.factory import get_vector_index_store
+
+        compacted = get_vector_index_store().compact_tables()
+        if compacted:
+            logger.info("Compacted LanceDB tables: %s", ", ".join(compacted))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("LanceDB compaction skipped: %s", exc)
+
+
 async def _compute_embeddings_async(
     chunks: List[ChunkForEmbedding],
     embedding_adapter: BaseEmbedding,
@@ -1415,6 +1432,8 @@ def _process_document_impl(
                 extra={"collection": collection, "doc_id": doc_id},
             )
             warnings.append(f"Collection statistics update failed: {stat_exc}")
+
+        _compact_storage_if_needed()
 
         _record_ingestion_status(
             collection,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -325,8 +325,16 @@ def _record_ingestion_status(
         )
 
 
-#: Tables every successful ingestion appends to, besides the embeddings table.
-_INGEST_TABLES = ("documents", "parses", "chunks", "collection_metadata")
+#: Tables every ingestion writes, besides the embeddings table. ``ingestion_runs``
+#: grows fastest of all: :func:`_record_ingestion_status` does a delete plus an
+#: add, so it gains two versions per run, on the failure path as well.
+_INGEST_TABLES = (
+    "documents",
+    "parses",
+    "chunks",
+    "collection_metadata",
+    "ingestion_runs",
+)
 
 
 def _compact_storage_if_needed(embedding_model_id: Optional[str]) -> None:

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -1342,6 +1342,13 @@ class VectorIndexStore(ABC):
             True if reindex was triggered successfully.
         """
 
+    def compact_tables(self, policy: Optional[IndexPolicy] = None) -> List[str]:
+        """Compact fragmented tables; returns the names actually compacted.
+
+        Best-effort maintenance; backends without compaction return an empty list.
+        """
+        return []
+
     # --- Async index management variants ---
 
     @abstractmethod

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -1398,11 +1398,15 @@ class VectorIndexStore(ABC):
     async def trigger_reindex_async(self, table_name: str) -> bool:
         """Async version of trigger_reindex.
 
+        Same optimization as the sync form -- compaction, version pruning, index
+        refresh -- but always with the backend's default retention window, since
+        there is no ``cleanup_older_than`` parameter here.
+
         Args:
-            table_name: Embeddings table name.
+            table_name: Table to optimize; need not be an embeddings table.
 
         Returns:
-            True if reindex was triggered successfully.
+            True if the table was optimized successfully.
 
         Note: Current implementation uses sync operations under the hood.
         True async I/O will be added in Phase 1B with RDB backend.

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -1404,18 +1404,6 @@ class VectorIndexStore(ABC):
         True async I/O will be added in Phase 1B with RDB backend.
         """
 
-    async def should_compact_async(
-        self, table_name: str, policy: Optional[IndexPolicy] = None
-    ) -> bool:
-        """Async version of should_compact."""
-        return self.should_compact(table_name, policy)
-
-    async def compact_tables_async(
-        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
-    ) -> List[str]:
-        """Async version of compact_tables."""
-        return self.compact_tables(table_names, policy)
-
     @abstractmethod
     def migrate_embeddings_table(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from typing import (
     Any,
@@ -1332,18 +1333,35 @@ class VectorIndexStore(ABC):
         """
 
     @abstractmethod
-    def trigger_reindex(self, table_name: str) -> bool:
+    def trigger_reindex(
+        self, table_name: str, cleanup_older_than: Optional[timedelta] = None
+    ) -> bool:
         """Trigger index rebuild operation.
 
         Args:
             table_name: Embeddings table name.
+            cleanup_older_than: Retention window for old table versions; versions
+                younger than this are always kept so concurrent readers stay
+                valid. ``None`` lets the backend apply its own safe default.
 
         Returns:
             True if reindex was triggered successfully.
         """
 
-    def compact_tables(self, policy: Optional[IndexPolicy] = None) -> List[str]:
-        """Compact fragmented tables; returns the names actually compacted.
+    def should_compact(
+        self, table_name: str, policy: Optional[IndexPolicy] = None
+    ) -> bool:
+        """Whether a table is fragmented enough to be worth compacting.
+
+        Separate from :meth:`should_reindex`: fragmentation is about read
+        latency, not index freshness. Backends without compaction return False.
+        """
+        return False
+
+    def compact_tables(
+        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
+    ) -> List[str]:
+        """Compact the fragmented tables among ``table_names``; returns those done.
 
         Best-effort maintenance; backends without compaction return an empty list.
         """
@@ -1385,6 +1403,18 @@ class VectorIndexStore(ABC):
         Note: Current implementation uses sync operations under the hood.
         True async I/O will be added in Phase 1B with RDB backend.
         """
+
+    async def should_compact_async(
+        self, table_name: str, policy: Optional[IndexPolicy] = None
+    ) -> bool:
+        """Async version of should_compact."""
+        return self.should_compact(table_name, policy)
+
+    async def compact_tables_async(
+        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
+    ) -> List[str]:
+        """Async version of compact_tables."""
+        return self.compact_tables(table_names, policy)
 
     @abstractmethod
     def migrate_embeddings_table(

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -1346,7 +1346,10 @@ class VectorIndexStore(ABC):
             table_name: Table to optimize; need not be an embeddings table.
             cleanup_older_than: Retention window for old table versions; versions
                 younger than this are always kept so concurrent readers stay
-                valid. ``None`` lets the backend apply its own safe default.
+                valid. ``None`` falls back to
+                ``DEFAULT_INDEX_POLICY.version_retention_days`` -- a value shared
+                with the compaction predicate, not something internal to the
+                backend.
 
         Returns:
             True if the table was optimized successfully.

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -1336,16 +1336,20 @@ class VectorIndexStore(ABC):
     def trigger_reindex(
         self, table_name: str, cleanup_older_than: Optional[timedelta] = None
     ) -> bool:
-        """Trigger index rebuild operation.
+        """Optimize a table: compact data files, prune old versions, refresh indices.
+
+        Called for any table :meth:`compact_tables` selects, including ones with
+        no index at all, so compaction and version pruning — not the index
+        rebuild — are the parts callers can rely on.
 
         Args:
-            table_name: Embeddings table name.
+            table_name: Table to optimize; need not be an embeddings table.
             cleanup_older_than: Retention window for old table versions; versions
                 younger than this are always kept so concurrent readers stay
                 valid. ``None`` lets the backend apply its own safe default.
 
         Returns:
-            True if reindex was triggered successfully.
+            True if the table was optimized successfully.
         """
 
     def should_compact(

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, cast
 
@@ -65,6 +66,69 @@ def _fragment_count(table: Any) -> int:
         return int(count)
     except Exception as e:  # noqa: BLE001
         logger.debug("Could not count fragments: %s", e)
+        return 0
+
+
+@contextmanager
+def _compaction_lock(conn: Any) -> Iterator[bool]:
+    """Yield whether this process took the database-wide compaction lock.
+
+    Concurrent ``optimize()`` calls each rewrite the table in full and then all
+    but one lose the commit, so the losers waste a complete rewrite. A
+    non-blocking ``flock`` keeps one worker doing the work; the rest skip, which
+    costs nothing because the next ingestion compacts instead.
+
+    Yields True (unlocked) when locking is unavailable -- a non-local database
+    URI, or a platform without ``fcntl`` -- leaving the previous behaviour.
+
+    ponytail: one lock for the whole database, not per table. Compaction is rare
+    and short; split it per table if two collections ever contend measurably.
+    """
+    uri = str(getattr(conn, "uri", "") or "")
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-Unix
+        yield True
+        return
+
+    if not uri or "://" in uri or not os.path.isdir(uri):
+        yield True
+        return
+
+    handle = None
+    try:
+        handle = open(os.path.join(uri, ".compaction.lock"), "w")
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            yield False
+            return
+        yield True
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Compaction lock unavailable, proceeding unlocked: %s", e)
+        yield True
+    finally:
+        if handle is not None:
+            handle.close()  # releases the flock
+
+
+def _version_count(table: Any) -> int:
+    """Number of retained versions of ``table`` (0 when unavailable).
+
+    Update-heavy tables never accumulate fragments -- ``merge_insert`` rewrites
+    rows rather than appending -- so version history is the only signal that
+    they need compacting.
+
+    ponytail: O(retained versions); measured 3.9 ms at 100, 87 ms at 2000. That
+    is affordable because the count only gets large on tables we are about to
+    spend far longer optimizing. If it ever dominates, the manifest file count
+    under ``<table>.lance/_versions`` is the same number for ~0.7 ms, at the
+    cost of depending on on-disk layout.
+    """
+    try:
+        return len(table.list_versions())
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Could not count versions: %s", e)
         return 0
 
 
@@ -1481,8 +1545,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             return False
 
         except Exception as e:  # noqa: BLE001
-            # warning, not error: every ingestion reaches this now, so a single
-            # unopenable table would shout ERROR on every upload forever after.
+            # warning, not error, to match the rest of this best-effort
+            # maintenance chain. Nothing in production calls should_reindex --
+            # compaction runs through should_compact -- so this is consistency,
+            # not a hot-path fix.
             logger.warning("Failed to check reindex status for %s: %s", table_name, e)
             return False
         finally:
@@ -1520,12 +1586,22 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     def should_compact(
         self, table_name: str, policy: Optional[IndexPolicy] = None
     ) -> bool:
-        """Whether a table has enough fragments that reads have degraded.
+        """Whether a table has degraded enough to be worth optimizing.
 
-        Deliberately independent of :meth:`should_reindex`: index staleness and
-        file fragmentation are different problems, and ``optimize()`` bundles
-        compaction with index rebuilds, so reusing the reindex predicate would
-        rebuild large unrelated indices on every ingest.
+        Two independent ways a table goes bad, and a table typically hits only
+        one of them:
+
+        * fragments -- append-heavy tables (documents, chunks, embeddings) gain
+          a data file per write and reads slow down with the file count;
+        * versions -- update-heavy tables (collection_metadata) upsert via
+          ``merge_insert``, which rewrites rows instead of appending, so
+          fragments plateau near the row count and never reach the threshold
+          while version history grows without bound and holds the disk.
+
+        Deliberately independent of :meth:`should_reindex`: index staleness is a
+        third, unrelated problem, and ``optimize()`` bundles compaction with
+        index rebuilds, so reusing that predicate would rebuild large unrelated
+        indices on every ingest.
         """
         from ..LanceDB.schema_manager import _safe_close_table
 
@@ -1533,7 +1609,12 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         table = None
         try:
             table = self._get_connection().open_table(table_name)
-            return _fragment_count(table) >= policy.compact_fragment_threshold
+            # Fragments first: it is a flat ~0.2 ms, while counting versions
+            # costs more the worse the table is.
+            return (
+                _fragment_count(table) >= policy.compact_fragment_threshold
+                or _version_count(table) >= policy.compact_version_threshold
+            )
         except Exception as e:  # noqa: BLE001
             logger.debug("Could not check fragmentation for %s: %s", table_name, e)
             return False
@@ -1543,20 +1624,45 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     def compact_tables(
         self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
     ) -> List[str]:
-        """Compact the fragmented tables among ``table_names``; returns those done.
+        """Compact the degraded tables among ``table_names``; returns those done.
 
         Callers pass the tables they just wrote; sweeping the whole database on
-        every ingest costs more than it saves. Best-effort maintenance:
-        individual failures are logged, never raised.
+        every ingest costs more than it saves. Names that do not exist are
+        skipped without opening anything -- callers probe more than one spelling
+        of the embeddings table, so a miss is routine, not exceptional.
+
+        Holds a database-wide advisory lock: concurrent ``optimize()`` calls all
+        rewrite the table and then all but one lose the commit, so the losers
+        burn a full rewrite for nothing. Whoever cannot take the lock skips,
+        which is free -- the next ingestion will compact instead.
+
+        Best-effort maintenance: individual failures are logged, never raised.
         """
+        if not table_names:
+            return []
+
         policy = policy or DEFAULT_INDEX_POLICY
         cleanup_older_than = timedelta(days=policy.version_retention_days)
-        return [
-            name
-            for name in table_names
-            if self.should_compact(name, policy)
-            and self.trigger_reindex(name, cleanup_older_than=cleanup_older_than)
-        ]
+        try:
+            existing = set(list_table_names(self._get_connection()))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Could not list tables, skipping compaction: %s", e)
+            return []
+
+        candidates = [name for name in table_names if name in existing]
+        if not candidates:
+            return []
+
+        with _compaction_lock(self._get_connection()) as acquired:
+            if not acquired:
+                logger.info("Another process is compacting; skipping this round")
+                return []
+            return [
+                name
+                for name in candidates
+                if self.should_compact(name, policy)
+                and self.trigger_reindex(name, cleanup_older_than=cleanup_older_than)
+            ]
 
     async def should_reindex_async(
         self, table_name: str, total_upserted: int, policy: IndexPolicy

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -66,7 +66,9 @@ def _fragment_count(table: Any) -> int:
         )
         return int(count)
     except Exception as e:  # noqa: BLE001
-        logger.debug("Could not count fragments: %s", e)
+        # WARNING, not DEBUG: a lancedb API shape change would otherwise disable
+        # compaction permanently with no operator-visible signal.
+        logger.warning("Could not count fragments, treating as 0: %s", e)
         return 0
 
 
@@ -150,7 +152,7 @@ def _stale_version_count(table: Any, cutoff: datetime) -> int:
                 stale += 1
         return stale
     except Exception as e:  # noqa: BLE001
-        logger.debug("Could not count stale versions: %s", e)
+        logger.warning("Could not count stale versions, treating as 0: %s", e)
         return 0
 
 
@@ -1638,7 +1640,9 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             # Fragment stats are the cheaper probe -- ~0.2 ms at 50 fragments,
             # ~2.2 ms at 1000, so it grows too, just far slower -- hence first.
             # ``or`` short-circuits only on True, so a healthy table always pays
-            # the version scan: ~4 ms at 100 retained versions, ~124 ms at 1000.
+            # the version scan, whose cost model lives on ``_stale_version_count``
+            # -- roughly linear in retained versions, and paid on every healthy
+            # table because ``or`` only short-circuits when fragments settle it.
             return (
                 _fragment_count(table) >= policy.compact_fragment_threshold
                 or _stale_version_count(table, cutoff)

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1453,11 +1453,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             conn = self._get_connection()
             table = conn.open_table(table_name)
 
-            # Fragmentation: every append/merge_insert writes a new data file and
-            # read latency scales with the file count, not the row count.
-            if _fragment_count(table) >= policy.compact_fragment_threshold:
-                return True
-
             # Immediate reindex if enabled
             if policy.enable_immediate_reindex and total_upserted > 0:
                 return True
@@ -1518,26 +1513,58 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         finally:
             _safe_close_table(table)
 
-    def compact_tables(self, policy: Optional[IndexPolicy] = None) -> List[str]:
-        """Compact every fragmented table in the database; returns compacted names.
+    def should_compact(
+        self, table_name: str, policy: Optional[IndexPolicy] = None
+    ) -> bool:
+        """Whether a table has enough fragments that reads have degraded.
 
-        Best-effort maintenance: individual failures are logged, never raised.
+        Deliberately independent of :meth:`should_reindex`: index staleness and
+        file fragmentation are different problems, and ``optimize()`` bundles
+        compaction with index rebuilds, so reusing the reindex predicate would
+        rebuild large unrelated indices on every ingest.
+        """
+        from ..LanceDB.schema_manager import _safe_close_table
+
+        policy = policy or DEFAULT_INDEX_POLICY
+        table = None
+        try:
+            table = self._get_connection().open_table(table_name)
+            return _fragment_count(table) >= policy.compact_fragment_threshold
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not check fragmentation for %s: %s", table_name, e)
+            return False
+        finally:
+            _safe_close_table(table)
+
+    def compact_tables(
+        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
+    ) -> List[str]:
+        """Compact the fragmented tables among ``table_names``; returns those done.
+
+        Callers pass the tables they just wrote; sweeping the whole database on
+        every ingest costs more than it saves. Best-effort maintenance:
+        individual failures are logged, never raised.
         """
         policy = policy or DEFAULT_INDEX_POLICY
         cleanup_older_than = timedelta(days=policy.version_retention_days)
-        compacted: List[str] = []
-        try:
-            table_names = list_table_names(self._get_connection())
-        except Exception as e:  # noqa: BLE001
-            logger.warning("Compaction skipped, cannot list tables: %s", e)
-            return compacted
+        return [
+            name
+            for name in table_names
+            if self.should_compact(name, policy)
+            and self.trigger_reindex(name, cleanup_older_than=cleanup_older_than)
+        ]
 
-        for name in table_names:
-            if self.should_reindex(name, 0, policy) and self.trigger_reindex(
-                name, cleanup_older_than=cleanup_older_than
-            ):
-                compacted.append(name)
-        return compacted
+    async def should_compact_async(
+        self, table_name: str, policy: Optional[IndexPolicy] = None
+    ) -> bool:
+        """Async version of should_compact; the check opens a table on disk."""
+        return await asyncio.to_thread(self.should_compact, table_name, policy)
+
+    async def compact_tables_async(
+        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
+    ) -> List[str]:
+        """Async version of compact_tables; ``optimize()`` blocks for seconds."""
+        return await asyncio.to_thread(self.compact_tables, table_names, policy)
 
     async def should_reindex_async(
         self, table_name: str, total_upserted: int, policy: IndexPolicy

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 from collections import OrderedDict, defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, cast
 
 import lancedb
@@ -16,6 +16,7 @@ from lancedb.db import DBConnection
 from xagent.providers.vector_store.lancedb import get_connection_from_env
 
 from ..core.config import (
+    DEFAULT_INDEX_POLICY,
     DEFAULT_VECTOR_STORE_DELETE_BATCH_SIZE,
     DEFAULT_VECTOR_STORE_SCAN_LIMIT,
     IndexPolicy,
@@ -47,6 +48,24 @@ from .lancedb_filter_utils import (
 from .logging_utils import log_audit, log_performance
 
 logger = logging.getLogger(__name__)
+
+
+def _fragment_count(table: Any) -> int:
+    """Number of on-disk data files backing ``table`` (0 when unavailable)."""
+    try:
+        stats = table.stats()
+        fragment_stats = (
+            stats["fragment_stats"] if isinstance(stats, dict) else stats.fragment_stats
+        )
+        count = (
+            fragment_stats["num_fragments"]
+            if isinstance(fragment_stats, dict)
+            else fragment_stats.num_fragments
+        )
+        return int(count)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Could not count fragments: %s", e)
+        return 0
 
 
 class LanceDBMetadataStore(MetadataStore):
@@ -1434,6 +1453,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             conn = self._get_connection()
             table = conn.open_table(table_name)
 
+            # Fragmentation: every append/merge_insert writes a new data file and
+            # read latency scales with the file count, not the row count.
+            if _fragment_count(table) >= policy.compact_fragment_threshold:
+                return True
+
             # Immediate reindex if enabled
             if policy.enable_immediate_reindex and total_upserted > 0:
                 return True
@@ -1467,8 +1491,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         finally:
             _safe_close_table(table)
 
-    def trigger_reindex(self, table_name: str) -> bool:
-        """Trigger reindex operation on the table (sync)."""
+    def trigger_reindex(
+        self, table_name: str, cleanup_older_than: Optional[timedelta] = None
+    ) -> bool:
+        """Compact data files, prune versions older than the retention window."""
         from ..LanceDB.schema_manager import _safe_close_table
 
         table = None
@@ -1476,7 +1502,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             logger.info("Triggering reindex for %s", table_name)
             conn = self._get_connection()
             table = conn.open_table(table_name)
-            table.optimize()
+            if cleanup_older_than is None:
+                cleanup_older_than = timedelta(
+                    days=DEFAULT_INDEX_POLICY.version_retention_days
+                )
+            table.optimize(cleanup_older_than=cleanup_older_than)
             logger.info("Reindex completed for %s", table_name)
             return True
         except Exception as e:  # noqa: BLE001
@@ -1484,6 +1514,27 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             return False
         finally:
             _safe_close_table(table)
+
+    def compact_tables(self, policy: Optional[IndexPolicy] = None) -> List[str]:
+        """Compact every fragmented table in the database; returns compacted names.
+
+        Best-effort maintenance: individual failures are logged, never raised.
+        """
+        policy = policy or DEFAULT_INDEX_POLICY
+        cleanup_older_than = timedelta(days=policy.version_retention_days)
+        compacted: List[str] = []
+        try:
+            table_names = list_table_names(self._get_connection())
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Compaction skipped, cannot list tables: %s", e)
+            return compacted
+
+        for name in table_names:
+            if self.should_reindex(name, 0, policy) and self.trigger_reindex(
+                name, cleanup_older_than=cleanup_older_than
+            ):
+                compacted.append(name)
+        return compacted
 
     async def should_reindex_async(
         self, table_name: str, total_upserted: int, policy: IndexPolicy

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -128,12 +128,15 @@ def _stale_version_count(table: Any, cutoff: datetime) -> int:
     run commits one more. This measures exactly what a compaction would reclaim,
     so a successful run drives it back to zero.
 
-    ponytail: O(retained versions); measured 3.9 ms at 100, 87 ms at 2000, and
-    bounded in practice because pruning keeps history near one retention window.
-    If it ever dominates, the manifest file count under ``<table>.lance/
-    _versions`` is the same total for ~0.7 ms, at the cost of depending on
-    on-disk layout -- but it cannot tell stale from fresh, so it would only work
-    as a pre-filter.
+    ponytail: O(retained versions), ~43 us each; measured 3.9 ms at 100 and
+    87 ms at 2000. Pruning bounds the *age* of history, not its size: versions
+    inside the retention window are write-rate x retention-days, so this grows
+    linearly with throughput. At 10k ingestions/day the ingestion_runs table
+    holds ~140k in-window versions, i.e. ~6 s of scanning on every ingestion --
+    unsolved, and the first thing to fix if a busy deployment slows down.
+    The upgrade path is scanning ``<table>.lance/_versions`` directly: the
+    manifests carry usable mtimes, so os.scandir gives both the count and the
+    stale/fresh split for ~0.7 ms, at the cost of depending on on-disk layout.
     """
     try:
         stale = 0

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1507,6 +1507,9 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                     days=DEFAULT_INDEX_POLICY.version_retention_days
                 )
             table.optimize(cleanup_older_than=cleanup_older_than)
+            # Pruning drops the versions cached handles point at, same reason
+            # the delete paths invalidate after mutating a table.
+            self.invalidate_table_cache(table_name)
             logger.info("Reindex completed for %s", table_name)
             return True
         except Exception as e:  # noqa: BLE001

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1480,8 +1480,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
             return False
 
-        except Exception as e:
-            logger.error("Failed to check reindex status for %s: %s", table_name, e)
+        except Exception as e:  # noqa: BLE001
+            # warning, not error: every ingestion reaches this now, so a single
+            # unopenable table would shout ERROR on every upload forever after.
+            logger.warning("Failed to check reindex status for %s: %s", table_name, e)
             return False
         finally:
             _safe_close_table(table)
@@ -1494,7 +1496,9 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         table = None
         try:
-            logger.info("Triggering reindex for %s", table_name)
+            # Neutral wording: compact_tables routes tables here that have no
+            # index at all (collection_metadata, ingestion_runs, parses).
+            logger.info("Optimizing %s", table_name)
             conn = self._get_connection()
             table = conn.open_table(table_name)
             if cleanup_older_than is None:
@@ -1505,10 +1509,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             # Pruning drops the versions cached handles point at, same reason
             # the delete paths invalidate after mutating a table.
             self.invalidate_table_cache(table_name)
-            logger.info("Reindex completed for %s", table_name)
+            logger.info("Optimized %s", table_name)
             return True
         except Exception as e:  # noqa: BLE001
-            logger.warning("Reindex failed for %s: %s", table_name, e)
+            logger.warning("Optimize failed for %s: %s", table_name, e)
             return False
         finally:
             _safe_close_table(table)

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1554,18 +1554,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             and self.trigger_reindex(name, cleanup_older_than=cleanup_older_than)
         ]
 
-    async def should_compact_async(
-        self, table_name: str, policy: Optional[IndexPolicy] = None
-    ) -> bool:
-        """Async version of should_compact; the check opens a table on disk."""
-        return await asyncio.to_thread(self.should_compact, table_name, policy)
-
-    async def compact_tables_async(
-        self, table_names: Sequence[str], policy: Optional[IndexPolicy] = None
-    ) -> List[str]:
-        """Async version of compact_tables; ``optimize()`` blocks for seconds."""
-        return await asyncio.to_thread(self.compact_tables, table_names, policy)
-
     async def should_reindex_async(
         self, table_name: str, total_upserted: int, policy: IndexPolicy
     ) -> bool:

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -92,12 +92,6 @@ def _compaction_lock(conn: Any, table_name: str) -> Iterator[bool]:
 
     try:
         lock = FileLock(os.path.join(uri, f".{table_name}.compaction.lock"), timeout=0)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("Compaction lock unavailable, proceeding unlocked: %s", e)
-        yield True
-        return
-
-    try:
         lock.acquire()
     except Timeout:
         yield False
@@ -112,7 +106,12 @@ def _compaction_lock(conn: Any, table_name: str) -> Iterator[bool]:
     try:
         yield True
     finally:
-        lock.release()
+        # release() can raise, and this is maintenance: never let it become the
+        # caller's exception, or mask one already propagating from the body.
+        try:
+            lock.release()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not release compaction lock for %s: %s", table_name, e)
 
 
 def _stale_version_count(table: Any, cutoff: datetime) -> int:
@@ -128,7 +127,7 @@ def _stale_version_count(table: Any, cutoff: datetime) -> int:
     run commits one more. This measures exactly what a compaction would reclaim,
     so a successful run drives it back to zero.
 
-    ponytail: O(retained versions), ~43 us each; measured 3.9 ms at 100 and
+    Cost: O(retained versions), ~43 us each; measured 3.9 ms at 100 and
     87 ms at 2000. Pruning bounds the *age* of history, not its size: versions
     inside the retention window are write-rate x retention-days, so this grows
     linearly with throughput. At 10k ingestions/day the ingestion_runs table
@@ -1636,10 +1635,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         table = None
         try:
             table = self._get_connection().open_table(table_name)
-            # Fragments are a flat ~0.2 ms, so they go first, but note this only
-            # short-circuits when the answer is already True. A healthy table
-            # always pays for the version scan; that cost stays bounded because
-            # pruning keeps history near one retention window.
+            # Fragment stats are the cheaper probe -- ~0.2 ms at 50 fragments,
+            # ~2.2 ms at 1000, so it grows too, just far slower -- hence first.
+            # ``or`` short-circuits only on True, so a healthy table always pays
+            # the version scan: ~4 ms at 100 retained versions, ~124 ms at 1000.
             return (
                 _fragment_count(table) >= policy.compact_fragment_threshold
                 or _stale_version_count(table, cutoff)
@@ -1674,11 +1673,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         policy = policy or DEFAULT_INDEX_POLICY
         cleanup_older_than = timedelta(days=policy.version_retention_days)
-        conn = self._get_connection()
         try:
+            conn = self._get_connection()
             existing = set(list_table_names(conn))
         except Exception as e:  # noqa: BLE001
-            logger.warning("Could not list tables, skipping compaction: %s", e)
+            logger.warning("Could not reach the database, skipping compaction: %s", e)
             return []
 
         candidates = [name for name in table_names if name in existing]
@@ -1718,6 +1717,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
     async def trigger_reindex_async(self, table_name: str) -> bool:
         """Async version of trigger_reindex.
+
+        Delegates to the sync path, so it also compacts data files and prunes
+        versions past the retention window -- not just an index rebuild. Uses
+        the backend default window, having no ``cleanup_older_than`` parameter.
 
         Note: Current implementation uses sync operations under the hood.
         True async I/O will be added in Phase 1B with RDB backend.

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple
 
 import lancedb
 import pyarrow as pa  # type: ignore
+from filelock import FileLock, Timeout
 from lancedb.db import DBConnection
 
 from xagent.providers.vector_store.lancedb import get_connection_from_env
@@ -70,65 +71,84 @@ def _fragment_count(table: Any) -> int:
 
 
 @contextmanager
-def _compaction_lock(conn: Any) -> Iterator[bool]:
-    """Yield whether this process took the database-wide compaction lock.
+def _compaction_lock(conn: Any, table_name: str) -> Iterator[bool]:
+    """Yield whether this process took the compaction lock for one table.
 
     Concurrent ``optimize()`` calls each rewrite the table in full and then all
     but one lose the commit, so the losers waste a complete rewrite. A
-    non-blocking ``flock`` keeps one worker doing the work; the rest skip, which
+    non-blocking lock keeps one worker doing the work; the rest skip, which
     costs nothing because the next ingestion compacts instead.
 
-    Yields True (unlocked) when locking is unavailable -- a non-local database
-    URI, or a platform without ``fcntl`` -- leaving the previous behaviour.
+    Per table, not per database: the work is per table, so a database-wide lock
+    would let one worker's collection starve another's embeddings table.
 
-    ponytail: one lock for the whole database, not per table. Compaction is rare
-    and short; split it per table if two collections ever contend measurably.
+    Yields True (unlocked) when locking is unavailable -- a non-local database
+    URI, or an unwritable directory -- which just restores the old behaviour.
     """
     uri = str(getattr(conn, "uri", "") or "")
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - non-Unix
-        yield True
-        return
-
     if not uri or "://" in uri or not os.path.isdir(uri):
         yield True
         return
 
-    handle = None
     try:
-        handle = open(os.path.join(uri, ".compaction.lock"), "w")
-        try:
-            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            yield False
-            return
-        yield True
+        lock = FileLock(os.path.join(uri, f".{table_name}.compaction.lock"), timeout=0)
     except Exception as e:  # noqa: BLE001
         logger.debug("Compaction lock unavailable, proceeding unlocked: %s", e)
         yield True
+        return
+
+    try:
+        lock.acquire()
+    except Timeout:
+        yield False
+        return
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Compaction lock unavailable, proceeding unlocked: %s", e)
+        yield True
+        return
+
+    # Nothing but the caller's body runs under this try, so an exception from
+    # the body propagates untouched instead of being caught and re-yielded.
+    try:
+        yield True
     finally:
-        if handle is not None:
-            handle.close()  # releases the flock
+        lock.release()
 
 
-def _version_count(table: Any) -> int:
-    """Number of retained versions of ``table`` (0 when unavailable).
+def _stale_version_count(table: Any, cutoff: datetime) -> int:
+    """How many of ``table``'s versions predate ``cutoff`` (0 when unavailable).
 
     Update-heavy tables never accumulate fragments -- ``merge_insert`` rewrites
     rows rather than appending -- so version history is the only signal that
     they need compacting.
 
-    ponytail: O(retained versions); measured 3.9 ms at 100, 87 ms at 2000. That
-    is affordable because the count only gets large on tables we are about to
-    spend far longer optimizing. If it ever dominates, the manifest file count
-    under ``<table>.lance/_versions`` is the same number for ~0.7 ms, at the
-    cost of depending on on-disk layout.
+    Counts only versions old enough for the next ``optimize()`` to delete, never
+    the total. Totals ratchet: once past a threshold they stay past it, because
+    compaction cannot remove versions still inside the retention window and each
+    run commits one more. This measures exactly what a compaction would reclaim,
+    so a successful run drives it back to zero.
+
+    ponytail: O(retained versions); measured 3.9 ms at 100, 87 ms at 2000, and
+    bounded in practice because pruning keeps history near one retention window.
+    If it ever dominates, the manifest file count under ``<table>.lance/
+    _versions`` is the same total for ~0.7 ms, at the cost of depending on
+    on-disk layout -- but it cannot tell stale from fresh, so it would only work
+    as a pre-filter.
     """
     try:
-        return len(table.list_versions())
+        stale = 0
+        for entry in table.list_versions():
+            ts = entry["timestamp"] if isinstance(entry, dict) else entry.timestamp
+            # LanceDB reports naive timestamps in *local* time, not UTC, so the
+            # cutoff must be local too; mixing in utcnow() skews the window by
+            # the whole UTC offset.
+            if ts.tzinfo is not None:
+                ts = ts.astimezone().replace(tzinfo=None)
+            if ts < cutoff:
+                stale += 1
+        return stale
     except Exception as e:  # noqa: BLE001
-        logger.debug("Could not count versions: %s", e)
+        logger.debug("Could not count stale versions: %s", e)
         return 0
 
 
@@ -1593,10 +1613,13 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         * fragments -- append-heavy tables (documents, chunks, embeddings) gain
           a data file per write and reads slow down with the file count;
-        * versions -- update-heavy tables (collection_metadata) upsert via
+        * stale versions -- update-heavy tables (collection_metadata) upsert via
           ``merge_insert``, which rewrites rows instead of appending, so
           fragments plateau near the row count and never reach the threshold
           while version history grows without bound and holds the disk.
+
+        Both measure something a compaction removes, so both fall back to zero
+        after a successful run and cannot latch the trigger on permanently.
 
         Deliberately independent of :meth:`should_reindex`: index staleness is a
         third, unrelated problem, and ``optimize()`` bundles compaction with
@@ -1606,14 +1629,18 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         from ..LanceDB.schema_manager import _safe_close_table
 
         policy = policy or DEFAULT_INDEX_POLICY
+        cutoff = datetime.now() - timedelta(days=policy.version_retention_days)
         table = None
         try:
             table = self._get_connection().open_table(table_name)
-            # Fragments first: it is a flat ~0.2 ms, while counting versions
-            # costs more the worse the table is.
+            # Fragments are a flat ~0.2 ms, so they go first, but note this only
+            # short-circuits when the answer is already True. A healthy table
+            # always pays for the version scan; that cost stays bounded because
+            # pruning keeps history near one retention window.
             return (
                 _fragment_count(table) >= policy.compact_fragment_threshold
-                or _version_count(table) >= policy.compact_version_threshold
+                or _stale_version_count(table, cutoff)
+                >= policy.compact_stale_version_threshold
             )
         except Exception as e:  # noqa: BLE001
             logger.debug("Could not check fragmentation for %s: %s", table_name, e)
@@ -1631,10 +1658,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         skipped without opening anything -- callers probe more than one spelling
         of the embeddings table, so a miss is routine, not exceptional.
 
-        Holds a database-wide advisory lock: concurrent ``optimize()`` calls all
+        Takes a per-table advisory lock: concurrent ``optimize()`` calls all
         rewrite the table and then all but one lose the commit, so the losers
-        burn a full rewrite for nothing. Whoever cannot take the lock skips,
-        which is free -- the next ingestion will compact instead.
+        burn a full rewrite for nothing. Whoever cannot take a table's lock
+        skips that table -- free, the next ingestion compacts instead -- and
+        moves on to the rest, so one busy table cannot starve the others.
 
         Best-effort maintenance: individual failures are logged, never raised.
         """
@@ -1643,26 +1671,36 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         policy = policy or DEFAULT_INDEX_POLICY
         cleanup_older_than = timedelta(days=policy.version_retention_days)
+        conn = self._get_connection()
         try:
-            existing = set(list_table_names(self._get_connection()))
+            existing = set(list_table_names(conn))
         except Exception as e:  # noqa: BLE001
             logger.warning("Could not list tables, skipping compaction: %s", e)
             return []
 
         candidates = [name for name in table_names if name in existing]
         if not candidates:
+            # list_table_names() returns [] rather than raising when it cannot
+            # read the listing, so without this compaction would switch itself
+            # off permanently and silently.
+            logger.warning(
+                "None of the tables to compact were found in the database "
+                "listing (asked for %s); skipping compaction",
+                ", ".join(table_names),
+            )
             return []
 
-        with _compaction_lock(self._get_connection()) as acquired:
-            if not acquired:
-                logger.info("Another process is compacting; skipping this round")
-                return []
-            return [
-                name
-                for name in candidates
-                if self.should_compact(name, policy)
-                and self.trigger_reindex(name, cleanup_older_than=cleanup_older_than)
-            ]
+        compacted: List[str] = []
+        for name in candidates:
+            with _compaction_lock(conn, name) as acquired:
+                if not acquired:
+                    logger.debug("%s is being compacted elsewhere; skipping", name)
+                    continue
+                if self.should_compact(name, policy) and self.trigger_reindex(
+                    name, cleanup_older_than=cleanup_older_than
+                ):
+                    compacted.append(name)
+        return compacted
 
     async def should_reindex_async(
         self, table_name: str, total_upserted: int, policy: IndexPolicy

--- a/tests/core/tools/core/RAG_tools/core/test_config.py
+++ b/tests/core/tools/core/RAG_tools/core/test_config.py
@@ -1,0 +1,26 @@
+"""Tests for RAG tool configuration defaults and their env overrides."""
+
+from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+
+def test_compaction_thresholds_read_the_environment(monkeypatch):
+    """The thresholds govern an always-on inline path, so they need a stand-down
+    switch that does not require a redeploy."""
+    monkeypatch.setenv("XAGENT_KB_COMPACT_FRAGMENT_THRESHOLD", "5000")
+    monkeypatch.setenv("XAGENT_KB_COMPACT_VERSION_THRESHOLD", "6000")
+    monkeypatch.setenv("XAGENT_KB_VERSION_RETENTION_DAYS", "30")
+    policy = IndexPolicy()
+    assert policy.compact_fragment_threshold == 5000
+    assert policy.compact_stale_version_threshold == 6000
+    assert policy.version_retention_days == 30
+
+
+def test_compaction_thresholds_ignore_unusable_environment_values(monkeypatch):
+    """A typo must not construct a policy that compacts on every single write."""
+    monkeypatch.setenv("XAGENT_KB_COMPACT_FRAGMENT_THRESHOLD", "nonsense")
+    monkeypatch.setenv("XAGENT_KB_COMPACT_VERSION_THRESHOLD", "-1")
+    monkeypatch.setenv("XAGENT_KB_VERSION_RETENTION_DAYS", "0")
+    policy = IndexPolicy()
+    assert policy.compact_fragment_threshold == 100
+    assert policy.compact_stale_version_threshold == 100
+    assert policy.version_retention_days == 7

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -1384,10 +1384,16 @@ def test_process_document_compacts_storage_after_success(
     assert result.status == "success"
     store.compact_tables.assert_called_once()
     tables = store.compact_tables.call_args.args[0]
-    assert "collection_metadata" in tables
-    # Fastest-growing table of all: delete+add per run, on failures too.
-    assert "ingestion_runs" in tables
-    assert any(name.startswith("embeddings_") for name in tables)
+    # Exact names, not a prefix match: a wrongly-derived embeddings table name
+    # silently resolves to nothing and skips the table this fix exists for.
+    assert set(tables) == {
+        "documents",
+        "parses",
+        "chunks",
+        "collection_metadata",
+        "ingestion_runs",
+        "embeddings_embedding_default",
+    }
 
 
 def test_process_document_succeeds_when_compaction_fails(
@@ -1413,3 +1419,39 @@ def test_process_document_succeeds_when_compaction_fails(
 
     assert result.status == "success"
     store.compact_tables.assert_called_once()
+
+
+def test_process_document_compacts_storage_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed ingestion must still compact: it fragmented the tables too.
+
+    Failed runs write ingestion_runs (delete+add) and whatever steps completed,
+    so a deployment with a high failure rate is exactly the one that must not
+    stop compacting (xorbitsai/xagent#1140 lists failed uploads as a symptom).
+    """
+    from unittest.mock import Mock, patch
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    def _boom(**_: object) -> dict:
+        raise RuntimeError("chunking exploded")
+
+    monkeypatch.setattr(document_ingestion, "chunk_document", _boom)
+
+    store = Mock()
+    store.compact_tables.return_value = []
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        result = document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/doc.pdf",
+            config=IngestionConfig(),
+        )
+
+    assert result.status != "success"
+    store.compact_tables.assert_called_once()
+    assert "ingestion_runs" in store.compact_tables.call_args.args[0]

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -28,6 +28,7 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
 )
 from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
 from xagent.core.tools.core.RAG_tools.progress.manager import ProgressManager
+from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
 
 
 class _StubEmbeddingAdapter(BaseEmbedding):
@@ -1371,10 +1372,7 @@ def test_process_document_compacts_storage_after_success(
     store = Mock()
     store.compact_tables.return_value = ["documents"]
 
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         result = document_ingestion.process_document(
             collection="demo",
             source_path="/tmp/doc.pdf",
@@ -1390,6 +1388,7 @@ def test_process_document_compacts_storage_after_success(
         "documents",
         "parses",
         "chunks",
+        "collection_config",
         "collection_metadata",
         "ingestion_runs",
         "embeddings_embedding_default",
@@ -1407,10 +1406,7 @@ def test_process_document_succeeds_when_compaction_fails(
     store = Mock()
     store.compact_tables.side_effect = RuntimeError("optimize exploded")
 
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         result = document_ingestion.process_document(
             collection="demo",
             source_path="/tmp/doc.pdf",
@@ -1442,10 +1438,7 @@ def test_process_document_compacts_storage_after_failure(
     store = Mock()
     store.compact_tables.return_value = []
 
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         result = document_ingestion.process_document(
             collection="demo",
             source_path="/tmp/doc.pdf",
@@ -1488,10 +1481,7 @@ def test_process_document_compaction_covers_vendor_prefixed_model_ids(
     store = Mock()
     store.compact_tables.return_value = []
 
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         result = document_ingestion.process_document(
             collection="demo",
             source_path="/tmp/doc.pdf",
@@ -1503,6 +1493,7 @@ def test_process_document_compaction_covers_vendor_prefixed_model_ids(
         "documents",
         "parses",
         "chunks",
+        "collection_config",
         "collection_metadata",
         "ingestion_runs",
         "embeddings_BAAI_bge_large_zh_v1_5",  # single-applied (legacy spelling)
@@ -1511,13 +1502,13 @@ def test_process_document_compaction_covers_vendor_prefixed_model_ids(
 
 
 def test_ingest_tables_are_real_schema_manager_tables() -> None:
-    """Every name in _INGEST_TABLES must correspond to a real ensure_*_table.
+    """_INGEST_TABLES is pinned exactly, and so is everything left out of it.
 
-    Binds the hardcoded list to the schema layer so a rename or typo cannot
-    leave it silently pointing at a table that does not exist.
-
-    Gap this does NOT close: a *new* table added to the ingest path is still
-    missed, because nothing enumerates which ensure_* calls ingestion makes.
+    Equality rather than a subset check: a subset assertion catches a typo'd
+    name but is structurally blind to an *omitted* one, which is how
+    ``collection_config`` stayed uncovered. Pinning the leftovers means a new
+    ``ensure_*_table`` forces a deliberate in-or-out decision here rather than
+    silently defaulting to never compacted.
     """
     from xagent.core.tools.core.RAG_tools.LanceDB import schema_manager
 
@@ -1526,4 +1517,16 @@ def test_ingest_tables_are_real_schema_manager_tables() -> None:
         for name in dir(schema_manager)
         if name.startswith("ensure_") and name.endswith("_table")
     }
-    assert set(document_ingestion._INGEST_TABLES) <= ensured
+    assert set(document_ingestion._INGEST_TABLES) == {
+        "documents",
+        "parses",
+        "chunks",
+        "collection_config",
+        "collection_metadata",
+        "ingestion_runs",
+    }
+    assert ensured - set(document_ingestion._INGEST_TABLES) == {
+        "embeddings",  # named per model tag; the caller appends it
+        "main_pointers",  # grows with collection count, not ingest count
+        "prompt_templates",  # same
+    }

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -1455,3 +1455,75 @@ def test_process_document_compacts_storage_after_failure(
     assert result.status != "success"
     store.compact_tables.assert_called_once()
     assert "ingestion_runs" in store.compact_tables.call_args.args[0]
+
+
+def test_process_document_compaction_covers_vendor_prefixed_model_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pipeline level: a slashed model id must reach the table writes create.
+
+    The other pipeline tests use ``embedding-default``, which is idempotent
+    under ``to_model_tag`` -- one application and two produce the same string,
+    so their assertions cannot tell a single probe from a double one. A vendor
+    prefixed id can, because ``to_model_tag`` lowercases the vendor segment on
+    the second pass.
+    """
+    from unittest.mock import Mock, patch
+
+    _patch_pipeline_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        document_ingestion,
+        "_resolve_embedding_adapter",
+        lambda _cfg: (
+            EmbeddingModelConfig(
+                id="BAAI/bge-large-zh-v1.5",
+                model_name="bge-large-zh-v1.5",
+                model_provider="huggingface",
+                dimension=2,
+            ),
+            _StubEmbeddingAdapter(),
+        ),
+    )
+
+    store = Mock()
+    store.compact_tables.return_value = []
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        result = document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/doc.pdf",
+            config=IngestionConfig(),
+        )
+
+    assert result.status == "success"
+    assert set(store.compact_tables.call_args.args[0]) == {
+        "documents",
+        "parses",
+        "chunks",
+        "collection_metadata",
+        "ingestion_runs",
+        "embeddings_BAAI_bge_large_zh_v1_5",  # single-applied (legacy spelling)
+        "embeddings_baai_bge_large_zh_v1_5",  # double-applied (what writes make)
+    }
+
+
+def test_ingest_tables_are_real_schema_manager_tables() -> None:
+    """Every name in _INGEST_TABLES must correspond to a real ensure_*_table.
+
+    Binds the hardcoded list to the schema layer so a rename or typo cannot
+    leave it silently pointing at a table that does not exist.
+
+    Gap this does NOT close: a *new* table added to the ingest path is still
+    missed, because nothing enumerates which ensure_* calls ingestion makes.
+    """
+    from xagent.core.tools.core.RAG_tools.LanceDB import schema_manager
+
+    ensured = {
+        name[len("ensure_") : -len("_table")]
+        for name in dir(schema_manager)
+        if name.startswith("ensure_") and name.endswith("_table")
+    }
+    assert set(document_ingestion._INGEST_TABLES) <= ensured

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -1385,6 +1385,8 @@ def test_process_document_compacts_storage_after_success(
     store.compact_tables.assert_called_once()
     tables = store.compact_tables.call_args.args[0]
     assert "collection_metadata" in tables
+    # Fastest-growing table of all: delete+add per run, on failures too.
+    assert "ingestion_runs" in tables
     assert any(name.startswith("embeddings_") for name in tables)
 
 

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -1353,3 +1353,61 @@ def test_batch_embedding_retries_transient_failure(
 
     assert result.status == "success"
     assert calls["n"] == 2  # first attempt raised, retry succeeded
+
+
+def test_process_document_compacts_storage_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful ingestion must actually trigger LanceDB compaction.
+
+    Guards the wiring itself (xorbitsai/xagent#1140): without this, deleting the
+    ``_compact_storage_if_needed`` call leaves the whole suite green while
+    fragmentation silently comes back.
+    """
+    from unittest.mock import Mock, patch
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    store = Mock()
+    store.compact_tables.return_value = ["documents"]
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        result = document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/doc.pdf",
+            config=IngestionConfig(),
+        )
+
+    assert result.status == "success"
+    store.compact_tables.assert_called_once()
+    tables = store.compact_tables.call_args.args[0]
+    assert "collection_metadata" in tables
+    assert any(name.startswith("embeddings_") for name in tables)
+
+
+def test_process_document_succeeds_when_compaction_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compaction is maintenance: its failure must not fail the ingestion."""
+    from unittest.mock import Mock, patch
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    store = Mock()
+    store.compact_tables.side_effect = RuntimeError("optimize exploded")
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        result = document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/doc.pdf",
+            config=IngestionConfig(),
+        )
+
+    assert result.status == "success"
+    store.compact_tables.assert_called_once()

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3093,6 +3093,23 @@ def test_trigger_reindex_keeps_recent_versions(mock_get_connection: Mock) -> Non
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
+def test_trigger_reindex_drops_the_cached_handle(mock_get_connection: Mock) -> None:
+    """Pruning removes the versions a cached handle points at, so it must go."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = Mock()
+
+    store = LanceDBVectorIndexStore()
+    store._get_table("documents")
+    assert "documents" in store._table_cache
+
+    assert store.trigger_reindex("documents") is True
+    assert "documents" not in store._table_cache
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
 def test_compact_tables_only_touches_fragmented_tables(
     mock_get_connection: Mock,
 ) -> None:

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3022,3 +3022,155 @@ def test_vis_cascade_delete_documents_unauthenticated_non_admin_returns_empty():
     )
     assert result == {}
     conn.open_table.assert_not_called()
+
+
+# ============================================================================
+# Compaction Tests (xorbitsai/xagent#1140)
+# ============================================================================
+
+
+def _mock_table_with_fragments(count: int) -> Mock:
+    table = Mock()
+    table.stats.return_value = {"fragment_stats": {"num_fragments": count}}
+    table.index_stats.side_effect = ValueError("no such index")
+    return table
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_should_reindex_triggers_on_fragmentation(mock_get_connection: Mock) -> None:
+    """Fragment count at or above the threshold triggers compaction."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = _mock_table_with_fragments(100)
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=100)
+
+    assert store.should_reindex("collection_metadata", 0, policy) is True
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_should_reindex_skips_below_fragment_threshold(
+    mock_get_connection: Mock,
+) -> None:
+    """A table below the fragment threshold is left alone."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = _mock_table_with_fragments(99)
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=100)
+
+    assert store.should_reindex("collection_metadata", 0, policy) is False
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_trigger_reindex_keeps_recent_versions(mock_get_connection: Mock) -> None:
+    """Version pruning always leaves a non-zero safety margin for live readers."""
+    from datetime import timedelta
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+
+    assert LanceDBVectorIndexStore().trigger_reindex("documents") is True
+    kwargs = mock_table.optimize.call_args.kwargs
+    assert kwargs["cleanup_older_than"] == timedelta(days=7)
+    assert kwargs["cleanup_older_than"] > timedelta(0)
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_only_touches_fragmented_tables(
+    mock_get_connection: Mock,
+) -> None:
+    """Every table is inspected; only the fragmented ones are optimized."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    fragmented = _mock_table_with_fragments(500)
+    healthy = _mock_table_with_fragments(3)
+    tables = {"documents": fragmented, "chunks": healthy}
+
+    mock_conn = Mock()
+    mock_conn.table_names.return_value = ["documents", "chunks"]
+    mock_conn.list_tables = None
+    del mock_conn.list_tables
+    mock_conn.open_table.side_effect = lambda name, *a, **k: tables[name]
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    compacted = store.compact_tables(IndexPolicy(compact_fragment_threshold=100))
+
+    assert compacted == ["documents"]
+    fragmented.optimize.assert_called_once()
+    healthy.optimize.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_swallows_optimize_failure(mock_get_connection: Mock) -> None:
+    """A failing optimize is reported, not raised: maintenance is not the flow."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    broken = _mock_table_with_fragments(500)
+    broken.optimize.side_effect = RuntimeError("disk full")
+
+    mock_conn = Mock()
+    mock_conn.table_names.return_value = ["documents"]
+    del mock_conn.list_tables
+    mock_conn.open_table.return_value = broken
+    mock_get_connection.return_value = mock_conn
+
+    assert LanceDBVectorIndexStore().compact_tables(IndexPolicy()) == []
+
+
+def test_ingestion_compaction_hook_never_raises() -> None:
+    """Compaction failure must not break a successful ingestion."""
+    from xagent.core.tools.core.RAG_tools.pipelines.document_ingestion import (
+        _compact_storage_if_needed,
+    )
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        side_effect=RuntimeError("store unavailable"),
+    ):
+        _compact_storage_if_needed()
+
+
+def test_compaction_reduces_fragments_and_prunes_versions(tmp_path: Any) -> None:
+    """End-to-end against real LanceDB: files collapse, recent versions survive."""
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    db = lancedb.connect(str(tmp_path))
+    schema = pa.schema([pa.field("name", pa.string())])
+    table = db.create_table("collection_metadata", schema=schema)
+    for i in range(12):
+        table.add([{"name": f"c{i}"}])
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=10)
+    with patch.object(store, "_get_connection", return_value=db):
+        assert store.should_reindex("collection_metadata", 0, policy) is True
+        assert store.compact_tables(policy) == ["collection_metadata"]
+
+    handle = db.open_table("collection_metadata")
+    assert handle.stats()["fragment_stats"]["num_fragments"] == 1
+    assert len(handle.search().to_arrow()) == 12
+    # 7-day retention: nothing written during this test may be pruned.
+    assert len(handle.list_versions()) > 1

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from xagent.core.tools.core.RAG_tools.core.config import DEFAULT_INDEX_POLICY
 from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
 from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
     LanceDBIngestionStatusStore,
@@ -3485,3 +3486,81 @@ def test_compaction_finds_the_embeddings_table_the_write_path_creates(
     # The name the write path really created must be asked for verbatim.
     assert created[0] in probed
     assert stats["fragment_stats"]["num_fragments"] == 1  # and really got compacted
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_with_empty_list_does_nothing(
+    mock_get_connection: Mock,
+) -> None:
+    """Empty input is a normal boundary: no work, no connection, no error."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    assert LanceDBVectorIndexStore().compact_tables([]) == []
+    mock_conn.open_table.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_trigger_reindex_returns_false_for_unopenable_table(
+    mock_get_connection: Mock,
+) -> None:
+    """A table that cannot even be opened reports False rather than raising.
+
+    Distinct from the covered case where an opened table's optimize() fails:
+    this is the open_table branch, which the probe-both-spellings scheme hits
+    routinely, since one of the two candidate names usually does not exist.
+    """
+    mock_conn = Mock()
+    mock_conn.open_table.side_effect = FileNotFoundError("no such table")
+    mock_get_connection.return_value = mock_conn
+
+    assert LanceDBVectorIndexStore().trigger_reindex("embeddings_nope") is False
+
+
+def test_vector_index_store_contract_defaults_to_no_compaction() -> None:
+    """A backend that does not implement compaction inherits safe no-ops.
+
+    Calls the base-class bodies unbound: VectorIndexStore has 42 abstract
+    methods, so a stub subclass would be 40 lines of noise to test two.
+    """
+    from xagent.core.tools.core.RAG_tools.storage.contracts import VectorIndexStore
+
+    backend = Mock(spec=VectorIndexStore)
+
+    assert VectorIndexStore.should_compact(backend, "documents") is False
+    assert VectorIndexStore.compact_tables(backend, ["documents"]) == []
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_maintenance_failures_never_log_at_error_level(
+    mock_get_connection: Mock,
+    caplog: Any,
+) -> None:
+    """Compaction is best-effort, so its failures stay at WARNING.
+
+    should_reindex now runs on every ingestion; at ERROR a single unopenable
+    table would page on every upload for every collection, forever.
+    """
+    import logging
+
+    mock_conn = Mock()
+    mock_conn.open_table.side_effect = FileNotFoundError("no such table")
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    with caplog.at_level(
+        logging.DEBUG, logger="xagent.core.tools.core.RAG_tools.storage.lancedb_stores"
+    ):
+        assert store.should_reindex("gone", 0, DEFAULT_INDEX_POLICY) is False
+        assert store.should_compact("gone") is False
+        assert store.trigger_reindex("gone") is False
+        assert store.compact_tables(["gone"]) == []
+
+    assert [r.levelno for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any(r.levelno == logging.WARNING for r in caplog.records)

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3753,13 +3753,20 @@ def test_compaction_lock_keeps_concurrent_workers_off_one_table(
         [
             sys.executable,
             "-c",
+            # Holds the lock through the real helper, so the test cannot drift
+            # out of step with how lock files are named.
             textwrap.dedent(f"""
                 import time
-                from filelock import FileLock
-                lock = FileLock({str(tmp_path / ".documents.compaction.lock")!r})
-                lock.acquire()
-                open({str(ready)!r}, "w").close()
-                time.sleep(30)
+                from unittest.mock import Mock
+                from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+                    _compaction_lock,
+                )
+                conn = Mock()
+                conn.uri = {str(tmp_path)!r}
+                with _compaction_lock(conn, "documents") as held:
+                    assert held is True
+                    open({str(ready)!r}, "w").close()
+                    time.sleep(30)
             """),
         ]
     )
@@ -3827,7 +3834,9 @@ def test_compaction_lock_does_not_swallow_body_exceptions(tmp_path: Any) -> None
         with _compaction_lock(conn, "documents"):
             raise ValueError("real failure from trigger_reindex")
 
-    # And the lock was released despite the exception.
+    # And the lock is takeable again afterwards, so the failure did not wedge it.
+    # (Only re-acquirability is asserted here; filelock also releases on __del__,
+    # so this cannot prove the explicit release ran.)
     with _compaction_lock(conn, "documents") as acquired:
         assert acquired is True
 
@@ -3977,3 +3986,86 @@ def test_compact_tables_warns_when_no_candidate_is_listed(
         r.levelno == logging.WARNING and "documents" in r.getMessage()
         for r in caplog.records
     )
+
+
+def test_stale_version_count_judges_aware_timestamps_by_instant() -> None:
+    """An aware timestamp is judged by the instant it names, not its wall clock.
+
+    LanceDB returns naive local timestamps today; this branch is what keeps that
+    assumption from silently inverting if it ever returns aware ones. Reading a
+    far zone's wall clock instead shifts a version by most of a day, in either
+    direction depending on the offset.
+    """
+    local_now = datetime.now()
+    cutoff = local_now - timedelta(hours=6)
+
+    # A zone at least 12 hours from local, on whichever side stays legal.
+    local_offset = local_now.astimezone().utcoffset() or timedelta(0)
+    shift = (
+        timedelta(hours=-12) if local_offset >= timedelta(0) else timedelta(hours=12)
+    )
+    far = timezone(local_offset + shift)
+
+    def _aware(hours_ago: int) -> datetime:
+        return (local_now - timedelta(hours=hours_ago)).astimezone().astimezone(far)
+
+    table = Mock()
+    # One version each side of the cutoff: any constant misreading of the offset
+    # moves both by the same amount and so flips exactly one of them.
+    table.list_versions.return_value = [
+        {"version": 1, "timestamp": _aware(1)},  # inside the window
+        {"version": 2, "timestamp": _aware(11)},  # outside it
+    ]
+
+    assert _stale_version_count(table, cutoff) == 1
+
+
+def test_should_compact_measures_the_retention_window_in_local_time() -> None:
+    """The cutoff comes from local time, matching LanceDB's naive timestamps.
+
+    Deriving it from utcnow() shifts the whole window by the UTC offset. West of
+    Greenwich that marks versions still inside the window as reclaimable, and
+    compaction then deletes versions live readers are holding.
+
+    Necessarily a no-op on a machine running at UTC, where the two clocks agree.
+    """
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    policy = IndexPolicy(compact_stale_version_threshold=1, version_retention_days=7)
+    boundary = datetime.now() - timedelta(days=policy.version_retention_days)
+
+    table = Mock()
+    table.stats.return_value = {"fragment_stats": {"num_fragments": 1}}
+    # Straddle the true cutoff by a minute, so any clock skew moves both across.
+    table.list_versions.return_value = [
+        {"version": 1, "timestamp": boundary - timedelta(minutes=1)},
+        {"version": 2, "timestamp": boundary + timedelta(minutes=1)},
+    ]
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(
+        store, "_get_connection", return_value=_mock_conn_with_tables(t=table)
+    ):
+        assert store.should_compact("t", policy) is True
+
+
+def test_should_compact_fires_at_exactly_the_stale_version_threshold() -> None:
+    """The comparison is >=, so the threshold value itself must trigger."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    table = Mock()
+    table.stats.return_value = {"fragment_stats": {"num_fragments": 2}}
+    table.list_versions.return_value = _versions(stale=100, fresh=5)
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(
+        store, "_get_connection", return_value=_mock_conn_with_tables(t=table)
+    ):
+        assert (
+            store.should_compact("t", IndexPolicy(compact_stale_version_threshold=100))
+            is True
+        )
+        assert (
+            store.should_compact("t", IndexPolicy(compact_stale_version_threshold=101))
+            is False
+        )

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3247,6 +3247,7 @@ def test_ingestion_compaction_hook_scopes_to_written_tables() -> None:
         "parses",
         "chunks",
         "collection_metadata",
+        "ingestion_runs",
         "embeddings_text_embedding_v4",
     }
 
@@ -3313,6 +3314,45 @@ def test_compaction_prunes_versions_outside_the_retention_window(
     handle = db.open_table("documents")
     assert len(handle.list_versions()) < before
     assert len(handle.search().to_arrow()) == 12  # data survives the pruning
+
+
+def test_compaction_preserves_live_rows_of_a_delete_add_table(
+    tmp_path: Any,
+) -> None:
+    """``ingestion_runs`` upserts by delete+add; compaction must keep the winners.
+
+    That pattern is the fastest source of fragmentation (two versions per run)
+    and the one where a wrong compaction would be most visible: superseded rows
+    must stay gone and the surviving status must be the last one written.
+    """
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    db = lancedb.connect(str(tmp_path))
+    schema = pa.schema(
+        [pa.field("doc_id", pa.string()), pa.field("status", pa.string())]
+    )
+    table = db.create_table("ingestion_runs", schema=schema)
+    for i in range(10):
+        table.delete(f"doc_id = 'd{i}'")
+        table.add([{"doc_id": f"d{i}", "status": "running"}])
+    # Re-run every doc: each is deleted then re-added with a terminal status.
+    for i in range(10):
+        table.delete(f"doc_id = 'd{i}'")
+        table.add([{"doc_id": f"d{i}", "status": "success"}])
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=10)
+    with patch.object(store, "_get_connection", return_value=db):
+        assert store.should_compact("ingestion_runs", policy) is True
+        assert store.compact_tables(["ingestion_runs"], policy) == ["ingestion_runs"]
+
+    rows = db.open_table("ingestion_runs").search().to_arrow().to_pylist()
+    assert {r["doc_id"] for r in rows} == {f"d{i}" for i in range(10)}
+    assert all(r["status"] == "success" for r in rows)  # no tombstone resurrection
+    assert len(rows) == 10  # no duplicates from the superseded versions
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3250,6 +3250,43 @@ def test_ingestion_compaction_hook_scopes_to_written_tables() -> None:
         "ingestion_runs",
         "embeddings_text_embedding_v4",
     }
+    assert len(names) == len(set(names))  # idempotent tag: no duplicate probe
+
+
+def test_ingestion_compaction_hook_covers_vendor_prefixed_model_ids() -> None:
+    """A vendor-prefixed id must reach the table the write path really creates.
+
+    ``to_model_tag`` is not idempotent for ids containing a slash, and the write
+    path applies it twice (CollectionHandle then upsert_embeddings), so probing
+    only the single-applied spelling silently misses the embeddings table.
+    """
+    from xagent.core.tools.core.RAG_tools.LanceDB.model_tag_utils import to_model_tag
+    from xagent.core.tools.core.RAG_tools.pipelines.document_ingestion import (
+        _compact_storage_if_needed,
+    )
+
+    model_id = "BAAI/bge-large-zh-v1.5"
+    # Guard the premise: if to_model_tag ever becomes idempotent this test is moot.
+    assert to_model_tag(model_id) != to_model_tag(to_model_tag(model_id))
+
+    store = Mock()
+    store.compact_tables.return_value = []
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        _compact_storage_if_needed(model_id)
+
+    names = store.compact_tables.call_args.args[0]
+    assert set(names) == {
+        "documents",
+        "parses",
+        "chunks",
+        "collection_metadata",
+        "ingestion_runs",
+        "embeddings_BAAI_bge_large_zh_v1_5",  # single-applied (legacy spelling)
+        "embeddings_baai_bge_large_zh_v1_5",  # double-applied (what writes create)
+    }
 
 
 def test_compaction_collapses_fragments_and_retains_recent_versions(
@@ -3370,3 +3407,81 @@ def test_trigger_reindex_drops_the_cached_handle(mock_get_connection: Mock) -> N
 
     assert store.trigger_reindex("documents") is True
     assert "documents" not in store._table_cache
+
+
+def test_compaction_finds_the_embeddings_table_the_write_path_creates(
+    tmp_path: Any,
+) -> None:
+    """End-to-end: the real write path's table name is one the hook actually probes.
+
+    Exercises the genuine double application of ``to_model_tag`` -- the caller
+    (CollectionHandle) tags the model id, then ``upsert_embeddings`` tags it
+    again -- and asserts the ingest hook asks for that name letter for letter.
+
+    The comparison is on the probed strings, not on whether ``open_table``
+    happens to succeed: a case-insensitive filesystem (macOS) resolves the
+    wrongly-cased name to the same directory, so an open-based assertion would
+    pass locally and still miss the table on a case-sensitive production box.
+    """
+    import lancedb
+
+    from xagent.core.tools.core.RAG_tools.LanceDB.model_tag_utils import to_model_tag
+    from xagent.core.tools.core.RAG_tools.pipelines.document_ingestion import (
+        _compact_storage_if_needed,
+    )
+
+    model_id = "BAAI/bge-large-zh-v1.5"
+    db = lancedb.connect(str(tmp_path))
+    store = LanceDBVectorIndexStore()
+    probed: List[str] = []
+
+    with patch.object(store, "_get_connection", return_value=db):
+        # CollectionHandle._upsert_model_embeddings tags once, then passes on.
+        model_tag = to_model_tag(model_id)
+        for i in range(12):
+            store.upsert_embeddings(
+                model_tag,
+                [
+                    {
+                        "collection": "demo",
+                        "doc_id": "doc-1",
+                        "chunk_id": f"chunk-{i}",
+                        "parse_hash": "hash-1",
+                        "model": model_id,
+                        "vector": [0.1, 0.2],
+                        "text": f"text-{i}",
+                        "chunk_hash": f"chunk-hash-{i}",
+                        "metadata": "{}",
+                    }
+                ],
+            )
+
+        created = [n for n in db.table_names() if n.startswith("embeddings_")]
+        assert created == ["embeddings_baai_bge_large_zh_v1_5"]
+
+        from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+        real_compact_tables = store.compact_tables
+
+        def _record(names: Any, policy: Any = None) -> List[str]:
+            probed.extend(names)
+            return real_compact_tables(names, policy)
+
+        with patch.object(store, "compact_tables", _record):
+            with patch(
+                "xagent.core.tools.core.RAG_tools.storage.factory."
+                "get_vector_index_store",
+                return_value=store,
+            ):
+                with patch(
+                    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores."
+                    "DEFAULT_INDEX_POLICY",
+                    IndexPolicy(compact_fragment_threshold=10),
+                ):
+                    _compact_storage_if_needed(model_id)
+
+        stats = db.open_table(created[0]).stats()
+
+    # The name the write path really created must be asked for verbatim.
+    assert created[0] in probed
+    assert stats["fragment_stats"]["num_fragments"] == 1  # and really got compacted

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -9,6 +9,7 @@ import pytest
 
 from xagent.core.tools.core.RAG_tools.core.config import DEFAULT_INDEX_POLICY
 from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
+from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
 from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
     LanceDBIngestionStatusStore,
     LanceDBMainPointerStore,
@@ -3278,8 +3279,9 @@ def test_ingestion_compaction_hook_never_raises() -> None:
         _compact_storage_if_needed,
     )
 
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+    with patch.object(
+        StorageFactory,
+        "get_vector_index_store",
         side_effect=RuntimeError("store unavailable"),
     ):
         _compact_storage_if_needed("embedding-default")
@@ -3293,10 +3295,7 @@ def test_ingestion_compaction_hook_scopes_to_written_tables() -> None:
 
     store = Mock()
     store.compact_tables.return_value = []
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         _compact_storage_if_needed("text-embedding-v4")
 
     names = store.compact_tables.call_args.args[0]
@@ -3304,6 +3303,7 @@ def test_ingestion_compaction_hook_scopes_to_written_tables() -> None:
         "documents",
         "parses",
         "chunks",
+        "collection_config",
         "collection_metadata",
         "ingestion_runs",
         "embeddings_text_embedding_v4",
@@ -3329,10 +3329,7 @@ def test_ingestion_compaction_hook_covers_vendor_prefixed_model_ids() -> None:
 
     store = Mock()
     store.compact_tables.return_value = []
-    with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
-        return_value=store,
-    ):
+    with patch.object(StorageFactory, "get_vector_index_store", return_value=store):
         _compact_storage_if_needed(model_id)
 
     names = store.compact_tables.call_args.args[0]
@@ -3340,6 +3337,7 @@ def test_ingestion_compaction_hook_covers_vendor_prefixed_model_ids() -> None:
         "documents",
         "parses",
         "chunks",
+        "collection_config",
         "collection_metadata",
         "ingestion_runs",
         "embeddings_BAAI_bge_large_zh_v1_5",  # single-applied (legacy spelling)
@@ -3524,10 +3522,8 @@ def test_compaction_finds_the_embeddings_table_the_write_path_creates(
             return real_compact_tables(names, policy)
 
         with patch.object(store, "compact_tables", _record):
-            with patch(
-                "xagent.core.tools.core.RAG_tools.storage.factory."
-                "get_vector_index_store",
-                return_value=store,
+            with patch.object(
+                StorageFactory, "get_vector_index_store", return_value=store
             ):
                 with patch(
                     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores."
@@ -3946,6 +3942,81 @@ def test_should_compact_counts_only_reclaimable_versions() -> None:
             store.should_compact("t", IndexPolicy(compact_stale_version_threshold=200))
             is False
         )
+
+
+def test_should_compact_probes_fragments_first_and_only_once() -> None:
+    """Pins the operand order of the ``or`` and bounds the probes per call.
+
+    ``or`` short-circuits only when the left side is already True, so which
+    operand comes first *is* the cost model: swap them and every ingestion pays
+    the version scan even when fragments alone settle the answer -- ~2.2 ms
+    against ~124 ms at 1000 retained versions. A doubled probe is the same bill
+    twice. Neither shows up as a failure anywhere else in the suite.
+    """
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    policy = IndexPolicy(compact_fragment_threshold=10)
+    calls: List[str] = []
+
+    def _recording_table(fragments: int) -> Mock:
+        table = Mock()
+
+        def stats() -> Dict[str, Any]:
+            calls.append("stats")
+            return {"fragment_stats": {"num_fragments": fragments}}
+
+        def list_versions() -> List[Dict[str, Any]]:
+            calls.append("list_versions")
+            return _versions(stale=0, fresh=3)
+
+        table.stats.side_effect = stats
+        table.list_versions.side_effect = list_versions
+        return table
+
+    store = LanceDBVectorIndexStore()
+
+    # Fragmented: settled by the cheap probe, so the scan is never reached.
+    with patch.object(
+        store,
+        "_get_connection",
+        return_value=_mock_conn_with_tables(t=_recording_table(50)),
+    ):
+        assert store.should_compact("t", policy) is True
+    assert calls == ["stats"]
+
+    # Healthy: both run, each exactly once, and fragments still go first.
+    calls.clear()
+    with patch.object(
+        store,
+        "_get_connection",
+        return_value=_mock_conn_with_tables(t=_recording_table(2)),
+    ):
+        assert store.should_compact("t", policy) is False
+    assert calls == ["stats", "list_versions"]
+
+
+def test_compact_tables_never_raises_from_the_connection() -> None:
+    """The "logged, never raised" promise has to cover opening the database.
+
+    ``_get_connection()`` used to sit outside every try in ``compact_tables``,
+    so an unreachable database raised straight out of a method documented as
+    best-effort; only the caller's own blanket except hid it.
+    """
+    store = LanceDBVectorIndexStore()
+    with patch.object(store, "_get_connection", side_effect=RuntimeError("no db")):
+        assert store.compact_tables(["documents"]) == []
+
+
+def test_compaction_lock_never_raises_from_release(tmp_path: Any) -> None:
+    """A failing unlock is maintenance noise, not the caller's exception."""
+    from filelock import FileLock
+
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import _compaction_lock
+
+    conn = _mock_conn_with_tables(tmp_path)
+    with patch.object(FileLock, "release", side_effect=RuntimeError("lock gone")):
+        with _compaction_lock(conn, "documents") as acquired:
+            assert acquired is True  # really locked, so release really runs
 
 
 def test_stale_version_count_returns_zero_when_unsupported() -> None:

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3032,15 +3032,14 @@ def test_vis_cascade_delete_documents_unauthenticated_non_admin_returns_empty():
 def _mock_table_with_fragments(count: int) -> Mock:
     table = Mock()
     table.stats.return_value = {"fragment_stats": {"num_fragments": count}}
-    table.index_stats.side_effect = ValueError("no such index")
     return table
 
 
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
-def test_should_reindex_triggers_on_fragmentation(mock_get_connection: Mock) -> None:
-    """Fragment count at or above the threshold triggers compaction."""
+def test_should_compact_triggers_on_fragmentation(mock_get_connection: Mock) -> None:
+    """Fragment count at or above the threshold marks a table for compaction."""
     from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 
     mock_conn = Mock()
@@ -3048,15 +3047,14 @@ def test_should_reindex_triggers_on_fragmentation(mock_get_connection: Mock) -> 
     mock_conn.open_table.return_value = _mock_table_with_fragments(100)
 
     store = LanceDBVectorIndexStore()
-    policy = IndexPolicy(compact_fragment_threshold=100)
 
-    assert store.should_reindex("collection_metadata", 0, policy) is True
+    assert store.should_compact("collection_metadata", IndexPolicy()) is True
 
 
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
-def test_should_reindex_skips_below_fragment_threshold(
+def test_should_compact_skips_below_fragment_threshold(
     mock_get_connection: Mock,
 ) -> None:
     """A table below the fragment threshold is left alone."""
@@ -3067,9 +3065,59 @@ def test_should_reindex_skips_below_fragment_threshold(
     mock_conn.open_table.return_value = _mock_table_with_fragments(99)
 
     store = LanceDBVectorIndexStore()
-    policy = IndexPolicy(compact_fragment_threshold=100)
 
-    assert store.should_reindex("collection_metadata", 0, policy) is False
+    assert store.should_compact("collection_metadata", IndexPolicy()) is False
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_should_compact_ignores_index_staleness(mock_get_connection: Mock) -> None:
+    """A barely-fragmented table is never compacted just because its index is stale.
+
+    ``optimize()`` bundles compaction with an index rebuild, so a shared
+    predicate would rebuild a large unrelated index on every ingest.
+    """
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    table = _mock_table_with_fragments(2)
+    stats = Mock()
+    stats.num_indexed_rows = 1000
+    stats.num_unindexed_rows = 50000  # blows past both smart-reindex thresholds
+    table.index_stats.return_value = stats
+
+    mock_conn = Mock()
+    mock_conn.open_table.return_value = table
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy()
+
+    # should_reindex still fires on staleness; compaction must not follow it.
+    assert store.should_reindex("embeddings_big", 0, policy) is True
+    assert store.should_compact("embeddings_big", policy) is False
+    assert store.compact_tables(["embeddings_big"], policy) == []
+    table.optimize.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_should_compact_returns_false_when_stats_unsupported(
+    mock_get_connection: Mock,
+) -> None:
+    """Older lancedb without ``stats()`` degrades to "do nothing", never raises."""
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import _fragment_count
+
+    table = Mock()
+    table.stats.side_effect = Exception("unsupported")
+
+    mock_conn = Mock()
+    mock_conn.open_table.return_value = table
+    mock_get_connection.return_value = mock_conn
+
+    assert _fragment_count(table) == 0
+    assert LanceDBVectorIndexStore().should_compact("documents") is False
 
 
 @patch(
@@ -3090,21 +3138,14 @@ def test_trigger_reindex_keeps_recent_versions(mock_get_connection: Mock) -> Non
     assert kwargs["cleanup_older_than"] > timedelta(0)
 
 
-@patch(
-    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
-)
-def test_trigger_reindex_drops_the_cached_handle(mock_get_connection: Mock) -> None:
-    """Pruning removes the versions a cached handle points at, so it must go."""
-    mock_conn = Mock()
-    mock_get_connection.return_value = mock_conn
-    mock_conn.open_table.return_value = Mock()
+def test_index_policy_rejects_zero_version_retention() -> None:
+    """A zero retention window would delete every version but the latest."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 
-    store = LanceDBVectorIndexStore()
-    store._get_table("documents")
-    assert "documents" in store._table_cache
-
-    assert store.trigger_reindex("documents") is True
-    assert "documents" not in store._table_cache
+    with pytest.raises(ValueError, match="version_retention_days must be positive"):
+        IndexPolicy(version_retention_days=0)
+    with pytest.raises(ValueError, match="version_retention_days must be positive"):
+        IndexPolicy(version_retention_days=-1)
 
 
 @patch(
@@ -3113,7 +3154,7 @@ def test_trigger_reindex_drops_the_cached_handle(mock_get_connection: Mock) -> N
 def test_compact_tables_only_touches_fragmented_tables(
     mock_get_connection: Mock,
 ) -> None:
-    """Every table is inspected; only the fragmented ones are optimized."""
+    """Only the named tables are inspected, and only fragmented ones optimized."""
     from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 
     fragmented = _mock_table_with_fragments(500)
@@ -3121,18 +3162,39 @@ def test_compact_tables_only_touches_fragmented_tables(
     tables = {"documents": fragmented, "chunks": healthy}
 
     mock_conn = Mock()
-    mock_conn.table_names.return_value = ["documents", "chunks"]
-    mock_conn.list_tables = None
-    del mock_conn.list_tables
     mock_conn.open_table.side_effect = lambda name, *a, **k: tables[name]
     mock_get_connection.return_value = mock_conn
 
     store = LanceDBVectorIndexStore()
-    compacted = store.compact_tables(IndexPolicy(compact_fragment_threshold=100))
+    compacted = store.compact_tables(["documents", "chunks"], IndexPolicy())
 
     assert compacted == ["documents"]
     fragmented.optimize.assert_called_once()
     healthy.optimize.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_never_sweeps_unrelated_tables(
+    mock_get_connection: Mock,
+) -> None:
+    """Compaction is scoped to the caller's list; the database is never listed."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    mock_conn = Mock()
+    mock_conn.open_table.return_value = _mock_table_with_fragments(500)
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    assert store.compact_tables(["documents"], IndexPolicy()) == ["documents"]
+
+    mock_conn.table_names.assert_not_called()
+    mock_conn.list_tables.assert_not_called()
+    assert [c.args[0] for c in mock_conn.open_table.call_args_list] == [
+        "documents",
+        "documents",
+    ]
 
 
 @patch(
@@ -3146,12 +3208,10 @@ def test_compact_tables_swallows_optimize_failure(mock_get_connection: Mock) -> 
     broken.optimize.side_effect = RuntimeError("disk full")
 
     mock_conn = Mock()
-    mock_conn.table_names.return_value = ["documents"]
-    del mock_conn.list_tables
     mock_conn.open_table.return_value = broken
     mock_get_connection.return_value = mock_conn
 
-    assert LanceDBVectorIndexStore().compact_tables(IndexPolicy()) == []
+    assert LanceDBVectorIndexStore().compact_tables(["documents"], IndexPolicy()) == []
 
 
 def test_ingestion_compaction_hook_never_raises() -> None:
@@ -3164,10 +3224,36 @@ def test_ingestion_compaction_hook_never_raises() -> None:
         "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
         side_effect=RuntimeError("store unavailable"),
     ):
-        _compact_storage_if_needed()
+        _compact_storage_if_needed("embedding-default")
 
 
-def test_compaction_reduces_fragments_and_prunes_versions(tmp_path: Any) -> None:
+def test_ingestion_compaction_hook_scopes_to_written_tables() -> None:
+    """The hook compacts exactly the tables an ingestion writes, nothing else."""
+    from xagent.core.tools.core.RAG_tools.pipelines.document_ingestion import (
+        _compact_storage_if_needed,
+    )
+
+    store = Mock()
+    store.compact_tables.return_value = []
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+        return_value=store,
+    ):
+        _compact_storage_if_needed("text-embedding-v4")
+
+    names = store.compact_tables.call_args.args[0]
+    assert set(names) == {
+        "documents",
+        "parses",
+        "chunks",
+        "collection_metadata",
+        "embeddings_text_embedding_v4",
+    }
+
+
+def test_compaction_collapses_fragments_and_retains_recent_versions(
+    tmp_path: Any,
+) -> None:
     """End-to-end against real LanceDB: files collapse, recent versions survive."""
     import lancedb
     import pyarrow as pa
@@ -3183,11 +3269,64 @@ def test_compaction_reduces_fragments_and_prunes_versions(tmp_path: Any) -> None
     store = LanceDBVectorIndexStore()
     policy = IndexPolicy(compact_fragment_threshold=10)
     with patch.object(store, "_get_connection", return_value=db):
-        assert store.should_reindex("collection_metadata", 0, policy) is True
-        assert store.compact_tables(policy) == ["collection_metadata"]
+        # collection_metadata has no vector index, so the fragment predicate is
+        # the only thing that can ever schedule it for compaction.
+        assert store.should_reindex("collection_metadata", 0, policy) is False
+        assert store.should_compact("collection_metadata", policy) is True
+        assert store.compact_tables(["collection_metadata"], policy) == [
+            "collection_metadata"
+        ]
 
     handle = db.open_table("collection_metadata")
     assert handle.stats()["fragment_stats"]["num_fragments"] == 1
     assert len(handle.search().to_arrow()) == 12
     # 7-day retention: nothing written during this test may be pruned.
     assert len(handle.list_versions()) > 1
+
+
+def test_compaction_prunes_versions_outside_the_retention_window(
+    tmp_path: Any,
+) -> None:
+    """A short retention window really does delete old versions on disk."""
+    from datetime import timedelta
+
+    import lancedb
+    import pyarrow as pa
+
+    db = lancedb.connect(str(tmp_path))
+    schema = pa.schema([pa.field("name", pa.string())])
+    table = db.create_table("documents", schema=schema)
+    for i in range(12):
+        table.add([{"name": f"d{i}"}])
+    before = len(db.open_table("documents").list_versions())
+    assert before > 10
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(store, "_get_connection", return_value=db):
+        assert (
+            store.trigger_reindex(
+                "documents", cleanup_older_than=timedelta(microseconds=1)
+            )
+            is True
+        )
+
+    handle = db.open_table("documents")
+    assert len(handle.list_versions()) < before
+    assert len(handle.search().to_arrow()) == 12  # data survives the pruning
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_trigger_reindex_drops_the_cached_handle(mock_get_connection: Mock) -> None:
+    """Pruning removes the versions a cached handle points at, so it must go."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = Mock()
+
+    store = LanceDBVectorIndexStore()
+    store._get_table("documents")
+    assert "documents" in store._table_cache
+
+    assert store.trigger_reindex("documents") is True
+    assert "documents" not in store._table_cache

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -3030,10 +3030,19 @@ def test_vis_cascade_delete_documents_unauthenticated_non_admin_returns_empty():
 # ============================================================================
 
 
-def _mock_table_with_fragments(count: int) -> Mock:
+def _mock_table_with_fragments(count: int, versions: int = 1) -> Mock:
     table = Mock()
     table.stats.return_value = {"fragment_stats": {"num_fragments": count}}
+    table.list_versions.return_value = [{"version": i} for i in range(versions)]
     return table
+
+
+def _mock_conn_with_tables(**tables: Mock) -> Mock:
+    """Connection whose table listing matches the tables it can open."""
+    conn = Mock()
+    conn.list_tables.return_value = list(tables)
+    conn.open_table.side_effect = lambda name, *a, **k: tables[name]
+    return conn
 
 
 @patch(
@@ -3160,11 +3169,9 @@ def test_compact_tables_only_touches_fragmented_tables(
 
     fragmented = _mock_table_with_fragments(500)
     healthy = _mock_table_with_fragments(3)
-    tables = {"documents": fragmented, "chunks": healthy}
-
-    mock_conn = Mock()
-    mock_conn.open_table.side_effect = lambda name, *a, **k: tables[name]
-    mock_get_connection.return_value = mock_conn
+    mock_get_connection.return_value = _mock_conn_with_tables(
+        documents=fragmented, chunks=healthy
+    )
 
     store = LanceDBVectorIndexStore()
     compacted = store.compact_tables(["documents", "chunks"], IndexPolicy())
@@ -3177,25 +3184,54 @@ def test_compact_tables_only_touches_fragmented_tables(
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
-def test_compact_tables_never_sweeps_unrelated_tables(
+def test_compact_tables_never_opens_unrelated_tables(
     mock_get_connection: Mock,
 ) -> None:
-    """Compaction is scoped to the caller's list; the database is never listed."""
+    """Only the caller's tables are opened, however many the database holds.
+
+    Listing names is a single cheap metadata call and is expected; opening every
+    table in the database is the cost this API exists to avoid.
+    """
     from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 
-    mock_conn = Mock()
-    mock_conn.open_table.return_value = _mock_table_with_fragments(500)
+    mock_conn = _mock_conn_with_tables(
+        documents=_mock_table_with_fragments(500),
+        chunks=_mock_table_with_fragments(500),
+        parses=_mock_table_with_fragments(500),
+    )
     mock_get_connection.return_value = mock_conn
 
     store = LanceDBVectorIndexStore()
     assert store.compact_tables(["documents"], IndexPolicy()) == ["documents"]
 
-    mock_conn.table_names.assert_not_called()
-    mock_conn.list_tables.assert_not_called()
-    assert [c.args[0] for c in mock_conn.open_table.call_args_list] == [
-        "documents",
-        "documents",
-    ]
+    opened = {c.args[0] for c in mock_conn.open_table.call_args_list}
+    assert opened == {"documents"}
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_skips_names_that_do_not_exist(
+    mock_get_connection: Mock,
+) -> None:
+    """A missing table is skipped without opening anything.
+
+    Callers probe both spellings of the embeddings table name, so for any
+    vendor-prefixed model id one candidate is guaranteed not to exist.
+    """
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    mock_conn = _mock_conn_with_tables(documents=_mock_table_with_fragments(500))
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    compacted = store.compact_tables(
+        ["embeddings_BAAI_bge_large_zh_v1_5", "documents"], IndexPolicy()
+    )
+
+    assert compacted == ["documents"]
+    opened = {c.args[0] for c in mock_conn.open_table.call_args_list}
+    assert "embeddings_BAAI_bge_large_zh_v1_5" not in opened
 
 
 @patch(
@@ -3301,22 +3337,20 @@ def test_compaction_collapses_fragments_and_retains_recent_versions(
 
     db = lancedb.connect(str(tmp_path))
     schema = pa.schema([pa.field("name", pa.string())])
-    table = db.create_table("collection_metadata", schema=schema)
+    table = db.create_table("documents", schema=schema)
     for i in range(12):
         table.add([{"name": f"c{i}"}])
 
     store = LanceDBVectorIndexStore()
     policy = IndexPolicy(compact_fragment_threshold=10)
     with patch.object(store, "_get_connection", return_value=db):
-        # collection_metadata has no vector index, so the fragment predicate is
-        # the only thing that can ever schedule it for compaction.
-        assert store.should_reindex("collection_metadata", 0, policy) is False
-        assert store.should_compact("collection_metadata", policy) is True
-        assert store.compact_tables(["collection_metadata"], policy) == [
-            "collection_metadata"
-        ]
+        # Append-driven table: one data file per write, so fragments are what
+        # schedule it. (Update-driven tables are covered separately below.)
+        assert store.should_reindex("documents", 0, policy) is False
+        assert store.should_compact("documents", policy) is True
+        assert store.compact_tables(["documents"], policy) == ["documents"]
 
-    handle = db.open_table("collection_metadata")
+    handle = db.open_table("documents")
     assert handle.stats()["fragment_stats"]["num_fragments"] == 1
     assert len(handle.search().to_arrow()) == 12
     # 7-day retention: nothing written during this test may be pruned.
@@ -3500,6 +3534,7 @@ def test_compact_tables_with_empty_list_does_nothing(
 
     assert LanceDBVectorIndexStore().compact_tables([]) == []
     mock_conn.open_table.assert_not_called()
+    mock_conn.list_tables.assert_not_called()  # short-circuits before any I/O
 
 
 @patch(
@@ -3564,3 +3599,131 @@ def test_maintenance_failures_never_log_at_error_level(
 
     assert [r.levelno for r in caplog.records if r.levelno >= logging.ERROR] == []
     assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_should_compact_catches_merge_insert_version_growth(tmp_path: Any) -> None:
+    """The collection_metadata case: real merge_insert upserts, no new fragments.
+
+    This is the table the whole fix exists for (229 MB in production). It is
+    only ever written through ``merge_insert(["name"])``, which rewrites the
+    matched rows instead of appending, so its fragment count stays pinned near
+    the row count and NEVER reaches the fragment threshold, however long it
+    degrades. Version history is what grows without bound and holds the disk.
+
+    Driven by real merge_insert rather than a mocked fragment count on purpose:
+    a mock said this table was fragmented, which is exactly why the gap was
+    invisible for four review rounds.
+    """
+    from datetime import datetime, timezone
+
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    db = lancedb.connect(str(tmp_path))
+    schema = pa.schema(
+        [
+            pa.field("name", pa.string()),
+            pa.field("description", pa.string()),
+            pa.field("updated_at", pa.timestamp("us")),
+        ]
+    )
+    rows = 20
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    table = db.create_table("collection_metadata", schema=schema)
+    table.add(
+        [{"name": f"c{i}", "description": "d", "updated_at": now} for i in range(rows)]
+    )
+
+    # Same upsert shape as MetadataStore.save_collection.
+    for i in range(120):
+        table.merge_insert(
+            "name"
+        ).when_matched_update_all().when_not_matched_insert_all().execute(
+            [
+                {
+                    "name": f"c{i % rows}",
+                    "description": f"rev-{i}",
+                    "updated_at": now,
+                }
+            ]
+        )
+
+    handle = db.open_table("collection_metadata")
+    fragments = handle.stats()["fragment_stats"]["num_fragments"]
+    versions = len(handle.list_versions())
+    assert handle.stats()["num_rows"] == rows  # updates, never appends
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(store, "_get_connection", return_value=db):
+        # The premise: fragments plateau at the row count and stay far below
+        # the default threshold no matter how much history piles up.
+        assert fragments <= rows
+        assert fragments < IndexPolicy().compact_fragment_threshold
+        assert store.should_compact("collection_metadata", IndexPolicy()) is False
+
+        # The version criterion is the only thing that can catch this table.
+        policy = IndexPolicy(compact_version_threshold=versions)
+        assert store.should_compact("collection_metadata", policy) is True
+        assert store.compact_tables(["collection_metadata"], policy) == [
+            "collection_metadata"
+        ]
+
+    after = db.open_table("collection_metadata")
+    assert len(after.search().to_arrow()) == rows  # data intact
+
+
+def test_index_policy_rejects_non_positive_compaction_thresholds() -> None:
+    """A zero threshold would make every table qualify on every ingestion."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    for field in ("compact_fragment_threshold", "compact_version_threshold"):
+        for bad in (0, -1):
+            with pytest.raises(ValueError, match=f"{field} must be positive"):
+                IndexPolicy(**{field: bad})
+
+
+def test_compaction_lock_lets_only_one_holder_through(tmp_path: Any) -> None:
+    """Two concurrent compactions must not both rewrite the same tables.
+
+    Without this, every loser of the commit race has already paid for a full
+    table rewrite by the time LanceDB rejects it.
+    """
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        _compaction_lock,
+    )
+
+    db = lancedb.connect(str(tmp_path))
+    table = db.create_table("documents", schema=pa.schema([pa.field("n", pa.string())]))
+    for i in range(12):
+        table.add([{"n": str(i)}])
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=10)
+
+    # Hold the lock as if another worker were mid-compaction.
+    with _compaction_lock(db) as first:
+        assert first is True
+        with patch.object(store, "_get_connection", return_value=db):
+            assert store.compact_tables(["documents"], policy) == []
+
+    # Once released, the same call proceeds.
+    with patch.object(store, "_get_connection", return_value=db):
+        assert store.compact_tables(["documents"], policy) == ["documents"]
+
+
+def test_compaction_lock_degrades_to_unlocked_for_remote_uris() -> None:
+    """A non-local database URI cannot be flocked; compaction still runs."""
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        _compaction_lock,
+    )
+
+    conn = Mock()
+    conn.uri = "s3://bucket/lancedb"
+    with _compaction_lock(conn) as acquired:
+        assert acquired is True

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -1,7 +1,7 @@
 """Tests for LanceDB-backed storage implementations."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -15,6 +15,7 @@ from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
     LanceDBMetadataStore,
     LanceDBPromptTemplateStore,
     LanceDBVectorIndexStore,
+    _stale_version_count,
 )
 
 
@@ -3033,13 +3034,33 @@ def test_vis_cascade_delete_documents_unauthenticated_non_admin_returns_empty():
 def _mock_table_with_fragments(count: int, versions: int = 1) -> Mock:
     table = Mock()
     table.stats.return_value = {"fragment_stats": {"num_fragments": count}}
-    table.list_versions.return_value = [{"version": i} for i in range(versions)]
+    table.list_versions.return_value = _versions(stale=0, fresh=versions)
     return table
 
 
-def _mock_conn_with_tables(**tables: Mock) -> Mock:
+def _versions(*, stale: int, fresh: int) -> List[Dict[str, Any]]:
+    """Version entries shaped like LanceDB's, split either side of a 7-day window.
+
+    LanceDB reports naive timestamps in local time, so these are local too.
+    """
+    from datetime import timedelta
+
+    now = datetime.now()
+    old = [
+        {"version": i, "timestamp": now - timedelta(days=30, seconds=i)}
+        for i in range(stale)
+    ]
+    new = [
+        {"version": stale + i, "timestamp": now - timedelta(seconds=i)}
+        for i in range(fresh)
+    ]
+    return old + new
+
+
+def _mock_conn_with_tables(tmp_dir: Any = None, **tables: Mock) -> Mock:
     """Connection whose table listing matches the tables it can open."""
     conn = Mock()
+    conn.uri = str(tmp_dir) if tmp_dir else "memory://not-a-real-path"
     conn.list_tables.return_value = list(tables)
     conn.open_table.side_effect = lambda name, *a, **k: tables[name]
     return conn
@@ -3095,10 +3116,7 @@ def test_should_compact_ignores_index_staleness(mock_get_connection: Mock) -> No
     stats.num_indexed_rows = 1000
     stats.num_unindexed_rows = 50000  # blows past both smart-reindex thresholds
     table.index_stats.return_value = stats
-
-    mock_conn = Mock()
-    mock_conn.open_table.return_value = table
-    mock_get_connection.return_value = mock_conn
+    mock_get_connection.return_value = _mock_conn_with_tables(embeddings_big=table)
 
     store = LanceDBVectorIndexStore()
     policy = IndexPolicy()
@@ -3204,8 +3222,12 @@ def test_compact_tables_never_opens_unrelated_tables(
     store = LanceDBVectorIndexStore()
     assert store.compact_tables(["documents"], IndexPolicy()) == ["documents"]
 
-    opened = {c.args[0] for c in mock_conn.open_table.call_args_list}
-    assert opened == {"documents"}
+    # Exact call list, not a set: it also pins how many times each table is
+    # opened (should_compact then trigger_reindex), so an extra open shows up.
+    assert [c.args[0] for c in mock_conn.open_table.call_args_list] == [
+        "documents",
+        "documents",
+    ]
 
 
 @patch(
@@ -3243,12 +3265,11 @@ def test_compact_tables_swallows_optimize_failure(mock_get_connection: Mock) -> 
 
     broken = _mock_table_with_fragments(500)
     broken.optimize.side_effect = RuntimeError("disk full")
-
-    mock_conn = Mock()
-    mock_conn.open_table.return_value = broken
-    mock_get_connection.return_value = mock_conn
+    mock_get_connection.return_value = _mock_conn_with_tables(documents=broken)
 
     assert LanceDBVectorIndexStore().compact_tables(["documents"], IndexPolicy()) == []
+    # The point of the test: optimize really was attempted and really failed.
+    broken.optimize.assert_called_once()
 
 
 def test_ingestion_compaction_hook_never_raises() -> None:
@@ -3577,14 +3598,17 @@ def test_maintenance_failures_never_log_at_error_level(
     mock_get_connection: Mock,
     caplog: Any,
 ) -> None:
-    """Compaction is best-effort, so its failures stay at WARNING.
+    """Compaction is best-effort, so its failures stay at WARNING, never ERROR.
 
-    should_reindex now runs on every ingestion; at ERROR a single unopenable
-    table would page on every upload for every collection, forever.
+    One unopenable table must not shout ERROR on every upload for every
+    collection, forever.
     """
     import logging
 
+    # Listed, so compact_tables reaches the body, but unopenable once there.
     mock_conn = Mock()
+    mock_conn.uri = "memory://not-a-real-path"
+    mock_conn.list_tables.return_value = ["gone"]
     mock_conn.open_table.side_effect = FileNotFoundError("no such table")
     mock_get_connection.return_value = mock_conn
 
@@ -3597,6 +3621,7 @@ def test_maintenance_failures_never_log_at_error_level(
         assert store.trigger_reindex("gone") is False
         assert store.compact_tables(["gone"]) == []
 
+    assert mock_conn.open_table.called  # the failing branch was really reached
     assert [r.levelno for r in caplog.records if r.levelno >= logging.ERROR] == []
     assert any(r.levelno == logging.WARNING for r in caplog.records)
 
@@ -3652,23 +3677,35 @@ def test_should_compact_catches_merge_insert_version_growth(tmp_path: Any) -> No
 
     handle = db.open_table("collection_metadata")
     fragments = handle.stats()["fragment_stats"]["num_fragments"]
-    versions = len(handle.list_versions())
     assert handle.stats()["num_rows"] == rows  # updates, never appends
+
+    # Fixed expectations, not values read back from the same API the code under
+    # test uses: a self-derived threshold would pass even if counting were wrong.
+    assert len(handle.list_versions()) >= 120  # history grows one per upsert
+    assert fragments <= rows  # fragments do not
+    assert fragments < IndexPolicy().compact_fragment_threshold
 
     store = LanceDBVectorIndexStore()
     with patch.object(store, "_get_connection", return_value=db):
-        # The premise: fragments plateau at the row count and stay far below
-        # the default threshold no matter how much history piles up.
-        assert fragments <= rows
-        assert fragments < IndexPolicy().compact_fragment_threshold
+        # Everything here was written seconds ago, so nothing is reclaimable
+        # yet and neither criterion fires -- including under the shipped default.
         assert store.should_compact("collection_metadata", IndexPolicy()) is False
+        assert store.should_compact("collection_metadata") is False
 
-        # The version criterion is the only thing that can catch this table.
-        policy = IndexPolicy(compact_version_threshold=versions)
-        assert store.should_compact("collection_metadata", policy) is True
-        assert store.compact_tables(["collection_metadata"], policy) == [
-            "collection_metadata"
-        ]
+        # Age the whole history past the retention window: now the stale-version
+        # criterion is the only thing that can catch this table.
+        cutoff = datetime.now() + timedelta(minutes=1)
+        assert _stale_version_count(handle, cutoff) >= 120
+        policy = IndexPolicy(compact_stale_version_threshold=100)
+        with patch(
+            "xagent.core.tools.core.RAG_tools.storage.lancedb_stores"
+            "._stale_version_count",
+            lambda table, _cutoff: _stale_version_count(table, cutoff),
+        ):
+            assert store.should_compact("collection_metadata", policy) is True
+            assert store.compact_tables(["collection_metadata"], policy) == [
+                "collection_metadata"
+            ]
 
     after = db.open_table("collection_metadata")
     assert len(after.search().to_arrow()) == rows  # data intact
@@ -3678,17 +3715,76 @@ def test_index_policy_rejects_non_positive_compaction_thresholds() -> None:
     """A zero threshold would make every table qualify on every ingestion."""
     from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 
-    for field in ("compact_fragment_threshold", "compact_version_threshold"):
+    for field in ("compact_fragment_threshold", "compact_stale_version_threshold"):
         for bad in (0, -1):
             with pytest.raises(ValueError, match=f"{field} must be positive"):
                 IndexPolicy(**{field: bad})
 
 
-def test_compaction_lock_lets_only_one_holder_through(tmp_path: Any) -> None:
-    """Two concurrent compactions must not both rewrite the same tables.
+def test_compaction_lock_keeps_concurrent_workers_off_one_table(
+    tmp_path: Any,
+) -> None:
+    """A table already being compacted elsewhere is skipped, not rewritten twice.
 
-    Without this, every loser of the commit race has already paid for a full
-    table rewrite by the time LanceDB rejects it.
+    Every loser of LanceDB's commit race has already paid for a full table
+    rewrite by the time the commit is rejected. Uses a real subprocess holding
+    a real lock, so it asserts cross-process exclusion -- the thing production
+    needs -- rather than the in-process behaviour of one locking primitive.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    import time
+
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    db = lancedb.connect(str(tmp_path))
+    table = db.create_table("documents", schema=pa.schema([pa.field("n", pa.string())]))
+    for i in range(12):
+        table.add([{"n": str(i)}])
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=10)
+    ready = tmp_path / "held.flag"
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(f"""
+                import time
+                from filelock import FileLock
+                lock = FileLock({str(tmp_path / ".documents.compaction.lock")!r})
+                lock.acquire()
+                open({str(ready)!r}, "w").close()
+                time.sleep(30)
+            """),
+        ]
+    )
+    try:
+        for _ in range(200):
+            if ready.exists():
+                break
+            time.sleep(0.05)
+        assert ready.exists(), "lock holder subprocess never started"
+
+        with patch.object(store, "_get_connection", return_value=db):
+            assert store.compact_tables(["documents"], policy) == []
+    finally:
+        holder.kill()
+        holder.wait()
+
+    # With the other process gone, the very same call goes through.
+    with patch.object(store, "_get_connection", return_value=db):
+        assert store.compact_tables(["documents"], policy) == ["documents"]
+
+
+def test_compaction_lock_is_per_table_not_per_database(tmp_path: Any) -> None:
+    """Holding one table's lock must not stop another table being compacted.
+
+    A database-wide lock would let a busy collection starve every other table.
     """
     import lancedb
     import pyarrow as pa
@@ -3699,6 +3795,51 @@ def test_compaction_lock_lets_only_one_holder_through(tmp_path: Any) -> None:
     )
 
     db = lancedb.connect(str(tmp_path))
+    for name in ("documents", "chunks"):
+        t = db.create_table(name, schema=pa.schema([pa.field("n", pa.string())]))
+        for i in range(12):
+            t.add([{"n": str(i)}])
+
+    store = LanceDBVectorIndexStore()
+    policy = IndexPolicy(compact_fragment_threshold=10)
+
+    with _compaction_lock(db, "documents") as held:
+        assert held is True
+        with patch.object(store, "_get_connection", return_value=db):
+            assert store.compact_tables(["chunks"], policy) == ["chunks"]
+
+
+def test_compaction_lock_does_not_swallow_body_exceptions(tmp_path: Any) -> None:
+    """The lock must re-raise the caller's error, with its own type and message.
+
+    A context manager that catches around its own ``yield`` turns any failure
+    inside the ``with`` into "generator didn't stop after throw()" and loses the
+    original traceback.
+    """
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        _compaction_lock,
+    )
+
+    conn = Mock()
+    conn.uri = str(tmp_path)
+
+    with pytest.raises(ValueError, match="real failure from trigger_reindex"):
+        with _compaction_lock(conn, "documents"):
+            raise ValueError("real failure from trigger_reindex")
+
+    # And the lock was released despite the exception.
+    with _compaction_lock(conn, "documents") as acquired:
+        assert acquired is True
+
+
+def test_compaction_still_runs_when_the_uri_cannot_be_locked(tmp_path: Any) -> None:
+    """A remote URI has no lock file, and compaction must still do its work."""
+    import lancedb
+    import pyarrow as pa
+
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    db = lancedb.connect(str(tmp_path))
     table = db.create_table("documents", schema=pa.schema([pa.field("n", pa.string())]))
     for i in range(12):
         table.add([{"n": str(i)}])
@@ -3706,24 +3847,133 @@ def test_compaction_lock_lets_only_one_holder_through(tmp_path: Any) -> None:
     store = LanceDBVectorIndexStore()
     policy = IndexPolicy(compact_fragment_threshold=10)
 
-    # Hold the lock as if another worker were mid-compaction.
-    with _compaction_lock(db) as first:
-        assert first is True
-        with patch.object(store, "_get_connection", return_value=db):
-            assert store.compact_tables(["documents"], policy) == []
+    # Same database, but reported under a URI that cannot host a lock file.
+    unlockable = Mock(wraps=db)
+    unlockable.uri = "s3://bucket/lancedb"
+    unlockable.list_tables.return_value = ["documents"]
+    unlockable.open_table.side_effect = db.open_table
 
-    # Once released, the same call proceeds.
-    with patch.object(store, "_get_connection", return_value=db):
+    with patch.object(store, "_get_connection", return_value=unlockable):
         assert store.compact_tables(["documents"], policy) == ["documents"]
 
+    assert db.open_table("documents").stats()["fragment_stats"]["num_fragments"] == 1
 
-def test_compaction_lock_degrades_to_unlocked_for_remote_uris() -> None:
-    """A non-local database URI cannot be flocked; compaction still runs."""
-    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
-        _compaction_lock,
+
+def test_compaction_clears_the_stale_version_backlog(tmp_path: Any) -> None:
+    """After compacting, the version criterion falls back to zero.
+
+    This is the anti-ratchet guarantee. If the predicate counted *all* versions
+    instead of reclaimable ones it would stay above the threshold forever once
+    crossed -- compaction cannot delete versions still inside the retention
+    window, and each run commits one more -- so every later ingestion would
+    rewrite every table, index rebuild included. Measuring only what a
+    compaction can actually remove makes that state unreachable.
+    """
+    from datetime import timedelta
+
+    import lancedb
+    import pyarrow as pa
+
+    db = lancedb.connect(str(tmp_path))
+    table = db.create_table("documents", schema=pa.schema([pa.field("n", pa.string())]))
+    for i in range(120):
+        table.add([{"n": str(i)}])
+
+    handle = db.open_table("documents")
+    # Treat the whole history as past the retention window.
+    cutoff = datetime.now() + timedelta(minutes=1)
+    before = _stale_version_count(handle, cutoff)
+    assert before >= 120
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(store, "_get_connection", return_value=db):
+        assert store.trigger_reindex(
+            "documents", cleanup_older_than=timedelta(microseconds=1)
+        )
+
+    after = _stale_version_count(db.open_table("documents"), cutoff)
+    assert after < before
+    assert after <= 2  # only what compaction itself just committed
+    assert len(db.open_table("documents").search().to_arrow()) == 120
+
+
+def test_should_compact_ignores_versions_inside_the_retention_window() -> None:
+    """Versions too young to delete must never trigger a compaction.
+
+    Counting them is what produces the ratchet: they cannot be removed, so the
+    count only grows and the predicate latches on.
+    """
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    table = Mock()
+    table.stats.return_value = {"fragment_stats": {"num_fragments": 2}}
+    table.list_versions.return_value = _versions(stale=0, fresh=5000)
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(
+        store, "_get_connection", return_value=_mock_conn_with_tables(t=table)
+    ):
+        assert store.should_compact("t", IndexPolicy()) is False
+
+
+def test_should_compact_counts_only_reclaimable_versions() -> None:
+    """The threshold applies to versions older than the retention window."""
+    from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
+
+    table = Mock()
+    table.stats.return_value = {"fragment_stats": {"num_fragments": 2}}
+    table.list_versions.return_value = _versions(stale=150, fresh=900)
+
+    store = LanceDBVectorIndexStore()
+    with patch.object(
+        store, "_get_connection", return_value=_mock_conn_with_tables(t=table)
+    ):
+        assert (
+            store.should_compact("t", IndexPolicy(compact_stale_version_threshold=100))
+            is True
+        )
+        # 150 stale is below this threshold even though 1050 versions exist.
+        assert (
+            store.should_compact("t", IndexPolicy(compact_stale_version_threshold=200))
+            is False
+        )
+
+
+def test_stale_version_count_returns_zero_when_unsupported() -> None:
+    """An older lancedb without list_versions degrades to "do nothing"."""
+    table = Mock()
+    table.list_versions.side_effect = Exception("unsupported")
+
+    assert _stale_version_count(table, datetime.now()) == 0
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_compact_tables_warns_when_no_candidate_is_listed(
+    mock_get_connection: Mock,
+    caplog: Any,
+) -> None:
+    """Compaction silently switching itself off must leave a trace.
+
+    list_table_names() returns [] instead of raising for any listing shape it
+    does not recognise, so a lancedb API change would disable compaction
+    permanently with no other signal.
+    """
+    import logging
+
+    mock_conn = Mock()
+    mock_conn.uri = "memory://not-a-real-path"
+    mock_conn.list_tables.return_value = []
+    mock_get_connection.return_value = mock_conn
+
+    store = LanceDBVectorIndexStore()
+    with caplog.at_level(
+        logging.DEBUG, logger="xagent.core.tools.core.RAG_tools.storage.lancedb_stores"
+    ):
+        assert store.compact_tables(["documents", "chunks"]) == []
+
+    assert any(
+        r.levelno == logging.WARNING and "documents" in r.getMessage()
+        for r in caplog.records
     )
-
-    conn = Mock()
-    conn.uri = "s3://bucket/lancedb"
-    with _compaction_lock(conn) as acquired:
-        assert acquired is True


### PR DESCRIPTION
Refs #1140

## Problem

`GET /api/kb/collections` gets slower the longer a deployment runs and eventually hits the 30s deadline in `list_collections_api` (`web/api/kb.py:4747`) — the `Failed to fetch collections` error in #1140.

The cost tracks how long the deployment has been in use, not how much data it holds. Every ingest appends a new data file; nothing ever merges them, and every write leaves a version behind.

Measured on a production deployment:

| table | rows | data files | versions | full scan | on disk |
|---|---|---|---|---|---|
| `ingestion_runs` | 2,544 | 22,469 | 52,459 | — | 9,638 MB |
| `documents` | 2,558 | 12,554 | 11,485 | **1.23 s** | 2,219 MB |
| `embeddings_*` | 39,440 | 6,032 | 3,017 | — | 1,436 MB |
| `collection_metadata` | 64 | 25,410 | 25,339 | 0.01 s | 721 MB |
| `parses` | 2,536 | 3,234 | 2,185 | **1.32 s** | 397 MB |
| `chunks` | 39,670 | 3,229 | 2,181 | **1.60 s** | 482 MB |
| `collection_config` | 72 | 741 | 1,392 | 0.03 s | 10 MB |

**73,669 data files, ~14.9 GB.** Scanning the six tables a listing touches takes **4.20 s** against a 30 s deadline.

Two things that table settles, both of which contradict a simpler story:

- **Read latency does not track the file count on disk.** `collection_metadata` holds 25,410 files and scans in 0.01 s, because the current version's manifest references only a small subset — the rest belong to retained history and are never opened. Latency tracks the *live fragment count*, which is why `documents` (12,554 files, 2,558 rows) costs 1.23 s while `collection_metadata` costs nothing.
- **Disk is a separate axis.** `ingestion_runs` is a log table: 2,544 rows updated ~20 times each, one version retained per update, two thirds of the deployment's storage.

## Two independent degradation modes

LanceDB tables degrade in two unrelated ways, and a given table usually suffers only one.

**Append-driven** (`documents`, `parses`, `chunks`, `embeddings_*`) — every write adds a data file. Read cost is linear in **live fragment count**, independent of row count. Measured with lancedb 0.29.2, appending one row at a time so that every file is live — the premise that makes file count and fragment count coincide here, and which production data does not satisfy:

| data files | one open + full column scan |
|---|---|
| 100 | 10.1 ms |
| 1,000 | 93.2 ms |
| 2,550 | 262.8 ms |
| after compaction (1 file) | **4.3 ms** |

**Update-driven** (`collection_metadata`) — written only through `merge_insert(["name"])`, which rewrites matched rows rather than appending. Its fragment count therefore plateaus near the row count and **never reaches a fragment threshold no matter how long it degrades**; what grows without bound is version history and the disk it holds. Measured on a 30-row table:

| merge_insert calls | fragments | rows | versions | disk | read |
|---|---|---|---|---|---|
| 0 | 1 | 30 | 2 | 0.02 MB | 1.7 ms |
| 100 | 30 | 30 | 100 | 0.44 MB | 4.1 ms |
| 2,000 | **30** | 30 | 2,000 | **8.79 MB** | 5.3 ms |

Fragments stop moving after roughly the hundredth write. Note read latency barely changes — **version accumulation costs disk, not read time**. Production's `collection_metadata` — 64 rows, 721 MB, 25,339 versions, and still a 0.01 s scan — is this mode.

So `should_compact` checks two criteria: fragment count (read latency) **or** retained version count (disk). Fragments alone would miss `collection_metadata` — the most visible case in this issue.

`ingestion_runs` suffers both: `write_ingestion_status` does a `delete` plus an `add` on every call, on the failure path as well. It is 706 MB in production, the largest table in the database.

## Root cause

Nothing in the ingest path ever compacts. The mechanism existed but was never wired up: `trigger_reindex()` calls `table.optimize()` and `should_reindex()` implements a threshold policy, but **neither had any caller** outside the abstract declarations in `storage/contracts.py`.

`optimize()` does three things at once: compacts fragments, prunes versions past the retention window, and refreshes indices, with `cleanup_older_than` defaulting to 7 days. That window is a deliberate safety margin for readers holding an older version, and it means **disk does not drop immediately** — a 2,550-file table goes from 262.8 ms to 4.3 ms on the spot, but the space comes back only once those versions age out and a later pass prunes them. Seeing disk unchanged right after deploying this is expected, not a failure.

## Results

| | median read | fragments |
|---|---|---|
| fragmented | 262.8 ms | 2,550 |
| after compaction | **4.3 ms** | 1 |

61x faster. `optimize()` itself takes 1.7s.

## Read latency recovers immediately; disk does not

Worth stating plainly, because it looks like a failure otherwise.

On a delete+add table such as `ingestion_runs`, deletes create versions but not fragments — they go through deletion vectors. So read latency is driven by fragment count while disk is driven by version count, and the two decouple. A 1,000-row bench:

| | median read | fragments | versions | on disk |
|---|---|---|---|---|
| fragmented | 110.3 ms | 1,000 | 2,001 | 86.3 MB |
| `optimize(7d)` | **3.0 ms** | 1 | 2,003 | 86.6 MB |
| `optimize(0d)` | 4.2 ms | 1 | 1 | **0.2 MB** |

Retention is doing its job — but it means space comes back a retention window later, not on the first pass. An operator watching disk right after deploying this will see nothing happen.

## Failure isolation

Compaction is maintenance and must never fail an ingestion. `should_compact` / `trigger_reindex` swallow their own exceptions, `compact_tables` evaluates each table independently, and the ingestion hook has a blanket except that only logs. The call site sits after all data is written. `_fragment_count` returns 0 when statistics are unavailable, so an environment where `table.stats()` behaves differently degrades to "never compact" rather than compacting on every ingestion.

## Limitations

- **Compaction only runs after an ingestion.** A deployment that only queries never compacts. Already-fragmented deployments need one ingestion — or a one-off `compact_tables([...])` — to recover.
- **Tables outside the ingest path are not covered** — `prompt_templates`, `main_pointers`. Their growth is bound to collection count rather than ingest count, orders of magnitude slower, but they have no compaction path at all today. (`collection_config` is now covered: it is rewritten with an unconditional delete + add on every upload, from a call site that runs before and outside this pipeline.)
- **A healthy table pays for the version scan on every ingest.** `should_compact` short-circuits only when the fragment check trips, which by definition it does not for a healthy table — so `list_versions()` runs each time: ~4 ms at 100 retained versions, ~124 ms at 1,000 (lancedb 0.29.2). Production's `ingestion_runs` currently holds 52,459 versions; if compaction leaves a large retained window, this cost is not negligible.
- **The fragment probe is cheaper, not free.** `stats()` measures ~0.2 ms at 50 fragments and ~2.2 ms at 1,000 — it grows with fragment count, it is simply the smaller of the two probes.
- **The 100-fragment threshold is a judgement call**, not a tuned optimum.
- **Concurrent compaction across celery workers is untested.** Two workers optimizing the same table would have one lose the commit race; that failure is swallowed, so the worst case is a skipped pass rather than data loss.

## Tests

Unit coverage for the predicate (threshold boundaries, index-staleness isolation, the stats-unavailable fallback), the retention window, and failure isolation; end-to-end cases against a real LanceDB table (fragments collapse without losing rows; versions outside the window are actually pruned; a delete+add table keeps exactly its live rows with no tombstone resurrection); and pipeline-level tests asserting the hook fires after a successful ingest, scopes to the written tables, and that a failing compaction still leaves the ingest successful.

Every change was mutation-tested, including the reviewer's own mutation — deleting the ingest call site — which the first revision survived.

```
pytest tests/core/tools/core/RAG_tools/
```

## Verification

pre-commit: ruff, ruff format, mypy, isort, codespell — all passed

