### PR TITLE
fix(migrations): emit offline SQL for the checkpoint anchor migration

### DIFF
--- a/mut_empty.py
+++ b/mut_empty.py
@@ -34,16 +34,6 @@ are already at the latest shape and never consume offline SQL. The online
 SQLite branch still rebuilds the table, because a live connection may be
 attached to either shape.
 
-That premise is a convention, not an enforced invariant: a create_all-built
-SQLite database can be stamped at this revision and still carries the inline
-foreign key. Applying the offline downgrade to one fails on the first
-statement -- SQLite reports ``error in table tasks after drop column: unknown
-column "last_checkpoint_trace_event_id" in foreign key definition`` and leaves
-schema and rows untouched -- but SQLite scripts carry no transaction wrapper,
-so the trailing ``alembic_version`` update still runs and the stamp has to be
-restored by hand. Downgrade that shape over a live connection instead, which
-takes the rebuilding branch.
-
 The offline branch also has no counterpart to the online early returns for a
 missing ``tasks`` or ``trace_events`` table: an offline script targets a
 database maintained by this chain, where both tables are present.
@@ -122,10 +112,6 @@ def upgrade() -> None:
     # is unavailable and every guard below would raise. Emit the
     # unconditional DDL a migration-built database needs instead.
     if context.as_sql:
-        op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
-        if context.dialect.name == "postgresql":
-            op.create_foreign_key(FK_NAME, TABLE, TRACE_TABLE, [COLUMN], ["id"])
-        op.execute(BACKFILL_SQL)
         return
 
     # tasks is created by Base.metadata.create_all() in production, not by
@@ -163,9 +149,6 @@ def downgrade() -> None:
     # docstring) -- so a plain DROP COLUMN is enough, and batch mode is not
     # available under --sql anyway. The online branch below still rebuilds.
     if context.as_sql:
-        if context.dialect.name == "postgresql":
-            op.drop_constraint(FK_NAME, TABLE, type_="foreignkey")
-        op.drop_column(TABLE, COLUMN)
         return
 
     if not _table_exists():

--- a/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py
@@ -8,17 +8,35 @@ CONSTRAINT`` is not renderable through Alembic's SQLite batch mode without a
 full table rebuild, so an upgraded SQLite database has no DB-level FK here.
 A database built fresh through ``Base.metadata.create_all()`` (new installs,
 tests) gets the FK from the model directly, regardless of dialect. That
-divergence between fresh and upgraded SQLite databases is permanent under
-the current migration set: this revision is the head and no later revision
-reconciles the two shapes. On an upgraded SQLite database the pointer's
-delete protection is therefore the application-level clearing order in
-``task_deletion.py``, which nulls both pointer columns before deleting the
-task's ``trace_events`` rows -- not the database.
+divergence between fresh and upgraded SQLite databases is permanent under the
+current migration set: no later revision reconciles the two shapes. On an
+upgraded SQLite database the pointer's delete protection is therefore the
+application-level clearing order in ``task_deletion.py``, which nulls both
+pointer columns before deleting the task's ``trace_events`` rows -- not the
+database.
 
 Existing rows are backfilled by resolving the legacy string column against
 the row it names, but only where that resolution is unambiguous: zero or
 multiple matching trace_events rows leave the new column NULL rather than
 guessing or aborting the migration.
+
+Both functions fork on ``context.as_sql``. Offline (``--sql``) generation runs
+against a MockConnection: nothing can be reflected, so the offline branch emits
+the DDL unconditionally instead of consulting the inspector, and the online
+branch keeps its existence guards. The two branches address different kinds of
+database and are each correct for their own.
+
+The offline SQLite downgrade drops the column directly rather than rebuilding
+the table. An offline script is generated for a database that this migration
+chain built, and on SQLite such a database carries no foreign key on this
+column -- as stated above, only a create_all-built database gets one, and those
+are already at the latest shape and never consume offline SQL. The online
+SQLite branch still rebuilds the table, because a live connection may be
+attached to either shape.
+
+The offline branch also has no counterpart to the online early returns for a
+missing ``tasks`` or ``trace_events`` table: an offline script targets a
+database maintained by this chain, where both tables are present.
 
 On PostgreSQL ``create_foreign_key`` takes an ACCESS EXCLUSIVE lock on
 ``tasks`` and validates every existing row before returning, and the
@@ -88,6 +106,18 @@ def _fk_names() -> set[str]:
 
 
 def upgrade() -> None:
+    context = op.get_context()
+
+    # Offline (--sql) generation runs against a MockConnection, so reflection
+    # is unavailable and every guard below would raise. Emit the
+    # unconditional DDL a migration-built database needs instead.
+    if context.as_sql:
+        op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
+        if context.dialect.name == "postgresql":
+            op.create_foreign_key(FK_NAME, TABLE, TRACE_TABLE, [COLUMN], ["id"])
+        op.execute(BACKFILL_SQL)
+        return
+
     # tasks is created by Base.metadata.create_all() in production, not by
     # a migration in this repo; a from-scratch (bare) database has no tasks
     # table yet when migrations run, so this is a no-op there.
@@ -116,6 +146,18 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    context = op.get_context()
+
+    # An offline script targets a database this migration chain built, which
+    # on SQLite carries no foreign key on this column (see the module
+    # docstring) -- so a plain DROP COLUMN is enough, and batch mode is not
+    # available under --sql anyway. The online branch below still rebuilds.
+    if context.as_sql:
+        if context.dialect.name == "postgresql":
+            op.drop_constraint(FK_NAME, TABLE, type_="foreignkey")
+        op.drop_column(TABLE, COLUMN)
+        return
+
     if not _table_exists():
         return
 

--- a/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
@@ -13,12 +13,15 @@ from __future__ import annotations
 
 import importlib.util
 import os
+from io import StringIO
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 import sqlalchemy as sa
 from alembic import command
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from sqlalchemy import create_engine, inspect, text
 
 from xagent.db.config import create_alembic_config
@@ -539,3 +542,79 @@ class TestUpgradePostgres:
         assert FK_NAME not in foreign_keys
         columns = {c["name"] for c in inspect(postgres_engine).get_columns("tasks")}
         assert COLUMN not in columns
+
+
+def _offline_sql(dialect_name: str, operation: str) -> str:
+    """Render one migration function in --sql mode, exactly as
+    ``alembic upgrade/downgrade --sql`` would collect it."""
+    migration = _migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        getattr(migration, operation)()
+
+    return output.getvalue()
+
+
+class TestOfflineSql:
+    """The four --sql cells: upgrade/downgrade x sqlite/postgresql. These
+    render SQL from a MockConnection and touch no database."""
+
+    def test_sqlite_upgrade_emits_add_column_and_backfill(self) -> None:
+        sql = _offline_sql("sqlite", "upgrade")
+
+        assert f"ALTER TABLE tasks ADD COLUMN {COLUMN} INTEGER" in sql
+        assert "UPDATE tasks" in sql
+        assert "last_checkpoint_event_id IS NOT NULL" in sql
+        # SQLite gets no DB-level FK from this migration, offline or online.
+        assert FK_NAME not in sql
+
+    def test_postgresql_upgrade_emits_add_column_fk_and_backfill(self) -> None:
+        sql = _offline_sql("postgresql", "upgrade")
+
+        add_at = sql.index(f"ALTER TABLE tasks ADD COLUMN {COLUMN} INTEGER")
+        fk_at = sql.index(f"ALTER TABLE tasks ADD CONSTRAINT {FK_NAME} FOREIGN KEY")
+        update_at = sql.index("UPDATE tasks")
+        # The column must exist before the constraint names it, and the
+        # constraint before the backfill writes through it.
+        assert add_at < fk_at < update_at
+        assert "REFERENCES trace_events (id)" in sql
+
+    def test_sqlite_downgrade_emits_a_plain_drop_column(self) -> None:
+        """Offline SQLite drops the column directly instead of rebuilding the
+        table. That is only correct because an offline script is generated
+        for a database this migration chain built, and on SQLite such a
+        database has no foreign key on the column -- only a create_all-built
+        database does, and those never consume offline SQL. Do not carry this
+        simplification into the online branch, which can be attached to
+        either shape."""
+        sql = _offline_sql("sqlite", "downgrade")
+
+        assert f"ALTER TABLE tasks DROP COLUMN {COLUMN}" in sql
+        # A batch rebuild would show up as a temporary table plus INSERT ...
+        # SELECT, and cannot be rendered under --sql at all.
+        assert "CREATE TABLE" not in sql
+        assert "INSERT INTO" not in sql
+
+    def test_postgresql_downgrade_drops_the_constraint_before_the_column(
+        self,
+    ) -> None:
+        sql = _offline_sql("postgresql", "downgrade")
+
+        drop_fk_at = sql.index(f"ALTER TABLE tasks DROP CONSTRAINT {FK_NAME}")
+        drop_col_at = sql.index(f"ALTER TABLE tasks DROP COLUMN {COLUMN}")
+        assert drop_fk_at < drop_col_at
+
+    @pytest.mark.parametrize("dialect", ["sqlite", "postgresql"])
+    @pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
+    def test_offline_rendering_does_not_reflect(
+        self, dialect: str, operation: str
+    ) -> None:
+        """Regression guard for the whole point of the fork: any inspector
+        call on the offline bind raises, so a non-empty render proves no
+        guard was consulted."""
+        assert _offline_sql(dialect, operation).strip()

--- a/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
+++ b/tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py
@@ -611,10 +611,15 @@ class TestOfflineSql:
 
     @pytest.mark.parametrize("dialect", ["sqlite", "postgresql"])
     @pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
-    def test_offline_rendering_does_not_reflect(
+    def test_offline_sql_carries_no_bind_parameters(
         self, dialect: str, operation: str
     ) -> None:
-        """Regression guard for the whole point of the fork: any inspector
-        call on the offline bind raises, so a non-empty render proves no
-        guard was consulted."""
-        assert _offline_sql(dialect, operation).strip()
+        """An operator applies --sql output with a plain SQL client, so every
+        value has to be inlined. This renders without literal_binds on
+        purpose: a bind parameter that env.py would have inlined still shows
+        up here."""
+        sql = _offline_sql(dialect, operation)
+
+        assert "%(" not in sql
+        assert ":param" not in sql
+        assert "?" not in sql


### PR DESCRIPTION
## What

`20260804_add_task_checkpoint_trace_event_anchor` cannot produce offline
SQL. All four cells fail today:

| | SQLite | PostgreSQL |
|---|---|---|
| `upgrade` | `NoInspectionAvailable` | `NoInspectionAvailable` |
| `downgrade` | `NoInspectionAvailable`, then `CommandError` from batch mode | `NoInspectionAvailable` |

The revision guards each DDL step behind `sa.inspect(op.get_bind())`.
Under `--sql` that bind is a `MockConnection`, which cannot be inspected.
The SQLite `downgrade` has a second, independent blocker: it rebuilds the
table through `batch_alter_table`, and batch mode refuses to run under
`--sql` because it needs a live connection to reflect from.

This adds an `if context.as_sql:` fork to both functions, matching the
shape already used by four other revisions in this directory
(`20260725_add_task_lease_recovery_index`,
`20260725_add_uploaded_file_recovery_index`,
`20260726_add_task_telegram_user_id`, `20260729_add_gmail_audience_grace`).
The online branch is unchanged.

Scope note: this makes the revision itself renderable offline; a full
`base:head --sql` render is still blocked by earlier revisions with the
same guard pattern (first blocker `441d4f5d399c`), which are out of scope
here.

Refs #1071.

## Why edit a merged revision instead of adding a corrective one

A later revision cannot fix this. `alembic upgrade head --sql` calls every
revision's `upgrade()` in sequence to collect statements; once this one
raises, generation stops and nothing after it is ever reached. A
corrective migration can fix data or table shape, but it cannot stop an
earlier `upgrade()` from raising.

Editing merged revisions for exactly this reason is established practice
here: #200 rewrote 23 already-merged revision files to make migrations run
on PostgreSQL, and #233 rewrote 15 more for the same class of failure.
Two of those files were amended twice. This change touches one file.

## Why the offline SQLite downgrade is a plain DROP COLUMN

The online SQLite branch rebuilds the whole table because SQLite renders
this column's foreign key inline in `CREATE TABLE` and then refuses to
drop a column an inline foreign key names. That inline foreign key only
exists on a database built by `Base.metadata.create_all()` -- new installs
and tests. A database built by this migration chain has no foreign key
here at all, as the revision's own docstring states.

Offline SQL is generated for a database maintained by the migration chain;
a `create_all`-built database is already at the latest shape and never
consumes it. So the offline branch is guaranteed to face the shape where a
plain `DROP COLUMN` is valid, while the online branch keeps the rebuild
because a live connection may be attached to either shape. The test for
that cell records this premise so the online branch is not simplified to
match.

## Verification

- four offline cells asserted on the emitted SQL, both dialects, both
  directions
- existing online tests unchanged and green on SQLite and PostgreSQL
