### PR TITLE
feat(task-lease): stamp a per-acquisition attempt identity on the task row

### DIFF
--- a/src/xagent/migrations/versions/20260808_add_task_lease_attempt_id.py
+++ b/src/xagent/migrations/versions/20260808_add_task_lease_attempt_id.py
@@ -1,0 +1,99 @@
+"""add lease attempt identity to tasks
+
+Revision ID: 20260808_add_task_lease_attempt_id
+Revises: 20260807_seed_notion_mcp_app
+Create Date: 2026-08-08
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260808_add_task_lease_attempt_id"
+down_revision: Union[str, None] = "20260807_seed_notion_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "tasks"
+COLUMN = "lease_attempt_id"
+
+# The schema of the *visible* tasks relation. version_table_schema names only
+# the Alembic version table, and current_schema() is merely the first entry on
+# search_path, so neither identifies the relation an unqualified reference
+# actually resolves to. Ask PostgreSQL which one it resolves.
+POSTGRES_VISIBLE_TABLE_SCHEMA_SQL = sa.text(
+    """
+    SELECT ns.nspname
+    FROM pg_catalog.pg_class AS cls
+    JOIN pg_catalog.pg_namespace AS ns ON ns.oid = cls.relnamespace
+    WHERE cls.oid = pg_catalog.to_regclass(:table_name)
+    """
+)
+
+
+def _target_schema() -> str | None:
+    """The schema holding the tasks relation this migration operates on."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        resolved = bind.execute(
+            POSTGRES_VISIBLE_TABLE_SCHEMA_SQL, {"table_name": TABLE}
+        ).scalar()
+        if resolved:
+            return str(resolved)
+    schema = op.get_context().version_table_schema
+    return str(schema) if schema else None
+
+
+def _online_columns(schema: str | None) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names(schema=schema):
+        return set()
+    return {str(item["name"]) for item in inspector.get_columns(TABLE, schema=schema)}
+
+
+def _online_table_exists(schema: str | None) -> bool:
+    return TABLE in sa.inspect(op.get_bind()).get_table_names(schema=schema)
+
+
+def upgrade() -> None:
+    context = op.get_context()
+
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable. Emit the unconditional DDL instead of inspecting. This is
+    # the 20260726 shape, not the inspector-only shape #1137 used -- the
+    # latter raises under --sql on both dialects.
+    if context.as_sql:
+        op.add_column(TABLE, sa.Column(COLUMN, sa.String(length=64), nullable=True))
+        return
+
+    # Address the same relation the catalog lookup inspects, so reflection and
+    # DDL can never diverge onto different schemas.
+    schema = _target_schema()
+
+    if not _online_table_exists(schema):
+        return
+
+    if COLUMN not in _online_columns(schema):
+        op.add_column(
+            TABLE,
+            sa.Column(COLUMN, sa.String(length=64), nullable=True),
+            schema=schema,
+        )
+
+
+def downgrade() -> None:
+    context = op.get_context()
+
+    if context.as_sql:
+        op.drop_column(TABLE, COLUMN)
+        return
+
+    schema = _target_schema()
+
+    if not _online_table_exists(schema):
+        return
+
+    if COLUMN in _online_columns(schema):
+        op.drop_column(TABLE, COLUMN, schema=schema)

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -1512,6 +1512,7 @@ def _finalize_a2a_cancel_sync(
                 control_state=TaskControlState.FAILED.value,
                 state_version=final_state_version,
                 runner_id=None,
+                lease_attempt_id=None,
                 lease_expires_at=None,
                 last_heartbeat_at=None,
                 output=None,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2095,6 +2095,10 @@ def _task_lease_snapshot(task: Any) -> TaskLease | None:
     if task_id is None or runner_id is None or run_id is None:
         return None
     return TaskLease(
+        # attempt_id is left at its None default on purpose: every field here
+        # comes from the task row, so reading lease_attempt_id from that same
+        # row would make any later attempt check compare a value against
+        # itself. See TaskLease's docstring in task_lease_service.py.
         task_id=int(task_id),
         runner_id=str(runner_id),
         run_id=str(run_id),

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -134,6 +134,17 @@ class Task(Base):  # type: ignore
     control_state = Column(
         String(32), nullable=False, default="idle", server_default="idle"
     )
+    # Identity of the lease attempt that currently owns this row. Written
+    # only by acquire_task_lease_no_commit (a fresh uuid per claim) and
+    # cleared by the lease release/recovery writers. A non-NULL value does
+    # not mean that attempt is still running -- it means no writer has
+    # cleared it since. Readers that need liveness must consult runner_id
+    # and lease_expires_at, not this column.
+    #
+    # Deliberately a bare nullable column: no FK, no CHECK, no UNIQUE. It is
+    # never a WHERE predicate -- consumers read the row by primary key and
+    # compare in Python -- so an index would be pure write cost.
+    lease_attempt_id = Column(String(64), nullable=True)
 
     # Model configuration
     model_name = Column(String(255), nullable=True)  # Main model used for the task

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -50,9 +50,35 @@ def _rowcount(result: Any) -> int:
 
 @dataclass(frozen=True)
 class TaskLease:
+    """One runner's claim on one task row.
+
+    ``attempt_id`` names the exact acquisition that produced this lease. It
+    is minted fresh by ``acquire_task_lease_no_commit`` on every successful
+    claim and mirrored into ``tasks.lease_attempt_id`` in the same UPDATE, so
+    a holder can later prove the row still belongs to *its* attempt rather
+    than to a successor that reused the same ``(runner_id, run_id)`` tuple.
+
+    ``attempt_id is None`` is a fail-open sentinel with two distinct sources:
+
+    * a lease acquired by a worker running code from before this column
+      existed -- a rolling-restart window that closes on its own once every
+      worker has restarted; and
+    * ``_task_lease_snapshot`` in ``websocket.py``, which reconstructs an
+      ambient lease from an already-loaded task row. That one carries None
+      permanently and on purpose: every one of its fields is read from the
+      task row, so populating ``attempt_id`` from the same row would make any
+      later ``task.lease_attempt_id != lease.attempt_id`` check compare a
+      value against itself -- an always-passing fence, which is strictly
+      worse than an explicit None that callers can detect and skip.
+
+    Consumers must therefore treat None as "cannot prove attempt identity"
+    and fall back to whatever fence they already had, never as "matches".
+    """
+
     task_id: int
     runner_id: str
     run_id: str | None = None
+    attempt_id: str | None = None
 
 
 _CURRENT_TASK_LEASE: ContextVar[TaskLease | None] = ContextVar(
@@ -567,6 +593,11 @@ def recover_expired_task_lease_no_commit(
         "control_state": control_state_for_status(status).value,
         "state_version": func.coalesce(Task.state_version, 0) + 1,
         "error_message": error_message,
+        # Defence in depth: the column must never outlive the attempt that
+        # wrote it. This writer already NULLs runner_id, so no live fence
+        # depends on the value -- clearing it keeps the column honest for
+        # anyone who reads it directly.
+        "lease_attempt_id": None,
     }
     if status == TaskStatus.FAILED:
         values["output"] = None
@@ -647,6 +678,7 @@ def acquire_task_lease_no_commit(
     now = utc_now()
     expires_at = task_lease_expires_at(now)
     candidate_run_id = expected_run_id or str(uuid.uuid4())
+    attempt_id = str(uuid.uuid4())
     current_version = func.coalesce(Task.state_version, 0)
     running_control_state = control_state_for_status(TaskStatus.RUNNING).value
     values: dict[str, Any] = {
@@ -661,6 +693,14 @@ def acquire_task_lease_no_commit(
         "state_version": lease_state_version_case(
             TaskStatus.RUNNING, running_control_state, current_version
         ),
+        # A fresh identity for this exact claim. Every successful acquisition
+        # mints a new one; no other writer ever assigns a value here (the
+        # release/recovery writers only clear it). That is precisely what
+        # state_version cannot offer -- _apply_pause_requested_isolated bumps
+        # state_version mid-run without changing attempt ownership, so a
+        # state_version fence pinned at acquisition would reject a legitimate
+        # finalizer that had been paused.
+        "lease_attempt_id": attempt_id,
     }
     if new_run:
         values["last_checkpoint_event_id"] = None
@@ -701,6 +741,7 @@ def acquire_task_lease_no_commit(
         task_id=task_id,
         runner_id=runner,
         run_id=str(stored_run_id) if stored_run_id is not None else None,
+        attempt_id=values["lease_attempt_id"],
     )
 
 
@@ -883,6 +924,7 @@ def release_task_lease_no_commit(
         "state_version": lease_state_version_case(
             status, control_state, current_version
         ),
+        "lease_attempt_id": None,
     }
     if status in _NON_TERMINAL_RELEASE_STATUSES:
         values["error_message"] = None
@@ -930,6 +972,7 @@ def fail_and_release_task_lease_no_commit(
             state_version=func.coalesce(Task.state_version, 0) + 1,
             error_message=error_message,
             output=None,
+            lease_attempt_id=None,
         )
     )
     result = db.execute(stmt.execution_options(synchronize_session=False))
@@ -963,6 +1006,7 @@ def release_current_runner_task_lease(
             state_version=lease_state_version_case(
                 status, control_state, current_version
             ),
+            lease_attempt_id=None,
         )
     )
     if expected_run_id is not None:

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -69,7 +69,10 @@ class TaskLease:
       task row, so populating ``attempt_id`` from the same row would make any
       later ``task.lease_attempt_id != lease.attempt_id`` check compare a
       value against itself -- an always-passing fence, which is strictly
-      worse than an explicit None that callers can detect and skip.
+      worse than an explicit None that callers can detect and skip. Today
+      that snapshot only feeds checkpoint fencing via
+      ``bind_task_lease_context`` and never reaches a settlement path, so
+      the permanent None also has no behavioural cost.
 
     Consumers must therefore treat None as "cannot prove attempt identity"
     and fall back to whatever fence they already had, never as "matches".

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -76,6 +76,13 @@ class TaskLease:
 
     Consumers must therefore treat None as "cannot prove attempt identity"
     and fall back to whatever fence they already had, never as "matches".
+
+    The existing lease writers (refresh, release, fail-and-release) do not
+    fence on this column yet, deliberately: rejecting a stale attempt there
+    turns its refresh into a LOST classification and an active cancellation,
+    which is a behavior change that belongs to the first consumer of this
+    column, with its own tests. Until then the pre-existing
+    ``(runner_id, run_id)`` fences are the only guards on those paths.
     """
 
     task_id: int

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -971,6 +971,7 @@ def _claim_turn_no_commit(
                 Task.output: None,
                 Task.error_message: None,
                 Task.runner_id: None,
+                Task.lease_attempt_id: None,
                 Task.lease_expires_at: None,
                 Task.last_heartbeat_at: None,
                 Task.run_id: run_id,

--- a/tests/alembic/test_20260808_add_task_lease_attempt_id.py
+++ b/tests/alembic/test_20260808_add_task_lease_attempt_id.py
@@ -3,7 +3,7 @@
 import importlib.util
 from io import StringIO
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import sqlalchemy as sa
@@ -157,3 +157,54 @@ def test_offline_sql_carries_no_bind_parameters(dialect_name) -> None:
     for sql in (upgrade_sql, downgrade_sql):
         assert "%(" not in sql
         assert ":table_name" not in sql
+
+
+def test_target_schema_resolves_the_visible_tasks_relation() -> None:
+    """version_table_schema names only the Alembic version table and
+    current_schema() is merely the first search_path entry, so neither
+    identifies the relation the unqualified DDL resolves to."""
+
+    migration = _migration_module()
+    sql = str(migration.POSTGRES_VISIBLE_TABLE_SCHEMA_SQL)
+
+    assert "to_regclass" in sql
+    assert "pg_catalog.pg_namespace" in sql
+
+    # Non-PostgreSQL falls back to version_table_schema, and None keeps every
+    # operation on plain unqualified behaviour.
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            assert migration._target_schema() is None
+
+
+def test_target_schema_uses_the_catalog_answer_on_postgresql() -> None:
+    """On PostgreSQL, ``_target_schema`` trusts the catalog lookup over
+    ``version_table_schema`` whenever the catalog resolves the relation, and
+    only falls back to the version table's configured schema when the
+    catalog has nothing to say (e.g. the relation is not visible yet)."""
+
+    migration = _migration_module()
+
+    resolving_op = MagicMock()
+    resolving_op.get_bind.return_value.dialect.name = "postgresql"
+    resolving_op.get_bind.return_value.execute.return_value.scalar.return_value = (
+        "tenant_x"
+    )
+
+    with patch.object(migration, "op", resolving_op):
+        assert migration._target_schema() == "tenant_x"
+
+    resolving_op.get_bind.return_value.execute.assert_called_once_with(
+        migration.POSTGRES_VISIBLE_TABLE_SCHEMA_SQL, {"table_name": TABLE}
+    )
+
+    empty_catalog_op = MagicMock()
+    empty_catalog_op.get_bind.return_value.dialect.name = "postgresql"
+    empty_catalog_op.get_bind.return_value.execute.return_value.scalar.return_value = (
+        None
+    )
+    empty_catalog_op.get_context.return_value.version_table_schema = "fallback_schema"
+
+    with patch.object(migration, "op", empty_catalog_op):
+        assert migration._target_schema() == "fallback_schema"

--- a/tests/alembic/test_20260808_add_task_lease_attempt_id.py
+++ b/tests/alembic/test_20260808_add_task_lease_attempt_id.py
@@ -1,0 +1,159 @@
+"""Tests for the tasks.lease_attempt_id migration (lease attempt identity)."""
+
+import importlib.util
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260808_add_task_lease_attempt_id.py"
+)
+TABLE = "tasks"
+COLUMN = "lease_attempt_id"
+
+
+def _migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "task_lease_attempt_id_migration", MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection: sa.Connection) -> Operations:
+    return Operations(MigrationContext.configure(connection))
+
+
+def _offline_sql(migration, dialect_name: str, operation: str) -> str:
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        getattr(migration, operation)()
+    return output.getvalue()
+
+
+def _legacy_tasks_table(engine) -> None:
+    """Migration-only schema: just the columns this migration reads."""
+    metadata = sa.MetaData()
+    sa.Table(
+        TABLE,
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("runner_id", sa.String(255)),
+        sa.Column("run_id", sa.String(64)),
+    )
+    metadata.create_all(engine)
+
+
+def _column_names(connection) -> set[str]:
+    return {column["name"] for column in sa.inspect(connection).get_columns(TABLE)}
+
+
+def test_online_upgrade_adds_a_nullable_column_and_downgrade_removes_it() -> None:
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+            columns = {c["name"]: c for c in sa.inspect(connection).get_columns(TABLE)}
+            assert COLUMN in columns
+            assert columns[COLUMN]["nullable"] is True
+
+            migration.downgrade()
+            assert COLUMN not in _column_names(connection)
+
+
+def test_online_upgrade_is_idempotent() -> None:
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+            columns = [c["name"] for c in sa.inspect(connection).get_columns(TABLE)]
+            assert columns.count(COLUMN) == 1
+
+
+def test_online_downgrade_is_idempotent_when_column_is_absent() -> None:
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+
+            assert COLUMN not in _column_names(connection)
+
+
+def test_online_upgrade_and_downgrade_noop_without_the_tasks_table() -> None:
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+
+        assert TABLE not in sa.inspect(connection).get_table_names()
+
+
+@pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
+def test_offline_upgrade_emits_plain_add_column_on_both_dialects(dialect_name) -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        upgrade_sql = _offline_sql(migration, dialect_name, "upgrade")
+
+    assert f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} VARCHAR(64)" in upgrade_sql
+    assert "CONCURRENTLY" not in upgrade_sql
+
+
+@pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
+def test_offline_downgrade_emits_plain_drop_column_on_both_dialects(
+    dialect_name,
+) -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        downgrade_sql = _offline_sql(migration, dialect_name, "downgrade")
+
+    assert f"ALTER TABLE {TABLE} DROP COLUMN {COLUMN}" in downgrade_sql
+    assert "CONCURRENTLY" not in downgrade_sql
+
+
+@pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
+def test_offline_sql_carries_no_bind_parameters(dialect_name) -> None:
+    migration = _migration_module()
+
+    upgrade_sql = _offline_sql(migration, dialect_name, "upgrade")
+    downgrade_sql = _offline_sql(migration, dialect_name, "downgrade")
+
+    for sql in (upgrade_sql, downgrade_sql):
+        assert "%(" not in sql
+        assert ":table_name" not in sql

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -2406,6 +2406,7 @@ async def test_direct_cancel_atomically_clears_execution_lease() -> None:
             run_id="run-direct-cancel",
             state_version=6,
             runner_id=get_runner_id(),
+            lease_attempt_id="attempt-direct-cancel",
             lease_expires_at=datetime.now(UTC) + timedelta(minutes=1),
             last_heartbeat_at=datetime.now(UTC),
             agent_id=agent_id,
@@ -2440,6 +2441,7 @@ async def test_direct_cancel_atomically_clears_execution_lease() -> None:
         assert canceled.run_id == "run-direct-cancel"
         assert canceled.state_version == 7
         assert canceled.runner_id is None
+        assert canceled.lease_attempt_id is None
         assert canceled.lease_expires_at is None
         assert canceled.last_heartbeat_at is None
         assert canceled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"

--- a/tests/web/services/test_lease_attempt_pairing.py
+++ b/tests/web/services/test_lease_attempt_pairing.py
@@ -1,0 +1,182 @@
+"""Static guard: the runner id and its attempt id are always cleared together.
+
+``tasks.runner_id`` names who holds the lease and ``tasks.lease_attempt_id``
+names which acquisition minted that hold. Every writer that clears the
+runner must also clear the attempt id in the same statement, or a later
+attempt check could compare a stale ``lease_attempt_id`` left over from a
+finished hold against a live one and treat them as a match. This check is
+the guard that keeps the pair together as call sites are added or edited.
+
+Unlike a plain "does this line mention runner_id" scan, matching here is
+restricted to statements that write through an update carrier -- a call
+whose method name is ``values`` or ``update``, the two SQLAlchemy entry
+points used to build ``UPDATE ... SET`` statements in this codebase. Reads,
+filters, and unrelated constructor/function calls that merely take a
+``runner_id`` keyword (building a ``TaskLease`` snapshot, calling
+``acquire_task_lease_no_commit``) are common and legitimate, and must not be
+flagged.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from xagent.web.api import a2a
+from xagent.web.services import task_lease_service, task_orchestrator
+
+LEASE_COLUMNS = frozenset({"runner_id", "lease_attempt_id"})
+
+CARRIER_METHOD_NAMES = frozenset({"values", "update"})
+
+SUBJECT_MODULES = [
+    task_lease_service,
+    task_orchestrator,
+    a2a,
+]
+
+
+def _mutated_lease_columns(statement: ast.stmt) -> set[str]:
+    """Lease columns this statement writes through an update carrier.
+
+    Only ``Call`` nodes whose method name is ``values`` or ``update`` are
+    considered carriers. Within such a call, both a keyword argument
+    (``.values(runner_id=None)``) and a dict-literal argument
+    (``.update({Task.runner_id: None})`` or ``.update({"runner_id": None})``)
+    count as a write of that column.
+    """
+    found: set[str] = set()
+    for node in ast.walk(statement):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in CARRIER_METHOD_NAMES):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg in LEASE_COLUMNS:
+                found.add(str(keyword.arg))
+        for arg in node.args:
+            if not isinstance(arg, ast.Dict):
+                continue
+            for key in arg.keys:
+                if isinstance(key, ast.Attribute) and key.attr in LEASE_COLUMNS:
+                    found.add(key.attr)
+                elif isinstance(key, ast.Constant) and key.value in LEASE_COLUMNS:
+                    found.add(str(key.value))
+    return found
+
+
+def unpaired_lease_writes(source: str) -> list[tuple[int, tuple[str, ...]]]:
+    """Statement blocks that write one lease column but not the other.
+
+    The pairing unit is the enclosing statement block, not the enclosing
+    function, mirroring the checkpoint-pointer guard this test is modeled
+    on: ``ast.walk`` from a block's statements descends into nested blocks,
+    so an outer block's union is a superset of its children's, and every
+    nested block is also checked on its own iteration.
+    """
+    tree = ast.parse(source)
+    findings: list[tuple[int, tuple[str, ...]]] = []
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if not isinstance(block, list):
+                continue
+            columns: set[str] = set()
+            first_line: int | None = None
+            for statement in block:
+                if not isinstance(statement, ast.stmt):
+                    continue
+                mutated = _mutated_lease_columns(statement)
+                if mutated and first_line is None:
+                    first_line = statement.lineno
+                columns |= mutated
+            if columns and columns != LEASE_COLUMNS:
+                findings.append((first_line or 0, tuple(sorted(columns))))
+    return sorted(set(findings))
+
+
+@pytest.mark.parametrize(
+    "module",
+    SUBJECT_MODULES,
+    ids=lambda module: module.__name__.rsplit(".", 1)[-1],
+)
+def test_lease_columns_are_always_written_in_pairs(module) -> None:
+    source = Path(module.__file__).read_text()
+    unpaired = unpaired_lease_writes(source)
+    assert unpaired == [], (
+        f"{module.__name__} writes runner_id or lease_attempt_id without "
+        f"the other: {unpaired}"
+    )
+
+
+def test_lease_pairing_ignores_a_function_call_keyword_naming_runner_id() -> None:
+    """Negative control: a constructor or plain function call that happens to
+    take a ``runner_id`` keyword is not an update carrier and must not be
+    flagged -- e.g. building a ``TaskLease`` snapshot or calling
+    ``acquire_task_lease_no_commit``."""
+    fixture = """
+def snapshot(task):
+    return TaskLease(task_id=task.id, runner_id=task.runner_id, run_id=task.run_id)
+
+def acquire(db, task_id):
+    return acquire_task_lease_no_commit(db, task_id, runner_id=get_runner_id())
+"""
+    assert unpaired_lease_writes(fixture) == []
+
+
+def test_lease_pairing_ignores_reads_and_filters() -> None:
+    """Negative control: reading or filtering on runner_id is not a mutation."""
+    fixture = """
+def h(db):
+    return db.query(Task.runner_id).filter(Task.runner_id == "x").one_or_none()
+"""
+    assert unpaired_lease_writes(fixture) == []
+
+
+@pytest.mark.parametrize(
+    "carrier,fixture",
+    [
+        (
+            "values_keyword",
+            """
+def write(db, task_id):
+    db.execute(
+        update(Task).where(Task.id == task_id).values(
+            runner_id=None,
+        )
+    )
+""",
+        ),
+        (
+            "update_dict_task_col",
+            """
+def purge(db, task_id):
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.runner_id: None},
+        synchronize_session=False,
+    )
+""",
+        ),
+        (
+            "update_dict_string_key",
+            """
+def purge(db, task_id):
+    db.query(Task).filter(Task.id == task_id).update(
+        {"runner_id": None},
+        synchronize_session=False,
+    )
+""",
+        ),
+    ],
+    ids=["values_keyword", "update_dict_task_col", "update_dict_string_key"],
+)
+def test_lease_pairing_flags_each_carrier_form(carrier: str, fixture: str) -> None:
+    """Positive controls, one per carrier form. Asserted on the flagged column
+    names rather than fixture line numbers, so the controls stay meaningful if
+    the fixture text is reformatted."""
+    unpaired = unpaired_lease_writes(fixture)
+    assert unpaired, carrier
+    assert {columns for _, columns in unpaired} == {("runner_id",)}

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import threading
+import uuid
 from datetime import timedelta
 
 import pytest
@@ -1257,6 +1258,9 @@ def test_same_run_resume_lease_preserves_checkpoint_pointer(db_session) -> None:
         task_id=int(task.id),
         runner_id="resume-runner",
         run_id="resumable-run",
+        # Not part of what this test pins: a fresh attempt id per claim is
+        # acquire's contract, exercised by the stamping tests below.
+        attempt_id=lease.attempt_id,
     )
     db_session.refresh(task)
     assert task.last_checkpoint_event_id == "current-run-checkpoint"
@@ -1437,3 +1441,156 @@ def test_stale_running_task_with_legacy_checkpoint_becomes_paused(db_session) ->
     assert task.status == TaskStatus.PAUSED
     assert task.runner_id is None
     assert task.lease_expires_at is None
+
+
+def test_acquire_stamps_a_fresh_attempt_id_onto_the_task_row(db_session) -> None:
+    """acquire -> tasks.lease_attempt_id -> TaskLease.attempt_id round-trips.
+
+    The lease is not stamped from RETURNING (see the values-dict read-back in
+    acquire_task_lease_no_commit), so the only thing proving the returned
+    identity is the one actually persisted is this three-way comparison.
+    """
+    task = _create_task(db_session, status=TaskStatus.PENDING)
+
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+
+    assert lease is not None
+    assert lease.attempt_id is not None
+    # Not a placeholder: it must parse as a uuid and fit String(64).
+    uuid.UUID(lease.attempt_id)
+    assert len(lease.attempt_id) <= 64
+
+    db_session.refresh(task)
+    assert task.lease_attempt_id == lease.attempt_id
+
+
+def test_each_acquisition_mints_a_new_attempt_id(db_session) -> None:
+    """A new value per claim -- this is what state_version cannot do."""
+    task = _create_task(db_session, status=TaskStatus.PENDING)
+
+    first = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert first is not None
+    release_task_lease(db_session, first, status=TaskStatus.PAUSED)
+
+    second = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert second is not None
+
+    assert first.attempt_id != second.attempt_id
+    db_session.refresh(task)
+    assert task.lease_attempt_id == second.attempt_id
+
+
+def test_same_run_resume_still_rotates_the_attempt_id(db_session) -> None:
+    """expected_run_id keeps the run but not the attempt: this is exactly the
+    shape where a successor run reacquires the SAME (runner_id, run_id)
+    tuple and must still be distinguishable from the stale run holding it."""
+    task = _create_task(db_session, status=TaskStatus.WAITING_FOR_USER)
+    task.run_id = "resumable-run"
+    db_session.commit()
+
+    first = acquire_task_lease(
+        db_session,
+        int(task.id),
+        runner_id="same-runner",
+        expected_run_id="resumable-run",
+    )
+    second = acquire_task_lease(
+        db_session,
+        int(task.id),
+        runner_id="same-runner",
+        expected_run_id="resumable-run",
+    )
+
+    assert first is not None and second is not None
+    assert (first.runner_id, first.run_id) == (second.runner_id, second.run_id)
+    assert first.attempt_id != second.attempt_id
+
+
+def test_new_run_acquisition_stamps_an_attempt_id(db_session) -> None:
+    """The stamp lives in the values-dict base, not a conditional branch --
+    it must fire on the new_run=True path too."""
+    task = _create_task(db_session, status=TaskStatus.PENDING)
+
+    lease = acquire_task_lease(
+        db_session, int(task.id), runner_id="runner-a", new_run=True
+    )
+
+    assert lease is not None
+    assert lease.attempt_id is not None
+    uuid.UUID(lease.attempt_id)
+    db_session.refresh(task)
+    assert task.lease_attempt_id == lease.attempt_id
+
+
+def test_release_clears_the_attempt_id(db_session) -> None:
+    """The column must not carry a finished attempt's value."""
+    task = _create_task(db_session, status=TaskStatus.PENDING)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    db_session.refresh(task)
+    assert task.lease_attempt_id is not None
+
+    release_task_lease(db_session, lease, status=TaskStatus.PAUSED)
+
+    db_session.refresh(task)
+    assert task.lease_attempt_id is None
+
+
+def test_expired_lease_recovery_clears_the_attempt_id(db_session) -> None:
+    """Same invariant as release, exercised through expiry recovery.
+
+    No checkpoint is set up, so recovery lands on FAILED rather than PAUSED
+    -- that branch distinction is orthogonal to what this test pins.
+    """
+    task = _create_task(db_session, status=TaskStatus.RUNNING)
+    task.runner_id = "dead-runner"
+    task.run_id = "expiring-run"
+    task.lease_expires_at = utc_now() - timedelta(seconds=1)
+    task.lease_attempt_id = "stale-attempt"
+    db_session.commit()
+    assert task.lease_attempt_id is not None
+
+    assert _recover_expired_task(db_session, task) == TaskStatus.FAILED
+
+    db_session.refresh(task)
+    assert task.lease_attempt_id is None
+
+
+def test_fail_and_release_clears_the_attempt_id(db_session) -> None:
+    """Same invariant, exercised through the fail-and-release writer."""
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    db_session.refresh(task)
+    assert task.lease_attempt_id is not None
+
+    changed = task_lease_service.fail_and_release_task_lease_no_commit(
+        db_session,
+        lease,
+        error_message="setup failed",
+    )
+    db_session.commit()
+
+    assert changed is True
+    db_session.refresh(task)
+    assert task.lease_attempt_id is None
+
+
+def test_release_current_runner_task_lease_clears_the_attempt_id(db_session) -> None:
+    """Same invariant, exercised through the current-runner release path."""
+    task = _create_task(db_session, status=TaskStatus.PENDING)
+    lease = acquire_task_lease(db_session, int(task.id), runner_id="runner-a")
+    assert lease is not None
+    db_session.refresh(task)
+    assert task.lease_attempt_id is not None
+
+    changed = task_lease_service.release_current_runner_task_lease(
+        db_session,
+        int(task.id),
+        status=TaskStatus.PAUSED,
+        runner_id="runner-a",
+    )
+
+    assert changed is True
+    db_session.refresh(task)
+    assert task.lease_attempt_id is None

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1347,6 +1347,7 @@ def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.runner_id = "dead-runner"
     task.run_id = "checkpoint-run"
+    task.lease_attempt_id = "stale-attempt"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "checkpoint-1"
     checkpoint_event = TraceEvent(
@@ -1374,6 +1375,7 @@ def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:
     assert task.status == TaskStatus.PAUSED
     assert task.runner_id is None
     assert task.lease_expires_at is None
+    assert task.lease_attempt_id is None
 
 
 def test_stale_running_task_ignores_child_agent_checkpoint(db_session) -> None:

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1253,6 +1253,7 @@ def test_same_run_resume_lease_preserves_checkpoint_pointer(db_session) -> None:
         runner_id="resume-runner",
         expected_run_id="resumable-run",
     )
+    assert lease is not None
 
     assert lease == TaskLease(
         task_id=int(task.id),

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -1597,3 +1597,22 @@ def test_release_current_runner_task_lease_clears_the_attempt_id(db_session) -> 
     assert changed is True
     db_session.refresh(task)
     assert task.lease_attempt_id is None
+
+
+def test_task_lease_snapshot_never_carries_an_attempt_id() -> None:
+    """The ambient snapshot rebuilt from a task row must keep attempt_id None
+    even when the row has one, so a later attempt check cannot compare a
+    value against itself and always pass."""
+    from types import SimpleNamespace
+
+    from xagent.web.api.websocket import _task_lease_snapshot
+
+    row = SimpleNamespace(
+        id=7,
+        runner_id="runner-a",
+        run_id="run-b",
+        lease_attempt_id="attempt-c",
+    )
+    lease = _task_lease_snapshot(row)
+    assert lease is not None
+    assert lease.attempt_id is None


### PR DESCRIPTION
## What

Adds a per-acquisition attempt identity to the task lease:

- `tasks.lease_attempt_id` — a bare nullable `String(64)`. No foreign key,
  no check constraint, no unique constraint, no index.
- `TaskLease.attempt_id` — a new trailing field on the frozen dataclass,
  defaulting to `None`.
- `acquire_task_lease_no_commit` mints a fresh uuid on every successful
  claim, writes it in the same conditional UPDATE, and returns it.
- Every writer that clears `runner_id` — release, expiry recovery,
  fail-and-release, release-current-runner, the A2A cancel finalization,
  and the turn claim — clears this column in the same statement, so it
  never outlives the attempt that wrote it. A static test enumerates the
  update carriers and fails on any site that writes one column without
  the other.
- Its own alembic migration, forked on `context.as_sql`.

## Why

This is the closure artifact for the stale-attempt fencing finding (BL-2)
raised against the interaction-handoff design. It carries no acceptance
criterion of its own from #1074, and the delivery series this PR belongs to
does not close #1074 either — the existing-table pairs and the datetime
read-back half remain on the issue.

The problem it addresses: a runner holding a `(runner_id, run_id)` tuple
cannot today prove that tuple still names *its* attempt. `state_version`
cannot serve as that proof — it is a task-lifecycle counter, not an attempt
counter. `_apply_pause_requested_isolated` increments it mid-run without
changing attempt ownership, so a fence pinned to the value seen at
acquisition rejects a legitimate finalizer that was merely paused. An
attempt identity minted per claim and touched by no other writer is exactly
the missing fact.

The margin over the existing fence is narrow but real, and worth stating so
it is not later removed as redundant: both online finalizers already compare
`runner_id` and `run_id`, and expiry recovery NULLs `runner_id`, so a bare
reaper recovery is already blocked. The attempt identity earns its keep in
one shape only — a successor run reacquiring the *same* `(runner_id, run_id)`
tuple, where every existing predicate matches for the stale holder too.

Scope note: the stale-attempt window this fences is a pre-existing defect,
reachable today. This PR does not fix it for the existing finalizers — their
fences are unchanged. It supplies the fact a future fence needs, and
guarantees the handoff path will not add a new stale writer on top of it.

## Compatibility window

`lease.attempt_id is None` means "cannot prove attempt identity". Consumers
must fall back to whatever fence they already have — never treat None as a
match. Two sources:

1. A lease claimed by a worker running code from before this column existed.
   This is a rolling-restart window that closes on its own. During it, the
   run-scoped identity key does not back the gap either, so both protections
   are down for the same interval.
2. `_task_lease_snapshot` in `websocket.py`, the second `TaskLease`
   construction point, which rebuilds an ambient lease from an already-loaded
   task row. It carries `None` permanently and deliberately: every field it
   sets is read from that row, so populating `attempt_id` from the same read
   would make a later `task.lease_attempt_id != lease.attempt_id` check
   compare a value against itself — an always-passing fence, strictly worse
   than an explicit sentinel a caller can detect and skip. Any future work
   routing this ambient lease into an attempt check must revisit this.

## Test changes

Exactly one existing assertion changes. `TaskLease` is a frozen dataclass,
so its generated `__eq__` compares every field, and
`test_same_run_resume_lease_preserves_checkpoint_pointer` asserts whole-object
equality. Its expectation now carries `attempt_id=lease.attempt_id`,
declaring the new field as not part of what that test pins. This is the only
whole-object `TaskLease` comparison in the test tree; every other lease test
is unchanged.

## Verification

- lease suites after the change: 127 passed across the six lease test
  files; with the new tests, 135 passed.
- full regression: six lease files plus `tests/alembic/` — 356 passed,
  1 pre-existing unrelated skip. Downstream `TaskLease` consumers
  (websocket, execution-scope, a2a, task-command transport) — 222 passed
  with PostgreSQL configured.
- migration: 10 new tests green; single alembic head before and after.

Migration integration baseline, recorded so this PR's migration tests are not
confounded with it: `test_postgresql_upgrade` and
`test_postgresql_idempotence_with_sqlalchemy` are red at the branch point
(`d97f440a`) and remain red, with the same traceback — the suite's teardown
issues `DROP TABLE mcp_servers_legacy` without CASCADE while four foreign keys
still reference it. Unrelated to this change and not fixed here.
`test_postgresql_incremental_upgrade` is green before and after.

This PR's own migration is covered by `tests/alembic/` against SQLite, plus a
one-off PostgreSQL run against a throwaway schema (online add / idempotent
re-run / downgrade / schema resolution).

