### PR TITLE
fix(chat): open markdown links in a new tab instead of the widget iframe

### DIFF
--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -680,39 +680,59 @@ describe('MarkdownRenderer', () => {
     expect(await screen.findByTestId('excel-preview')).toHaveTextContent('WFk=')
   })
 
-  it('preserves standard relative markdown links and images', () => {
+  it('preserves standard relative markdown links and images, and does not open them in a new tab by default', () => {
     const content = '[relative doc](../doc.md)\n\n![relative image](./a.png)'
     render(<MarkdownRenderer content={content} />)
 
     const link = screen.getByText('relative doc')
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '../doc.md')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
 
     const image = screen.getByAltText('relative image')
     expect(image).toBeInTheDocument()
     expect(image).toHaveAttribute('src', './a.png')
   })
 
-  it('opens ordinary external links in a new tab', () => {
-    render(<MarkdownRenderer content="[Google](https://www.google.com)" />)
+  it('opens ordinary links in a new tab only when linksOpenInNewTab is enabled', () => {
+    render(<MarkdownRenderer content="[Google](https://www.google.com)" linksOpenInNewTab />)
 
     const link = screen.getByRole('link', { name: 'Google' })
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
-  it('keeps in-page anchor links and mailto links in the current tab', () => {
+  it('keeps in-page anchor links and mailto links in the current tab even when linksOpenInNewTab is enabled', () => {
     const content = [
       '[Jump to section](#section)',
       '[Email us](mailto:hello@example.com)',
     ].join('\n\n')
-    render(<MarkdownRenderer content={content} />)
+    render(<MarkdownRenderer content={content} linksOpenInNewTab />)
 
     for (const name of ['Jump to section', 'Email us']) {
       const link = screen.getByRole('link', { name })
       expect(link).not.toHaveAttribute('target')
       expect(link).not.toHaveAttribute('rel')
     }
+  })
+
+  it('neutralizes javascript: hrefs before the new-tab check ever sees them', () => {
+    render(<MarkdownRenderer content="[click me](javascript:alert(1))" />)
+
+    const link = screen.getByText('click me')
+    expect(link).not.toHaveAttribute('href')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
+  })
+
+  it('does not add target/rel to a link with an empty href', () => {
+    render(<MarkdownRenderer content="[x]()" />)
+
+    const link = screen.getByText('x')
+    expect(link).not.toHaveAttribute('href')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
   })
 
   it('uses authenticated preview fallback for non-uuid file: images', async () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -701,6 +701,20 @@ describe('MarkdownRenderer', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
+  it('keeps in-page anchor links and mailto links in the current tab', () => {
+    const content = [
+      '[Jump to section](#section)',
+      '[Email us](mailto:hello@example.com)',
+    ].join('\n\n')
+    render(<MarkdownRenderer content={content} />)
+
+    for (const name of ['Jump to section', 'Email us']) {
+      const link = screen.getByRole('link', { name })
+      expect(link).not.toHaveAttribute('target')
+      expect(link).not.toHaveAttribute('rel')
+    }
+  })
+
   it('uses authenticated preview fallback for non-uuid file: images', async () => {
     apiRequestMock.mockResolvedValue({ ok: false })
     const content = '![final image](file:output/screenshot.png)'

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -693,6 +693,14 @@ describe('MarkdownRenderer', () => {
     expect(image).toHaveAttribute('src', './a.png')
   })
 
+  it('opens ordinary external links in a new tab', () => {
+    render(<MarkdownRenderer content="[Google](https://www.google.com)" />)
+
+    const link = screen.getByRole('link', { name: 'Google' })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
   it('uses authenticated preview fallback for non-uuid file: images', async () => {
     apiRequestMock.mockResolvedValue({ ok: false })
     const content = '![final image](file:output/screenshot.png)'

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -52,7 +52,10 @@ vi.mock('@/contexts/i18n-context', () => ({
 }))
 
 import { JsonRenderer, MarkdownRenderer } from '../markdown-renderer'
-import { AgentCardPresentationCapability } from '@/contexts/presentation-capabilities'
+import {
+  AgentCardPresentationCapability,
+  LinksOpenInNewTabCapability,
+} from '@/contexts/presentation-capabilities'
 import {
   getFilesDisabledPresentationFileLabel,
   projectFilesDisabledPresentation,
@@ -695,20 +698,28 @@ describe('MarkdownRenderer', () => {
     expect(image).toHaveAttribute('src', './a.png')
   })
 
-  it('opens ordinary links in a new tab only when linksOpenInNewTab is enabled', () => {
-    render(<MarkdownRenderer content="[Google](https://www.google.com)" linksOpenInNewTab />)
+  it('opens ordinary links in a new tab only when the LinksOpenInNewTab capability is enabled', () => {
+    render(
+      <LinksOpenInNewTabCapability.Provider value={true}>
+        <MarkdownRenderer content="[Google](https://www.google.com)" />
+      </LinksOpenInNewTabCapability.Provider>,
+    )
 
     const link = screen.getByRole('link', { name: 'Google' })
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
-  it('keeps in-page anchor links and mailto links in the current tab even when linksOpenInNewTab is enabled', () => {
+  it('keeps in-page anchor links and mailto links in the current tab even when the capability is enabled', () => {
     const content = [
       '[Jump to section](#section)',
       '[Email us](mailto:hello@example.com)',
     ].join('\n\n')
-    render(<MarkdownRenderer content={content} linksOpenInNewTab />)
+    render(
+      <LinksOpenInNewTabCapability.Provider value={true}>
+        <MarkdownRenderer content={content} />
+      </LinksOpenInNewTabCapability.Provider>,
+    )
 
     for (const name of ['Jump to section', 'Email us']) {
       const link = screen.getByRole('link', { name })

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -18,7 +18,9 @@ import {
 import { getApiUrl } from '@/lib/utils'
 import {
   AgentCardPresentationCapability,
+  LinksOpenInNewTabCapability,
   resolveAgentCardPresentationCapability,
+  resolveLinksOpenInNewTabCapability,
 } from '@/contexts/presentation-capabilities'
 import {
   isManagedFileUrl,
@@ -61,6 +63,7 @@ interface MarkdownRendererProps {
   className?: string
   filesDisabled?: boolean
   agentCardsEnabled?: boolean
+  linksOpenInNewTab?: boolean
   onFileClick?: (filePath: string, fileName: string) => void
   onAgentClick?: (agentId: string, agentName: string) => void
 }
@@ -260,6 +263,7 @@ function containsPreviewFileLinkNode(node: any): boolean {
 type MarkdownRendererContextValue = {
   filesDisabled: boolean
   agentCardsEnabled: boolean
+  linksOpenInNewTab: boolean
   onFileClick?: (filePath: string, fileName: string) => void
   onAgentClick?: (agentId: string, agentName: string) => void
   openLabel: string
@@ -309,6 +313,7 @@ function MarkdownLink({
   const {
     filesDisabled,
     agentCardsEnabled,
+    linksOpenInNewTab,
     onFileClick,
     onAgentClick,
     openLabel,
@@ -404,15 +409,15 @@ function MarkdownLink({
     return <span>{presentationChildren}</span>
   }
 
-  const opensInNewTab = Boolean(href) && !/^(#|mailto:|tel:)/i.test(href ?? '')
+  const opensInNewTab = linksOpenInNewTab && !!href && !/^(#|mailto:)/i.test(href)
 
   return (
     <a
+      {...props}
       href={href || undefined}
       title={presentationTitle || undefined}
       target={opensInNewTab ? '_blank' : undefined}
       rel={opensInNewTab ? 'noopener noreferrer' : undefined}
-      {...props}
     >
       {presentationChildren}
     </a>
@@ -496,6 +501,7 @@ export function MarkdownRenderer({
   className = '',
   filesDisabled = false,
   agentCardsEnabled,
+  linksOpenInNewTab,
   onFileClick,
   onAgentClick,
 }: MarkdownRendererProps) {
@@ -506,16 +512,22 @@ export function MarkdownRenderer({
     agentCardsEnabled,
     inheritedAgentCardsEnabled,
   )
+  const inheritedLinksOpenInNewTab = React.useContext(LinksOpenInNewTabCapability)
+  const resolvedLinksOpenInNewTab = resolveLinksOpenInNewTabCapability(
+    linksOpenInNewTab,
+    inheritedLinksOpenInNewTab,
+  )
   const contextValue = React.useMemo<MarkdownRendererContextValue>(
     () => ({
       filesDisabled,
       agentCardsEnabled: resolvedAgentCardsEnabled,
+      linksOpenInNewTab: resolvedLinksOpenInNewTab,
       onFileClick,
       onAgentClick,
       openLabel: t('files.previewDialog.buttons.open'),
       loadErrorText: t('files.previewDialog.errors.loadFailed'),
     }),
-    [filesDisabled, onFileClick, onAgentClick, resolvedAgentCardsEnabled, t]
+    [filesDisabled, onFileClick, onAgentClick, resolvedAgentCardsEnabled, resolvedLinksOpenInNewTab, t]
   )
   const displayContent = filesDisabled
     ? sanitizeFilesDisabledPresentationText(content)

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -405,7 +405,13 @@ function MarkdownLink({
   }
 
   return (
-    <a href={href || undefined} title={presentationTitle || undefined} {...props}>
+    <a
+      href={href || undefined}
+      title={presentationTitle || undefined}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...props}
+    >
       {presentationChildren}
     </a>
   )

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -20,7 +20,6 @@ import {
   AgentCardPresentationCapability,
   LinksOpenInNewTabCapability,
   resolveAgentCardPresentationCapability,
-  resolveLinksOpenInNewTabCapability,
 } from '@/contexts/presentation-capabilities'
 import {
   isManagedFileUrl,
@@ -63,7 +62,6 @@ interface MarkdownRendererProps {
   className?: string
   filesDisabled?: boolean
   agentCardsEnabled?: boolean
-  linksOpenInNewTab?: boolean
   onFileClick?: (filePath: string, fileName: string) => void
   onAgentClick?: (agentId: string, agentName: string) => void
 }
@@ -409,7 +407,8 @@ function MarkdownLink({
     return <span>{presentationChildren}</span>
   }
 
-  const opensInNewTab = linksOpenInNewTab && !!href && !/^(#|mailto:)/i.test(href)
+  const opensInNewTab = linksOpenInNewTab && !!href
+    && !(href.startsWith('#') || href.toLowerCase().startsWith('mailto:'))
 
   return (
     <a
@@ -501,7 +500,6 @@ export function MarkdownRenderer({
   className = '',
   filesDisabled = false,
   agentCardsEnabled,
-  linksOpenInNewTab,
   onFileClick,
   onAgentClick,
 }: MarkdownRendererProps) {
@@ -512,22 +510,18 @@ export function MarkdownRenderer({
     agentCardsEnabled,
     inheritedAgentCardsEnabled,
   )
-  const inheritedLinksOpenInNewTab = React.useContext(LinksOpenInNewTabCapability)
-  const resolvedLinksOpenInNewTab = resolveLinksOpenInNewTabCapability(
-    linksOpenInNewTab,
-    inheritedLinksOpenInNewTab,
-  )
+  const linksOpenInNewTab = React.useContext(LinksOpenInNewTabCapability)
   const contextValue = React.useMemo<MarkdownRendererContextValue>(
     () => ({
       filesDisabled,
       agentCardsEnabled: resolvedAgentCardsEnabled,
-      linksOpenInNewTab: resolvedLinksOpenInNewTab,
+      linksOpenInNewTab,
       onFileClick,
       onAgentClick,
       openLabel: t('files.previewDialog.buttons.open'),
       loadErrorText: t('files.previewDialog.errors.loadFailed'),
     }),
-    [filesDisabled, onFileClick, onAgentClick, resolvedAgentCardsEnabled, resolvedLinksOpenInNewTab, t]
+    [filesDisabled, onFileClick, onAgentClick, resolvedAgentCardsEnabled, linksOpenInNewTab, t]
   )
   const displayContent = filesDisabled
     ? sanitizeFilesDisabledPresentationText(content)

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -404,12 +404,14 @@ function MarkdownLink({
     return <span>{presentationChildren}</span>
   }
 
+  const opensInNewTab = Boolean(href) && !/^(#|mailto:|tel:)/i.test(href ?? '')
+
   return (
     <a
       href={href || undefined}
       title={presentationTitle || undefined}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={opensInNewTab ? '_blank' : undefined}
+      rel={opensInNewTab ? 'noopener noreferrer' : undefined}
       {...props}
     >
       {presentationChildren}

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -170,6 +170,7 @@ function expectPublicProviderToken() {
   expect(app.provider?.transport?.capabilities).toEqual({
     agentCards: "disabled",
     voice: "disabled",
+    linksOpenInNewTab: "enabled",
   })
   expect(app.startScreenProps?.voiceInputEnabled).toBe(false)
   expect(app.provider?.transport?.buildWebSocketUrl?.({
@@ -578,6 +579,9 @@ describe("PublicAgentChatPage", () => {
       taskId: 42,
       token: app.provider?.token,
     })).toBe("wss://api.example/api/share/chat/ws/42?token=public-access-token")
+    // A share visitor already has the full page; unlike the embedded widget
+    // iframe, an in-tab navigation away from it is ordinary browser behavior.
+    expect(app.provider?.transport?.capabilities?.linksOpenInNewTab).toBe("disabled")
   })
 
   it("reuses a persisted, unexpired share token without re-authing", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -591,6 +591,10 @@ export function PublicAgentChatPage({
     capabilities: {
       agentCards: "disabled",
       voice: "disabled",
+      // Only the embedded widget iframe needs this: a "share" visitor already
+      // has the page to themselves, so an in-tab navigation away from it is
+      // ordinary browser behavior, not a lost conversation.
+      linksOpenInNewTab: authMode === "widget" ? "enabled" : "disabled",
     },
     buildWebSocketUrl: ({ baseUrl, taskId, token }) =>
       `${baseUrl}/${authMode === "share" ? "api/share" : "api/widget"}/chat/ws/${taskId}${token ? `?token=${token}` : ""}`,

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -591,9 +591,10 @@ export function PublicAgentChatPage({
     capabilities: {
       agentCards: "disabled",
       voice: "disabled",
-      // Only the embedded widget iframe needs this: a "share" visitor already
-      // has the page to themselves, so an in-tab navigation away from it is
-      // ordinary browser behavior, not a lost conversation.
+      // Widget mode covers both the embedded iframe and direct top-level
+      // visits to the widget URL; in either case the conversation has no
+      // other home, so an in-tab navigation loses it. A "share" visitor has
+      // an ordinary full page, where in-tab navigation is expected behavior.
       linksOpenInNewTab: authMode === "widget" ? "enabled" : "disabled",
     },
     buildWebSocketUrl: ({ baseUrl, taskId, token }) =>

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -199,6 +199,11 @@ describe("SessionAgentChatPage", () => {
       voice: "disabled",
       taskControls: "disabled",
     })
+    // The session page always serves the widget surface, so links must leave
+    // the conversation in place by opening a new tab.
+    expect(app.provider?.transport?.capabilities).toEqual({
+      linksOpenInNewTab: "enabled",
+    })
   })
 
   it("constructs the exact active Session transport and does not leak credentials", () => {

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -261,6 +261,11 @@ export function SessionAgentChatPage() {
   }, [bridge.session, bridge.status])
 
   const transport = useMemo<AppProviderTransportConfig>(() => ({
+    capabilities: {
+      // This page only renders for the embedded widget's session-resume
+      // route, so an in-tab navigation always abandons the visitor's iframe.
+      linksOpenInNewTab: "enabled",
+    },
     session: {
       connection,
       onConnectionClose: bridge.handleConnectionClose,

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -3268,4 +3268,30 @@ describe("AppProvider websocket message routing", () => {
     expect(container.querySelector("[data-agent-card-wrapper]")).toBeNull()
     expect(apiRequestMock).not.toHaveBeenCalled()
   })
+
+  it("opens markdown links in a new tab only when the transport enables linksOpenInNewTab", () => {
+    const { unmount } = render(
+      <AppProvider
+        token="public-token"
+        transport={{ capabilities: { linksOpenInNewTab: "enabled" } }}
+      >
+        <MarkdownRenderer content="[Docs](https://example.com/docs)" />
+      </AppProvider>,
+    )
+
+    const widgetLink = screen.getByRole("link", { name: "Docs" })
+    expect(widgetLink).toHaveAttribute("target", "_blank")
+    expect(widgetLink).toHaveAttribute("rel", "noopener noreferrer")
+    unmount()
+
+    render(
+      <AppProvider token="public-token" transport={{ capabilities: {} }}>
+        <MarkdownRenderer content="[Docs](https://example.com/docs)" />
+      </AppProvider>,
+    )
+
+    const defaultLink = screen.getByRole("link", { name: "Docs" })
+    expect(defaultLink).not.toHaveAttribute("target")
+    expect(defaultLink).not.toHaveAttribute("rel")
+  })
 })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { ClarificationForm } from "@/components/chat/clarification-form"
 import {
   AgentCardPresentationCapability,
+  LinksOpenInNewTabCapability,
   resolveAgentCardPresentationCapability,
 } from "@/contexts/presentation-capabilities"
 import {
@@ -1510,6 +1511,10 @@ export interface AppProviderTransportCapabilities {
   agentCards?: TransportCapabilityState
   voice?: TransportCapabilityState
   taskControls?: TransportCapabilityState
+  // Unlike the capabilities above, this defaults closed for every transport
+  // (including "page"): only the embedded Chat Widget opts in, since that is
+  // the only surface where an in-tab navigation abandons the visitor's iframe.
+  linksOpenInNewTab?: TransportCapabilityState
 }
 
 export interface AppProviderTransportConfig {
@@ -1672,6 +1677,11 @@ export function AppProvider({
     filesDisabled,
     requestedAgentCardsEnabled,
   )
+  // Deliberately not resolveTransportCapability: that helper defaults every
+  // other capability to "enabled" for non-session transports, which is the
+  // wrong default here — this must stay off everywhere except the transports
+  // that explicitly request it.
+  const linksOpenInNewTab = transport?.capabilities?.linksOpenInNewTab === "enabled"
   const voiceInputEnabled = resolveTransportCapability(
     sessionTransport,
     sessionTransport?.voice,
@@ -5994,6 +6004,7 @@ export function AppProvider({
 
   return (
     <AgentCardPresentationCapability.Provider value={agentCardsEnabled}>
+      <LinksOpenInNewTabCapability.Provider value={linksOpenInNewTab}>
       <FileAccessProvider policy={transport?.fileAccess}>
         <AppContext.Provider
         value={{
@@ -6036,6 +6047,7 @@ export function AppProvider({
         {children}
         </AppContext.Provider>
       </FileAccessProvider>
+      </LinksOpenInNewTabCapability.Provider>
     </AgentCardPresentationCapability.Provider>
   )
 }

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -6005,48 +6005,48 @@ export function AppProvider({
   return (
     <AgentCardPresentationCapability.Provider value={agentCardsEnabled}>
       <LinksOpenInNewTabCapability.Provider value={linksOpenInNewTab}>
-      <FileAccessProvider policy={transport?.fileAccess}>
-        <AppContext.Provider
-        value={{
-        state,
-        dispatch,
-        filesDisabled,
-        agentCardsEnabled,
-        voiceInputEnabled,
-        taskControlsEnabled,
-        sendMessage,
-        executeTask,
-        pauseTask,
-        resumeTask,
-        selectStep,
-        clearMessages,
-        isConnected,
-        connectionError,
-        startNewConversation,
-        isConversationResetPending:
-          state.sessionConversation.phase === "reset_requested",
-        isMessageDeliveryPending: messageDeliveryCount > 0,
-        isSessionInteractionLocked:
-          state.sessionConversation.phase === "reload_required",
-        sessionConversationState: state.sessionConversation.phase,
-        setTaskId,
-        requestStatus,
-        getFilePreviewUrl,
-        getFileDownloadUrl,
-        openFilePreview,
-        switchFilePreview,
-        closeFilePreview,
-        startReplay,
-        stopReplay,
-        setReplayPlaying,
-        setReplaySpeed,
-        setReplayProgress,
-        setPendingMessage,
-        }}
-      >
-        {children}
-        </AppContext.Provider>
-      </FileAccessProvider>
+        <FileAccessProvider policy={transport?.fileAccess}>
+          <AppContext.Provider
+          value={{
+          state,
+          dispatch,
+          filesDisabled,
+          agentCardsEnabled,
+          voiceInputEnabled,
+          taskControlsEnabled,
+          sendMessage,
+          executeTask,
+          pauseTask,
+          resumeTask,
+          selectStep,
+          clearMessages,
+          isConnected,
+          connectionError,
+          startNewConversation,
+          isConversationResetPending:
+            state.sessionConversation.phase === "reset_requested",
+          isMessageDeliveryPending: messageDeliveryCount > 0,
+          isSessionInteractionLocked:
+            state.sessionConversation.phase === "reload_required",
+          sessionConversationState: state.sessionConversation.phase,
+          setTaskId,
+          requestStatus,
+          getFilePreviewUrl,
+          getFileDownloadUrl,
+          openFilePreview,
+          switchFilePreview,
+          closeFilePreview,
+          startReplay,
+          stopReplay,
+          setReplayPlaying,
+          setReplaySpeed,
+          setReplayProgress,
+          setPendingMessage,
+          }}
+        >
+          {children}
+          </AppContext.Provider>
+        </FileAccessProvider>
       </LinksOpenInNewTabCapability.Provider>
     </AgentCardPresentationCapability.Provider>
   )

--- a/frontend/src/contexts/presentation-capabilities.tsx
+++ b/frontend/src/contexts/presentation-capabilities.tsx
@@ -16,13 +16,6 @@ export function resolveAgentCardPresentationCapability(
 
 // Off by default so every existing MarkdownRenderer consumer (skill-hub docs,
 // the file viewer, conversation logs, ...) keeps opening links in the same
-// tab. AppProvider turns this on only for the embedded Chat Widget, where an
-// in-tab navigation would carry the visitor's iframe away from the page.
+// tab. AppProvider turns this on only for the Chat Widget surface, where an
+// in-tab navigation would carry the visitor away from the conversation.
 export const LinksOpenInNewTabCapability = React.createContext(false)
-
-export function resolveLinksOpenInNewTabCapability(
-  requestedLinksOpenInNewTab: boolean | undefined,
-  inheritedLinksOpenInNewTab = false,
-): boolean {
-  return requestedLinksOpenInNewTab ?? inheritedLinksOpenInNewTab
-}

--- a/frontend/src/contexts/presentation-capabilities.tsx
+++ b/frontend/src/contexts/presentation-capabilities.tsx
@@ -13,3 +13,16 @@ export function resolveAgentCardPresentationCapability(
 ): boolean {
   return !filesDisabled && (requestedAgentCards ?? inheritedAgentCards)
 }
+
+// Off by default so every existing MarkdownRenderer consumer (skill-hub docs,
+// the file viewer, conversation logs, ...) keeps opening links in the same
+// tab. AppProvider turns this on only for the embedded Chat Widget, where an
+// in-tab navigation would carry the visitor's iframe away from the page.
+export const LinksOpenInNewTabCapability = React.createContext(false)
+
+export function resolveLinksOpenInNewTabCapability(
+  requestedLinksOpenInNewTab: boolean | undefined,
+  inheritedLinksOpenInNewTab = false,
+): boolean {
+  return requestedLinksOpenInNewTab ?? inheritedLinksOpenInNewTab
+}


### PR DESCRIPTION
## Summary
- Clicking an ordinary link in an AI reply inside the embedded Chat Widget (an iframe on a third-party site) navigated the iframe itself away from the conversation instead of opening a new tab
- `MarkdownLink` now renders `target="_blank"` and `rel="noopener noreferrer"` for real navigations (not in-page anchors or `mailto:` links), matching how external links are already handled elsewhere in the repo (sidebar, inline-file-preview, etc.)
- The behavior is scoped to the widget via a new `LinksOpenInNewTabCapability` context (same pattern as `AgentCardPresentationCapability`): off by default for every `MarkdownRenderer` consumer (skill-hub docs, file viewer, conversation logs, share pages, ...), enabled only by the two widget entry points (`PublicAgentChatPage` in widget mode and `SessionAgentChatPage`)
- `file:` (file preview) and `agent:` (agent card) links go through their own dedicated branches and are unaffected

## Test plan
- [x] `npx vitest run src/components/ui/__tests__/markdown-renderer.test.tsx` (38 tests pass: target/rel applied only when the capability is enabled; anchors/mailto stay same-tab; javascript:/empty hrefs never get target/rel; relative links unchanged by default)
- [x] `npx vitest run` full frontend suite (only pre-existing kb test failures, reproduced on the base branch)
- [x] `npx tsc --noEmit` passes
- [x] Manually click a link in a live Chat Widget (valid token + backend) to confirm it opens a new tab