### PR TITLE
ref(trace): extract trace-row staging into a caller-owned-transaction primitive

### DIFF
--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -41,12 +41,12 @@ from ...web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
     current_task_lease,
 )
+from ...web.services.trace_event_staging import stage_trace_event_row
 from ...web.services.trace_message_storage import (
     SQL_IN_CLAUSE_CHUNK_SIZE,
     CheckpointMessageDecodeError,
     chunks,
     decode_trace_event_data,
-    encode_checkpoint_data_for_storage,
 )
 
 logger = logging.getLogger(__name__)
@@ -687,32 +687,22 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 checkpoint_lease = (
                     current_task_lease() if self.build_id is None else None
                 )
-                if checkpoint_lease is not None:
-                    data = {
-                        **data,
-                        TASK_RUN_ID_TRACE_FIELD: checkpoint_lease.run_id,
-                    }
-                data = encode_checkpoint_data_for_storage(
-                    db,
-                    task_id=self.task_id,
-                    data=data,
-                )
             else:
                 checkpoint_lease = None
 
-            # Create trace event record
-            trace_event = DatabaseTraceEvent(
+            staged = stage_trace_event_row(
+                db,
                 task_id=self.task_id,
-                build_id=self.build_id,  # ← 添加 build_id
+                build_id=self.build_id,
                 event_id=str(event.id),
                 event_type=event_type_str,
                 timestamp=timestamp,
                 step_id=event.step_id,
                 parent_event_id=str(event.parent_id) if event.parent_id else None,
                 data=data,
+                checkpoint_lease=checkpoint_lease,
             )
-
-            db.add(trace_event)
+            data = staged.stored_data
 
             if (
                 event_type_str == "system_update_general"
@@ -721,18 +711,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
                 and self.build_id is None
                 and checkpoint_lease is not None
             ):
-                # Flush the pending insert so trace_event.id (the row's
-                # primary key) is assigned before the pointer UPDATE below
-                # reads it. autoflush is off for this session, so without
-                # this the exact-row anchor column would be built from an
-                # unassigned id and silently written NULL.
-                db.flush()
-                if trace_event.id is None:
-                    raise RuntimeError(
-                        f"Task {self.task_id} checkpoint {event.id} row has no "
-                        "primary key after flush; refusing to write a NULL "
-                        "checkpoint anchor"
-                    )
+                # The anchor's primary key was already flushed and
+                # NULL-checked inside stage_trace_event_row before it
+                # returned staged.anchor; consume it directly here. This
+                # guard is the same is_checkpoint / build_id / lease test
+                # stage_trace_event_row itself gates its flush on, so the
+                # anchor here is never None.
+                assert staged.anchor is not None
                 pointer_update = db.execute(
                     update(Task)
                     .where(
@@ -743,7 +728,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     )
                     .values(
                         last_checkpoint_event_id=str(event.id),
-                        last_checkpoint_trace_event_id=trace_event.id,
+                        last_checkpoint_trace_event_id=staged.anchor.trace_event_id,
                     )
                     .execution_options(synchronize_session=False)
                 )
@@ -869,6 +854,10 @@ class DatabaseTraceHandler(BaseTraceHandler):
         task's exact-row pointer names a row that itself ranks outside the
         window, protecting that row keeps ``limit + 1``.
         """
+        if db.new or db.dirty or db.deleted:
+            raise RuntimeError(
+                "checkpoint prune must not run with pending writes on the session"
+            )
         limit = get_checkpoint_history_limit()
         if limit <= 0:
             return

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -704,20 +704,15 @@ class DatabaseTraceHandler(BaseTraceHandler):
             )
             data = staged.stored_data
 
-            if (
-                event_type_str == "system_update_general"
-                and isinstance(data, dict)
-                and data.get("checkpoint_type") == CHECKPOINT_TYPE
-                and self.build_id is None
-                and checkpoint_lease is not None
-            ):
-                # The anchor's primary key was already flushed and
-                # NULL-checked inside stage_trace_event_row before it
-                # returned staged.anchor; consume it directly here. This
-                # guard is the same is_checkpoint / build_id / lease test
-                # stage_trace_event_row itself gates its flush on, so the
-                # anchor here is never None.
-                assert staged.anchor is not None
+            if staged.anchor is not None and checkpoint_lease is not None:
+                # staged.anchor is set on exactly the path that needs this
+                # pointer UPDATE, so it is read here rather than re-derived.
+                # Re-deriving would test the post-encode payload rebound at
+                # the line above, not the pre-encode payload the flush
+                # decision was actually made from; the two agree today only
+                # because no encoder touches checkpoint_type. The lease is
+                # re-tested only to narrow it for the fence below -- it is
+                # never None when the anchor is set.
                 pointer_update = db.execute(
                     update(Task)
                     .where(
@@ -849,6 +844,14 @@ class DatabaseTraceHandler(BaseTraceHandler):
         dedup, but a blob referenced only by pruned rows (e.g. a message
         later dropped by context compaction) is orphaned until whole-task
         deletion cleans it up.
+
+        The entry guard below is a caller-contract check, not one of those
+        prune failures: it fires only when a caller hands this method a
+        session with uncommitted work, which the sole call site -- right
+        after the checkpoint commit -- never does. It raises outside the
+        degrade-and-log block deliberately, because that block's rollback
+        would discard the caller's pending writes and turn a misuse bug into
+        silent data loss.
 
         Retention is exactly ``limit`` rows, with one exception: when the
         task's exact-row pointer names a row that itself ranks outside the

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -70,10 +70,16 @@ class StagedTraceRow:
     module docstring); where it is set, it names a real row only after the
     caller's commit succeeds. ``anchor`` is ``None`` on every path except
     the root-checkpoint-with-a-live-lease path.
+
+    ``stored_data`` is the payload as written to the row: the caller's own
+    ``data``, unchanged except on the checkpoint paths, which merge the
+    run-id field and encode blobs. It carries whatever type the caller
+    passed, which is why it is not annotated more tightly than the
+    ``data`` parameter itself.
     """
 
     row_id: int | None
-    stored_data: dict[str, Any]
+    stored_data: Any
     anchor: StagedCheckpointAnchor | None
 
 

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -1,0 +1,154 @@
+"""Stage one trace row (and, on the live-lease checkpoint path, its
+exact-row anchor) into a session the caller already owns.
+
+``stage_trace_event_row`` is the construction step factored out of
+``DatabaseTraceHandler._save_trace_event`` (``web/api/trace_handlers.py``):
+building the row, encoding checkpoint blobs, stamping the run partition, and
+flushing to get a primary key for the anchor column. Everything that used to
+follow that construction in the same function -- the pointer UPDATE and its
+rowcount classification, tool-usage counters, the commit, the prune trigger,
+and both rollback handlers -- stays in the caller.
+
+Caller obligations, because none of them happen here:
+
+* This function joins the ``Session`` passed in; it never commits, never
+  rolls back, never signals anyone else about the row, and never prunes.
+  The caller owns the transaction and must commit it (or roll it back)
+  itself.
+* If this function raises ``IntegrityError`` (a stale FK on ``task_id``, for
+  instance), the session is left mid-transaction. The caller must roll back
+  before issuing another statement on it.
+
+``StagedTraceRow.row_id`` and ``.anchor`` are only meaningful once the
+caller commits: ``row_id`` is the primary key SQLAlchemy assigned during
+this call's flush, but it names a real, durable row only after commit
+succeeds. ``anchor`` is non-``None`` only on the root-checkpoint-with-a-live-
+lease path (flush happens there because the caller needs the anchor's
+primary key to write ``tasks.last_checkpoint_trace_event_id`` before it
+commits); every other path returns ``anchor=None`` and does not flush.
+
+Known bypass: ``_persist_agent_outbound_event`` (``web/api/websocket.py``)
+constructs its own ``TraceEvent`` row and adds it to the session directly,
+without going through ``_save_trace_event`` or this function. This function
+is the sole construction point on the ``_save_trace_event`` path, not the
+only place a trace row is ever built in the codebase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ...core.agent.checkpoint import CHECKPOINT_TYPE
+from ..models.task import TraceEvent as DatabaseTraceEvent
+from .task_lease_service import TASK_RUN_ID_TRACE_FIELD, TaskLease
+from .trace_message_storage import encode_checkpoint_data_for_storage
+
+
+@dataclass(frozen=True)
+class StagedCheckpointAnchor:
+    """The exact-row anchor for a checkpoint staged under a live task lease.
+
+    Non-``None`` only on the root-checkpoint-with-a-live-lease path.
+    ``trace_event_id`` is the primary key the caller writes into
+    ``tasks.last_checkpoint_trace_event_id``; it names a real row only once
+    the caller commits the transaction this row was staged into.
+    """
+
+    checkpoint_event_id: str
+    trace_event_id: int
+
+
+@dataclass(frozen=True)
+class StagedTraceRow:
+    """A trace row added to a caller-owned session, not yet committed.
+
+    ``row_id`` is ``None`` on every path that does not flush (see the
+    module docstring); where it is set, it names a real row only after the
+    caller's commit succeeds. ``anchor`` is ``None`` on every path except
+    the root-checkpoint-with-a-live-lease path.
+    """
+
+    row_id: int | None
+    stored_data: dict[str, Any]
+    anchor: StagedCheckpointAnchor | None
+
+
+def stage_trace_event_row(
+    db: Session,
+    *,
+    task_id: int,
+    build_id: str | None,
+    event_id: str,
+    event_type: str,
+    timestamp: datetime,
+    step_id: str | None,
+    parent_event_id: str | None,
+    data: Any,
+    checkpoint_lease: TaskLease | None,
+) -> StagedTraceRow:
+    """Add one trace row to ``db`` and, on the live-lease checkpoint path,
+    flush it to stage its exact-row anchor. See the module docstring for
+    what the caller still owns.
+
+    ``checkpoint_lease`` is the caller's own ``current_task_lease()``
+    result, already gated on ``build_id is None`` before this is called --
+    a sub-agent checkpoint (``build_id`` set) must be passed
+    ``checkpoint_lease=None`` regardless of whether a lease is live.
+    """
+    is_checkpoint = (
+        event_type == "system_update_general"
+        and isinstance(data, dict)
+        and data.get("checkpoint_type") == CHECKPOINT_TYPE
+    )
+    if is_checkpoint and checkpoint_lease is not None:
+        data = {
+            **data,
+            TASK_RUN_ID_TRACE_FIELD: checkpoint_lease.run_id,
+        }
+    if is_checkpoint:
+        data = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=data,
+        )
+
+    trace_event = DatabaseTraceEvent(
+        task_id=task_id,
+        build_id=build_id,
+        event_id=event_id,
+        event_type=event_type,
+        timestamp=timestamp,
+        step_id=step_id,
+        parent_event_id=parent_event_id,
+        data=data,
+    )
+    db.add(trace_event)
+
+    if is_checkpoint and build_id is None and checkpoint_lease is not None:
+        # Flush the pending insert so trace_event.id (the row's primary
+        # key) is assigned before the caller builds the exact-row anchor
+        # column from it. autoflush is off for this session, so without
+        # this the anchor would be built from an unassigned id and
+        # silently written NULL.
+        db.flush()
+        if trace_event.id is None:
+            raise RuntimeError(
+                f"Task {task_id} checkpoint {event_id} row has no "
+                "primary key after flush; refusing to write a NULL "
+                "checkpoint anchor"
+            )
+        row_id = int(trace_event.id)
+        return StagedTraceRow(
+            row_id=row_id,
+            stored_data=data,
+            anchor=StagedCheckpointAnchor(
+                checkpoint_event_id=event_id,
+                trace_event_id=row_id,
+            ),
+        )
+
+    return StagedTraceRow(row_id=None, stored_data=data, anchor=None)

--- a/tests/web/services/test_checkpoint_pointer_pairing.py
+++ b/tests/web/services/test_checkpoint_pointer_pairing.py
@@ -19,6 +19,34 @@ therefore accepts two sibling statements that each write one column against
 write both columns through one carrier (or two sibling assignments into the
 same dict), so the blind spot has no live instance; it is recorded here so a
 future reviewer does not mistake the guard for a per-statement check.
+
+``**`` unpacking resolution: ``.values(**name)`` / ``.update(**name)`` name
+a dict whose keys this walk cannot see without resolving what ``name`` is
+bound to. A name bound to a dict *literal* somewhere in the enclosing
+function is resolved -- its keys were already picked up by the ``ast.Dict``
+branch below when the literal itself was walked, so the carrier contributes
+nothing further and is treated as already-inspected. Every other carrier
+(the call result of a builder, a name that only ever arrives as a function
+parameter, ...) cannot be resolved statically, so it is counted as an
+opaque, and therefore unpaired, write.
+
+This resolution is by name, not dataflow: once a name has been bound to a
+dict literal anywhere in its function, every ``**`` of that name in that
+function is accepted, even if the name is later reassigned or mutated.
+Two shapes escape as a known consequence, both covered by a dedicated
+negative-control test below so the limit stays visible instead of being
+rediscovered:
+
+* a local dict literal later merged with ``.update(builder())`` before
+  being unpacked -- the merge's keys are invisible to this walk;
+* a local dict literal later rebound to the result of a call before being
+  unpacked -- the same name now points at unrelated content, but the name
+  was "seen" as a literal once, so it stays resolved.
+
+Widening the walk to be dataflow-sensitive would close both gaps, but that
+is a materially different (and materially more expensive) analysis; the
+name-based rule is deliberately the cheaper, coarser one, with its blind
+spots recorded rather than silently accepted.
 """
 
 from __future__ import annotations
@@ -35,6 +63,12 @@ POINTER_COLUMNS = frozenset(
     {"last_checkpoint_event_id", "last_checkpoint_trace_event_id"}
 )
 
+# Sentinel column name for a ** carrier this walk could not resolve to a
+# local dict literal. It is never a real column name, so it can never
+# accidentally complete a pair -- it can only ever make a block's column set
+# diverge from POINTER_COLUMNS and therefore get flagged.
+_OPAQUE_STAR_CARRIER = "<opaque **>"
+
 SUBJECT_MODULES = [
     trace_handlers,
     admin_users,
@@ -44,9 +78,60 @@ SUBJECT_MODULES = [
 ]
 
 
-def _mutated_pointer_columns(statement: ast.stmt) -> set[str]:
-    """Pointer columns this statement *writes*, in any of the three carrier
-    forms the call sites actually use."""
+def _enclosing_scopes(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    """Map every node to the nearest enclosing function, or the module
+    itself for top-level code.
+
+    A node's own scope is the function that directly contains it -- a
+    nested function gets its own entry, not its parent's, so a name local
+    to the inner function can never be resolved against the outer one's
+    dict-literal bindings.
+    """
+    scope_of: dict[ast.AST, ast.AST] = {}
+
+    def visit(node: ast.AST, scope: ast.AST) -> None:
+        scope_of[node] = scope
+        child_scope = (
+            node if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) else scope
+        )
+        for child in ast.iter_child_nodes(node):
+            visit(child, child_scope)
+
+    visit(tree, tree)
+    return scope_of
+
+
+def _local_dict_literal_names(
+    tree: ast.Module, scope_of: dict[ast.AST, ast.AST]
+) -> dict[ast.AST, set[str]]:
+    """Per scope, the names ever bound to a dict literal in that scope:
+    ``name = {...}`` / ``name: T = {...}``. A name resolved this way is
+    treated as already inspected wherever it is later unpacked with ``**``
+    in the same scope, regardless of what happens to it in between."""
+    names_by_scope: dict[ast.AST, set[str]] = {}
+    for node in ast.walk(tree):
+        targets: list[ast.Name] = []
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+            targets = [t for t in node.targets if isinstance(t, ast.Name)]
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.value, ast.Dict)
+            and isinstance(node.target, ast.Name)
+        ):
+            targets = [node.target]
+        if targets:
+            scope = scope_of[node]
+            names_by_scope.setdefault(scope, set()).update(t.id for t in targets)
+    return names_by_scope
+
+
+def _mutated_pointer_columns(
+    statement: ast.stmt,
+    scope_of: dict[ast.AST, ast.AST],
+    local_dict_names: dict[ast.AST, set[str]],
+) -> set[str]:
+    """Pointer columns this statement *writes*, in any of the carrier forms
+    the call sites actually use."""
     found: set[str] = set()
     for node in ast.walk(statement):
         if isinstance(node, ast.Dict):
@@ -57,11 +142,33 @@ def _mutated_pointer_columns(statement: ast.stmt) -> set[str]:
                 elif isinstance(key, ast.Constant) and key.value in POINTER_COLUMNS:
                     found.add(str(key.value))
         elif isinstance(node, ast.Call):
-            # .values(last_checkpoint_event_id=..., ...). ``else_=Task.<col>``
-            # inside a case() is a keyword named "else_", so it never matches.
             for keyword in node.keywords:
                 if keyword.arg in POINTER_COLUMNS:
+                    # .values(last_checkpoint_event_id=..., ...). ``else_=
+                    # Task.<col>`` inside a case() is a keyword named
+                    # "else_", so it never matches.
                     found.add(str(keyword.arg))
+                elif keyword.arg is None:
+                    # .values(**name) / .update(**name). Resolve only for
+                    # these two method names -- an unrelated **-call (e.g.
+                    # log.info(**kwargs)) is not a pointer-column carrier
+                    # at all and must not be flagged.
+                    callee = node.func
+                    method_name = (
+                        callee.attr if isinstance(callee, ast.Attribute) else None
+                    )
+                    if method_name in {"values", "update"}:
+                        scope = scope_of.get(node)
+                        resolved_names = (
+                            local_dict_names.get(scope, set())
+                            if scope is not None
+                            else set()
+                        )
+                        if not (
+                            isinstance(keyword.value, ast.Name)
+                            and keyword.value.id in resolved_names
+                        ):
+                            found.add(_OPAQUE_STAR_CARRIER)
         elif isinstance(node, ast.Assign):
             # values["last_checkpoint_event_id"] = ...
             for target in node.targets:
@@ -86,6 +193,8 @@ def unpaired_pointer_writes(source: str) -> list[tuple[int, tuple[str, ...]]]:
     iteration and no imbalance can hide inside one.
     """
     tree = ast.parse(source)
+    scope_of = _enclosing_scopes(tree)
+    local_dict_names = _local_dict_literal_names(tree, scope_of)
     findings: list[tuple[int, tuple[str, ...]]] = []
     for node in ast.walk(tree):
         for field in ("body", "orelse", "finalbody"):
@@ -97,7 +206,9 @@ def unpaired_pointer_writes(source: str) -> list[tuple[int, tuple[str, ...]]]:
             for statement in block:
                 if not isinstance(statement, ast.stmt):
                     continue
-                mutated = _mutated_pointer_columns(statement)
+                mutated = _mutated_pointer_columns(
+                    statement, scope_of, local_dict_names
+                )
                 if mutated and first_line is None:
                     first_line = statement.lineno
                 columns |= mutated
@@ -183,4 +294,130 @@ def test_pointer_pairing_flags_each_carrier_form(carrier: str, fixture: str) -> 
     the fixture text is reformatted."""
     unpaired = unpaired_pointer_writes(fixture)
     assert unpaired, carrier
+    assert {columns for _, columns in unpaired} == {("last_checkpoint_event_id",)}
+
+
+def test_pointer_pairing_accepts_a_paired_local_dict_unpacked_with_star() -> None:
+    """Positive control for the ** resolution itself: a dict literal that
+    pairs both columns, later unpacked with ``**``, must not be flagged --
+    its keys were already seen on the literal."""
+    fixture = """
+def write(db, task_id, event):
+    values = {
+        "last_checkpoint_event_id": str(event.id),
+        "last_checkpoint_trace_event_id": event.trace_event_id,
+    }
+    db.execute(update(Task).where(Task.id == task_id).values(**values))
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+def test_pointer_pairing_ignores_an_unrelated_star_call() -> None:
+    """Negative control: ``**`` unpacking into a method that is not
+    ``.values``/``.update`` is not a pointer-column carrier at all."""
+    fixture = """
+def log_event(**kwargs):
+    log.info(**kwargs)
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+def test_pointer_pairing_flags_a_builder_result_unpacked_directly() -> None:
+    """The gap this hardening closes: unpacking a builder call's result
+    gives the walk no dict literal to read, so it must be flagged rather
+    than silently treated as paired."""
+    fixture = """
+def write(db, task_id, anchor):
+    db.execute(
+        update(Task).where(Task.id == task_id).values(
+            **checkpoint_pointer_values(anchor)
+        )
+    )
+"""
+    unpaired = unpaired_pointer_writes(fixture)
+    assert unpaired
+    assert {columns for _, columns in unpaired} == {(_OPAQUE_STAR_CARRIER,)}
+
+
+def test_pointer_pairing_flags_a_name_bound_only_from_a_call() -> None:
+    """A name that is never bound to a dict literal -- only ever assigned
+    from a call -- stays unresolved even though it has a name at all."""
+    fixture = """
+def write(db, task_id, anchor):
+    vals = checkpoint_pointer_values(anchor)
+    db.execute(update(Task).where(Task.id == task_id).values(**vals))
+"""
+    unpaired = unpaired_pointer_writes(fixture)
+    assert unpaired
+    assert {columns for _, columns in unpaired} == {(_OPAQUE_STAR_CARRIER,)}
+
+
+def test_pointer_pairing_flags_a_cross_function_dict_parameter() -> None:
+    """A dict arriving as a parameter is never "seen" as a literal in this
+    function's own body, so it stays unresolved regardless of what the
+    caller passed."""
+    fixture = """
+def write(db, task_id, vals):
+    db.execute(update(Task).where(Task.id == task_id).values(**vals))
+"""
+    unpaired = unpaired_pointer_writes(fixture)
+    assert unpaired
+    assert {columns for _, columns in unpaired} == {(_OPAQUE_STAR_CARRIER,)}
+
+
+def test_pointer_pairing_known_gap_a_literal_merged_via_update_before_star() -> None:
+    """Known gap (not a bug): a paired local dict literal later merged with
+    ``.update(builder())`` before being unpacked. The merge's keys are
+    invisible to this walk -- only the original literal's keys were ever
+    seen -- so this stays green even though the values actually unpacked
+    could differ from the literal. Changing this to catch the merge is a
+    deliberate rule change, not a bug fix; if this test ever needs to
+    become a positive control, that change needs its own decision, not a
+    silent tightening.
+    """
+    fixture = """
+def write(db, task_id, anchor):
+    values = {
+        "last_checkpoint_event_id": None,
+        "last_checkpoint_trace_event_id": None,
+    }
+    values.update(checkpoint_pointer_values(anchor))
+    db.execute(update(Task).where(Task.id == task_id).values(**values))
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+def test_pointer_pairing_known_gap_a_literal_rebound_to_a_call_before_star() -> None:
+    """Known gap (not a bug): a name first bound to a paired dict literal,
+    then rebound to the result of a call, then unpacked. The rule is by
+    name, not dataflow -- once ``values`` has been "seen" as a literal
+    anywhere in the function, every ``**values`` in that function is
+    accepted, even though this particular unpack sees only the rebound
+    call result. See the sibling ``..._via_update...`` test for the other
+    known gap; both are recorded rather than silently accepted.
+    """
+    fixture = """
+def write(db, task_id, anchor):
+    values = {
+        "last_checkpoint_event_id": None,
+        "last_checkpoint_trace_event_id": None,
+    }
+    values = checkpoint_pointer_values(anchor)
+    db.execute(update(Task).where(Task.id == task_id).values(**values))
+"""
+    assert unpaired_pointer_writes(fixture) == []
+
+
+def test_pointer_pairing_still_flags_a_single_column_keyword() -> None:
+    """Regression control: the pre-existing single-column-keyword carrier
+    (no ``**`` involved at all) must still be flagged after this
+    hardening -- the ** resolution must not loosen the old rule."""
+    fixture = """
+def write(db, task_id):
+    db.execute(update(Task).where(Task.id == task_id).values(
+        last_checkpoint_event_id=None,
+    ))
+"""
+    unpaired = unpaired_pointer_writes(fixture)
+    assert unpaired
     assert {columns for _, columns in unpaired} == {("last_checkpoint_event_id",)}

--- a/tests/web/services/test_checkpoint_pointer_pairing.py
+++ b/tests/web/services/test_checkpoint_pointer_pairing.py
@@ -30,6 +30,16 @@ nothing further and is treated as already-inspected. Every other carrier
 parameter, ...) cannot be resolved statically, so it is counted as an
 opaque, and therefore unpaired, write.
 
+Because a plain ``dict.update(**name)`` is spelled the same way as a
+SQLAlchemy bulk ``.update(**name)``, an unrelated dict merge in one of
+these five modules is flagged too, even with no pointer column anywhere
+near it. That is deliberate: separating the two would mean trusting the
+receiver expression, and a real pointer write through a query object
+bound to a local name (``stmt.update(**vals)``) would then stop being
+flagged. A loud false positive on an unrelated merge is the better
+trade for a guard whose silent failure mode is "recovery stops working";
+write ``d.update(other)`` rather than ``d.update(**other)`` here.
+
 This resolution is by name, not dataflow: once a name has been bound to a
 dict literal anywhere in its function, every ``**`` of that name in that
 function is accepted, even if the name is later reassigned or mutated.

--- a/tests/web/services/test_trace_event_staging.py
+++ b/tests/web/services/test_trace_event_staging.py
@@ -26,6 +26,7 @@ does not give.
 
 from __future__ import annotations
 
+import ast
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -469,13 +470,23 @@ def test_stage_trace_event_row_refuses_a_null_anchor_after_a_no_op_flush(
 
 
 def test_trace_event_staging_module_sends_no_notifications() -> None:
-    """No implicit notification is delivered as a zero-site fact
-    about this module's own source (there is nothing to move out), the
-    same way trace_handlers.py:_save_trace_event has zero notify/dispatch/
-    publish/broadcast sites today."""
-    source = Path(trace_event_staging.__file__).read_text()
-    for symbol in ("notify", "notification", "dispatch", "publish", "broadcast"):
-        assert symbol not in source, symbol
+    """No notification is delivered, asserted as a zero-site fact about this
+    module's imports and call targets rather than its prose: the substring
+    form also matched comments, which constrained how this module could be
+    documented."""
+    tree = ast.parse(Path(trace_event_staging.__file__).read_text())
+    roots = ("notify", "notification", "dispatch", "publish", "broadcast")
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(a.name.split(".")[-1] for a in node.names)
+            names.update(a.asname for a in node.names if a.asname)
+    offenders = sorted(n for n in names if any(r in n.lower() for r in roots))
+    assert offenders == [], offenders
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_trace_event_staging.py
+++ b/tests/web/services/test_trace_event_staging.py
@@ -1,0 +1,575 @@
+"""Contract tests for ``stage_trace_event_row``: the invariants the existing
+``_save_trace_event`` tests cannot see because they only observe the shell's
+combined, already-assembled behaviour (see the door tests in
+``tests/web/test_agent_checkpoint_stream.py`` and
+``tests/web/test_trace_message_storage.py``, which these tests leave
+untouched). The tests below pin, directly on the primitive: that it never
+commits, rolls back, or prunes on its own; the flush/encode/partition shape
+of its four paths plus the NULL-anchor guard; and, as a source-level fact,
+that it sends no notification.
+
+The shell-side tests are supplements that exercise ``trace_handlers.py``
+directly: one guards the single most dangerous line there -- the
+``data = staged.stored_data`` rebind after the ``stage_trace_event_row``
+call (see that file's comment above the pointer UPDATE) -- and two more are
+the forward and reverse controls for the new prune-entry guard.
+
+Each test builds its own file-backed sqlite database under ``tmp_path``
+rather than the process-wide ``get_engine()`` singleton, so none of these
+tests need ``tests/shared/db_teardown.py::drop_all_tables`` -- pytest tears
+down ``tmp_path`` itself. A file-backed engine (not an in-memory
+``StaticPool`` one) is used deliberately: the commit- and rollback-isolation
+checks need two independent sessions with genuine transaction isolation
+between them, which an in-memory database shared over one pooled connection
+does not give.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
+from xagent.core.agent.trace import TraceEvent as CoreTraceEvent
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.user import User
+from xagent.web.services import trace_event_staging
+from xagent.web.services.task_lease_service import (
+    TASK_RUN_ID_TRACE_FIELD,
+    TaskLease,
+    bind_task_lease_context,
+)
+from xagent.web.services.trace_event_staging import stage_trace_event_row
+
+
+def _engine(tmp_path: Path):
+    """A file-backed sqlite engine, private to one test, with the same FK
+    enforcement production connections get (src/xagent/db/sqlite.py's
+    connect hook applies only to the process-wide engine, so a private
+    test engine has to opt in separately)."""
+    db_path = tmp_path / "trace_event_staging.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+
+    @event.listens_for(engine, "connect")
+    def _enable_foreign_keys(dbapi_connection, connection_record) -> None:  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _create_task(session_factory, *, username: str) -> tuple[Session, int]:
+    db = session_factory()
+    user = User(username=username, password_hash="hashed_password", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    task = Task(
+        user_id=int(user.id),
+        title="Trace staging task",
+        description="Trace staging task",
+        status=TaskStatus.PENDING,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return db, int(task.id)
+
+
+def _checkpoint_data(execution_id: str, label: str) -> dict[str, Any]:
+    return {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "execution_id": execution_id,
+        "snapshot": {"label": label},
+    }
+
+
+def _count_flush_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    calls: list[int] = []
+    original_flush = Session.flush
+
+    def counting_flush(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        calls.append(1)
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", counting_flush)
+    return calls
+
+
+def _count_encode_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    calls: list[int] = []
+    original_encode = trace_event_staging.encode_checkpoint_data_for_storage
+
+    def counting_encode(db, *, task_id, data, use_v2=None):  # noqa: ANN001
+        calls.append(1)
+        return original_encode(db, task_id=task_id, data=data, use_v2=use_v2)
+
+    monkeypatch.setattr(
+        trace_event_staging, "encode_checkpoint_data_for_storage", counting_encode
+    )
+    return calls
+
+
+# --------------------------------------------------------------------------
+# Commit, rollback, and prune independence -- verbs the shell-level tests
+# cannot pin directly on the primitive
+# --------------------------------------------------------------------------
+
+
+def test_stage_trace_event_row_does_not_commit(tmp_path: Path) -> None:
+    """Joins the caller's transaction, does not commit it. Path (d) is
+    used because it is the one path that flushes -- the row is genuinely
+    written at the database level (not just held in the ORM's identity
+    map), so "a second session can't see it" is a real transaction-
+    isolation check, not an artifact of ORM-local state."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s1-commit")
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s1",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s1", "s1"),
+        checkpoint_lease=lease,
+    )
+    assert staged.row_id is not None
+
+    other = session_factory()
+    try:
+        assert db.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 1
+        assert other.query(DatabaseTraceEvent).filter_by(task_id=task_id).count() == 0
+        assert db.in_transaction()
+    finally:
+        other.close()
+        db.rollback()
+        db.close()
+
+
+def test_stage_trace_event_row_does_not_rollback_after_integrity_error(
+    tmp_path: Path,
+) -> None:
+    """An IntegrityError raised inside the primitive (here, a
+    trace_events.task_id FK violation on a task that was never created)
+    must propagate without being rolled back. The session is left in the
+    "flush failed, roll back before you can use it again" state SQLAlchemy
+    itself puts a session into after an uncaught flush error; the caller
+    (the shell's own except IntegrityError block) is who rolls it back."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db = session_factory()
+    missing_task_id = 999999
+    lease = TaskLease(task_id=missing_task_id, runner_id="runner-a", run_id="run-a")
+
+    with pytest.raises(IntegrityError):
+        stage_trace_event_row(
+            db,
+            task_id=missing_task_id,
+            build_id=None,
+            event_id="evt-s2",
+            event_type="system_update_general",
+            timestamp=datetime.now(timezone.utc),
+            step_id=None,
+            parent_event_id=None,
+            data=_checkpoint_data("exec-s2", "s2"),
+            checkpoint_lease=lease,
+        )
+
+    assert db.in_transaction()
+    # Proof the primitive did not roll back on its own: SQLAlchemy refuses
+    # any further statement on a session left in this state until the
+    # caller rolls it back explicitly. If the primitive had already rolled
+    # back, this query would succeed instead of raising.
+    with pytest.raises(Exception, match="rolled back|PendingRollback"):
+        db.query(DatabaseTraceEvent).count()
+
+    db.rollback()
+    assert db.query(DatabaseTraceEvent).count() == 0
+    db.close()
+
+
+def test_stage_trace_event_row_does_not_prune(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The primitive has no reference to _prune_checkpoint_history at
+    all -- it does not import trace_handlers, let alone call the method.
+    Patching the method and calling the primitive directly (not through
+    DatabaseTraceHandler) proves the call count stays zero even on the one
+    path (d) that does the most work."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        DatabaseTraceHandler,
+        "_prune_checkpoint_history",
+        lambda self, db, data: calls.append(data),
+    )
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s3-prune")
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+
+    stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s3",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s3", "s3"),
+        checkpoint_lease=lease,
+    )
+
+    assert calls == []
+    db.rollback()
+    db.close()
+
+
+# --------------------------------------------------------------------------
+# The four paths' flush / encode / partition shape
+# --------------------------------------------------------------------------
+
+
+def test_stage_trace_event_row_path_a_non_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-checkpoint event neither encodes nor flushes."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s4-non-checkpoint")
+
+    # Patched only after setup's own commits run, so those aren't counted.
+    flush_calls = _count_flush_calls(monkeypatch)
+    encode_calls = _count_encode_calls(monkeypatch)
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s4",
+        event_type="tool_execution_start",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data={"tool_name": "noop"},
+        checkpoint_lease=None,
+    )
+
+    assert staged.row_id is None
+    assert staged.anchor is None
+    assert flush_calls == []
+    assert encode_calls == []
+    assert TASK_RUN_ID_TRACE_FIELD not in staged.stored_data
+    db.rollback()
+    db.close()
+
+
+def test_stage_trace_event_row_path_b_sub_agent_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sub-agent checkpoint (build_id set) encodes but never
+    flushes and never gets a run partition stamp. The realistic call
+    mirrors the shell's own calling convention (checkpoint_lease=None,
+    since the shell never passes a live lease when build_id is set); the
+    second call additionally proves the primitive's own build_id is None
+    guard holds even if a caller passed a live lease anyway -- the
+    original function had this same redundant check (trace_handlers.py
+    checked self.build_id is None a second time even though the lease
+    variable it was paired with could only be non-None when build_id was
+    already None), and this defends the same thing here."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s5-sub-agent")
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a-s5")
+
+    flush_calls = _count_flush_calls(monkeypatch)
+    encode_calls = _count_encode_calls(monkeypatch)
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id="agent_123_abcd1234",
+        event_id="evt-s5",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s5", "s5"),
+        checkpoint_lease=None,
+    )
+
+    assert staged.row_id is None
+    assert staged.anchor is None
+    assert flush_calls == []
+    assert encode_calls == [1]
+    assert TASK_RUN_ID_TRACE_FIELD not in staged.stored_data
+
+    # Defense in depth: even a caller that (incorrectly) passes a live
+    # lease alongside a non-None build_id must not get a flush.
+    staged_off_label = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id="agent_123_abcd1234",
+        event_id="evt-s5-off-label",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s5-off-label", "s5-off-label"),
+        checkpoint_lease=lease,
+    )
+    assert staged_off_label.row_id is None
+    assert staged_off_label.anchor is None
+    assert flush_calls == []
+
+    db.rollback()
+    db.close()
+
+
+def test_stage_trace_event_row_path_c_root_checkpoint_without_a_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A root checkpoint with no live lease (current_task_lease()
+    returned None) encodes but never flushes and gets no run partition."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s6-no-lease")
+
+    flush_calls = _count_flush_calls(monkeypatch)
+    encode_calls = _count_encode_calls(monkeypatch)
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s6",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s6", "s6"),
+        checkpoint_lease=None,
+    )
+
+    assert staged.row_id is None
+    assert staged.anchor is None
+    assert flush_calls == []
+    assert encode_calls == [1]
+    assert TASK_RUN_ID_TRACE_FIELD not in staged.stored_data
+    db.rollback()
+    db.close()
+
+
+def test_stage_trace_event_row_path_d_root_checkpoint_under_a_live_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A root checkpoint under a live lease flushes exactly once,
+    stamps the run partition, and returns an anchor naming the flushed
+    row's own primary key."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s7-live-lease")
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a-s7")
+
+    flush_calls = _count_flush_calls(monkeypatch)
+    encode_calls = _count_encode_calls(monkeypatch)
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s7",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=_checkpoint_data("exec-s7", "s7"),
+        checkpoint_lease=lease,
+    )
+
+    assert flush_calls == [1]
+    assert encode_calls == [1]
+    assert staged.row_id is not None
+    assert staged.anchor is not None
+    assert staged.anchor.trace_event_id == staged.row_id
+    assert staged.anchor.checkpoint_event_id == "evt-s7"
+    assert staged.stored_data[TASK_RUN_ID_TRACE_FIELD] == lease.run_id
+    db.rollback()
+    db.close()
+
+
+# --------------------------------------------------------------------------
+# The NULL-anchor guard, pinned directly on the primitive
+# --------------------------------------------------------------------------
+
+
+def test_stage_trace_event_row_refuses_a_null_anchor_after_a_no_op_flush(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirrors the shell-level guard test
+    ``test_database_trace_handler_flush_without_primary_key_refuses_to_write_the_anchor``
+    in test_agent_checkpoint_stream.py, but exercised directly against the
+    primitive, and additionally checking that the primitive itself does not
+    roll back on this path -- the shell-level test's NULL/zero-rows
+    assertions depend on the shell's own bare except doing that rollback,
+    not on this function doing it."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s8-null-anchor")
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a-s8")
+
+    monkeypatch.setattr(Session, "flush", lambda self, *a, **k: None)  # noqa: ARG005
+
+    with pytest.raises(
+        RuntimeError, match="refusing to write a NULL checkpoint anchor"
+    ):
+        stage_trace_event_row(
+            db,
+            task_id=task_id,
+            build_id=None,
+            event_id="evt-s8",
+            event_type="system_update_general",
+            timestamp=datetime.now(timezone.utc),
+            step_id=None,
+            parent_event_id=None,
+            data=_checkpoint_data("exec-s8", "s8"),
+            checkpoint_lease=lease,
+        )
+
+    assert db.in_transaction()
+    db.rollback()
+    db.close()
+
+
+# --------------------------------------------------------------------------
+# No notification, pinned as a source-level fact
+# --------------------------------------------------------------------------
+
+
+def test_trace_event_staging_module_sends_no_notifications() -> None:
+    """No implicit notification is delivered as a zero-site fact
+    about this module's own source (there is nothing to move out), the
+    same way trace_handlers.py:_save_trace_event has zero notify/dispatch/
+    publish/broadcast sites today."""
+    source = Path(trace_event_staging.__file__).read_text()
+    for symbol in ("notify", "notification", "dispatch", "publish", "broadcast"):
+        assert symbol not in source, symbol
+
+
+# --------------------------------------------------------------------------
+# Shell-side supplements (trace_handlers.py, not the primitive)
+# --------------------------------------------------------------------------
+
+
+def test_shell_passes_the_partition_stamped_data_into_prune(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards the single most dangerous line in trace_handlers.py --
+    the ``data = staged.stored_data`` rebind after the
+    stage_trace_event_row call. Without that rebind, the shell's local
+    ``data`` stays the pre-partition-stamp object and
+    _prune_checkpoint_history silently loses its run-partition filter,
+    which would not necessarily turn any existing assertion red."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="t6-prune-data")
+    task = db.get(Task, task_id)
+    task.status = TaskStatus.RUNNING
+    task.runner_id = "runner-a"
+    task.run_id = "run-a-t6"
+    db.commit()
+    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a-t6")
+
+    captured: list[dict[str, Any]] = []
+    original_prune = DatabaseTraceHandler._prune_checkpoint_history
+
+    def capturing_prune(self, db, data):  # noqa: ANN001
+        captured.append(data)
+        return original_prune(self, db, data)
+
+    monkeypatch.setattr(
+        DatabaseTraceHandler, "_prune_checkpoint_history", capturing_prune
+    )
+
+    event = CoreTraceEvent(
+        CHECKPOINT_EVENT_TYPE,
+        task_id=str(task_id),
+        data={
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "execution_id": str(task_id),
+            "snapshot": {"label": "t6"},
+        },
+    )
+
+    try:
+        with bind_task_lease_context(lease):
+            DatabaseTraceHandler(task_id)._save_trace_event(db, event)
+
+        assert len(captured) == 1
+        assert captured[0].get(TASK_RUN_ID_TRACE_FIELD) == lease.run_id
+    finally:
+        db.close()
+
+
+def test_prune_checkpoint_history_guard_rejects_pending_writes(
+    tmp_path: Path,
+) -> None:
+    """Reverse control: a session carrying an uncommitted write must
+    not be handed to the prune path -- without the guard, prune's own
+    db.commit() would silently commit that pending write as a side effect
+    of retention cleanup."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="t7-reverse")
+
+    db.add(User(username="t7-dirty", password_hash="x", is_admin=False))
+
+    with pytest.raises(RuntimeError, match="pending writes"):
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db, {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "exec-t7"}
+        )
+
+    db.rollback()
+    db.close()
+
+
+def test_prune_checkpoint_history_guard_allows_a_clean_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forward control: the guard must not reject the one state the
+    real call site ever hands it -- a clean session, since prune always
+    runs immediately after the checkpoint commit."""
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit", lambda: 5
+    )
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="t7-forward")
+
+    DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+        db, {"checkpoint_type": CHECKPOINT_TYPE, "execution_id": "exec-t7-forward"}
+    )
+
+    db.close()


### PR DESCRIPTION
## What

`_save_trace_event` in `trace_handlers.py` used to both build the trace row and own the transaction wrapped around it, so nothing could stage a checkpoint row inside a transaction it did not also commit. Its four write paths now delegate row construction to a new staging primitive, `stage_trace_event_row` (`src/xagent/web/services/trace_event_staging.py`), which joins the caller's already-open session and performs no commit, rollback, notification, or prune of its own. The shell keeps every boundary action: the pointer UPDATE and its rowcount classification, the tool-usage counters, the commit, the prune trigger, and both rollback handlers.

The four paths keep their exact shapes: a non-checkpoint event neither encodes nor flushes; a sub-agent checkpoint encodes without a run-partition stamp; a root checkpoint with no live lease encodes without flushing; a root checkpoint under a live lease stamps the partition, flushes, and returns the exact-row anchor the shell writes into `tasks.last_checkpoint_trace_event_id`.

Alongside the extraction, the pairing guard in `tests/web/services/test_checkpoint_pointer_pairing.py` (`_mutated_pointer_columns`) is hardened against opaque `**` carriers. It previously only recognized `.values(**name)` / `.update(**name)` as transparent when it could read `name`'s keys directly off a dict literal it had already walked; a `.values(**builder())` call carried both pointer columns past it with no finding. The guard now resolves names bound to a dict literal within the same function and treats every other `**` carrier as opaque, and therefore unpaired. Two shapes knowingly escape this hardening and are pinned as negative controls rather than left to be rediscovered: a paired local dict literal later merged with `.update(builder())` before being unpacked, and a paired local dict literal later rebound to the result of a call before being unpacked.

## Why

#1071 asks to "Expose checkpoint staging that joins a caller-owned transaction and performs no implicit commit, rollback, notification, or prune." Delivers the staging clause of #1071 (jointly closed with the offline-SQL migration fix and the deletion-path rows change).

Behavior is preserved by construction, not by re-testing from scratch: the two test files that call `_save_trace_event` directly (`tests/web/test_agent_checkpoint_stream.py`, 16 call sites, and `tests/web/test_trace_message_storage.py`, 9 call sites) are unmodified by this PR, and the pairing-guard file's pre-existing cases stay green under the hardened rule. The primary-key guard's `RuntimeError` keeps its exact type and message text; no new exception type is introduced anywhere in this change.

## Disposition table

Four write paths through `_save_trace_event`, five boundary actions:

| Path | commit | IntegrityError rollback | bare-except rollback | task-gone rollback | prune |
|---|---|---|---|---|---|
| (a) non-checkpoint | shell, always reached | shell, reachable | shell, reachable | unreachable | not triggered |
| (b) sub-agent checkpoint | shell, always reached | shell, reachable | shell, reachable | unreachable | shell triggers |
| (c) root checkpoint, no lease | shell, always reached | shell, reachable | shell, reachable | unreachable | shell triggers |
| (d) root checkpoint + live lease | shell, always reached | shell, reachable | shell, reachable | shell | shell triggers |

The primitive occupies zero of these twenty cells. That is the row-by-row proof behind "no implicit commit, rollback, notification, or prune": every action either lands in the shell or is unreachable on that path. The fifth verb, notification, has zero call sites in `_save_trace_event` at all -- no notify/dispatch/publish/broadcast symbol appears anywhere in the function -- so it ships as a zero-site fact about the existing function, not as something moved out of it.

## Teardown-guard evaluation

Two counts taken against the tree this PR lands on:

```
grep -rn "Base\.metadata\.drop_all" --include="*.py" tests/ src/ | wc -l   ->  89
grep -rn "drop_all_tables"          --include="*.py" tests/ src/ | wc -l   ->  16
```

The 89 figure moved from a baseline of 88 for a reason unrelated to this PR: an earlier, already-merged change added one test file with a bare `drop_all` that names no checkpoint column at all. The 16 figure moved from a baseline of 15 because of this PR's own new contract-test file for the primitive: it adds exactly one more raw match of the string `drop_all_tables`, and that match is a sentence in the file's module docstring explaining why the file does *not* need the shared teardown helper (it builds its own file-backed, per-test SQLite engine under `tmp_path` rather than using the process-wide shared engine). It is not a call.

16 is a raw line count of that grep, not a count of call sites, and reading it as one produces a wrong "coverage" ratio. The breakdown:

| Category | Count |
|---|---|
| Real call sites | 7 |
| Import lines | 6 |
| Helper function definition | 1 |
| Test-function name containing the phrase | 1 |
| Docstring mention (this PR's new contract-test file) | 1 |
| **Total** | **16** |

Only 7 real call sites across 6 files use the shared teardown helper today; that set is unchanged by this PR. Comparing 16 against 89 as a coverage percentage would be comparing the wrong things -- the real ratio of interest is 7 real call sites against however many files could plausibly need one, which is the question the next paragraph answers directly rather than by ratio.

Ten files in the tree name the anchor column `last_checkpoint_trace_event_id` at all -- the full set that could plausibly persist a populated checkpoint anchor into the shared database:

```
tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py   naked=0  helper=0
tests/web/test_db_teardown.py                                             naked=1  helper=4
tests/web/test_agent_checkpoint_stream.py                                 naked=0  helper=0
tests/web/test_task_lease_service.py                                      naked=0  helper=2
tests/web/services/test_task_deletion_checkpoint_pointer.py               naked=0  helper=0
tests/web/services/test_task_orchestrator.py                              naked=0  helper=2
tests/web/services/test_checkpoint_pointer_pairing.py                     naked=0  helper=0
tests/web/services/test_task_lease_recovery.py                            naked=0  helper=2
tests/web/services/checkpoint_anchor_shared.py                            naked=0  helper=0
tests/shared/db_teardown.py                                               naked=3  helper=1
```

Both `naked > 0` rows are accounted for and neither is a violation: the three hits in `tests/shared/db_teardown.py` are the helper's own implementation (one docstring line, one non-SQLite branch, one SQLite branch that runs only after foreign keys are turned off), and the one hit in `tests/web/test_db_teardown.py` is a dedicated negative-control test that calls the bare drop deliberately, to prove it breaks on a populated anchor, and cleans up with the helper in its `finally` block.

This PR's own new contract-test file for the primitive, `tests/web/services/test_trace_event_staging.py`, does not appear in this list at all -- it has zero occurrences of the string `last_checkpoint_trace_event_id`, because every one of its assertions works in terms of `staged.anchor.trace_event_id`, a value returned by the primitive before any commit, never written into the `tasks` table by the test itself. It structurally cannot trigger this guard's failure mode.

**Conclusion: no CI guard ships this round.** The argument is a reverse check, not a forward classifier: any test that could persist a populated anchor into the shared engine must, at minimum, name the anchor column somewhere in its source, so the ten files above are a superset of every test that could possibly be at risk. Checking each of those ten and finding zero risky bare-drop usages is therefore sufficient to conclude the risky set is empty, without needing to decide, file by file, whether a given test actually persists an anchor -- a forward question that would require tracing data flow through fixtures and shared helpers, which static analysis cannot answer reliably and which was already flagged as unreliable ground for a guard. The reverse check costs two greps and one loop; nothing more elaborate is warranted for a set that has come up empty twice in a row.

## Verification

Full-suite result across the four files this PR touches or pins:

```
pytest tests/web/test_agent_checkpoint_stream.py tests/web/test_trace_message_storage.py \
       tests/web/services/test_checkpoint_pointer_pairing.py tests/web/services/test_trace_event_staging.py
145 passed
```

125 of those 145 are pre-existing tests with a zero-line diff against the base commit -- `git diff` on both `tests/web/test_agent_checkpoint_stream.py` and `tests/web/test_trace_message_storage.py` against the base returns nothing, and the pairing-guard file's 10 original cases are untouched (18 total in that file now, 8 new). The remaining 20 are new: 12 in the new primitive contract-test file, 8 new controls in the pairing-guard file.

Mutations applied by hand, run, confirmed red, and reverted:

- Adding a commit right after the primitive stages the row turns the commit-independence test red.
- Adding a rollback on the flush-failure branch turns the rollback-independence test red (that test specifically checks the session is left mid-transaction, which is exactly the state a rollback there would erase).
- Adding an internal call to the prune method inside the primitive turns the prune-independence test red (a call-count assertion).
- Removing the `build_id is None` gate, so a sub-agent checkpoint also flushes, turns the sub-agent-checkpoint path test red.
- Removing the run-partition stamp turns both the root-checkpoint-with-lease path test and the pre-existing door test that asserts the sub-agent path carries no run-id field red.
- Removing the primary-key guard's raise, leaving the flush in place, turns both the primitive-level guard test and the shell-level door test (`test_database_trace_handler_flush_without_primary_key_refuses_to_write_the_anchor`) red -- but the failure is not a clean "did not raise." Independently reproduced outside the guard tests themselves: with the raise deleted, the following line assigns `trace_event.id` (which is `None`, because the flush that would assign it was itself replaced with a no-op for this test) into `int(...)`, which raises `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`. That is not a `RuntimeError`, so `pytest.raises(RuntimeError, ...)` does not catch it -- the escaped `TypeError` propagates out and fails the test, rather than the test reporting that nothing was raised at all. Confirming the failure takes this exact form (an escaped wrong-type exception, not a silent pass-through) matters more than just seeing red, because a mutation that happened to raise some other `RuntimeError`-compatible error by accident would produce a misleadingly clean-looking red too.
- Changing one character in the raise's message text turns the shell-level anchor-guard door test red, because its match string is verbatim.
- Deleting the `data = staged.stored_data` rebind from the shell turns the test asserting that prune receives the run-id-stamped data red.
- Removing the `arg is None` branch from the guard's `**` resolution turns all three positive controls red at once: unpacking a builder call's result directly, a name only ever bound from a call, and a dict arriving as a cross-function parameter.
- Reverting the guard's resolution to the naive "any `**` is opaque" rule turns only the `task_lease_service` case red among the five-module parametrized guard test; the other four modules have no `.values(**local_dict)` sites at all and stay green either way.
- Removing the prune-entry guard turns its own reverse control red (calling prune directly against a session that still has pending writes).

Uncovered cells, named as a known gap rather than silently accepted: the primitive's own no-commit / no-rollback / no-prune tests are pinned only on the root-checkpoint-with-a-live-lease path, the one path that flushes. A rollback or prune call placed in the non-checkpoint fallthrough, or in either of the two paths that encode without flushing, would still pass every test in this PR -- those paths' own tests check the returned shape (row id, anchor, which fields got stamped) but do not additionally assert that rollback or prune stayed uncalled there.

## Scope notes

`_persist_agent_outbound_event` (`web/api/websocket.py`) constructs and adds its own trace row directly; it does not call `_save_trace_event` and never reaches the new primitive. That file has a zero-line diff in this PR -- the bypass is pre-existing and deliberately out of scope, not something this change introduces or touches. The primitive's own docstring names this bypass explicitly so a future reader does not mistake it for the only construction point in the codebase.

The primitive's "sends no notification" test works by scanning the primitive module's own source text for the literal words notify, notification, dispatch, publish, and broadcast. That couples the test directly to whatever wording the module's docstring happens to use -- a future docstring edit that needed one of those words to explain why there is *no* notification would have to change this test in the same commit, not treat its failure as an unrelated regression.
