### PR TITLE
fix: render generated videos as inline players in chat

### DIFF
--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -33,6 +33,12 @@ describe('inline-file-preview-utils', () => {
     expect(getInlineFilePreviewKind({ filename: 'chart.png' })).toBe('image')
     expect(getInlineFilePreviewKind({ filename: 'podcast.mp3' })).toBe('audio')
     expect(getInlineFilePreviewKind({ mimeType: 'audio/mpeg' })).toBe('audio')
+    expect(getInlineFilePreviewKind({ filename: 'clip.mp4' })).toBe('video')
+    expect(getInlineFilePreviewKind({ filename: 'clip.webm' })).toBe('video')
+    expect(getInlineFilePreviewKind({ mimeType: 'video/mp4' })).toBe('video')
+    expect(getInlineFilePreviewKind({ type: 'video', filename: 'unknown.bin' })).toBe(
+      'video'
+    )
   })
 
   it('classifies .pptx (OOXML) as inline-previewable presentation', () => {

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -49,9 +49,12 @@ const SPREADSHEET_MIME_TYPES = new Set<string>([
   'text/csv',
 ])
 
-/** Default OOXML mime types for inline preview kinds (images vary by file). */
+/**
+ * Default OOXML mime types for inline preview kinds. Kinds without an
+ * entry (file/image/audio/video vary per file) resolve to undefined.
+ */
 export const INLINE_FILE_PREVIEW_MIME_BY_KIND: Partial<
-  Record<PreviewableInlineFileKind, string>
+  Record<InlineFilePreviewKind, string>
 > = {
   presentation:
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -61,11 +64,7 @@ export const INLINE_FILE_PREVIEW_MIME_BY_KIND: Partial<
 
 export const getInlineFilePreviewMimeType = (
   kind: InlineFilePreviewKind
-): string | undefined => {
-  if (kind === 'file' || kind === 'image' || kind === 'audio' || kind === 'video')
-    return undefined
-  return INLINE_FILE_PREVIEW_MIME_BY_KIND[kind]
-}
+): string | undefined => INLINE_FILE_PREVIEW_MIME_BY_KIND[kind]
 
 export const isPreviewableInlineFileKind = (
   kind: InlineFilePreviewKind

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -3,6 +3,7 @@ import { getFilePublicDownloadUrl, getFilePublicPreviewUrl } from '@/lib/utils'
 export type InlineFilePreviewKind =
   | 'image'
   | 'audio'
+  | 'video'
   | 'presentation'
   | 'document'
   | 'spreadsheet'
@@ -27,6 +28,7 @@ export type PreviewUrlTrust = {
 const PREVIEWABLE_KINDS = new Set<PreviewableInlineFileKind>([
   'image',
   'audio',
+  'video',
   'presentation',
   'document',
   'spreadsheet',
@@ -60,7 +62,8 @@ export const INLINE_FILE_PREVIEW_MIME_BY_KIND: Partial<
 export const getInlineFilePreviewMimeType = (
   kind: InlineFilePreviewKind
 ): string | undefined => {
-  if (kind === 'file' || kind === 'image' || kind === 'audio') return undefined
+  if (kind === 'file' || kind === 'image' || kind === 'audio' || kind === 'video')
+    return undefined
   return INLINE_FILE_PREVIEW_MIME_BY_KIND[kind]
 }
 
@@ -78,6 +81,7 @@ export const getInlineFilePreviewKind = (
 
   if (type === 'image') return 'image'
   if (type === 'audio') return 'audio'
+  if (type === 'video') return 'video'
   if (type === 'presentation') {
     // An explicit ``type: 'presentation'`` artifact must still be
     // cross-checked: pptxviewjs only supports OOXML .pptx, so a
@@ -108,6 +112,7 @@ export const getInlineFilePreviewKind = (
 
   if (mimeType.startsWith('image/')) return 'image'
   if (mimeType.startsWith('audio/')) return 'audio'
+  if (mimeType.startsWith('video/')) return 'video'
   if (PRESENTATION_MIME_TYPES.has(mimeType) || mimeType.includes('presentationml')) {
     return 'presentation'
   }
@@ -118,6 +123,7 @@ export const getInlineFilePreviewKind = (
 
   if (/\.(jpg|jpeg|png|gif|webp|svg)$/.test(filename)) return 'image'
   if (/\.(mp3|wav|ogg|opus|flac|m4a|aac)$/.test(filename)) return 'audio'
+  if (/\.(mp4|m4v|mov|webm|mpeg|mpg)$/.test(filename)) return 'video'
   // Only OOXML .pptx is previewable inline — see PRESENTATION_MIME_TYPES
   // comment. Legacy .ppt falls through to the generic 'file' kind.
   if (filename.endsWith('.pptx')) return 'presentation'

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -393,6 +393,29 @@ describe('InlineFilePreview', () => {
     expect(screen.getByRole('link', { name: 'Open' })).toBeInTheDocument()
   })
 
+  it('keeps the player mounted when an error follows successful loading', async () => {
+    // A mid-playback decode hiccup fires the same native error event as a
+    // load failure; once data has loaded the element surfaces the problem
+    // itself and must not be replaced by the terminal error state.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    fireEvent.loadedData(video)
+    fireEvent.error(video)
+
+    expect(screen.getByLabelText('clip.mp4')).toBeInTheDocument()
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
+  })
+
   it('renders a video link with a filename extension as an inline video preview', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -277,6 +277,47 @@ describe('InlineFilePreview', () => {
     )
   })
 
+  it('loads managed video files through authenticated preview', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/video-file-id',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+
+    const video = await screen.findByLabelText('clip.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+    expect(video.getAttribute('src')).toMatch(/^blob:/)
+    expect(screen.getByRole('link', { name: 'Open' }).getAttribute('href')).toMatch(
+      /^blob:/
+    )
+  })
+
+  it('renders a video link with a filename extension as an inline video preview', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/webm' }),
+    })
+
+    render(
+      <InlineFilePreview source={{ fileId: 'abc-123', filename: 'clip.webm' }} />
+    )
+
+    const video = await screen.findByLabelText('clip.webm')
+    expect(video.tagName.toLowerCase()).toBe('video')
+  })
+
   it('loads legacy workspace audio paths through authenticated preview', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -328,6 +328,71 @@ describe('InlineFilePreview', () => {
     expect(apiRequestMock).not.toHaveBeenCalled()
   })
 
+  it('falls back to the public video preview when authenticated loading fails', async () => {
+    apiRequestMock.mockResolvedValue({ ok: false, status: 401 })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    expect(video).toHaveAttribute(
+      'src',
+      'http://api.local/api/files/public/preview/video-file-id'
+    )
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      'http://api.local/api/files/public/preview/video-file-id'
+    )
+  })
+
+  it('revokes the video blob URL on unmount', async () => {
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL')
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    const blobUrl = video.getAttribute('src') || ''
+    expect(blobUrl).toMatch(/^blob:/)
+
+    unmount()
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith(blobUrl)
+
+    revokeObjectUrlSpy.mockRestore()
+  })
+
+  it('shows the load error text when the video fails on both paths', async () => {
+    // The hook already fell back to the public preview URL after the
+    // authenticated fetch failed; an error event from the element itself
+    // means both paths are exhausted.
+    apiRequestMock.mockResolvedValue({ ok: false, status: 403 })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    fireEvent.error(video)
+
+    expect(await screen.findByText('Failed to load preview.')).toBeInTheDocument()
+    expect(screen.queryByLabelText('clip.mp4')).not.toBeInTheDocument()
+    // The header keeps the filename and Open link so the file stays reachable.
+    expect(screen.getByText('clip.mp4')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open' })).toBeInTheDocument()
+  })
+
   it('renders a video link with a filename extension as an inline video preview', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -82,11 +82,11 @@ describe('InlineFilePreview', () => {
     })
   })
 
-  it('uses the provider-scoped public credential for image and audio bytes', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: async () => new Blob(['media'], { type: 'image/png' }),
-    })
+  it('uses the provider-scoped public credential for image and audio elements', async () => {
+    // With the public policy the tokened URL is handed to the media element
+    // directly — no blob fetch is made (preserving HTTP range requests for
+    // media playback) and the authenticated apiRequest path is never touched.
+    const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     render(
@@ -102,15 +102,16 @@ describe('InlineFilePreview', () => {
       </FileAccessProvider>,
     )
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    expect(fetchMock).toHaveBeenCalledWith(
+    const image = await screen.findByAltText('image.png')
+    expect(image.getAttribute('src')).toBe(
       'http://api.local/api/files/public/preview/image-id?token=guest-a',
-      expect.objectContaining({ credentials: 'omit' }),
     )
-    expect(fetchMock).toHaveBeenCalledWith(
+    const audio = await screen.findByTitle('audio.mp3')
+    expect(audio.tagName).toBe('AUDIO')
+    expect(audio.getAttribute('src')).toBe(
       'http://api.local/api/files/public/preview/audio-id?token=guest-a',
-      expect.objectContaining({ credentials: 'omit' }),
     )
+    expect(fetchMock).not.toHaveBeenCalled()
     expect(apiRequestMock).not.toHaveBeenCalled()
   })
 
@@ -302,6 +303,29 @@ describe('InlineFilePreview', () => {
     expect(screen.getByRole('link', { name: 'Open' }).getAttribute('href')).toMatch(
       /^blob:/
     )
+  })
+
+  it('streams video directly from the tokened URL under the public policy', async () => {
+    // Range requests only work when the media element loads the URL itself;
+    // a blob fetch would force the full download before playback starts.
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <FileAccessProvider policy={createPublicFileAccessPolicy('guest-a')}>
+        <InlineFilePreview
+          source={{ type: 'video', fileId: 'video-id', filename: 'clip.mp4' }}
+        />
+      </FileAccessProvider>,
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+    expect(video.getAttribute('src')).toBe(
+      'http://api.local/api/files/public/preview/video-id?token=guest-a',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(apiRequestMock).not.toHaveBeenCalled()
   })
 
   it('renders a video link with a filename extension as an inline video preview', async () => {

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -150,22 +150,38 @@ function InlineImagePreview({
   )
 }
 
-function InlineAudioPreview({
+function InlineMediaPreview({
   source,
   previewUrl,
   filename,
   openLabel,
+  loadErrorText,
   className,
   fileAccess,
+  icon: Icon,
+  bodyClassName,
+  spinnerClassName,
+  renderMedia,
 }: {
   source: InlineFilePreviewSource
   previewUrl: string
   filename: string
   openLabel: string
+  loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
+  icon: React.ComponentType<{ className?: string }>
+  bodyClassName: string
+  spinnerClassName: string
+  renderMedia: (resolvedUrl: string, onError: () => void) => React.ReactNode
 }) {
   const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
+  const [failedUrl, setFailedUrl] = useState('')
+  // Terminal failure only: useResolvedMediaUrl already falls back from the
+  // authenticated fetch to the public preview URL, so an error event from
+  // the media element means both paths are exhausted. Keyed by URL so a
+  // later successful re-resolve (e.g. blob after fallback) clears it.
+  const failed = Boolean(resolvedUrl) && failedUrl === resolvedUrl
 
   return (
     <div
@@ -176,7 +192,7 @@ function InlineAudioPreview({
       data-inline-file-preview-wrapper
     >
       <div className="flex items-center gap-2 border-b border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-        <Volume2 className="h-4 w-4 shrink-0" />
+        <Icon className="h-4 w-4 shrink-0" />
         <span className="min-w-0 flex-1 truncate">{filename}</span>
         {resolvedUrl ? (
           <a
@@ -189,83 +205,88 @@ function InlineAudioPreview({
           </a>
         ) : null}
       </div>
-      <div className="p-3">
-        {resolvedUrl ? (
-          <audio
-            controls
-            preload="metadata"
-            src={resolvedUrl}
-            className="w-full"
-            aria-label={filename}
-            title={filename}
-          />
-        ) : (
-          <div className="flex h-14 items-center justify-center text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-          </div>
-        )}
-      </div>
+      {failed ? (
+        <div className="p-3 text-xs text-muted-foreground">{loadErrorText}</div>
+      ) : (
+        <div className={bodyClassName}>
+          {resolvedUrl ? (
+            renderMedia(resolvedUrl, () => setFailedUrl(resolvedUrl))
+          ) : (
+            <div
+              className={cn(
+                'flex items-center justify-center text-muted-foreground',
+                spinnerClassName
+              )}
+            >
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
 
-function InlineVideoPreview({
-  source,
-  previewUrl,
-  filename,
-  openLabel,
-  className,
-  fileAccess,
-}: {
+function InlineAudioPreview(props: {
   source: InlineFilePreviewSource
   previewUrl: string
   filename: string
   openLabel: string
+  loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
 }) {
-  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
-
+  const { filename } = props
   return (
-    <div
-      className={cn(
-        'overflow-hidden rounded-md border border-border/50 bg-background',
-        className
+    <InlineMediaPreview
+      {...props}
+      icon={Volume2}
+      bodyClassName="p-3"
+      spinnerClassName="h-14"
+      renderMedia={(resolvedUrl, onError) => (
+        <audio
+          controls
+          preload="metadata"
+          src={resolvedUrl}
+          className="w-full"
+          aria-label={filename}
+          title={filename}
+          onError={onError}
+        />
       )}
-      data-inline-file-preview-wrapper
-    >
-      <div className="flex items-center gap-2 border-b border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-        <Video className="h-4 w-4 shrink-0" />
-        <span className="min-w-0 flex-1 truncate">{filename}</span>
-        {resolvedUrl ? (
-          <a
-            href={resolvedUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="shrink-0 text-foreground hover:underline"
-          >
-            {openLabel}
-          </a>
-        ) : null}
-      </div>
-      <div className="flex items-center justify-center bg-black/95 p-2">
-        {resolvedUrl ? (
-          <video
-            controls
-            playsInline
-            preload="metadata"
-            src={resolvedUrl}
-            className="max-h-[360px] w-full max-w-full rounded bg-black"
-            aria-label={filename}
-            title={filename}
-          />
-        ) : (
-          <div className="flex h-40 w-full items-center justify-center text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-          </div>
-        )}
-      </div>
-    </div>
+    />
+  )
+}
+
+function InlineVideoPreview(props: {
+  source: InlineFilePreviewSource
+  previewUrl: string
+  filename: string
+  openLabel: string
+  loadErrorText: string
+  className?: string
+  fileAccess: FileAccessPolicy
+}) {
+  const { filename } = props
+  return (
+    <InlineMediaPreview
+      {...props}
+      icon={Video}
+      bodyClassName="flex items-center justify-center bg-black/95 p-2"
+      spinnerClassName="h-40 w-full"
+      renderMedia={(resolvedUrl, onError) => (
+        <video
+          controls
+          playsInline
+          preload="metadata"
+          src={resolvedUrl}
+          className="max-h-[360px] w-full max-w-full rounded bg-black"
+          aria-label={filename}
+          title={filename}
+          onError={onError}
+        />
+      )}
+    />
   )
 }
 
@@ -457,6 +478,7 @@ export function InlineFilePreview({
         previewUrl={previewUrl}
         filename={filename}
         openLabel={openLabel}
+        loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
       />
@@ -470,6 +492,7 @@ export function InlineFilePreview({
         previewUrl={previewUrl}
         filename={filename}
         openLabel={openLabel}
+        loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
       />

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -42,11 +42,12 @@ const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
  * but a spinner with no recovery path is worse than attempting the
  * anonymous endpoint.
  *
- * When the policy's authenticated route resolves to the same URL as the
- * public inline route — the public widget/share policy carries its token in
- * the query string — the URL is handed to the media element directly
- * instead: a blob fetch would add no authorization there, and skipping it
- * preserves HTTP range requests for progressive audio/video playback.
+ * A policy that declares ``requiresBlobFetch: false`` (the public
+ * widget/share policy carries its guest token in the query string) hands
+ * the URL to the media element directly instead: a blob fetch would add no
+ * authorization there, and skipping it preserves HTTP range requests for
+ * progressive audio/video playback. Policies that do not declare the
+ * capability get the conservative blob path, which works everywhere.
  */
 function useResolvedMediaUrl(
   source: InlineFilePreviewSource,
@@ -54,7 +55,7 @@ function useResolvedMediaUrl(
   fileAccess: FileAccessPolicy
 ): string {
   const fileId = source.fileId
-  const needsBlobFetch = Boolean(fileId) && fileAccess.previewUrl(fileId!) !== previewUrl
+  const needsBlobFetch = Boolean(fileId) && (fileAccess.requiresBlobFetch ?? true)
   const [resolvedUrl, setResolvedUrl] = useState(needsBlobFetch ? '' : previewUrl)
 
   useEffect(() => {
@@ -173,14 +174,20 @@ function InlineMediaPreview({
   icon: React.ComponentType<{ className?: string }>
   bodyClassName: string
   spinnerClassName: string
-  renderMedia: (resolvedUrl: string, onError: () => void) => React.ReactNode
+  renderMedia: (
+    resolvedUrl: string,
+    media: { onError: () => void; onLoaded: () => void }
+  ) => React.ReactNode
 }) {
   const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
   const [failedUrl, setFailedUrl] = useState('')
-  // Terminal failure only: useResolvedMediaUrl already falls back from the
-  // authenticated fetch to the public preview URL, so an error event from
-  // the media element means both paths are exhausted. Keyed by URL so a
-  // later successful re-resolve (e.g. blob after fallback) clears it.
+  const [loadedUrl, setLoadedUrl] = useState('')
+  // Terminal load failure only: useResolvedMediaUrl already falls back from
+  // the authenticated fetch to the public preview URL, so an error event
+  // from a media element that never loaded data means both paths are
+  // exhausted. Errors after data has loaded (e.g. a mid-playback decode
+  // hiccup) keep the player mounted — the element surfaces those itself.
+  // Keyed by URL so a later re-resolve clears the failure.
   const failed = Boolean(resolvedUrl) && failedUrl === resolvedUrl
 
   return (
@@ -210,7 +217,12 @@ function InlineMediaPreview({
       ) : (
         <div className={bodyClassName}>
           {resolvedUrl ? (
-            renderMedia(resolvedUrl, () => setFailedUrl(resolvedUrl))
+            renderMedia(resolvedUrl, {
+              onError: () => {
+                if (loadedUrl !== resolvedUrl) setFailedUrl(resolvedUrl)
+              },
+              onLoaded: () => setLoadedUrl(resolvedUrl),
+            })
           ) : (
             <div
               className={cn(
@@ -227,7 +239,7 @@ function InlineMediaPreview({
   )
 }
 
-function InlineAudioPreview(props: {
+type MediaWrapperProps = {
   source: InlineFilePreviewSource
   previewUrl: string
   filename: string
@@ -235,7 +247,9 @@ function InlineAudioPreview(props: {
   loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
-}) {
+}
+
+function InlineAudioPreview(props: MediaWrapperProps) {
   const { filename } = props
   return (
     <InlineMediaPreview
@@ -243,7 +257,7 @@ function InlineAudioPreview(props: {
       icon={Volume2}
       bodyClassName="p-3"
       spinnerClassName="h-14"
-      renderMedia={(resolvedUrl, onError) => (
+      renderMedia={(resolvedUrl, { onError, onLoaded }) => (
         <audio
           controls
           preload="metadata"
@@ -252,21 +266,14 @@ function InlineAudioPreview(props: {
           aria-label={filename}
           title={filename}
           onError={onError}
+          onLoadedData={onLoaded}
         />
       )}
     />
   )
 }
 
-function InlineVideoPreview(props: {
-  source: InlineFilePreviewSource
-  previewUrl: string
-  filename: string
-  openLabel: string
-  loadErrorText: string
-  className?: string
-  fileAccess: FileAccessPolicy
-}) {
+function InlineVideoPreview(props: MediaWrapperProps) {
   const { filename } = props
   return (
     <InlineMediaPreview
@@ -274,7 +281,7 @@ function InlineVideoPreview(props: {
       icon={Video}
       bodyClassName="flex items-center justify-center bg-black/95 p-2"
       spinnerClassName="h-40 w-full"
-      renderMedia={(resolvedUrl, onError) => (
+      renderMedia={(resolvedUrl, { onError, onLoaded }) => (
         <video
           controls
           playsInline
@@ -284,6 +291,7 @@ function InlineVideoPreview(props: {
           aria-label={filename}
           title={filename}
           onError={onError}
+          onLoadedData={onLoaded}
         />
       )}
     />

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -32,6 +32,74 @@ const fileNameFromSource = (source: InlineFilePreviewSource) =>
 const DEFAULT_OPEN_LABEL = 'Open'
 const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
 
+/**
+ * Resolve the URL a media element (<img>/<audio>/<video>) can load.
+ *
+ * The default in-app policy's authenticated preview route needs a Bearer
+ * header that media elements cannot send, so managed files are fetched into
+ * a blob object URL first. If that fetch fails, the public preview URL is a
+ * last-resort fallback: on Agent Builder surfaces it may also require auth,
+ * but a spinner with no recovery path is worse than attempting the
+ * anonymous endpoint.
+ *
+ * When the policy's authenticated route resolves to the same URL as the
+ * public inline route — the public widget/share policy carries its token in
+ * the query string — the URL is handed to the media element directly
+ * instead: a blob fetch would add no authorization there, and skipping it
+ * preserves HTTP range requests for progressive audio/video playback.
+ */
+function useResolvedMediaUrl(
+  source: InlineFilePreviewSource,
+  previewUrl: string,
+  fileAccess: FileAccessPolicy
+): string {
+  const fileId = source.fileId
+  const needsBlobFetch = Boolean(fileId) && fileAccess.previewUrl(fileId!) !== previewUrl
+  const [resolvedUrl, setResolvedUrl] = useState(needsBlobFetch ? '' : previewUrl)
+
+  useEffect(() => {
+    let objectUrl: string | null = null
+    let isCancelled = false
+
+    setResolvedUrl(needsBlobFetch ? '' : previewUrl)
+
+    const loadAuthenticatedMedia = async () => {
+      if (!needsBlobFetch || !fileId) return
+      try {
+        const response = await fileAccess.request(fileAccess.previewUrl(fileId), {
+          cache: 'no-cache',
+          headers: {
+            'Cache-Control': 'no-cache',
+            Pragma: 'no-cache',
+          },
+        })
+        if (isCancelled) return
+        if (!response.ok) {
+          setResolvedUrl(previewUrl)
+          return
+        }
+        const blob = await response.blob()
+        if (isCancelled) return
+        objectUrl = URL.createObjectURL(blob)
+        setResolvedUrl(objectUrl)
+      } catch {
+        if (!isCancelled) {
+          setResolvedUrl(previewUrl)
+        }
+      }
+    }
+
+    void loadAuthenticatedMedia()
+
+    return () => {
+      isCancelled = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [fileAccess, fileId, needsBlobFetch, previewUrl])
+
+  return resolvedUrl
+}
+
 function InlineImagePreview({
   source,
   previewUrl,
@@ -47,56 +115,7 @@ function InlineImagePreview({
   onFileClick?: (filePath: string, fileName: string) => void
   fileAccess: FileAccessPolicy
 }) {
-  const shouldFallback = Boolean(source.fileId)
-  const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
-
-  useEffect(() => {
-    let objectUrl: string | null = null
-    let isCancelled = false
-
-    setResolvedUrl(shouldFallback ? '' : previewUrl)
-
-    const runFallback = async () => {
-      if (!shouldFallback) return
-      try {
-        const response = await fileAccess.request(
-          fileAccess.previewUrl(source.fileId!),
-          {
-            cache: 'no-cache',
-            headers: {
-              'Cache-Control': 'no-cache',
-              Pragma: 'no-cache',
-            },
-          }
-        )
-        if (isCancelled) return
-        if (!response.ok) {
-          // Last-resort fallback: try the public preview URL when the
-          // authenticated route fails. On Agent Builder surfaces that
-          // route may also require auth, but a spinner with no recovery
-          // path is worse than attempting the anonymous endpoint.
-          setResolvedUrl(previewUrl)
-          return
-        }
-        const blob = await response.blob()
-        if (isCancelled) return
-        objectUrl = URL.createObjectURL(blob)
-        setResolvedUrl(objectUrl)
-      } catch {
-        if (!isCancelled) {
-          // See comment above: public preview is best-effort after auth errors.
-          setResolvedUrl(previewUrl)
-        }
-      }
-    }
-
-    void runFallback()
-
-    return () => {
-      isCancelled = true
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-    }
-  }, [fileAccess, previewUrl, shouldFallback, source.fileId])
+  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
 
   const handleClick = (event: React.MouseEvent<HTMLImageElement>) => {
     if (!onFileClick || !source.fileId) return
@@ -146,51 +165,7 @@ function InlineAudioPreview({
   className?: string
   fileAccess: FileAccessPolicy
 }) {
-  const shouldFallback = Boolean(source.fileId)
-  const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
-
-  useEffect(() => {
-    let objectUrl: string | null = null
-    let isCancelled = false
-
-    setResolvedUrl(shouldFallback ? '' : previewUrl)
-
-    const loadAuthenticatedAudio = async () => {
-      if (!shouldFallback || !source.fileId) return
-      try {
-        const response = await fileAccess.request(
-          fileAccess.previewUrl(source.fileId),
-          {
-            cache: 'no-cache',
-            headers: {
-              'Cache-Control': 'no-cache',
-              Pragma: 'no-cache',
-            },
-          }
-        )
-        if (isCancelled) return
-        if (!response.ok) {
-          setResolvedUrl(previewUrl)
-          return
-        }
-        const blob = await response.blob()
-        if (isCancelled) return
-        objectUrl = URL.createObjectURL(blob)
-        setResolvedUrl(objectUrl)
-      } catch {
-        if (!isCancelled) {
-          setResolvedUrl(previewUrl)
-        }
-      }
-    }
-
-    void loadAuthenticatedAudio()
-
-    return () => {
-      isCancelled = true
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-    }
-  }, [fileAccess, previewUrl, shouldFallback, source.fileId])
+  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
 
   return (
     <div
@@ -249,51 +224,7 @@ function InlineVideoPreview({
   className?: string
   fileAccess: FileAccessPolicy
 }) {
-  const shouldFallback = Boolean(source.fileId)
-  const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
-
-  useEffect(() => {
-    let objectUrl: string | null = null
-    let isCancelled = false
-
-    setResolvedUrl(shouldFallback ? '' : previewUrl)
-
-    const loadAuthenticatedVideo = async () => {
-      if (!shouldFallback || !source.fileId) return
-      try {
-        const response = await fileAccess.request(
-          fileAccess.previewUrl(source.fileId),
-          {
-            cache: 'no-cache',
-            headers: {
-              'Cache-Control': 'no-cache',
-              Pragma: 'no-cache',
-            },
-          }
-        )
-        if (isCancelled) return
-        if (!response.ok) {
-          setResolvedUrl(previewUrl)
-          return
-        }
-        const blob = await response.blob()
-        if (isCancelled) return
-        objectUrl = URL.createObjectURL(blob)
-        setResolvedUrl(objectUrl)
-      } catch {
-        if (!isCancelled) {
-          setResolvedUrl(previewUrl)
-        }
-      }
-    }
-
-    void loadAuthenticatedVideo()
-
-    return () => {
-      isCancelled = true
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-    }
-  }, [fileAccess, previewUrl, shouldFallback, source.fileId])
+  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
 
   return (
     <div

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { FileText, Loader2, Volume2 } from 'lucide-react'
+import { FileText, Loader2, Video, Volume2 } from 'lucide-react'
 
 import { DocxPreviewRenderer } from '@/components/file/docx-preview-renderer'
 import { ExcelPreviewRenderer } from '@/components/file/excel-preview-renderer'
@@ -234,6 +234,110 @@ function InlineAudioPreview({
   )
 }
 
+function InlineVideoPreview({
+  source,
+  previewUrl,
+  filename,
+  openLabel,
+  className,
+  fileAccess,
+}: {
+  source: InlineFilePreviewSource
+  previewUrl: string
+  filename: string
+  openLabel: string
+  className?: string
+  fileAccess: FileAccessPolicy
+}) {
+  const shouldFallback = Boolean(source.fileId)
+  const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
+
+  useEffect(() => {
+    let objectUrl: string | null = null
+    let isCancelled = false
+
+    setResolvedUrl(shouldFallback ? '' : previewUrl)
+
+    const loadAuthenticatedVideo = async () => {
+      if (!shouldFallback || !source.fileId) return
+      try {
+        const response = await fileAccess.request(
+          fileAccess.previewUrl(source.fileId),
+          {
+            cache: 'no-cache',
+            headers: {
+              'Cache-Control': 'no-cache',
+              Pragma: 'no-cache',
+            },
+          }
+        )
+        if (isCancelled) return
+        if (!response.ok) {
+          setResolvedUrl(previewUrl)
+          return
+        }
+        const blob = await response.blob()
+        if (isCancelled) return
+        objectUrl = URL.createObjectURL(blob)
+        setResolvedUrl(objectUrl)
+      } catch {
+        if (!isCancelled) {
+          setResolvedUrl(previewUrl)
+        }
+      }
+    }
+
+    void loadAuthenticatedVideo()
+
+    return () => {
+      isCancelled = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [fileAccess, previewUrl, shouldFallback, source.fileId])
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-md border border-border/50 bg-background',
+        className
+      )}
+      data-inline-file-preview-wrapper
+    >
+      <div className="flex items-center gap-2 border-b border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <Video className="h-4 w-4 shrink-0" />
+        <span className="min-w-0 flex-1 truncate">{filename}</span>
+        {resolvedUrl ? (
+          <a
+            href={resolvedUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0 text-foreground hover:underline"
+          >
+            {openLabel}
+          </a>
+        ) : null}
+      </div>
+      <div className="flex items-center justify-center bg-black/95 p-2">
+        {resolvedUrl ? (
+          <video
+            controls
+            playsInline
+            preload="metadata"
+            src={resolvedUrl}
+            className="max-h-[360px] w-full max-w-full rounded bg-black"
+            aria-label={filename}
+            title={filename}
+          />
+        ) : (
+          <div className="flex h-40 w-full items-center justify-center text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function InlineOfficeContent({
   kind,
   previewUrl,
@@ -418,6 +522,19 @@ export function InlineFilePreview({
   if (kind === 'audio') {
     return (
       <InlineAudioPreview
+        source={resolvedSource}
+        previewUrl={previewUrl}
+        filename={filename}
+        openLabel={openLabel}
+        className={className}
+        fileAccess={fileAccess}
+      />
+    )
+  }
+
+  if (kind === 'video') {
+    return (
+      <InlineVideoPreview
         source={resolvedSource}
         previewUrl={previewUrl}
         filename={filename}

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -772,6 +772,21 @@ describe('MarkdownRenderer', () => {
     )
   })
 
+  it('renders video file links as an inline video preview', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+    const content = '[puppy_drinking.mp4](file:550e8400-e29b-41d4-a716-446655440000)'
+    render(<MarkdownRenderer content={content} />)
+
+    const video = await screen.findByLabelText('puppy_drinking.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+    await waitFor(() => {
+      expect(video.getAttribute('src')).toMatch(/^blob:/)
+    })
+  })
+
   it('renders file links as image previews when the path has an image extension', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -787,6 +787,21 @@ describe('MarkdownRenderer', () => {
     })
   })
 
+  it('renders image-syntax video references as an inline video preview', async () => {
+    // The backend restores the filename as the label even for ![...] refs
+    // pointing at media files; the image renderer then resolves the video
+    // kind from the label instead of falling back to a broken <img>.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+    const content = '![puppy_drinking.mp4](file:550e8400-e29b-41d4-a716-446655440000)'
+    render(<MarkdownRenderer content={content} />)
+
+    const video = await screen.findByLabelText('puppy_drinking.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+  })
+
   it('renders file links as image previews when the path has an image extension', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -19,6 +19,16 @@ export interface FileAccessPolicy {
   pdfPreviewUrl?: (fileId: string) => string
   request: FileAccessRequest
   listFiles?: (query: string) => Promise<Response>
+  /**
+   * Whether media elements must load managed files through an
+   * authenticated fetch into a blob URL. True when previewUrl requires
+   * headers a media element cannot send (the default Bearer policy);
+   * false when the URL is directly loadable (the public policy carries
+   * its guest token in the query string), which preserves HTTP range
+   * requests for progressive playback. Policies that do not declare the
+   * capability get the conservative blob path.
+   */
+  requiresBlobFetch?: boolean
 }
 
 const encodeFileId = (fileId: string) => encodeURIComponent(fileId)
@@ -45,6 +55,9 @@ const defaultFileAccessPolicy: FileAccessPolicy = {
     if (query.trim()) params.set("search", query.trim())
     return apiRequest(buildUrl(`/api/files/list?${params.toString()}`))
   },
+  // previewUrl needs the Bearer header apiRequest attaches; media elements
+  // cannot send it, so they must go through the blob fetch.
+  requiresBlobFetch: true,
 }
 
 const FileAccessContext = createContext<FileAccessPolicy>(defaultFileAccessPolicy)
@@ -110,6 +123,9 @@ export function createPublicFileAccessPolicy(accessToken: string): FileAccessPol
       headers.delete("Authorization")
       return fetch(url, { ...options, headers, credentials: "omit" })
     },
+    // The guest token rides the query string, so media elements can load
+    // previewUrl directly — no headers needed, and range requests work.
+    requiresBlobFetch: false,
   }
 }
 

--- a/src/xagent/core/tools/artifacts.py
+++ b/src/xagent/core/tools/artifacts.py
@@ -16,6 +16,7 @@ GENERATED_ARTIFACT_EXTENSIONS = {
     ".gif",
     ".jpeg",
     ".jpg",
+    ".m4v",
     ".mov",
     ".mp4",
     ".mpeg",
@@ -56,7 +57,7 @@ def artifact_type_for_filename(filename: str) -> str:
     suffix = Path(filename).suffix.lower()
     if suffix in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg"}:
         return "image"
-    if suffix in {".mp4", ".mov", ".mpeg", ".mpg", ".webm"}:
+    if suffix in {".mp4", ".m4v", ".mov", ".mpeg", ".mpg", ".webm"}:
         return "video"
     # Only OOXML .pptx maps to ``presentation`` — the frontend's inline
     # ``PptxPreviewRenderer`` (pptxviewjs) cannot render legacy binary

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -52,13 +52,16 @@ def _is_inline_preview_media(filename: str) -> bool:
 # file like ``clip ].mp4`` must never be substituted into a ``[label](...)``
 # span unescaped: an embedded ``]`` (or ``[``/``\``) terminates the link
 # early and the file reference is lost entirely — worse than the plain
-# download link this rewrite is trying to improve on. Escaping instead of
-# skipping would work for a single pass, but ``_MARKDOWN_FILE_REFERENCE_RE``
-# has no notion of backslash-escapes, so a later reconcile pass over
-# already-escaped content would mis-locate the label boundary at the
-# escaped bracket. Skipping the rewrite for these filenames is the safe,
-# idempotent choice; the link still falls back to a plain download label.
-_UNSAFE_LABEL_CHARS = frozenset("[]\\")
+# download link this rewrite is trying to improve on. Control characters
+# are just as destructive through a different mechanism: a filename with a
+# blank line splits the paragraph before the inline link is even parsed.
+# Escaping instead of skipping would work for a single pass, but
+# ``_MARKDOWN_FILE_REFERENCE_RE`` has no notion of backslash-escapes, so a
+# later reconcile pass over already-escaped content would mis-locate the
+# label boundary at the escaped bracket. Skipping the rewrite for these
+# filenames is the safe, idempotent choice; the link still falls back to a
+# plain download label.
+_UNSAFE_LABEL_RE = re.compile(r"[\[\]\\\x00-\x1f\x7f]")
 
 
 def load_assistant_file_reference_records(
@@ -162,7 +165,7 @@ def reconcile_assistant_file_references(
         if (
             not prefix
             and _is_inline_preview_media(filename)
-            and not any(char in _UNSAFE_LABEL_CHARS for char in filename)
+            and not _UNSAFE_LABEL_RE.search(filename)
         ):
             suffix = Path(filename).suffix.casefold()
             if suffix and not label.strip().casefold().endswith(suffix):

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -162,11 +162,12 @@ def reconcile_assistant_file_references(
 
         display_label = label
         filename = str(record.filename or "")
-        if (
-            not prefix
-            and _is_inline_preview_media(filename)
-            and not _UNSAFE_LABEL_RE.search(filename)
-        ):
+        # Applies to ``![...]`` references too: _is_inline_preview_media only
+        # matches video/audio, so genuine image alt text is never touched,
+        # while a model that wraps a video in image syntax still gets a label
+        # the frontend can classify (its image renderer resolves the preview
+        # kind from the label and would otherwise fall back to a broken img).
+        if _is_inline_preview_media(filename) and not _UNSAFE_LABEL_RE.search(filename):
             suffix = Path(filename).suffix.casefold()
             if suffix and not label.strip().casefold().endswith(suffix):
                 display_label = filename

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -21,17 +21,6 @@ _MARKDOWN_FILE_REFERENCE_RE = re.compile(
     r"(?P<image>!)?\[(?P<label>[^\]]*)\]\((?P<target>file:[^)\s]+)\)"
 )
 
-# Media artifact types the frontend renders as inline players but only
-# detects by filename extension, since ``[label](file:id)`` targets are
-# opaque UUIDs. The model is free to rewrite ``label`` into descriptive
-# prose that drops the extension (e.g. "下载视频（MP4）"), which silently
-# degrades the player to a plain download link. Force the label back to the
-# real filename in that case so the extension survives into the rendered
-# markdown. Deliberately limited to lightweight media players: office types
-# (presentation/document/spreadsheet) keep the model's prose label because
-# rewriting it would flip existing compact links into heavy inline preview
-# boxes that eagerly fetch file bytes.
-_INLINE_PREVIEW_LINK_TYPES = {"video"}
 # ``artifact_type_for_filename`` only knows image/video/office extensions
 # and never returns "audio", so audio must be matched by extension here.
 # This set mirrors the frontend's audio detection (see
@@ -40,10 +29,36 @@ _INLINE_PREVIEW_LINK_TYPES = {"video"}
 _AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".opus", ".flac", ".m4a", ".aac"}
 
 
-def _is_inline_preview_media(filename: str, suffix: str) -> bool:
-    return artifact_type_for_filename(filename) in _INLINE_PREVIEW_LINK_TYPES or (
-        suffix in _AUDIO_EXTENSIONS
-    )
+def _is_inline_preview_media(filename: str) -> bool:
+    """Whether ``filename`` is a video/audio artifact the frontend plays inline.
+
+    These types are only detected by filename extension, since
+    ``[label](file:id)`` targets are opaque UUIDs. The model is free to
+    rewrite the label into descriptive prose that drops the extension (e.g.
+    "下载视频（MP4）"), which silently degrades the player to a plain download
+    link — callers restore the real filename as the label in that case so
+    the extension survives into the rendered markdown. Deliberately limited
+    to lightweight media players: office types (presentation/document/
+    spreadsheet) keep the model's prose label because rewriting it would
+    flip existing compact links into heavy inline preview boxes that
+    eagerly fetch file bytes.
+    """
+    if artifact_type_for_filename(filename) == "video":
+        return True
+    return Path(filename).suffix.casefold() in _AUDIO_EXTENSIONS
+
+
+# ``UploadedFile.filename`` has no charset constraint, so a user-uploaded
+# file like ``clip ].mp4`` must never be substituted into a ``[label](...)``
+# span unescaped: an embedded ``]`` (or ``[``/``\``) terminates the link
+# early and the file reference is lost entirely — worse than the plain
+# download link this rewrite is trying to improve on. Escaping instead of
+# skipping would work for a single pass, but ``_MARKDOWN_FILE_REFERENCE_RE``
+# has no notion of backslash-escapes, so a later reconcile pass over
+# already-escaped content would mis-locate the label boundary at the
+# escaped bracket. Skipping the rewrite for these filenames is the safe,
+# idempotent choice; the link still falls back to a plain download label.
+_UNSAFE_LABEL_CHARS = frozenset("[]\\")
 
 
 def load_assistant_file_reference_records(
@@ -144,9 +159,13 @@ def reconcile_assistant_file_references(
 
         display_label = label
         filename = str(record.filename or "")
-        suffix = Path(filename).suffix.casefold()
-        if not prefix and suffix and _is_inline_preview_media(filename, suffix):
-            if not label.strip().casefold().endswith(suffix):
+        if (
+            not prefix
+            and _is_inline_preview_media(filename)
+            and not any(char in _UNSAFE_LABEL_CHARS for char in filename)
+        ):
+            suffix = Path(filename).suffix.casefold()
+            if suffix and not label.strip().casefold().endswith(suffix):
                 display_label = filename
 
         return f"{prefix}[{display_label}]({canonical_ref})"

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -31,7 +31,19 @@ _MARKDOWN_FILE_REFERENCE_RE = re.compile(
 # (presentation/document/spreadsheet) keep the model's prose label because
 # rewriting it would flip existing compact links into heavy inline preview
 # boxes that eagerly fetch file bytes.
-_INLINE_PREVIEW_LINK_TYPES = {"video", "audio"}
+_INLINE_PREVIEW_LINK_TYPES = {"video"}
+# ``artifact_type_for_filename`` only knows image/video/office extensions
+# and never returns "audio", so audio must be matched by extension here.
+# This set mirrors the frontend's audio detection (see
+# ``getInlineFilePreviewKind`` in ``inline-file-preview-utils.ts``) — keep
+# the two in sync.
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".opus", ".flac", ".m4a", ".aac"}
+
+
+def _is_inline_preview_media(filename: str, suffix: str) -> bool:
+    return artifact_type_for_filename(filename) in _INLINE_PREVIEW_LINK_TYPES or (
+        suffix in _AUDIO_EXTENSIONS
+    )
 
 
 def load_assistant_file_reference_records(
@@ -132,12 +144,9 @@ def reconcile_assistant_file_references(
 
         display_label = label
         filename = str(record.filename or "")
-        if (
-            not prefix
-            and artifact_type_for_filename(filename) in _INLINE_PREVIEW_LINK_TYPES
-        ):
-            suffix = Path(filename).suffix.casefold()
-            if suffix and not label.strip().casefold().endswith(suffix):
+        suffix = Path(filename).suffix.casefold()
+        if not prefix and suffix and _is_inline_preview_media(filename, suffix):
+            if not label.strip().casefold().endswith(suffix):
                 display_label = filename
 
         return f"{prefix}[{display_label}]({canonical_ref})"

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -12,6 +12,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...core.file_ref import build_file_id_ref, parse_file_id_ref
+from ...core.tools.artifacts import artifact_type_for_filename
 from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,18 @@ logger = logging.getLogger(__name__)
 _MARKDOWN_FILE_REFERENCE_RE = re.compile(
     r"(?P<image>!)?\[(?P<label>[^\]]*)\]\((?P<target>file:[^)\s]+)\)"
 )
+
+# Media artifact types the frontend renders as inline players but only
+# detects by filename extension, since ``[label](file:id)`` targets are
+# opaque UUIDs. The model is free to rewrite ``label`` into descriptive
+# prose that drops the extension (e.g. "下载视频（MP4）"), which silently
+# degrades the player to a plain download link. Force the label back to the
+# real filename in that case so the extension survives into the rendered
+# markdown. Deliberately limited to lightweight media players: office types
+# (presentation/document/spreadsheet) keep the model's prose label because
+# rewriting it would flip existing compact links into heavy inline preview
+# boxes that eagerly fetch file bytes.
+_INLINE_PREVIEW_LINK_TYPES = {"video", "audio"}
 
 
 def load_assistant_file_reference_records(
@@ -116,6 +129,17 @@ def reconcile_assistant_file_references(
                 record.file_id,
             )
             return label
-        return f"{prefix}[{label}]({canonical_ref})"
+
+        display_label = label
+        filename = str(record.filename or "")
+        if (
+            not prefix
+            and artifact_type_for_filename(filename) in _INLINE_PREVIEW_LINK_TYPES
+        ):
+            suffix = Path(filename).suffix.casefold()
+            if suffix and not label.strip().casefold().endswith(suffix):
+                display_label = filename
+
+        return f"{prefix}[{display_label}]({canonical_ref})"
 
     return _MARKDOWN_FILE_REFERENCE_RE.sub(replacement, content)

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -385,6 +385,58 @@ def test_reconcile_skips_label_rewrite_for_filename_with_control_chars():
         db.close()
 
 
+def test_reconcile_rewrites_label_for_image_syntax_video_reference():
+    # A model may wrap a video in image syntax. The frontend's image
+    # renderer resolves the preview kind from the label, so restoring the
+    # filename there turns a would-be broken <img> into a video player.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="![预览视频](file:real-id)",
+        )
+
+        assert content == "![generated_video.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_alt_text_for_image_syntax_image_reference():
+    # Genuine image references keep their (possibly descriptive) alt text —
+    # only video/audio labels are restored.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="chart.png",
+            mime_type="image/png",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="![季度收入图表](file:real-id)",
+        )
+
+        assert content == "![季度收入图表](file:real-id)"
+    finally:
+        db.close()
+
+
 def test_reconcile_rewrites_empty_label_to_filename_for_media():
     db, user, task = _create_context()
     try:

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.tools.artifacts import artifact_type_for_filename
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
@@ -199,6 +200,57 @@ def test_reconcile_rewrites_label_to_filename_for_audio_when_extension_is_missin
         db.close()
 
 
+def test_reconcile_rewrites_label_for_m4v_extension():
+    # Regression test: the frontend's video regex
+    # (inline-file-preview-utils.ts) recognizes .m4v, and
+    # artifact_type_for_filename must agree or this rewrite silently
+    # no-ops for .m4v the same way it used to for all audio extensions.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.m4v",
+            mime_type="video/mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（M4V）](file:real-id)",
+        )
+
+        assert content == "[generated_video.m4v](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_rewrites_label_case_insensitively():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="CLIP.MP4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频](file:real-id)",
+        )
+
+        assert content == "[CLIP.MP4](file:real-id)"
+    finally:
+        db.close()
+
+
 def test_reconcile_keeps_custom_label_for_plain_download_file():
     db, user, task = _create_context()
     try:
@@ -220,6 +272,100 @@ def test_reconcile_keeps_custom_label_for_plain_download_file():
         assert content == "[下载笔记](file:real-id)"
     finally:
         db.close()
+
+
+def test_reconcile_keeps_custom_label_for_office_document():
+    # Office types are deliberately excluded from label-restore (rewriting
+    # them would flip existing compact links into heavy inline preview
+    # boxes). Use .docx so this fails loudly if "document" is ever added
+    # to the inline-preview media set by mistake.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="quarterly_report.docx",
+            mime_type=(
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document"
+            ),
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载报告](file:real-id)",
+        )
+
+        assert content == "[下载报告](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_mismatched_label_that_already_has_media_extension():
+    # A label that already ends in a valid media suffix is left alone even
+    # when it names a different file than the record's real filename —
+    # there's no signal that the mismatch is wrong rather than intentional.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video_a1b2c3.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[my_clip.mp4](file:real-id)",
+        )
+
+        assert content == "[my_clip.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_skips_label_rewrite_for_filename_with_unsafe_chars():
+    # A real filename containing "]" must never be substituted into the
+    # label unescaped -- it would terminate the markdown link early and
+    # drop the file reference entirely, which is worse than leaving the
+    # model's prose label (and its plain-download fallback) in place.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="clip ].mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+
+        assert content == "[下载视频（MP4）](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_video_extension_detection_matches_frontend_set():
+    # Pins the backend's video-extension coverage to the frontend's regex
+    # in inline-file-preview-utils.ts (`/\.(mp4|m4v|mov|webm|mpeg|mpg)$/`).
+    # A mismatch here (like the missing .m4v this test was added to catch)
+    # makes the label-restore rewrite silently no-op for that extension.
+    frontend_video_extensions = {".mp4", ".m4v", ".mov", ".webm", ".mpeg", ".mpg"}
+    for extension in frontend_video_extensions:
+        assert artifact_type_for_filename(f"clip{extension}") == "video", extension
 
 
 def test_reconcile_reuses_prefetched_records_without_querying():

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -150,6 +150,52 @@ def test_reconcile_unlinks_record_with_invalid_file_id():
         db.close()
 
 
+def test_reconcile_rewrites_label_to_filename_when_extension_is_missing():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+
+        assert content == "[generated_video.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_custom_label_for_plain_download_file():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="notes.txt",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载笔记](file:real-id)",
+        )
+
+        assert content == "[下载笔记](file:real-id)"
+    finally:
+        db.close()
+
+
 def test_reconcile_reuses_prefetched_records_without_querying():
     db, user, task = _create_context()
     try:

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -31,14 +31,16 @@ def _create_context():
     return db, user, task
 
 
-def _add_file(db, user, task, *, file_id: str, filename: str):
+def _add_file(
+    db, user, task, *, file_id: str, filename: str, mime_type: str = "video/mp4"
+):
     record = UploadedFile(
         file_id=file_id,
         user_id=int(user.id),
         task_id=int(task.id) if task is not None else None,
         filename=filename,
         storage_path=f"/tmp/{file_id}/{filename}",
-        mime_type="video/mp4",
+        mime_type=mime_type,
         file_size=123,
     )
     db.add(record)
@@ -169,6 +171,30 @@ def test_reconcile_rewrites_label_to_filename_when_extension_is_missing():
         )
 
         assert content == "[generated_video.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_rewrites_label_to_filename_for_audio_when_extension_is_missing():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_podcast.mp3",
+            mime_type="audio/mpeg",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载音频（MP3）](file:real-id)",
+        )
+
+        assert content == "[generated_podcast.mp3](file:real-id)"
     finally:
         db.close()
 

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -9,6 +9,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.file_reference_output_service import (
+    _AUDIO_EXTENSIONS,
     reconcile_assistant_file_references,
 )
 
@@ -358,6 +359,55 @@ def test_reconcile_skips_label_rewrite_for_filename_with_unsafe_chars():
         db.close()
 
 
+def test_reconcile_skips_label_rewrite_for_filename_with_control_chars():
+    # A filename containing a blank line would split the paragraph before
+    # CommonMark ever parses the inline link -- same failure mode as "]",
+    # through a different character class.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="a\n\nb.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+
+        assert content == "[下载视频（MP4）](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_rewrites_empty_label_to_filename_for_media():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[](file:real-id)",
+        )
+
+        assert content == "[generated_video.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
 def test_video_extension_detection_matches_frontend_set():
     # Pins the backend's video-extension coverage to the frontend's regex
     # in inline-file-preview-utils.ts (`/\.(mp4|m4v|mov|webm|mpeg|mpg)$/`).
@@ -366,6 +416,23 @@ def test_video_extension_detection_matches_frontend_set():
     frontend_video_extensions = {".mp4", ".m4v", ".mov", ".webm", ".mpeg", ".mpg"}
     for extension in frontend_video_extensions:
         assert artifact_type_for_filename(f"clip{extension}") == "video", extension
+
+
+def test_audio_extension_detection_matches_frontend_set():
+    # Same parity guard for audio, pinning _AUDIO_EXTENSIONS against the
+    # frontend regex (`/\.(mp3|wav|ogg|opus|flac|m4a|aac)$/`). Audio is the
+    # category that actually drifted historically: the initial label-restore
+    # fix silently no-oped for every audio extension.
+    frontend_audio_extensions = {
+        ".mp3",
+        ".wav",
+        ".ogg",
+        ".opus",
+        ".flac",
+        ".m4a",
+        ".aac",
+    }
+    assert frontend_audio_extensions == _AUDIO_EXTENSIONS
 
 
 def test_reconcile_reuses_prefetched_records_without_querying():


### PR DESCRIPTION
## Problem

Generated videos (e.g. from the video generation tool) show up in the
conversation UI as a plain filename/download link instead of a playable
video element.

## Root causes

There were two independent layers to this bug:

1. **The frontend had no video preview support at all.**
   `getInlineFilePreviewKind` in `inline-file-preview-utils.ts` never
   matched `video/*` mime types or `.mp4/.mov/.webm/...` extensions, so
   every video fell through to the generic `'file'` kind and rendered
   as a download link.

2. **The model rewrites link labels, breaking extension detection.**
   Assistant messages reference files as `[label](file:<uuid>)` — the
   target is an opaque UUID with no extension, so the frontend can only
   detect the file type from the label text. The model frequently
   rewrites the label into descriptive prose (e.g. `下载视频（MP4）`),
   which silently degrades the preview even once video detection
   exists.

## Changes

**Frontend**
- Add a `'video'` kind to the inline file preview pipeline
  (`inline-file-preview-utils.ts`): explicit `type: 'video'` artifacts,
  `video/*` mime types, and `.mp4/.m4v/.mov/.webm/.mpeg/.mpg`
  extensions.
- Add an inline video player (`inline-file-preview.tsx`): authenticated
  blob fetch with public-preview fallback, filename header with an Open
  link, and a `<video controls playsInline>` player. The shared
  loading logic now lives in a `useResolvedMediaUrl` hook and the
  shared wrapper JSX in `InlineMediaPreview`, both reused by the audio
  player.
- Audio/video players now show `loadErrorText` when the media element
  errors after both load paths (authenticated blob, public preview
  fallback) are exhausted, instead of a silent broken player. The
  header keeps the filename and Open link.
- This also fixes video artifacts in the tool execution trace view,
  which already passes `type: "video"` through to `InlineFilePreview`.

**Backend**
- `reconcile_assistant_file_references` now restores the real filename
  as the markdown label for **video/audio** links when the model's
  label drops the extension, so the frontend's extension-based
  detection always fires. Scoped to media player types on purpose:
  rewriting office-document labels would flip existing compact links
  into heavy inline preview boxes that eagerly fetch file bytes.
- The rewrite is skipped for filenames containing `[`, `]`, backslash,
  or control characters — substituting those into a markdown label
  would destroy the link outright (escaping is not idempotent across
  repeated reconcile passes, so skipping is the safe choice).
- `.m4v` added to the backend video extension sets
  (`artifact_type_for_filename`, `GENERATED_ARTIFACT_EXTENSIONS`),
  closing a frontend/backend drift; parity tests now pin both the
  video and audio extension lists against the frontend regexes.

## Behavior change on public/share surfaces (deliberate)

`useResolvedMediaUrl` skips the blob fetch when the policy's
authenticated route resolves to the same URL as the public inline
route — i.e. under `createPublicFileAccessPolicy`, whose guest token
rides the query string. There the tokened URL is assigned directly as
the media element's `src`. This applies to **image and audio as well
as video**, and means the guest token now appears in DOM `src`
attributes, page HTML, and the browser media cache on public widget
pages.

Why this is acceptable:
- The query-string token exists precisely because media elements
  cannot send an `Authorization` header — direct media loads are what
  that policy was designed for (see the comment in
  `file-access-context.tsx`).
- Tokened URLs already land in DOM `href`s on the same surfaces today:
  every generic file download link and office-preview Open link uses
  `inlineDownloadUrl`/`inlinePreviewUrl` in a plain `<a href>`. This PR
  extends an existing exposure pattern to media `src`, it does not
  create a new one.
- The token is a per-guest, 30-day JWT scoped to the guest's own
  session on an already-public share; a leaked URL grants access to
  the leaker's own conversation files, not other users'.
- The win: no double-download, and HTTP range requests work, so
  video/audio can start playing before the full file downloads.

The default in-app (Bearer-authenticated) policy still blob-fetches;
making the authenticated preview route Range-capable is a possible
follow-up (see review discussion).

## Testing

- `tests/web/services/test_file_reference_output_service.py`: 17 cases
  covering the prose-label scenario from the bug report, `.m4v`,
  case-insensitive extensions, office-document exclusion,
  mismatched-but-suffixed labels, unsafe/control-character filenames,
  empty labels, and frontend/backend extension parity for both video
  and audio.
- Frontend: cases across `inline-file-preview-utils.test.ts`,
  `inline-file-preview.test.tsx` and `markdown-renderer.test.tsx`,
  including the end-to-end `MarkdownRenderer → MarkdownLink →
  InlineFilePreview` path, public-policy direct streaming for video,
  the public fallback path, blob-URL revocation on unmount, and the
  terminal-failure error state (86 passed across the touched suites).
- `tsc --noEmit`, `mypy`, `ruff`, `eslint` all clean (the two eslint
  warnings in `inline-file-preview.tsx` are pre-existing).
